### PR TITLE
feat: observal-shim (stdio) + observal-proxy (HTTP) MCP wrappers (Phase 3-4)

### DIFF
--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -12,9 +12,18 @@ def _sanitize_name(name: str) -> str:
     return re.sub(r'[^a-zA-Z0-9_-]', '-', name)
 
 
+def _inject_agent_id(mcp_config: dict, agent_id: str):
+    """Add OBSERVAL_AGENT_ID env var to all MCP server entries for parent trace grouping."""
+    for _name, cfg in mcp_config.items():
+        if isinstance(cfg, dict):
+            cfg.setdefault("env", {})
+            cfg["env"]["OBSERVAL_AGENT_ID"] = agent_id
+
+
 def generate_agent_config(agent: Agent, ide: str) -> dict:
     """Generate IDE-specific config for an agent, bundling prompt + MCP configs."""
     mcp_configs = {}
+    agent_id = str(agent.id)
 
     # Registry MCPs
     for link in agent.mcp_links:
@@ -27,7 +36,7 @@ def generate_agent_config(agent: Agent, ide: str) -> dict:
         elif "mcpServers" in cfg:
             mcp_configs.update(cfg["mcpServers"])
 
-    # External MCPs — use list-based args, never shell strings
+    # External MCPs — wrap with shim
     for ext in (agent.external_mcps or []):
         name = _sanitize_name(ext.get("name", ""))
         if not name:
@@ -37,16 +46,28 @@ def generate_agent_config(agent: Agent, ide: str) -> dict:
         if isinstance(args, str):
             args = args.split()
         env = ext.get("env", {})
+        ext_mcp_id = ext.get("id", name)
+
+        shim_args = ["--mcp-id", ext_mcp_id, "--", cmd] + args
 
         if ide == "claude-code":
-            mcp_configs[name] = {"command": ["claude", "mcp", "add", name, "--", cmd] + args, "type": "shell_command"}
+            mcp_configs[name] = {
+                "command": ["claude", "mcp", "add", name, "--", "observal-shim"] + shim_args,
+                "type": "shell_command",
+            }
         elif ide == "gemini-cli":
-            mcp_configs[name] = {"command": cmd, "args": args}
+            mcp_configs[name] = {"command": "observal-shim", "args": shim_args}
         else:
-            mcp_configs[name] = {"command": cmd, "args": args, "env": env}
+            mcp_configs[name] = {"command": "observal-shim", "args": shim_args, "env": env}
+
+    # Inject OBSERVAL_AGENT_ID into all MCP configs
+    _inject_agent_id(mcp_configs, agent_id)
 
     if ide == "claude-code":
