### PR TITLE
Enforce FastMCP + download tracking with bot prevention

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -1,7 +1,7 @@
 import uuid
 import uuid as _uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -252,6 +252,7 @@ async def update_agent(
 async def install_agent(
     agent_id: str,
     req: AgentInstallRequest,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -262,15 +263,32 @@ async def install_agent(
             raise HTTPException(status_code=404, detail="Agent not found or not active")
 
     snippet = generate_agent_config(agent, req.ide)
-    db.add(AgentDownloadRecord(
+    from services.download_tracker import record_agent_download
+    await record_agent_download(
         agent_id=agent.id,
         user_id=current_user.id,
-        ide=req.ide,
         source="api",
-    ))
+        ide=req.ide,
+        request=request,
+        db=db,
+    )
     await db.commit()
 
     return AgentInstallResponse(agent_id=agent.id, ide=req.ide, config_snippet=snippet)
+
+
+@router.get("/{agent_id}/downloads")
+async def agent_download_stats(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    from services.download_tracker import get_download_stats
+    stats = await get_download_stats(agent.id, db)
+    return stats
 
 
 @router.delete("/{agent_id}")

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -59,6 +59,7 @@ async def submit_mcp(
     except Exception:
         pass
 
+    await db.refresh(listing)
     return McpListingResponse.model_validate(listing)
 
 

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -90,6 +90,15 @@ async def approve(
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
+    if listing_type == "mcp" and not listing.fastmcp_validated:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Cannot approve: MCP server has not passed FastMCP validation. "
+                "Server must use FastMCP (from mcp.server.fastmcp import FastMCP). "
+                "See: https://github.com/jlowin/fastmcp"
+            ),
+        )
     listing.status = ListingStatus.approved
     await db.commit()
     await db.refresh(listing)

--- a/observal-server/schemas/mcp.py
+++ b/observal-server/schemas/mcp.py
@@ -44,6 +44,7 @@ class McpListingResponse(BaseModel):
     supported_ides: list[str]
     setup_instructions: str | None
     changelog: str | None
+    fastmcp_validated: bool = False
     status: ListingStatus
     rejection_reason: str | None = None
     submitted_by: uuid.UUID

--- a/observal-server/services/download_tracker.py
+++ b/observal-server/services/download_tracker.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import uuid
 from datetime import UTC, datetime
 
@@ -6,6 +7,8 @@ from fastapi import Request
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from models.agent import Agent
 from models.download import AgentDownloadRecord, ComponentDownloadRecord
@@ -27,7 +30,7 @@ async def record_agent_download(
     db: AsyncSession,
 ) -> bool:
     """Record an agent download with deduplication. Returns True if new download, False if duplicate."""
-    fingerprint = _anonymous_fingerprint(request) if not user_id else None
+    fingerprint = _anonymous_fingerprint(request) if user_id is None else None
 
     record = AgentDownloadRecord(
         agent_id=agent_id,
@@ -43,6 +46,7 @@ async def record_agent_download(
         await _update_agent_counts(agent_id, db)
         return True
     except IntegrityError:
+        logger.debug("Duplicate download for agent %s (user=%s), skipping", agent_id, user_id)
         await db.rollback()
         return False
 

--- a/observal-server/services/download_tracker.py
+++ b/observal-server/services/download_tracker.py
@@ -1,0 +1,110 @@
+import hashlib
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import Request
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.agent import Agent
+from models.download import AgentDownloadRecord, ComponentDownloadRecord
+
+
+def _anonymous_fingerprint(request: Request) -> str:
+    """Generate fingerprint from IP + user-agent for anonymous deduplication."""
+    ip = request.client.host if request.client else "unknown"
+    ua = request.headers.get("user-agent", "")
+    return hashlib.sha256(f"{ip}:{ua}".encode()).hexdigest()
+
+
+async def record_agent_download(
+    agent_id: uuid.UUID,
+    user_id: uuid.UUID | None,
+    source: str,
+    ide: str | None,
+    request: Request,
+    db: AsyncSession,
+) -> bool:
+    """Record an agent download with deduplication. Returns True if new download, False if duplicate."""
+    fingerprint = _anonymous_fingerprint(request) if not user_id else None
+
+    record = AgentDownloadRecord(
+        agent_id=agent_id,
+        user_id=user_id,
+        fingerprint=fingerprint,
+        source=source,
+        ide=ide,
+    )
+    try:
+        db.add(record)
+        await db.flush()
+        # Update aggregate counts
+        await _update_agent_counts(agent_id, db)
+        return True
+    except IntegrityError:
+        await db.rollback()
+        return False
+
+
+async def record_component_download(
+    component_type: str,
+    component_id: uuid.UUID,
+    version_ref: str,
+    agent_id: uuid.UUID,
+    source: str,
+    db: AsyncSession,
+) -> None:
+    """Record a component download (not deduplicated)."""
+    db.add(ComponentDownloadRecord(
+        component_type=component_type,
+        component_id=component_id,
+        version_ref=version_ref,
+        agent_id=agent_id,
+        source=source,
+    ))
+    await db.flush()
+
+
+async def _update_agent_counts(agent_id: uuid.UUID, db: AsyncSession) -> None:
+    """Recompute download_count and unique_users for an agent."""
+    total = await db.scalar(
+        select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)
+    ) or 0
+    unique = await db.scalar(
+        select(func.count(func.distinct(AgentDownloadRecord.user_id))).where(
+            AgentDownloadRecord.agent_id == agent_id,
+            AgentDownloadRecord.user_id.isnot(None),
+        )
+    ) or 0
+    agent = await db.get(Agent, agent_id)
+    if agent:
+        agent.download_count = total
+        agent.unique_users = unique
+
+
+async def get_download_stats(agent_id: uuid.UUID, db: AsyncSession) -> dict:
+    """Get download statistics for an agent."""
+    total = await db.scalar(
+        select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)
+    ) or 0
+    unique = await db.scalar(
+        select(func.count(func.distinct(AgentDownloadRecord.user_id))).where(
+            AgentDownloadRecord.agent_id == agent_id,
+            AgentDownloadRecord.user_id.isnot(None),
+        )
+    ) or 0
+
+    # Source breakdown
+    source_rows = await db.execute(
+        select(AgentDownloadRecord.source, func.count(AgentDownloadRecord.id).label("cnt"))
+        .where(AgentDownloadRecord.agent_id == agent_id)
+        .group_by(AgentDownloadRecord.source)
+    )
+    sources = {r.source: r.cnt for r in source_rows.all()}
+
+    return {
+        "total_downloads": total,
+        "unique_users": unique,
+        "sources": sources,
+    }

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -82,6 +82,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
             continue
 
     if not entry_point:
+        listing.fastmcp_validated = False
         db.add(
             McpValidationResult(
                 listing_id=listing.id,
@@ -93,6 +94,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
         await db.commit()
         return None
 
+    listing.fastmcp_validated = True
     db.add(
         McpValidationResult(
             listing_id=listing.id,
@@ -174,6 +176,9 @@ async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_poin
     details = f"Server: {server_name or 'unknown'}, Tools: {len(tools_found)}"
     if issues:
         details += "\nIssues:\n- " + "\n- ".join(issues)
+
+    if not passed:
+        listing.fastmcp_validated = False
 
     db.add(
         McpValidationResult(

--- a/tests/test_schema_redesign.py
+++ b/tests/test_schema_redesign.py
@@ -424,6 +424,7 @@ class TestFastMcpEnforcement:
         from unittest.mock import AsyncMock, MagicMock
         from api.routes.review import approve
         from models.mcp import ListingStatus
+        from models.user import UserRole
 
         # Create a mock MCP listing with fastmcp_validated=False
         listing = MagicMock()
@@ -434,8 +435,7 @@ class TestFastMcpEnforcement:
 
         mock_db = AsyncMock()
         mock_user = MagicMock()
-        mock_user.role = MagicMock(value="admin")
-        mock_user.role.__eq__ = lambda self, other: True  # pass admin check
+        mock_user.role = UserRole.admin
 
         # Patch _find_listing to return our mock
         import api.routes.review as review_mod
@@ -457,6 +457,7 @@ class TestFastMcpEnforcement:
         from unittest.mock import AsyncMock, MagicMock
         from api.routes.review import approve
         from models.mcp import ListingStatus
+        from models.user import UserRole
 
         listing = MagicMock()
         listing.id = uuid.uuid4()
@@ -466,8 +467,7 @@ class TestFastMcpEnforcement:
 
         mock_db = AsyncMock()
         mock_user = MagicMock()
-        mock_user.role = MagicMock(value="admin")
-        mock_user.role.__eq__ = lambda self, other: True
+        mock_user.role = UserRole.admin
 
         import api.routes.review as review_mod
         original_find = review_mod._find_listing
@@ -485,6 +485,7 @@ class TestFastMcpEnforcement:
         from unittest.mock import AsyncMock, MagicMock
         from api.routes.review import approve
         from models.mcp import ListingStatus
+        from models.user import UserRole
 
         listing = MagicMock()
         listing.id = uuid.uuid4()
@@ -494,8 +495,7 @@ class TestFastMcpEnforcement:
 
         mock_db = AsyncMock()
         mock_user = MagicMock()
-        mock_user.role = MagicMock(value="admin")
-        mock_user.role.__eq__ = lambda self, other: True
+        mock_user.role = UserRole.admin
 
         import api.routes.review as review_mod
         original_find = review_mod._find_listing

--- a/tests/test_schema_redesign.py
+++ b/tests/test_schema_redesign.py
@@ -318,3 +318,191 @@ class TestFeedbackSubmissionUpdates:
         from models.submission import Submission
         col = Submission.__table__.c.listing_type
         assert col.type.length >= 50
+
+
+class TestDownloadTracking:
+    """Tests for download tracking with bot prevention (#93)."""
+
+    def test_anonymous_fingerprint_deterministic(self):
+        from unittest.mock import MagicMock
+        from services.download_tracker import _anonymous_fingerprint
+
+        request = MagicMock()
+        request.client.host = "192.168.1.1"
+        request.headers.get.return_value = "Mozilla/5.0"
+
+        fp1 = _anonymous_fingerprint(request)
+        fp2 = _anonymous_fingerprint(request)
+        assert fp1 == fp2
+        assert len(fp1) == 64  # SHA-256 hex digest
+
+    def test_anonymous_fingerprint_varies_by_ip(self):
+        from unittest.mock import MagicMock
+        from services.download_tracker import _anonymous_fingerprint
+
+        req1 = MagicMock()
+        req1.client.host = "192.168.1.1"
+        req1.headers.get.return_value = "Mozilla/5.0"
+
+        req2 = MagicMock()
+        req2.client.host = "10.0.0.1"
+        req2.headers.get.return_value = "Mozilla/5.0"
+
+        assert _anonymous_fingerprint(req1) != _anonymous_fingerprint(req2)
+
+    def test_anonymous_fingerprint_varies_by_ua(self):
+        from unittest.mock import MagicMock
+        from services.download_tracker import _anonymous_fingerprint
+
+        req1 = MagicMock()
+        req1.client.host = "192.168.1.1"
+        req1.headers.get.return_value = "Mozilla/5.0"
+
+        req2 = MagicMock()
+        req2.client.host = "192.168.1.1"
+        req2.headers.get.return_value = "curl/7.88"
+
+        assert _anonymous_fingerprint(req1) != _anonymous_fingerprint(req2)
+
+    def test_download_record_model_constraints(self):
+        from models.download import AgentDownloadRecord
+        constraints = {c.name for c in AgentDownloadRecord.__table__.constraints if hasattr(c, 'name') and c.name}
+        assert "uq_agent_downloads_agent_user" in constraints
+        assert "uq_agent_downloads_agent_fingerprint" in constraints
+
+    def test_component_download_not_deduplicated(self):
+        """ComponentDownloadRecord should have no multi-column unique constraints."""
+        from models.download import ComponentDownloadRecord
+        unique_constraints = [
+            c for c in ComponentDownloadRecord.__table__.constraints
+            if hasattr(c, 'columns') and len(c.columns) > 1
+        ]
+        # Only the PK constraint, no multi-column uniques
+        assert len(unique_constraints) == 0
+
+    def test_agent_has_download_count_fields(self):
+        from models.agent import Agent
+        assert hasattr(Agent, "download_count")
+        assert hasattr(Agent, "unique_users")
+        col_dl = Agent.__table__.columns["download_count"]
+        col_uu = Agent.__table__.columns["unique_users"]
+        assert col_dl.default.arg == 0
+        assert col_uu.default.arg == 0
+
+    def test_download_tracker_module_exists(self):
+        from services.download_tracker import record_agent_download, record_component_download, get_download_stats, _anonymous_fingerprint
+        assert callable(record_agent_download)
+        assert callable(record_component_download)
+        assert callable(get_download_stats)
+        assert callable(_anonymous_fingerprint)
+
+    def test_install_agent_route_accepts_request(self):
+        """The install_agent endpoint should accept a Request parameter for fingerprinting."""
+        import inspect
+        from api.routes.agent import install_agent
+        sig = inspect.signature(install_agent)
+        param_names = list(sig.parameters.keys())
+        assert "request" in param_names
+
+
+class TestFastMcpEnforcement:
+    """Tests for FastMCP validation enforcement (#92)."""
+
+    def test_mcp_has_fastmcp_validated_field(self):
+        from models.mcp import McpListing
+        assert hasattr(McpListing, "fastmcp_validated")
+
+    def test_fastmcp_validated_defaults_false(self):
+        from models.mcp import McpListing
+        col = McpListing.__table__.columns["fastmcp_validated"]
+        # default is False
+        assert col.default.arg is False
+
+    @pytest.mark.asyncio
+    async def test_approve_blocks_non_fastmcp(self):
+        """Review approve should reject MCPs that haven't passed FastMCP validation."""
+        from unittest.mock import AsyncMock, MagicMock
+        from api.routes.review import approve
+        from models.mcp import ListingStatus
+
+        # Create a mock MCP listing with fastmcp_validated=False
+        listing = MagicMock()
+        listing.id = uuid.uuid4()
+        listing.name = "test-mcp"
+        listing.status = ListingStatus.pending
+        listing.fastmcp_validated = False
+
+        mock_db = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.role = MagicMock(value="admin")
+        mock_user.role.__eq__ = lambda self, other: True  # pass admin check
+
+        # Patch _find_listing to return our mock
+        import api.routes.review as review_mod
+        original_find = review_mod._find_listing
+        review_mod._find_listing = AsyncMock(return_value=("mcp", listing))
+
+        from fastapi import HTTPException
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await approve(str(listing.id), mock_db, mock_user)
+            assert exc_info.value.status_code == 400
+            assert "FastMCP" in exc_info.value.detail
+        finally:
+            review_mod._find_listing = original_find
+
+    @pytest.mark.asyncio
+    async def test_approve_allows_fastmcp_validated(self):
+        """Review approve should allow MCPs that passed FastMCP validation."""
+        from unittest.mock import AsyncMock, MagicMock
+        from api.routes.review import approve
+        from models.mcp import ListingStatus
+
+        listing = MagicMock()
+        listing.id = uuid.uuid4()
+        listing.name = "validated-mcp"
+        listing.status = ListingStatus.pending
+        listing.fastmcp_validated = True
+
+        mock_db = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.role = MagicMock(value="admin")
+        mock_user.role.__eq__ = lambda self, other: True
+
+        import api.routes.review as review_mod
+        original_find = review_mod._find_listing
+        review_mod._find_listing = AsyncMock(return_value=("mcp", listing))
+
+        try:
+            result = await approve(str(listing.id), mock_db, mock_user)
+            assert result["status"] == "approved"
+        finally:
+            review_mod._find_listing = original_find
+
+    @pytest.mark.asyncio
+    async def test_approve_non_mcp_not_affected(self):
+        """Non-MCP listings should not be affected by FastMCP check."""
+        from unittest.mock import AsyncMock, MagicMock
+        from api.routes.review import approve
+        from models.mcp import ListingStatus
+
+        listing = MagicMock()
+        listing.id = uuid.uuid4()
+        listing.name = "test-skill"
+        listing.status = ListingStatus.pending
+        # Skills don't have fastmcp_validated
+
+        mock_db = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.role = MagicMock(value="admin")
+        mock_user.role.__eq__ = lambda self, other: True
+
+        import api.routes.review as review_mod
+        original_find = review_mod._find_listing
+        review_mod._find_listing = AsyncMock(return_value=("skill", listing))
+
+        try:
+            result = await approve(str(listing.id), mock_db, mock_user)
+            assert result["status"] == "approved"
+        finally:
+            review_mod._find_listing = original_find


### PR DESCRIPTION
## Summary

- **#92** Enforce FastMCP for all MCPs: validation now sets `fastmcp_validated` flag on the listing; admin approve route blocks MCPs that haven't passed FastMCP validation with clear error message and migration link
- **#93** Download tracking with bot prevention: new `download_tracker` service with SHA-256 fingerprinting (IP + user-agent) for anonymous dedup, IntegrityError-based dedup for authenticated users, inline aggregate count updates, new `/downloads` stats endpoint

## Changes

### FastMCP enforcement (#92)
- `mcp_validator.py`: sets `listing.fastmcp_validated` during clone_and_inspect and manifest_validation stages
- `api/routes/review.py`: approve route returns HTTP 400 for MCPs without FastMCP validation
- `api/routes/mcp.py`: refreshes listing after validation so response includes `fastmcp_validated` status
- `schemas/mcp.py`: added `fastmcp_validated` to `McpListingResponse`

### Download tracking (#93)
- New `services/download_tracker.py`: `record_agent_download` (deduped), `record_component_download` (not deduped), `_anonymous_fingerprint`, `_update_agent_counts`, `get_download_stats`
- `api/routes/agent.py`: install_agent now uses download tracker; new `GET /{agent_id}/downloads` endpoint
- 13 new tests across both features

## Test plan

- [x] 390 tests pass (13 new), 0 failures
- [x] FastMCP gate: non-validated MCPs blocked, validated MCPs approved, non-MCP types unaffected
- [x] Fingerprint: deterministic, varies by IP, varies by user-agent
- [x] Dedup constraints verified on model level
- [x] install_agent route signature includes Request parameter

Closes #92, closes #93