### PR TITLE
feat: Eval engine, feedback dual-write, CLI commands, demo framework (Phase 8-10)

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,92 @@
+# Observal Demo Framework
+
+End-to-end demos showing Observal's telemetry capture across different MCP server types and IDE configurations.
+
+## Prerequisites
+
+- Docker stack running (`cd docker && docker compose up -d`)
+- `observal-shim` installed (`uv tool install --editable .`)
+- `jq` and `curl` available
+- An Observal API key (via `observal init` or `OBSERVAL_KEY` env var)
+
+## Quick Start
+
+```bash
+cd demo
+./run_demo.sh
+```
+
+The script checks the Docker stack, authenticates, runs all 3 mock MCPs through `observal-shim`, then queries ClickHouse and GraphQL to show captured telemetry.
+
+## Mock MCP Servers
+
+### mock_mcp.py — General Purpose
+
+Tools: `echo`, `add`, `read_file`, `write_file`, `search`
+
+Also responds to `resources/read`, `prompts/get`, and `ping`. Generates diverse span types: `tool_call`, `resource_read`, `prompt_get`, `initialize`, `tool_list`, `ping`.
+
+### mock_graphrag_mcp.py — Knowledge Graph
+
+Tools: `graph_query`, `graph_traverse`, `entity_lookup`
+
+Returns fake knowledge graph data with entities (AuthService, UserDB, APIGateway, etc.) and relationships (reads_from, routes_to, caches_in). Exercises graph-specific span columns: `hop_count`, `entities_retrieved`, `relationships_used`.
+
+### mock_agent_mcp.py — Multi-Agent
+
+Tools: `delegate_task`, `reasoning_step`, `memory_store`, `memory_retrieve`
+
+Simulates multi-agent coordination with task delegation, chain-of-thought reasoning, and key-value memory. Tests agent-specific span types.
+
+## IDE Configs
+
+| File | IDE | Description |
+|------|-----|-------------|
+| `kiro_agent.json` | Kiro | Agent config with hooks (PreToolUse, PostToolUse, Stop) |
+| `claude_code_hooks.json` | Claude Code | Settings with hooks and MCP configs |
+| `cursor_mcp.json` | Cursor / VS Code | MCP server config |
+| `gemini_cli_mcp.json` | Gemini CLI | MCP server config |
+
+### Using with Kiro
+
+```bash
+mkdir -p .kiro/agents
+cp demo/kiro_agent.json .kiro/agents/observal-demo.json
+```
+
+### Using with Claude Code
+
+```bash
+cp demo/claude_code_hooks.json .claude/settings.json
+```
+
+### Using with Cursor / VS Code
+
+Copy `demo/cursor_mcp.json` to `.cursor/mcp.json` or `.vscode/mcp.json`.
+
+### Using with Gemini CLI
+
+Copy `demo/gemini_cli_mcp.json` to `.gemini/settings.json`.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OBSERVAL_SERVER` | `http://localhost:8000` | API server URL |
+| `OBSERVAL_KEY` | from `~/.observal/config.json` | API key |
+| `OBSERVAL_IDE` | `demo` | IDE identifier for telemetry |
+
+## What Gets Captured
+
+After running the demo, you can verify telemetry in ClickHouse:
+
+```sql
+-- Span counts by type
+SELECT type, count() FROM spans FINAL WHERE is_deleted=0 GROUP BY type ORDER BY count() DESC;
+
+-- Spans by MCP server
+SELECT t.mcp_id, count() FROM traces t FINAL JOIN spans s FINAL ON t.trace_id = s.trace_id WHERE t.is_deleted=0 AND s.is_deleted=0 GROUP BY t.mcp_id;
+
+-- Graph-specific columns
+SELECT name, hop_count, entities_retrieved, relationships_used FROM spans FINAL WHERE hop_count IS NOT NULL;
+```

--- a/demo/claude_code_hooks.json
+++ b/demo/claude_code_hooks.json
@@ -1,0 +1,53 @@
+{
+  "permissions": {
+    "allow": ["mcp__mock-mcp__*", "mcp__graphrag__*", "mcp__agent-tools__*"]
+  },
+  "mcpServers": {
+    "mock-mcp": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-mcp", "--", "python3", "demo/mock_mcp.py"]
+    },
+    "graphrag": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-graphrag", "--", "python3", "demo/mock_graphrag_mcp.py"]
+    },
+    "agent-tools": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-agent", "--", "python3", "demo/mock_agent_mcp.py"]
+    }
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__mock-mcp__*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"[observal] pre-tool: $(cat | jq -r .tool_name)\" >&2"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"[observal] post-tool: $(cat | jq -r .tool_name)\" >&2"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"[observal] session complete\" >&2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/demo/cursor_mcp.json
+++ b/demo/cursor_mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "mock-mcp": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-mcp", "--", "python3", "demo/mock_mcp.py"]
+    },
+    "graphrag": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-graphrag", "--", "python3", "demo/mock_graphrag_mcp.py"]
+    },
+    "agent-tools": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-agent", "--", "python3", "demo/mock_agent_mcp.py"]
+    }
+  }
+}

--- a/demo/gemini_cli_mcp.json
+++ b/demo/gemini_cli_mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "mock-mcp": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-mcp", "--", "python3", "demo/mock_mcp.py"]
+    },
+    "graphrag": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-graphrag", "--", "python3", "demo/mock_graphrag_mcp.py"]
+    },
+    "agent-tools": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-agent", "--", "python3", "demo/mock_agent_mcp.py"]
+    }
+  }
+}

--- a/demo/kiro_agent.json
+++ b/demo/kiro_agent.json
@@ -1,0 +1,55 @@
+{
+  "name": "observal-demo",
+  "description": "Demo agent with Observal telemetry — bundles 3 mock MCP servers with shim wrapping for full trace capture",
+  "prompt": "You are a demo agent instrumented with Observal telemetry. You have access to general tools (echo, add, read_file, write_file, search), a knowledge graph (graph_query, graph_traverse, entity_lookup), and multi-agent coordination tools (delegate_task, reasoning_step, memory_store, memory_retrieve). Use these tools to demonstrate Observal's telemetry capture capabilities.",
+  "mcpServers": {
+    "mock-mcp": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-mcp", "--", "python3", "demo/mock_mcp.py"]
+    },
+    "graphrag": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-graphrag", "--", "python3", "demo/mock_graphrag_mcp.py"]
+    },
+    "agent-tools": {
+      "command": "observal-shim",
+      "args": ["--mcp-id", "demo-agent", "--", "python3", "demo/mock_agent_mcp.py"]
+    }
+  },
+  "tools": ["@mock-mcp", "@graphrag", "@agent-tools", "read", "write", "shell"],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "@mock-mcp",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"[observal] pre-tool: $(cat | jq -r .tool_name)\" >&2"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"[observal] post-tool: $(cat | jq -r .tool_name)\" >&2"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"[observal] session complete\" >&2"
+          }
+        ]
+      }
+    ]
+  },
+  "includeMcpJson": true
+}

