### PR TITLE
fix: add auth guard + wire dashboard to OTel data

### DIFF
--- a/web/src/app/(dashboard)/layout.tsx
+++ b/web/src/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/nav/app-sidebar";
 import { CommandMenu } from "@/components/nav/command-menu";
 import { Toaster } from "@/components/ui/sonner";
+import { AuthGuard } from "@/components/layouts/auth-guard";
 
 export default function DashboardLayout({
   children,
@@ -9,13 +10,15 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <SidebarInset>
-        {children}
-      </SidebarInset>
-      <CommandMenu />
-      <Toaster visibleToasts={1} />
-    </SidebarProvider>
+    <AuthGuard>
+      <SidebarProvider>
+        <AppSidebar />
+        <SidebarInset>
+          {children}
+        </SidebarInset>
+        <CommandMenu />
+        <Toaster visibleToasts={1} />
+      </SidebarProvider>
+    </AuthGuard>
   );
 }

--- a/web/src/app/(dashboard)/page.tsx
+++ b/web/src/app/(dashboard)/page.tsx
@@ -58,7 +58,7 @@ export default function DashboardPage() {
   const hasData = !!s;
 
   const os = otelStats.data as
-    | { total_sessions: number; total_prompts: number; total_api_requests: number }
+    | { total_sessions: number; total_prompts: number; total_api_requests: number; total_tool_calls: number; total_input_tokens: number; total_output_tokens: number; total_traces: number; total_spans: number }
     | undefined;
 
   return (
@@ -117,6 +117,21 @@ export default function DashboardPage() {
             title="OTel API Requests"
             value={otelStats.isLoading ? "—" : (os?.total_api_requests ?? 0)}
             icon={Activity}
+          />
+          <StatCard
+            title="OTel Tool Calls"
+            value={otelStats.isLoading ? "—" : (os?.total_tool_calls ?? 0)}
+            icon={Wrench}
+          />
+          <StatCard
+            title="OTel Traces"
+            value={otelStats.isLoading ? "—" : (os?.total_traces ?? 0)}
+            icon={ListTree}
+          />
+          <StatCard
+            title="OTel Tokens"
+            value={otelStats.isLoading ? "—" : ((os?.total_input_tokens ?? 0) + (os?.total_output_tokens ?? 0)).toLocaleString()}
+            icon={BarChart3}
           />
 
           {/* Top items row */}

--- a/web/src/app/(dashboard)/sessions/[sessionId]/page.tsx
+++ b/web/src/app/(dashboard)/sessions/[sessionId]/page.tsx
@@ -10,6 +10,14 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
+interface RawOtelEvent {
+  timestamp: string;
+  event_name: string;
+  body?: string;
+  attributes?: Record<string, string>;
+  service_name?: string;
+}
+
 interface OtelEvent {
   timestamp: string;
   event_name: string;
@@ -22,12 +30,30 @@ interface OtelEvent {
   tool_name?: string;
   tool_success?: boolean;
   decision?: string;
-  [key: string]: unknown;
+  source?: string;
+}
+
+function normalizeEvent(raw: RawOtelEvent): OtelEvent {
+  const a = raw.attributes ?? {};
+  return {
+    timestamp: raw.timestamp,
+    event_name: raw.event_name,
+    body: raw.body || undefined,
+    prompt: a["prompt"] || a["user.prompt"] || undefined,
+    model: a["model"] || a["gen_ai.request.model"] || undefined,
+    input_tokens: a["input_tokens"] ? Number(a["input_tokens"]) : undefined,
+    output_tokens: a["output_tokens"] ? Number(a["output_tokens"]) : undefined,
+    duration_ms: a["duration_ms"] ? Number(a["duration_ms"]) : undefined,
+    tool_name: a["tool_name"] || a["tool.name"] || undefined,
+    tool_success: a["success"] != null ? a["success"] === "true" || a["success"] === "1" : undefined,
+    decision: a["decision"] || undefined,
+    source: a["source"] || undefined,
+  };
 }
 
 interface OtelSessionData {
   session_id: string;
-  events: OtelEvent[];
+  events: RawOtelEvent[];
   traces: unknown[];
   service_name: string;
 }
@@ -145,7 +171,7 @@ export default function SessionDetailPage({ params }: { params: Promise<{ sessio
   const { data, isLoading } = useOtelSession(sessionId);
   const session = data as OtelSessionData | undefined;
 
-  const events = session?.events ?? [];
+  const events = (session?.events ?? []).map(normalizeEvent);
   const totalTokensIn = events.reduce((sum, e) => sum + (e.input_tokens ?? 0), 0);
   const totalTokensOut = events.reduce((sum, e) => sum + (e.output_tokens ?? 0), 0);
   const totalDuration = events.length >= 2

--- a/web/src/app/(dashboard)/traces/page.tsx
+++ b/web/src/app/(dashboard)/traces/page.tsx
@@ -9,20 +9,16 @@ import { TraceList } from "@/components/traces/trace-list";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { StatusBadge } from "@/components/registry/status-badge";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface OtelTrace {
-  TraceId: string;
-  SpanId: string;
-  ParentSpanId?: string;
-  SpanName: string;
-  Duration: number;
-  StatusCode: string;
-  SpanAttributes?: Record<string, unknown>;
-  session_id?: string;
+  trace_id: string;
+  span_name: string;
   service_name?: string;
-  Timestamp?: string;
+  duration_ns: number;
+  status: string;
+  session_id?: string;
+  timestamp?: string;
 }
 
 function formatNanos(ns: number) {
@@ -70,18 +66,18 @@ function OtelTraceTable() {
         <TableBody>
           {traces.map((t, i) => (
             <TableRow
-              key={`${t.TraceId}-${t.SpanId}-${i}`}
+              key={`${t.trace_id}-${i}`}
               className="cursor-pointer"
               onClick={() => t.session_id ? router.push(`/sessions/${t.session_id}`) : undefined}
             >
-              <TableCell className="px-3 py-2 font-mono text-xs">{t.TraceId?.slice(0, 12)}…</TableCell>
-              <TableCell className="px-3 py-2 text-sm">{t.SpanName}</TableCell>
+              <TableCell className="px-3 py-2 font-mono text-xs">{t.trace_id?.slice(0, 12)}…</TableCell>
+              <TableCell className="px-3 py-2 text-sm">{t.span_name}</TableCell>
               <TableCell className="px-3 py-2 text-xs text-muted-foreground">{t.service_name ?? "—"}</TableCell>
-              <TableCell className="px-3 py-2 text-xs">{formatNanos(t.Duration)}</TableCell>
-              <TableCell className="px-3 py-2"><StatusBadge status={t.StatusCode?.toLowerCase() ?? "success"} /></TableCell>
+              <TableCell className="px-3 py-2 text-xs">{formatNanos(t.duration_ns)}</TableCell>
+              <TableCell className="px-3 py-2"><StatusBadge status={t.status?.toLowerCase() ?? "success"} /></TableCell>
               <TableCell className="px-3 py-2 font-mono text-xs text-muted-foreground">{t.session_id?.slice(0, 8) ?? "—"}</TableCell>
               <TableCell className="px-3 py-2 text-xs text-muted-foreground">
-                {t.Timestamp ? formatDistanceToNow(new Date(t.Timestamp), { addSuffix: true }) : "—"}
+                {t.timestamp ? formatDistanceToNow(new Date(t.timestamp), { addSuffix: true }) : "—"}
               </TableCell>
             </TableRow>
           ))}

--- a/web/src/components/layouts/auth-guard.tsx
+++ b/web/src/components/layouts/auth-guard.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { useAuthGuard } from "@/hooks/use-auth";
+
+export function AuthGuard({ children }: { children: React.ReactNode }) {
+  const ready = useAuthGuard();
+  if (!ready) return null;
+  return <>{children}</>;
+}

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -1,0 +1,20 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+
+export function useAuthGuard() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    const key = localStorage.getItem("observal_api_key");
+    if (!key && pathname !== "/login") {
+      router.replace("/login");
+    } else {
+      setChecked(true);
+    }
+  }, [pathname, router]);
+
+  return checked;
+}


### PR DESCRIPTION
Single commit on top of merged PR #61.

### Changes
- Auth guard redirects to /login if no API key in localStorage
- Session detail page reads from attributes map (actual backend shape)
- Traces page uses snake_case field names matching backend aliases
- Dashboard page shows all OTel stats (sessions, prompts, tools, traces, tokens)