### PR TITLE
fix(web): handle Tooltip formatter value to fix TypeScript build error

### DIFF
--- a/web/src/components/dashboard/dimension-radar.tsx
+++ b/web/src/components/dashboard/dimension-radar.tsx
@@ -37,7 +37,7 @@ export function DimensionRadar({ dimensionScores }: DimensionRadarProps) {
         <PolarGrid />
         <PolarAngleAxis dataKey="dimension" tick={{ fontSize: 12 }} />
         <PolarRadiusAxis angle={90} domain={[0, 100]} tick={{ fontSize: 10 }} />
-        <Tooltip formatter={(value: number) => [`${value.toFixed(0)}/100`, "Score"]} />
+        <Tooltip formatter={(value) => [typeof value === "number" ? `${value.toFixed(0)}/100` : "—", "Score"]} />
         <Radar
           name="Score"
           dataKey="score"


### PR DESCRIPTION
this fixes #74 

Resolves a TypeScript error in the Tooltip formatter in `dimension-radar.tsx` that caused `next build` (and Docker setup) to fail
The formatter previously assumed the value was always a number. This adds a simple type check to handle it safely

This allows `docker compose up --build` to run without errors. Small change, but it ensures the project builds correctly from a clean setup

