### PR TITLE
feat: Strawberry GraphQL layer with DataLoaders and subscriptions (Phase 6)

### DIFF
--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -1,0 +1,459 @@
+"""Strawberry GraphQL schema — types, resolvers, DataLoaders, subscriptions."""
+
+import json
+import logging
+from datetime import datetime
+from typing import AsyncGenerator
+
+import strawberry
+from strawberry.dataloader import DataLoader
+from strawberry.scalars import JSON
+from strawberry.types import Info
+
+from services.clickhouse import (
+    _escape,
+    _query,
+    query_scores,
+    query_span_by_id,
+    query_spans,
+    query_trace_by_id,
+    query_traces,
+)
+from services.redis import subscribe
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROJECT = "default"
+
+
+# --- Helpers ---
+
+
+async def _ch_json(sql: str) -> list[dict]:
+    try:
+        r = await _query(f"{sql} FORMAT JSON")
+        if r.status_code == 200:
+            return r.json().get("data", [])
+    except Exception as e:
+        logger.warning(f"ClickHouse query failed: {e}")
+    return []
+
+
+def _parse_json(val: str | None) -> JSON | None:
+    if not val:
+        return None
+    try:
+        return json.loads(val)
+    except (json.JSONDecodeError, TypeError):
+        return val
+
+
+# --- DataLoaders ---
+
+
+async def _load_spans_by_trace_ids(keys: list[str]) -> list[list[dict]]:
+    ids = ", ".join(f"'{_escape(k)}'" for k in keys)
+    sql = (
+        f"SELECT * FROM spans FINAL WHERE project_id = '{_escape(DEFAULT_PROJECT)}' "
+        f"AND trace_id IN ({ids}) AND is_deleted = 0 ORDER BY start_time ASC FORMAT JSON"
+    )
+    rows = await _ch_json(sql)
+    grouped: dict[str, list[dict]] = {k: [] for k in keys}
+    for r in rows:
+        tid = r.get("trace_id", "")
+        if tid in grouped:
+            grouped[tid].append(r)
+    return [grouped[k] for k in keys]
+
+
+async def _load_scores_by_trace_ids(keys: list[str]) -> list[list[dict]]:
+    ids = ", ".join(f"'{_escape(k)}'" for k in keys)
+    sql = (
+        f"SELECT * FROM scores FINAL WHERE project_id = '{_escape(DEFAULT_PROJECT)}' "
+        f"AND trace_id IN ({ids}) AND is_deleted = 0 ORDER BY timestamp DESC FORMAT JSON"
+    )
+    rows = await _ch_json(sql)
+    grouped: dict[str, list[dict]] = {k: [] for k in keys}
+    for r in rows:
+        tid = r.get("trace_id", "")
+        if tid in grouped:
+            grouped[tid].append(r)
+    return [grouped[k] for k in keys]
+
+
+async def _load_scores_by_span_ids(keys: list[str]) -> list[list[dict]]:
+    ids = ", ".join(f"'{_escape(k)}'" for k in keys)
+    sql = (
+        f"SELECT * FROM scores FINAL WHERE project_id = '{_escape(DEFAULT_PROJECT)}' "
+        f"AND span_id IN ({ids}) AND is_deleted = 0 ORDER BY timestamp DESC FORMAT JSON"
+    )
+    rows = await _ch_json(sql)
+    grouped: dict[str, list[dict]] = {k: [] for k in keys}
+    for r in rows:
+        sid = r.get("span_id", "")
+        if sid in grouped:
+            grouped[sid].append(r)
+    return [grouped[k] for k in keys]
+
+
+# --- Types ---
+
+
+@strawberry.type
+class Score:
+    score_id: str
+    trace_id: str | None
+    span_id: str | None
+    name: str
+    source: str
+    data_type: str
+    value: float
+    string_value: str | None
+    comment: str | None
+    timestamp: str
+
+
+@strawberry.type
+class Span:
+    span_id: str
+    trace_id: str
+    parent_span_id: str | None
+    type: str
+    name: str
+    method: str | None
+    input: JSON | None
+    output: JSON | None
+    error: JSON | None
+    start_time: str
+    end_time: str | None
+    latency_ms: int | None
+    status: str
+    token_count_input: int | None
+    token_count_output: int | None
+    token_count_total: int | None
+    cost: float | None
+    hop_count: int | None
+    tool_schema_valid: bool | None
+    tools_available: int | None
+    metadata: JSON | None
+
+    @strawberry.field
+    async def scores(self, info: Info) -> list[Score]:
+        loader = info.context["score_by_span_loader"]
+        rows = await loader.load(self.span_id)
+        return [_row_to_score(r) for r in rows]
+
+
+@strawberry.type
+class TraceMetrics:
+    total_spans: int
+    error_count: int
+    total_latency_ms: int | None
+    tool_call_count: int
+    token_count_total: int | None
+
+
+@strawberry.type
+class Trace:
+    trace_id: str
+    parent_trace_id: str | None
+    trace_type: str
+    mcp_id: str | None
+    agent_id: str | None
+    user_id: str
+    session_id: str | None
+    ide: str | None
+    name: str | None
+    start_time: str
+    end_time: str | None
+    input: JSON | None
+    output: JSON | None
+    tags: list[str] | None
+    metadata: JSON | None
+
+    @strawberry.field
+    async def spans(self, info: Info, type: str | None = None) -> list[Span]:
+        loader = info.context["span_loader"]
+        rows = await loader.load(self.trace_id)
+        if type:
+            rows = [r for r in rows if r.get("type") == type]
+        return [_row_to_span(r) for r in rows]
+
+    @strawberry.field
+    async def scores(self, info: Info) -> list[Score]:
+        loader = info.context["score_by_trace_loader"]
+        rows = await loader.load(self.trace_id)
+        return [_row_to_score(r) for r in rows]
+
+    @strawberry.field
+    async def metrics(self, info: Info) -> TraceMetrics:
+        loader = info.context["span_loader"]
+        rows = await loader.load(self.trace_id)
+        errors = sum(1 for r in rows if r.get("status") == "error")
+        tool_calls = sum(1 for r in rows if r.get("type") == "tool_call")
+        tokens = sum(int(r.get("token_count_total") or 0) for r in rows)
+        latencies = [int(r.get("latency_ms") or 0) for r in rows if r.get("latency_ms")]
+        return TraceMetrics(
+            total_spans=len(rows),
+            error_count=errors,
+            total_latency_ms=sum(latencies) if latencies else None,
+            tool_call_count=tool_calls,
+            token_count_total=tokens or None,
+        )
+
+
+@strawberry.type
+class TraceConnection:
+    items: list[Trace]
+    total_count: int
+    has_more: bool
+
+
+@strawberry.type
+class McpMetrics:
+    tool_call_count: int
+    error_rate: float
+    avg_latency_ms: float
+    p50_latency_ms: float
+    p90_latency_ms: float
+    p99_latency_ms: float
+    timeout_rate: float
+    schema_compliance_rate: float
+
+
+@strawberry.type
+class OverviewStats:
+    total_traces: int
+    total_spans: int
+    tool_calls_today: int
+    errors_today: int
+
+
+@strawberry.type
+class TrendPoint:
+    date: str
+    traces: int
+    spans: int
+    errors: int
+
+
+# --- Row converters ---
+
+
+def _row_to_trace(r: dict) -> Trace:
+    return Trace(
+        trace_id=r.get("trace_id", ""),
+        parent_trace_id=r.get("parent_trace_id"),
+        trace_type=r.get("trace_type", "mcp"),
+        mcp_id=r.get("mcp_id"),
+        agent_id=r.get("agent_id"),
+        user_id=r.get("user_id", ""),
+        session_id=r.get("session_id"),
+        ide=r.get("ide"),
+        name=r.get("name"),
+        start_time=r.get("start_time", ""),
+        end_time=r.get("end_time"),
+        input=_parse_json(r.get("input")),
+        output=_parse_json(r.get("output")),
+        tags=r.get("tags", []),
+        metadata=r.get("metadata"),
+    )
+
+
+def _row_to_span(r: dict) -> Span:
+    tsv = r.get("tool_schema_valid")
+    return Span(
+        span_id=r.get("span_id", ""),
+        trace_id=r.get("trace_id", ""),
+        parent_span_id=r.get("parent_span_id"),
+        type=r.get("type", ""),
+        name=r.get("name", ""),
+        method=r.get("method"),
+        input=_parse_json(r.get("input")),
+        output=_parse_json(r.get("output")),
+        error=_parse_json(r.get("error")),
+        start_time=r.get("start_time", ""),
+        end_time=r.get("end_time"),
+        latency_ms=int(r["latency_ms"]) if r.get("latency_ms") else None,
+        status=r.get("status", "success"),
+        token_count_input=int(r["token_count_input"]) if r.get("token_count_input") else None,
+        token_count_output=int(r["token_count_output"]) if r.get("token_count_output") else None,
+        token_count_total=int(r["token_count_total"]) if r.get("token_count_total") else None,
+        cost=float(r["cost"]) if r.get("cost") else None,
+        hop_count=int(r["hop_count"]) if r.get("hop_count") else None,
+        tool_schema_valid=bool(int(tsv)) if tsv is not None and tsv != "" else None,
+        tools_available=int(r["tools_available"]) if r.get("tools_available") else None,
+        metadata=r.get("metadata"),
+    )
+
+
+def _row_to_score(r: dict) -> Score:
+    return Score(
+        score_id=r.get("score_id", ""),
+        trace_id=r.get("trace_id"),
+        span_id=r.get("span_id"),
+        name=r.get("name", ""),
+        source=r.get("source", ""),
+        data_type=r.get("data_type", "numeric"),
+        value=float(r.get("value", 0)),
+        string_value=r.get("string_value"),
+        comment=r.get("comment"),
+        timestamp=r.get("timestamp", ""),
+    )
+
+
+# --- Query resolvers ---
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def traces(
+        self,
+        info: Info,
+        trace_type: str | None = None,
+        mcp_id: str | None = None,
+        agent_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> TraceConnection:
+        rows = await query_traces(
+            DEFAULT_PROJECT,
+            trace_type=trace_type,
+            mcp_id=mcp_id,
+            agent_id=agent_id,
+            limit=limit + 1,
+            offset=offset,
+        )
+        has_more = len(rows) > limit
+        items = [_row_to_trace(r) for r in rows[:limit]]
+        return TraceConnection(items=items, total_count=len(items), has_more=has_more)
+
+    @strawberry.field
+    async def trace(self, info: Info, trace_id: str) -> Trace | None:
+        r = await query_trace_by_id(DEFAULT_PROJECT, trace_id)
+        return _row_to_trace(r) if r else None
+
+    @strawberry.field
+    async def span(self, info: Info, span_id: str) -> Span | None:
+        r = await query_span_by_id(DEFAULT_PROJECT, span_id)
+        return _row_to_span(r) if r else None
+
+    @strawberry.field
+    async def mcp_metrics(self, mcp_id: str, start: str, end: str) -> McpMetrics:
+        rows = await _ch_json(
+            f"SELECT count() as cnt, "
+            f"countIf(status='error') as errs, "
+            f"countIf(status='timeout') as timeouts, "
+            f"avg(latency_ms) as avg_lat, "
+            f"quantile(0.5)(latency_ms) as p50, "
+            f"quantile(0.9)(latency_ms) as p90, "
+            f"quantile(0.99)(latency_ms) as p99, "
+            f"countIf(tool_schema_valid=1) as schema_ok, "
+            f"countIf(tool_schema_valid IS NOT NULL) as schema_total "
+            f"FROM spans FINAL WHERE project_id='{_escape(DEFAULT_PROJECT)}' "
+            f"AND mcp_id='{_escape(mcp_id)}' AND type='tool_call' "
+            f"AND start_time >= '{_escape(start)}' AND start_time <= '{_escape(end)}' "
+            f"AND is_deleted=0"
+        )
+        r = rows[0] if rows else {}
+        cnt = int(r.get("cnt", 0))
+        errs = int(r.get("errs", 0))
+        timeouts = int(r.get("timeouts", 0))
+        schema_total = int(r.get("schema_total", 0))
+        schema_ok = int(r.get("schema_ok", 0))
+        return McpMetrics(
+            tool_call_count=cnt,
+            error_rate=errs / cnt if cnt else 0,
+            avg_latency_ms=float(r.get("avg_lat", 0)),
+            p50_latency_ms=float(r.get("p50", 0)),
+            p90_latency_ms=float(r.get("p90", 0)),
+            p99_latency_ms=float(r.get("p99", 0)),
+            timeout_rate=timeouts / cnt if cnt else 0,
+            schema_compliance_rate=schema_ok / schema_total if schema_total else 0,
+        )
+
+    @strawberry.field
+    async def overview(self, start: str, end: str) -> OverviewStats:
+        rows = await _ch_json(
+            f"SELECT count() as traces FROM traces FINAL "
+            f"WHERE project_id='{_escape(DEFAULT_PROJECT)}' AND is_deleted=0 "
+            f"AND start_time >= '{_escape(start)}' AND start_time <= '{_escape(end)}'"
+        )
+        span_rows = await _ch_json(
+            f"SELECT count() as spans, "
+            f"countIf(type='tool_call') as tools, "
+            f"countIf(status='error') as errs "
+            f"FROM spans FINAL WHERE project_id='{_escape(DEFAULT_PROJECT)}' AND is_deleted=0 "
+            f"AND start_time >= '{_escape(start)}' AND start_time <= '{_escape(end)}'"
+        )
+        tr = rows[0] if rows else {}
+        sr = span_rows[0] if span_rows else {}
+        return OverviewStats(
+            total_traces=int(tr.get("traces", 0)),
+            total_spans=int(sr.get("spans", 0)),
+            tool_calls_today=int(sr.get("tools", 0)),
+            errors_today=int(sr.get("errs", 0)),
+        )
+
+    @strawberry.field
+    async def trends(self, start: str, end: str, granularity: str = "DAY") -> list[TrendPoint]:
+        trunc = {"HOUR": "toStartOfHour", "DAY": "toDate", "WEEK": "toStartOfWeek", "MONTH": "toStartOfMonth"}.get(granularity, "toDate")
+        rows = await _ch_json(
+            f"SELECT {trunc}(start_time) as d, count() as traces "
+            f"FROM traces FINAL WHERE project_id='{_escape(DEFAULT_PROJECT)}' AND is_deleted=0 "
+            f"AND start_time >= '{_escape(start)}' AND start_time <= '{_escape(end)}' "
+            f"GROUP BY d ORDER BY d"
+        )
+        span_rows = await _ch_json(
+            f"SELECT {trunc}(start_time) as d, count() as spans, countIf(status='error') as errs "
+            f"FROM spans FINAL WHERE project_id='{_escape(DEFAULT_PROJECT)}' AND is_deleted=0 "
+            f"AND start_time >= '{_escape(start)}' AND start_time <= '{_escape(end)}' "
+            f"GROUP BY d ORDER BY d"
+        )
+        span_map = {r["d"]: r for r in span_rows}
+        return [
+            TrendPoint(
+                date=r["d"],
+                traces=int(r.get("traces", 0)),
+                spans=int(span_map.get(r["d"], {}).get("spans", 0)),
+                errors=int(span_map.get(r["d"], {}).get("errs", 0)),
+            )
+            for r in rows
+        ]
+
+
+# --- Subscriptions ---
+
+
+@strawberry.type
+class Subscription:
+    @strawberry.subscription
+    async def trace_created(self, mcp_id: str | None = None, agent_id: str | None = None) -> AsyncGenerator[Trace, None]:
+        channel = "traces:created"
+        async for data in subscribe(channel):
+            if mcp_id and data.get("mcp_id") != mcp_id:
+                continue
+            if agent_id and data.get("agent_id") != agent_id:
+                continue
+            yield _row_to_trace(data)
+
+    @strawberry.subscription
+    async def span_created(self, trace_id: str) -> AsyncGenerator[Span, None]:
+        channel = f"spans:{trace_id}"
+        async for data in subscribe(channel):
+            yield _row_to_span(data)
+
+
+# --- Schema ---
+
+
+def get_context() -> dict:
+    return {
+        "span_loader": DataLoader(load_fn=_load_spans_by_trace_ids),
+        "score_by_trace_loader": DataLoader(load_fn=_load_scores_by_trace_ids),
+        "score_by_span_loader": DataLoader(load_fn=_load_scores_by_span_ids),
+    }
+
+
+schema = strawberry.Schema(query=Query, subscription=Subscription)

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -2,11 +2,12 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from strawberry.fastapi import GraphQLRouter
 
+from api.graphql import get_context, schema
 from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
 from api.routes.auth import router as auth_router
-from api.routes.dashboard import router as dashboard_router
 from api.routes.eval import router as eval_router
 from api.routes.feedback import router as feedback_router
 from api.routes.mcp import router as mcp_router
@@ -30,12 +31,16 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Observal", version="0.1.0", lifespan=lifespan)
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
 
+# GraphQL (replaces REST dashboard endpoints)
+graphql_app = GraphQLRouter(schema, context_getter=get_context)
+app.include_router(graphql_app, prefix="/api/v1/graphql")
+
+# REST (CLI operations, auth, telemetry ingestion)
 app.include_router(auth_router)
 app.include_router(mcp_router)
 app.include_router(review_router)
 app.include_router(agent_router)
 app.include_router(telemetry_router)
-app.include_router(dashboard_router)
 app.include_router(feedback_router)
 app.include_router(eval_router)
 app.include_router(admin_router)

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
     "boto3",
     "redis[hiredis]",
     "arq",
+    "strawberry-graphql[fastapi]",
 ]