-        setup_commands = [c.get("command", []) for c in mcp_configs.values() if isinstance(c, dict) and c.get("type") == "shell_command"]
+        setup_commands = [
+            c.get("command", []) for c in mcp_configs.values()
+            if isinstance(c, dict) and c.get("type") == "shell_command"
+        ]
         return {
             "rules_file": {"path": f".claude/rules/{_sanitize_name(agent.name)}.md", "content": agent.prompt},
             "mcp_setup_commands": setup_commands,

--- a/observal-server/services/config_generator.py
+++ b/observal-server/services/config_generator.py
@@ -13,13 +13,18 @@ def _sanitize_name(name: str) -> str:
 
 def generate_config(listing: McpListing, ide: str) -> dict:
     name = _sanitize_name(listing.name)
-    if ide in ("cursor", "vscode"):
-        return {"mcpServers": {name: {"command": "python", "args": ["-m", name], "env": {}}}}
-    if ide == "kiro":
-        return {"mcpServers": {name: {"command": "python", "args": ["-m", name], "env": {}}}}
+    mcp_id = str(listing.id)
+
+    # Shim wraps the original command; auth comes from ~/.observal/config.json
+    shim_args = ["--mcp-id", mcp_id, "--", "python", "-m", name]
+
     if ide == "claude-code":
-        # Use list format, not shell string
-        return {"command": ["claude", "mcp", "add", name, "--", "python", "-m", name], "type": "shell_command"}
+        return {
+            "command": ["claude", "mcp", "add", name, "--", "observal-shim"] + shim_args,
+            "type": "shell_command",
+        }
     if ide == "gemini-cli":
-        return {"mcpServers": {name: {"command": "python", "args": ["-m", name]}}}
-    return {"mcpServers": {name: {"command": "python", "args": ["-m", name], "env": {}}}}
+        return {"mcpServers": {name: {"command": "observal-shim", "args": shim_args}}}
+
+    # cursor, vscode, kiro, windsurf, default
+    return {"mcpServers": {name: {"command": "observal-shim", "args": shim_args, "env": {}}}}

--- a/observal-server/services/config_generator.py
+++ b/observal-server/services/config_generator.py
@@ -11,11 +11,21 @@ def _sanitize_name(name: str) -> str:
     return re.sub(r'[^a-zA-Z0-9_-]', '-', name)
 
 
-def generate_config(listing: McpListing, ide: str) -> dict:
+def generate_config(listing: McpListing, ide: str, proxy_port: int | None = None) -> dict:
     name = _sanitize_name(listing.name)
     mcp_id = str(listing.id)
 
-    # Shim wraps the original command; auth comes from ~/.observal/config.json
+    # HTTP transport: point IDE at the proxy URL
+    if proxy_port is not None:
+        proxy_url = f"http://localhost:{proxy_port}"
+        if ide == "claude-code":
+            return {
+                "command": ["claude", "mcp", "add", name, "--url", proxy_url],
+                "type": "shell_command",
+            }
+        return {"mcpServers": {name: {"url": proxy_url}}}
+
+    # Stdio transport: shim wraps the original command
     shim_args = ["--mcp-id", mcp_id, "--", "python", "-m", name]
 
     if ide == "claude-code":

--- a/observal_cli/proxy.py
+++ b/observal_cli/proxy.py
@@ -1,0 +1,187 @@
+"""observal-proxy: transparent HTTP reverse proxy for MCP servers.
+
+Sits between IDE and an HTTP-transport MCP server, forwards all requests
+untouched, and async fire-and-forgets copies to the Observal server.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+
+import httpx
+
+from observal_cli.config import load as load_config
+from observal_cli.shim import ShimState, extract_span_name, extract_span_type
+
+logger = logging.getLogger("observal-proxy")
+
+
+def _parse_jsonrpc_body(body: bytes) -> dict | None:
+    """Try to parse a JSON-RPC message from an HTTP body."""
+    try:
+        return json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+class ProxyState(ShimState):
+    """Extends ShimState for HTTP proxy use."""
+
+    def __init__(self, mcp_id: str, target_url: str, server_url: str, api_key: str, agent_id: str | None = None):
+        super().__init__(mcp_id, server_url, api_key, agent_id)
+        self.target_url = target_url.rstrip("/")
+
+
+async def _handle_request(state: ProxyState, method: str, path: str, headers: dict, body: bytes) -> tuple[int, dict, bytes]:
+    """Forward a request to the target MCP server and capture telemetry."""
+    url = f"{state.target_url}{path}"
+
+    # Forward headers, skip hop-by-hop
+    fwd_headers = {k: v for k, v in headers.items() if k.lower() not in ("host", "transfer-encoding")}
+
+    start = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.request(method, url, headers=fwd_headers, content=body)
+        latency_ms = int((time.monotonic() - start) * 1000)
+        resp_body = resp.content
+        resp_headers = dict(resp.headers)
+
+        # Try to capture JSON-RPC telemetry
+        req_msg = _parse_jsonrpc_body(body)
+        resp_msg = _parse_jsonrpc_body(resp_body)
+
+        if req_msg and isinstance(req_msg, dict) and "method" in req_msg:
+            state.on_request(req_msg)
+        if resp_msg and isinstance(resp_msg, dict):
+            span = state.on_response(resp_msg)
+            if span:
+                span["latency_ms"] = latency_ms
+                await state.buffer_span(span)
+
+        return resp.status_code, resp_headers, resp_body
+    except Exception as e:
+        latency_ms = int((time.monotonic() - start) * 1000)
+        return 502, {"content-type": "application/json"}, json.dumps({"error": str(e)}).encode()
+
+
+async def run_proxy(mcp_id: str, target_url: str, port: int = 0):
+    """Start the HTTP proxy server."""
+    # Resolve auth
+    api_key = os.environ.get("OBSERVAL_KEY", "")
+    server_url = os.environ.get("OBSERVAL_SERVER", "")
+    if not api_key or not server_url:
+        cfg = load_config()
+        api_key = api_key or cfg.get("api_key", "")
+        server_url = server_url or cfg.get("server_url", "")
+
+    state = ProxyState(mcp_id, target_url, server_url or "", api_key or "", os.environ.get("OBSERVAL_AGENT_ID"))
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            # Read HTTP request line
+            request_line = await reader.readline()
+            if not request_line:
+                writer.close()
+                return
+            parts = request_line.decode().strip().split(" ")
+            if len(parts) < 3:
+                writer.close()
+                return
+            method, path, _ = parts[0], parts[1], parts[2]
+
+            # Read headers
+            headers = {}
+            content_length = 0
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                decoded = line.decode().strip()
+                if ":" in decoded:
+                    k, v = decoded.split(":", 1)
+                    headers[k.strip().lower()] = v.strip()
+                    if k.strip().lower() == "content-length":
+                        content_length = int(v.strip())
+
+            # Read body
+            body = b""
+            if content_length > 0:
+                body = await reader.readexactly(content_length)
+
+            # Forward
+            status, resp_headers, resp_body = await _handle_request(state, method, path, headers, body)
+
+            # Write response
+            status_text = {200: "OK", 201: "Created", 204: "No Content", 400: "Bad Request", 404: "Not Found", 500: "Internal Server Error", 502: "Bad Gateway"}.get(status, "OK")
+            writer.write(f"HTTP/1.1 {status} {status_text}\r\n".encode())
+            resp_headers["content-length"] = str(len(resp_body))
+            for k, v in resp_headers.items():
+                if k.lower() not in ("transfer-encoding",):
+                    writer.write(f"{k}: {v}\r\n".encode())
+            writer.write(b"\r\n")
+            writer.write(resp_body)
+            await writer.drain()
+        except Exception:
+            pass
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", port)
+    actual_port = server.sockets[0].getsockname()[1]
+    print(json.dumps({"proxy_port": actual_port, "target": target_url}), flush=True)
+
+    # Periodic flush
+    flush_task = asyncio.create_task(_periodic_flush(state))
+    try:
+        async with server:
+            await server.serve_forever()
+    finally:
+        flush_task.cancel()
+        await state.send_final()
+
+
+async def _periodic_flush(state: ShimState, interval: float = 5.0):
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            await state.flush()
+    except asyncio.CancelledError:
+        pass
+
+
+def main():
+    """CLI entry point for observal-proxy."""
+    args = sys.argv[1:]
+
+    mcp_id = ""
+    target_url = ""
+    port = 0
+    i = 0
+    while i < len(args):
+        if args[i] == "--mcp-id" and i + 1 < len(args):
+            mcp_id = args[i + 1]
+            i += 2
+        elif args[i] == "--target" and i + 1 < len(args):
+            target_url = args[i + 1]
+            i += 2
+        elif args[i] == "--port" and i + 1 < len(args):
+            port = int(args[i + 1])
+            i += 2
+        else:
+            i += 1
+
+    if not target_url:
+        print("Usage: observal-proxy --mcp-id <id> --target <url> [--port <port>]", file=sys.stderr)
+        sys.exit(1)
+
+    asyncio.run(run_proxy(mcp_id, target_url, port))
+
+
+if __name__ == "__main__":
+    main()

--- a/observal_cli/shim.py
+++ b/observal_cli/shim.py
@@ -1,0 +1,418 @@
+"""observal-shim: transparent stdio wrapper for MCP servers.
+
+Sits on the stdio pipe between IDE and MCP, passes all JSON-RPC messages
+through untouched, and async fire-and-forgets copies to the Observal server.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+
+import httpx
+
+from observal_cli.config import load as load_config
+
+logger = logging.getLogger("observal-shim")
+
+# --- JSON-RPC span type mapping ---
+
+METHOD_TO_SPAN: dict[str, tuple[str, str | None]] = {
+    "tools/call": ("tool_call", "params.name"),
+    "tools/list": ("tool_list", None),
+    "resources/read": ("resource_read", "params.uri"),
+    "resources/list": ("resource_list", None),
+    "resources/subscribe": ("resource_subscribe", "params.uri"),
+    "prompts/get": ("prompt_get", "params.name"),
+    "prompts/list": ("prompt_list", None),
+    "initialize": ("initialize", None),
+    "ping": ("ping", None),
+    "completion/complete": ("completion", None),
+    "logging/setLevel": ("config", None),
+}
+
+
+def classify_message(msg: dict) -> str:
+    """Classify a JSON-RPC message as 'request', 'response', or 'notification'."""
+    if "method" in msg and "id" in msg:
+        return "request"
+    if "result" in msg or "error" in msg:
+        return "response"
+    return "notification"
+
+
+def extract_span_type(method: str) -> str:
+    """Map a JSON-RPC method to a span type."""
+    entry = METHOD_TO_SPAN.get(method)
+    return entry[0] if entry else "other"
+
+
+def extract_span_name(method: str, params: dict | None) -> str:
+    """Extract a human-readable span name from a JSON-RPC request."""
+    entry = METHOD_TO_SPAN.get(method)
+    if entry and entry[1] and params:
+        # Navigate dotted path like "params.name"
+        parts = entry[1].split(".")
+        val = params
+        for p in parts:
+            if p == "params":
+                continue
+            if isinstance(val, dict):
+                val = val.get(p)
+            else:
+                val = None
+                break
+        if val and isinstance(val, str):
+            return val
+    return method or "unknown"
+
+
+def check_schema_compliance(
+    params: dict | None, tool_schemas: dict
+) -> tuple[int | None, int | None]:
+    """Check if tool_call args match cached schema. Returns (tool_schema_valid, tools_available)."""
+    if not tool_schemas:
+        return None, None
+    tools_available = len(tool_schemas)
+    if not params or "name" not in params:
+        return None, tools_available
+    tool_name = params["name"]
+    if tool_name not in tool_schemas:
+        return 0, tools_available  # tool not in schema = hallucinated
+    schema = tool_schemas[tool_name]
+    args = params.get("arguments", {})
+    if not schema:
+        return 1, tools_available
+    # Check required properties
+    required = schema.get("required", [])
+    properties = schema.get("properties", {})
+    for r in required:
+        if r not in args:
+            return 0, tools_available
+    # Check no extra properties if schema defines them
+    if properties:
+        for k in args:
+            if k not in properties:
+                return 0, tools_available
+    return 1, tools_available
+
+
+class ShimState:
+    """Mutable state for the shim process."""
+
+    def __init__(self, mcp_id: str, server_url: str, api_key: str, agent_id: str | None = None):
+        self.mcp_id = mcp_id
+        self.server_url = server_url.rstrip("/")
+        self.api_key = api_key
+        self.agent_id = agent_id
+        self.trace_id = os.environ.get("OBSERVAL_TRACE_ID") or str(uuid.uuid4())
+        self.parent_trace_id = os.environ.get("OBSERVAL_TRACE_ID")  # if set, we're a child
+        self.session_id = os.environ.get("OBSERVAL_SESSION_ID", "")
+        self.ide = os.environ.get("OBSERVAL_IDE", "")
+        self.environment = os.environ.get("OBSERVAL_ENVIRONMENT", "default")
+        self.trace_start = datetime.now(timezone.utc)
+
+        # Request tracking: id -> (method, params, start_time)
+        self.pending: dict[str | int, tuple[str, dict | None, float]] = {}
+        # Buffered spans for batch sending
+        self.buffer: list[dict] = []
+        self.tool_schemas: dict[str, dict] = {}  # tool_name -> inputSchema
+        self.lock = asyncio.Lock()
+
+    def _now_iso(self) -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+    def on_request(self, msg: dict):
+        """Track an outgoing request for later pairing."""
+        msg_id = msg.get("id")
+        method = msg.get("method", "")
+        params = msg.get("params")
+        if msg_id is not None:
+            self.pending[msg_id] = (method, params, time.monotonic())
+
+    def on_response(self, msg: dict) -> dict | None:
+        """Pair a response with its request and create a span."""
+        msg_id = msg.get("id")
+        if msg_id is None or msg_id not in self.pending:
+            return None
+        method, params, start_mono = self.pending.pop(msg_id)
+        latency_ms = int((time.monotonic() - start_mono) * 1000)
+        now = self._now_iso()
+
+        span_type = extract_span_type(method)
+        span_name = extract_span_name(method, params)
+
+        # Cache tool schemas from tools/list response
+        if method == "tools/list" and "result" in msg:
+            tools = msg["result"].get("tools", [])
+            self.tool_schemas = {
+                t["name"]: t.get("inputSchema", {}) for t in tools if "name" in t
+            }
+
+        # Schema compliance for tool_call
+        tool_schema_valid = None
+        tools_available = None
+        if method == "tools/call":
+            tool_schema_valid, tools_available = check_schema_compliance(
+                params, self.tool_schemas
+            )
+
+        error_str = None
+        status = "success"
+        if "error" in msg:
+            status = "error"
+            error_str = json.dumps(msg["error"])
+
+        return {
+            "span_id": str(uuid.uuid4()),
+            "trace_id": self.trace_id,
+            "type": span_type,
+            "name": span_name,
+            "method": method,
+            "input": json.dumps(params) if params else None,
+            "output": json.dumps(msg.get("result")) if "result" in msg else None,
+            "error": error_str,
+            "start_time": now,  # approximate
+            "end_time": now,
+            "latency_ms": latency_ms,
+            "status": status,
+            "ide": self.ide,
+            "metadata": {},
+            "tool_schema_valid": tool_schema_valid,
+            "tools_available": tools_available,
+        }
+
+    async def buffer_span(self, span: dict):
+        async with self.lock:
+            self.buffer.append(span)
+            if len(self.buffer) >= 50:
+                await self._flush_locked()
+
+    async def flush(self):
+        async with self.lock:
+            await self._flush_locked()
+
+    async def _flush_locked(self):
+        if not self.buffer:
+            return
+        spans = self.buffer[:]
+        self.buffer.clear()
+        await self._send(spans)
+
+    async def _send(self, spans: list[dict]):
+        """Fire-and-forget send to Observal server."""
+        payload = {
+            "traces": [{
+                "trace_id": self.trace_id,
+                "parent_trace_id": self.parent_trace_id,
+                "trace_type": "mcp",
+                "mcp_id": self.mcp_id,
+                "agent_id": self.agent_id,
+                "session_id": self.session_id,
+                "ide": self.ide,
+                "name": f"shim:{self.mcp_id}",
+                "start_time": self.trace_start.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+                "tags": [],
+                "metadata": {},
+            }],
+            "spans": spans,
+            "scores": [],
+        }
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                await client.post(
+                    f"{self.server_url}/api/v1/telemetry/ingest",
+                    json=payload,
+                    headers={
+                        "X-API-Key": self.api_key,
+                        "X-Observal-Environment": self.environment,
+                    },
+                )
+        except Exception:
+            pass  # fire-and-forget: never block, never retry
+
+    async def send_final(self):
+        """Flush remaining buffer and send trace end_time."""
+        await self.flush()
+
+
+# --- Stdio relay ---
+
+
+async def _read_messages(stream: asyncio.StreamReader) -> asyncio.Queue:
+    """Read newline-delimited JSON-RPC messages from a stream into a queue."""
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def _reader():
+        buf = b""
+        while True:
+            chunk = await stream.read(65536)
+            if not chunk:
+                await queue.put(None)  # EOF sentinel
+                break
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                    await queue.put(msg)
+                except json.JSONDecodeError:
+                    pass  # skip malformed
+
+    asyncio.create_task(_reader())
+    return queue
+
+
+async def _relay_ide_to_mcp(
+    ide_queue: asyncio.Queue,
+    mcp_stdin: asyncio.StreamWriter,
+    state: ShimState,
+):
+    """Relay messages from IDE to MCP, tracking requests."""
+    while True:
+        msg = await ide_queue.get()
+        if msg is None:
+            mcp_stdin.close()
+            break
+        kind = classify_message(msg)
+        if kind == "request":
+            state.on_request(msg)
+        raw = json.dumps(msg) + "\n"
+        mcp_stdin.write(raw.encode())
+        await mcp_stdin.drain()
+
+
+async def _relay_mcp_to_ide(
+    mcp_queue: asyncio.Queue,
+    ide_stdout: asyncio.StreamWriter,
+    state: ShimState,
+):
+    """Relay messages from MCP to IDE, pairing responses to create spans."""
+    while True:
+        msg = await mcp_queue.get()
+        if msg is None:
+            break
+        kind = classify_message(msg)
+        if kind == "response":
+            span = state.on_response(msg)
+            if span:
+                await state.buffer_span(span)
+        raw = json.dumps(msg) + "\n"
+        ide_stdout.write(raw.encode())
+        await ide_stdout.drain()
+
+
+async def _periodic_flush(state: ShimState, interval: float = 5.0):
+    """Flush buffered spans every `interval` seconds."""
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            await state.flush()
+    except asyncio.CancelledError:
+        pass
+
+
+async def run_shim(mcp_id: str, command: list[str]):
+    """Main shim entry point: spawn MCP process and relay stdio."""
+    # Resolve auth
+    api_key = os.environ.get("OBSERVAL_KEY", "")
+    server_url = os.environ.get("OBSERVAL_SERVER", "")
+    if not api_key or not server_url:
+        cfg = load_config()
+        api_key = api_key or cfg.get("api_key", "")
+        server_url = server_url or cfg.get("server_url", "")
+
+    if not server_url or not api_key:
+        # No config — pass through without capturing
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        sys.exit(await proc.wait())
+
+    agent_id = os.environ.get("OBSERVAL_AGENT_ID")
+    state = ShimState(mcp_id, server_url, api_key, agent_id)
+
+    # Spawn the real MCP process
+    proc = await asyncio.create_subprocess_exec(
+        *command,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    # Set up async readers
+    ide_reader = asyncio.StreamReader()
+    protocol = asyncio.StreamReaderProtocol(ide_reader)
+    await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin)
+
+    ide_writer_transport, ide_writer_protocol = await asyncio.get_event_loop().connect_write_pipe(
+        asyncio.streams.FlowControlMixin, sys.stdout
+    )
+    ide_stdout = asyncio.StreamWriter(ide_writer_transport, ide_writer_protocol, None, asyncio.get_event_loop())
+
+    ide_queue = await _read_messages(ide_reader)
+    mcp_queue = await _read_messages(proc.stdout)
+
+    # Forward stderr
+    async def _forward_stderr():
+        while True:
+            data = await proc.stderr.read(65536)
+            if not data:
+                break
+            sys.stderr.buffer.write(data)
+            sys.stderr.buffer.flush()
+
+    flush_task = asyncio.create_task(_periodic_flush(state))
+    stderr_task = asyncio.create_task(_forward_stderr())
+
+    try:
+        await asyncio.gather(
+            _relay_ide_to_mcp(ide_queue, proc.stdin, state),
+            _relay_mcp_to_ide(mcp_queue, ide_stdout, state),
+        )
+    finally:
+        flush_task.cancel()
+        stderr_task.cancel()
+        await state.send_final()
+
+    return await proc.wait()
+
+
+def main():
+    """CLI entry point for observal-shim."""
+    args = sys.argv[1:]
+
+    # Parse --mcp-id <id> -- <command...>
+    mcp_id = ""
+    command = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--mcp-id" and i + 1 < len(args):
+            mcp_id = args[i + 1]
+            i += 2
+        elif args[i] == "--":
+            command = args[i + 1:]
+            break
+        else:
+            i += 1
+
+    if not command:
+        print("Usage: observal-shim --mcp-id <id> -- <command> [args...]", file=sys.stderr)
+        sys.exit(1)
+
+    exit_code = asyncio.run(run_shim(mcp_id, command))
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 [project.scripts]
 observal = "observal_cli.main:app"
 observal-shim = "observal_cli.shim:main"
+observal-proxy = "observal_cli.proxy:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
 
 [project.scripts]
 observal = "observal_cli.main:app"
+observal-shim = "observal_cli.shim:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_proxy_phase4.py
+++ b/tests/test_proxy_phase4.py
@@ -1,0 +1,166 @@
+"""Unit tests for observal-proxy — Phase 4."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from observal_cli.proxy import ProxyState, _handle_request, _parse_jsonrpc_body
+
+
+# --- JSON-RPC body parsing ---
+
+
+class TestParseJsonrpcBody:
+    def test_valid_json(self):
+        body = json.dumps({"method": "tools/call", "id": 1}).encode()
+        assert _parse_jsonrpc_body(body) == {"method": "tools/call", "id": 1}
+
+    def test_invalid_json(self):
+        assert _parse_jsonrpc_body(b"not json") is None
+
+    def test_empty(self):
+        assert _parse_jsonrpc_body(b"") is None
+
+    def test_binary(self):
+        assert _parse_jsonrpc_body(b"\x00\x01\x02") is None
+
+
+# --- ProxyState ---
+
+
+class TestProxyState:
+    def test_inherits_shim_state(self):
+        state = ProxyState("mcp-1", "http://target:3000", "http://server:8000", "key")
+        assert state.target_url == "http://target:3000"
+        assert state.mcp_id == "mcp-1"
+        assert state.server_url == "http://server:8000"
+        assert state.trace_id  # auto-generated
+
+
+# --- Request handling ---
+
+
+class TestHandleRequest:
+    @pytest.mark.asyncio
+    async def test_forwards_request(self):
+        state = ProxyState("mcp-1", "http://target:3000", "http://server:8000", "key")
+        req_body = json.dumps({"method": "tools/call", "id": 1, "params": {"name": "x"}}).encode()
+        resp_body = json.dumps({"id": 1, "result": {"content": "ok"}}).encode()
+
+        with patch("observal_cli.proxy.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.content = resp_body
+            mock_resp.headers = {"content-type": "application/json"}
+            mock_client.request.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            with patch.object(state, "buffer_span", new_callable=AsyncMock) as mock_buf:
+                status, headers, body = await _handle_request(state, "POST", "/", {}, req_body)
+
+            assert status == 200
+            assert body == resp_body
+            mock_buf.assert_called_once()
+            span = mock_buf.call_args[0][0]
+            assert span["type"] == "tool_call"
+            assert span["latency_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_returns_502_on_target_error(self):
+        state = ProxyState("mcp-1", "http://target:3000", "http://server:8000", "key")
+
+        with patch("observal_cli.proxy.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.request.side_effect = Exception("connection refused")
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            status, headers, body = await _handle_request(state, "POST", "/", {}, b"{}")
+
+        assert status == 502
+        assert b"connection refused" in body
+
+    @pytest.mark.asyncio
+    async def test_non_jsonrpc_passthrough(self):
+        state = ProxyState("mcp-1", "http://target:3000", "http://server:8000", "key")
+
+        with patch("observal_cli.proxy.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.content = b"plain text"
+            mock_resp.headers = {"content-type": "text/plain"}
+            mock_client.request.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            with patch.object(state, "buffer_span", new_callable=AsyncMock) as mock_buf:
+                status, _, body = await _handle_request(state, "GET", "/health", {}, b"")
+
+            assert status == 200
+            assert body == b"plain text"
+            mock_buf.assert_not_called()  # no JSON-RPC, no span
+
+    @pytest.mark.asyncio
+    async def test_error_response_creates_error_span(self):
+        state = ProxyState("mcp-1", "http://target:3000", "http://server:8000", "key")
+        req_body = json.dumps({"method": "tools/call", "id": 1, "params": {"name": "x"}}).encode()
+        resp_body = json.dumps({"id": 1, "error": {"code": -32600, "message": "bad"}}).encode()
+
+        with patch("observal_cli.proxy.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.content = resp_body
+            mock_resp.headers = {}
+            mock_client.request.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            with patch.object(state, "buffer_span", new_callable=AsyncMock) as mock_buf:
+                await _handle_request(state, "POST", "/", {}, req_body)
+
+            span = mock_buf.call_args[0][0]
+            assert span["status"] == "error"
+
+
+# --- Config generator HTTP transport ---
+
+
+class TestConfigGeneratorHTTP:
+    def _make_listing(self, name="my-http-mcp", listing_id="http-123"):
+        listing = MagicMock()
+        listing.name = name
+        listing.id = listing_id
+        return listing
+
+    def test_proxy_port_cursor(self):
+        from services.config_generator import generate_config
+        cfg = generate_config(self._make_listing(), "cursor", proxy_port=9999)
+        server = cfg["mcpServers"]["my-http-mcp"]
+        assert server["url"] == "http://localhost:9999"
+        assert "command" not in server
+
+    def test_proxy_port_claude_code(self):
+        from services.config_generator import generate_config
+        cfg = generate_config(self._make_listing(), "claude-code", proxy_port=9999)
+        assert "http://localhost:9999" in str(cfg["command"])
+
+    def test_proxy_port_kiro(self):
+        from services.config_generator import generate_config
+        cfg = generate_config(self._make_listing(), "kiro", proxy_port=8888)
+        server = cfg["mcpServers"]["my-http-mcp"]
+        assert server["url"] == "http://localhost:8888"
+
+    def test_stdio_still_works(self):
+        from services.config_generator import generate_config
+        cfg = generate_config(self._make_listing(), "cursor")
+        server = cfg["mcpServers"]["my-http-mcp"]
+        assert server["command"] == "observal-shim"

--- a/tests/test_shim_phase3.py
+++ b/tests/test_shim_phase3.py
@@ -1,0 +1,323 @@
+"""Unit tests for observal-shim — Phase 3."""
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from observal_cli.shim import (
+    ShimState,
+    check_schema_compliance,
+    classify_message,
+    extract_span_name,
+    extract_span_type,
+)
+
+
+# --- Message classification ---
+
+
+class TestClassifyMessage:
+    def test_request(self):
+        assert classify_message({"method": "tools/call", "id": 1}) == "request"
+
+    def test_response_result(self):
+        assert classify_message({"id": 1, "result": {}}) == "response"
+
+    def test_response_error(self):
+        assert classify_message({"id": 1, "error": {"code": -1}}) == "response"
+
+    def test_notification(self):
+        assert classify_message({"method": "notifications/log"}) == "notification"
+
+    def test_notification_no_id(self):
+        assert classify_message({"method": "progress"}) == "notification"
+
+
+# --- Span type mapping ---
+
+
+class TestExtractSpanType:
+    def test_tool_call(self):
+        assert extract_span_type("tools/call") == "tool_call"
+
+    def test_tool_list(self):
+        assert extract_span_type("tools/list") == "tool_list"
+
+    def test_resource_read(self):
+        assert extract_span_type("resources/read") == "resource_read"
+
+    def test_prompt_get(self):
+        assert extract_span_type("prompts/get") == "prompt_get"
+
+    def test_initialize(self):
+        assert extract_span_type("initialize") == "initialize"
+
+    def test_ping(self):
+        assert extract_span_type("ping") == "ping"
+
+    def test_unknown(self):
+        assert extract_span_type("custom/method") == "other"
+
+
+class TestExtractSpanName:
+    def test_tool_call_name(self):
+        assert extract_span_name("tools/call", {"name": "read_file"}) == "read_file"
+
+    def test_resource_read_uri(self):
+        assert extract_span_name("resources/read", {"uri": "file:///tmp/x"}) == "file:///tmp/x"
+
+    def test_no_params(self):
+        assert extract_span_name("tools/list", None) == "tools/list"
+
+    def test_unknown_method(self):
+        assert extract_span_name("custom/foo", {}) == "custom/foo"
+
+    def test_missing_field(self):
+        assert extract_span_name("tools/call", {"other": "val"}) == "tools/call"
+
+
+# --- Schema compliance ---
+
+
+class TestSchemaCompliance:
+    def test_no_schemas(self):
+        assert check_schema_compliance({"name": "x"}, {}) == (None, None)
+
+    def test_tool_not_in_schema(self):
+        schemas = {"read_file": {"properties": {"path": {}}}}
+        valid, avail = check_schema_compliance({"name": "hallucinated_tool"}, schemas)
+        assert valid == 0
+        assert avail == 1
+
+    def test_valid_call(self):
+        schemas = {"read_file": {"properties": {"path": {}}, "required": ["path"]}}
+        valid, avail = check_schema_compliance(
+            {"name": "read_file", "arguments": {"path": "/tmp"}}, schemas
+        )
+        assert valid == 1
+        assert avail == 1
+
+    def test_missing_required(self):
+        schemas = {"read_file": {"properties": {"path": {}}, "required": ["path"]}}
+        valid, avail = check_schema_compliance(
+            {"name": "read_file", "arguments": {}}, schemas
+        )
+        assert valid == 0
+
+    def test_extra_property(self):
+        schemas = {"read_file": {"properties": {"path": {}}}}
+        valid, avail = check_schema_compliance(
+            {"name": "read_file", "arguments": {"path": "/tmp", "extra": "bad"}}, schemas
+        )
+        assert valid == 0
+
+    def test_empty_schema(self):
+        schemas = {"simple_tool": {}}
+        valid, avail = check_schema_compliance(
+            {"name": "simple_tool", "arguments": {"anything": "goes"}}, schemas
+        )
+        assert valid == 1
+
+    def test_no_params(self):
+        schemas = {"x": {}}
+        valid, avail = check_schema_compliance(None, schemas)
+        assert valid is None
+        assert avail == 1
+
+    def test_multiple_tools_available(self):
+        schemas = {"a": {}, "b": {}, "c": {}}
+        _, avail = check_schema_compliance({"name": "a"}, schemas)
+        assert avail == 3
+
+
+# --- ShimState request/response pairing ---
+
+
+class TestShimState:
+    def _make_state(self):
+        return ShimState("mcp-1", "http://localhost:8000", "test-key")
+
+    def test_on_request_tracks_pending(self):
+        state = self._make_state()
+        state.on_request({"method": "tools/call", "id": 1, "params": {"name": "x"}})
+        assert 1 in state.pending
+
+    def test_on_response_creates_span(self):
+        state = self._make_state()
+        state.on_request({"method": "tools/call", "id": 1, "params": {"name": "read_file"}})
+        span = state.on_response({"id": 1, "result": {"content": "data"}})
+        assert span is not None
+        assert span["type"] == "tool_call"
+        assert span["name"] == "read_file"
+        assert span["status"] == "success"
+        assert span["latency_ms"] >= 0
+        assert span["output"] is not None
+
+    def test_on_response_error(self):
+        state = self._make_state()
+        state.on_request({"method": "tools/call", "id": 2, "params": {"name": "x"}})
+        span = state.on_response({"id": 2, "error": {"code": -32600, "message": "bad"}})
+        assert span["status"] == "error"
+        assert span["error"] is not None
+
+    def test_on_response_unknown_id(self):
+        state = self._make_state()
+        span = state.on_response({"id": 999, "result": {}})
+        assert span is None
+
+    def test_on_response_no_id(self):
+        state = self._make_state()
+        span = state.on_response({"result": {}})
+        assert span is None
+
+    def test_tools_list_caches_schemas(self):
+        state = self._make_state()
+        state.on_request({"method": "tools/list", "id": 1})
+        state.on_response({
+            "id": 1,
+            "result": {
+                "tools": [
+                    {"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}},
+                    {"name": "write_file", "inputSchema": {"properties": {"path": {}, "content": {}}}},
+                ]
+            }
+        })
+        assert "read_file" in state.tool_schemas
+        assert "write_file" in state.tool_schemas
+
+    def test_tool_call_after_list_checks_schema(self):
+        state = self._make_state()
+        # First cache schemas
+        state.on_request({"method": "tools/list", "id": 1})
+        state.on_response({
+            "id": 1,
+            "result": {"tools": [
+                {"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}}
+            ]}
+        })
+        # Now make a valid tool call
+        state.on_request({"method": "tools/call", "id": 2, "params": {"name": "read_file", "arguments": {"path": "/tmp"}}})
+        span = state.on_response({"id": 2, "result": {"content": "ok"}})
+        assert span["tool_schema_valid"] == 1
+        assert span["tools_available"] == 1
+
+    def test_tool_call_hallucinated_params(self):
+        state = self._make_state()
+        state.on_request({"method": "tools/list", "id": 1})
+        state.on_response({
+            "id": 1,
+            "result": {"tools": [
+                {"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}}
+            ]}
+        })
+        state.on_request({"method": "tools/call", "id": 2, "params": {"name": "read_file", "arguments": {"wrong_param": "x"}}})
+        span = state.on_response({"id": 2, "result": {}})
+        assert span["tool_schema_valid"] == 0
+
+    @pytest.mark.asyncio
+    async def test_buffer_and_flush(self):
+        state = self._make_state()
+        with patch.object(state, "_send", new_callable=AsyncMock) as mock_send:
+            span = {"span_id": "s1", "type": "tool_call"}
+            await state.buffer_span(span)
+            assert len(state.buffer) == 1
+            await state.flush()
+            mock_send.assert_called_once()
+            assert len(state.buffer) == 0
+
+    @pytest.mark.asyncio
+    async def test_auto_flush_at_50(self):
+        state = self._make_state()
+        with patch.object(state, "_send", new_callable=AsyncMock) as mock_send:
+            for i in range(50):
+                await state.buffer_span({"span_id": f"s{i}"})
+            mock_send.assert_called_once()
+            assert len(state.buffer) == 0
+
+    @pytest.mark.asyncio
+    async def test_send_fire_and_forget(self):
+        state = self._make_state()
+        # Even if httpx fails, _send should not raise
+        with patch("observal_cli.shim.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = Exception("network error")
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+            await state._send([{"span_id": "s1"}])  # should not raise
+
+
+# --- Config generator tests ---
+
+
+class TestConfigGenerator:
+    def _make_listing(self, name="my-mcp", listing_id="abc-123"):
+        listing = MagicMock()
+        listing.name = name
+        listing.id = listing_id
+        return listing
+
+    def test_cursor_wraps_with_shim(self):
+        from services.config_generator import generate_config
+        cfg = generate_config(self._make_listing(), "cursor")
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["command"] == "observal-shim"
+        assert "--mcp-id" in server["args"]
+        assert "abc-123" in server["args"]
+        assert "--" in server["args"]
+
+    def test_no_api_key_in_config(self):
+        from services.config_generator import generate_config
+        cfg = generate_config(self._make_listing(), "cursor")
+        server = cfg["mcpServers"]["my-mcp"]
+        env = server.get("env", {})
+        assert "OBSERVAL_KEY" not in env
+        assert "api_key" not in json.dumps(cfg).lower()
+
+    def test_claude_code_format(self):
+        from services.config_generator import generate_config
+        cfg = generate_config(self._make_listing(), "claude-code")
+        assert cfg["type"] == "shell_command"
+        assert "observal-shim" in cfg["command"]
+
+    def test_gemini_cli_format(self):
+        from services.config_generator import generate_config
+        cfg = generate_config(self._make_listing(), "gemini-cli")
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["command"] == "observal-shim"
+
+
+class TestAgentConfigGenerator:
+    def _make_agent(self, name="test-agent", agent_id="agent-xyz"):
+        agent = MagicMock()
+        agent.name = name
+        agent.id = agent_id
+        agent.prompt = "You are a test agent."
+        agent.mcp_links = []
+        agent.external_mcps = [
+            {"name": "ext-mcp", "command": "npx", "args": ["ext-mcp-server"], "id": "ext-1"}
+        ]
+        return agent
+
+    def test_injects_agent_id(self):
+        from services.agent_config_generator import generate_agent_config
+        cfg = generate_agent_config(self._make_agent(), "cursor")
+        mcp_cfg = cfg["mcp_config"]["mcpServers"]["ext-mcp"]
+        assert mcp_cfg["env"]["OBSERVAL_AGENT_ID"] == "agent-xyz"
+
+    def test_external_mcp_wrapped_with_shim(self):
+        from services.agent_config_generator import generate_agent_config
+        cfg = generate_agent_config(self._make_agent(), "cursor")
+        mcp_cfg = cfg["mcp_config"]["mcpServers"]["ext-mcp"]
+        assert mcp_cfg["command"] == "observal-shim"
+        assert "--mcp-id" in mcp_cfg["args"]
+
+    def test_kiro_format(self):
+        from services.agent_config_generator import generate_agent_config
+        cfg = generate_agent_config(self._make_agent(), "kiro")
+        assert "rules_file" in cfg
+        assert "mcp_json" in cfg
+        mcp_cfg = cfg["mcp_json"]["mcpServers"]["ext-mcp"]
+        assert mcp_cfg["env"]["OBSERVAL_AGENT_ID"] == "agent-xyz"


### PR DESCRIPTION
## Summary

Transparent telemetry wrappers for MCP servers. The shim wraps stdio transport, the proxy wraps HTTP transport. Both capture tool calls as spans and flush telemetry to the server asynchronously.

Fixes #12
Fixes #13

## Phase 3 — Shim (#12)

- `observal-shim`: transparent stdio JSON-RPC proxy between IDE and MCP server
- Pairs requests/responses into spans with latency, status, method
- Caches `tools/list` responses for schema compliance checking
- Buffered async telemetry flush (every 5s or 50 spans)
- Fire-and-forget POST to ingestion endpoint — never blocks the MCP server
- Registered as `observal-shim` entry point
- 43 unit tests

## Phase 4 — Proxy (#13)

- `observal-proxy`: HTTP reverse proxy reusing `ShimState` from the shim
- Intercepts HTTP requests/responses to MCP servers, extracts spans
- Same telemetry pipeline as the shim
- Registered as `observal-proxy` entry point
- 13 unit tests

## Config Generation

- `generate_config()` now wraps MCP commands with `observal-shim` automatically
- Agent config generator injects `OBSERVAL_AGENT_ID` env var into all MCP configs
- HTTP transport MCPs get `proxy_port` config pointing to `observal-proxy`

## Testing
```
56 tests passing (43 shim + 13 proxy)
```