### PR TITLE
feat(web): rewrite dashboard with Tailwind, shadcn-style UI, recharts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docker/data/
 
 # Local config
 .kiro/
+observal-web/tsconfig.tsbuildinfo

--- a/observal-web/package-lock.json
+++ b/observal-web/package-lock.json
@@ -8,16 +8,25 @@
       "name": "observal-web",
       "version": "0.1.0",
       "dependencies": {
+        "@tailwindcss/vite": "^4.2.2",
         "@urql/exchange-graphcache": "^7.2.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "graphql": "^16.9.0",
         "graphql-ws": "^5.16.0",
+        "lucide-react": "^1.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-is": "^19.2.4",
         "react-router-dom": "^7.1.0",
+        "recharts": "^3.8.1",
+        "tailwind-merge": "^3.5.0",
+        "tailwindcss": "^4.2.2",
         "urql": "^4.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/node": "^25.5.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
@@ -951,7 +960,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -962,7 +970,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -973,7 +980,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -983,18 +989,52 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1354,6 +1394,275 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1399,6 +1708,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1420,6 +1792,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1439,6 +1821,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -1859,6 +2247,27 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1901,6 +2310,127 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1919,6 +2449,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1926,12 +2462,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2180,6 +2748,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2308,6 +2882,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/graphql": {
       "version": "16.13.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
@@ -2356,6 +2936,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2364,6 +2954,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -2395,6 +2994,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2474,6 +3082,255 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2498,6 +3355,24 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/minimatch": {
@@ -2716,6 +3591,35 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2763,6 +3667,57 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -2858,11 +3813,45 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -2945,6 +3934,13 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2998,6 +3994,37 @@
       "peerDependencies": {
         "@urql/core": "^5.0.0",
         "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/observal-web/package.json
+++ b/observal-web/package.json
@@ -12,16 +12,25 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "@urql/exchange-graphcache": "^7.2.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "graphql": "^16.9.0",
     "graphql-ws": "^5.16.0",
+    "lucide-react": "^1.7.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-is": "^19.2.4",
     "react-router-dom": "^7.1.0",
+    "recharts": "^3.8.1",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.2",
     "urql": "^4.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/node": "^25.5.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/observal-web/src/App.tsx
+++ b/observal-web/src/App.tsx
@@ -1,27 +1,33 @@
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
-import { Provider } from 'urql';
-import { client } from './lib/urql';
-import { TraceExplorer } from './components/TraceExplorer';
-import { TraceDetail } from './components/TraceDetail';
-import { Overview } from './components/Overview';
-import { McpMetrics } from './components/McpMetrics';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Provider } from "urql";
+import { client } from "@/lib/urql";
+import { AppLayout } from "@/components/layout/AppLayout";
+import { Overview } from "@/components/Overview";
+import { TraceExplorer } from "@/components/TraceExplorer";
+import { TraceDetail } from "@/components/TraceDetail";
+import { McpMetrics } from "@/components/McpMetrics";
+import { McpList, AgentList, ReviewList, FeedbackPage, EvalsPage, SettingsPage } from "@/pages";
+import { Login } from "@/pages/Login";
 
 export default function App() {
   return (
     <Provider value={client}>
       <BrowserRouter>
-        <nav style={{ padding: '1rem', borderBottom: '1px solid #ccc' }}>
-          <Link to="/">Overview</Link>{' | '}
-          <Link to="/traces">Traces</Link>
-        </nav>
-        <main style={{ padding: '1rem' }}>
-          <Routes>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route element={<AppLayout />}>
             <Route path="/" element={<Overview />} />
             <Route path="/traces" element={<TraceExplorer />} />
             <Route path="/traces/:traceId" element={<TraceDetail />} />
+            <Route path="/mcps" element={<McpList />} />
             <Route path="/mcps/:mcpId/metrics" element={<McpMetrics />} />
-          </Routes>
-        </main>
+            <Route path="/agents" element={<AgentList />} />
+            <Route path="/reviews" element={<ReviewList />} />
+            <Route path="/feedback" element={<FeedbackPage />} />
+            <Route path="/evals" element={<EvalsPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+          </Route>
+        </Routes>
       </BrowserRouter>
     </Provider>
   );

--- a/observal-web/src/components/McpMetrics.tsx
+++ b/observal-web/src/components/McpMetrics.tsx
@@ -1,40 +1,61 @@
-import { useQuery } from 'urql';
-import { MCP_METRICS_QUERY } from '../lib/queries';
-import { useParams } from 'react-router-dom';
+import { useQuery } from "urql";
+import { MCP_METRICS_QUERY } from "@/lib/queries";
+import { useParams, Link } from "react-router-dom";
+import { PageHeader, StatCard, Card, Spinner } from "@/components/ui";
+import { ArrowLeft, Zap, AlertTriangle, Clock, Shield } from "lucide-react";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 
 function daysAgo(n: number): string {
   const d = new Date();
   d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 19).replace('T', ' ');
+  return d.toISOString().slice(0, 19).replace("T", " ");
 }
 
 export function McpMetrics() {
   const { mcpId } = useParams<{ mcpId: string }>();
-  const [result] = useQuery({
-    query: MCP_METRICS_QUERY,
-    variables: { mcpId, start: daysAgo(30), end: daysAgo(0) },
-  });
+  const [result] = useQuery({ query: MCP_METRICS_QUERY, variables: { mcpId, start: daysAgo(30), end: daysAgo(0) } });
   const { data, fetching, error } = result;
 
-  if (fetching) return <p>Loading…</p>;
-  if (error) return <p>Error: {error.message}</p>;
+  if (fetching) return <div className="flex h-64 items-center justify-center"><Spinner /></div>;
+  if (error) return <p className="text-destructive">Error: {error.message}</p>;
 
   const m = data?.mcpMetrics;
-  if (!m) return <p>No metrics.</p>;
+  if (!m) return <p className="text-muted-foreground">No metrics available.</p>;
+
+  const latencyData = [
+    { name: "p50", value: m.p50LatencyMs },
+    { name: "p90", value: m.p90LatencyMs },
+    { name: "p99", value: m.p99LatencyMs },
+  ];
 
   return (
     <div>
-      <h2>MCP Metrics</h2>
-      <dl>
-        <dt>Tool Calls</dt><dd>{m.toolCallCount}</dd>
-        <dt>Error Rate</dt><dd>{(m.errorRate * 100).toFixed(1)}%</dd>
-        <dt>Avg Latency</dt><dd>{m.avgLatencyMs.toFixed(1)}ms</dd>
-        <dt>p50</dt><dd>{m.p50LatencyMs.toFixed(0)}ms</dd>
-        <dt>p90</dt><dd>{m.p90LatencyMs.toFixed(0)}ms</dd>
-        <dt>p99</dt><dd>{m.p99LatencyMs.toFixed(0)}ms</dd>
-        <dt>Timeout Rate</dt><dd>{(m.timeoutRate * 100).toFixed(1)}%</dd>
-        <dt>Schema Compliance</dt><dd>{(m.schemaComplianceRate * 100).toFixed(1)}%</dd>
-      </dl>
+      <Link to="/mcps" className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" /> Back to MCPs
+      </Link>
+
+      <PageHeader title="MCP Metrics" />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard title="Tool Calls" value={m.toolCallCount} icon={<Zap className="h-4 w-4" />} />
+        <StatCard title="Error Rate" value={`${(m.errorRate * 100).toFixed(1)}%`}
+          trend={m.errorRate > 0.05 ? "down" : "neutral"} icon={<AlertTriangle className="h-4 w-4" />} />
+        <StatCard title="Avg Latency" value={`${m.avgLatencyMs.toFixed(0)}ms`} icon={<Clock className="h-4 w-4" />} />
+        <StatCard title="Schema Compliance" value={`${(m.schemaComplianceRate * 100).toFixed(0)}%`}
+          trend={m.schemaComplianceRate > 0.95 ? "up" : "down"} icon={<Shield className="h-4 w-4" />} />
+      </div>
+
+      <Card className="mt-6">
+        <h3 className="mb-4 text-sm font-medium text-muted-foreground">Latency Percentiles</h3>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={latencyData}>
+            <XAxis dataKey="name" tick={{ fontSize: 12, fill: "#a1a1aa" }} tickLine={false} axisLine={false} />
+            <YAxis tick={{ fontSize: 12, fill: "#a1a1aa" }} tickLine={false} axisLine={false} />
+            <Tooltip contentStyle={{ background: "#18181b", border: "1px solid #27272a", borderRadius: 8, fontSize: 13 }} />
+            <Bar dataKey="value" fill="#3b82f6" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </Card>
     </div>
   );
 }

--- a/observal-web/src/components/Overview.tsx
+++ b/observal-web/src/components/Overview.tsx
@@ -1,48 +1,62 @@
-import { useQuery } from 'urql';
-import { OVERVIEW_QUERY } from '../lib/queries';
+import { useQuery } from "urql";
+import { OVERVIEW_QUERY } from "@/lib/queries";
+import { StatCard, PageHeader, Spinner, Card } from "@/components/ui";
+import { Activity, Layers, Zap, AlertTriangle } from "lucide-react";
+import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 
 function daysAgo(n: number): string {
   const d = new Date();
   d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 19).replace('T', ' ');
+  return d.toISOString().slice(0, 19).replace("T", " ");
 }
 
 export function Overview() {
-  const now = daysAgo(0);
-  const start = daysAgo(30);
-  const [result] = useQuery({ query: OVERVIEW_QUERY, variables: { start, end: now } });
+  const [result] = useQuery({ query: OVERVIEW_QUERY, variables: { start: daysAgo(30), end: daysAgo(0) } });
   const { data, fetching, error } = result;
 
-  if (fetching) return <p>Loading…</p>;
-  if (error) return <p>Error: {error.message}</p>;
+  if (fetching) return <div className="flex h-64 items-center justify-center"><Spinner /></div>;
+  if (error) return <p className="text-destructive">Error: {error.message}</p>;
 
   const stats = data?.overview;
   const trends = data?.trends ?? [];
 
   return (
     <div>
-      <h2>Overview</h2>
-      {stats && (
-        <div style={{ display: 'flex', gap: '2rem' }}>
-          <div><strong>{stats.totalTraces}</strong><br />Traces</div>
-          <div><strong>{stats.totalSpans}</strong><br />Spans</div>
-          <div><strong>{stats.toolCallsToday}</strong><br />Tool Calls Today</div>
-          <div><strong>{stats.errorsToday}</strong><br />Errors Today</div>
-        </div>
-      )}
+      <PageHeader title="Overview" description="Enterprise telemetry at a glance" />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard title="Total Traces" value={stats?.totalTraces ?? 0} icon={<Activity className="h-4 w-4" />} />
+        <StatCard title="Total Spans" value={stats?.totalSpans ?? 0} icon={<Layers className="h-4 w-4" />} />
+        <StatCard title="Tool Calls Today" value={stats?.toolCallsToday ?? 0} subtitle="Last 24h" icon={<Zap className="h-4 w-4" />} />
+        <StatCard title="Errors Today" value={stats?.errorsToday ?? 0}
+          subtitle={stats?.errorsToday > 0 ? "Needs attention" : "All clear"}
+          trend={stats?.errorsToday > 0 ? "down" : "neutral"}
+          icon={<AlertTriangle className="h-4 w-4" />} />
+      </div>
 
       {trends.length > 0 && (
-        <>
-          <h3>Trends (30d)</h3>
-          <table>
-            <thead><tr><th>Date</th><th>Traces</th><th>Spans</th><th>Errors</th></tr></thead>
-            <tbody>
-              {trends.map((t: any) => (
-                <tr key={t.date}><td>{t.date}</td><td>{t.traces}</td><td>{t.spans}</td><td>{t.errors}</td></tr>
-              ))}
-            </tbody>
-          </table>
-        </>
+        <Card className="mt-6">
+          <h3 className="mb-4 text-sm font-medium text-muted-foreground">Traces & Errors (30 days)</h3>
+          <ResponsiveContainer width="100%" height={300}>
+            <AreaChart data={trends}>
+              <defs>
+                <linearGradient id="gTraces" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id="gErrors" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#ef4444" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <XAxis dataKey="date" tick={{ fontSize: 12, fill: "#a1a1aa" }} tickLine={false} axisLine={false} />
+              <YAxis tick={{ fontSize: 12, fill: "#a1a1aa" }} tickLine={false} axisLine={false} />
+              <Tooltip contentStyle={{ background: "#18181b", border: "1px solid #27272a", borderRadius: 8, fontSize: 13 }} />
+              <Area type="monotone" dataKey="traces" stroke="#3b82f6" fill="url(#gTraces)" strokeWidth={2} />
+              <Area type="monotone" dataKey="errors" stroke="#ef4444" fill="url(#gErrors)" strokeWidth={2} />
+            </AreaChart>
+          </ResponsiveContainer>
+        </Card>
       )}
     </div>
   );

--- a/observal-web/src/components/TraceDetail.tsx
+++ b/observal-web/src/components/TraceDetail.tsx
@@ -1,64 +1,88 @@
-import { useParams } from 'react-router-dom';
-import { useQuery, useSubscription } from 'urql';
-import { TRACE_DETAIL_QUERY, SPAN_SUBSCRIPTION } from '../lib/queries';
+import { useParams, Link } from "react-router-dom";
+import { useQuery, useSubscription } from "urql";
+import { TRACE_DETAIL_QUERY, SPAN_SUBSCRIPTION } from "@/lib/queries";
+import { PageHeader, Card, Badge, DataTable, Spinner } from "@/components/ui";
+import { ArrowLeft, CheckCircle2, XCircle, Minus } from "lucide-react";
 
 export function TraceDetail() {
   const { traceId } = useParams<{ traceId: string }>();
   const [result] = useQuery({ query: TRACE_DETAIL_QUERY, variables: { traceId } });
   const [subResult] = useSubscription({ query: SPAN_SUBSCRIPTION, variables: { traceId } });
-
   const { data, fetching, error } = result;
 
-  if (fetching) return <p>Loading…</p>;
-  if (error) return <p>Error: {error.message}</p>;
+  if (fetching) return <div className="flex h-64 items-center justify-center"><Spinner /></div>;
+  if (error) return <p className="text-destructive">Error: {error.message}</p>;
 
   const trace = data?.trace;
-  if (!trace) return <p>Trace not found.</p>;
+  if (!trace) return <p className="text-muted-foreground">Trace not found.</p>;
+
+  const spanColumns = [
+    { key: "type", label: "Type", render: (s: any) => <Badge variant="outline">{s.type}</Badge> },
+    { key: "name", label: "Name", className: "font-medium" },
+    { key: "method", label: "Method", className: "font-mono text-xs text-muted-foreground",
+      render: (s: any) => s.method || "—" },
+    { key: "status", label: "Status",
+      render: (s: any) => s.status === "error"
+        ? <Badge variant="destructive">error</Badge>
+        : s.status === "success"
+        ? <Badge variant="success">success</Badge>
+        : <Badge variant="outline">{s.status}</Badge> },
+    { key: "latencyMs", label: "Latency", className: "text-right",
+      render: (s: any) => s.latencyMs ? `${s.latencyMs}ms` : "—" },
+    { key: "schema", label: "Schema", className: "text-center",
+      render: (s: any) => s.toolSchemaValid === true
+        ? <CheckCircle2 className="inline h-4 w-4 text-success" />
+        : s.toolSchemaValid === false
+        ? <XCircle className="inline h-4 w-4 text-destructive" />
+        : <Minus className="inline h-4 w-4 text-muted-foreground" /> },
+  ];
 
   return (
     <div>
-      <h2>Trace: {trace.traceId.slice(0, 8)}…</h2>
-      <dl>
-        <dt>Type</dt><dd>{trace.traceType}</dd>
-        <dt>Name</dt><dd>{trace.name || '—'}</dd>
-        <dt>Start</dt><dd>{trace.startTime}</dd>
-        <dt>End</dt><dd>{trace.endTime || 'ongoing'}</dd>
-      </dl>
+      <Link to="/traces" className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" /> Back to traces
+      </Link>
 
-      <h3>Spans ({trace.spans.length})</h3>
-      <table>
-        <thead>
-          <tr><th>Type</th><th>Name</th><th>Status</th><th>Latency</th><th>Schema</th></tr>
-        </thead>
-        <tbody>
-          {trace.spans.map((s: any) => (
-            <tr key={s.spanId} style={{ color: s.status === 'error' ? 'red' : undefined }}>
-              <td>{s.type}</td>
-              <td>{s.name}</td>
-              <td>{s.status}</td>
-              <td>{s.latencyMs ? `${s.latencyMs}ms` : '—'}</td>
-              <td>{s.toolSchemaValid === true ? '✓' : s.toolSchemaValid === false ? '✗' : '—'}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <PageHeader title={`Trace ${trace.traceId.slice(0, 12)}…`} description={trace.name || undefined} />
+
+      <div className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Card className="p-4">
+          <p className="text-xs text-muted-foreground">Type</p>
+          <p className="mt-1 font-medium">{trace.traceType}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs text-muted-foreground">Spans</p>
+          <p className="mt-1 font-medium">{trace.spans.length}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs text-muted-foreground">Start</p>
+          <p className="mt-1 text-sm">{new Date(trace.startTime).toLocaleString()}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs text-muted-foreground">End</p>
+          <p className="mt-1 text-sm">{trace.endTime ? new Date(trace.endTime).toLocaleString() : "ongoing"}</p>
+        </Card>
+      </div>
+
+      <h3 className="mb-3 text-sm font-medium text-muted-foreground">Spans ({trace.spans.length})</h3>
+      <DataTable columns={spanColumns} data={trace.spans} />
 
       {trace.scores.length > 0 && (
-        <>
-          <h3>Scores</h3>
-          <table>
-            <thead><tr><th>Name</th><th>Source</th><th>Value</th></tr></thead>
-            <tbody>
-              {trace.scores.map((sc: any) => (
-                <tr key={sc.scoreId}><td>{sc.name}</td><td>{sc.source}</td><td>{sc.value}</td></tr>
-              ))}
-            </tbody>
-          </table>
-        </>
+        <div className="mt-6">
+          <h3 className="mb-3 text-sm font-medium text-muted-foreground">Scores</h3>
+          <DataTable columns={[
+            { key: "name", label: "Name", className: "font-medium" },
+            { key: "source", label: "Source", render: (s: any) => <Badge variant="outline">{s.source}</Badge> },
+            { key: "value", label: "Value", className: "text-right font-mono" },
+          ]} data={trace.scores} />
+        </div>
       )}
 
       {subResult.data && (
-        <p>Live: new span — {subResult.data.spanCreated.name} ({subResult.data.spanCreated.status})</p>
+        <div className="mt-4 rounded-md border border-primary/20 bg-primary/5 p-3 text-sm">
+          <span className="mr-2 inline-block h-2 w-2 animate-pulse rounded-full bg-primary" />
+          Live: {subResult.data.spanCreated.name} ({subResult.data.spanCreated.status})
+        </div>
       )}
     </div>
   );

--- a/observal-web/src/components/TraceExplorer.tsx
+++ b/observal-web/src/components/TraceExplorer.tsx
@@ -1,46 +1,42 @@
-import { useQuery } from 'urql';
-import { TRACES_QUERY } from '../lib/queries';
-import { Link } from 'react-router-dom';
+import { useQuery } from "urql";
+import { TRACES_QUERY } from "@/lib/queries";
+import { PageHeader, DataTable, Badge, Spinner, EmptyState } from "@/components/ui";
+import { Activity } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 export function TraceExplorer() {
   const [result] = useQuery({ query: TRACES_QUERY, variables: { limit: 50 } });
+  const navigate = useNavigate();
   const { data, fetching, error } = result;
 
-  if (fetching) return <p>Loading traces…</p>;
-  if (error) return <p>Error: {error.message}</p>;
+  if (fetching) return <div className="flex h-64 items-center justify-center"><Spinner /></div>;
+  if (error) return <p className="text-destructive">Error: {error.message}</p>;
 
   const traces = data?.traces?.items ?? [];
 
+  if (!traces.length) return <EmptyState icon={<Activity className="h-8 w-8" />} title="No traces yet" description="Submit an MCP server and start using it to generate traces." />;
+
+  const columns = [
+    { key: "traceId", label: "Trace ID", className: "font-mono text-xs",
+      render: (r: any) => <span className="text-primary">{r.traceId.slice(0, 12)}…</span> },
+    { key: "traceType", label: "Type",
+      render: (r: any) => <Badge variant={r.traceType === "mcp" ? "default" : "outline"}>{r.traceType}</Badge> },
+    { key: "name", label: "Name", render: (r: any) => r.name || <span className="text-muted-foreground">—</span> },
+    { key: "spans", label: "Spans", className: "text-right", render: (r: any) => r.metrics.totalSpans },
+    { key: "errors", label: "Errors", className: "text-right",
+      render: (r: any) => r.metrics.errorCount > 0
+        ? <Badge variant="destructive">{r.metrics.errorCount}</Badge>
+        : <span className="text-muted-foreground">0</span> },
+    { key: "latency", label: "Latency", className: "text-right",
+      render: (r: any) => r.metrics.totalLatencyMs ? `${r.metrics.totalLatencyMs}ms` : <span className="text-muted-foreground">—</span> },
+    { key: "startTime", label: "Time", className: "text-muted-foreground text-xs",
+      render: (r: any) => new Date(r.startTime).toLocaleString() },
+  ];
+
   return (
     <div>
-      <h2>Trace Explorer</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Trace ID</th>
-            <th>Type</th>
-            <th>Name</th>
-            <th>Spans</th>
-            <th>Errors</th>
-            <th>Latency</th>
-            <th>Start</th>
-          </tr>
-        </thead>
-        <tbody>
-          {traces.map((t: any) => (
-            <tr key={t.traceId}>
-              <td><Link to={`/traces/${t.traceId}`}>{t.traceId.slice(0, 8)}…</Link></td>
-              <td>{t.traceType}</td>
-              <td>{t.name || '—'}</td>
-              <td>{t.metrics.totalSpans}</td>
-              <td>{t.metrics.errorCount}</td>
-              <td>{t.metrics.totalLatencyMs ? `${t.metrics.totalLatencyMs}ms` : '—'}</td>
-              <td>{t.startTime}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      {traces.length === 0 && <p>No traces yet.</p>}
+      <PageHeader title="Traces" description={`${traces.length} recent traces`} />
+      <DataTable columns={columns} data={traces} onRowClick={(r) => navigate(`/traces/${r.traceId}`)} />
     </div>
   );
 }

--- a/observal-web/src/components/layout/AppLayout.tsx
+++ b/observal-web/src/components/layout/AppLayout.tsx
@@ -1,0 +1,58 @@
+import { NavLink, Outlet } from "react-router-dom";
+import { cn } from "@/lib/utils";
+import {
+  LayoutDashboard, Activity, Server, Bot, ShieldCheck,
+  MessageSquare, FlaskConical, Settings, ChevronLeft, ChevronRight,
+} from "lucide-react";
+import { useState } from "react";
+
+const NAV = [
+  { to: "/", icon: LayoutDashboard, label: "Overview" },
+  { to: "/traces", icon: Activity, label: "Traces" },
+  { to: "/mcps", icon: Server, label: "MCP Servers" },
+  { to: "/agents", icon: Bot, label: "Agents" },
+  { to: "/reviews", icon: ShieldCheck, label: "Reviews" },
+  { to: "/feedback", icon: MessageSquare, label: "Feedback" },
+  { to: "/evals", icon: FlaskConical, label: "Evaluations" },
+  { to: "/settings", icon: Settings, label: "Settings" },
+];
+
+export function AppLayout() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <aside className={cn(
+        "flex flex-col border-r border-border bg-card transition-all duration-200",
+        collapsed ? "w-16" : "w-56"
+      )}>
+        <div className="flex h-14 items-center gap-2 border-b border-border px-4">
+          {!collapsed && <span className="text-lg font-bold">Observal</span>}
+          <button onClick={() => setCollapsed(!collapsed)}
+            className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground">
+            {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+          </button>
+        </div>
+        <nav className="flex-1 space-y-1 p-2">
+          {NAV.map(({ to, icon: Icon, label }) => (
+            <NavLink key={to} to={to} end={to === "/"}
+              className={({ isActive }) => cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                isActive ? "bg-primary/10 text-primary" : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                collapsed && "justify-center px-2"
+              )}>
+              <Icon className="h-4 w-4 shrink-0" />
+              {!collapsed && <span>{label}</span>}
+            </NavLink>
+          ))}
+        </nav>
+        <div className="border-t border-border p-3">
+          {!collapsed && <p className="text-xs text-muted-foreground">v0.1.0</p>}
+        </div>
+      </aside>
+      <main className="flex-1 overflow-y-auto p-6">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/observal-web/src/components/ui/index.tsx
+++ b/observal-web/src/components/ui/index.tsx
@@ -1,0 +1,109 @@
+import { cn } from "@/lib/utils";
+import { Loader2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function Card({ className, children }: { className?: string; children: ReactNode }) {
+  return <div className={cn("rounded-lg border border-border bg-card p-6", className)}>{children}</div>;
+}
+
+export function StatCard({ title, value, subtitle, trend, icon }: {
+  title: string; value: string | number; subtitle?: string; trend?: "up" | "down" | "neutral";
+  icon?: ReactNode;
+}) {
+  return (
+    <Card>
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">{title}</p>
+        {icon && <span className="text-muted-foreground">{icon}</span>}
+      </div>
+      <p className="mt-2 text-3xl font-bold">{value}</p>
+      {subtitle && (
+        <p className={cn("mt-1 text-sm", trend === "up" ? "text-success" : trend === "down" ? "text-destructive" : "text-muted-foreground")}>
+          {subtitle}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+export function Badge({ children, variant = "default" }: { children: ReactNode; variant?: "default" | "success" | "warning" | "destructive" | "outline" }) {
+  const styles = {
+    default: "bg-primary/10 text-primary",
+    success: "bg-success/10 text-success",
+    warning: "bg-warning/10 text-warning",
+    destructive: "bg-destructive/10 text-destructive",
+    outline: "border border-border text-muted-foreground",
+  };
+  return <span className={cn("inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium", styles[variant])}>{children}</span>;
+}
+
+export function Spinner() {
+  return <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />;
+}
+
+export function EmptyState({ icon, title, description }: { icon?: ReactNode; title: string; description?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      {icon && <div className="mb-4 text-muted-foreground">{icon}</div>}
+      <h3 className="text-lg font-medium">{title}</h3>
+      {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
+    </div>
+  );
+}
+
+export function PageHeader({ title, description, children }: { title: string; description?: string; children?: ReactNode }) {
+  return (
+    <div className="mb-6 flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function DataTable({ columns, data, onRowClick }: {
+  columns: { key: string; label: string; className?: string; render?: (row: any) => ReactNode }[];
+  data: any[]; onRowClick?: (row: any) => void;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted/50">
+            {columns.map(col => (
+              <th key={col.key} className={cn("px-4 py-3 text-left font-medium text-muted-foreground", col.className)}>{col.label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} onClick={() => onRowClick?.(row)}
+              className={cn("border-b border-border transition-colors", onRowClick && "cursor-pointer hover:bg-muted/30")}>
+              {columns.map(col => (
+                <td key={col.key} className={cn("px-4 py-3", col.className)}>
+                  {col.render ? col.render(row) : row[col.key]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function Tabs({ tabs, active, onChange }: { tabs: { key: string; label: string; count?: number }[]; active: string; onChange: (key: string) => void }) {
+  return (
+    <div className="flex gap-1 border-b border-border">
+      {tabs.map(tab => (
+        <button key={tab.key} onClick={() => onChange(tab.key)}
+          className={cn("px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px",
+            active === tab.key ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground")}>
+          {tab.label}{tab.count !== undefined && <span className="ml-1.5 text-xs text-muted-foreground">({tab.count})</span>}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/observal-web/src/index.css
+++ b/observal-web/src/index.css
@@ -1,0 +1,31 @@
+@import "tailwindcss";
+
+@theme {
+  --color-background: #09090b;
+  --color-foreground: #fafafa;
+  --color-card: #0a0a0c;
+  --color-card-foreground: #fafafa;
+  --color-popover: #09090b;
+  --color-popover-foreground: #fafafa;
+  --color-primary: #3b82f6;
+  --color-primary-foreground: #fafafa;
+  --color-secondary: #1e1e24;
+  --color-secondary-foreground: #fafafa;
+  --color-muted: #18181b;
+  --color-muted-foreground: #a1a1aa;
+  --color-accent: #1e1e24;
+  --color-accent-foreground: #fafafa;
+  --color-destructive: #ef4444;
+  --color-border: #27272a;
+  --color-input: #27272a;
+  --color-ring: #3b82f6;
+  --color-success: #22c55e;
+  --color-warning: #eab308;
+  --radius: 0.5rem;
+}
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}

--- a/observal-web/src/lib/utils.ts
+++ b/observal-web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/observal-web/src/main.tsx
+++ b/observal-web/src/main.tsx
@@ -1,9 +1,10 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
     <App />
-  </StrictMode>,
+  </React.StrictMode>,
 );

--- a/observal-web/src/pages/Login.tsx
+++ b/observal-web/src/pages/Login.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card } from "@/components/ui";
+
+export function Login() {
+  const [key, setKey] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    try {
+      const r = await fetch("/api/v1/auth/whoami", { headers: { "X-API-Key": key } });
+      if (!r.ok) throw new Error("Invalid API key");
+      localStorage.setItem("observal_api_key", key);
+      navigate("/");
+    } catch {
+      setError("Invalid API key. Run 'observal init' to get one.");
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <Card className="w-full max-w-sm">
+        <h1 className="mb-1 text-xl font-bold">Observal</h1>
+        <p className="mb-6 text-sm text-muted-foreground">Enter your API key to continue</p>
+        <form onSubmit={handleLogin}>
+          <input type="password" value={key} onChange={(e) => setKey(e.target.value)} placeholder="API Key"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+          {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+          <button type="submit"
+            className="mt-4 w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors">
+            Login
+          </button>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/observal-web/src/pages/index.tsx
+++ b/observal-web/src/pages/index.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { PageHeader, DataTable, Badge, Spinner, EmptyState } from "@/components/ui";
+import { Server } from "lucide-react";
+
+const API_KEY = localStorage.getItem("observal_api_key") || "";
+
+async function apiFetch(path: string) {
+  const r = await fetch(path, { headers: { "X-API-Key": API_KEY } });
+  if (!r.ok) throw new Error(`${r.status}`);
+  return r.json();
+}
+
+export function McpList() {
+  const [data, setData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => { apiFetch("/api/v1/mcps").then(setData).finally(() => setLoading(false)); }, []);
+
+  if (loading) return <div className="flex h-64 items-center justify-center"><Spinner /></div>;
+  if (!data.length) return <EmptyState icon={<Server className="h-8 w-8" />} title="No MCP servers" description="Submit one via the CLI: observal submit <git-url>" />;
+
+  return (
+    <div>
+      <PageHeader title="MCP Servers" description={`${data.length} approved`} />
+      <DataTable columns={[
+        { key: "name", label: "Name", className: "font-medium" },
+        { key: "version", label: "Version", className: "font-mono text-xs" },
+        { key: "category", label: "Category", render: (r: any) => <Badge variant="outline">{r.category}</Badge> },
+        { key: "owner", label: "Owner", className: "text-muted-foreground" },
+        { key: "supported_ides", label: "IDEs", render: (r: any) => (r.supported_ides || []).map((ide: string) => <Badge key={ide} variant="default">{ide}</Badge>) },
+      ]} data={data} onRowClick={(r) => navigate(`/mcps/${r.id}/metrics`)} />
+    </div>
+  );
+}
+
+export function AgentList() {
+  const [data, setData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => { apiFetch("/api/v1/agents").then(setData).finally(() => setLoading(false)); }, []);
+
+  if (loading) return <div className="flex h-64 items-center justify-center"><Spinner /></div>;
+  if (!data.length) return <EmptyState icon={<Server className="h-8 w-8" />} title="No agents" description="Create one via the CLI: observal agent create" />;
+
+  return (
+    <div>
+      <PageHeader title="Agents" description={`${data.length} active`} />
+      <DataTable columns={[
+        { key: "name", label: "Name", className: "font-medium" },
+        { key: "version", label: "Version", className: "font-mono text-xs" },
+        { key: "model_name", label: "Model" },
+        { key: "owner", label: "Owner", className: "text-muted-foreground" },
+        { key: "supported_ides", label: "IDEs", render: (r: any) => (r.supported_ides || []).map((ide: string) => <Badge key={ide} variant="default">{ide}</Badge>) },
+      ]} data={data} />
+    </div>
+  );
+}
+
+export function ReviewList() {
+  const [data, setData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => { apiFetch("/api/v1/review").then(setData).finally(() => setLoading(false)); }, []);
+
+  if (loading) return <div className="flex h-64 items-center justify-center"><Spinner /></div>;
+  if (!data.length) return <EmptyState title="No pending reviews" description="All submissions have been reviewed." />;
+
+  return (
+    <div>
+      <PageHeader title="Pending Reviews" description={`${data.length} awaiting review`} />
+      <DataTable columns={[
+        { key: "name", label: "Name", className: "font-medium" },
+        { key: "submitted_by", label: "Submitted By", className: "text-muted-foreground" },
+        { key: "status", label: "Status", render: (r: any) => <Badge variant={r.status === "pending" ? "warning" : "outline"}>{r.status}</Badge> },
+      ]} data={data} />
+    </div>
+  );
+}
+
+export function FeedbackPage() {
+  return (
+    <div>
+      <PageHeader title="Feedback" description="Ratings and reviews from users" />
+      <EmptyState title="Coming soon" description="View feedback for MCP servers and agents." />
+    </div>
+  );
+}
+
+export function EvalsPage() {
+  return (
+    <div>
+      <PageHeader title="Evaluations" description="LLM-as-judge scorecards" />
+      <EmptyState title="Coming soon" description="Run evaluations from the CLI: observal eval run <agent-id>" />
+    </div>
+  );
+}
+
+export function SettingsPage() {
+  const [data, setData] = useState<any[]>([]);
+  const [users, setUsers] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      apiFetch("/api/v1/admin/settings").then(setData).catch(() => {}),
+      apiFetch("/api/v1/admin/users").then(setUsers).catch(() => {}),
+    ]).finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div className="flex h-64 items-center justify-center"><Spinner /></div>;
+
+  return (
+    <div>
+      <PageHeader title="Settings" description="Enterprise configuration and user management" />
+      {data.length > 0 && (
+        <div className="mb-6">
+          <h3 className="mb-3 text-sm font-medium text-muted-foreground">Enterprise Settings</h3>
+          <DataTable columns={[
+            { key: "key", label: "Key", className: "font-mono font-medium" },
+            { key: "value", label: "Value" },
+          ]} data={data} />
+        </div>
+      )}
+      {users.length > 0 && (
+        <div>
+          <h3 className="mb-3 text-sm font-medium text-muted-foreground">Users ({users.length})</h3>
+          <DataTable columns={[
+            { key: "name", label: "Name", className: "font-medium" },
+            { key: "email", label: "Email" },
+            { key: "role", label: "Role", render: (r: any) => <Badge variant={r.role === "admin" ? "default" : "outline"}>{r.role}</Badge> },
+          ]} data={users} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/observal-web/vite.config.ts
+++ b/observal-web/vite.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import path from 'path'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   server: {
     port: 3000,
     proxy: {
@@ -10,6 +12,6 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: { '@': '/src' },
+    alias: { '@': path.resolve(__dirname, './src') },
   },
 })


### PR DESCRIPTION
## Summary

Complete web UI rewrite from raw HTML to a proper dark-themed dashboard with Tailwind CSS, shadcn-style components, recharts, and lucide icons.

## Before → After

**Before**: Raw HTML tables, inline styles, no CSS framework, 2-link nav bar, 4 pages.

**After**: Dark theme, collapsible sidebar, 8 sections, stat cards, charts, data tables with badges, login page.

## Stack
- Tailwind v4 (CSS variables, dark theme)
- recharts (area charts, bar charts)
- lucide-react (icons)
- clsx + tailwind-merge (cn utility)

## Pages

| Page | What it shows |
|------|--------------|
| Overview | Stat cards (traces, spans, tool calls, errors) + 30-day area chart |
| Traces | DataTable with type badges, error counts, click to drill down |
| Trace Detail | Span table with status/schema badges, scores, live subscription |
| MCP Servers | Registry browser with category/IDE badges, click to metrics |
| MCP Metrics | Stat cards + latency percentile bar chart |
| Agents | Agent list with model/IDE info |
| Reviews | Pending submissions table |
| Feedback | Placeholder |
| Evaluations | Placeholder |
| Settings | Enterprise config + user management tables |
| Login | API key auth |

## Component Library (`src/components/ui/`)
Card, StatCard, Badge, DataTable, Tabs, EmptyState, PageHeader, Spinner

## Layout
Collapsible sidebar with 8 nav items (Overview, Traces, MCP Servers, Agents, Reviews, Feedback, Evaluations, Settings). Collapses to icon-only mode.