--- a/demo/mock_agent_mcp.py
+++ b/demo/mock_agent_mcp.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Mock multi-agent MCP server: delegate_task, reasoning_step, memory_store, memory_retrieve.
+
+Tests agent-specific span types (agent_turn, agent_handoff, reasoning_step).
+"""
+import json
+import sys
+import time
+
+TOOLS = [
+    {"name": "delegate_task", "description": "Delegate a task to a sub-agent", "inputSchema": {"type": "object", "properties": {"agent_name": {"type": "string"}, "task": {"type": "string"}, "context": {"type": "string"}}, "required": ["agent_name", "task"]}},
+    {"name": "reasoning_step", "description": "Execute a chain-of-thought reasoning step", "inputSchema": {"type": "object", "properties": {"step": {"type": "string"}, "premises": {"type": "array", "items": {"type": "string"}}}, "required": ["step"]}},
+    {"name": "memory_store", "description": "Store a key-value pair in agent memory", "inputSchema": {"type": "object", "properties": {"key": {"type": "string"}, "value": {"type": "string"}, "ttl_seconds": {"type": "integer"}}, "required": ["key", "value"]}},
+    {"name": "memory_retrieve", "description": "Retrieve a value from agent memory", "inputSchema": {"type": "object", "properties": {"key": {"type": "string"}}, "required": ["key"]}},
+]
+
+MEMORY = {}
+
+FAKE_AGENTS = {
+    "researcher": "I found 3 relevant papers on the topic.",
+    "coder": "Implementation complete. 42 lines of Python added.",
+    "reviewer": "Code review passed with 2 minor suggestions.",
+}
+
+
+def respond(msg_id, result):
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "result": result}) + "\n")
+    sys.stdout.flush()
+
+
+def handle_tool_call(msg_id, name, args):
+    if name == "delegate_task":
+        agent = args.get("agent_name", "researcher")
+        result = FAKE_AGENTS.get(agent, f"Agent '{agent}' completed the task.")
+        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
+            "agent": agent,
+            "task": args.get("task", ""),
+            "status": "completed",
+            "result": result,
+            "tokens_used": 1250,
+        })}]})
+    elif name == "reasoning_step":
+        premises = args.get("premises", [])
+        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
+            "step": args.get("step", ""),
+            "premises_count": len(premises),
+            "conclusion": f"Based on {len(premises)} premises, the conclusion follows logically.",
+            "confidence": 0.87,
+        })}]})
+    elif name == "memory_store":
+        key = args.get("key", "")
+        MEMORY[key] = args.get("value", "")
+        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({"stored": key, "ttl": args.get("ttl_seconds", 3600)})}]})
+    elif name == "memory_retrieve":
+        key = args.get("key", "")
+        val = MEMORY.get(key, None)
+        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({"key": key, "value": val, "found": val is not None})}]})
+    else:
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32601, "message": f"Unknown tool: {name}"}}) + "\n")
+        sys.stdout.flush()
+
+
+def main():
+    sys.stderr.write("mock-agent-mcp: started\n")
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = msg.get("method", "")
+        msg_id = msg.get("id")
+        params = msg.get("params", {})
+
+        if method == "initialize":
+            respond(msg_id, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "mock-agent-mcp", "version": "1.0.0"}})
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            handle_tool_call(msg_id, params.get("name", ""), params.get("arguments", {}))
+        elif method == "ping":
+            respond(msg_id, {})
+        else:
+            respond(msg_id, {})
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/mock_graphrag_mcp.py
+++ b/demo/mock_graphrag_mcp.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Mock GraphRAG MCP server: graph_query, graph_traverse, entity_lookup.
+
+Returns fake knowledge graph data to exercise graph-specific span columns
+(hop_count, entities_retrieved, relationships_used).
+"""
+import json
+import sys
+
+TOOLS = [
+    {"name": "graph_query", "description": "Run a natural language query against the knowledge graph", "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}, "max_hops": {"type": "integer"}}, "required": ["query"]}},
+    {"name": "graph_traverse", "description": "Traverse the graph from a starting entity", "inputSchema": {"type": "object", "properties": {"entity_id": {"type": "string"}, "depth": {"type": "integer"}, "relationship_types": {"type": "array", "items": {"type": "string"}}}, "required": ["entity_id"]}},
+    {"name": "entity_lookup", "description": "Look up an entity by name or ID", "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}},
+]
+
+FAKE_ENTITIES = [
+    {"id": "e-001", "name": "AuthService", "type": "service", "properties": {"language": "Python", "team": "platform"}},
+    {"id": "e-002", "name": "UserDB", "type": "database", "properties": {"engine": "PostgreSQL", "tables": 12}},
+    {"id": "e-003", "name": "APIGateway", "type": "service", "properties": {"language": "Go", "team": "infra"}},
+    {"id": "e-004", "name": "CacheLayer", "type": "service", "properties": {"engine": "Redis", "team": "platform"}},
+    {"id": "e-005", "name": "EventBus", "type": "service", "properties": {"engine": "Kafka", "team": "data"}},
+]
+
+FAKE_RELATIONSHIPS = [
+    {"source": "e-001", "target": "e-002", "type": "reads_from"},
+    {"source": "e-003", "target": "e-001", "type": "routes_to"},
+    {"source": "e-001", "target": "e-004", "type": "caches_in"},
+    {"source": "e-003", "target": "e-005", "type": "publishes_to"},
+    {"source": "e-005", "target": "e-002", "type": "writes_to"},
+]
+
+
+def respond(msg_id, result):
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "result": result}) + "\n")
+    sys.stdout.flush()
+
+
+def handle_tool_call(msg_id, name, args):
+    if name == "graph_query":
+        hops = min(args.get("max_hops", 2), 4)
+        entities = FAKE_ENTITIES[:hops + 1]
+        rels = FAKE_RELATIONSHIPS[:hops]
+        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
+            "query": args.get("query", ""),
+            "hop_count": hops,
+            "entities_retrieved": len(entities),
+            "relationships_used": len(rels),
+            "entities": entities,
+            "relationships": rels,
+        })}]})
+    elif name == "graph_traverse":
+        depth = min(args.get("depth", 2), 4)
+        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
+            "start_entity": args.get("entity_id", "e-001"),
+            "depth": depth,
+            "hop_count": depth,
+            "entities_retrieved": depth + 1,
+            "relationships_used": depth,
+            "path": [{"entity": FAKE_ENTITIES[i % len(FAKE_ENTITIES)], "relationship": FAKE_RELATIONSHIPS[i % len(FAKE_RELATIONSHIPS)]} for i in range(depth)],
+        })}]})
+    elif name == "entity_lookup":
+        name_q = args.get("name", "").lower()
+        matches = [e for e in FAKE_ENTITIES if name_q in e["name"].lower()]
+        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
+            "entities_retrieved": len(matches),
+            "entities": matches or [FAKE_ENTITIES[0]],
+        })}]})
+    else:
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32601, "message": f"Unknown tool: {name}"}}) + "\n")
+        sys.stdout.flush()
+
+
+def main():
+    sys.stderr.write("mock-graphrag-mcp: started\n")
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = msg.get("method", "")
+        msg_id = msg.get("id")
+        params = msg.get("params", {})
+
+        if method == "initialize":
+            respond(msg_id, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "mock-graphrag-mcp", "version": "1.0.0"}})
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            handle_tool_call(msg_id, params.get("name", ""), params.get("arguments", {}))
+        elif method == "ping":
+            respond(msg_id, {})
+        else:
+            respond(msg_id, {})
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/mock_mcp.py
+++ b/demo/mock_mcp.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Mock MCP server with general-purpose tools: echo, add, read_file, write_file, search."""
+import json
+import sys
+import os
+
+TOOLS = [
+    {"name": "echo", "description": "Echo input text back", "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]}},
+    {"name": "add", "description": "Add two numbers", "inputSchema": {"type": "object", "properties": {"a": {"type": "number"}, "b": {"type": "number"}}, "required": ["a", "b"]}},
+    {"name": "read_file", "description": "Read a file's contents", "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}},
+    {"name": "write_file", "description": "Write content to a file", "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}, "content": {"type": "string"}}, "required": ["path", "content"]}},
+    {"name": "search", "description": "Search for a pattern in files", "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}, "directory": {"type": "string"}}, "required": ["query"]}},
+]
+
+RESOURCES = [
+    {"uri": "file:///demo/config.json", "name": "Demo Config", "mimeType": "application/json"},
+]
+
+PROMPTS = [
+    {"name": "summarize", "description": "Summarize text", "arguments": [{"name": "text", "required": True}]},
+]
+
+
+def respond(msg_id, result):
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "result": result}) + "\n")
+    sys.stdout.flush()
+
+
+def error(msg_id, code, message):
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}) + "\n")
+    sys.stdout.flush()
+
+
+def handle_tool_call(msg_id, name, args):
+    if name == "echo":
+        respond(msg_id, {"content": [{"type": "text", "text": args.get("text", "")}]})
+    elif name == "add":
+        respond(msg_id, {"content": [{"type": "text", "text": str(args.get("a", 0) + args.get("b", 0))}]})
+    elif name == "read_file":
+        path = args.get("path", "/tmp/demo.txt")
+        respond(msg_id, {"content": [{"type": "text", "text": f"Contents of {path}:\n# Demo file\nline1\nline2\nline3"}]})
+    elif name == "write_file":
+        respond(msg_id, {"content": [{"type": "text", "text": f"Wrote {len(args.get('content', ''))} bytes to {args.get('path', '')}"}]})
+    elif name == "search":
+        q = args.get("query", "")
+        respond(msg_id, {"content": [{"type": "text", "text": f"Found 3 matches for '{q}':\n  src/main.py:10: {q}_handler()\n  src/utils.py:25: def {q}():\n  README.md:5: {q} documentation"}]})
+    else:
+        error(msg_id, -32601, f"Unknown tool: {name}")
+
+
+def main():
+    sys.stderr.write("mock-mcp: started\n")
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = msg.get("method", "")
+        msg_id = msg.get("id")
+        params = msg.get("params", {})
+
+        if method == "initialize":
+            respond(msg_id, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}, "resources": {}, "prompts": {}}, "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}})
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            handle_tool_call(msg_id, params.get("name", ""), params.get("arguments", {}))
+        elif method == "resources/list":
+            respond(msg_id, {"resources": RESOURCES})
+        elif method == "resources/read":
+            respond(msg_id, {"contents": [{"uri": params.get("uri", ""), "mimeType": "application/json", "text": '{"demo": true, "version": "1.0.0"}'}]})
+        elif method == "prompts/list":
+            respond(msg_id, {"prompts": PROMPTS})
+        elif method == "prompts/get":
+            respond(msg_id, {"messages": [{"role": "user", "content": {"type": "text", "text": f"Please summarize: {params.get('arguments', {}).get('text', '')}"}}]})
+        elif method == "ping":
+            respond(msg_id, {})
+        else:
+            respond(msg_id, {})
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/run_demo.sh
+++ b/demo/run_demo.sh
@@ -54,7 +54,7 @@ else
     die "API server not reachable at ${OBSERVAL_SERVER}. Is the Docker stack running?"
 fi
 
-if curl -sf "http://localhost:8123/?query=SELECT%201" > /dev/null 2>&1; then
+if curl -sf "http://localhost:8123/?user=default&password=clickhouse&query=SELECT%201&user=default&password=clickhouse" > /dev/null 2>&1; then
     ok "ClickHouse reachable"
 else
     die "ClickHouse not reachable on :8123"
@@ -143,18 +143,18 @@ header "Captured Telemetry"
 info "Querying ClickHouse for recent spans..."
 sleep 2
 
-SPAN_COUNT="$(curl -sf 'http://localhost:8123/?query=SELECT+count()+FROM+spans+WHERE+trace_id+LIKE+%27%25%27+FORMAT+TabSeparated' 2>/dev/null || echo '?')"
+CH="http://localhost:8123/?user=default&password=clickhouse&database=observal"
+
+SPAN_COUNT="$(curl -sf "${CH}&query=SELECT+count()+FROM+spans+FINAL+WHERE+is_deleted%3D0+FORMAT+TabSeparated" 2>/dev/null || echo '?')"
 echo -e "  Total spans in ClickHouse: ${BOLD}${SPAN_COUNT}${NC}"
 
 info "Recent spans by type:"
-curl -sf 'http://localhost:8123/' \
-  --data-urlencode "query=SELECT type, count() as cnt FROM spans FINAL WHERE is_deleted=0 GROUP BY type ORDER BY cnt DESC FORMAT PrettyCompact" \
+curl -sf "${CH}" --data "SELECT type, count() as cnt FROM spans FINAL WHERE is_deleted=0 GROUP BY type ORDER BY cnt DESC FORMAT PrettyCompact" \
   2>/dev/null || warn "Could not query ClickHouse"
 
 echo ""
 info "Recent spans by MCP:"
-curl -sf 'http://localhost:8123/' \
-  --data-urlencode "query=SELECT t.mcp_id, count() as spans FROM traces t FINAL JOIN spans s FINAL ON t.trace_id = s.trace_id WHERE t.is_deleted=0 AND s.is_deleted=0 GROUP BY t.mcp_id ORDER BY spans DESC FORMAT PrettyCompact" \
+curl -sf "${CH}" --data "SELECT t.mcp_id, count() as spans FROM traces t FINAL JOIN spans s FINAL ON t.trace_id = s.trace_id WHERE t.is_deleted=0 AND s.is_deleted=0 GROUP BY t.mcp_id ORDER BY spans DESC FORMAT PrettyCompact" \
   2>/dev/null || warn "Could not query ClickHouse"
 
 # --- Query GraphQL ---
@@ -162,10 +162,9 @@ curl -sf 'http://localhost:8123/' \
 header "GraphQL Trace Query"
 
 info "Querying traces via GraphQL..."
-GQL_QUERY='{"query":"{ traces(limit: 5) { traceId name mcp_id spans { spanId type name latencyMs status } } }"}'
-GQL_RESULT="$(curl -sf -X POST "${OBSERVAL_SERVER}/graphql" \
+GQL_QUERY='{"query":"{ traces(limit: 5) { items { traceId name mcpId metrics { totalSpans errorCount toolCallCount } } } }"}'
+GQL_RESULT="$(curl -sf -X POST "${OBSERVAL_SERVER}/api/v1/graphql" \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: ${OBSERVAL_KEY}" \
   -d "$GQL_QUERY" 2>/dev/null || echo '{"error":"GraphQL query failed"}')"
 
 echo "$GQL_RESULT" | jq '.' 2>/dev/null || echo "$GQL_RESULT"

--- a/demo/run_demo.sh
+++ b/demo/run_demo.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}[info]${NC}  $*"; }
+ok()    { echo -e "${GREEN}[ok]${NC}    $*"; }
+warn()  { echo -e "${YELLOW}[warn]${NC}  $*"; }
+fail()  { echo -e "${RED}[fail]${NC}  $*"; }
+header(){ echo -e "\n${BOLD}=== $* ===${NC}\n"; }
+
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$DEMO_DIR")"
+
+OBSERVAL_SERVER="${OBSERVAL_SERVER:-http://localhost:8000}"
+OBSERVAL_IDE="${OBSERVAL_IDE:-demo}"
+export OBSERVAL_SERVER OBSERVAL_IDE
+
+# --- Helpers ---
+
+die() { fail "$@"; exit 1; }
+
+check_cmd() {
+    command -v "$1" &>/dev/null || die "'$1' not found in PATH"
+}
+
+send_jsonrpc() {
+    # Usage: send_jsonrpc <mcp_id> <script> <messages_json_array>
+    local mcp_id="$1" script="$2" messages="$3"
+    info "Running observal-shim --mcp-id $mcp_id -- python3 $script"
+    echo "$messages" | jq -c '.[]' | observal-shim --mcp-id "$mcp_id" -- python3 "$script" > /dev/null 2>&1 || true
+    sleep 1
+}
+
+# --- Preflight ---
+
+header "Preflight Checks"
+
+check_cmd observal-shim
+check_cmd jq
+check_cmd curl
+ok "Required commands found"
+
+# Check Docker stack
+if curl -sf "${OBSERVAL_SERVER}/docs" > /dev/null 2>&1; then
+    ok "API server reachable at ${OBSERVAL_SERVER}"
+else
+    die "API server not reachable at ${OBSERVAL_SERVER}. Is the Docker stack running?"
+fi
+
+if curl -sf "http://localhost:8123/?query=SELECT%201" > /dev/null 2>&1; then
+    ok "ClickHouse reachable"
+else
+    die "ClickHouse not reachable on :8123"
+fi
+
+# --- Auth ---
+
+header "Authentication"
+
+if [ -n "${OBSERVAL_KEY:-}" ]; then
+    ok "Using OBSERVAL_KEY from environment"
+elif [ -f "$HOME/.observal/config.json" ]; then
+    OBSERVAL_KEY="$(jq -r '.api_key // empty' "$HOME/.observal/config.json")"
+    if [ -n "$OBSERVAL_KEY" ]; then
+        ok "Loaded API key from ~/.observal/config.json"
+    fi
+fi
+
+if [ -z "${OBSERVAL_KEY:-}" ]; then
+    info "No API key found, running 'observal init'..."
+    INIT_OUT="$(observal init 2>&1)" || die "observal init failed: $INIT_OUT"
+    OBSERVAL_KEY="$(jq -r '.api_key // empty' "$HOME/.observal/config.json" 2>/dev/null)"
+    [ -n "$OBSERVAL_KEY" ] || die "Could not extract API key after init"
+    ok "Created admin account"
+fi
+
+export OBSERVAL_KEY
+
+# --- Demo: General MCP ---
+
+header "Demo 1: General MCP Server (mock_mcp.py)"
+
+MESSAGES='[
+  {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}},
+  {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}},
+  {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hello observal"}}},
+  {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"add","arguments":{"a":17,"b":25}}},
+  {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/etc/hostname"}}},
+  {"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"search","arguments":{"query":"telemetry"}}},
+  {"jsonrpc":"2.0","id":7,"method":"resources/read","params":{"uri":"file:///demo/config.json"}},
+  {"jsonrpc":"2.0","id":8,"method":"prompts/get","params":{"name":"summarize","arguments":{"text":"Observal demo"}}},
+  {"jsonrpc":"2.0","id":9,"method":"ping","params":{}}
+]'
+
+send_jsonrpc "demo-mcp" "$DEMO_DIR/mock_mcp.py" "$MESSAGES"
+ok "General MCP demo complete"
+
+# --- Demo: GraphRAG MCP ---
+
+header "Demo 2: GraphRAG MCP Server (mock_graphrag_mcp.py)"
+
+MESSAGES='[
+  {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}},
+  {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}},
+  {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"graph_query","arguments":{"query":"How does AuthService connect to UserDB?","max_hops":3}}},
+  {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"graph_traverse","arguments":{"entity_id":"e-003","depth":2,"relationship_types":["routes_to","publishes_to"]}}},
+  {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"entity_lookup","arguments":{"name":"Cache"}}},
+  {"jsonrpc":"2.0","id":6,"method":"ping","params":{}}
+]'
+
+send_jsonrpc "demo-graphrag" "$DEMO_DIR/mock_graphrag_mcp.py" "$MESSAGES"
+ok "GraphRAG MCP demo complete"
+
+# --- Demo: Agent MCP ---
+
+header "Demo 3: Multi-Agent MCP Server (mock_agent_mcp.py)"
+
+MESSAGES='[
+  {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}},
+  {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}},
+  {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"memory_store","arguments":{"key":"project","value":"Observal demo run"}}},
+  {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"memory_retrieve","arguments":{"key":"project"}}},
+  {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"delegate_task","arguments":{"agent_name":"researcher","task":"Find best practices for MCP telemetry"}}},
+  {"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"reasoning_step","arguments":{"step":"Evaluate findings","premises":["MCP is JSON-RPC","Shim is transparent","Telemetry is async"]}}},
+  {"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"delegate_task","arguments":{"agent_name":"coder","task":"Implement telemetry pipeline","context":"Based on researcher findings"}}},
+  {"jsonrpc":"2.0","id":8,"method":"ping","params":{}}
+]'
+
+send_jsonrpc "demo-agent" "$DEMO_DIR/mock_agent_mcp.py" "$MESSAGES"
+ok "Multi-Agent MCP demo complete"
+
+# --- Query ClickHouse ---
+
+header "Captured Telemetry"
+
+info "Querying ClickHouse for recent spans..."
+sleep 2
+
+SPAN_COUNT="$(curl -sf 'http://localhost:8123/?query=SELECT+count()+FROM+spans+WHERE+trace_id+LIKE+%27%25%27+FORMAT+TabSeparated' 2>/dev/null || echo '?')"
+echo -e "  Total spans in ClickHouse: ${BOLD}${SPAN_COUNT}${NC}"
+
+info "Recent spans by type:"
+curl -sf 'http://localhost:8123/' \
+  --data-urlencode "query=SELECT type, count() as cnt FROM spans FINAL WHERE is_deleted=0 GROUP BY type ORDER BY cnt DESC FORMAT PrettyCompact" \
+  2>/dev/null || warn "Could not query ClickHouse"
+
+echo ""
+info "Recent spans by MCP:"
+curl -sf 'http://localhost:8123/' \
+  --data-urlencode "query=SELECT t.mcp_id, count() as spans FROM traces t FINAL JOIN spans s FINAL ON t.trace_id = s.trace_id WHERE t.is_deleted=0 AND s.is_deleted=0 GROUP BY t.mcp_id ORDER BY spans DESC FORMAT PrettyCompact" \
+  2>/dev/null || warn "Could not query ClickHouse"
+
+# --- Query GraphQL ---
+
+header "GraphQL Trace Query"
+
+info "Querying traces via GraphQL..."
+GQL_QUERY='{"query":"{ traces(limit: 5) { traceId name mcp_id spans { spanId type name latencyMs status } } }"}'
+GQL_RESULT="$(curl -sf -X POST "${OBSERVAL_SERVER}/graphql" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: ${OBSERVAL_KEY}" \
+  -d "$GQL_QUERY" 2>/dev/null || echo '{"error":"GraphQL query failed"}')"
+
+echo "$GQL_RESULT" | jq '.' 2>/dev/null || echo "$GQL_RESULT"
+
+# --- Summary ---
+
+header "Demo Summary"
+
+ok "3 mock MCP servers exercised through observal-shim"
+ok "Spans captured: initialize, tools/list, tools/call, resources/read, prompts/get, ping"
+ok "Graph-specific fields: hop_count, entities_retrieved, relationships_used"
+ok "Agent-specific tools: delegate_task, reasoning_step, memory_store, memory_retrieve"
+echo ""
+info "IDE configs available in demo/:"
+echo "  - kiro_agent.json       (Kiro agent with hooks)"
+echo "  - claude_code_hooks.json (Claude Code hooks)"
+echo "  - cursor_mcp.json       (Cursor/VS Code MCP config)"
+echo "  - gemini_cli_mcp.json   (Gemini CLI MCP config)"
+echo ""
+ok "Demo complete!"

--- a/docs/CONTEXT-HANDOFF.md
+++ b/docs/CONTEXT-HANDOFF.md
@@ -1,0 +1,179 @@
+# Context Handoff — Observal Overhaul (Session 2)
+
+> Complete context dump for continuing work. Delete after use.
+
+## What Was Done This Session
+
+Started from the original CONTEXT-HANDOFF.md. Completed Phases 1–10 + Phase 13, plus demo framework, Docker stack fixes, and end-to-end testing.
+
+## Current State
+
+- **Git branch**: `fixups`
+- **Git remote**: origin = `Haz3-jolt/Observal`, upstream = `BlazeUp-AI/Observal`
+- **GitHub Issues**: #10–#24 (all 15 phases) created on `BlazeUp-AI/Observal`
+- **Docker stack**: Running (6 containers: API, web, DB, ClickHouse, Redis, worker)
+- **CLI installed**: `observal`, `observal-shim`, `observal-proxy`, `observal-tui` (4 executables)
+- **Tests**: 181 passing (run from `observal-server/` with `uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with textual pytest ../tests/ -q`)
+- **API key**: `b950f7fc1c690ebabd449f2686846f6b8d1f51aff94a67feca4d605dd867694e` (admin@test.com)
+- **Config**: `~/.observal/config.json` has server_url + api_key
+
+## Phase Status
+
+| Phase | Issue | Status | Summary |
+|-------|-------|--------|---------|
+| 1 — ClickHouse Schema | #10 | ✅ | traces, spans, scores tables with project_id, ReplacingMergeTree, bloom filters |
+| 2 — Ingestion Endpoint | #11 | ✅ | POST /api/v1/telemetry/ingest with server-side user_id/environment injection |
+| 3 — Shim (stdio) | #12 | ✅ | observal-shim: JSON-RPC parsing, request/response pairing, schema compliance, buffered telemetry |
+| 4 — Proxy (HTTP) | #13 | ✅ | observal-proxy: HTTP reverse proxy reusing ShimState |
+| 5 — Redis + Worker | #14 | ✅ | Redis 7 container, arq worker, pub/sub service, eval job queue |
+| 6 — GraphQL Layer | #15 | ✅ | Strawberry at /api/v1/graphql, DataLoaders, subscriptions, REST dashboard killed |
+| 7 — Dashboard Rewrite | #16 | ✅ | Vite + React + urql SPA replacing Next.js |
+| 8 — Eval Engine | #17 | ✅ | Pluggable EvalBackend ABC, LLMJudgeBackend, FallbackBackend, 6 managed templates |
+| 9 — Score Unification | #18 | ✅ | Feedback dual-writes to PostgreSQL + ClickHouse scores table |
+| 10 — CLI Updates | #19 | ✅ | observal upgrade/downgrade/traces/spans commands |
+| 11 — Testing & CI | #20 | ❌ | pytest infra exists but no GitHub Actions, no Playwright |
+| 12 — Auth / SSO | #21 | ❌ | Deferred per design doc — needs Keycloak, OIDC review |
+| 13 — TUI Overhaul | #22 | ✅ | Textual app: Overview, MCPs, Agents, Traces (with span drill-down), Account |
+| 14 — ITJ Integration | #23 | ❌ | Future — Information-Theoretic Judge |
+| 15 — Release Engineering | #24 | ❌ | Future — compiled binaries, package registries |
+
+## Key Files Created/Modified
+
+### Phase 1-2 (ClickHouse + Ingestion)
+- `observal-server/services/clickhouse.py` — INIT_SQL with 5 tables (2 legacy + 3 new), insert_traces/spans/scores, query functions, SQL helpers
+- `observal-server/schemas/telemetry.py` — TraceIngest, SpanIngest, ScoreIngest, IngestBatch, IngestResponse
+- `observal-server/api/routes/telemetry.py` — POST /ingest route + legacy /events preserved
+
+### Phase 3-4 (Shim + Proxy)
+- `observal_cli/shim.py` — ShimState, classify_message, extract_span_type/name, check_schema_compliance, run_shim, main
+- `observal_cli/proxy.py` — ProxyState(extends ShimState), _handle_request, run_proxy, main
+- `observal-server/services/config_generator.py` — generate_config wraps with observal-shim, proxy_port for HTTP
+- `observal-server/services/agent_config_generator.py` — _inject_agent_id for OBSERVAL_AGENT_ID
+
+### Phase 5-6 (Redis + GraphQL)
+- `observal-server/services/redis.py` — get_redis, publish, subscribe, enqueue_eval, close
+- `observal-server/worker.py` — arq WorkerSettings, run_eval job
+- `observal-server/api/graphql.py` — Strawberry schema: Query (traces, trace, span, mcpMetrics, overview, trends) + Subscription (traceCreated, spanCreated), DataLoaders, row converters
+- `observal-server/main.py` — GraphQL mounted at /api/v1/graphql, dashboard router removed
+
+### Phase 7 (Dashboard)
+- `observal-web/` — Complete Vite + React + urql rewrite (replaced Next.js)
+- Components: TraceExplorer, TraceDetail, Overview, McpMetrics
+- `observal-web/src/lib/urql.ts` — urql client with WebSocket subscriptions
+- `observal-web/src/lib/queries.ts` — GraphQL queries and subscriptions
+
+### Phase 8 (Eval Engine)
+- `observal-server/services/eval_engine.py` — EvalBackend ABC, LLMJudgeBackend, FallbackBackend, 6 templates (tool_selection_accuracy, tool_output_utility, reasoning_clarity, response_quality, graph_faithfulness, recall_accuracy), run_eval_on_trace
+
+### Phase 9-10 (Score Unification + CLI)
+- `observal-server/api/routes/feedback.py` — Dual-write to PostgreSQL + ClickHouse scores
+- `observal_cli/main.py` — Added: tui, upgrade, downgrade, traces, spans commands
+
+### Phase 13 (TUI)
+- `observal_cli/tui.py` — Textual app: ObservalTUI with OverviewPanel, McpPanel, AgentPanel, TracePanel, FeedbackPanel, StatCard widget
+
+### Demo Framework
+- `demo/mock_mcp.py` — 5 tools (echo, add, read_file, write_file, search)
+- `demo/mock_graphrag_mcp.py` — 3 tools (graph_query, graph_traverse, entity_lookup)
+- `demo/mock_agent_mcp.py` — 4 tools (delegate_task, reasoning_step, memory_store, memory_retrieve)
+- `demo/run_demo.sh` — End-to-end demo script
+- `demo/kiro_agent.json` — Kiro agent config with hooks (PreToolUse, PostToolUse, Stop)
+- `demo/claude_code_hooks.json` — Claude Code hooks config
+- `demo/cursor_mcp.json` — Cursor/VS Code MCP config
+- `demo/gemini_cli_mcp.json` — Gemini CLI config
+
+### Tests
+- `tests/test_clickhouse_phase1.py` — 43 tests (DDL, helpers, insert, query)
+- `tests/test_ingest_phase2.py` — 15 tests (schemas, endpoint, partial failure)
+- `tests/test_shim_phase3.py` — 43 tests (JSON-RPC, schema compliance, ShimState, config gen)
+- `tests/test_proxy_phase4.py` — 13 tests (proxy, HTTP transport config)
+- `tests/test_worker_phase5.py` — 16 tests (Redis, arq, docker-compose)
+- `tests/test_graphql_phase6.py` — 27 tests (types, DataLoaders, resolvers, schema)
+- `tests/test_eval_phase8.py` — 17 tests (templates, backends, run_eval_on_trace)
+- `tests/test_phase9_10.py` — 7 tests (dual-write, CLI commands)
+
+### Docker
+- `docker/docker-compose.yml` — 6 services: api, web, db, clickhouse, redis, worker
+- `docker/Dockerfile.api` — uv-based Python build
+- `docker/Dockerfile.web` — Multi-stage Vite build with serve
+
+### Config
+- `.env` — Has REDIS_URL=redis://observal-redis:6379
+- `.env.example` — Updated with REDIS_URL
+- `pyproject.toml` — 4 entry points: observal, observal-shim, observal-proxy, observal-tui; deps: typer, httpx, rich, textual
+- `observal-server/pyproject.toml` — deps include redis[hiredis], arq, strawberry-graphql[fastapi]
+- `observal-server/config.py` — REDIS_URL setting added
+
+## Bugs Fixed During Session
+
+1. **Worker crash**: Changed `python -m worker` → `uv run arq worker.WorkerSettings` in docker-compose
+2. **GraphQL DataLoaders empty**: Removed duplicate `FORMAT JSON` (was in both DataLoader SQL and `_ch_json` helper)
+3. **Missing package-lock.json**: Generated for web app (npm ci needs it)
+4. **Missing REDIS_URL**: Added to .env
+5. **Stale uv.lock**: Regenerated with redis, arq, strawberry deps
+6. **Demo ClickHouse auth**: Added user/password params to all ClickHouse HTTP queries
+
+## What's Left
+
+| Phase | What | Notes |
+|-------|------|-------|
+| 11 — Testing & CI | GitHub Actions, Playwright | Dev process, not product |
+| 12 — Auth / SSO | Keycloak, OIDC, scoped keys, RBAC | Big scope, needs design review |
+| 14 — ITJ | Information-Theoretic Judge | Research, replaces LLM-as-judge |
+| 15 — Release Engineering | Compiled binaries, package registries | Distribution |
+
+## How to Run
+
+```bash
+# Start Docker stack
+cd docker && docker compose up -d
+
+# Install CLI
+cd .. && uv tool install --editable . --force
+
+# Init (if fresh DB)
+observal init
+
+# Run demo
+bash demo/run_demo.sh
+
+# Launch TUI
+observal tui
+# or: observal-tui
+
+# Run tests
+cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with textual pytest ../tests/ -q
+
+# CLI commands
+observal traces --limit 10
+observal spans <trace-id>
+observal list
+observal whoami
+```
+
+## Architecture Summary
+
+```
+IDE (Kiro/Claude/Cursor/etc.)
+    ↕ stdio (JSON-RPC)
+observal-shim (transparent wrapper)
+    ├── passes all messages through untouched
+    ├── pairs requests/responses → spans
+    ├── caches tools/list for schema compliance
+    ├── buffers spans (flush every 5s or 50)
+    ├── async fire-and-forget POST to server
+    ↕ stdio
+Actual MCP Server (unchanged, unaware)
+
+Server Stack:
+├── FastAPI API (port 8000)
+│   ├── REST: auth, mcps, agents, review, telemetry, feedback, eval, admin
+│   ├── GraphQL: /api/v1/graphql (Strawberry + DataLoaders + subscriptions)
+│   └── Ingestion: POST /api/v1/telemetry/ingest
+├── PostgreSQL 16 (users, mcps, agents, feedback, eval runs)
+├── ClickHouse (traces, spans, scores — new; mcp_tool_calls, agent_interactions — legacy)
+├── Redis 7 (pub/sub for subscriptions, arq job queue)
+├── arq Worker (background eval jobs)
+├── Vite + React Web UI (port 3000, urql GraphQL client)
+└── Textual TUI (observal-tui, queries GraphQL + REST)
+```

--- a/observal-server/api/routes/feedback.py
+++ b/observal-server/api/routes/feedback.py
@@ -10,6 +10,7 @@ from models.feedback import Feedback
 from models.mcp import McpListing
 from models.user import User
 from schemas.feedback import FeedbackCreateRequest, FeedbackResponse, FeedbackSummary
+from services.clickhouse import insert_scores
 
 router = APIRouter(prefix="/api/v1/feedback", tags=["feedback"])
 
@@ -38,6 +39,28 @@ async def create_feedback(
     db.add(fb)
     await db.commit()
     await db.refresh(fb)
+
+    # Dual-write: also insert into ClickHouse scores table
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    try:
+        await insert_scores([{
+            "score_id": str(fb.id),
+            "project_id": "default",
+            "mcp_id": str(req.listing_id) if req.listing_type == "mcp" else None,
+            "agent_id": str(req.listing_id) if req.listing_type == "agent" else None,
+            "user_id": str(current_user.id),
+            "name": "user_rating",
+            "source": "api",
+            "data_type": "numeric",
+            "value": float(req.rating),
+            "comment": req.comment,
+            "metadata": {"listing_type": req.listing_type},
+            "timestamp": now,
+        }])
+    except Exception:
+        pass  # Don't fail the request if ClickHouse write fails
+
     return FeedbackResponse.model_validate(fb)
 
 

--- a/observal-server/services/eval_engine.py
+++ b/observal-server/services/eval_engine.py
@@ -1,0 +1,234 @@
+"""Eval engine v2 — managed LLM-as-judge with pluggable backend.
+
+Reads traces/spans from ClickHouse, runs eval templates, writes scores back.
+Designed as a pluggable interface so ITJ can replace LLM-as-judge later.
+"""
+
+import json
+import logging
+import uuid
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+
+import httpx
+
+from config import settings
+from services.clickhouse import insert_scores, query_spans, query_trace_by_id
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROJECT = "default"
+
+# --- Managed eval templates (no custom authoring) ---
+
+EVAL_TEMPLATES: dict[str, dict] = {
+    "tool_selection_accuracy": {
+        "id": "tpl-tool-selection",
+        "name": "Tool Selection Accuracy",
+        "applies_to": "tool_call",
+        "prompt": "Given the user's goal and available tools, was the correct tool selected?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (wrong tool) to 1.0 (perfect selection). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+    },
+    "tool_output_utility": {
+        "id": "tpl-tool-utility",
+        "name": "Tool Output Utility",
+        "applies_to": "tool_call",
+        "prompt": "Did the tool's output advance the user's goal?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (useless) to 1.0 (essential). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+    },
+    "reasoning_clarity": {
+        "id": "tpl-reasoning",
+        "name": "Reasoning Clarity",
+        "applies_to": "reasoning_step",
+        "prompt": "Evaluate the logical soundness of this reasoning step.\nTrace: {trace}\nSpan: {span}\nScore 0.0 (incoherent) to 1.0 (clear and logical). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+    },
+    "response_quality": {
+        "id": "tpl-response-quality",
+        "name": "Response Quality",
+        "applies_to": "agent_turn",
+        "prompt": "Evaluate the overall quality of this agent response.\nTrace: {trace}\nSpan: {span}\nScore 0.0 (poor) to 1.0 (excellent). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+    },
+    "graph_faithfulness": {
+        "id": "tpl-graph-faith",
+        "name": "Graph Faithfulness",
+        "applies_to": "graph_traverse",
+        "prompt": "Does the output contradict the knowledge graph relationships?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (contradicts graph) to 1.0 (faithful). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+    },
+    "recall_accuracy": {
+        "id": "tpl-recall",
+        "name": "Recall Accuracy",
+        "applies_to": "memory_retrieve",
+        "prompt": "Is the retrieved memory relevant to the current context?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (irrelevant) to 1.0 (highly relevant). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+    },
+}
+
+
+# --- Pluggable backend interface ---
+
+
+class EvalBackend(ABC):
+    """Abstract eval backend. LLM-as-judge now, ITJ later."""
+
+    @abstractmethod
+    async def score(self, template: dict, trace: dict, span: dict) -> dict:
+        """Return {"score": float, "reason": str}."""
+        ...
+
+
+class LLMJudgeBackend(EvalBackend):
+    """LLM-as-judge backend using OpenAI-compatible or Bedrock APIs."""
+
+    async def score(self, template: dict, trace: dict, span: dict) -> dict:
+        prompt = template["prompt"].format(
+            trace=json.dumps(trace, default=str)[:2000],
+            span=json.dumps(span, default=str)[:2000],
+        )
+        result = await _call_model(prompt)
+        if isinstance(result, dict) and "score" in result:
+            return {"score": float(result["score"]), "reason": result.get("reason", "")}
+        return {"score": 0.5, "reason": "Model returned invalid response"}
+
+
+class FallbackBackend(EvalBackend):
+    """Heuristic fallback when no LLM is configured."""
+
+    async def score(self, template: dict, trace: dict, span: dict) -> dict:
+        status = span.get("status", "success")
+        latency = int(span.get("latency_ms") or 0)
+        score = 0.8 if status == "success" else 0.2
+        if latency > 5000:
+            score -= 0.2
+        return {"score": max(0, min(1, score)), "reason": f"Heuristic: status={status}, latency={latency}ms"}
+
+
+def get_backend() -> EvalBackend:
+    """Get the configured eval backend."""
+    if getattr(settings, "EVAL_MODEL_NAME", ""):
+        return LLMJudgeBackend()
+    return FallbackBackend()
+
+
+# --- Model calling ---
+
+
+async def _call_model(prompt: str) -> dict:
+    provider = getattr(settings, "EVAL_MODEL_PROVIDER", "") or ""
+    model = getattr(settings, "EVAL_MODEL_NAME", "") or ""
+    if not model:
+        return {}
+    if provider == "bedrock" or (not provider and "anthropic" in model):
+        return await _call_bedrock(prompt, model)
+    return await _call_openai(prompt, model)
+
+
+async def _call_bedrock(prompt: str, model_id: str) -> dict:
+    import asyncio
+
+    def _sync():
+        import boto3
+        client = boto3.client("bedrock-runtime", region_name=getattr(settings, "AWS_REGION", "us-east-1"))
+        r = client.converse(
+            modelId=model_id,
+            messages=[{"role": "user", "content": [{"text": prompt}]}],
+            inferenceConfig={"temperature": 0.1, "maxTokens": 1024},
+        )
+        text = r["output"]["message"]["content"][0]["text"]
+        return _extract_json(text)
+
+    try:
+        return await asyncio.get_event_loop().run_in_executor(None, _sync)
+    except Exception as e:
+        logger.error(f"Bedrock eval failed: {e}")
+        return {}
+
+
+async def _call_openai(prompt: str, model: str) -> dict:
+    url = getattr(settings, "EVAL_MODEL_URL", "") or "http://localhost:11434/v1"
+    key = getattr(settings, "EVAL_MODEL_API_KEY", "") or ""
+    headers = {"Content-Type": "application/json"}
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    try:
+        async with httpx.AsyncClient(timeout=60) as client:
+            r = await client.post(
+                f"{url}/chat/completions",
+                headers=headers,
+                json={"model": model, "messages": [{"role": "user", "content": prompt}], "temperature": 0.1},
+            )
+            r.raise_for_status()
+            return _extract_json(r.json()["choices"][0]["message"]["content"])
+    except Exception as e:
+        logger.error(f"OpenAI eval failed: {e}")
+        return {}
+
+
+def _extract_json(text: str) -> dict:
+    if "```json" in text:
+        text = text.split("```json")[1].split("```")[0]
+    elif "```" in text:
+        text = text.split("```")[1].split("```")[0]
+    try:
+        return json.loads(text.strip())
+    except (json.JSONDecodeError, IndexError):
+        return {}
+
+
+# --- Eval runner ---
+
+
+async def run_eval_on_trace(
+    agent_id: str,
+    trace_id: str,
+    project_id: str = DEFAULT_PROJECT,
+) -> list[dict]:
+    """Run all applicable eval templates on a trace's spans. Returns scores written."""
+    backend = get_backend()
+    trace = await query_trace_by_id(project_id, trace_id)
+    if not trace:
+        logger.warning(f"Trace {trace_id} not found")
+        return []
+
+    spans = await query_spans(project_id, trace_id, limit=500)
+    if not spans:
+        return []
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    scores_to_insert = []
+
+    for span in spans:
+        span_type = span.get("type", "")
+        for tpl_name, tpl in EVAL_TEMPLATES.items():
+            if tpl["applies_to"] != span_type:
+                continue
+            try:
+                result = await backend.score(tpl, trace, span)
+                scores_to_insert.append({
+                    "score_id": str(uuid.uuid4()),
+                    "trace_id": trace_id,
+                    "span_id": span.get("span_id", ""),
+                    "project_id": project_id,
+                    "mcp_id": span.get("mcp_id"),
+                    "agent_id": agent_id,
+                    "user_id": trace.get("user_id", ""),
+                    "name": tpl_name,
+                    "source": "eval",
+                    "data_type": "numeric",
+                    "value": result.get("score", 0),
+                    "comment": result.get("reason", ""),
+                    "eval_template_id": tpl["id"],
+                    "metadata": {},
+                    "timestamp": now,
+                })
+            except Exception as e:
+                logger.error(f"Eval template {tpl_name} failed on span {span.get('span_id')}: {e}")
+
+    if scores_to_insert:
+        try:
+            await insert_scores(scores_to_insert)
+        except Exception as e:
+            logger.error(f"Failed to insert eval scores: {e}")
+
+    return scores_to_insert
+
+
+def list_templates() -> list[dict]:
+    """List all managed eval templates."""
+    return [{"name": k, **v} for k, v in EVAL_TEMPLATES.items()]

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -28,20 +28,24 @@ async def run_eval(ctx: dict, agent_id: str, trace_id: str | None = None):
     """Background job: run eval on an agent's traces."""
     logger.info(f"Running eval for agent={agent_id} trace={trace_id}")
     try:
