### PR TITLE
docs: add AGENTS.md — internal context for contributors and AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# AGENTS.md
+
+Internal context for contributors and AI coding agents. Use `README.md` as the public source of truth for API endpoints and CLI usage. Use `SETUP.md` for environment setup. Use `docs/telemetry-overhaul.md` for the telemetry pipeline design.
+
+## Commands
+
+```bash
+# Docker stack (6 containers: api, web, db, clickhouse, redis, worker)
+make up                  # start
+make down                # stop
+make rebuild             # rebuild and restart
+make logs                # tail logs
+
+# CLI (installed via uv)
+uv tool install --editable .
+observal init            # first-run admin setup
+observal whoami          # check auth
+observal status          # server health check
+
+# Linting
+make lint                # ruff check + eslint
+make format              # ruff format + ruff fix
+make check               # pre-commit on all files
+make hooks               # install pre-commit hooks
+
+# Tests (181 unit tests, run from observal-server/)
+make test                # quick
+make test-v              # verbose
+# or manually:
+cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich pytest ../tests/ -q
+
+# Web UI dev
+cd observal-web && npm run dev        # vite dev server
+cd observal-web && npm run lint       # eslint
+cd observal-web && npm run typecheck  # tsc --noEmit
+```
+
+## Important files
+
+### API Server (`observal-server/`)
+
+- `main.py` — FastAPI app entrypoint; mounts REST routes + GraphQL at `/api/v1/graphql`
+- `config.py` — pydantic-settings: DATABASE_URL, CLICKHOUSE_URL, REDIS_URL, SECRET_KEY, eval model config
+- `worker.py` — arq WorkerSettings; background eval jobs consume from Redis queue
+- `api/deps.py` — auth dependency (`get_current_user` via X-API-Key header), DB session injection
+- `api/graphql.py` — Strawberry schema: Query (traces, spans, metrics) + Subscription (traceCreated, spanCreated); DataLoaders for ClickHouse batch queries
+- `api/routes/auth.py` — init, login, whoami
+- `api/routes/mcp.py` — MCP server CRUD; submit triggers async validation pipeline
+- `api/routes/agent.py` — Agent CRUD with goal templates, MCP linking, external MCP support
+- `api/routes/review.py` — Admin approve/reject workflow
+- `api/routes/telemetry.py` — `POST /ingest` (new batch traces/spans/scores) + legacy `/events`
+- `api/routes/dashboard.py` — MCP metrics, agent metrics, overview stats, top items, trends
+- `api/routes/feedback.py` — Ratings with dual-write to PostgreSQL + ClickHouse scores table
+- `api/routes/eval.py` — Run evals, list scorecards, compare versions
+- `api/routes/admin.py` — Enterprise settings CRUD, user management, role changes
+
+### Models (`observal-server/models/`)
+
+- `user.py` — User with UserRole enum (admin, developer, user); API key is hashed with SECRET_KEY
+- `mcp.py` — McpListing, McpCustomField, McpValidationResult, McpDownload; ListingStatus enum (pending, approved, rejected)
+- `agent.py` — Agent, AgentMcpLink, GoalTemplate, GoalSection, AgentDownload; AgentStatus enum
+- `eval.py` — EvalRun, Scorecard, ScoreCardDimension; EvalRunStatus enum
+- `feedback.py` — Feedback (polymorphic on listing_type: mcp or agent)
+- `enterprise_config.py` — Key-value enterprise settings
+
+### Services (`observal-server/services/`)
+
+- `clickhouse.py` — ClickHouse HTTP client; DDL for 5 tables (2 legacy + 3 new); insert/query helpers with parameterized SQL builder; `INIT_SQL` runs on startup
+- `redis.py` — Redis connection, pub/sub (publish/subscribe), eval job queue (enqueue_eval)
+- `config_generator.py` — Generates IDE config snippets per MCP; wraps commands with `observal-shim`; handles stdio vs HTTP transport
+- `agent_config_generator.py` — Generates bundled agent configs (rules file + MCP configs); injects OBSERVAL_AGENT_ID env var
+- `mcp_validator.py` — 2-stage validation: clone+inspect (git clone, find entry point, parse AST for FastMCP tools) + manifest validation
+- `eval_engine.py` — `EvalBackend` ABC; `LLMJudgeBackend` (Bedrock/OpenAI); `FallbackBackend` (deterministic); 6 managed prompt templates
+- `eval_service.py` — Orchestrates eval runs: fetch traces, run backend, create scorecards
+
+### Schemas (`observal-server/schemas/`)
+
+- Pydantic request/response models mirroring the API surface
+- `telemetry.py` — TraceIngest, SpanIngest, ScoreIngest, IngestBatch, IngestResponse
+
+### CLI (`observal_cli/`)
+
+- `main.py` — Typer app wiring; imports and registers all command modules
+- `cmd_auth.py` — init, login, logout, whoami, status, version; `config` subcommand (show, set, path, alias, aliases)
+- `cmd_mcp.py` — submit (with --yes for non-interactive), list (--sort, --limit, --output), show, install (--raw), delete
+- `cmd_agent.py` — create (--from-file), list, show (tree view for goal templates), install, delete
+- `cmd_ops.py` — review, telemetry, dashboard (overview, metrics --watch, top), feedback, eval (run, scorecards, show, compare), admin, traces, spans, upgrade/downgrade
+- `client.py` — httpx wrapper with get/post/put/delete/health; contextual error messages per status code
+- `config.py` — ~/.observal/config.json management; alias system (@name → UUID resolution)
+- `render.py` — Shared Rich rendering: status badges, relative timestamps, IDE color tags, star ratings, kv panels, spinners
+- `shim.py` — `observal-shim`: transparent stdio JSON-RPC proxy; pairs requests/responses into spans; caches tools/list for schema compliance; buffered async telemetry flush
+- `proxy.py` — `observal-proxy`: HTTP reverse proxy reusing ShimState; same telemetry pipeline
+
+### Web UI (`observal-web/`)
+
+- Vite + React + urql SPA; queries GraphQL at `/api/v1/graphql`
+- `src/App.tsx` — Router: Overview, TraceExplorer, TraceDetail, McpMetrics
+- `src/lib/urql.ts` — urql client with WebSocket subscriptions
+- `src/lib/queries.ts` — GraphQL queries and subscriptions
+- `src/components/` — TraceExplorer, TraceDetail, Overview, McpMetrics
+
+### Docker (`docker/`)
+
+- `docker-compose.yml` — 6 services: api (8000), web (3000), db (PostgreSQL 16), clickhouse (8123/9000), redis (6379), worker (arq)
+- `Dockerfile.api` — uv-based Python build
+- `Dockerfile.web` — Multi-stage Vite build with `serve`
+
+### Tests (`tests/`)
+
+- 181 unit tests; all mock external services (no Docker needed to run)
+- `test_clickhouse_phase1.py` — DDL, SQL helpers, insert/query functions (43 tests)
+- `test_ingest_phase2.py` — Ingestion schemas, endpoint, partial failure (15 tests)
+- `test_shim_phase3.py` — JSON-RPC parsing, schema compliance, ShimState, config gen (43 tests)
+- `test_proxy_phase4.py` — Proxy, HTTP transport config (13 tests)
+- `test_worker_phase5.py` — Redis, arq, docker-compose validation (16 tests)
+- `test_graphql_phase6.py` — Strawberry types, DataLoaders, resolvers (27 tests)
+- `test_eval_phase8.py` — Templates, backends, run_eval_on_trace (17 tests)
+- `test_phase9_10.py` — Dual-write, CLI commands (7 tests)
+- `conftest.py` — Adds observal-server to sys.path so tests can import server modules
+
+## Implementation notes
+
+- Two databases: PostgreSQL for relational data (users, MCPs, agents, feedback, eval runs), ClickHouse for time-series telemetry (traces, spans, scores). They are not interchangeable.
+- ClickHouse uses ReplacingMergeTree with bloom filter indexes. Queries go through the HTTP interface, not a native driver. The `_query` helper in `clickhouse.py` handles parameterized queries.
+- The shim is the core telemetry collection mechanism. It sits between the IDE and the MCP server, completely transparent. It never modifies messages — only observes. Telemetry is fire-and-forget via async POST; if the server is down, spans are silently dropped.
+- Config generators automatically wrap MCP commands with `observal-shim` for stdio transport or point to `observal-proxy` for HTTP transport. This is how telemetry collection is opt-in per install.
+- GraphQL replaced the REST dashboard endpoints. REST still exists for auth, CRUD, feedback, eval, admin. The GraphQL layer is read-only for telemetry data and uses DataLoaders to batch ClickHouse queries.
+- Redis serves two purposes: pub/sub for GraphQL subscriptions (live trace/span events) and arq job queue for background eval runs.
+- The eval engine is pluggable. `LLMJudgeBackend` calls Bedrock or OpenAI-compatible endpoints. `FallbackBackend` returns deterministic scores when no LLM is configured. The 6 managed templates are prompt strings, not code.
+- Feedback dual-writes: when a user rates an MCP/agent, it writes to PostgreSQL (for the feedback API) AND ClickHouse scores table (for unified analytics). The ClickHouse write is best-effort.
+- Auth is API key based. Keys are hashed with SECRET_KEY before storage. The `X-API-Key` header is checked on every authenticated request via `get_current_user` dependency.
+- The CLI stores config in `~/.observal/config.json`. Aliases are in `~/.observal/aliases.json`. Both are plain JSON.
+- All CLI list/show commands support `--output table|json|plain`. Use `--output json` for scripting. Use `--raw` on install commands to pipe config directly to files.
+- Ruff is the Python linter and formatter. Line length is 120. ESLint with typescript-eslint for the web project. Pre-commit hooks enforce both.
+- The `B008` ruff rule is suppressed because Typer requires function calls in argument defaults (`typer.Option(...)`, `typer.Argument(...)`).


### PR DESCRIPTION
## Summary

Add `AGENTS.md` at the repo root — the internal context file for contributors and AI coding agents working on the codebase.

Fixes #33

## What's in it

- **Commands**: Docker, CLI, linting, tests, web dev — all the `make` targets and manual commands
- **Important files**: Every key file across all 5 components (server, CLI, web, docker, tests) with one-line descriptions
- **Implementation notes**: Architecture decisions, conventions, and gotchas that aren't obvious from the code
- **Open questions**: Known issues and deferred decisions with issue links

## Why

AI agents (Kiro, Claude Code, Cursor, Copilot) and new contributors need a single file that gives them the full project context. This is NOT user-facing docs — it's the "how this codebase works" reference that prevents agents from making incorrect assumptions about the architecture.