### PR TITLE
fix: add standalone output to next.config for Docker build

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   async rewrites() {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
     return [


### PR DESCRIPTION
The Dockerfile expects a standalone Next.js build (`.next/standalone`) but `next.config.ts` was missing `output: "standalone"`, causing the Docker build to fail at the COPY stage.