-        from services.eval_service import evaluate_trace, fetch_traces
+        from services.eval_engine import run_eval_on_trace
+        from services.clickhouse import query_traces
 
-        traces = await fetch_traces(agent_id, limit=1 if trace_id else 20, trace_id=trace_id)
-        for trace in traces:
-            result = await evaluate_trace(
-                type("Agent", (), {"id": agent_id, "name": "", "prompt": ""})(),
-                trace,
-            )
-            # Publish result for GraphQL subscriptions
+        if trace_id:
+            scores = await run_eval_on_trace(agent_id, trace_id)
             await publish(f"eval:{agent_id}", {
-                "agent_id": agent_id,
-                "trace_id": trace.get("trace_id", ""),
-                "result": result,
+                "agent_id": agent_id, "trace_id": trace_id,
+                "scores_written": len(scores),
             })
+        else:
+            traces = await query_traces("default", agent_id=agent_id, limit=20)
+            for t in traces:
+                tid = t.get("trace_id", "")
+                scores = await run_eval_on_trace(agent_id, tid)
+                await publish(f"eval:{agent_id}", {
+                    "agent_id": agent_id, "trace_id": tid,
+                    "scores_written": len(scores),
+                })
     except Exception as e:
         logger.exception(f"Eval job failed: {e}")
 

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -588,3 +588,167 @@ def admin_users():
 
 if __name__ == "__main__":
     app()
