### PR TITLE
chore: add linting, pre-commit hooks, and OSS project scaffolding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{ts,tsx,js,jsx,json,css,html,yaml,yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,37 @@
 __pycache__/
 *.pyc
+*.pyo
 .env
 *.egg-info/
 dist/
 build/
+.eggs/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Python
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+htmlcov/
+.coverage
+*.cover
+
+# Node
+observal-web/node_modules/
+observal-web/dist/
+
+# Docker
+docker/data/
+
+# Local config
+.kiro/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+repos:
+  # ── Python ─────────────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  # ── YAML / TOML / JSON ────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+        exclude: tsconfig\.json  # tsconfig allows comments
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: no-commit-to-branch
+        args: [--branch, main]
+
+  # ── TypeScript / JS ────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: bash -c 'cd observal-web && npx eslint --fix "$@"' --
+        language: system
+        files: ^observal-web/src/.*\.(ts|tsx)$
+        types: [file]
+
+      - id: tsc
+        name: typecheck
+        entry: bash -c 'cd observal-web && npx tsc --noEmit'
+        language: system
+        files: ^observal-web/src/.*\.(ts|tsx)$
+        pass_filenames: false
+
+  # ── Docker ─────────────────────────────────────────────
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint-docker
+        args: [--ignore, DL3008, --ignore, DL3013]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+.PHONY: lint format check test hooks clean
+
+# ── Linting ──────────────────────────────────────────────
+
+lint:  ## Run all linters
+	uv run ruff check .
+	cd observal-web && npx eslint src/
+
+format:  ## Auto-format all code
+	uv run ruff format .
+	uv run ruff check --fix .
+
+check:  ## Full pre-commit check on all files
+	pre-commit run --all-files
+
+# ── Testing ──────────────────────────────────────────────
+
+test:  ## Run Python tests
+	cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich pytest ../tests/ -q
+
+test-v:  ## Run Python tests (verbose)
+	cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich pytest ../tests/ -v
+
+# ── Setup ────────────────────────────────────────────────
+
+hooks:  ## Install pre-commit hooks
+	pip install pre-commit
+	pre-commit install
+	pre-commit install --hook-type commit-msg
+	@echo "✓ Hooks installed"
+
+# ── Docker ───────────────────────────────────────────────
+
+up:  ## Start Docker stack
+	cd docker && docker compose up -d
+
+down:  ## Stop Docker stack
+	cd docker && docker compose down
+
+rebuild:  ## Rebuild and restart Docker stack
+	cd docker && docker compose up --build -d
+
+logs:  ## Tail Docker logs
+	cd docker && docker compose logs -f --tail=50
+
+# ── Cleanup ──────────────────────────────────────────────
+
+clean:  ## Remove build artifacts and caches
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .ruff_cache -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name '*.egg-info' -exec rm -rf {} + 2>/dev/null || true
+	rm -rf dist/ build/ htmlcov/ .coverage
+
+help:  ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/demo/mock_agent_mcp.py
+++ b/demo/mock_agent_mcp.py
@@ -3,15 +3,43 @@
 
 Tests agent-specific span types (agent_turn, agent_handoff, reasoning_step).
 """
+
 import json
 import sys
-import time
 
 TOOLS = [
-    {"name": "delegate_task", "description": "Delegate a task to a sub-agent", "inputSchema": {"type": "object", "properties": {"agent_name": {"type": "string"}, "task": {"type": "string"}, "context": {"type": "string"}}, "required": ["agent_name", "task"]}},
-    {"name": "reasoning_step", "description": "Execute a chain-of-thought reasoning step", "inputSchema": {"type": "object", "properties": {"step": {"type": "string"}, "premises": {"type": "array", "items": {"type": "string"}}}, "required": ["step"]}},
-    {"name": "memory_store", "description": "Store a key-value pair in agent memory", "inputSchema": {"type": "object", "properties": {"key": {"type": "string"}, "value": {"type": "string"}, "ttl_seconds": {"type": "integer"}}, "required": ["key", "value"]}},
-    {"name": "memory_retrieve", "description": "Retrieve a value from agent memory", "inputSchema": {"type": "object", "properties": {"key": {"type": "string"}}, "required": ["key"]}},
+    {
+        "name": "delegate_task",
+        "description": "Delegate a task to a sub-agent",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"agent_name": {"type": "string"}, "task": {"type": "string"}, "context": {"type": "string"}},
+            "required": ["agent_name", "task"],
+        },
+    },
+    {
+        "name": "reasoning_step",
+        "description": "Execute a chain-of-thought reasoning step",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"step": {"type": "string"}, "premises": {"type": "array", "items": {"type": "string"}}},
+            "required": ["step"],
+        },
+    },
+    {
+        "name": "memory_store",
+        "description": "Store a key-value pair in agent memory",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"key": {"type": "string"}, "value": {"type": "string"}, "ttl_seconds": {"type": "integer"}},
+            "required": ["key", "value"],
+        },
+    },
+    {
+        "name": "memory_retrieve",
+        "description": "Retrieve a value from agent memory",
+        "inputSchema": {"type": "object", "properties": {"key": {"type": "string"}}, "required": ["key"]},
+    },
 ]
 
 MEMORY = {}
@@ -32,31 +60,64 @@ def handle_tool_call(msg_id, name, args):
     if name == "delegate_task":
         agent = args.get("agent_name", "researcher")
         result = FAKE_AGENTS.get(agent, f"Agent '{agent}' completed the task.")
-        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
-            "agent": agent,
-            "task": args.get("task", ""),
-            "status": "completed",
-            "result": result,
-            "tokens_used": 1250,
-        })}]})
+        respond(
+            msg_id,
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "agent": agent,
+                                "task": args.get("task", ""),
+                                "status": "completed",
+                                "result": result,
+                                "tokens_used": 1250,
+                            }
+                        ),
+                    }
+                ]
+            },
+        )
     elif name == "reasoning_step":
         premises = args.get("premises", [])
-        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
-            "step": args.get("step", ""),
-            "premises_count": len(premises),
-            "conclusion": f"Based on {len(premises)} premises, the conclusion follows logically.",
-            "confidence": 0.87,
-        })}]})
+        respond(
+            msg_id,
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "step": args.get("step", ""),
+                                "premises_count": len(premises),
+                                "conclusion": f"Based on {len(premises)} premises, the conclusion follows logically.",
+                                "confidence": 0.87,
+                            }
+                        ),
+                    }
+                ]
+            },
+        )
     elif name == "memory_store":
         key = args.get("key", "")
         MEMORY[key] = args.get("value", "")
-        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({"stored": key, "ttl": args.get("ttl_seconds", 3600)})}]})
+        respond(
+            msg_id,
+            {"content": [{"type": "text", "text": json.dumps({"stored": key, "ttl": args.get("ttl_seconds", 3600)})}]},
+        )
     elif name == "memory_retrieve":
         key = args.get("key", "")
-        val = MEMORY.get(key, None)
-        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({"key": key, "value": val, "found": val is not None})}]})
+        val = MEMORY.get(key)
+        respond(
+            msg_id,
+            {"content": [{"type": "text", "text": json.dumps({"key": key, "value": val, "found": val is not None})}]},
+        )
     else:
-        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32601, "message": f"Unknown tool: {name}"}}) + "\n")
+        sys.stdout.write(
+            json.dumps({"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32601, "message": f"Unknown tool: {name}"}})
+            + "\n"
+        )
         sys.stdout.flush()
 
 
@@ -76,7 +137,14 @@ def main():
         params = msg.get("params", {})
 
         if method == "initialize":
-            respond(msg_id, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "mock-agent-mcp", "version": "1.0.0"}})
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mock-agent-mcp", "version": "1.0.0"},
+                },
+            )
         elif method == "tools/list":
             respond(msg_id, {"tools": TOOLS})
         elif method == "tools/call":

--- a/demo/mock_graphrag_mcp.py
+++ b/demo/mock_graphrag_mcp.py
@@ -4,13 +4,38 @@
 Returns fake knowledge graph data to exercise graph-specific span columns
 (hop_count, entities_retrieved, relationships_used).
 """
+
 import json
 import sys
 
 TOOLS = [
-    {"name": "graph_query", "description": "Run a natural language query against the knowledge graph", "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}, "max_hops": {"type": "integer"}}, "required": ["query"]}},
-    {"name": "graph_traverse", "description": "Traverse the graph from a starting entity", "inputSchema": {"type": "object", "properties": {"entity_id": {"type": "string"}, "depth": {"type": "integer"}, "relationship_types": {"type": "array", "items": {"type": "string"}}}, "required": ["entity_id"]}},
-    {"name": "entity_lookup", "description": "Look up an entity by name or ID", "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}},
+    {
+        "name": "graph_query",
+        "description": "Run a natural language query against the knowledge graph",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "max_hops": {"type": "integer"}},
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "graph_traverse",
+        "description": "Traverse the graph from a starting entity",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string"},
+                "depth": {"type": "integer"},
+                "relationship_types": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["entity_id"],
+        },
+    },
+    {
+        "name": "entity_lookup",
+        "description": "Look up an entity by name or ID",
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
+    },
 ]
 
 FAKE_ENTITIES = [
@@ -38,35 +63,80 @@ def respond(msg_id, result):
 def handle_tool_call(msg_id, name, args):
     if name == "graph_query":
         hops = min(args.get("max_hops", 2), 4)
-        entities = FAKE_ENTITIES[:hops + 1]
+        entities = FAKE_ENTITIES[: hops + 1]
         rels = FAKE_RELATIONSHIPS[:hops]
-        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
-            "query": args.get("query", ""),
-            "hop_count": hops,
-            "entities_retrieved": len(entities),
-            "relationships_used": len(rels),
-            "entities": entities,
-            "relationships": rels,
-        })}]})
+        respond(
+            msg_id,
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "query": args.get("query", ""),
+                                "hop_count": hops,
+                                "entities_retrieved": len(entities),
+                                "relationships_used": len(rels),
+                                "entities": entities,
+                                "relationships": rels,
+                            }
+                        ),
+                    }
+                ]
+            },
+        )
     elif name == "graph_traverse":
         depth = min(args.get("depth", 2), 4)
-        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
-            "start_entity": args.get("entity_id", "e-001"),
-            "depth": depth,
-            "hop_count": depth,
-            "entities_retrieved": depth + 1,
-            "relationships_used": depth,
-            "path": [{"entity": FAKE_ENTITIES[i % len(FAKE_ENTITIES)], "relationship": FAKE_RELATIONSHIPS[i % len(FAKE_RELATIONSHIPS)]} for i in range(depth)],
-        })}]})
+        respond(
+            msg_id,
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "start_entity": args.get("entity_id", "e-001"),
+                                "depth": depth,
+                                "hop_count": depth,
+                                "entities_retrieved": depth + 1,
+                                "relationships_used": depth,
+                                "path": [
+                                    {
+                                        "entity": FAKE_ENTITIES[i % len(FAKE_ENTITIES)],
+                                        "relationship": FAKE_RELATIONSHIPS[i % len(FAKE_RELATIONSHIPS)],
+                                    }
+                                    for i in range(depth)
+                                ],
+                            }
+                        ),
+                    }
+                ]
+            },
+        )
     elif name == "entity_lookup":
         name_q = args.get("name", "").lower()
         matches = [e for e in FAKE_ENTITIES if name_q in e["name"].lower()]
-        respond(msg_id, {"content": [{"type": "text", "text": json.dumps({
-            "entities_retrieved": len(matches),
-            "entities": matches or [FAKE_ENTITIES[0]],
-        })}]})
+        respond(
+            msg_id,
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "entities_retrieved": len(matches),
+                                "entities": matches or [FAKE_ENTITIES[0]],
+                            }
+                        ),
+                    }
+                ]
+            },
+        )
     else:
-        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32601, "message": f"Unknown tool: {name}"}}) + "\n")
+        sys.stdout.write(
+            json.dumps({"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32601, "message": f"Unknown tool: {name}"}})
+            + "\n"
+        )
         sys.stdout.flush()
 
 
@@ -86,7 +156,14 @@ def main():
         params = msg.get("params", {})
 
         if method == "initialize":
-            respond(msg_id, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "mock-graphrag-mcp", "version": "1.0.0"}})
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mock-graphrag-mcp", "version": "1.0.0"},
+                },
+            )
         elif method == "tools/list":
             respond(msg_id, {"tools": TOOLS})
         elif method == "tools/call":

--- a/demo/mock_mcp.py
+++ b/demo/mock_mcp.py
@@ -1,15 +1,47 @@
 #!/usr/bin/env python3
 """Mock MCP server with general-purpose tools: echo, add, read_file, write_file, search."""
+
 import json
 import sys
-import os
 
 TOOLS = [
-    {"name": "echo", "description": "Echo input text back", "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]}},
-    {"name": "add", "description": "Add two numbers", "inputSchema": {"type": "object", "properties": {"a": {"type": "number"}, "b": {"type": "number"}}, "required": ["a", "b"]}},
-    {"name": "read_file", "description": "Read a file's contents", "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}},
-    {"name": "write_file", "description": "Write content to a file", "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}, "content": {"type": "string"}}, "required": ["path", "content"]}},
-    {"name": "search", "description": "Search for a pattern in files", "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}, "directory": {"type": "string"}}, "required": ["query"]}},
+    {
+        "name": "echo",
+        "description": "Echo input text back",
+        "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+    },
+    {
+        "name": "add",
+        "description": "Add two numbers",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
+            "required": ["a", "b"],
+        },
+    },
+    {
+        "name": "read_file",
+        "description": "Read a file's contents",
+        "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]},
+    },
+    {
+        "name": "write_file",
+        "description": "Write content to a file",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"],
+        },
+    },
+    {
+        "name": "search",
+        "description": "Search for a pattern in files",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "directory": {"type": "string"}},
+            "required": ["query"],
+        },
+    },
 ]
 
 RESOURCES = [
@@ -38,12 +70,31 @@ def handle_tool_call(msg_id, name, args):
         respond(msg_id, {"content": [{"type": "text", "text": str(args.get("a", 0) + args.get("b", 0))}]})
     elif name == "read_file":
         path = args.get("path", "/tmp/demo.txt")
-        respond(msg_id, {"content": [{"type": "text", "text": f"Contents of {path}:\n# Demo file\nline1\nline2\nline3"}]})
+        respond(
+            msg_id, {"content": [{"type": "text", "text": f"Contents of {path}:\n# Demo file\nline1\nline2\nline3"}]}
+        )
     elif name == "write_file":
-        respond(msg_id, {"content": [{"type": "text", "text": f"Wrote {len(args.get('content', ''))} bytes to {args.get('path', '')}"}]})
+        respond(
+            msg_id,
+            {
+                "content": [
+                    {"type": "text", "text": f"Wrote {len(args.get('content', ''))} bytes to {args.get('path', '')}"}
+                ]
+            },
+        )
     elif name == "search":
         q = args.get("query", "")
-        respond(msg_id, {"content": [{"type": "text", "text": f"Found 3 matches for '{q}':\n  src/main.py:10: {q}_handler()\n  src/utils.py:25: def {q}():\n  README.md:5: {q} documentation"}]})
+        respond(
+            msg_id,
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Found 3 matches for '{q}':\n  src/main.py:10: {q}_handler()\n  src/utils.py:25: def {q}():\n  README.md:5: {q} documentation",
+                    }
+                ]
+            },
+        )
     else:
         error(msg_id, -32601, f"Unknown tool: {name}")
 
@@ -64,7 +115,14 @@ def main():
         params = msg.get("params", {})
 
         if method == "initialize":
-            respond(msg_id, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}, "resources": {}, "prompts": {}}, "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}})
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
+                    "serverInfo": {"name": "mock-mcp", "version": "1.0.0"},
+                },
+            )
         elif method == "tools/list":
             respond(msg_id, {"tools": TOOLS})
         elif method == "tools/call":
@@ -72,11 +130,35 @@ def main():
         elif method == "resources/list":
             respond(msg_id, {"resources": RESOURCES})
         elif method == "resources/read":
-            respond(msg_id, {"contents": [{"uri": params.get("uri", ""), "mimeType": "application/json", "text": '{"demo": true, "version": "1.0.0"}'}]})
+            respond(
+                msg_id,
+                {
+                    "contents": [
+                        {
+                            "uri": params.get("uri", ""),
+                            "mimeType": "application/json",
+                            "text": '{"demo": true, "version": "1.0.0"}',
+                        }
+                    ]
+                },
+            )
         elif method == "prompts/list":
             respond(msg_id, {"prompts": PROMPTS})
         elif method == "prompts/get":
-            respond(msg_id, {"messages": [{"role": "user", "content": {"type": "text", "text": f"Please summarize: {params.get('arguments', {}).get('text', '')}"}}]})
+            respond(
+                msg_id,
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": {
+                                "type": "text",
+                                "text": f"Please summarize: {params.get('arguments', {}).get('text', '')}",
+                            },
+                        }
+                    ]
+                },
+            )
         elif method == "ping":
             respond(msg_id, {})
         else:

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -1,6 +1,6 @@
 import hashlib
+from collections.abc import AsyncGenerator
 from functools import wraps
-from typing import AsyncGenerator
 
 from fastapi import Depends, Header, HTTPException
 from sqlalchemy import select
@@ -34,5 +34,7 @@ def require_role(*roles: UserRole):
             if current_user.role not in roles:
                 raise HTTPException(status_code=403, detail="Insufficient permissions")
             return await func(*args, current_user=current_user, **kwargs)
+
         return wrapper
+
     return decorator

--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -2,8 +2,7 @@
 
 import json
 import logging
-from datetime import datetime
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 
 import strawberry
 from strawberry.dataloader import DataLoader
@@ -13,9 +12,7 @@ from strawberry.types import Info
 from services.clickhouse import (
     _escape,
     _query,
-    query_scores,
     query_span_by_id,
-    query_spans,
     query_trace_by_id,
     query_traces,
 )
@@ -398,7 +395,9 @@ class Query:
 
     @strawberry.field
     async def trends(self, start: str, end: str, granularity: str = "DAY") -> list[TrendPoint]:
-        trunc = {"HOUR": "toStartOfHour", "DAY": "toDate", "WEEK": "toStartOfWeek", "MONTH": "toStartOfMonth"}.get(granularity, "toDate")
+        trunc = {"HOUR": "toStartOfHour", "DAY": "toDate", "WEEK": "toStartOfWeek", "MONTH": "toStartOfMonth"}.get(
+            granularity, "toDate"
+        )
         rows = await _ch_json(
             f"SELECT {trunc}(start_time) as d, count() as traces "
             f"FROM traces FINAL WHERE project_id='{_escape(DEFAULT_PROJECT)}' AND is_deleted=0 "
@@ -429,7 +428,9 @@ class Query:
 @strawberry.type
 class Subscription:
     @strawberry.subscription
-    async def trace_created(self, mcp_id: str | None = None, agent_id: str | None = None) -> AsyncGenerator[Trace, None]:
+    async def trace_created(
+        self, mcp_id: str | None = None, agent_id: str | None = None
+    ) -> AsyncGenerator[Trace, None]:
         channel = "traces:created"
         async for data in subscribe(channel):
             if mcp_id and data.get("mcp_id") != mcp_id:

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -10,7 +10,14 @@ from api.deps import get_current_user, get_db
 from config import settings
 from models.enterprise_config import EnterpriseConfig
 from models.user import User, UserRole
-from schemas.admin import EnterpriseConfigResponse, EnterpriseConfigUpdate, UserAdminResponse, UserCreateRequest, UserCreateResponse, UserRoleUpdate
+from schemas.admin import (
+    EnterpriseConfigResponse,
+    EnterpriseConfigUpdate,
+    UserAdminResponse,
+    UserCreateRequest,
+    UserCreateResponse,
+    UserRoleUpdate,
+)
 
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 
@@ -123,7 +130,11 @@ async def create_user(
     await db.refresh(user)
 
     return UserCreateResponse(
-        id=user.id, email=user.email, name=user.name, role=user.role.value, api_key=api_key,
+        id=user.id,
+        email=user.email,
+        name=user.name,
+        role=user.role.value,
+        api_key=api_key,
     )
 
 

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -39,13 +39,19 @@ async def _load_agent(db: AsyncSession, *where_clauses) -> Agent | None:
 
 def _agent_to_response(agent: Agent) -> AgentResponse:
     mcp_links = [
-        McpLinkResponse(mcp_listing_id=link.mcp_listing_id, mcp_name=link.mcp_listing.name if link.mcp_listing else "(deleted)", order=link.order)
+        McpLinkResponse(
+            mcp_listing_id=link.mcp_listing_id,
+            mcp_name=link.mcp_listing.name if link.mcp_listing else "(deleted)",
+            order=link.order,
+        )
         for link in agent.mcp_links
     ]
     goal_template = None
     if agent.goal_template:
         sections = [
-            GoalSectionResponse(name=s.name, description=s.description, grounding_required=s.grounding_required, order=s.order)
+            GoalSectionResponse(
+                name=s.name, description=s.description, grounding_required=s.grounding_required, order=s.order
+            )
             for s in agent.goal_template.sections
         ]
         goal_template = GoalTemplateResponse(description=agent.goal_template.description, sections=sections)
@@ -100,13 +106,15 @@ async def create_agent(
     await db.flush()
 
     for i, sec in enumerate(req.goal_template.sections):
-        db.add(AgentGoalSection(
-            goal_template_id=goal.id,
-            name=sec.name,
-            description=sec.description,
-            grounding_required=sec.grounding_required,
-            order=i,
-        ))
+        db.add(
+            AgentGoalSection(
+                goal_template_id=goal.id,
+                name=sec.name,
+                description=sec.description,
+                grounding_required=sec.grounding_required,
+                order=i,
+            )
+        )
 
     await db.commit()
     agent = await _load_agent(db, Agent.id == agent.id)
@@ -146,7 +154,16 @@ async def update_agent(
     if agent.created_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the agent owner")
 
-    for field in ("name", "version", "description", "owner", "prompt", "model_name", "model_config_json", "supported_ides"):
+    for field in (
+        "name",
+        "version",
+        "description",
+        "owner",
+        "prompt",
+        "model_name",
+        "model_config_json",
+        "supported_ides",
+    ):
         val = getattr(req, field)
         if val is not None:
             setattr(agent, field, val)
@@ -164,9 +181,15 @@ async def update_agent(
 
     if req.goal_template is not None:
         if agent.goal_template:
-            old_sections = (await db.execute(
-                select(AgentGoalSection).where(AgentGoalSection.goal_template_id == agent.goal_template.id)
-            )).scalars().all()
+            old_sections = (
+                (
+                    await db.execute(
+                        select(AgentGoalSection).where(AgentGoalSection.goal_template_id == agent.goal_template.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
             for sec in old_sections:
                 await db.delete(sec)
             await db.delete(agent.goal_template)
@@ -175,13 +198,15 @@ async def update_agent(
         db.add(goal)
         await db.flush()
         for i, sec in enumerate(req.goal_template.sections):
-            db.add(AgentGoalSection(
-                goal_template_id=goal.id,
-                name=sec.name,
-                description=sec.description,
-                grounding_required=sec.grounding_required,
-                order=i,
-            ))
+            db.add(
+                AgentGoalSection(
+                    goal_template_id=goal.id,
+                    name=sec.name,
+                    description=sec.description,
+                    grounding_required=sec.grounding_required,
+                    order=i,
+                )
+            )
 
     await db.commit()
     agent = await _load_agent(db, Agent.id == agent_id)
@@ -223,7 +248,11 @@ async def delete_agent(
         raise HTTPException(status_code=403, detail="Not authorized")
 
     # Delete related records with correct type filters
-    for r in (await db.execute(select(Feedback).where(Feedback.listing_id == agent_id, Feedback.listing_type == "agent"))).scalars().all():
+    for r in (
+        (await db.execute(select(Feedback).where(Feedback.listing_id == agent_id, Feedback.listing_type == "agent")))
+        .scalars()
+        .all()
+    ):
         await db.delete(r)
     for r in (await db.execute(select(Scorecard).where(Scorecard.agent_id == agent_id))).scalars().all():
         await db.delete(r)

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from datetime import UTC
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import func, select
@@ -33,9 +34,7 @@ async def mcp_metrics(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    dl_count = await db.scalar(
-        select(func.count(McpDownload.id)).where(McpDownload.listing_id == listing_id)
-    ) or 0
+    dl_count = await db.scalar(select(func.count(McpDownload.id)).where(McpDownload.listing_id == listing_id)) or 0
 
     rows = await _ch_json(
         "SELECT "
@@ -71,9 +70,7 @@ async def agent_metrics(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    dl_count = await db.scalar(
-        select(func.count(AgentDownload.id)).where(AgentDownload.agent_id == agent_id)
-    ) or 0
+    dl_count = await db.scalar(select(func.count(AgentDownload.id)).where(AgentDownload.agent_id == agent_id)) or 0
 
     rows = await _ch_json(
         "SELECT "
@@ -103,12 +100,10 @@ async def overview_stats(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    total_mcps = await db.scalar(
-        select(func.count(McpListing.id)).where(McpListing.status == ListingStatus.approved)
-    ) or 0
-    total_agents = await db.scalar(
-        select(func.count(Agent.id)).where(Agent.status == AgentStatus.active)
-    ) or 0
+    total_mcps = (
+        await db.scalar(select(func.count(McpListing.id)).where(McpListing.status == ListingStatus.approved)) or 0
+    )
+    total_agents = await db.scalar(select(func.count(Agent.id)).where(Agent.status == AgentStatus.active)) or 0
     total_users = await db.scalar(select(func.count(User.id))) or 0
 
     tool_rows = await _ch_json("SELECT count() as cnt FROM mcp_tool_calls WHERE timestamp > today()")
@@ -149,30 +144,30 @@ async def top_agents(db: AsyncSession = Depends(get_db), current_user: User = De
 
 @router.get("/overview/trends", response_model=list[TrendPoint])
 async def trends(db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)):
-    from datetime import timedelta, timezone, datetime as dt
+    from datetime import datetime as dt
+    from datetime import timedelta
 
-    now = dt.now(timezone.utc)
+    now = dt.now(UTC)
     start = now - timedelta(days=30)
 
     day_col_mcp = func.date_trunc("day", McpListing.created_at).label("day")
     mcp_rows = await db.execute(
         select(day_col_mcp, func.count(McpListing.id).label("cnt"))
         .where(McpListing.created_at >= start)
-        .group_by(day_col_mcp).order_by(day_col_mcp)
+        .group_by(day_col_mcp)
+        .order_by(day_col_mcp)
     )
 
     day_col_user = func.date_trunc("day", User.created_at).label("day")
     user_rows = await db.execute(
         select(day_col_user, func.count(User.id).label("cnt"))
         .where(User.created_at >= start)
-        .group_by(day_col_user).order_by(day_col_user)
+        .group_by(day_col_user)
+        .order_by(day_col_user)
     )
 
     submissions = {str(r.day.date()): r.cnt for r in mcp_rows.all()}
     users = {str(r.day.date()): r.cnt for r in user_rows.all()}
     all_dates = sorted(set(list(submissions.keys()) + list(users.keys())))
 
-    return [
-        TrendPoint(date=d, submissions=submissions.get(d, 0), users=users.get(d, 0))
-        for d in all_dates
-    ]
+    return [TrendPoint(date=d, submissions=submissions.get(d, 0), users=users.get(d, 0)) for d in all_dates]

--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
@@ -8,7 +8,7 @@ from sqlalchemy.orm import selectinload
 
 from api.deps import get_current_user, get_db
 from models.agent import Agent, AgentGoalTemplate
-from models.eval import EvalRun, EvalRunStatus, Scorecard, ScorecardDimension
+from models.eval import EvalRun, EvalRunStatus, Scorecard
 from models.user import User
 from schemas.eval import EvalRequest, EvalRunDetailResponse, EvalRunResponse, ScorecardResponse
 from services.eval_service import evaluate_trace, fetch_traces, parse_scorecard
@@ -28,7 +28,8 @@ async def run_evaluation(
 ):
     # Load agent with goal template
     result = await db.execute(
-        select(Agent).where(Agent.id == agent_id)
+        select(Agent)
+        .where(Agent.id == agent_id)
         .options(selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections))
     )
     agent = result.scalar_one_or_none()
@@ -46,7 +47,7 @@ async def run_evaluation(
     if not traces:
         eval_run.status = EvalRunStatus.completed
         eval_run.traces_evaluated = 0
-        eval_run.completed_at = datetime.now(timezone.utc)
+        eval_run.completed_at = datetime.now(UTC)
         await db.commit()
         run = await db.execute(select(EvalRun).where(EvalRun.id == eval_run.id).options(*_eval_run_load))
         return EvalRunDetailResponse.model_validate(run.scalar_one())
@@ -60,11 +61,11 @@ async def run_evaluation(
             eval_run.traces_evaluated += 1
 
         eval_run.status = EvalRunStatus.completed
-        eval_run.completed_at = datetime.now(timezone.utc)
+        eval_run.completed_at = datetime.now(UTC)
     except Exception as e:
         eval_run.status = EvalRunStatus.failed
         eval_run.error_message = str(e)[:2000]
-        eval_run.completed_at = datetime.now(timezone.utc)
+        eval_run.completed_at = datetime.now(UTC)
 
     await db.commit()
     run = await db.execute(select(EvalRun).where(EvalRun.id == eval_run.id).options(*_eval_run_load))
@@ -77,9 +78,7 @@ async def list_eval_runs(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    result = await db.execute(
-        select(EvalRun).where(EvalRun.agent_id == agent_id).order_by(EvalRun.started_at.desc())
-    )
+    result = await db.execute(select(EvalRun).where(EvalRun.agent_id == agent_id).order_by(EvalRun.started_at.desc()))
     return [EvalRunResponse.model_validate(r) for r in result.scalars().all()]
 
 
@@ -103,9 +102,7 @@ async def get_scorecard(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    result = await db.execute(
-        select(Scorecard).where(Scorecard.id == scorecard_id).options(*_scorecard_load)
-    )
+    result = await db.execute(select(Scorecard).where(Scorecard.id == scorecard_id).options(*_scorecard_load))
     sc = result.scalar_one_or_none()
     if not sc:
         raise HTTPException(status_code=404, detail="Scorecard not found")

--- a/observal-server/api/routes/feedback.py
+++ b/observal-server/api/routes/feedback.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import UTC
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select
@@ -41,23 +42,28 @@ async def create_feedback(
     await db.refresh(fb)
 
     # Dual-write: also insert into ClickHouse scores table
-    from datetime import datetime, timezone
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    from datetime import datetime
+
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     try:
-        await insert_scores([{
-            "score_id": str(fb.id),
-            "project_id": "default",
-            "mcp_id": str(req.listing_id) if req.listing_type == "mcp" else None,
-            "agent_id": str(req.listing_id) if req.listing_type == "agent" else None,
-            "user_id": str(current_user.id),
-            "name": "user_rating",
-            "source": "api",
-            "data_type": "numeric",
-            "value": float(req.rating),
-            "comment": req.comment,
-            "metadata": {"listing_type": req.listing_type},
-            "timestamp": now,
-        }])
+        await insert_scores(
+            [
+                {
+                    "score_id": str(fb.id),
+                    "project_id": "default",
+                    "mcp_id": str(req.listing_id) if req.listing_type == "mcp" else None,
+                    "agent_id": str(req.listing_id) if req.listing_type == "agent" else None,
+                    "user_id": str(current_user.id),
+                    "name": "user_rating",
+                    "source": "api",
+                    "data_type": "numeric",
+                    "value": float(req.rating),
+                    "comment": req.comment,
+                    "metadata": {"listing_type": req.listing_type},
+                    "timestamp": now,
+                }
+            ]
+        )
     except Exception:
         pass  # Don't fail the request if ClickHouse write fails
 
@@ -90,7 +96,9 @@ async def my_feedback_received(
     current_user: User = Depends(get_current_user),
 ):
     """Feedback received on listings submitted/created by the current user."""
-    mcp_ids = list((await db.execute(select(McpListing.id).where(McpListing.submitted_by == current_user.id))).scalars().all())
+    mcp_ids = list(
+        (await db.execute(select(McpListing.id).where(McpListing.submitted_by == current_user.id))).scalars().all()
+    )
     agent_ids = list((await db.execute(select(Agent.id).where(Agent.created_by == current_user.id))).scalars().all())
 
     all_ids = mcp_ids + agent_ids

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -128,7 +128,11 @@ async def delete_mcp(
         raise HTTPException(status_code=403, detail="Not authorized")
 
     # Delete related records with correct type filter
-    for r in (await db.execute(select(Feedback).where(Feedback.listing_id == listing_id, Feedback.listing_type == "mcp"))).scalars().all():
+    for r in (
+        (await db.execute(select(Feedback).where(Feedback.listing_id == listing_id, Feedback.listing_type == "mcp")))
+        .scalars()
+        .all()
+    ):
         await db.delete(r)
     for r in (await db.execute(select(McpDownload).where(McpDownload.listing_id == listing_id))).scalars().all():
         await db.delete(r)

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Header
 
@@ -36,7 +36,7 @@ async def ingest(
     """New ingestion endpoint for shim/proxy telemetry."""
     user_id = str(current_user.id)
     environment = x_observal_environment or "default"
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     ingested = 0
     errors = 0
 
@@ -45,25 +45,27 @@ async def ingest(
         try:
             rows = []
             for t in batch.traces:
-                rows.append({
-                    "trace_id": t.trace_id,
-                    "parent_trace_id": t.parent_trace_id,
-                    "project_id": DEFAULT_PROJECT,
-                    "mcp_id": t.mcp_id,
-                    "agent_id": t.agent_id,
-                    "user_id": user_id,
-                    "session_id": t.session_id,
-                    "ide": t.ide,
-                    "environment": environment,
-                    "start_time": t.start_time,
-                    "end_time": t.end_time,
-                    "trace_type": t.trace_type,
-                    "name": t.name,
-                    "metadata": t.metadata,
-                    "tags": t.tags,
-                    "input": t.input,
-                    "output": t.output,
-                })
+                rows.append(
+                    {
+                        "trace_id": t.trace_id,
+                        "parent_trace_id": t.parent_trace_id,
+                        "project_id": DEFAULT_PROJECT,
+                        "mcp_id": t.mcp_id,
+                        "agent_id": t.agent_id,
+                        "user_id": user_id,
+                        "session_id": t.session_id,
+                        "ide": t.ide,
+                        "environment": environment,
+                        "start_time": t.start_time,
+                        "end_time": t.end_time,
+                        "trace_type": t.trace_type,
+                        "name": t.name,
+                        "metadata": t.metadata,
+                        "tags": t.tags,
+                        "input": t.input,
+                        "output": t.output,
+                    }
+                )
             await insert_traces(rows)
             ingested += len(rows)
         except Exception:
@@ -75,42 +77,42 @@ async def ingest(
         try:
             rows = []
             for s in batch.spans:
-                rows.append({
-                    "span_id": s.span_id,
-                    "trace_id": s.trace_id,
-                    "parent_span_id": s.parent_span_id,
-                    "project_id": DEFAULT_PROJECT,
-                    "mcp_id": None,
-                    "agent_id": None,
-                    "user_id": user_id,
-                    "type": s.type,
-                    "name": s.name,
-                    "method": s.method,
-                    "input": s.input,
-                    "output": s.output,
-                    "error": s.error,
-                    "start_time": s.start_time,
-                    "end_time": s.end_time,
-                    "latency_ms": s.latency_ms,
-                    "status": s.status,
-                    "ide": s.ide,
-                    "environment": environment,
-                    "metadata": s.metadata,
-                    "token_count_input": s.token_count_input,
-                    "token_count_output": s.token_count_output,
-                    "token_count_total": s.token_count_total,
-                    "cost": s.cost,
-                    "cpu_ms": s.cpu_ms,
-                    "memory_mb": s.memory_mb,
-                    "hop_count": s.hop_count,
-                    "entities_retrieved": s.entities_retrieved,
-                    "relationships_used": s.relationships_used,
-                    "retry_count": s.retry_count,
-                    "tools_available": s.tools_available,
-                    "tool_schema_valid": (
-                        int(s.tool_schema_valid) if s.tool_schema_valid is not None else None
-                    ),
-                })
+                rows.append(
+                    {
+                        "span_id": s.span_id,
+                        "trace_id": s.trace_id,
+                        "parent_span_id": s.parent_span_id,
+                        "project_id": DEFAULT_PROJECT,
+                        "mcp_id": None,
+                        "agent_id": None,
+                        "user_id": user_id,
+                        "type": s.type,
+                        "name": s.name,
+                        "method": s.method,
+                        "input": s.input,
+                        "output": s.output,
+                        "error": s.error,
+                        "start_time": s.start_time,
+                        "end_time": s.end_time,
+                        "latency_ms": s.latency_ms,
+                        "status": s.status,
+                        "ide": s.ide,
+                        "environment": environment,
+                        "metadata": s.metadata,
+                        "token_count_input": s.token_count_input,
+                        "token_count_output": s.token_count_output,
+                        "token_count_total": s.token_count_total,
+                        "cost": s.cost,
+                        "cpu_ms": s.cpu_ms,
+                        "memory_mb": s.memory_mb,
+                        "hop_count": s.hop_count,
+                        "entities_retrieved": s.entities_retrieved,
+                        "relationships_used": s.relationships_used,
+                        "retry_count": s.retry_count,
+                        "tools_available": s.tools_available,
+                        "tool_schema_valid": (int(s.tool_schema_valid) if s.tool_schema_valid is not None else None),
+                    }
+                )
             await insert_spans(rows)
             ingested += len(rows)
         except Exception:
@@ -122,23 +124,25 @@ async def ingest(
         try:
             rows = []
             for sc in batch.scores:
-                rows.append({
-                    "score_id": sc.score_id,
-                    "trace_id": sc.trace_id,
-                    "span_id": sc.span_id,
-                    "project_id": DEFAULT_PROJECT,
-                    "mcp_id": sc.mcp_id,
-                    "agent_id": sc.agent_id,
-                    "user_id": user_id,
-                    "name": sc.name,
-                    "source": sc.source,
-                    "data_type": sc.data_type,
-                    "value": sc.value,
-                    "string_value": sc.string_value,
-                    "comment": sc.comment,
-                    "metadata": sc.metadata,
-                    "timestamp": now,
-                })
+                rows.append(
+                    {
+                        "score_id": sc.score_id,
+                        "trace_id": sc.trace_id,
+                        "span_id": sc.span_id,
+                        "project_id": DEFAULT_PROJECT,
+                        "mcp_id": sc.mcp_id,
+                        "agent_id": sc.agent_id,
+                        "user_id": user_id,
+                        "name": sc.name,
+                        "source": sc.source,
+                        "data_type": sc.data_type,
+                        "value": sc.value,
+                        "string_value": sc.string_value,
+                        "comment": sc.comment,
+                        "metadata": sc.metadata,
+                        "timestamp": now,
+                    }
+                )
             await insert_scores(rows)
             ingested += len(rows)
         except Exception:
@@ -153,43 +157,47 @@ async def ingest_events(
     batch: TelemetryBatch,
     current_user: User = Depends(get_current_user),
 ):
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     ingested = 0
     errors = 0
 
     for tc in batch.tool_calls:
         try:
-            await insert_tool_call({
-                "event_id": str(uuid.uuid4()),
-                "timestamp": now,
-                "mcp_server_id": tc.mcp_server_id,
-                "tool_name": tc.tool_name,
-                "input_params": tc.input_params,
-                "response": tc.response,
-                "latency_ms": tc.latency_ms,
-                "status": tc.status,
-                "user_action": tc.user_action,
-                "session_id": tc.session_id,
-                "user_id": str(current_user.id),
-                "ide": tc.ide,
-            })
+            await insert_tool_call(
+                {
+                    "event_id": str(uuid.uuid4()),
+                    "timestamp": now,
+                    "mcp_server_id": tc.mcp_server_id,
+                    "tool_name": tc.tool_name,
+                    "input_params": tc.input_params,
+                    "response": tc.response,
+                    "latency_ms": tc.latency_ms,
+                    "status": tc.status,
+                    "user_action": tc.user_action,
+                    "session_id": tc.session_id,
+                    "user_id": str(current_user.id),
+                    "ide": tc.ide,
+                }
+            )
             ingested += 1
         except Exception:
             errors += 1
 
     for ai in batch.agent_interactions:
         try:
-            await insert_agent_interaction({
-                "event_id": str(uuid.uuid4()),
-                "timestamp": now,
-                "agent_id": ai.agent_id,
-                "session_id": ai.session_id,
-                "tool_calls": ai.tool_calls,
-                "user_action": ai.user_action,
-                "latency_ms": ai.latency_ms,
-                "user_id": str(current_user.id),
-                "ide": ai.ide,
-            })
+            await insert_agent_interaction(
+                {
+                    "event_id": str(uuid.uuid4()),
+                    "timestamp": now,
+                    "agent_id": ai.agent_id,
+                    "session_id": ai.session_id,
+                    "tool_calls": ai.tool_calls,
+                    "user_action": ai.user_action,
+                    "latency_ms": ai.latency_ms,
+                    "user_id": str(current_user.id),
+                    "ide": ai.ide,
+                }
+            )
             ingested += 1
         except Exception:
             errors += 1

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -7,9 +7,9 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379"
     SECRET_KEY: str = "change-me-in-production"
     API_KEY_LENGTH: int = 32
-    EVAL_MODEL_URL: str = ""       # OpenAI-compatible endpoint (e.g., https://bedrock-runtime.us-east-1.amazonaws.com)
-    EVAL_MODEL_API_KEY: str = ""   # API key or empty for AWS credential chain
-    EVAL_MODEL_NAME: str = ""      # e.g., us.anthropic.claude-3-5-haiku-20241022-v1:0
+    EVAL_MODEL_URL: str = ""  # OpenAI-compatible endpoint (e.g., https://bedrock-runtime.us-east-1.amazonaws.com)
+    EVAL_MODEL_API_KEY: str = ""  # API key or empty for AWS credential chain
+    EVAL_MODEL_NAME: str = ""  # e.g., us.anthropic.claude-3-5-haiku-20241022-v1:0
     EVAL_MODEL_PROVIDER: str = ""  # "bedrock", "openai", or "" for auto-detect
     AWS_REGION: str = "us-east-1"
 

--- a/observal-server/models/__init__.py
+++ b/observal-server/models/__init__.py
@@ -1,29 +1,29 @@
+from models.agent import Agent, AgentDownload, AgentGoalSection, AgentGoalTemplate, AgentMcpLink, AgentStatus
 from models.base import Base
 from models.enterprise_config import EnterpriseConfig
 from models.eval import EvalRun, EvalRunStatus, Scorecard, ScorecardDimension
 from models.feedback import Feedback
 from models.mcp import McpCustomField, McpDownload, McpListing, McpValidationResult
 from models.user import User, UserRole
-from models.agent import Agent, AgentDownload, AgentGoalSection, AgentGoalTemplate, AgentMcpLink, AgentStatus
 
 __all__ = [
-    "Base",
-    "User",
-    "UserRole",
-    "EnterpriseConfig",
-    "McpListing",
-    "McpCustomField",
-    "McpDownload",
-    "McpValidationResult",
     "Agent",
-    "AgentMcpLink",
-    "AgentGoalTemplate",
-    "AgentGoalSection",
     "AgentDownload",
+    "AgentGoalSection",
+    "AgentGoalTemplate",
+    "AgentMcpLink",
     "AgentStatus",
-    "Feedback",
+    "Base",
+    "EnterpriseConfig",
     "EvalRun",
     "EvalRunStatus",
+    "Feedback",
+    "McpCustomField",
+    "McpDownload",
+    "McpListing",
+    "McpValidationResult",
     "Scorecard",
     "ScorecardDimension",
+    "User",
+    "UserRole",
 ]

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -1,8 +1,8 @@
 import enum
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -30,22 +30,28 @@ class Agent(Base):
     supported_ides: Mapped[list] = mapped_column(JSON, default=list)
     status: Mapped[AgentStatus] = mapped_column(Enum(AgentStatus), default=AgentStatus.active)
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
     )
 
-    mcp_links: Mapped[list["AgentMcpLink"]] = relationship(back_populates="agent", lazy="selectin", order_by="AgentMcpLink.order", cascade="all, delete-orphan")
-    goal_template: Mapped["AgentGoalTemplate | None"] = relationship(back_populates="agent", lazy="selectin", uselist=False, cascade="all, delete-orphan")
+    mcp_links: Mapped[list["AgentMcpLink"]] = relationship(
+        back_populates="agent", lazy="selectin", order_by="AgentMcpLink.order", cascade="all, delete-orphan"
+    )
+    goal_template: Mapped["AgentGoalTemplate | None"] = relationship(
+        back_populates="agent", lazy="selectin", uselist=False, cascade="all, delete-orphan"
+    )
 
 
 class AgentMcpLink(Base):
     __tablename__ = "agent_mcp_links"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
+    )
     mcp_listing_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("mcp_listings.id"), nullable=False)
     order: Mapped[int] = mapped_column(Integer, default=0)
 
@@ -57,18 +63,24 @@ class AgentGoalTemplate(Base):
     __tablename__ = "agent_goal_templates"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), unique=True, nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), unique=True, nullable=False
+    )
     description: Mapped[str] = mapped_column(Text, nullable=False)
 
     agent: Mapped["Agent"] = relationship(back_populates="goal_template")
-    sections: Mapped[list["AgentGoalSection"]] = relationship(back_populates="goal_template", lazy="selectin", order_by="AgentGoalSection.order", cascade="all, delete-orphan")
+    sections: Mapped[list["AgentGoalSection"]] = relationship(
+        back_populates="goal_template", lazy="selectin", order_by="AgentGoalSection.order", cascade="all, delete-orphan"
+    )
 
 
 class AgentGoalSection(Base):
     __tablename__ = "agent_goal_sections"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    goal_template_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agent_goal_templates.id", ondelete="CASCADE"), nullable=False)
+    goal_template_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agent_goal_templates.id", ondelete="CASCADE"), nullable=False
+    )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     grounding_required: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -84,8 +96,8 @@ class AgentDownload(Base):
     agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False)
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     ide: Mapped[str] = mapped_column(String(50), nullable=False)
-    downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
 
 # Need to import McpListing for the relationship in AgentMcpLink
-from models.mcp import McpListing  # noqa: E402
+from models.mcp import McpListing  # noqa: E402, TC001

--- a/observal-server/models/enterprise_config.py
+++ b/observal-server/models/enterprise_config.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from sqlalchemy import DateTime, String, Text
 from sqlalchemy.dialects.postgresql import UUID
@@ -16,6 +16,6 @@ class EnterpriseConfig(Base):
     value: Mapped[str] = mapped_column(Text, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
     )

--- a/observal-server/models/eval.py
+++ b/observal-server/models/eval.py
@@ -1,6 +1,6 @@
 import enum
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from sqlalchemy import DateTime, Enum, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSON, UUID
@@ -24,10 +24,12 @@ class EvalRun(Base):
     status: Mapped[EvalRunStatus] = mapped_column(Enum(EvalRunStatus), default=EvalRunStatus.running)
     traces_evaluated: Mapped[int] = mapped_column(Integer, default=0)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
-    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    scorecards: Mapped[list["Scorecard"]] = relationship(back_populates="eval_run", lazy="raise", cascade="all, delete-orphan")
+    scorecards: Mapped[list["Scorecard"]] = relationship(
+        back_populates="eval_run", lazy="raise", cascade="all, delete-orphan"
+    )
 
 
 class Scorecard(Base):
@@ -35,7 +37,9 @@ class Scorecard(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False)
-    eval_run_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("eval_runs.id", ondelete="CASCADE"), nullable=False)
+    eval_run_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("eval_runs.id", ondelete="CASCADE"), nullable=False
+    )
     trace_id: Mapped[str] = mapped_column(String(255), nullable=False)
     version: Mapped[str] = mapped_column(String(50), nullable=False)
     overall_score: Mapped[float] = mapped_column(Float, nullable=False)
@@ -43,17 +47,21 @@ class Scorecard(Base):
     recommendations: Mapped[str | None] = mapped_column(Text, nullable=True)
     bottleneck: Mapped[str | None] = mapped_column(String(255), nullable=True)
     raw_output: Mapped[dict | None] = mapped_column(JSON, nullable=True)
-    evaluated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    evaluated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
     eval_run: Mapped["EvalRun"] = relationship(back_populates="scorecards")
-    dimensions: Mapped[list["ScorecardDimension"]] = relationship(back_populates="scorecard", lazy="selectin", cascade="all, delete-orphan")
+    dimensions: Mapped[list["ScorecardDimension"]] = relationship(
+        back_populates="scorecard", lazy="selectin", cascade="all, delete-orphan"
+    )
 
 
 class ScorecardDimension(Base):
     __tablename__ = "scorecard_dimensions"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    scorecard_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("scorecards.id", ondelete="CASCADE"), nullable=False)
+    scorecard_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("scorecards.id", ondelete="CASCADE"), nullable=False
+    )
     dimension: Mapped[str] = mapped_column(String(100), nullable=False)
     score: Mapped[float] = mapped_column(Float, nullable=False)
     grade: Mapped[str] = mapped_column(String(2), nullable=False)

--- a/observal-server/models/feedback.py
+++ b/observal-server/models/feedback.py
@@ -1,7 +1,7 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, CheckConstraint
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -21,4 +21,4 @@ class Feedback(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     rating: Mapped[int] = mapped_column(Integer, nullable=False)
     comment: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -1,6 +1,6 @@
 import enum
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSON, UUID
@@ -31,15 +31,19 @@ class McpListing(Base):
     status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
     rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     submitted_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
     )
 
-    custom_fields: Mapped[list["McpCustomField"]] = relationship(back_populates="listing", lazy="selectin", cascade="all, delete-orphan")
-    validation_results: Mapped[list["McpValidationResult"]] = relationship(back_populates="listing", lazy="selectin", cascade="all, delete-orphan")
+    custom_fields: Mapped[list["McpCustomField"]] = relationship(
+        back_populates="listing", lazy="selectin", cascade="all, delete-orphan"
+    )
+    validation_results: Mapped[list["McpValidationResult"]] = relationship(
+        back_populates="listing", lazy="selectin", cascade="all, delete-orphan"
+    )
 
 
 class McpCustomField(Base):
@@ -60,7 +64,7 @@ class McpDownload(Base):
     listing_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("mcp_listings.id"), nullable=False)
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     ide: Mapped[str] = mapped_column(String(50), nullable=False)
-    downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
 
 class McpValidationResult(Base):
@@ -71,6 +75,6 @@ class McpValidationResult(Base):
     stage: Mapped[str] = mapped_column(String(100), nullable=False)
     passed: Mapped[bool] = mapped_column(Boolean, nullable=False)
     details: Mapped[str | None] = mapped_column(Text, nullable=True)
-    run_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    run_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
     listing: Mapped["McpListing"] = relationship(back_populates="validation_results")

--- a/observal-server/models/user.py
+++ b/observal-server/models/user.py
@@ -1,6 +1,6 @@
 import enum
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from sqlalchemy import DateTime, Enum, String
 from sqlalchemy.dialects.postgresql import UUID
@@ -23,4 +23,4 @@ class User(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.user)
     api_key_hash: Mapped[str] = mapped_column(String(64), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/observal-server/schemas/dashboard.py
+++ b/observal-server/schemas/dashboard.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime
 
 from pydantic import BaseModel
 

--- a/observal-server/schemas/telemetry.py
+++ b/observal-server/schemas/telemetry.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from pydantic import BaseModel
 
 

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -3,13 +3,13 @@ import re
 from models.agent import Agent
 from services.config_generator import generate_config
 
-_SAFE_NAME = re.compile(r'^[a-zA-Z0-9_-]+$')
+_SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def _sanitize_name(name: str) -> str:
     if _SAFE_NAME.match(name):
         return name
-    return re.sub(r'[^a-zA-Z0-9_-]', '-', name)
+    return re.sub(r"[^a-zA-Z0-9_-]", "-", name)
 
 
 def _inject_agent_id(mcp_config: dict, agent_id: str):
@@ -37,7 +37,7 @@ def generate_agent_config(agent: Agent, ide: str) -> dict:
             mcp_configs.update(cfg["mcpServers"])
 
     # External MCPs — wrap with shim
-    for ext in (agent.external_mcps or []):
+    for ext in agent.external_mcps or []:
         name = _sanitize_name(ext.get("name", ""))
         if not name:
             continue
@@ -48,11 +48,11 @@ def generate_agent_config(agent: Agent, ide: str) -> dict:
         env = ext.get("env", {})
         ext_mcp_id = ext.get("id", name)
 
-        shim_args = ["--mcp-id", ext_mcp_id, "--", cmd] + args
+        shim_args = ["--mcp-id", ext_mcp_id, "--", cmd, *args]
 
         if ide == "claude-code":
             mcp_configs[name] = {
-                "command": ["claude", "mcp", "add", name, "--", "observal-shim"] + shim_args,
+                "command": ["claude", "mcp", "add", name, "--", "observal-shim", *shim_args],
                 "type": "shell_command",
             }
         elif ide == "gemini-cli":
@@ -65,7 +65,8 @@ def generate_agent_config(agent: Agent, ide: str) -> dict:
 
     if ide == "claude-code":
         setup_commands = [
-            c.get("command", []) for c in mcp_configs.values()
+            c.get("command", [])
+            for c in mcp_configs.values()
             if isinstance(c, dict) and c.get("type") == "shell_command"
         ]
         return {

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from urllib.parse import urlparse
 
 import httpx
@@ -288,7 +288,7 @@ async def insert_agent_interaction(event: dict):
 
 def _now_ms() -> str:
     """Current UTC timestamp as ISO string with millisecond precision."""
-    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
 
 async def insert_traces(traces: list[dict]):
@@ -313,8 +313,7 @@ async def insert_traces(traces: list[dict]):
     sql = (
         "INSERT INTO traces (trace_id, parent_trace_id, project_id, mcp_id, agent_id, "
         "user_id, session_id, ide, environment, start_time, end_time, trace_type, name, "
-        "metadata, tags, input, output, created_at, event_ts, is_deleted) VALUES "
-        + ", ".join(rows)
+        "metadata, tags, input, output, created_at, event_ts, is_deleted) VALUES " + ", ".join(rows)
     )
     try:
         r = await _query(sql)
@@ -362,8 +361,7 @@ async def insert_spans(spans: list[dict]):
         "end_time, latency_ms, status, level, token_count_input, token_count_output, "
         "token_count_total, cost, cpu_ms, memory_mb, hop_count, entities_retrieved, "
         "relationships_used, retry_count, tools_available, tool_schema_valid, ide, "
-        "environment, metadata, created_at, event_ts, is_deleted) VALUES "
-        + ", ".join(rows)
+        "environment, metadata, created_at, event_ts, is_deleted) VALUES " + ", ".join(rows)
     )
     try:
         r = await _query(sql)
@@ -399,8 +397,7 @@ async def insert_scores(scores: list[dict]):
         "INSERT INTO scores (score_id, trace_id, span_id, project_id, mcp_id, agent_id, "
         "user_id, name, source, data_type, value, string_value, comment, "
         "eval_template_id, eval_config_id, eval_run_id, environment, metadata, "
-        "timestamp, created_at, event_ts, is_deleted) VALUES "
-        + ", ".join(rows)
+        "timestamp, created_at, event_ts, is_deleted) VALUES " + ", ".join(rows)
     )
     try:
         r = await _query(sql)
@@ -509,10 +506,7 @@ async def query_spans(
     if status:
         conditions.append(f"status = '{_escape(status)}'")
     where = " AND ".join(conditions)
-    sql = (
-        f"SELECT * FROM spans FINAL WHERE {where} "
-        f"ORDER BY start_time ASC LIMIT {int(limit)} FORMAT JSON"
-    )
+    sql = f"SELECT * FROM spans FINAL WHERE {where} ORDER BY start_time ASC LIMIT {int(limit)} FORMAT JSON"
     try:
         r = await _query(sql)
         r.raise_for_status()
@@ -558,10 +552,7 @@ async def query_scores(
     if name:
         conditions.append(f"name = '{_escape(name)}'")
     where = " AND ".join(conditions)
-    sql = (
-        f"SELECT * FROM scores FINAL WHERE {where} "
-        f"ORDER BY timestamp DESC LIMIT {int(limit)} FORMAT JSON"
-    )
+    sql = f"SELECT * FROM scores FINAL WHERE {where} ORDER BY timestamp DESC LIMIT {int(limit)} FORMAT JSON"
     try:
         r = await _query(sql)
         r.raise_for_status()

--- a/observal-server/services/config_generator.py
+++ b/observal-server/services/config_generator.py
@@ -2,13 +2,13 @@ import re
 
 from models.mcp import McpListing
 
-_SAFE_NAME = re.compile(r'^[a-zA-Z0-9_-]+$')
+_SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def _sanitize_name(name: str) -> str:
     if _SAFE_NAME.match(name):
         return name
-    return re.sub(r'[^a-zA-Z0-9_-]', '-', name)
+    return re.sub(r"[^a-zA-Z0-9_-]", "-", name)
 
 
 def generate_config(listing: McpListing, ide: str, proxy_port: int | None = None) -> dict:
@@ -30,7 +30,7 @@ def generate_config(listing: McpListing, ide: str, proxy_port: int | None = None
 
     if ide == "claude-code":
         return {
-            "command": ["claude", "mcp", "add", name, "--", "observal-shim"] + shim_args,
+            "command": ["claude", "mcp", "add", name, "--", "observal-shim", *shim_args],
             "type": "shell_command",
         }
     if ide == "gemini-cli":

--- a/observal-server/services/eval_engine.py
+++ b/observal-server/services/eval_engine.py
@@ -8,7 +8,7 @@ import json
 import logging
 import uuid
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import httpx
 
@@ -26,37 +26,37 @@ EVAL_TEMPLATES: dict[str, dict] = {
         "id": "tpl-tool-selection",
         "name": "Tool Selection Accuracy",
         "applies_to": "tool_call",
-        "prompt": "Given the user's goal and available tools, was the correct tool selected?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (wrong tool) to 1.0 (perfect selection). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+        "prompt": 'Given the user\'s goal and available tools, was the correct tool selected?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (wrong tool) to 1.0 (perfect selection). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
     },
     "tool_output_utility": {
         "id": "tpl-tool-utility",
         "name": "Tool Output Utility",
         "applies_to": "tool_call",
-        "prompt": "Did the tool's output advance the user's goal?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (useless) to 1.0 (essential). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+        "prompt": 'Did the tool\'s output advance the user\'s goal?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (useless) to 1.0 (essential). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
     },
     "reasoning_clarity": {
         "id": "tpl-reasoning",
         "name": "Reasoning Clarity",
         "applies_to": "reasoning_step",
-        "prompt": "Evaluate the logical soundness of this reasoning step.\nTrace: {trace}\nSpan: {span}\nScore 0.0 (incoherent) to 1.0 (clear and logical). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+        "prompt": 'Evaluate the logical soundness of this reasoning step.\nTrace: {trace}\nSpan: {span}\nScore 0.0 (incoherent) to 1.0 (clear and logical). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
     },
     "response_quality": {
         "id": "tpl-response-quality",
         "name": "Response Quality",
         "applies_to": "agent_turn",
-        "prompt": "Evaluate the overall quality of this agent response.\nTrace: {trace}\nSpan: {span}\nScore 0.0 (poor) to 1.0 (excellent). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+        "prompt": 'Evaluate the overall quality of this agent response.\nTrace: {trace}\nSpan: {span}\nScore 0.0 (poor) to 1.0 (excellent). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
     },
     "graph_faithfulness": {
         "id": "tpl-graph-faith",
         "name": "Graph Faithfulness",
         "applies_to": "graph_traverse",
-        "prompt": "Does the output contradict the knowledge graph relationships?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (contradicts graph) to 1.0 (faithful). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+        "prompt": 'Does the output contradict the knowledge graph relationships?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (contradicts graph) to 1.0 (faithful). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
     },
     "recall_accuracy": {
         "id": "tpl-recall",
         "name": "Recall Accuracy",
         "applies_to": "memory_retrieve",
-        "prompt": "Is the retrieved memory relevant to the current context?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (irrelevant) to 1.0 (highly relevant). Respond with JSON: {{\"score\": <float>, \"reason\": \"<brief>\"}}",
+        "prompt": 'Is the retrieved memory relevant to the current context?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (irrelevant) to 1.0 (highly relevant). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
     },
 }
 
@@ -124,6 +124,7 @@ async def _call_bedrock(prompt: str, model_id: str) -> dict:
 
     def _sync():
         import boto3
+
         client = boto3.client("bedrock-runtime", region_name=getattr(settings, "AWS_REGION", "us-east-1"))
         r = client.converse(
             modelId=model_id,
@@ -190,7 +191,7 @@ async def run_eval_on_trace(
     if not spans:
         return []
 
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     scores_to_insert = []
 
     for span in spans:
@@ -200,23 +201,25 @@ async def run_eval_on_trace(
                 continue
             try:
                 result = await backend.score(tpl, trace, span)
-                scores_to_insert.append({
-                    "score_id": str(uuid.uuid4()),
-                    "trace_id": trace_id,
-                    "span_id": span.get("span_id", ""),
-                    "project_id": project_id,
-                    "mcp_id": span.get("mcp_id"),
-                    "agent_id": agent_id,
-                    "user_id": trace.get("user_id", ""),
-                    "name": tpl_name,
-                    "source": "eval",
-                    "data_type": "numeric",
-                    "value": result.get("score", 0),
-                    "comment": result.get("reason", ""),
-                    "eval_template_id": tpl["id"],
-                    "metadata": {},
-                    "timestamp": now,
-                })
+                scores_to_insert.append(
+                    {
+                        "score_id": str(uuid.uuid4()),
+                        "trace_id": trace_id,
+                        "span_id": span.get("span_id", ""),
+                        "project_id": project_id,
+                        "mcp_id": span.get("mcp_id"),
+                        "agent_id": agent_id,
+                        "user_id": trace.get("user_id", ""),
+                        "name": tpl_name,
+                        "source": "eval",
+                        "data_type": "numeric",
+                        "value": result.get("score", 0),
+                        "comment": result.get("reason", ""),
+                        "eval_template_id": tpl["id"],
+                        "metadata": {},
+                        "timestamp": now,
+                    }
+                )
             except Exception as e:
                 logger.error(f"Eval template {tpl_name} failed on span {span.get('span_id')}: {e}")
 

--- a/observal-server/services/eval_service.py
+++ b/observal-server/services/eval_service.py
@@ -1,13 +1,12 @@
 import json
 import logging
 import uuid
-from datetime import datetime, timezone
 
 import httpx
 
 from config import settings
 from models.agent import Agent
-from models.eval import EvalRun, EvalRunStatus, Scorecard, ScorecardDimension
+from models.eval import Scorecard, ScorecardDimension
 from services.clickhouse import _query
 
 logger = logging.getLogger(__name__)
@@ -99,6 +98,7 @@ async def _call_bedrock(prompt: str, model_id: str) -> dict:
 
     def _sync_call():
         import boto3
+
         region = getattr(settings, "AWS_REGION", "us-east-1")
         client = boto3.client("bedrock-runtime", region_name=region)
         response = client.converse(
@@ -213,11 +213,13 @@ def parse_scorecard(result: dict, agent: Agent, eval_run_id: uuid.UUID, trace_id
     for dim_name in DIMENSIONS:
         dim_data = dims.get(dim_name, {})
         score = float(dim_data.get("score", 0))
-        sc.dimensions.append(ScorecardDimension(
-            dimension=dim_name,
-            score=score,
-            grade=_score_to_grade(score),
-            notes=dim_data.get("notes"),
-        ))
+        sc.dimensions.append(
+            ScorecardDimension(
+                dimension=dim_name,
+                score=score,
+                grade=_score_to_grade(score),
+                notes=dim_data.get("notes"),
+            )
+        )
 
     return sc

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -26,7 +26,12 @@ def _validate_git_url(url: str) -> str | None:
         return "URL has no hostname"
     # Block internal/private IPs
     hostname = parsed.hostname.lower()
-    if hostname in ("localhost", "127.0.0.1", "0.0.0.0", "::1") or hostname.startswith("10.") or hostname.startswith("192.168.") or hostname.startswith("172."):
+    if (
+        hostname in ("localhost", "127.0.0.1", "0.0.0.0", "::1")
+        or hostname.startswith("10.")
+        or hostname.startswith("192.168.")
+        or hostname.startswith("172.")
+    ):
         return "Internal/private URLs not allowed"
     return None
 
@@ -54,10 +59,14 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
     try:
         Repo.clone_from(listing.git_url, tmp_dir, depth=1)
     except Exception as e:
-        db.add(McpValidationResult(
-            listing_id=listing.id, stage="clone_and_inspect", passed=False,
-            details=f"Failed to clone repo: {e}",
-        ))
+        db.add(
+            McpValidationResult(
+                listing_id=listing.id,
+                stage="clone_and_inspect",
+                passed=False,
+                details=f"Failed to clone repo: {e}",
+            )
+        )
         await db.commit()
         return None
 
@@ -73,17 +82,25 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
             continue
 
     if not entry_point:
-        db.add(McpValidationResult(
-            listing_id=listing.id, stage="clone_and_inspect", passed=False,
-            details="No FastMCP server found. Expected FastMCP() or @mcp.server in a .py file.",
-        ))
+        db.add(
+            McpValidationResult(
+                listing_id=listing.id,
+                stage="clone_and_inspect",
+                passed=False,
+                details="No FastMCP server found. Expected FastMCP() or @mcp.server in a .py file.",
+            )
+        )
         await db.commit()
         return None
 
-    db.add(McpValidationResult(
-        listing_id=listing.id, stage="clone_and_inspect", passed=True,
-        details=f"Found FastMCP entry point: {entry_point.relative_to(tmp_dir)}",
-    ))
+    db.add(
+        McpValidationResult(
+            listing_id=listing.id,
+            stage="clone_and_inspect",
+            passed=True,
+            details=f"Found FastMCP entry point: {entry_point.relative_to(tmp_dir)}",
+        )
+    )
     await db.commit()
     return entry_point
 
@@ -95,27 +112,36 @@ async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_poin
     try:
         tree = ast.parse(entry_point.read_text(errors="ignore"))
     except SyntaxError as e:
-        db.add(McpValidationResult(
-            listing_id=listing.id, stage="manifest_validation", passed=False,
-            details=f"Syntax error in entry point: {e}",
-        ))
+        db.add(
+            McpValidationResult(
+                listing_id=listing.id,
+                stage="manifest_validation",
+                passed=False,
+                details=f"Syntax error in entry point: {e}",
+            )
+        )
         await db.commit()
         return
 
     # Extract server name from FastMCP() constructor
     server_name = None
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "FastMCP":
-            if node.args and isinstance(node.args[0], ast.Constant):
-                server_name = node.args[0].value
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "FastMCP"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            server_name = node.args[0].value
 
     # Find @mcp.tool decorated functions
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         is_tool = any(
-            (isinstance(d, ast.Attribute) and d.attr == "tool") or
-            (isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "tool")
+            (isinstance(d, ast.Attribute) and d.attr == "tool")
+            or (isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "tool")
             for d in node.decorator_list
         )
         if not is_tool:
@@ -125,11 +151,13 @@ async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_poin
         # Check params have type annotations (skip 'self' and 'return')
         untyped = [a.arg for a in node.args.args if a.arg != "self" and a.annotation is None]
 
-        tools_found.append({
-            "name": node.name,
-            "docstring": docstring[:100],
-            "has_types": len(untyped) == 0,
-        })
+        tools_found.append(
+            {
+                "name": node.name,
+                "docstring": docstring[:100],
+                "has_types": len(untyped) == 0,
+            }
+        )
 
         if len(docstring) < 20:
             issues.append(f"Tool '{node.name}' docstring too short ({len(docstring)} chars, need 20+)")
@@ -147,9 +175,14 @@ async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_poin
     if issues:
         details += "\nIssues:\n- " + "\n- ".join(issues)
 
-    db.add(McpValidationResult(
-        listing_id=listing.id, stage="manifest_validation", passed=passed, details=details,
-    ))
+    db.add(
+        McpValidationResult(
+            listing_id=listing.id,
+            stage="manifest_validation",
+            passed=passed,
+            details=details,
+        )
+    )
     await db.commit()
 
 
@@ -193,8 +226,8 @@ async def analyze_repo(git_url: str) -> dict:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             is_tool = any(
-                (isinstance(d, ast.Attribute) and d.attr == "tool") or
-                (isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "tool")
+                (isinstance(d, ast.Attribute) and d.attr == "tool")
+                or (isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "tool")
                 for d in node.decorator_list
             )
             if is_tool:

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -1,9 +1,7 @@
 """arq background worker for eval jobs and async tasks."""
 
-import json
 import logging
 
-from arq import create_pool
 from arq.connections import RedisSettings
 
 from config import settings
@@ -15,6 +13,7 @@ logger = logging.getLogger(__name__)
 def _redis_settings() -> RedisSettings:
     """Parse REDIS_URL into arq RedisSettings."""
     from urllib.parse import urlparse
+
     parsed = urlparse(settings.REDIS_URL)
     return RedisSettings(
         host=parsed.hostname or "localhost",
@@ -28,24 +27,32 @@ async def run_eval(ctx: dict, agent_id: str, trace_id: str | None = None):
     """Background job: run eval on an agent's traces."""
     logger.info(f"Running eval for agent={agent_id} trace={trace_id}")
     try:
-        from services.eval_engine import run_eval_on_trace
         from services.clickhouse import query_traces
+        from services.eval_engine import run_eval_on_trace
 
         if trace_id:
             scores = await run_eval_on_trace(agent_id, trace_id)
-            await publish(f"eval:{agent_id}", {
-                "agent_id": agent_id, "trace_id": trace_id,
-                "scores_written": len(scores),
-            })
+            await publish(
+                f"eval:{agent_id}",
+                {
+                    "agent_id": agent_id,
+                    "trace_id": trace_id,
+                    "scores_written": len(scores),
+                },
+            )
         else:
             traces = await query_traces("default", agent_id=agent_id, limit=20)
             for t in traces:
                 tid = t.get("trace_id", "")
                 scores = await run_eval_on_trace(agent_id, tid)
-                await publish(f"eval:{agent_id}", {
-                    "agent_id": agent_id, "trace_id": tid,
-                    "scores_written": len(scores),
-                })
+                await publish(
+                    f"eval:{agent_id}",
+                    {
+                        "agent_id": agent_id,
+                        "trace_id": tid,
+                        "scores_written": len(scores),
+                    },
+                )
     except Exception as e:
         logger.exception(f"Eval job failed: {e}")
 
@@ -60,6 +67,7 @@ async def shutdown(ctx: dict):
 
 class WorkerSettings:
     """arq worker configuration."""
+
     functions = [run_eval]
     on_startup = startup
     on_shutdown = shutdown

--- a/observal-web/eslint.config.js
+++ b/observal-web/eslint.config.js
@@ -1,0 +1,22 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+export default tseslint.config(
+  { ignores: ["dist"] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ["src/**/*.{ts,tsx}"],
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
+);

--- a/observal-web/package-lock.json
+++ b/observal-web/package-lock.json
@@ -17,10 +17,15 @@
         "urql": "^4.2.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "eslint": "^10.1.0",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.5.2",
         "typescript": "^5.6.0",
+        "typescript-eslint": "^8.58.0",
         "vite": "^6.0.0"
       }
     },
@@ -762,6 +767,186 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1214,10 +1399,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1239,6 +1438,249 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
+      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/type-utils": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
+      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
+      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@urql/core": {
@@ -1286,6 +1728,56 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
@@ -1297,6 +1789,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1374,6 +1879,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1398,6 +1918,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",
@@ -1458,6 +1985,222 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
+      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1475,6 +2218,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1501,6 +2295,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/graphql": {
       "version": "16.13.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
@@ -1522,6 +2329,73 @@
         "graphql": ">=0.11 <=16"
       }
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1542,6 +2416,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1555,6 +2450,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1563,6 +2498,22 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -1591,12 +2542,89 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1645,6 +2673,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -1783,6 +2831,29 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1810,6 +2881,32 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1822,6 +2919,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
+      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.0",
+        "@typescript-eslint/parser": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1853,6 +2974,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/urql": {
@@ -1944,11 +3075,37 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wonka": {
       "version": "6.3.6",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
       "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
       "license": "MIT"
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -1956,6 +3113,42 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   }
 }

--- a/observal-web/package.json
+++ b/observal-web/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@urql/exchange-graphcache": "^7.2.0",
@@ -18,10 +21,15 @@
     "urql": "^4.2.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "eslint": "^10.1.0",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
     "typescript": "^5.6.0",
+    "typescript-eslint": "^8.58.0",
     "vite": "^6.0.0"
   }
 }

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -1,8 +1,10 @@
 import time
+
 import httpx
 import typer
 from rich import print as rprint
 from rich.console import Console
+
 from observal_cli import config
 
 console = Console(stderr=True)
@@ -17,10 +19,7 @@ def _client() -> tuple[str, dict]:
 
 def _handle_error(e: httpx.HTTPStatusError):
     ct = e.response.headers.get("content-type", "")
-    if "application/json" in ct:
-        detail = e.response.json().get("detail", e.response.text)
-    else:
-        detail = e.response.text
+    detail = e.response.json().get("detail", e.response.text) if "application/json" in ct else e.response.text
     code = e.response.status_code
     if code == 401:
         rprint("[red]Authentication failed.[/red] Run [bold]observal login[/bold] to re-authenticate.")

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -1,8 +1,8 @@
 """Agent CLI commands."""
+
 from __future__ import annotations
 
 import json as _json
-from typing import Optional
 
 import typer
 from rich import print as rprint
@@ -11,7 +11,13 @@ from rich.tree import Tree
 
 from observal_cli import client, config
 from observal_cli.render import (
-    console, ide_tags, kv_panel, output_json, relative_time, spinner, status_badge,
+    console,
+    ide_tags,
+    kv_panel,
+    output_json,
+    relative_time,
+    spinner,
+    status_badge,
 )
 
 agent_app = typer.Typer(help="Agent registry commands")
@@ -19,11 +25,12 @@ agent_app = typer.Typer(help="Agent registry commands")
 
 @agent_app.command(name="create")
 def agent_create(
-    from_file: Optional[str] = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
+    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
 ):
     """Create a new agent (interactive or from file)."""
     if from_file:
         import json
+
         with open(from_file) as f:
             payload = json.load(f)
         with spinner("Creating agent..."):
@@ -79,7 +86,7 @@ def agent_create(
         if sec_name.lower() == "done":
             break
         sec_desc = typer.prompt(f"  Description for '{sec_name}'", default="")
-        grounding = typer.confirm(f"  Grounding required?", default=False)
+        grounding = typer.confirm("  Grounding required?", default=False)
         sections.append({"name": sec_name, "description": sec_desc, "grounding_required": grounding})
 
     if not sections:
@@ -87,24 +94,27 @@ def agent_create(
         raise typer.Exit(1)
 
     with spinner("Creating agent..."):
-        result = client.post("/api/v1/agents", {
-            "name": name,
-            "version": version,
-            "description": description,
-            "owner": owner,
-            "prompt": prompt_text,
-            "model_name": model_name,
-            "model_config_json": model_cfg,
-            "supported_ides": supported_ides,
-            "mcp_server_ids": mcp_ids,
-            "goal_template": {"description": goal_desc, "sections": sections},
-        })
+        result = client.post(
+            "/api/v1/agents",
+            {
+                "name": name,
+                "version": version,
+                "description": description,
+                "owner": owner,
+                "prompt": prompt_text,
+                "model_name": model_name,
+                "model_config_json": model_cfg,
+                "supported_ides": supported_ides,
+                "mcp_server_ids": mcp_ids,
+                "goal_template": {"description": goal_desc, "sections": sections},
+            },
+        )
     rprint(f"\n[green]✓ Agent created![/green] ID: [bold]{result['id']}[/bold]")
 
 
 @agent_app.command(name="list")
 def agent_list(
-    search: Optional[str] = typer.Option(None, "--search", "-s"),
+    search: str | None = typer.Option(None, "--search", "-s"),
     limit: int = typer.Option(50, "--limit", "-n"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
@@ -163,19 +173,21 @@ def agent_show(
         output_json(item)
         return
 
-    console.print(kv_panel(
-        f"{item['name']} v{item.get('version', '?')}",
-        [
-            ("Status", status_badge(item.get("status", ""))),
-            ("Model", f"[bold]{item.get('model_name', 'N/A')}[/bold]"),
-            ("Owner", item.get("owner", "N/A")),
-            ("Description", item.get("description", "")),
-            ("IDEs", ide_tags(item.get("supported_ides", []))),
-            ("Created", relative_time(item.get("created_at"))),
-            ("ID", f"[dim]{item['id']}[/dim]"),
-        ],
-        border_style="magenta",
-    ))
+    console.print(
+        kv_panel(
+            f"{item['name']} v{item.get('version', '?')}",
+            [
+                ("Status", status_badge(item.get("status", ""))),
+                ("Model", f"[bold]{item.get('model_name', 'N/A')}[/bold]"),
+                ("Owner", item.get("owner", "N/A")),
+                ("Description", item.get("description", "")),
+                ("IDEs", ide_tags(item.get("supported_ides", []))),
+                ("Created", relative_time(item.get("created_at"))),
+                ("ID", f"[dim]{item['id']}[/dim]"),
+            ],
+            border_style="magenta",
+        )
+    )
 
     # MCP links
     if item.get("mcp_links"):

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -1,4 +1,5 @@
 """Auth & config CLI commands."""
+
 from __future__ import annotations
 
 import json as _json
@@ -7,7 +8,7 @@ import httpx
 import typer
 from rich import print as rprint
 
-from observal_cli import config, client
+from observal_cli import client, config
 from observal_cli.render import console, kv_panel, spinner, status_badge
 
 config_app = typer.Typer(help="CLI configuration")
@@ -33,9 +34,9 @@ def register_auth(app: typer.Typer):
                 data = r.json()
             config.save({"server_url": server_url, "api_key": data["api_key"]})
             rprint(f"\n[green]✓ Initialized![/green] Config saved to [dim]{config.CONFIG_FILE}[/dim]")
-            rprint(f"\n[bold]Your API key:[/bold]")
+            rprint("\n[bold]Your API key:[/bold]")
             rprint(f"  {data['api_key']}")
-            rprint(f"\n[dim]Keep this safe — you'll need it to log in on other machines.[/dim]")
+            rprint("\n[dim]Keep this safe — you'll need it to log in on other machines.[/dim]")
         except httpx.ConnectError:
             rprint(f"[red]✗ Connection failed.[/red] Is the server running at {server_url}?")
             raise typer.Exit(1)
@@ -78,13 +79,19 @@ def register_auth(app: typer.Typer):
             user = client.get("/api/v1/auth/whoami")
         if output == "json":
             from observal_cli.render import output_json
+
             output_json(user)
             return
-        console.print(kv_panel(user["name"], [
-            ("Email", user["email"]),
-            ("Role", status_badge(user.get("role", "user"))),
-            ("ID", f"[dim]{user['id']}[/dim]"),
-        ]))
+        console.print(
+            kv_panel(
+                user["name"],
+                [
+                    ("Email", user["email"]),
+                    ("Role", status_badge(user.get("role", "user"))),
+                    ("ID", f"[dim]{user['id']}[/dim]"),
+                ],
+            )
+        )
 
     @app.command()
     def status():
@@ -100,12 +107,13 @@ def register_auth(app: typer.Typer):
             color = "green" if latency < 200 else "yellow" if latency < 1000 else "red"
             rprint(f"  Health:  [{color}]✓ ok[/{color}] ({latency:.0f}ms)")
         else:
-            rprint(f"  Health:  [red]✗ unreachable[/red]")
+            rprint("  Health:  [red]✗ unreachable[/red]")
 
     @app.command()
     def version():
         """Show CLI version."""
         from importlib.metadata import version as pkg_version
+
         try:
             v = pkg_version("observal-cli")
         except Exception:

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1,7 +1,6 @@
 """MCP server CLI commands."""
-from __future__ import annotations
 
-from typing import Optional
+from __future__ import annotations
 
 import typer
 from rich import print as rprint
@@ -9,8 +8,13 @@ from rich.table import Table
 
 from observal_cli import client, config
 from observal_cli.render import (
-    console, ide_tags, kv_panel, output_json, relative_time, spinner,
-    star_rating, status_badge,
+    console,
+    ide_tags,
+    kv_panel,
+    output_json,
+    relative_time,
+    spinner,
+    status_badge,
 )
 
 
@@ -40,9 +44,15 @@ def register_mcp(app: typer.Typer):
             rprint()
 
         _name = name or (prefill.get("name", "") if yes else typer.prompt("Name", default=prefill.get("name", "")))
-        _version = prefill.get("version", "0.1.0") if yes else typer.prompt("Version", default=prefill.get("version", "0.1.0"))
+        _version = (
+            prefill.get("version", "0.1.0") if yes else typer.prompt("Version", default=prefill.get("version", "0.1.0"))
+        )
         _category = category or ("general" if yes else typer.prompt("Category"))
-        _desc = prefill.get("description", "") if yes else typer.prompt("Description (min 100 chars)", default=prefill.get("description", ""))
+        _desc = (
+            prefill.get("description", "")
+            if yes
+            else typer.prompt("Description (min 100 chars)", default=prefill.get("description", ""))
+        )
         _owner = typer.prompt("Owner / Team") if not yes else "default"
 
         ide_choices = ["vscode", "cursor", "windsurf", "kiro", "claude_code", "gemini_cli"]
@@ -57,24 +67,27 @@ def register_mcp(app: typer.Typer):
         _changelog = "Initial release" if yes else typer.prompt("Changelog", default="Initial release")
 
         with spinner("Submitting..."):
-            result = client.post("/api/v1/mcps/submit", {
-                "git_url": git_url,
-                "name": _name,
-                "version": _version,
-                "category": _category,
-                "description": _desc,
-                "owner": _owner,
-                "supported_ides": supported_ides,
-                "setup_instructions": _setup,
-                "changelog": _changelog,
-            })
+            result = client.post(
+                "/api/v1/mcps/submit",
+                {
+                    "git_url": git_url,
+                    "name": _name,
+                    "version": _version,
+                    "category": _category,
+                    "description": _desc,
+                    "owner": _owner,
+                    "supported_ides": supported_ides,
+                    "setup_instructions": _setup,
+                    "changelog": _changelog,
+                },
+            )
         rprint(f"\n[green]✓ Submitted![/green] ID: [bold]{result['id']}[/bold]")
         rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
 
     @app.command(name="list")
     def list_mcps(
-        category: Optional[str] = typer.Option(None, "--category", "-c", help="Filter by category"),
-        search: Optional[str] = typer.Option(None, "--search", "-s", help="Search by name/description"),
+        category: str | None = typer.Option(None, "--category", "-c", help="Filter by category"),
+        search: str | None = typer.Option(None, "--search", "-s", help="Search by name/description"),
         limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
         sort: str = typer.Option("name", "--sort", help="Sort by: name, category, version"),
         output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
@@ -141,22 +154,24 @@ def register_mcp(app: typer.Typer):
             output_json(item)
             return
 
-        console.print(kv_panel(
-            f"{item['name']} v{item.get('version', '?')}",
-            [
-                ("Status", status_badge(item.get("status", ""))),
-                ("Category", item.get("category", "N/A")),
-                ("Owner", item.get("owner", "N/A")),
-                ("Description", item.get("description", "")),
-                ("IDEs", ide_tags(item.get("supported_ides", []))),
-                ("Git", f"[link={item.get('git_url', '')}]{item.get('git_url', 'N/A')}[/link]"),
-                ("Setup", item.get("setup_instructions") or "[dim]none[/dim]"),
-                ("Changelog", item.get("changelog") or "[dim]none[/dim]"),
-                ("Created", relative_time(item.get("created_at"))),
-                ("ID", f"[dim]{item['id']}[/dim]"),
-            ],
-            border_style="cyan",
-        ))
+        console.print(
+            kv_panel(
+                f"{item['name']} v{item.get('version', '?')}",
+                [
+                    ("Status", status_badge(item.get("status", ""))),
+                    ("Category", item.get("category", "N/A")),
+                    ("Owner", item.get("owner", "N/A")),
+                    ("Description", item.get("description", "")),
+                    ("IDEs", ide_tags(item.get("supported_ides", []))),
+                    ("Git", f"[link={item.get('git_url', '')}]{item.get('git_url', 'N/A')}[/link]"),
+                    ("Setup", item.get("setup_instructions") or "[dim]none[/dim]"),
+                    ("Changelog", item.get("changelog") or "[dim]none[/dim]"),
+                    ("Created", relative_time(item.get("created_at"))),
+                    ("ID", f"[dim]{item['id']}[/dim]"),
+                ],
+                border_style="cyan",
+            )
+        )
 
         if item.get("validation_results"):
             rprint("\n[bold]Validation:[/bold]")
@@ -172,6 +187,7 @@ def register_mcp(app: typer.Typer):
     ):
         """Get install config snippet for an MCP server."""
         import json as _json
+
         resolved = config.resolve_alias(mcp_id)
         with spinner(f"Generating {ide} config..."):
             result = client.post(f"/api/v1/mcps/{resolved}/install", {"ide": ide})
@@ -183,7 +199,7 @@ def register_mcp(app: typer.Typer):
 
         rprint(f"\n[bold]Config for {ide}:[/bold]\n")
         console.print_json(_json.dumps(snippet, indent=2))
-        rprint(f"\n[dim]Tip: Use --raw to pipe directly into a config file.[/dim]")
+        rprint("\n[dim]Tip: Use --raw to pipe directly into a config file.[/dim]")
 
     @app.command(name="delete")
     def delete_mcp(

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -1,19 +1,22 @@
 """Review, telemetry, dashboard, feedback, eval, admin, and trace CLI commands."""
+
 from __future__ import annotations
 
-import json as _json
 import time
-from typing import Optional
 
 import typer
 from rich import print as rprint
-from rich.bar import Bar
 from rich.table import Table
 
 from observal_cli import client, config
 from observal_cli.render import (
-    console, kv_panel, output_json, relative_time, spinner,
-    star_rating, status_badge,
+    console,
+    kv_panel,
+    output_json,
+    relative_time,
+    spinner,
+    star_rating,
+    status_badge,
 )
 
 # ── Review ───────────────────────────────────────────────
@@ -39,7 +42,13 @@ def review_list(output: str = typer.Option("table", "--output", "-o")):
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
-        table.add_row(str(i), item.get("name", ""), item.get("submitted_by", ""), status_badge(item.get("status", "")), str(item["id"])[:8] + "…")
+        table.add_row(
+            str(i),
+            item.get("name", ""),
+            item.get("submitted_by", ""),
+            status_badge(item.get("status", "")),
+            str(item["id"])[:8] + "…",
+        )
     console.print(table)
 
 
@@ -51,13 +60,18 @@ def review_show(review_id: str = typer.Argument(...), output: str = typer.Option
     if output == "json":
         output_json(item)
         return
-    console.print(kv_panel(item.get("name", "Review"), [
-        ("Status", status_badge(item.get("status", ""))),
-        ("Submitted By", item.get("submitted_by", "N/A")),
-        ("Git URL", item.get("git_url", "N/A")),
-        ("Description", item.get("description", "")),
-        ("ID", f"[dim]{item['id']}[/dim]"),
-    ]))
+    console.print(
+        kv_panel(
+            item.get("name", "Review"),
+            [
+                ("Status", status_badge(item.get("status", ""))),
+                ("Submitted By", item.get("submitted_by", "N/A")),
+                ("Git URL", item.get("git_url", "N/A")),
+                ("Description", item.get("description", "")),
+                ("ID", f"[dim]{item['id']}[/dim]"),
+            ],
+        )
+    )
 
 
 @review_app.command(name="approve")
@@ -98,19 +112,25 @@ def telemetry_status():
 def telemetry_test():
     """Send a test telemetry event."""
     with spinner("Sending test event..."):
-        result = client.post("/api/v1/telemetry/events", {
-            "tool_calls": [{
-                "mcp_server_id": "test-mcp",
-                "tool_name": "test_tool",
-                "status": "success",
-                "latency_ms": 42,
-                "ide": "test",
-            }],
-        })
+        result = client.post(
+            "/api/v1/telemetry/events",
+            {
+                "tool_calls": [
+                    {
+                        "mcp_server_id": "test-mcp",
+                        "tool_name": "test_tool",
+                        "status": "success",
+                        "latency_ms": 42,
+                        "ide": "test",
+                    }
+                ],
+            },
+        )
     rprint(f"[green]✓ Test event sent![/green] Ingested: {result.get('ingested', 0)}")
 
 
 # ── Dashboard ────────────────────────────────────────────
+
 
 def register_dashboard(app: typer.Typer):
 
@@ -148,10 +168,12 @@ def register_dashboard(app: typer.Typer):
                     return
                 total = data.get("total_interactions", 0)
                 rate = data.get("acceptance_rate") or 0
-                rprint(f"\n  [bold]Agent Metrics[/bold]")
+                rprint("\n  [bold]Agent Metrics[/bold]")
                 rprint(f"  Interactions:   {total}")
                 rprint(f"  Downloads:      {data.get('total_downloads', 0)}")
-                rprint(f"  Acceptance:     [{'green' if rate > 0.7 else 'yellow' if rate > 0.4 else 'red'}]{rate:.1%}[/]")
+                rprint(
+                    f"  Acceptance:     [{'green' if rate > 0.7 else 'yellow' if rate > 0.4 else 'red'}]{rate:.1%}[/]"
+                )
                 rprint(f"  Avg tool calls: {data.get('avg_tool_calls', 0)}")
                 rprint(f"  Avg latency:    {(data.get('avg_latency_ms') or 0):.0f}ms")
             else:
@@ -160,12 +182,16 @@ def register_dashboard(app: typer.Typer):
                     output_json(data)
                     return
                 err_rate = data.get("error_rate") or 0
-                rprint(f"\n  [bold]MCP Metrics[/bold]")
+                rprint("\n  [bold]MCP Metrics[/bold]")
                 rprint(f"  Downloads:  {data.get('total_downloads', 0)}")
                 rprint(f"  Total calls: {data.get('total_calls', 0)}")
-                rprint(f"  Error rate:  [{'red' if err_rate > 0.1 else 'yellow' if err_rate > 0.01 else 'green'}]{err_rate:.2%}[/]")
+                rprint(
+                    f"  Error rate:  [{'red' if err_rate > 0.1 else 'yellow' if err_rate > 0.01 else 'green'}]{err_rate:.2%}[/]"
+                )
                 rprint(f"  Avg latency: {(data.get('avg_latency_ms') or 0):.0f}ms")
-                rprint(f"  Latency p50/p90/p99: {data.get('p50_latency_ms', 0)}/{data.get('p90_latency_ms', 0)}/{data.get('p99_latency_ms', 0)}ms")
+                rprint(
+                    f"  Latency p50/p90/p99: {data.get('p50_latency_ms', 0)}/{data.get('p90_latency_ms', 0)}/{data.get('p99_latency_ms', 0)}ms"
+                )
             rprint()
 
         if watch:
@@ -210,6 +236,7 @@ def register_dashboard(app: typer.Typer):
 
 # ── Feedback ─────────────────────────────────────────────
 
+
 def register_feedback(app: typer.Typer):
 
     @app.command()
@@ -217,17 +244,20 @@ def register_feedback(app: typer.Typer):
         listing_id: str = typer.Argument(..., help="MCP or Agent ID, or @alias"),
         stars: int = typer.Option(..., "--stars", "-s", min=1, max=5, help="Rating 1-5"),
         listing_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
-        comment: Optional[str] = typer.Option(None, "--comment", "-c"),
+        comment: str | None = typer.Option(None, "--comment", "-c"),
     ):
         """Rate an MCP server or agent."""
         resolved = config.resolve_alias(listing_id)
         with spinner("Submitting rating..."):
-            client.post("/api/v1/feedback", {
-                "listing_id": resolved,
-                "listing_type": listing_type,
-                "rating": stars,
-                "comment": comment,
-            })
+            client.post(
+                "/api/v1/feedback",
+                {
+                    "listing_id": resolved,
+                    "listing_type": listing_type,
+                    "rating": stars,
+                    "comment": comment,
+                },
+            )
         rprint(f"[green]✓ Rated {star_rating(stars)}[/green]")
 
     @app.command()
@@ -268,7 +298,7 @@ eval_app = typer.Typer(help="Evaluation engine commands")
 @eval_app.command(name="run")
 def eval_run(
     agent_id: str = typer.Argument(..., help="Agent ID or @alias"),
-    trace_id: Optional[str] = typer.Option(None, "--trace"),
+    trace_id: str | None = typer.Option(None, "--trace"),
 ):
     """Run evaluation on an agent's traces."""
     resolved = config.resolve_alias(agent_id)
@@ -288,7 +318,7 @@ def eval_run(
 @eval_app.command(name="scorecards")
 def eval_scorecards(
     agent_id: str = typer.Argument(...),
-    version: Optional[str] = typer.Option(None, "--version", "-v"),
+    version: str | None = typer.Option(None, "--version", "-v"),
     output: str = typer.Option("table", "--output", "-o"),
 ):
     """List scorecards for an agent."""
@@ -343,15 +373,17 @@ def eval_show(
 
     score = sc.get("overall_score", 0)
     color = "green" if score >= 7 else "yellow" if score >= 4 else "red"
-    console.print(kv_panel(
-        f"Scorecard — {sc.get('overall_grade', '?')} ({score:.1f}/10)",
-        [
-            ("Bottleneck", sc.get("bottleneck", "N/A")),
-            ("Recommendations", sc.get("recommendations", "N/A")),
-            ("ID", f"[dim]{sc['id']}[/dim]"),
-        ],
-        border_style=color,
-    ))
+    console.print(
+        kv_panel(
+            f"Scorecard — {sc.get('overall_grade', '?')} ({score:.1f}/10)",
+            [
+                ("Bottleneck", sc.get("bottleneck", "N/A")),
+                ("Recommendations", sc.get("recommendations", "N/A")),
+                ("ID", f"[dim]{sc['id']}[/dim]"),
+            ],
+            border_style=color,
+        )
+    )
 
     dims = sc.get("dimensions", [])
     if dims:
@@ -383,7 +415,9 @@ def eval_compare(
     """Compare two agent versions."""
     resolved = config.resolve_alias(agent_id)
     with spinner("Comparing versions..."):
-        data = client.get(f"/api/v1/eval/agents/{resolved}/compare", params={"version_a": version_a, "version_b": version_b})
+        data = client.get(
+            f"/api/v1/eval/agents/{resolved}/compare", params={"version_a": version_a, "version_b": version_b}
+        )
 
     if output == "json":
         output_json(data)
@@ -395,7 +429,7 @@ def eval_compare(
     diff = sb - sa
     arrow = "[green]↑[/green]" if diff > 0 else "[red]↓[/red]" if diff < 0 else "→"
 
-    rprint(f"\n  [bold]Version Comparison[/bold]")
+    rprint("\n  [bold]Version Comparison[/bold]")
     rprint(f"  {a.get('version', '?'):>8}  →  {b.get('version', '?')}")
     rprint(f"  {sa:.1f}/10     {arrow}  {sb:.1f}/10  ({diff:+.1f})")
     rprint(f"  ({a.get('count', 0)} scorecards)    ({b.get('count', 0)} scorecards)")
@@ -453,19 +487,22 @@ def admin_users(output: str = typer.Option("table", "--output", "-o")):
     table.add_column("ID", style="dim", max_width=12)
     for i, u in enumerate(data, 1):
         role_color = "green" if u["role"] == "admin" else "cyan" if u["role"] == "developer" else "white"
-        table.add_row(str(i), u["email"], u["name"], f"[{role_color}]{u['role']}[/{role_color}]", str(u["id"])[:8] + "…")
+        table.add_row(
+            str(i), u["email"], u["name"], f"[{role_color}]{u['role']}[/{role_color}]", str(u["id"])[:8] + "…"
+        )
     console.print(table)
 
 
 # ── Traces ───────────────────────────────────────────────
 
+
 def register_traces(app: typer.Typer):
 
     @app.command()
     def traces(
-        trace_type: Optional[str] = typer.Option(None, "--type", "-t"),
-        mcp_id: Optional[str] = typer.Option(None, "--mcp"),
-        agent_id: Optional[str] = typer.Option(None, "--agent"),
+        trace_type: str | None = typer.Option(None, "--type", "-t"),
+        mcp_id: str | None = typer.Option(None, "--mcp"),
+        agent_id: str | None = typer.Option(None, "--agent"),
         limit: int = typer.Option(20, "--limit", "-n"),
         output: str = typer.Option("table", "--output", "-o"),
     ):
@@ -487,6 +524,7 @@ def register_traces(app: typer.Typer):
             }
         }"""
         import httpx
+
         cfg = config.get_or_exit()
         with spinner("Querying traces..."):
             try:
@@ -555,6 +593,7 @@ def register_traces(app: typer.Typer):
             }
         }"""
         import httpx
+
         cfg = config.get_or_exit()
         with spinner("Querying spans..."):
             try:
@@ -594,7 +633,11 @@ def register_traces(app: typer.Typer):
         table.add_column("Status")
         table.add_column("Schema")
         for i, s in enumerate(spans_data, 1):
-            schema = "[green]✓[/green]" if s.get("toolSchemaValid") is True else ("[red]✗[/red]" if s.get("toolSchemaValid") is False else "[dim]—[/dim]")
+            schema = (
+                "[green]✓[/green]"
+                if s.get("toolSchemaValid") is True
+                else ("[red]✗[/red]" if s.get("toolSchemaValid") is False else "[dim]—[/dim]")
+            )
             latency = f"{s['latencyMs']}ms" if s.get("latencyMs") else "—"
             st = s.get("status", "")
             st_display = f"[red]{st}[/red]" if st == "error" else f"[green]{st}[/green]" if st == "success" else st
@@ -613,19 +656,23 @@ def register_traces(app: typer.Typer):
 
 # ── Upgrade / Downgrade ──────────────────────────────────
 
+
 def register_lifecycle(app: typer.Typer):
 
     @app.command()
     def upgrade():
         """Upgrade observal CLI to the latest version."""
         import subprocess
+
         with spinner("Upgrading..."):
             result = subprocess.run(
                 ["uv", "tool", "upgrade", "observal-cli"],
-                capture_output=True, text=True, timeout=120,
+                capture_output=True,
+                text=True,
+                timeout=120,
             )
         if result.returncode == 0:
-            rprint(f"[green]✓ Upgraded![/green]")
+            rprint("[green]✓ Upgraded![/green]")
             if result.stdout.strip():
                 rprint(f"[dim]{result.stdout.strip()}[/dim]")
         else:

--- a/observal_cli/config.py
+++ b/observal_cli/config.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Any
 
 CONFIG_DIR = Path.home() / ".observal"
 CONFIG_FILE = CONFIG_DIR / "config.json"
@@ -32,12 +31,14 @@ def get_or_exit() -> dict:
     if not cfg.get("server_url") or not cfg.get("api_key"):
         import typer
         from rich import print as rprint
+
         rprint("[red]Not configured.[/red] Run [bold]observal init[/bold] or [bold]observal login[/bold] first.")
         raise typer.Exit(1)
     return cfg
 
 
 # ── Aliases ──────────────────────────────────────────────
+
 
 def load_aliases() -> dict[str, str]:
     if ALIASES_FILE.exists():
@@ -59,6 +60,7 @@ def resolve_alias(name: str) -> str:
             return resolved
         import typer
         from rich import print as rprint
+
         rprint(f"[red]Unknown alias: {name}[/red]")
         rprint(f"[dim]Set it with: observal config alias {name[1:]} <id>[/dim]")
         raise typer.Exit(1)

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -1,4 +1,5 @@
 """Observal CLI — MCP Server & Agent Registry."""
+
 import typer
 
 app = typer.Typer(
@@ -11,13 +12,18 @@ app = typer.Typer(
 
 # ── Register command groups ──────────────────────────────
 
+from observal_cli.cmd_agent import agent_app
 from observal_cli.cmd_auth import register_auth, register_config
 from observal_cli.cmd_mcp import register_mcp
-from observal_cli.cmd_agent import agent_app
 from observal_cli.cmd_ops import (
-    review_app, telemetry_app, eval_app, admin_app,
-    register_dashboard, register_feedback, register_traces,
+    admin_app,
+    eval_app,
+    register_dashboard,
+    register_feedback,
     register_lifecycle,
+    register_traces,
+    review_app,
+    telemetry_app,
 )
 
 register_auth(app)

--- a/observal_cli/proxy.py
+++ b/observal_cli/proxy.py
@@ -10,13 +10,11 @@ import logging
 import os
 import sys
 import time
-import uuid
-from datetime import datetime, timezone
 
 import httpx
 
 from observal_cli.config import load as load_config
-from observal_cli.shim import ShimState, extract_span_name, extract_span_type
+from observal_cli.shim import ShimState
 
 logger = logging.getLogger("observal-proxy")
 
@@ -37,7 +35,9 @@ class ProxyState(ShimState):
         self.target_url = target_url.rstrip("/")
 
 
-async def _handle_request(state: ProxyState, method: str, path: str, headers: dict, body: bytes) -> tuple[int, dict, bytes]:
+async def _handle_request(
+    state: ProxyState, method: str, path: str, headers: dict, body: bytes
+) -> tuple[int, dict, bytes]:
     """Forward a request to the target MCP server and capture telemetry."""
     url = f"{state.target_url}{path}"
 
@@ -118,7 +118,15 @@ async def run_proxy(mcp_id: str, target_url: str, port: int = 0):
             status, resp_headers, resp_body = await _handle_request(state, method, path, headers, body)
 
             # Write response
-            status_text = {200: "OK", 201: "Created", 204: "No Content", 400: "Bad Request", 404: "Not Found", 500: "Internal Server Error", 502: "Bad Gateway"}.get(status, "OK")
+            status_text = {
+                200: "OK",
+                201: "Created",
+                204: "No Content",
+                400: "Bad Request",
+                404: "Not Found",
+                500: "Internal Server Error",
+                502: "Bad Gateway",
+            }.get(status, "OK")
             writer.write(f"HTTP/1.1 {status} {status_text}\r\n".encode())
             resp_headers["content-length"] = str(len(resp_body))
             for k, v in resp_headers.items():

--- a/observal_cli/render.py
+++ b/observal_cli/render.py
@@ -1,16 +1,15 @@
 """Shared rendering helpers for the Observal CLI."""
+
 from __future__ import annotations
 
 import json as _json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
+from rich import print as rprint
 from rich.console import Console
 from rich.panel import Panel
-from rich.table import Table
-from rich.text import Text
-from rich.tree import Tree
-from rich import print as rprint
+from rich.table import Table  # noqa: TC002 - used at runtime
 
 console = Console()
 
@@ -34,12 +33,13 @@ def status_badge(status: str) -> str:
 
 # ── Relative time ────────────────────────────────────────
 
+
 def relative_time(iso: str | None) -> str:
     if not iso:
         return "—"
     try:
         dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         delta = now - dt
         secs = int(delta.total_seconds())
         if secs < 60:
@@ -58,11 +58,13 @@ def relative_time(iso: str | None) -> str:
 
 # ── Stars ────────────────────────────────────────────────
 
+
 def star_rating(n: int, max_stars: int = 5) -> str:
     return "[yellow]" + "★" * n + "[/yellow][dim]" + "☆" * (max_stars - n) + "[/dim]"
 
 
 # ── Output format dispatch ───────────────────────────────
+
 
 def output_json(data: Any):
     console.print_json(_json.dumps(data, default=str))
@@ -78,6 +80,7 @@ def output_plain(lines: list[str]):
 
 
 # ── Detail panels ────────────────────────────────────────
+
 
 def kv_panel(title: str, fields: list[tuple[str, str]], border_style: str = "blue") -> Panel:
     lines = []
@@ -109,6 +112,7 @@ def ide_tags(ides: list[str]) -> str:
 
 
 # ── Progress spinner context ─────────────────────────────
+
 
 def spinner(msg: str = "Loading..."):
     return console.status(f"[dim]{msg}[/dim]", spinner="dots")

--- a/observal_cli/shim.py
+++ b/observal_cli/shim.py
@@ -11,7 +11,7 @@ import os
 import sys
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import httpx
 
@@ -71,9 +71,7 @@ def extract_span_name(method: str, params: dict | None) -> str:
     return method or "unknown"
 
 
-def check_schema_compliance(
-    params: dict | None, tool_schemas: dict
-) -> tuple[int | None, int | None]:
+def check_schema_compliance(params: dict | None, tool_schemas: dict) -> tuple[int | None, int | None]:
     """Check if tool_call args match cached schema. Returns (tool_schema_valid, tools_available)."""
     if not tool_schemas:
         return None, None
@@ -114,7 +112,7 @@ class ShimState:
         self.session_id = os.environ.get("OBSERVAL_SESSION_ID", "")
         self.ide = os.environ.get("OBSERVAL_IDE", "")
         self.environment = os.environ.get("OBSERVAL_ENVIRONMENT", "default")
-        self.trace_start = datetime.now(timezone.utc)
+        self.trace_start = datetime.now(UTC)
 
         # Request tracking: id -> (method, params, start_time)
         self.pending: dict[str | int, tuple[str, dict | None, float]] = {}
@@ -124,7 +122,7 @@ class ShimState:
         self.lock = asyncio.Lock()
 
     def _now_iso(self) -> str:
-        return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
     def on_request(self, msg: dict):
         """Track an outgoing request for later pairing."""
@@ -149,17 +147,13 @@ class ShimState:
         # Cache tool schemas from tools/list response
         if method == "tools/list" and "result" in msg:
             tools = msg["result"].get("tools", [])
-            self.tool_schemas = {
-                t["name"]: t.get("inputSchema", {}) for t in tools if "name" in t
-            }
+            self.tool_schemas = {t["name"]: t.get("inputSchema", {}) for t in tools if "name" in t}
 
         # Schema compliance for tool_call
         tool_schema_valid = None
         tools_available = None
         if method == "tools/call":
-            tool_schema_valid, tools_available = check_schema_compliance(
-                params, self.tool_schemas
-            )
+            tool_schema_valid, tools_available = check_schema_compliance(params, self.tool_schemas)
 
         error_str = None
         status = "success"
@@ -206,19 +200,21 @@ class ShimState:
     async def _send(self, spans: list[dict]):
         """Fire-and-forget send to Observal server."""
         payload = {
-            "traces": [{
-                "trace_id": self.trace_id,
-                "parent_trace_id": self.parent_trace_id,
-                "trace_type": "mcp",
-                "mcp_id": self.mcp_id,
-                "agent_id": self.agent_id,
-                "session_id": self.session_id,
-                "ide": self.ide,
-                "name": f"shim:{self.mcp_id}",
-                "start_time": self.trace_start.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
-                "tags": [],
-                "metadata": {},
-            }],
+            "traces": [
+                {
+                    "trace_id": self.trace_id,
+                    "parent_trace_id": self.parent_trace_id,
+                    "trace_type": "mcp",
+                    "mcp_id": self.mcp_id,
+                    "agent_id": self.agent_id,
+                    "session_id": self.session_id,
+                    "ide": self.ide,
+                    "name": f"shim:{self.mcp_id}",
+                    "start_time": self.trace_start.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+                    "tags": [],
+                    "metadata": {},
+                }
+            ],
             "spans": spans,
             "scores": [],
         }
@@ -266,7 +262,7 @@ async def _read_messages(stream: asyncio.StreamReader) -> asyncio.Queue:
                 except json.JSONDecodeError:
                     pass  # skip malformed
 
-    asyncio.create_task(_reader())
+    _task = asyncio.create_task(_reader())  # noqa: RUF006 - fire-and-forget by design
     return queue
 
 
@@ -401,7 +397,7 @@ def main():
             mcp_id = args[i + 1]
             i += 2
         elif args[i] == "--":
-            command = args[i + 1:]
+            command = args[i + 1 :]
             break
         else:
             i += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,52 @@ observal-proxy = "observal_cli.proxy:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# ── Ruff ─────────────────────────────────────────────────
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+src = ["observal_cli", "observal-server", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort
+    "N",     # pep8-naming
+    "UP",    # pyupgrade
+    "B",     # flake8-bugbear
+    "SIM",   # flake8-simplify
+    "TCH",   # flake8-type-checking
+    "RUF",   # ruff-specific
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "B008",   # do not perform function calls in argument defaults (typer needs this)
+    "UP007",  # use X | Y for union (keep Optional for typer compat)
+    "N805",   # first argument of a method should be named self (pydantic validators)
+    "B904",   # raise from in except (too noisy for HTTPException patterns)
+    "SIM105", # contextlib.suppress (explicit try/except is clearer for us)
+    "UP042",  # str enum inheritance (needed for SQLAlchemy compatibility)
+    "RUF012", # mutable class defaults (pydantic/sqlalchemy models)
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["observal_cli", "models", "schemas", "services", "api"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["F841", "RUF059", "B007"]  # unused vars common in test assertions
+"observal_cli/main.py" = ["E402"]       # imports after app = typer.Typer()
+"demo/*" = ["E402"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+# ── Pytest ───────────────────────────────────────────────
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add server source to path so `from config import settings` works
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "observal-server"))

--- a/tests/mock_mcp.py
+++ b/tests/mock_mcp.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Minimal MCP server for testing the observal-shim."""
+
+import json
+import sys
+
+
+def respond(msg_id, result):
+    resp = json.dumps({"jsonrpc": "2.0", "id": msg_id, "result": result})
+    sys.stdout.write(resp + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    sys.stderr.write("mock-mcp: started\n")
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = msg.get("method", "")
+        msg_id = msg.get("id")
+
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mock-mcp", "version": "0.1.0"},
+                },
+            )
+        elif method == "tools/list":
+            respond(
+                msg_id,
+                {
+                    "tools": [
+                        {
+                            "name": "echo",
+                            "description": "Echo input back",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"text": {"type": "string"}},
+                                "required": ["text"],
+                            },
+                        },
+                        {
+                            "name": "add",
+                            "description": "Add two numbers",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
+                                "required": ["a", "b"],
+                            },
+                        },
+                    ]
+                },
+            )
+        elif method == "tools/call":
+            tool_name = msg.get("params", {}).get("name", "")
+            args = msg.get("params", {}).get("arguments", {})
+            if tool_name == "echo":
+                respond(msg_id, {"content": [{"type": "text", "text": args.get("text", "")}]})
+            elif tool_name == "add":
+                respond(msg_id, {"content": [{"type": "text", "text": str(args.get("a", 0) + args.get("b", 0))}]})
+            else:
+                sys.stdout.write(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": msg_id,
+                            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
+                        }
+                    )
+                    + "\n"
+                )
+                sys.stdout.flush()
+        elif method == "ping":
+            respond(msg_id, {})
+        else:
+            respond(msg_id, {})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_clickhouse_phase1.py
+++ b/tests/test_clickhouse_phase1.py
@@ -1,6 +1,5 @@
 """Unit tests for ClickHouse service — Phase 1 (traces, spans, scores)."""
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -23,7 +22,6 @@ from services.clickhouse import (
     query_trace_by_id,
     query_traces,
 )
-
 
 # --- Helper function tests ---
 
@@ -122,25 +120,66 @@ class TestInitSQL:
 
     def test_traces_columns(self):
         traces_ddl = INIT_SQL[2]
-        for col in ["trace_id", "parent_trace_id", "trace_type", "mcp_id",
-                     "agent_id", "user_id", "session_id", "ide", "environment",
-                     "start_time", "end_time", "event_ts", "is_deleted", "tags"]:
+        for col in [
+            "trace_id",
+            "parent_trace_id",
+            "trace_type",
+            "mcp_id",
+            "agent_id",
+            "user_id",
+            "session_id",
+            "ide",
+            "environment",
+            "start_time",
+            "end_time",
+            "event_ts",
+            "is_deleted",
+            "tags",
+        ]:
             assert col in traces_ddl
 
     def test_spans_columns(self):
         spans_ddl = INIT_SQL[3]
-        for col in ["span_id", "trace_id", "parent_span_id", "type", "name",
-                     "method", "input", "output", "error", "latency_ms", "status",
-                     "token_count_input", "token_count_output", "cost",
-                     "cpu_ms", "memory_mb", "hop_count", "entities_retrieved",
-                     "tool_schema_valid", "tools_available"]:
+        for col in [
+            "span_id",
+            "trace_id",
+            "parent_span_id",
+            "type",
+            "name",
+            "method",
+            "input",
+            "output",
+            "error",
+            "latency_ms",
+            "status",
+            "token_count_input",
+            "token_count_output",
+            "cost",
+            "cpu_ms",
+            "memory_mb",
+            "hop_count",
+            "entities_retrieved",
+            "tool_schema_valid",
+            "tools_available",
+        ]:
             assert col in spans_ddl
 
     def test_scores_columns(self):
         scores_ddl = INIT_SQL[4]
-        for col in ["score_id", "trace_id", "span_id", "name", "source",
-                     "data_type", "value", "string_value", "comment",
-                     "eval_template_id", "eval_config_id", "eval_run_id"]:
+        for col in [
+            "score_id",
+            "trace_id",
+            "span_id",
+            "name",
+            "source",
+            "data_type",
+            "value",
+            "string_value",
+            "comment",
+            "eval_template_id",
+            "eval_config_id",
+            "eval_run_id",
+        ]:
             assert col in scores_ddl
 
 
@@ -199,8 +238,7 @@ class TestInsertTraces:
     @pytest.mark.asyncio
     async def test_batch_traces(self):
         traces = [
-            {"trace_id": f"t{i}", "project_id": "p1", "user_id": "u1",
-             "start_time": "2026-01-01 00:00:00.000"}
+            {"trace_id": f"t{i}", "project_id": "p1", "user_id": "u1", "start_time": "2026-01-01 00:00:00.000"}
             for i in range(3)
         ]
         with patch("services.clickhouse._query", new_callable=AsyncMock) as mock_q:
@@ -216,10 +254,16 @@ class TestInsertTraces:
         with patch("services.clickhouse._query", new_callable=AsyncMock) as mock_q:
             mock_q.side_effect = Exception("connection refused")
             with pytest.raises(Exception, match="connection refused"):
-                await insert_traces([{
-                    "trace_id": "t1", "project_id": "p1", "user_id": "u1",
-                    "start_time": "2026-01-01 00:00:00.000",
-                }])
+                await insert_traces(
+                    [
+                        {
+                            "trace_id": "t1",
+                            "project_id": "p1",
+                            "user_id": "u1",
+                            "start_time": "2026-01-01 00:00:00.000",
+                        }
+                    ]
+                )
 
 
 class TestInsertSpans:
@@ -232,8 +276,12 @@ class TestInsertSpans:
     @pytest.mark.asyncio
     async def test_single_span(self):
         span = {
-            "span_id": "s1", "trace_id": "t1", "project_id": "p1",
-            "user_id": "u1", "type": "tool_call", "name": "my_tool",
+            "span_id": "s1",
+            "trace_id": "t1",
+            "project_id": "p1",
+            "user_id": "u1",
+            "type": "tool_call",
+            "name": "my_tool",
             "start_time": "2026-01-01 00:00:00.000",
         }
         with patch("services.clickhouse._query", new_callable=AsyncMock) as mock_q:
@@ -247,11 +295,17 @@ class TestInsertSpans:
     @pytest.mark.asyncio
     async def test_domain_specific_fields(self):
         span = {
-            "span_id": "s1", "trace_id": "t1", "project_id": "p1",
-            "user_id": "u1", "type": "graph_traverse", "name": "query",
+            "span_id": "s1",
+            "trace_id": "t1",
+            "project_id": "p1",
+            "user_id": "u1",
+            "type": "graph_traverse",
+            "name": "query",
             "start_time": "2026-01-01 00:00:00.000",
-            "hop_count": 3, "entities_retrieved": 12,
-            "relationships_used": 8, "tool_schema_valid": 1,
+            "hop_count": 3,
+            "entities_retrieved": 12,
+            "relationships_used": 8,
+            "tool_schema_valid": 1,
         }
         with patch("services.clickhouse._query", new_callable=AsyncMock) as mock_q:
             mock_q.return_value = _mock_response()
@@ -272,9 +326,14 @@ class TestInsertScores:
     @pytest.mark.asyncio
     async def test_single_score(self):
         score = {
-            "score_id": "sc1", "project_id": "p1", "user_id": "u1",
-            "name": "accuracy", "source": "eval", "data_type": "numeric",
-            "value": 0.95, "timestamp": "2026-01-01 00:00:00.000",
+            "score_id": "sc1",
+            "project_id": "p1",
+            "user_id": "u1",
+            "name": "accuracy",
+            "source": "eval",
+            "data_type": "numeric",
+            "value": 0.95,
+            "timestamp": "2026-01-01 00:00:00.000",
         }
         with patch("services.clickhouse._query", new_callable=AsyncMock) as mock_q:
             mock_q.return_value = _mock_response()

--- a/tests/test_eval_phase8.py
+++ b/tests/test_eval_phase8.py
@@ -6,7 +6,6 @@ import pytest
 
 from services.eval_engine import (
     EVAL_TEMPLATES,
-    EvalBackend,
     FallbackBackend,
     LLMJudgeBackend,
     _extract_json,
@@ -18,8 +17,14 @@ from services.eval_engine import (
 
 class TestEvalTemplates:
     def test_has_required_templates(self):
-        for name in ["tool_selection_accuracy", "tool_output_utility", "reasoning_clarity",
-                      "response_quality", "graph_faithfulness", "recall_accuracy"]:
+        for name in [
+            "tool_selection_accuracy",
+            "tool_output_utility",
+            "reasoning_clarity",
+            "response_quality",
+            "graph_faithfulness",
+            "recall_accuracy",
+        ]:
             assert name in EVAL_TEMPLATES
 
     def test_templates_have_required_fields(self):

--- a/tests/test_graphql_phase6.py
+++ b/tests/test_graphql_phase6.py
@@ -3,18 +3,10 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-import strawberry
 
 from api.graphql import (
-    McpMetrics,
-    OverviewStats,
     Query,
-    Score,
-    Span,
-    Trace,
     TraceConnection,
-    TraceMetrics,
-    TrendPoint,
     _load_scores_by_span_ids,
     _load_scores_by_trace_ids,
     _load_spans_by_trace_ids,
@@ -25,7 +17,6 @@ from api.graphql import (
     get_context,
     schema,
 )
-
 
 # --- Helpers ---
 
@@ -54,33 +45,65 @@ class TestRowToTrace:
         assert t.trace_type == "mcp"
 
     def test_full(self):
-        t = _row_to_trace({
-            "trace_id": "t1", "parent_trace_id": "p1", "trace_type": "agent",
-            "mcp_id": "m1", "agent_id": "a1", "user_id": "u1",
-            "session_id": "s1", "ide": "cursor", "name": "test",
-            "start_time": "2026-01-01", "end_time": "2026-01-02",
-            "tags": ["a", "b"], "metadata": {"k": "v"},
-        })
+        t = _row_to_trace(
+            {
+                "trace_id": "t1",
+                "parent_trace_id": "p1",
+                "trace_type": "agent",
+                "mcp_id": "m1",
+                "agent_id": "a1",
+                "user_id": "u1",
+                "session_id": "s1",
+                "ide": "cursor",
+                "name": "test",
+                "start_time": "2026-01-01",
+                "end_time": "2026-01-02",
+                "tags": ["a", "b"],
+                "metadata": {"k": "v"},
+            }
+        )
         assert t.parent_trace_id == "p1"
         assert t.tags == ["a", "b"]
 
 
 class TestRowToSpan:
     def test_minimal(self):
-        s = _row_to_span({"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"})
+        s = _row_to_span(
+            {"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"}
+        )
         assert s.type == "tool_call"
         assert s.status == "success"
 
     def test_tool_schema_valid(self):
-        s = _row_to_span({"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01", "tool_schema_valid": "1"})
+        s = _row_to_span(
+            {
+                "span_id": "s1",
+                "trace_id": "t1",
+                "type": "tool_call",
+                "name": "x",
+                "start_time": "2026-01-01",
+                "tool_schema_valid": "1",
+            }
+        )
         assert s.tool_schema_valid is True
 
     def test_tool_schema_invalid(self):
-        s = _row_to_span({"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01", "tool_schema_valid": "0"})
+        s = _row_to_span(
+            {
+                "span_id": "s1",
+                "trace_id": "t1",
+                "type": "tool_call",
+                "name": "x",
+                "start_time": "2026-01-01",
+                "tool_schema_valid": "0",
+            }
+        )
         assert s.tool_schema_valid is False
 
     def test_nullable_fields(self):
-        s = _row_to_span({"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"})
+        s = _row_to_span(
+            {"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"}
+        )
         assert s.latency_ms is None
         assert s.cost is None
         assert s.tool_schema_valid is None
@@ -88,7 +111,9 @@ class TestRowToSpan:
 
 class TestRowToScore:
     def test_basic(self):
-        sc = _row_to_score({"score_id": "sc1", "name": "acc", "source": "eval", "value": "0.95", "timestamp": "2026-01-01"})
+        sc = _row_to_score(
+            {"score_id": "sc1", "name": "acc", "source": "eval", "value": "0.95", "timestamp": "2026-01-01"}
+        )
         assert sc.value == 0.95
         assert sc.source == "eval"
 
@@ -171,7 +196,11 @@ class TestQueryResolvers:
 
     @pytest.mark.asyncio
     async def test_trace_by_id(self):
-        with patch("api.graphql.query_trace_by_id", new_callable=AsyncMock, return_value={"trace_id": "t1", "user_id": "u1", "start_time": "2026-01-01"}):
+        with patch(
+            "api.graphql.query_trace_by_id",
+            new_callable=AsyncMock,
+            return_value={"trace_id": "t1", "user_id": "u1", "start_time": "2026-01-01"},
+        ):
             q = Query()
             result = await q.trace(info=None, trace_id="t1")
             assert result.trace_id == "t1"
@@ -185,14 +214,36 @@ class TestQueryResolvers:
 
     @pytest.mark.asyncio
     async def test_span_by_id(self):
-        with patch("api.graphql.query_span_by_id", new_callable=AsyncMock, return_value={"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01"}):
+        with patch(
+            "api.graphql.query_span_by_id",
+            new_callable=AsyncMock,
+            return_value={
+                "span_id": "s1",
+                "trace_id": "t1",
+                "type": "tool_call",
+                "name": "x",
+                "start_time": "2026-01-01",
+            },
+        ):
             q = Query()
             result = await q.span(info=None, span_id="s1")
             assert result.span_id == "s1"
 
     @pytest.mark.asyncio
     async def test_mcp_metrics(self):
-        mock_rows = [{"cnt": "100", "errs": "5", "timeouts": "2", "avg_lat": "50.5", "p50": "40", "p90": "80", "p99": "150", "schema_ok": "90", "schema_total": "95"}]
+        mock_rows = [
+            {
+                "cnt": "100",
+                "errs": "5",
+                "timeouts": "2",
+                "avg_lat": "50.5",
+                "p50": "40",
+                "p90": "80",
+                "p99": "150",
+                "schema_ok": "90",
+                "schema_total": "95",
+            }
+        ]
         with patch("api.graphql._ch_json", new_callable=AsyncMock, return_value=mock_rows):
             q = Query()
             result = await q.mcp_metrics(mcp_id="m1", start="2026-01-01", end="2026-02-01")
@@ -201,10 +252,14 @@ class TestQueryResolvers:
 
     @pytest.mark.asyncio
     async def test_overview(self):
-        with patch("api.graphql._ch_json", new_callable=AsyncMock, side_effect=[
-            [{"traces": "500"}],
-            [{"spans": "2000", "tools": "1500", "errs": "50"}],
-        ]):
+        with patch(
+            "api.graphql._ch_json",
+            new_callable=AsyncMock,
+            side_effect=[
+                [{"traces": "500"}],
+                [{"spans": "2000", "tools": "1500", "errs": "50"}],
+            ],
+        ):
             q = Query()
             result = await q.overview(start="2026-01-01", end="2026-02-01")
             assert result.total_traces == 500
@@ -217,6 +272,7 @@ class TestQueryResolvers:
 class TestMainIntegration:
     def test_dashboard_router_removed(self):
         from main import app
+
         paths = [r.path for r in app.routes]
         # Old dashboard endpoints should not exist
         assert "/api/v1/overview/stats" not in paths
@@ -224,5 +280,6 @@ class TestMainIntegration:
 
     def test_graphql_mounted(self):
         from main import app
+
         paths = [r.path for r in app.routes]
         assert "/api/v1/graphql" in paths

--- a/tests/test_ingest_phase2.py
+++ b/tests/test_ingest_phase2.py
@@ -4,11 +4,11 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from httpx import ASGITransport, AsyncClient
 
 # We need to test the route handler logic. Build a minimal FastAPI app
 # that mounts just the telemetry router with auth mocked out.
 from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
 from api.routes.telemetry import router
 from models.user import User
@@ -47,6 +47,7 @@ def app(user):
 class TestIngestSchemas:
     def test_trace_ingest_minimal(self):
         from schemas.telemetry import TraceIngest
+
         t = TraceIngest(trace_id="t1", start_time="2026-01-01 00:00:00.000")
         assert t.trace_type == "mcp"
         assert t.tags == []
@@ -54,31 +55,42 @@ class TestIngestSchemas:
 
     def test_span_ingest_minimal(self):
         from schemas.telemetry import SpanIngest
+
         s = SpanIngest(
-            span_id="s1", trace_id="t1", type="tool_call",
-            name="my_tool", start_time="2026-01-01 00:00:00.000",
+            span_id="s1",
+            trace_id="t1",
+            type="tool_call",
+            name="my_tool",
+            start_time="2026-01-01 00:00:00.000",
         )
         assert s.status == "success"
         assert s.tool_schema_valid is None
 
     def test_score_ingest_minimal(self):
         from schemas.telemetry import ScoreIngest
+
         sc = ScoreIngest(score_id="sc1", name="accuracy", value=0.9)
         assert sc.source == "api"
         assert sc.data_type == "numeric"
 
     def test_ingest_batch_empty(self):
         from schemas.telemetry import IngestBatch
+
         b = IngestBatch()
         assert b.traces == []
         assert b.spans == []
         assert b.scores == []
 
     def test_ingest_batch_full(self):
-        from schemas.telemetry import IngestBatch, TraceIngest, SpanIngest, ScoreIngest
+        from schemas.telemetry import IngestBatch, ScoreIngest, SpanIngest, TraceIngest
+
         b = IngestBatch(
             traces=[TraceIngest(trace_id="t1", start_time="2026-01-01 00:00:00.000")],
-            spans=[SpanIngest(span_id="s1", trace_id="t1", type="tool_call", name="x", start_time="2026-01-01 00:00:00.000")],
+            spans=[
+                SpanIngest(
+                    span_id="s1", trace_id="t1", type="tool_call", name="x", start_time="2026-01-01 00:00:00.000"
+                )
+            ],
             scores=[ScoreIngest(score_id="sc1", name="acc", value=1.0)],
         )
         assert len(b.traces) == 1
@@ -101,12 +113,15 @@ class TestIngestEndpoint:
     async def test_ingest_traces(self, app):
         with patch("api.routes.telemetry.insert_traces", new_callable=AsyncMock) as mock_ins:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/telemetry/ingest", json={
-                    "traces": [
-                        {"trace_id": "t1", "start_time": "2026-01-01 00:00:00.000"},
-                        {"trace_id": "t2", "start_time": "2026-01-01 00:00:01.000"},
-                    ]
-                })
+                r = await ac.post(
+                    "/api/v1/telemetry/ingest",
+                    json={
+                        "traces": [
+                            {"trace_id": "t1", "start_time": "2026-01-01 00:00:00.000"},
+                            {"trace_id": "t2", "start_time": "2026-01-01 00:00:01.000"},
+                        ]
+                    },
+                )
             assert r.status_code == 200
             assert r.json()["ingested"] == 2
             assert r.json()["errors"] == 0
@@ -122,12 +137,20 @@ class TestIngestEndpoint:
     async def test_ingest_spans(self, app):
         with patch("api.routes.telemetry.insert_spans", new_callable=AsyncMock) as mock_ins:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/telemetry/ingest", json={
-                    "spans": [{
-                        "span_id": "s1", "trace_id": "t1", "type": "tool_call",
-                        "name": "my_tool", "start_time": "2026-01-01 00:00:00.000",
-                    }]
-                })
+                r = await ac.post(
+                    "/api/v1/telemetry/ingest",
+                    json={
+                        "spans": [
+                            {
+                                "span_id": "s1",
+                                "trace_id": "t1",
+                                "type": "tool_call",
+                                "name": "my_tool",
+                                "start_time": "2026-01-01 00:00:00.000",
+                            }
+                        ]
+                    },
+                )
             assert r.status_code == 200
             assert r.json()["ingested"] == 1
             rows = mock_ins.call_args[0][0]
@@ -137,12 +160,19 @@ class TestIngestEndpoint:
     async def test_ingest_scores(self, app):
         with patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as mock_ins:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/telemetry/ingest", json={
-                    "scores": [{
-                        "score_id": "sc1", "name": "accuracy",
-                        "value": 0.95, "source": "eval",
-                    }]
-                })
+                r = await ac.post(
+                    "/api/v1/telemetry/ingest",
+                    json={
+                        "scores": [
+                            {
+                                "score_id": "sc1",
+                                "name": "accuracy",
+                                "value": 0.95,
+                                "source": "eval",
+                            }
+                        ]
+                    },
+                )
             assert r.status_code == 200
             assert r.json()["ingested"] == 1
             rows = mock_ins.call_args[0][0]
@@ -159,11 +189,22 @@ class TestIngestEndpoint:
             patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock),
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/telemetry/ingest", json={
-                    "traces": [{"trace_id": "t1", "start_time": "2026-01-01 00:00:00.000"}],
-                    "spans": [{"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01 00:00:00.000"}],
-                    "scores": [{"score_id": "sc1", "name": "acc", "value": 1.0}],
-                })
+                r = await ac.post(
+                    "/api/v1/telemetry/ingest",
+                    json={
+                        "traces": [{"trace_id": "t1", "start_time": "2026-01-01 00:00:00.000"}],
+                        "spans": [
+                            {
+                                "span_id": "s1",
+                                "trace_id": "t1",
+                                "type": "tool_call",
+                                "name": "x",
+                                "start_time": "2026-01-01 00:00:00.000",
+                            }
+                        ],
+                        "scores": [{"score_id": "sc1", "name": "acc", "value": 1.0}],
+                    },
+                )
             assert r.json() == {"ingested": 3, "errors": 0}
 
     @pytest.mark.asyncio
@@ -173,10 +214,21 @@ class TestIngestEndpoint:
             patch("api.routes.telemetry.insert_spans", new_callable=AsyncMock) as mock_spans,
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/telemetry/ingest", json={
-                    "traces": [{"trace_id": "t1", "start_time": "2026-01-01 00:00:00.000"}],
-                    "spans": [{"span_id": "s1", "trace_id": "t1", "type": "tool_call", "name": "x", "start_time": "2026-01-01 00:00:00.000"}],
-                })
+                r = await ac.post(
+                    "/api/v1/telemetry/ingest",
+                    json={
+                        "traces": [{"trace_id": "t1", "start_time": "2026-01-01 00:00:00.000"}],
+                        "spans": [
+                            {
+                                "span_id": "s1",
+                                "trace_id": "t1",
+                                "type": "tool_call",
+                                "name": "x",
+                                "start_time": "2026-01-01 00:00:00.000",
+                            }
+                        ],
+                    },
+                )
             data = r.json()
             assert data["errors"] == 1  # trace failed
             assert data["ingested"] == 1  # span succeeded
@@ -198,22 +250,33 @@ class TestIngestEndpoint:
     async def test_tool_schema_valid_bool_to_int(self, app):
         with patch("api.routes.telemetry.insert_spans", new_callable=AsyncMock) as mock_ins:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/telemetry/ingest", json={
-                    "spans": [{
-                        "span_id": "s1", "trace_id": "t1", "type": "tool_call",
-                        "name": "x", "start_time": "2026-01-01 00:00:00.000",
-                        "tool_schema_valid": True,
-                    }]
-                })
+                r = await ac.post(
+                    "/api/v1/telemetry/ingest",
+                    json={
+                        "spans": [
+                            {
+                                "span_id": "s1",
+                                "trace_id": "t1",
+                                "type": "tool_call",
+                                "name": "x",
+                                "start_time": "2026-01-01 00:00:00.000",
+                                "tool_schema_valid": True,
+                            }
+                        ]
+                    },
+                )
             rows = mock_ins.call_args[0][0]
             assert rows[0]["tool_schema_valid"] == 1  # bool → int for ClickHouse UInt8
 
     @pytest.mark.asyncio
     async def test_validation_error_returns_422(self, app):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-            r = await ac.post("/api/v1/telemetry/ingest", json={
-                "spans": [{"span_id": "s1"}]  # missing required fields
-            })
+            r = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "spans": [{"span_id": "s1"}]  # missing required fields
+                },
+            )
         assert r.status_code == 422
 
 

--- a/tests/test_phase9_10.py
+++ b/tests/test_phase9_10.py
@@ -4,13 +4,12 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
-from api.routes.feedback import router as feedback_router
 from api.deps import get_current_user, get_db
+from api.routes.feedback import router as feedback_router
 from models.user import User
-
 
 # --- Phase 9: Score Unification ---
 
@@ -31,7 +30,9 @@ def _make_app(user):
     mock_db.scalar = AsyncMock(return_value=uuid.uuid4())  # listing exists
     mock_db.add = MagicMock()
     mock_db.commit = AsyncMock()
-    mock_db.refresh = AsyncMock(side_effect=lambda fb: setattr(fb, 'id', uuid.uuid4()) or setattr(fb, 'created_at', '2026-01-01'))
+    mock_db.refresh = AsyncMock(
+        side_effect=lambda fb: setattr(fb, "id", uuid.uuid4()) or setattr(fb, "created_at", "2026-01-01")
+    )
     app.dependency_overrides[get_db] = lambda: mock_db
     return app
 
@@ -45,12 +46,15 @@ class TestFeedbackDualWrite:
 
         with patch("api.routes.feedback.insert_scores", new_callable=AsyncMock) as mock_insert:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/feedback", json={
-                    "listing_id": listing_id,
-                    "listing_type": "mcp",
-                    "rating": 5,
-                    "comment": "Great tool!",
-                })
+                r = await ac.post(
+                    "/api/v1/feedback",
+                    json={
+                        "listing_id": listing_id,
+                        "listing_type": "mcp",
+                        "rating": 5,
+                        "comment": "Great tool!",
+                    },
+                )
             assert r.status_code == 200
             mock_insert.assert_called_once()
             scores = mock_insert.call_args[0][0]
@@ -69,11 +73,14 @@ class TestFeedbackDualWrite:
 
         with patch("api.routes.feedback.insert_scores", new_callable=AsyncMock) as mock_insert:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/feedback", json={
-                    "listing_id": listing_id,
-                    "listing_type": "agent",
-                    "rating": 4,
-                })
+                r = await ac.post(
+                    "/api/v1/feedback",
+                    json={
+                        "listing_id": listing_id,
+                        "listing_type": "agent",
+                        "rating": 4,
+                    },
+                )
             scores = mock_insert.call_args[0][0]
             assert scores[0]["agent_id"] == listing_id
             assert scores[0]["mcp_id"] is None
@@ -85,11 +92,14 @@ class TestFeedbackDualWrite:
 
         with patch("api.routes.feedback.insert_scores", new_callable=AsyncMock, side_effect=Exception("CH down")):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/feedback", json={
-                    "listing_id": str(uuid.uuid4()),
-                    "listing_type": "mcp",
-                    "rating": 3,
-                })
+                r = await ac.post(
+                    "/api/v1/feedback",
+                    json={
+                        "listing_id": str(uuid.uuid4()),
+                        "listing_type": "mcp",
+                        "rating": 3,
+                    },
+                )
             assert r.status_code == 200  # request still succeeds
 
 
@@ -98,32 +108,40 @@ class TestFeedbackDualWrite:
 
 class TestCLICommands:
     def test_downgrade_is_wip(self):
-        from observal_cli.main import app as cli_app
         from typer.testing import CliRunner
+
+        from observal_cli.main import app as cli_app
+
         runner = CliRunner()
         result = runner.invoke(cli_app, ["downgrade"])
         assert result.exit_code == 0
         assert "WIP" in result.output
 
     def test_upgrade_command_exists(self):
-        from observal_cli.main import app as cli_app
         from typer.testing import CliRunner
+
+        from observal_cli.main import app as cli_app
+
         runner = CliRunner()
         result = runner.invoke(cli_app, ["upgrade", "--help"])
         assert result.exit_code == 0
         assert "Upgrade" in result.output or "upgrade" in result.output
 
     def test_traces_command_exists(self):
-        from observal_cli.main import app as cli_app
         from typer.testing import CliRunner
+
+        from observal_cli.main import app as cli_app
+
         runner = CliRunner()
         result = runner.invoke(cli_app, ["traces", "--help"])
         assert result.exit_code == 0
         assert "trace" in result.output.lower()
 
     def test_spans_command_exists(self):
-        from observal_cli.main import app as cli_app
         from typer.testing import CliRunner
+
+        from observal_cli.main import app as cli_app
+
         runner = CliRunner()
         result = runner.invoke(cli_app, ["spans", "--help"])
         assert result.exit_code == 0

--- a/tests/test_proxy_phase4.py
+++ b/tests/test_proxy_phase4.py
@@ -7,7 +7,6 @@ import pytest
 
 from observal_cli.proxy import ProxyState, _handle_request, _parse_jsonrpc_body
 
-
 # --- JSON-RPC body parsing ---
 
 
@@ -143,6 +142,7 @@ class TestConfigGeneratorHTTP:
 
     def test_proxy_port_cursor(self):
         from services.config_generator import generate_config
+
         cfg = generate_config(self._make_listing(), "cursor", proxy_port=9999)
         server = cfg["mcpServers"]["my-http-mcp"]
         assert server["url"] == "http://localhost:9999"
@@ -150,17 +150,20 @@ class TestConfigGeneratorHTTP:
 
     def test_proxy_port_claude_code(self):
         from services.config_generator import generate_config
+
         cfg = generate_config(self._make_listing(), "claude-code", proxy_port=9999)
         assert "http://localhost:9999" in str(cfg["command"])
 
     def test_proxy_port_kiro(self):
         from services.config_generator import generate_config
+
         cfg = generate_config(self._make_listing(), "kiro", proxy_port=8888)
         server = cfg["mcpServers"]["my-http-mcp"]
         assert server["url"] == "http://localhost:8888"
 
     def test_stdio_still_works(self):
         from services.config_generator import generate_config
+
         cfg = generate_config(self._make_listing(), "cursor")
         server = cfg["mcpServers"]["my-http-mcp"]
         assert server["command"] == "observal-shim"

--- a/tests/test_shim_phase3.py
+++ b/tests/test_shim_phase3.py
@@ -1,7 +1,6 @@
 """Unit tests for observal-shim — Phase 3."""
 
 import json
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,7 +12,6 @@ from observal_cli.shim import (
     extract_span_name,
     extract_span_type,
 )
-
 
 # --- Message classification ---
 
@@ -93,17 +91,13 @@ class TestSchemaCompliance:
 
     def test_valid_call(self):
         schemas = {"read_file": {"properties": {"path": {}}, "required": ["path"]}}
-        valid, avail = check_schema_compliance(
-            {"name": "read_file", "arguments": {"path": "/tmp"}}, schemas
-        )
+        valid, avail = check_schema_compliance({"name": "read_file", "arguments": {"path": "/tmp"}}, schemas)
         assert valid == 1
         assert avail == 1
 
     def test_missing_required(self):
         schemas = {"read_file": {"properties": {"path": {}}, "required": ["path"]}}
-        valid, avail = check_schema_compliance(
-            {"name": "read_file", "arguments": {}}, schemas
-        )
+        valid, avail = check_schema_compliance({"name": "read_file", "arguments": {}}, schemas)
         assert valid == 0
 
     def test_extra_property(self):
@@ -115,9 +109,7 @@ class TestSchemaCompliance:
 
     def test_empty_schema(self):
         schemas = {"simple_tool": {}}
-        valid, avail = check_schema_compliance(
-            {"name": "simple_tool", "arguments": {"anything": "goes"}}, schemas
-        )
+        valid, avail = check_schema_compliance({"name": "simple_tool", "arguments": {"anything": "goes"}}, schemas)
         assert valid == 1
 
     def test_no_params(self):
@@ -175,15 +167,17 @@ class TestShimState:
     def test_tools_list_caches_schemas(self):
         state = self._make_state()
         state.on_request({"method": "tools/list", "id": 1})
-        state.on_response({
-            "id": 1,
-            "result": {
-                "tools": [
-                    {"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}},
-                    {"name": "write_file", "inputSchema": {"properties": {"path": {}, "content": {}}}},
-                ]
+        state.on_response(
+            {
+                "id": 1,
+                "result": {
+                    "tools": [
+                        {"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}},
+                        {"name": "write_file", "inputSchema": {"properties": {"path": {}, "content": {}}}},
+                    ]
+                },
             }
-        })
+        )
         assert "read_file" in state.tool_schemas
         assert "write_file" in state.tool_schemas
 
@@ -191,14 +185,18 @@ class TestShimState:
         state = self._make_state()
         # First cache schemas
         state.on_request({"method": "tools/list", "id": 1})
-        state.on_response({
-            "id": 1,
-            "result": {"tools": [
-                {"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}}
-            ]}
-        })
+        state.on_response(
+            {
+                "id": 1,
+                "result": {
+                    "tools": [{"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}}]
+                },
+            }
+        )
         # Now make a valid tool call
-        state.on_request({"method": "tools/call", "id": 2, "params": {"name": "read_file", "arguments": {"path": "/tmp"}}})
+        state.on_request(
+            {"method": "tools/call", "id": 2, "params": {"name": "read_file", "arguments": {"path": "/tmp"}}}
+        )
         span = state.on_response({"id": 2, "result": {"content": "ok"}})
         assert span["tool_schema_valid"] == 1
         assert span["tools_available"] == 1
@@ -206,13 +204,17 @@ class TestShimState:
     def test_tool_call_hallucinated_params(self):
         state = self._make_state()
         state.on_request({"method": "tools/list", "id": 1})
-        state.on_response({
-            "id": 1,
-            "result": {"tools": [
-                {"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}}
-            ]}
-        })
-        state.on_request({"method": "tools/call", "id": 2, "params": {"name": "read_file", "arguments": {"wrong_param": "x"}}})
+        state.on_response(
+            {
+                "id": 1,
+                "result": {
+                    "tools": [{"name": "read_file", "inputSchema": {"properties": {"path": {}}, "required": ["path"]}}]
+                },
+            }
+        )
+        state.on_request(
+            {"method": "tools/call", "id": 2, "params": {"name": "read_file", "arguments": {"wrong_param": "x"}}}
+        )
         span = state.on_response({"id": 2, "result": {}})
         assert span["tool_schema_valid"] == 0
 
@@ -261,6 +263,7 @@ class TestConfigGenerator:
 
     def test_cursor_wraps_with_shim(self):
         from services.config_generator import generate_config
+
         cfg = generate_config(self._make_listing(), "cursor")
         server = cfg["mcpServers"]["my-mcp"]
         assert server["command"] == "observal-shim"
@@ -270,6 +273,7 @@ class TestConfigGenerator:
 
     def test_no_api_key_in_config(self):
         from services.config_generator import generate_config
+
         cfg = generate_config(self._make_listing(), "cursor")
         server = cfg["mcpServers"]["my-mcp"]
         env = server.get("env", {})
@@ -278,12 +282,14 @@ class TestConfigGenerator:
 
     def test_claude_code_format(self):
         from services.config_generator import generate_config
+
         cfg = generate_config(self._make_listing(), "claude-code")
         assert cfg["type"] == "shell_command"
         assert "observal-shim" in cfg["command"]
 
     def test_gemini_cli_format(self):
         from services.config_generator import generate_config
+
         cfg = generate_config(self._make_listing(), "gemini-cli")
         server = cfg["mcpServers"]["my-mcp"]
         assert server["command"] == "observal-shim"
@@ -296,19 +302,19 @@ class TestAgentConfigGenerator:
         agent.id = agent_id
         agent.prompt = "You are a test agent."
         agent.mcp_links = []
-        agent.external_mcps = [
-            {"name": "ext-mcp", "command": "npx", "args": ["ext-mcp-server"], "id": "ext-1"}
-        ]
+        agent.external_mcps = [{"name": "ext-mcp", "command": "npx", "args": ["ext-mcp-server"], "id": "ext-1"}]
         return agent
 
     def test_injects_agent_id(self):
         from services.agent_config_generator import generate_agent_config
+
         cfg = generate_agent_config(self._make_agent(), "cursor")
         mcp_cfg = cfg["mcp_config"]["mcpServers"]["ext-mcp"]
         assert mcp_cfg["env"]["OBSERVAL_AGENT_ID"] == "agent-xyz"
 
     def test_external_mcp_wrapped_with_shim(self):
         from services.agent_config_generator import generate_agent_config
+
         cfg = generate_agent_config(self._make_agent(), "cursor")
         mcp_cfg = cfg["mcp_config"]["mcpServers"]["ext-mcp"]
         assert mcp_cfg["command"] == "observal-shim"
@@ -316,6 +322,7 @@ class TestAgentConfigGenerator:
 
     def test_kiro_format(self):
         from services.agent_config_generator import generate_agent_config
+
         cfg = generate_agent_config(self._make_agent(), "kiro")
         assert "rules_file" in cfg
         assert "mcp_json" in cfg

--- a/tests/test_worker_phase5.py
+++ b/tests/test_worker_phase5.py
@@ -6,8 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.redis import close, enqueue_eval, get_pool, get_redis, publish, subscribe
-
+from services.redis import close, enqueue_eval, get_redis, publish
 
 # --- Redis client ---
 
@@ -80,18 +79,22 @@ class TestClose:
 class TestWorkerSettings:
     def test_has_functions(self):
         from worker import WorkerSettings
+
         assert len(WorkerSettings.functions) > 0
 
     def test_has_redis_settings(self):
         from worker import WorkerSettings
+
         assert WorkerSettings.redis_settings is not None
 
     def test_job_timeout(self):
         from worker import WorkerSettings
+
         assert WorkerSettings.job_timeout == 300
 
     def test_max_jobs(self):
         from worker import WorkerSettings
+
         assert WorkerSettings.max_jobs == 5
 
 
@@ -129,6 +132,7 @@ COMPOSE_PATH = str(Path(__file__).resolve().parent.parent / "docker" / "docker-c
 class TestDockerCompose:
     def test_redis_service_exists(self):
         import yaml
+
         with open(COMPOSE_PATH) as f:
             compose = yaml.safe_load(f)
         assert "observal-redis" in compose["services"]
@@ -136,6 +140,7 @@ class TestDockerCompose:
 
     def test_worker_service_exists(self):
         import yaml
+
         with open(COMPOSE_PATH) as f:
             compose = yaml.safe_load(f)
         assert "observal-worker" in compose["services"]
@@ -143,12 +148,14 @@ class TestDockerCompose:
 
     def test_redis_volume_exists(self):
         import yaml
+
         with open(COMPOSE_PATH) as f:
             compose = yaml.safe_load(f)
         assert "redisdata" in compose["volumes"]
 
     def test_api_depends_on_redis(self):
         import yaml
+
         with open(COMPOSE_PATH) as f:
             compose = yaml.safe_load(f)
         deps = compose["services"]["observal-api"]["depends_on"]


### PR DESCRIPTION
## Summary

Set up linting, formatting, and developer tooling for OSS readiness.

## Pre-commit Hooks (`.pre-commit-config.yaml`)

- **ruff**: lint + format (auto-fix on commit)
- **pre-commit-hooks**: trailing whitespace, EOF fixer, YAML/TOML/JSON checks, large file check, merge conflict detection, private key detection, no-commit-to-main
- **ESLint + tsc**: TypeScript lint and typecheck for web project
- **hadolint**: Dockerfile linting

## Ruff Config (`pyproject.toml`)

- Line length: 120
- Rules: pycodestyle, pyflakes, isort, pep8-naming, pyupgrade, bugbear, simplify, type-checking, ruff-specific
- Per-file ignores for tests and main.py
- isort with known first-party packages

## ESLint (`observal-web/eslint.config.js`)

- Flat config with typescript-eslint, react-hooks, react-refresh
- Added `lint`, `lint:fix`, `typecheck` scripts to package.json

## Makefile

- `make lint` / `make format` / `make check` — linting shortcuts
- `make test` / `make test-v` — pytest runners
- `make hooks` — install pre-commit hooks
- `make up` / `make down` / `make rebuild` / `make logs` — Docker shortcuts
- `make clean` — remove caches and build artifacts

## Other

- `.editorconfig` — consistent formatting across editors
- `.gitignore` — expanded for OSS (IDE files, OS files, caches, node_modules)
- Fixed all 150+ ruff lint errors across the codebase
- Reformatted all 42 Python files with ruff format

## Testing
```
181 tests passing
```