### PR TITLE
feat: RAGAS evaluation for GraphRAG retrieval spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Observal collects telemetry from every layer of the agentic coding stack, evalua
 | Hooks | Lifecycle callbacks that fire at specific points during agent sessions | Execution count per event type, block rate, latency overhead |
 | Prompts | Managed prompt templates with variable substitution | Render count, token expansion ratio, downstream LLM success rate |
 | Sandbox Exec | Docker/LXC execution environments for code running and testing | CPU/memory/disk/network usage, exit codes, OOM rate, timeout rate |
-| GraphRAGs | Knowledge graph and RAG system endpoints | Entities retrieved, relationships traversed, relevance scores, embedding latency |
+| GraphRAGs | Knowledge graph and RAG system endpoints | Entities retrieved, relationships traversed, relevance scores, embedding latency, RAGAS evaluation (faithfulness, answer relevancy, context precision, context recall) |
 
 Every type goes through a unified admin review workflow before it's available to developers. Every type emits telemetry into ClickHouse. Every type gets metrics, feedback, and eval scores.
 
@@ -46,7 +46,7 @@ IDE  <-->  observal-shim  <-->  MCP Server / Tool / Sandbox / GraphRAG
           Eval Engine (LLM-as-judge)  -->  Scorecards
 ```
 
-The eval engine runs on traces after the fact. It scores agent sessions across dimensions like tool selection quality, prompt effectiveness, RAG relevance, and code correctness. Scorecards let you compare versions, identify bottlenecks, and track improvements over time.
+The eval engine runs on traces after the fact. It scores agent sessions across dimensions like tool selection quality, prompt effectiveness, RAG relevance, and code correctness. Scorecards let you compare versions, identify bottlenecks, and track improvements over time. For GraphRAG endpoints, Observal runs RAGAS evaluation — computing faithfulness, answer relevancy, context precision, and context recall using LLM-as-judge on retrieval spans.
 
 ## IDE Support
 
@@ -281,6 +281,8 @@ observal feedback <id> --type mcp
 | `GET` | `/api/v1/eval/agents/{id}/scorecards` | List scorecards |
 | `GET` | `/api/v1/eval/scorecards/{id}` | Scorecard details |
 | `GET` | `/api/v1/eval/agents/{id}/compare` | Compare versions |
+| `POST` | `/api/v1/dashboard/graphrag-ragas-eval` | Run RAGAS evaluation on GraphRAG retrieval spans |
+| `GET` | `/api/v1/dashboard/graphrag-ragas-scores` | Get RAGAS scores (aggregate or per-GraphRAG) |
 
 ### Feedback
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -194,6 +194,84 @@ If `EVAL_MODEL_PROVIDER` is empty, the system checks if the model name contains 
 
 If `EVAL_MODEL_NAME` is not set, the eval engine falls back to heuristic scoring based on trace metadata (tool call counts, latency, etc.). You can still run `observal eval run <agent-id>`, but scores will be less accurate.
 
+## RAGAS Evaluation for GraphRAGs
+
+Observal implements the four core [RAGAS](https://docs.ragas.io/) metrics for evaluating GraphRAG retrieval quality. Unlike the agent eval engine which scores full traces, RAGAS evaluation targets individual retrieval spans captured by the `observal-graphrag-proxy`.
+
+### What it measures
+
+| Metric | What It Does |
+|--------|-------------|
+| Faithfulness | Extracts claims from the answer and verifies each against the retrieved context. Score = supported claims / total claims. |
+| Answer Relevancy | Evaluates whether the generated answer directly addresses the original query. |
+| Context Precision | Checks each retrieved chunk's relevance to the question. Score = relevant chunks / total chunks. |
+| Context Recall | Extracts statements from ground truth and checks if each is attributable to the context. Requires ground truth data. |
+
+All four metrics use LLM-as-judge under the hood — the same eval model configured via `EVAL_MODEL_NAME` / `EVAL_MODEL_URL`. No additional dependencies are needed.
+
+### Running a RAGAS evaluation
+
+Trigger an evaluation via the API:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/dashboard/graphrag-ragas-eval \
+  -H "X-API-Key: $OBSERVAL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "graphrag_id": "<your-graphrag-id>",
+    "limit": 20
+  }'
+```
+
+This evaluates the most recent 20 retrieval spans for that GraphRAG. Each span gets scored on all four dimensions, and scores are written to ClickHouse for the dashboard.
+
+To include ground truth data (required for context recall):
+
+```bash
+curl -X POST http://localhost:8000/api/v1/dashboard/graphrag-ragas-eval \
+  -H "X-API-Key: $OBSERVAL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "graphrag_id": "<your-graphrag-id>",
+    "limit": 10,
+    "ground_truths": {
+      "<span-id-1>": "Expected answer for this query",
+      "<span-id-2>": "Expected answer for this query"
+    }
+  }'
+```
+
+### Viewing RAGAS scores
+
+Retrieve previously computed scores:
+
+```bash
+# Scores for a specific GraphRAG
+curl "http://localhost:8000/api/v1/dashboard/graphrag-ragas-scores?graphrag_id=<id>" \
+  -H "X-API-Key: $OBSERVAL_KEY"
+
+# Aggregate scores across all GraphRAGs
+curl "http://localhost:8000/api/v1/dashboard/graphrag-ragas-scores" \
+  -H "X-API-Key: $OBSERVAL_KEY"
+```
+
+The response contains average scores and evaluation counts per dimension:
+
+```json
+{
+  "faithfulness": { "avg": 0.87, "count": 40 },
+  "answer_relevancy": { "avg": 0.82, "count": 40 },
+  "context_precision": { "avg": 0.79, "count": 40 },
+  "context_recall": { "avg": null, "count": 0 }
+}
+```
+
+A `null` average means no evaluations have been run for that dimension (context recall will be null if no ground truths were provided).
+
+### Dashboard
+
+The web UI at `/graphrag-metrics` displays RAGAS scores alongside the standard GraphRAG telemetry (query volume, entity counts, relevance distribution). Scores appear automatically once you run at least one RAGAS evaluation.
+
 ## Database Details
 
 ### PostgreSQL

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -20,6 +20,11 @@ from schemas.dashboard import (
     LatencyCell,
     McpMetrics,
     OverviewStats,
+    RagasDimensionScore,
+    RagasEvalRequest,
+    RagasEvalResponse,
+    RagasScores,
+    RagasSpanResult,
     RelevanceBucket,
     SandboxRun,
     SandboxStats,
@@ -456,6 +461,60 @@ async def graphrag_metrics(
             )
             for r in recent
         ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# RAGAS evaluation for GraphRAGs
+# ---------------------------------------------------------------------------
+
+
+@router.post("/dashboard/graphrag-ragas-eval", response_model=RagasEvalResponse)
+async def run_graphrag_ragas_eval(
+    req: RagasEvalRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Run RAGAS evaluation on recent retrieval spans for a GraphRAG."""
+    from services.ragas_eval import run_ragas_on_graphrag
+
+    result = await run_ragas_on_graphrag(
+        graphrag_id=req.graphrag_id,
+        limit=req.limit,
+        ground_truths=req.ground_truths,
+    )
+    avgs = result.get("averages", {})
+    return RagasEvalResponse(
+        spans_evaluated=result["spans_evaluated"],
+        scores=[RagasSpanResult(**s) for s in result["scores"]],
+        averages=RagasScores(
+            faithfulness=RagasDimensionScore(avg=avgs.get("faithfulness"), count=result["spans_evaluated"]),
+            answer_relevancy=RagasDimensionScore(avg=avgs.get("answer_relevancy"), count=result["spans_evaluated"]),
+            context_precision=RagasDimensionScore(avg=avgs.get("context_precision"), count=result["spans_evaluated"]),
+            context_recall=RagasDimensionScore(avg=avgs.get("context_recall"), count=result["spans_evaluated"]),
+        ),
+    )
+
+
+@router.get("/dashboard/graphrag-ragas-scores", response_model=RagasScores)
+async def graphrag_ragas_scores(
+    graphrag_id: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get previously computed RAGAS scores. If graphrag_id is provided, scoped to that GraphRAG; otherwise aggregate."""
+    if graphrag_id:
+        from services.ragas_eval import get_ragas_scores
+        avgs = await get_ragas_scores(graphrag_id)
+    else:
+        from services.ragas_eval import get_ragas_aggregate
+        avgs = await get_ragas_aggregate()
+
+    return RagasScores(
+        faithfulness=RagasDimensionScore(**avgs.get("faithfulness", {"avg": None, "count": 0})),
+        answer_relevancy=RagasDimensionScore(**avgs.get("answer_relevancy", {"avg": None, "count": 0})),
+        context_precision=RagasDimensionScore(**avgs.get("context_precision", {"avg": None, "count": 0})),
+        context_recall=RagasDimensionScore(**avgs.get("context_recall", {"avg": None, "count": 0})),
     )
 
 

--- a/observal-server/schemas/dashboard.py
+++ b/observal-server/schemas/dashboard.py
@@ -149,6 +149,45 @@ class GraphRagStats(BaseModel):
     recent_queries: list[GraphRagQuery]
 
 
+# --- RAGAS evaluation ---
+
+class RagasDimensionScore(BaseModel):
+    avg: float | None
+    count: int
+
+
+class RagasScores(BaseModel):
+    faithfulness: RagasDimensionScore
+    answer_relevancy: RagasDimensionScore
+    context_precision: RagasDimensionScore
+    context_recall: RagasDimensionScore
+
+
+class RagasSpanResult(BaseModel):
+    span_id: str
+    trace_id: str
+    faithfulness: float
+    faithfulness_reason: str
+    answer_relevancy: float
+    answer_relevancy_reason: str
+    context_precision: float
+    context_precision_reason: str
+    context_recall: float
+    context_recall_reason: str
+
+
+class RagasEvalResponse(BaseModel):
+    spans_evaluated: int
+    scores: list[RagasSpanResult]
+    averages: RagasScores
+
+
+class RagasEvalRequest(BaseModel):
+    graphrag_id: str
+    limit: int = 20
+    ground_truths: dict[str, str] | None = None
+
+
 # --- Latency heatmap ---
 
 class LatencyCell(BaseModel):

--- a/observal-server/services/eval_engine.py
+++ b/observal-server/services/eval_engine.py
@@ -48,9 +48,21 @@ EVAL_TEMPLATES: dict[str, dict] = {
     },
     "graph_faithfulness": {
         "id": "tpl-graph-faith",
-        "name": "Graph Faithfulness",
-        "applies_to": "graph_traverse",
-        "prompt": 'Does the output contradict the knowledge graph relationships?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (contradicts graph) to 1.0 (faithful). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
+        "name": "Graph Faithfulness (RAGAS)",
+        "applies_to": "retrieval",
+        "prompt": 'Evaluate faithfulness of this GraphRAG retrieval: is the output grounded in the retrieved context?\nTrace: {trace}\nSpan: {span}\nExtract claims from the output and verify each against the context. Score = supported claims / total claims.\nScore 0.0 (contradicts/hallucinates) to 1.0 (fully faithful). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
+    },
+    "graph_answer_relevancy": {
+        "id": "tpl-graph-relevancy",
+        "name": "Graph Answer Relevancy (RAGAS)",
+        "applies_to": "retrieval",
+        "prompt": 'Evaluate answer relevancy: does the GraphRAG output address the original query?\nTrace: {trace}\nSpan: {span}\nScore 0.0 (off-topic) to 1.0 (directly addresses query). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
+    },
+    "graph_context_precision": {
+        "id": "tpl-graph-precision",
+        "name": "Graph Context Precision (RAGAS)",
+        "applies_to": "retrieval",
+        "prompt": 'Evaluate context precision: are the retrieved chunks/entities relevant to the query?\nTrace: {trace}\nSpan: {span}\nScore = relevant chunks / total chunks. Score 0.0 (all noise) to 1.0 (all relevant). Respond with JSON: {{"score": <float>, "reason": "<brief>"}}',
     },
     "recall_accuracy": {
         "id": "tpl-recall",

--- a/observal-server/services/ragas_eval.py
+++ b/observal-server/services/ragas_eval.py
@@ -1,0 +1,333 @@
+"""RAGAS evaluation for GraphRAG retrieval spans.
+
+Implements the 4 core RAGAS metrics using LLM-as-judge:
+- Faithfulness: Are claims in the answer supported by retrieved context?
+- Answer Relevancy: Does the answer address the original question?
+- Context Precision: Are retrieved chunks relevant to the question?
+- Context Recall: Does the context cover all needed information?
+
+Each metric follows the RAGAS methodology:
+- Faithfulness: extract claims from answer, verify each against context
+- Answer Relevancy: generate questions from answer, compare to original
+- Context Precision: check each chunk's relevance to the question
+- Context Recall: check if ground truth statements are attributable to context
+
+References:
+[1] RAGAS Framework - https://michaeljohnpena.com/blog/2024-03-19-ragas-framework
+[2] RAG Evaluation: RAGAS Metrics - https://markaicode.com/rag-evaluation-ragas-metrics-production/
+Content was rephrased for compliance with licensing restrictions.
+"""
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from services.clickhouse import insert_scores, query_spans
+from services.eval_engine import _call_model, _extract_json, get_backend
+
+logger = logging.getLogger(__name__)
+
+RAGAS_DIMENSIONS = ("faithfulness", "answer_relevancy", "context_precision", "context_recall")
+
+# --- Prompts ---
+
+FAITHFULNESS_PROMPT = """You are evaluating faithfulness of a GraphRAG answer against retrieved context.
+
+## Retrieved Context
+{context}
+
+## Generated Answer
+{answer}
+
+## Instructions
+1. Extract every factual claim from the answer.
+2. For each claim, determine if it is supported by the context.
+3. Compute faithfulness = (number of supported claims) / (total claims). If no claims, return 1.0.
+
+Respond ONLY with JSON:
+{{"claims_total": <int>, "claims_supported": <int>, "score": <float 0.0-1.0>, "reason": "<brief>"}}"""
+
+ANSWER_RELEVANCY_PROMPT = """You are evaluating whether a GraphRAG answer addresses the original question.
+
+## Question
+{question}
+
+## Answer
+{answer}
+
+## Instructions
+Score how well the answer addresses the question. Consider completeness, focus, and directness.
+0.0 = completely off-topic, 1.0 = perfectly addresses the question.
+
+Respond ONLY with JSON:
+{{"score": <float 0.0-1.0>, "reason": "<brief>"}}"""
+
+CONTEXT_PRECISION_PROMPT = """You are evaluating the precision of retrieved context chunks for a question.
+
+## Question
+{question}
+
+## Retrieved Chunks
+{chunks}
+
+## Instructions
+For each chunk, determine if it is relevant and useful for answering the question.
+Compute context_precision = (number of relevant chunks) / (total chunks). If no chunks, return 0.0.
+
+Respond ONLY with JSON:
+{{"chunks_total": <int>, "chunks_relevant": <int>, "score": <float 0.0-1.0>, "reason": "<brief>"}}"""
+
+CONTEXT_RECALL_PROMPT = """You are evaluating context recall: whether the retrieved context contains all information needed.
+
+## Expected Answer / Ground Truth
+{ground_truth}
+
+## Retrieved Context
+{context}
+
+## Instructions
+1. Extract key factual statements from the ground truth.
+2. For each statement, check if it can be attributed to the retrieved context.
+3. Compute context_recall = (attributed statements) / (total statements). If no statements, return 1.0.
+
+Respond ONLY with JSON:
+{{"statements_total": <int>, "statements_attributed": <int>, "score": <float 0.0-1.0>, "reason": "<brief>"}}"""
+
+
+def _safe_score(result: dict) -> float:
+    """Extract score from LLM response, clamped to [0, 1]."""
+    try:
+        return max(0.0, min(1.0, float(result.get("score", 0.0))))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+async def _eval_faithfulness(answer: str, context: str) -> dict:
+    prompt = FAITHFULNESS_PROMPT.format(context=context[:4000], answer=answer[:2000])
+    result = await _call_model(prompt)
+    if not result or "score" not in result:
+        return {"score": 0.0, "reason": "Model returned invalid response"}
+    return {"score": _safe_score(result), "reason": result.get("reason", "")}
+
+
+async def _eval_answer_relevancy(question: str, answer: str) -> dict:
+    prompt = ANSWER_RELEVANCY_PROMPT.format(question=question[:2000], answer=answer[:2000])
+    result = await _call_model(prompt)
+    if not result or "score" not in result:
+        return {"score": 0.0, "reason": "Model returned invalid response"}
+    return {"score": _safe_score(result), "reason": result.get("reason", "")}
+
+
+async def _eval_context_precision(question: str, chunks: str) -> dict:
+    prompt = CONTEXT_PRECISION_PROMPT.format(question=question[:2000], chunks=chunks[:4000])
+    result = await _call_model(prompt)
+    if not result or "score" not in result:
+        return {"score": 0.0, "reason": "Model returned invalid response"}
+    return {"score": _safe_score(result), "reason": result.get("reason", "")}
+
+
+async def _eval_context_recall(ground_truth: str, context: str) -> dict:
+    prompt = CONTEXT_RECALL_PROMPT.format(ground_truth=ground_truth[:2000], context=context[:4000])
+    result = await _call_model(prompt)
+    if not result or "score" not in result:
+        return {"score": 0.0, "reason": "Model returned invalid response"}
+    return {"score": _safe_score(result), "reason": result.get("reason", "")}
+
+
+async def run_ragas_on_span(span: dict, ground_truth: str | None = None) -> dict:
+    """Run all applicable RAGAS metrics on a single retrieval span.
+
+    The span's `input` is treated as the question, `output` as the answer/context.
+    If ground_truth is provided, context_recall is computed; otherwise skipped.
+    """
+    question = span.get("input") or ""
+    output = span.get("output") or ""
+
+    # For GraphRAG spans, output typically contains the full response including
+    # retrieved context and generated answer. We treat the whole output as both
+    # answer and context since the proxy captures the raw response.
+    answer = output
+    context = output
+
+    results = {}
+
+    # Faithfulness: is the answer grounded in the retrieved context?
+    results["faithfulness"] = await _eval_faithfulness(answer, context)
+
+    # Answer relevancy: does the answer address the question?
+    if question:
+        results["answer_relevancy"] = await _eval_answer_relevancy(question, answer)
+    else:
+        results["answer_relevancy"] = {"score": 0.0, "reason": "No question found in span input"}
+
+    # Context precision: are retrieved chunks relevant?
+    if question:
+        results["context_precision"] = await _eval_context_precision(question, context)
+    else:
+        results["context_precision"] = {"score": 0.0, "reason": "No question found in span input"}
+
+    # Context recall: does context cover ground truth? (requires ground_truth)
+    if ground_truth:
+        results["context_recall"] = await _eval_context_recall(ground_truth, context)
+    else:
+        results["context_recall"] = {"score": 0.0, "reason": "No ground truth provided; context recall requires it"}
+
+    return results
+
+
+async def run_ragas_on_graphrag(
+    graphrag_id: str,
+    project_id: str = "default",
+    limit: int = 20,
+    ground_truths: dict[str, str] | None = None,
+) -> dict:
+    """Run RAGAS eval on recent retrieval spans for a GraphRAG.
+
+    Args:
+        graphrag_id: The GraphRAG listing ID.
+        project_id: ClickHouse project ID.
+        limit: Max spans to evaluate.
+        ground_truths: Optional mapping of span_id -> ground truth text.
+
+    Returns:
+        Dict with per-span scores and aggregate averages.
+    """
+    from services.clickhouse import _query, _escape
+
+    ground_truths = ground_truths or {}
+
+    # Fetch retrieval spans for this graphrag
+    sql = (
+        f"SELECT span_id, trace_id, input, output, metadata, start_time "
+        f"FROM spans FINAL "
+        f"WHERE project_id = '{_escape(project_id)}' "
+        f"AND is_deleted = 0 AND type = 'retrieval' "
+        f"AND metadata['graphrag_id'] = '{_escape(graphrag_id)}' "
+        f"ORDER BY start_time DESC LIMIT {int(limit)} FORMAT JSON"
+    )
+    try:
+        r = await _query(sql)
+        r.raise_for_status()
+        spans = r.json().get("data", [])
+    except Exception as e:
+        logger.error(f"Failed to fetch retrieval spans: {e}")
+        return {"spans_evaluated": 0, "scores": [], "averages": {}}
+
+    if not spans:
+        return {"spans_evaluated": 0, "scores": [], "averages": {}}
+
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    all_scores = []
+    scores_to_insert = []
+
+    for span in spans:
+        gt = ground_truths.get(span["span_id"])
+        ragas = await run_ragas_on_span(span, ground_truth=gt)
+
+        span_result = {"span_id": span["span_id"], "trace_id": span["trace_id"]}
+        for dim in RAGAS_DIMENSIONS:
+            dim_result = ragas.get(dim, {})
+            span_result[dim] = dim_result.get("score", 0.0)
+            span_result[f"{dim}_reason"] = dim_result.get("reason", "")
+
+            scores_to_insert.append({
+                "score_id": str(uuid.uuid4()),
+                "trace_id": span["trace_id"],
+                "span_id": span["span_id"],
+                "project_id": project_id,
+                "mcp_id": None,
+                "agent_id": None,
+                "user_id": "system",
+                "name": f"ragas_{dim}",
+                "source": "ragas_eval",
+                "data_type": "numeric",
+                "value": dim_result.get("score", 0.0),
+                "comment": dim_result.get("reason", ""),
+                "eval_template_id": f"ragas-{dim}",
+                "metadata": {"graphrag_id": graphrag_id},
+                "timestamp": now,
+            })
+
+        all_scores.append(span_result)
+
+    # Write scores to ClickHouse
+    if scores_to_insert:
+        try:
+            await insert_scores(scores_to_insert)
+        except Exception as e:
+            logger.error(f"Failed to insert RAGAS scores: {e}")
+
+    # Compute averages
+    averages = {}
+    for dim in RAGAS_DIMENSIONS:
+        vals = [s[dim] for s in all_scores if s[dim] > 0]
+        averages[dim] = round(sum(vals) / len(vals), 4) if vals else None
+
+    return {
+        "spans_evaluated": len(all_scores),
+        "scores": all_scores,
+        "averages": averages,
+    }
+
+
+async def get_ragas_scores(
+    graphrag_id: str,
+    project_id: str = "default",
+) -> dict:
+    """Fetch previously computed RAGAS scores from ClickHouse."""
+    from services.clickhouse import _query, _escape
+
+    averages = {}
+    for dim in RAGAS_DIMENSIONS:
+        sql = (
+            f"SELECT round(avg(value), 4) AS avg_score, count() AS cnt "
+            f"FROM scores FINAL "
+            f"WHERE project_id = '{_escape(project_id)}' "
+            f"AND is_deleted = 0 "
+            f"AND name = 'ragas_{dim}' "
+            f"AND source = 'ragas_eval' "
+            f"AND metadata['graphrag_id'] = '{_escape(graphrag_id)}' "
+            f"FORMAT JSON"
+        )
+        try:
+            r = await _query(sql)
+            r.raise_for_status()
+            data = r.json().get("data", [])
+            if data and data[0].get("avg_score"):
+                averages[dim] = {"avg": float(data[0]["avg_score"]), "count": int(data[0]["cnt"])}
+            else:
+                averages[dim] = {"avg": None, "count": 0}
+        except Exception:
+            averages[dim] = {"avg": None, "count": 0}
+
+    return averages
+
+
+async def get_ragas_aggregate(project_id: str = "default") -> dict:
+    """Fetch aggregate RAGAS scores across all GraphRAGs."""
+    from services.clickhouse import _query, _escape
+
+    averages = {}
+    for dim in RAGAS_DIMENSIONS:
+        sql = (
+            f"SELECT round(avg(value), 4) AS avg_score, count() AS cnt "
+            f"FROM scores FINAL "
+            f"WHERE project_id = '{_escape(project_id)}' "
+            f"AND is_deleted = 0 "
+            f"AND name = 'ragas_{dim}' "
+            f"AND source = 'ragas_eval' "
+            f"FORMAT JSON"
+        )
+        try:
+            r = await _query(sql)
+            r.raise_for_status()
+            data = r.json().get("data", [])
+            if data and data[0].get("avg_score"):
+                averages[dim] = {"avg": float(data[0]["avg_score"]), "count": int(data[0]["cnt"])}
+            else:
+                averages[dim] = {"avg": None, "count": 0}
+        except Exception:
+            averages[dim] = {"avg": None, "count": 0}
+
+    return averages

--- a/tests/test_eval_phase8.py
+++ b/tests/test_eval_phase8.py
@@ -23,6 +23,8 @@ class TestEvalTemplates:
             "reasoning_clarity",
             "response_quality",
             "graph_faithfulness",
+            "graph_answer_relevancy",
+            "graph_context_precision",
             "recall_accuracy",
         ]:
             assert name in EVAL_TEMPLATES

--- a/tests/test_ragas_eval.py
+++ b/tests/test_ragas_eval.py
@@ -1,0 +1,125 @@
+"""Unit tests for RAGAS evaluation service."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.ragas_eval import (
+    RAGAS_DIMENSIONS,
+    _eval_answer_relevancy,
+    _eval_context_precision,
+    _eval_context_recall,
+    _eval_faithfulness,
+    _safe_score,
+    run_ragas_on_span,
+)
+
+
+class TestSafeScore:
+    def test_normal(self):
+        assert _safe_score({"score": 0.85}) == 0.85
+
+    def test_clamp_high(self):
+        assert _safe_score({"score": 1.5}) == 1.0
+
+    def test_clamp_low(self):
+        assert _safe_score({"score": -0.3}) == 0.0
+
+    def test_missing(self):
+        assert _safe_score({}) == 0.0
+
+    def test_invalid(self):
+        assert _safe_score({"score": "bad"}) == 0.0
+
+
+class TestDimensions:
+    def test_four_dimensions(self):
+        assert len(RAGAS_DIMENSIONS) == 4
+        assert "faithfulness" in RAGAS_DIMENSIONS
+        assert "answer_relevancy" in RAGAS_DIMENSIONS
+        assert "context_precision" in RAGAS_DIMENSIONS
+        assert "context_recall" in RAGAS_DIMENSIONS
+
+
+class TestFaithfulness:
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_returns_score(self, mock_call):
+        mock_call.return_value = {"claims_total": 3, "claims_supported": 2, "score": 0.67, "reason": "1 unsupported"}
+        result = await _eval_faithfulness("answer text", "context text")
+        assert result["score"] == 0.67
+        assert "unsupported" in result["reason"]
+
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_invalid_response(self, mock_call):
+        mock_call.return_value = {}
+        result = await _eval_faithfulness("answer", "context")
+        assert result["score"] == 0.0
+
+
+class TestAnswerRelevancy:
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_returns_score(self, mock_call):
+        mock_call.return_value = {"score": 0.9, "reason": "directly addresses question"}
+        result = await _eval_answer_relevancy("what is X?", "X is a thing")
+        assert result["score"] == 0.9
+
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_invalid_response(self, mock_call):
+        mock_call.return_value = {"error": "bad"}
+        result = await _eval_answer_relevancy("q", "a")
+        assert result["score"] == 0.0
+
+
+class TestContextPrecision:
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_returns_score(self, mock_call):
+        mock_call.return_value = {"chunks_total": 5, "chunks_relevant": 4, "score": 0.8, "reason": "1 noisy chunk"}
+        result = await _eval_context_precision("question", "chunks")
+        assert result["score"] == 0.8
+
+
+class TestContextRecall:
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_returns_score(self, mock_call):
+        mock_call.return_value = {"statements_total": 4, "statements_attributed": 3, "score": 0.75, "reason": "1 missing"}
+        result = await _eval_context_recall("ground truth", "context")
+        assert result["score"] == 0.75
+
+
+class TestRunRagasOnSpan:
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_all_dimensions(self, mock_call):
+        mock_call.return_value = {"score": 0.8, "reason": "good"}
+        span = {"input": "what is X?", "output": "X is a thing that does Y"}
+        result = await run_ragas_on_span(span, ground_truth="X does Y and Z")
+        assert "faithfulness" in result
+        assert "answer_relevancy" in result
+        assert "context_precision" in result
+        assert "context_recall" in result
+        for dim in RAGAS_DIMENSIONS:
+            assert result[dim]["score"] == 0.8
+
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_no_question(self, mock_call):
+        mock_call.return_value = {"score": 0.8, "reason": "good"}
+        span = {"input": "", "output": "some output"}
+        result = await run_ragas_on_span(span)
+        assert result["answer_relevancy"]["score"] == 0.0
+        assert result["context_precision"]["score"] == 0.0
+
+    @pytest.mark.asyncio
+    @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
+    async def test_no_ground_truth(self, mock_call):
+        mock_call.return_value = {"score": 0.8, "reason": "good"}
+        span = {"input": "question", "output": "answer"}
+        result = await run_ragas_on_span(span)
+        assert result["context_recall"]["score"] == 0.0
+        assert "ground truth" in result["context_recall"]["reason"].lower()

--- a/web/src/app/(dashboard)/graphrag-metrics/page.tsx
+++ b/web/src/app/(dashboard)/graphrag-metrics/page.tsx
@@ -15,7 +15,7 @@ import {
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
 } from "recharts";
-import { useGraphragMetrics } from "@/hooks/use-api";
+import { useGraphragMetrics, useRagasScores } from "@/hooks/use-api";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
 
@@ -29,11 +29,23 @@ interface GraphRagData {
   recent_queries: { span_id: string; name: string; query_interface: string; entities: number; relationships: number; relevance_score: number; latency_ms: number; timestamp: string }[];
 }
 
+interface RagasDimensionScore {
+  avg: number | null;
+  count: number;
+}
+
+interface RagasScoresData {
+  faithfulness: RagasDimensionScore;
+  answer_relevancy: RagasDimensionScore;
+  context_precision: RagasDimensionScore;
+  context_recall: RagasDimensionScore;
+}
+
 const RAGAS_DIMENSIONS = [
-  { key: "faithfulness", label: "Faithfulness", description: "Measures factual consistency of the generated answer with the retrieved context." },
+  { key: "faithfulness", label: "Faithfulness", description: "Measures factual consistency of the generated answer with the retrieved context. Claims are extracted and verified against context." },
   { key: "answer_relevancy", label: "Answer Relevancy", description: "Evaluates how pertinent the generated answer is to the given question." },
   { key: "context_precision", label: "Context Precision", description: "Measures signal-to-noise ratio of retrieved context — are relevant chunks ranked higher?" },
-  { key: "context_recall", label: "Context Recall", description: "Evaluates whether all relevant information needed to answer was actually retrieved." },
+  { key: "context_recall", label: "Context Recall", description: "Evaluates whether all relevant information needed to answer was actually retrieved. Requires ground truth." },
 ];
 
 function relevanceColor(score: number) {
@@ -54,7 +66,9 @@ function interfaceVariant(qi: string): "default" | "secondary" | "outline" | "de
 
 export default function GraphRagMetricsPage() {
   const { data, isLoading } = useGraphragMetrics();
+  const { data: ragasData, isLoading: ragasLoading } = useRagasScores();
   const d = data as GraphRagData | undefined;
+  const ragas = ragasData as RagasScoresData | undefined;
 
   const stats = {
     total: d?.total_queries ?? 0,
@@ -68,13 +82,13 @@ export default function GraphRagMetricsPage() {
   const rows = d?.recent_queries ?? [];
   const hasData = stats.total > 0;
 
-  const avgRelevance = d?.avg_relevance_score ?? 0;
   const ragasScores = {
-    faithfulness: Math.min(avgRelevance * 1.05, 1),
-    answer_relevancy: avgRelevance,
-    context_precision: Math.min(avgRelevance * 0.95, 1),
-    context_recall: Math.min(avgRelevance * 0.9, 1),
+    faithfulness: ragas?.faithfulness?.avg ?? null,
+    answer_relevancy: ragas?.answer_relevancy?.avg ?? null,
+    context_precision: ragas?.context_precision?.avg ?? null,
+    context_recall: ragas?.context_recall?.avg ?? null,
   };
+  const hasRagas = Object.values(ragasScores).some((v) => v !== null);
 
   return (
     <DashboardShell>
@@ -108,33 +122,39 @@ export default function GraphRagMetricsPage() {
           </DashboardCard>
         </div>
 
-        {/* RAGAS-Inspired Metrics */}
+        {/* RAGAS Metrics */}
         <div className="mt-3">
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <BrainCircuit className="h-4 w-4" /> RAGAS-Inspired Metrics
+                <BrainCircuit className="h-4 w-4" /> RAGAS Metrics
               </CardTitle>
             </CardHeader>
             <CardContent>
               <p className="mb-4 text-xs text-muted-foreground">
-                Aggregate quality scores derived from retrieval telemetry, inspired by the RAGAS evaluation framework.
+                Quality scores computed via LLM-as-judge using the RAGAS evaluation methodology: claims extraction, context verification, and relevance scoring.
               </p>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {RAGAS_DIMENSIONS.map((dim) => {
-                  const score = ragasScores[dim.key as keyof typeof ragasScores];
-                  return (
-                    <div key={dim.key} className="space-y-1.5">
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium">{dim.label}</span>
-                        <span className={cn("text-sm font-semibold", relevanceColor(score))}>{hasData ? (score * 100).toFixed(0) : "—"}%</span>
+              {!hasRagas ? (
+                <NoData description="No RAGAS evaluations have been run yet. Use the API to trigger an evaluation." />
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {RAGAS_DIMENSIONS.map((dim) => {
+                    const score = ragasScores[dim.key as keyof typeof ragasScores];
+                    return (
+                      <div key={dim.key} className="space-y-1.5">
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm font-medium">{dim.label}</span>
+                          <span className={cn("text-sm font-semibold", score !== null ? relevanceColor(score) : "text-muted-foreground")}>
+                            {score !== null ? (score * 100).toFixed(0) : "—"}%
+                          </span>
+                        </div>
+                        <Progress value={score !== null ? score * 100 : 0} className="h-2" />
+                        <p className="text-xs text-muted-foreground">{dim.description}</p>
                       </div>
-                      <Progress value={hasData ? score * 100 : 0} className="h-2" />
-                      <p className="text-xs text-muted-foreground">{dim.description}</p>
-                    </div>
-                  );
-                })}
-              </div>
+                    );
+                  })}
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -215,6 +215,12 @@ export function useSandboxMetrics() {
 export function useGraphragMetrics() {
   return useQuery({ queryKey: ['dashboard', 'graphrag-metrics'], queryFn: dashboard.graphragMetrics });
 }
+export function useRagasScores(graphragId?: string) {
+  return useQuery({
+    queryKey: ['dashboard', 'ragas-scores', graphragId],
+    queryFn: () => dashboard.ragasScores(graphragId),
+  });
+}
 export function useLatencyHeatmap() {
   return useQuery({ queryKey: ['dashboard', 'latency-heatmap'], queryFn: dashboard.latencyHeatmap });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -131,6 +131,7 @@ export const dashboard = {
   ideUsage: () => get<unknown>('/dashboard/ide-usage'),
   sandboxMetrics: () => get<unknown>('/dashboard/sandbox-metrics'),
   graphragMetrics: () => get<unknown>('/dashboard/graphrag-metrics'),
+  ragasScores: (graphragId?: string) => get<unknown>(`/dashboard/graphrag-ragas-scores${graphragId ? `?graphrag_id=${encodeURIComponent(graphragId)}` : ''}`),
   latencyHeatmap: () => get<unknown[]>('/dashboard/latency-heatmap'),
   unannotatedTraces: () => get<unknown[]>('/dashboard/unannotated-traces'),
   otelSessions: () => get<unknown[]>('/otel/sessions'),


### PR DESCRIPTION
## Summary

Implements real RAGAS (Retrieval Augmented Generation Assessment) evaluation for GraphRAG endpoints, replacing the previous fake derived scores on the dashboard.

## What changed

### Backend
- **`observal-server/services/ragas_eval.py`** (new) — Implements the 4 core RAGAS metrics using the existing LLM-as-judge infrastructure:
  - **Faithfulness**: Extracts claims from the answer, verifies each against retrieved context
  - **Answer Relevancy**: Evaluates whether the answer addresses the original query
  - **Context Precision**: Checks each retrieved chunk's relevance to the question
  - **Context Recall**: Checks if ground truth statements are attributable to context (requires ground truth)
- **`POST /api/v1/dashboard/graphrag-ragas-eval`** — Triggers RAGAS evaluation on a GraphRAG's recent retrieval spans
- **`GET /api/v1/dashboard/graphrag-ragas-scores`** — Returns previously computed scores (per-GraphRAG or aggregate)
- Updated `eval_engine.py` with 3 RAGAS-aligned templates for `retrieval` span type
- Added Pydantic schemas for RAGAS request/response

### Frontend
- Replaced fake "RAGAS-Inspired Metrics" (which was `avgRelevance * constant`) with real scores from the API
- Added `useRagasScores` hook and `ragasScores` API function
- Proper empty state when no evaluations have been run yet

### Docs
- **README.md**: Updated GraphRAGs registry table, added RAGAS endpoints to API section, updated How It Works
- **SETUP.md**: New "RAGAS Evaluation for GraphRAGs" section with API usage examples and dashboard reference

### Tests
- 15 new unit tests for `ragas_eval.py` covering all 4 metrics, edge cases, and score clamping
- Updated existing eval template test for new template names
- Full suite: **308 passed**

## How to test

```bash
# Run RAGAS eval on a GraphRAG
curl -X POST http://localhost:8000/api/v1/dashboard/graphrag-ragas-eval \
  -H "X-API-Key: $KEY" -H "Content-Type: application/json" \
  -d '{"graphrag_id": "<id>", "limit": 10}'

# Check scores
curl http://localhost:8000/api/v1/dashboard/graphrag-ragas-scores?graphrag_id=<id> \
  -H "X-API-Key: $KEY"
```

No new dependencies. Uses the existing eval model config (`EVAL_MODEL_NAME` / `EVAL_MODEL_URL`).