+
+
+# ── Phase 10: CLI Updates ────────────────────────────────
+
+
+@app.command()
+def upgrade():
+    """Upgrade observal CLI, shim, and proxy to the latest version."""
+    import subprocess
+    rprint("[dim]Upgrading observal...[/dim]")
+    try:
+        result = subprocess.run(
+            ["uv", "tool", "upgrade", "observal-cli"],
+            capture_output=True, text=True, timeout=120,
+        )
+        if result.returncode == 0:
+            rprint(f"[green]Upgraded successfully![/green]")
+            if result.stdout.strip():
+                rprint(result.stdout.strip())
+        else:
+            # Try pip fallback
+            result = subprocess.run(
+                ["pip", "install", "--upgrade", "observal-cli"],
+                capture_output=True, text=True, timeout=120,
+            )
+            if result.returncode == 0:
+                rprint(f"[green]Upgraded successfully![/green]")
+            else:
+                rprint(f"[red]Upgrade failed: {result.stderr.strip()}[/red]")
+                raise typer.Exit(1)
+    except FileNotFoundError:
+        rprint("[red]Neither uv nor pip found. Install manually.[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def downgrade():
+    """Downgrade observal CLI to a previous version."""
+    rprint("[yellow]WIP — observal downgrade is not yet implemented.[/yellow]")
+    rprint("[dim]Track progress: https://github.com/BlazeUp-AI/Observal/issues/19[/dim]")
+
+
+@app.command()
+def traces(
+    trace_type: Optional[str] = typer.Option(None, "--type", "-t", help="Filter by trace type"),
+    mcp_id: Optional[str] = typer.Option(None, "--mcp", help="Filter by MCP ID"),
+    agent_id: Optional[str] = typer.Option(None, "--agent", help="Filter by agent ID"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
+):
+    """List recent traces from ClickHouse (via GraphQL)."""
+    import json as _json
+    variables = {"limit": limit}
+    if trace_type:
+        variables["traceType"] = trace_type
+    if mcp_id:
+        variables["mcpId"] = mcp_id
+    if agent_id:
+        variables["agentId"] = agent_id
+
+    query = """query($traceType: String, $mcpId: String, $agentId: String, $limit: Int) {
+        traces(traceType: $traceType, mcpId: $mcpId, agentId: $agentId, limit: $limit) {
+            items {
+                traceId traceType name mcpId agentId ide startTime
+                metrics { totalSpans errorCount toolCallCount }
+            }
+        }
+    }"""
+    cfg = config.get_or_exit()
+    try:
+        r = httpx.post(
+            f"{cfg['server_url'].rstrip('/')}/api/v1/graphql",
+            json={"query": query, "variables": variables},
+            timeout=30,
+        )
+        r.raise_for_status()
+        items = r.json().get("data", {}).get("traces", {}).get("items", [])
+    except Exception as e:
+        rprint(f"[red]Failed to query traces: {e}[/red]")
+        raise typer.Exit(1)
+
+    table = Table(title="Recent Traces")
+    table.add_column("Trace ID", style="dim")
+    table.add_column("Type")
+    table.add_column("Name")
+    table.add_column("MCP/Agent")
+    table.add_column("IDE")
+    table.add_column("Spans")
+    table.add_column("Errors")
+    table.add_column("Tools")
+    for t in items:
+        m = t.get("metrics", {})
+        ref = t.get("mcpId") or t.get("agentId") or "—"
+        table.add_row(
+            t["traceId"][:12] + "…",
+            t.get("traceType", ""),
+            t.get("name", "") or "—",
+            ref[:16],
+            t.get("ide", "") or "—",
+            str(m.get("totalSpans", 0)),
+            str(m.get("errorCount", 0)),
+            str(m.get("toolCallCount", 0)),
+        )
+    console.print(table)
+
+
+@app.command()
+def spans(
+    trace_id: str = typer.Argument(..., help="Trace ID"),
+):
+    """List spans for a trace (via GraphQL)."""
+    query = """query($traceId: String!) {
+        trace(traceId: $traceId) {
+            traceId name
+            spans {
+                spanId type name method latencyMs status
+                toolSchemaValid toolsAvailable
+            }
+        }
+    }"""
+    cfg = config.get_or_exit()
+    try:
+        r = httpx.post(
+            f"{cfg['server_url'].rstrip('/')}/api/v1/graphql",
+            json={"query": query, "variables": {"traceId": trace_id}},
+            timeout=30,
+        )
+        r.raise_for_status()
+        trace_data = r.json().get("data", {}).get("trace")
+    except Exception as e:
+        rprint(f"[red]Failed to query spans: {e}[/red]")
+        raise typer.Exit(1)
+
+    if not trace_data:
+        rprint(f"[yellow]Trace {trace_id} not found.[/yellow]")
+        raise typer.Exit(1)
+
+    rprint(f"[bold]Trace: {trace_data['traceId']}[/bold] — {trace_data.get('name', '')}")
+
+    table = Table(title="Spans")
+    table.add_column("Span ID", style="dim")
+    table.add_column("Type")
+    table.add_column("Name")
+    table.add_column("Method")
+    table.add_column("Latency")
+    table.add_column("Status")
+    table.add_column("Schema")
+    for s in trace_data.get("spans", []):
+        schema = "✓" if s.get("toolSchemaValid") is True else ("✗" if s.get("toolSchemaValid") is False else "—")
+        latency = f"{s['latencyMs']}ms" if s.get("latencyMs") else "—"
+        status_style = "red" if s.get("status") == "error" else ""
+        table.add_row(
+            s["spanId"][:12] + "…",
+            s.get("type", ""),
+            s.get("name", ""),
+            s.get("method", "") or "—",
+            latency,
+            f"[{status_style}]{s.get('status', '')}[/{status_style}]" if status_style else s.get("status", ""),
+            schema,
+        )
+    console.print(table)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_eval_phase8.py
+++ b/tests/test_eval_phase8.py
@@ -1,0 +1,163 @@
+"""Unit tests for eval engine v2 — Phase 8."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.eval_engine import (
+    EVAL_TEMPLATES,
+    EvalBackend,
+    FallbackBackend,
+    LLMJudgeBackend,
+    _extract_json,
+    get_backend,
+    list_templates,
+    run_eval_on_trace,
+)
+
+
+class TestEvalTemplates:
+    def test_has_required_templates(self):
+        for name in ["tool_selection_accuracy", "tool_output_utility", "reasoning_clarity",
+                      "response_quality", "graph_faithfulness", "recall_accuracy"]:
+            assert name in EVAL_TEMPLATES
+
+    def test_templates_have_required_fields(self):
+        for name, tpl in EVAL_TEMPLATES.items():
+            assert "id" in tpl
+            assert "name" in tpl
+            assert "applies_to" in tpl
+            assert "prompt" in tpl
+            assert "{trace}" in tpl["prompt"]
+            assert "{span}" in tpl["prompt"]
+
+    def test_list_templates(self):
+        result = list_templates()
+        assert len(result) == len(EVAL_TEMPLATES)
+        assert all("name" in t for t in result)
+
+
+class TestExtractJson:
+    def test_plain_json(self):
+        assert _extract_json('{"score": 0.8}') == {"score": 0.8}
+
+    def test_json_in_code_block(self):
+        assert _extract_json('```json\n{"score": 0.9}\n```') == {"score": 0.9}
+
+    def test_json_in_generic_block(self):
+        assert _extract_json('```\n{"score": 0.7}\n```') == {"score": 0.7}
+
+    def test_invalid(self):
+        assert _extract_json("not json") == {}
+
+
+class TestFallbackBackend:
+    @pytest.mark.asyncio
+    async def test_success_span(self):
+        backend = FallbackBackend()
+        result = await backend.score({}, {}, {"status": "success", "latency_ms": 100})
+        assert result["score"] == 0.8
+        assert "success" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_error_span(self):
+        backend = FallbackBackend()
+        result = await backend.score({}, {}, {"status": "error", "latency_ms": 100})
+        assert result["score"] == 0.2
+
+    @pytest.mark.asyncio
+    async def test_high_latency_penalty(self):
+        backend = FallbackBackend()
+        result = await backend.score({}, {}, {"status": "success", "latency_ms": 10000})
+        assert result["score"] < 0.8
+
+
+class TestGetBackend:
+    def test_returns_fallback_when_no_model(self):
+        with patch("services.eval_engine.settings") as mock_settings:
+            mock_settings.EVAL_MODEL_NAME = ""
+            assert isinstance(get_backend(), FallbackBackend)
+
+    def test_returns_llm_when_model_set(self):
+        with patch("services.eval_engine.settings") as mock_settings:
+            mock_settings.EVAL_MODEL_NAME = "gpt-4"
+            assert isinstance(get_backend(), LLMJudgeBackend)
+
+
+class TestRunEvalOnTrace:
+    @pytest.mark.asyncio
+    async def test_no_trace_returns_empty(self):
+        with patch("services.eval_engine.query_trace_by_id", new_callable=AsyncMock, return_value=None):
+            result = await run_eval_on_trace("agent-1", "missing-trace")
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_no_spans_returns_empty(self):
+        with (
+            patch("services.eval_engine.query_trace_by_id", new_callable=AsyncMock, return_value={"trace_id": "t1"}),
+            patch("services.eval_engine.query_spans", new_callable=AsyncMock, return_value=[]),
+        ):
+            result = await run_eval_on_trace("agent-1", "t1")
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_scores_tool_call_spans(self):
+        trace = {"trace_id": "t1", "user_id": "u1"}
+        spans = [
+            {"span_id": "s1", "type": "tool_call", "status": "success", "latency_ms": 50},
+            {"span_id": "s2", "type": "initialize", "status": "success"},  # no template
+        ]
+        with (
+            patch("services.eval_engine.query_trace_by_id", new_callable=AsyncMock, return_value=trace),
+            patch("services.eval_engine.query_spans", new_callable=AsyncMock, return_value=spans),
+            patch("services.eval_engine.get_backend") as mock_get,
+            patch("services.eval_engine.insert_scores", new_callable=AsyncMock) as mock_insert,
+        ):
+            mock_backend = AsyncMock()
+            mock_backend.score.return_value = {"score": 0.9, "reason": "good"}
+            mock_get.return_value = mock_backend
+
+            result = await run_eval_on_trace("agent-1", "t1")
+
+            # tool_call has 2 templates (tool_selection_accuracy, tool_output_utility)
+            assert len(result) == 2
+            assert all(s["source"] == "eval" for s in result)
+            assert all(s["trace_id"] == "t1" for s in result)
+            mock_insert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_scores_written_to_clickhouse(self):
+        trace = {"trace_id": "t1", "user_id": "u1"}
+        spans = [{"span_id": "s1", "type": "tool_call", "status": "success"}]
+        with (
+            patch("services.eval_engine.query_trace_by_id", new_callable=AsyncMock, return_value=trace),
+            patch("services.eval_engine.query_spans", new_callable=AsyncMock, return_value=spans),
+            patch("services.eval_engine.get_backend") as mock_get,
+            patch("services.eval_engine.insert_scores", new_callable=AsyncMock) as mock_insert,
+        ):
+            mock_backend = AsyncMock()
+            mock_backend.score.return_value = {"score": 0.85, "reason": "test"}
+            mock_get.return_value = mock_backend
+
+            await run_eval_on_trace("agent-1", "t1")
+
+            scores = mock_insert.call_args[0][0]
+            assert all(s["eval_template_id"].startswith("tpl-") for s in scores)
+            assert all(s["data_type"] == "numeric" for s in scores)
+
+    @pytest.mark.asyncio
+    async def test_handles_backend_error(self):
+        trace = {"trace_id": "t1", "user_id": "u1"}
+        spans = [{"span_id": "s1", "type": "tool_call", "status": "success"}]
+        with (
+            patch("services.eval_engine.query_trace_by_id", new_callable=AsyncMock, return_value=trace),
+            patch("services.eval_engine.query_spans", new_callable=AsyncMock, return_value=spans),
+            patch("services.eval_engine.get_backend") as mock_get,
+            patch("services.eval_engine.insert_scores", new_callable=AsyncMock),
+        ):
+            mock_backend = AsyncMock()
+            mock_backend.score.side_effect = Exception("model down")
+            mock_get.return_value = mock_backend
+
+            result = await run_eval_on_trace("agent-1", "t1")
+            assert result == []  # errors caught, no scores

--- a/tests/test_phase9_10.py
+++ b/tests/test_phase9_10.py
@@ -1,0 +1,130 @@
+"""Unit tests for Phase 9 (Score Unification) and Phase 10 (CLI Updates)."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from fastapi import FastAPI
+
+from api.routes.feedback import router as feedback_router
+from api.deps import get_current_user, get_db
+from models.user import User
+
+
+# --- Phase 9: Score Unification ---
+
+
+def _make_user():
+    u = MagicMock(spec=User)
+    u.id = uuid.uuid4()
+    u.role = "admin"
+    return u
+
+
+def _make_app(user):
+    app = FastAPI()
+    app.include_router(feedback_router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    # Mock DB session
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=uuid.uuid4())  # listing exists
+    mock_db.add = MagicMock()
+    mock_db.commit = AsyncMock()
+    mock_db.refresh = AsyncMock(side_effect=lambda fb: setattr(fb, 'id', uuid.uuid4()) or setattr(fb, 'created_at', '2026-01-01'))
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app
+
+
+class TestFeedbackDualWrite:
+    @pytest.mark.asyncio
+    async def test_writes_to_clickhouse_scores(self):
+        user = _make_user()
+        app = _make_app(user)
+        listing_id = str(uuid.uuid4())
+
+        with patch("api.routes.feedback.insert_scores", new_callable=AsyncMock) as mock_insert:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.post("/api/v1/feedback", json={
+                    "listing_id": listing_id,
+                    "listing_type": "mcp",
+                    "rating": 5,
+                    "comment": "Great tool!",
+                })
+            assert r.status_code == 200
+            mock_insert.assert_called_once()
+            scores = mock_insert.call_args[0][0]
+            assert len(scores) == 1
+            assert scores[0]["name"] == "user_rating"
+            assert scores[0]["source"] == "api"
+            assert scores[0]["value"] == 5.0
+            assert scores[0]["comment"] == "Great tool!"
+            assert scores[0]["mcp_id"] == listing_id
+
+    @pytest.mark.asyncio
+    async def test_agent_feedback_sets_agent_id(self):
+        user = _make_user()
+        app = _make_app(user)
+        listing_id = str(uuid.uuid4())
+
+        with patch("api.routes.feedback.insert_scores", new_callable=AsyncMock) as mock_insert:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.post("/api/v1/feedback", json={
+                    "listing_id": listing_id,
+                    "listing_type": "agent",
+                    "rating": 4,
+                })
+            scores = mock_insert.call_args[0][0]
+            assert scores[0]["agent_id"] == listing_id
+            assert scores[0]["mcp_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_clickhouse_failure_doesnt_break_request(self):
+        user = _make_user()
+        app = _make_app(user)
+
+        with patch("api.routes.feedback.insert_scores", new_callable=AsyncMock, side_effect=Exception("CH down")):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.post("/api/v1/feedback", json={
+                    "listing_id": str(uuid.uuid4()),
+                    "listing_type": "mcp",
+                    "rating": 3,
+                })
+            assert r.status_code == 200  # request still succeeds
+
+
+# --- Phase 10: CLI Updates ---
+
+
+class TestCLICommands:
+    def test_downgrade_is_wip(self):
+        from observal_cli.main import app as cli_app
+        from typer.testing import CliRunner
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["downgrade"])
+        assert result.exit_code == 0
+        assert "WIP" in result.output
+
+    def test_upgrade_command_exists(self):
+        from observal_cli.main import app as cli_app
+        from typer.testing import CliRunner
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["upgrade", "--help"])
+        assert result.exit_code == 0
+        assert "Upgrade" in result.output or "upgrade" in result.output
+
+    def test_traces_command_exists(self):
+        from observal_cli.main import app as cli_app
+        from typer.testing import CliRunner
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["traces", "--help"])
+        assert result.exit_code == 0
+        assert "trace" in result.output.lower()
+
+    def test_spans_command_exists(self):
+        from observal_cli.main import app as cli_app
+        from typer.testing import CliRunner
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["spans", "--help"])
+        assert result.exit_code == 0
+        assert "span" in result.output.lower() or "trace" in result.output.lower()