--- a/tests/test_graphql_phase6.py
+++ b/tests/test_graphql_phase6.py
@@ -1,0 +1,228 @@
+"""Unit tests for GraphQL layer — Phase 6."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import strawberry
+
+from api.graphql import (
+    McpMetrics,
+    OverviewStats,
+    Query,
+    Score,
+    Span,
+    Trace,
+    TraceConnection,
+    TraceMetrics,
+    TrendPoint,
+    _load_scores_by_span_ids,
+    _load_scores_by_trace_ids,
+    _load_spans_by_trace_ids,
+    _parse_json,
+    _row_to_score,
+    _row_to_span,
+    _row_to_trace,
+    get_context,
+    schema,
+)
+
+
+# --- Helpers ---
+
+
+class TestParseJson:
+    def test_valid(self):
+        assert _parse_json('{"a": 1}') == {"a": 1}
+
+    def test_none(self):
+        assert _parse_json(None) is None
+
+    def test_invalid(self):
+        assert _parse_json("not json") == "not json"
+
+    def test_empty(self):
+        assert _parse_json("") is None
+
+
+# --- Row converters ---
+
+
+class TestRowToTrace:
+    def test_minimal(self):
+        t = _row_to_trace({"trace_id": "t1", "user_id": "u1", "start_time": "2026-01-01"})
+        assert t.trace_id == "t1"
+        assert t.trace_type == "mcp"
+
+    def test_full(self):
+        t = _row_to_trace({
+            "trace_id": "t1", "parent_trace_id": "p1", "trace_type": "agent",
+            "mcp_id": "m1", "agent_id": "a1", "user_id": "u1",
+            "session_id": "s1", "ide": "cursor", "name": "test",
+            "start_time": "2026-01-01", "end_time": "2026-01-02",
+            "tags": ["a", "b"], "metadata": {"k": "v"},
+        })
+        assert t.parent_trace_id == "p1"
+        assert t.tags == ["a", "b"]
+
+
+class TestRowToSpan:
+    def test_minimal(self):
+        s = _row_to_span({"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"})
+        assert s.type == "tool_call"
+        assert s.status == "success"
+
+    def test_tool_schema_valid(self):
+        s = _row_to_span({"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01", "tool_schema_valid": "1"})
+        assert s.tool_schema_valid is True
+
+    def test_tool_schema_invalid(self):
+        s = _row_to_span({"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01", "tool_schema_valid": "0"})
+        assert s.tool_schema_valid is False
+
+    def test_nullable_fields(self):
+        s = _row_to_span({"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"})
+        assert s.latency_ms is None
+        assert s.cost is None
+        assert s.tool_schema_valid is None
+
+
+class TestRowToScore:
+    def test_basic(self):
+        sc = _row_to_score({"score_id": "sc1", "name": "acc", "source": "eval", "value": "0.95", "timestamp": "2026-01-01"})
+        assert sc.value == 0.95
+        assert sc.source == "eval"
+
+
+# --- DataLoaders ---
+
+
+class TestDataLoaders:
+    @pytest.mark.asyncio
+    async def test_load_spans_by_trace_ids(self):
+        mock_rows = [
+            {"trace_id": "t1", "span_id": "s1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"},
+            {"trace_id": "t2", "span_id": "s2", "type": "tool_call", "name": "y", "start_time": "2026-01-01"},
+        ]
+        with patch("api.graphql._ch_json", new_callable=AsyncMock, return_value=mock_rows):
+            result = await _load_spans_by_trace_ids(["t1", "t2", "t3"])
+        assert len(result) == 3
+        assert len(result[0]) == 1  # t1
+        assert len(result[1]) == 1  # t2
+        assert len(result[2]) == 0  # t3
+
+    @pytest.mark.asyncio
+    async def test_load_scores_by_trace_ids(self):
+        mock_rows = [{"trace_id": "t1", "score_id": "sc1", "name": "acc", "value": "1"}]
+        with patch("api.graphql._ch_json", new_callable=AsyncMock, return_value=mock_rows):
+            result = await _load_scores_by_trace_ids(["t1"])
+        assert len(result[0]) == 1
+
+    @pytest.mark.asyncio
+    async def test_load_scores_by_span_ids(self):
+        mock_rows = [{"span_id": "s1", "score_id": "sc1", "name": "acc", "value": "1"}]
+        with patch("api.graphql._ch_json", new_callable=AsyncMock, return_value=mock_rows):
+            result = await _load_scores_by_span_ids(["s1"])
+        assert len(result[0]) == 1
+
+
+# --- Schema structure ---
+
+
+class TestSchema:
+    def test_schema_exists(self):
+        assert schema is not None
+
+    def test_has_query_type(self):
+        assert schema._schema.query_type is not None
+
+    def test_has_subscription_type(self):
+        assert schema._schema.subscription_type is not None
+
+    def test_context_has_loaders(self):
+        ctx = get_context()
+        assert "span_loader" in ctx
+        assert "score_by_trace_loader" in ctx
+        assert "score_by_span_loader" in ctx
+
+
+# --- Query resolvers ---
+
+
+class TestQueryResolvers:
+    @pytest.mark.asyncio
+    async def test_traces_resolver(self):
+        mock_rows = [{"trace_id": "t1", "user_id": "u1", "start_time": "2026-01-01"}]
+        with patch("api.graphql.query_traces", new_callable=AsyncMock, return_value=mock_rows):
+            q = Query()
+            result = await q.traces(info=None)
+            assert isinstance(result, TraceConnection)
+            assert len(result.items) == 1
+            assert result.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_traces_has_more(self):
+        # Return limit+1 rows to trigger has_more
+        mock_rows = [{"trace_id": f"t{i}", "user_id": "u1", "start_time": "2026-01-01"} for i in range(51)]
+        with patch("api.graphql.query_traces", new_callable=AsyncMock, return_value=mock_rows):
+            q = Query()
+            result = await q.traces(info=None, limit=50)
+            assert result.has_more is True
+            assert len(result.items) == 50
+
+    @pytest.mark.asyncio
+    async def test_trace_by_id(self):
+        with patch("api.graphql.query_trace_by_id", new_callable=AsyncMock, return_value={"trace_id": "t1", "user_id": "u1", "start_time": "2026-01-01"}):
+            q = Query()
+            result = await q.trace(info=None, trace_id="t1")
+            assert result.trace_id == "t1"
+
+    @pytest.mark.asyncio
+    async def test_trace_not_found(self):
+        with patch("api.graphql.query_trace_by_id", new_callable=AsyncMock, return_value=None):
+            q = Query()
+            result = await q.trace(info=None, trace_id="missing")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_span_by_id(self):
+        with patch("api.graphql.query_span_by_id", new_callable=AsyncMock, return_value={"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"}):
+            q = Query()
+            result = await q.span(info=None, span_id="s1")
+            assert result.span_id == "s1"
+
+    @pytest.mark.asyncio
+    async def test_mcp_metrics(self):
+        mock_rows = [{"cnt": "100", "errs": "5", "timeouts": "2", "avg_lat": "50.5", "p50": "40", "p90": "80", "p99": "150", "schema_ok": "90", "schema_total": "95"}]
+        with patch("api.graphql._ch_json", new_callable=AsyncMock, return_value=mock_rows):
+            q = Query()
+            result = await q.mcp_metrics(mcp_id="m1", start="2026-01-01", end="2026-02-01")
+            assert result.tool_call_count == 100
+            assert result.error_rate == 0.05
+
+    @pytest.mark.asyncio
+    async def test_overview(self):
+        with patch("api.graphql._ch_json", new_callable=AsyncMock, side_effect=[
+            [{"traces": "500"}],
+            [{"spans": "2000", "tools": "1500", "errs": "50"}],
+        ]):
+            q = Query()
+            result = await q.overview(start="2026-01-01", end="2026-02-01")
+            assert result.total_traces == 500
+            assert result.total_spans == 2000
+
+
+# --- Main.py integration ---
+
+
+class TestMainIntegration:
+    def test_dashboard_router_removed(self):
+        from main import app
+        paths = [r.path for r in app.routes]
+        # Old dashboard endpoints should not exist
+        assert "/api/v1/overview/stats" not in paths
+        assert "/api/v1/overview/trends" not in paths
+
+    def test_graphql_mounted(self):
+        from main import app
+        paths = [r.path for r in app.routes]
+        assert "/api/v1/graphql" in paths


### PR DESCRIPTION
## Summary

Replace REST dashboard endpoints with a Strawberry GraphQL layer at `/api/v1/graphql`, with DataLoaders for efficient ClickHouse queries and WebSocket subscriptions for live updates.

Fixes #15

## Changes

- `observal-server/api/graphql.py`: Strawberry schema with Query + Subscription types
- **Query resolvers**: traces, trace (by ID), span, mcpMetrics, overview, trends
- **DataLoaders**: batch ClickHouse queries for traces and spans
- **Subscriptions**: `traceCreated`, `spanCreated` via Redis pub/sub
- Row converters from ClickHouse JSON to Strawberry types
- Mounted at `/api/v1/graphql` in main.py, REST dashboard router removed
- `strawberry-graphql[fastapi]` added to server dependencies
- 27 unit tests

## Testing
```
27 tests passing
```