### PR DESCRIPTION
## Summary

Pluggable eval engine with LLM-as-judge scoring, feedback dual-write to ClickHouse, new CLI commands, and a demo framework with mock MCP servers.

Fixes #17
Fixes #18
Fixes #19

## Phase 8 — Eval Engine (#17)

- `EvalBackend` ABC with `LLMJudgeBackend` (Bedrock/OpenAI) and `FallbackBackend`
- 6 managed templates: tool_selection_accuracy, tool_output_utility, reasoning_clarity, response_quality, graph_faithfulness, recall_accuracy
- `run_eval_on_trace()` orchestrator with scorecard generation
- 17 unit tests

## Phase 9 — Score Unification (#18)

- Feedback endpoint dual-writes ratings to PostgreSQL + ClickHouse scores table
- Scores stored with source=`api`, data_type=`numeric`, linked to MCP/agent ID

## Phase 10 — CLI Updates (#19)

- `observal traces` — list recent traces via GraphQL (with --type, --mcp, --agent, --limit filters)
- `observal spans <trace-id>` — drill into spans for a trace
- `observal upgrade` — upgrade CLI via uv tool
- `observal downgrade` — placeholder (WIP)
- 7 unit tests

## Demo Framework

- Mock MCP servers: general (5 tools), GraphRAG (3 tools), agent delegation (4 tools)
- IDE configs: Kiro agent hooks, Cursor MCP, Claude Code hooks, Gemini CLI
- `demo/run_demo.sh` — end-to-end demo script

## Testing
```
24 tests passing (17 eval + 7 phase 9-10)
```