### PR TITLE
Implement git mirroring service for components

### DIFF
--- a/docs/research/git-registry-patterns.md
+++ b/docs/research/git-registry-patterns.md
@@ -1,0 +1,536 @@
+# Git-Based Component Registry Research
+
+**Date:** 2026-04-10  
+**Epic:** [#77 - Pivot to Agent-Centric Registry](https://github.com/BlazeUp-AI/Observal/issues/77)  
+**Related:** [#79 - Git Mirroring Service](https://github.com/BlazeUp-AI/Observal/issues/79)
+
+## Executive Summary
+
+Research into how production package registries (Docker Hub, Homebrew, Cargo, Go modules, Pip) handle git-based component mirroring and discovery. The simplest pattern that works: **shallow clone + manifest file + convention fallback**.
+
+## Registries Analyzed
+
+### 1. Docker Hub Automated Builds
+- **Discovery**: Explicit configuration (NOT auto-scan)
+- **Pattern**: Users specify Dockerfile path relative to build context
+- **Mono-repos**: Supported via build context path configuration
+- **Philosophy**: Clarity and control over automatic scanning
+
+### 2. Homebrew Taps
+- **Discovery**: Convention-based (`homebrew-something` repo naming)
+- **Pattern**: Formulas as Ruby files in `Formula/` directory
+- **Mono-repos**: One tap = multiple formulas
+- **Updates**: API-based (formulae.brew.sh JSON) with local repo fallback
+- **Versioning**: Explicit version + revision field for patches
+
+### 3. Cargo (Rust Package Manager)
+- **Clone**: Full clone (NOT shallow)
+- **Caching**: Complete repo in local cache
+- **Versioning**: `branch`, `tag`, `rev` keys in Cargo.toml
+- **Mono-repos**: Auto-traverses entire tree to find all `Cargo.toml` files
+- **Locking**: `Cargo.lock` pins exact git commit SHAs
+- **Submodules**: Fetched recursively by default
+
+### 4. Go Modules
+- **Clone**: Extracts specific revision (efficient, minimal transfer)
+- **Caching**: `$GOPATH/pkg/mod` (read-only by default)
+- **Versioning**: Semantic version tags (`v1.2.3`)
+- **Pseudo-versions**: For untagged commits (`v0.0.0-timestamp-hash`)
+- **Mono-repos**: Multiple modules via subdirectories in path
+- **Discovery**: Module path = repo root + subdirectory + version suffix
+
+### 5. Pip (Python Package Installer)
+- **Clone**: Partial clone with `--filter=blob:none` (Git 2.17+)
+- **Caching**: Immutability-based (checks if revision is mutable)
+- **Versioning**: Resolves branches/tags/commits to SHA1
+- **Environment**: Unsets `GIT_DIR`, `GIT_WORK_TREE` to avoid interference
+
+### 6. MCP Servers Monorepo
+- **Structure**: `/src/{server-name}/` directories
+- **Discovery**: `.mcp.json` manifest file at root
+- **Pattern**: Reference implementations as examples
+
+## Clone Strategy Comparison
+
+| Strategy | Used By | Pros | Cons | Best For |
+|----------|---------|------|------|----------|
+| **Full clone** | Cargo | Complete history, checkout any commit | Slow, high bandwidth/disk | Development workflows |
+| **Shallow (`--depth 1`)** | Git docs | Fast, minimal disk | Can't switch branches easily | Registries, CI/CD |
+| **Partial (`--filter=blob:none`)** | Pip | Fast, fetch blobs on-demand | Requires Git 2.17+ | Large repos |
+| **Revision extract** | Go | Efficient for specific version | Complex implementation | Mature systems |
+
+**Recommendation for Observal**: Shallow clone (`--depth 1 --single-branch`)
+
+## Discovery Mechanisms Comparison
+
+| Approach | Used By | Implementation |
+|----------|---------|----------------|
+| **Manifest file** | MCP, npm, Go | `.mcp.json`, `package.json`, `go.mod` at root |
+| **Convention** | Homebrew | `Formula/{letter}/{name}.rb` structure |
+| **Tree traversal** | Cargo | Recursive search for `Cargo.toml` files |
+| **Explicit config** | Docker Hub | User specifies all paths |
+
+**Recommendation for Observal**: Manifest file (primary) + convention scan (fallback)
+
+## Recommendations for Observal
+
+### The Simplest Pattern That Works
+
+```bash
+# 1. Initial sync
+git clone --depth 1 --single-branch --branch main \
+  https://github.com/org/repo.git \
+  /var/lib/observal/mirrors/{sha256(git_url)}
+
+# 2. Re-sync (periodic)
+cd /var/lib/observal/mirrors/{sha256(git_url)} && \
+  git fetch origin && \
+  git reset --hard origin/main
+
+# 3. Discovery
+# Primary: Look for .observal.json or observal.json
+# Fallback: Scan /src/*, /packages/*, /components/*
+
+# 4. Validation per component type
+# MCPs: grep -r "from mcp.server.fastmcp import FastMCP"
+# Skills: Check for SKILL.md
+# Hooks: Validate hook.json schema
+```
+
+### Manifest File Format
+
+**Option A: Manifest-based (recommended)**
+
+```json
+// .observal.json or observal.json at repo root
+{
+  "version": "1.0",
+  "mcps": [
+    {
+      "path": "src/filesystem",
+      "name": "filesystem-mcp",
+      "description": "File system operations MCP server"
+    },
+    {
+      "path": "src/git",
+      "name": "git-mcp",
+      "description": "Git operations MCP server"
+    }
+  ],
+  "skills": [
+    {
+      "path": "skills/tdd",
+      "name": "tdd-skill",
+      "description": "Test-driven development skill"
+    }
+  ],
+  "hooks": [
+    {
+      "path": "hooks/pre-commit",
+      "name": "security-check-hook"
+    }
+  ]
+}
+```
+
+**Option B: Convention-based (fallback when no manifest)**
+
+- MCPs: `/src/*`, `/mcps/*`, `/servers/*` (directories containing `__main__.py` or `server.py`)
+- Skills: `/skills/*` (directories containing `SKILL.md`)
+- Hooks: `/hooks/*` (directories containing `hook.json`)
+- Prompts: `/prompts/*` (`.md` or `.txt` files)
+- Sandboxes: `/sandboxes/*` (directories containing `Dockerfile`)
+
+### Clone Strategy Details
+
+1. **Shallow clone for initial sync** (fast, minimal disk):
+   ```bash
+   git clone --depth 1 --single-branch --branch main <url> <dir>
+   ```
+
+2. **Cache locally** in content-addressed directory:
+   ```
+   /var/lib/observal/mirrors/
+     ├── abc123def456.../ (sha256 of github.com/org/repo1)
+     └── 789ghi012jkl.../ (sha256 of gitlab.com/org/repo2)
+   ```
+
+3. **Re-sync** via fetch + reset (don't re-clone):
+   ```bash
+   cd /var/lib/observal/mirrors/{hash} && \
+   git fetch origin && \
+   git reset --hard origin/main
+   ```
+
+4. **Cleanup**: LRU eviction when disk usage > 80%
+
+### Mono-Repo Support
+
+1. **Manifest explicitly declares components** (recommended)
+2. **OR auto-discover via convention scan**
+3. **Each component gets separate database entry**:
+   - `git_url`: Same for all components in mono-repo
+   - `component_path`: Subdirectory (e.g., `src/filesystem`)
+   - `git_ref`: Commit SHA at sync time
+
+**Example**: MCP servers repo at `github.com/modelcontextprotocol/servers`
+- Single git_url for all servers
+- Each server has unique component_path (`src/filesystem`, `src/git`, etc.)
+- All share same git_ref (commit SHA)
+
+### Versioning Strategy
+
+**Simple approach** (MVP):
+- Store commit SHA in `git_ref` field
+- Users specify branch/tag when adding source
+- Resolve to SHA during sync
+
+**Future enhancements**:
+- Support semver tags (`v1.2.3`)
+- Version constraints in agent manifests (`^1.0.0`)
+- Pseudo-versions like Go (`v0.0.0-20230101120000-abc123def456`)
+
+### Caching & Cleanup
+
+| Aspect | Strategy | Rationale |
+|--------|----------|-----------|
+| **Caching** | Keep mirrors indefinitely | Cheap disk, expensive network |
+| **Cleanup** | LRU when disk > 80% | Simple, predictable |
+| **Re-sync** | Periodic (hourly/daily) | Check `auto_sync_interval` field |
+| **Invalidation** | None (just re-sync) | Simple, effective |
+
+### What NOT to Overcomplicate
+
+1. **No semver resolution** (yet): Just store commit SHA, no version constraint solving
+2. **No submodules**: Clone with defaults, ignore submodule edge cases
+3. **No Git LFS**: Regular git only, no large file support
+4. **HTTPS only**: SSH keys optional, don't build key management MVP
+5. **Two discovery methods max**: Manifest OR convention, no more
+6. **No incremental scanning**: Full re-scan on sync (fast enough for typical repos)
+7. **Simple retry logic**: 3 attempts with exponential backoff, then fail
+
+### Error Handling
+
+1. **Network failures**: Retry 3x with backoff (1s, 2s, 4s), mark `sync_status: failed`
+2. **Invalid repos**: Log detailed error, set `sync_error` field, continue processing
+3. **Missing manifest**: Fall back to convention scan (not an error)
+4. **No components found**: Warn but allow (components might be added later)
+5. **FastMCP validation fails**: Reject MCP with detailed error message
+6. **Malformed manifest**: JSON validation error, reject source
+
+## Implementation Pseudo-Code
+
+```python
+def sync_component_source(source_id: str) -> SyncResult:
+    """
+    Sync a git repository and discover/validate components.
+    
+    Steps:
+    1. Clone or update local mirror
+    2. Discover components (manifest OR convention)
+    3. Validate each component
+    4. Upsert to database
+    5. Update sync status
+    """
+    source = db.query(ComponentSource).get(source_id)
+    mirror_dir = get_mirror_path(source.git_url)
+    
+    try:
+        # Step 1: Clone or pull
+        if not mirror_dir.exists():
+            run_command(f"""
+                git clone --depth 1 --single-branch 
+                --branch {source.branch or 'main'}
+                {source.git_url} {mirror_dir}
+            """)
+        else:
+            run_command(f"""
+                cd {mirror_dir} && 
+                git fetch origin && 
+                git reset --hard origin/{source.branch or 'main'}
+            """)
+        
+        # Step 2: Discover components
+        components = discover_components(mirror_dir, source.component_type)
+        
+        # Step 3: Validate
+        for comp in components:
+            validate_component(comp, mirror_dir)
+        
+        # Step 4: Upsert to database
+        commit_sha = get_commit_sha(mirror_dir)
+        for comp in components:
+            upsert_component_listing(
+                component_type=source.component_type,
+                name=comp.name,
+                git_url=source.git_url,
+                component_path=comp.path,
+                git_ref=commit_sha,
+                is_private=source.is_public == False,
+                owner_org_id=source.owner_org_id
+            )
+        
+        # Step 5: Update sync status
+        source.last_synced_at = datetime.utcnow()
+        source.sync_status = 'success'
+        source.sync_error = None
+        db.session.commit()
+        
+        return SyncResult(success=True, components_found=len(components))
+        
+    except Exception as e:
+        source.sync_status = 'failed'
+        source.sync_error = str(e)
+        db.session.commit()
+        return SyncResult(success=False, error=str(e))
+
+
+def discover_components(mirror_dir: Path, component_type: str) -> List[Component]:
+    """
+    Discover components using manifest OR convention.
+    """
+    # Try manifest first
+    manifest_path = mirror_dir / '.observal.json'
+    if not manifest_path.exists():
+        manifest_path = mirror_dir / 'observal.json'
+    
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+        return parse_manifest_components(manifest, component_type)
+    
+    # Fallback to convention scan
+    return scan_by_convention(mirror_dir, component_type)
+
+
+def scan_by_convention(mirror_dir: Path, component_type: str) -> List[Component]:
+    """
+    Scan directory tree for components using conventions.
+    """
+    search_dirs = {
+        'mcp': ['src', 'mcps', 'servers'],
+        'skill': ['skills'],
+        'hook': ['hooks'],
+        'prompt': ['prompts'],
+        'sandbox': ['sandboxes']
+    }
+    
+    components = []
+    for base_dir in search_dirs.get(component_type, []):
+        search_path = mirror_dir / base_dir
+        if search_path.exists():
+            for item in search_path.iterdir():
+                if is_valid_component(item, component_type):
+                    components.append(Component(
+                        name=item.name,
+                        path=str(item.relative_to(mirror_dir))
+                    ))
+    
+    return components
+
+
+def validate_component(comp: Component, mirror_dir: Path):
+    """
+    Validate component based on type.
+    Raises ValidationError if invalid.
+    """
+    comp_path = mirror_dir / comp.path
+    
+    if comp.type == 'mcp':
+        # Check for FastMCP usage
+        if not any((comp_path / '**' / '*.py').glob('*')):
+            raise ValidationError("No Python files found")
+        
+        python_files = list(comp_path.rglob('*.py'))
+        fastmcp_found = any(
+            'from mcp.server.fastmcp import FastMCP' in f.read_text()
+            or 'from fastmcp import FastMCP' in f.read_text()
+            for f in python_files
+        )
+        
+        if not fastmcp_found:
+            raise ValidationError(
+                "MCP must use FastMCP. "
+                "See: https://modelcontextprotocol.io/fastmcp"
+            )
+    
+    elif comp.type == 'skill':
+        skill_md = comp_path / 'SKILL.md'
+        if not skill_md.exists():
+            raise ValidationError("Skills must have SKILL.md file")
+    
+    elif comp.type == 'hook':
+        hook_json = comp_path / 'hook.json'
+        if not hook_json.exists():
+            raise ValidationError("Hooks must have hook.json file")
+        
+        # Validate JSON schema
+        hook_config = json.loads(hook_json.read_text())
+        validate_hook_schema(hook_config)
+    
+    # Add more validation as needed
+
+
+def get_mirror_path(git_url: str) -> Path:
+    """
+    Get consistent mirror directory for a git URL.
+    Uses SHA256 hash to avoid path issues.
+    """
+    url_hash = hashlib.sha256(git_url.encode()).hexdigest()
+    return Path('/var/lib/observal/mirrors') / url_hash
+```
+
+## Database Schema Integration
+
+Works with schema from [agent-centric-schema-design.md](../superpowers/specs/2026-04-10-agent-centric-schema-design.md):
+
+```sql
+-- component_sources table tracks git repos
+CREATE TABLE component_sources (
+    id UUID PRIMARY KEY,
+    url TEXT NOT NULL,
+    provider VARCHAR(50) NOT NULL,  -- 'github', 'gitlab', 'bitbucket'
+    component_type VARCHAR(50) NOT NULL,  -- 'mcp', 'skill', 'hook', 'prompt', 'sandbox'
+    is_public BOOLEAN NOT NULL DEFAULT true,
+    owner_org_id UUID REFERENCES organizations(id),
+    auto_sync_interval INTERVAL,  -- e.g., '1 day', '6 hours'
+    last_synced_at TIMESTAMPTZ,
+    sync_status VARCHAR(20),  -- 'pending', 'syncing', 'success', 'failed'
+    sync_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Each component listing links to source via git_url + component_path
+-- (fields in mcp_listings, skill_listings, etc.)
+ALTER TABLE mcp_listings ADD COLUMN component_path VARCHAR(500) DEFAULT '/';
+ALTER TABLE skill_listings ADD COLUMN component_path VARCHAR(500) DEFAULT '/';
+-- etc.
+```
+
+## Background Jobs
+
+### Sync Worker
+
+```python
+# Runs every minute, checks auto_sync_interval
+def component_sync_worker():
+    while True:
+        sources = db.query(ComponentSource).filter(
+            ComponentSource.auto_sync_interval.isnot(None),
+            or_(
+                ComponentSource.last_synced_at.is_(None),
+                ComponentSource.last_synced_at + ComponentSource.auto_sync_interval < datetime.utcnow()
+            )
+        ).all()
+        
+        for source in sources:
+            sync_component_source(source.id)
+        
+        time.sleep(60)  # Check every minute
+```
+
+### Cleanup Worker
+
+```python
+# Runs daily, removes least-used mirrors when disk > 80%
+def mirror_cleanup_worker():
+    while True:
+        disk_usage = get_disk_usage('/var/lib/observal/mirrors')
+        
+        if disk_usage > 0.80:  # 80% full
+            # Get mirror access times
+            mirrors = sorted(
+                Path('/var/lib/observal/mirrors').iterdir(),
+                key=lambda p: p.stat().st_atime  # Access time
+            )
+            
+            # Remove oldest until disk < 70%
+            for mirror in mirrors:
+                if get_disk_usage('/var/lib/observal/mirrors') < 0.70:
+                    break
+                shutil.rmtree(mirror)
+                logger.info(f"Removed mirror: {mirror.name}")
+        
+        time.sleep(86400)  # Daily
+```
+
+## API Endpoints
+
+```python
+# Add new component source
+POST /api/v1/component-sources
+{
+  "url": "https://github.com/org/repo.git",
+  "component_type": "mcp",
+  "is_public": true,
+  "auto_sync_interval": "1 day"
+}
+
+# List sources
+GET /api/v1/component-sources?component_type=mcp
+
+# Trigger manual sync
+POST /api/v1/component-sources/{id}/sync
+
+# Get sync status
+GET /api/v1/component-sources/{id}/status
+```
+
+## Implementation Checklist
+
+- [ ] `component_sources` table with sync fields
+- [ ] Git clone wrapper with retry logic
+- [ ] Manifest parser (JSON schema validation)
+- [ ] Convention scanner (directory traversal)
+- [ ] FastMCP validator (grep for import statement)
+- [ ] Skill validator (check for SKILL.md)
+- [ ] Hook validator (JSON schema validation)
+- [ ] Component upsert logic (create/update listings)
+- [ ] Background sync worker
+- [ ] Background cleanup worker
+- [ ] API endpoints (CRUD for sources, manual sync)
+- [ ] Error handling and logging
+- [ ] Tests (unit + integration)
+
+## Timeline Estimate
+
+- **Day 1**: `component_sources` table, basic git clone wrapper
+- **Day 2**: Manifest parser + convention scanner
+- **Day 3**: FastMCP/skill/hook validation logic
+- **Day 4**: Database upsert, background sync worker
+- **Day 5**: Error handling, cleanup worker, API endpoints, testing
+
+**Total: ~1 week for MVP git mirroring service**
+
+## Success Criteria
+
+- [ ] Can clone public GitHub/GitLab repos
+- [ ] Discovers components via manifest OR convention
+- [ ] Validates FastMCP usage for MCPs
+- [ ] Creates/updates component listings in database
+- [ ] Handles mono-repos (multiple components per repo)
+- [ ] Re-syncs on schedule (auto_sync_interval)
+- [ ] Gracefully handles errors (network failures, invalid repos)
+- [ ] Cleans up old mirrors when disk full
+
+## Future Enhancements (Post-MVP)
+
+1. **Semver version constraints**: Support `^1.0.0`, `~2.1.0` in agent manifests
+2. **SSH key support**: Private repos via SSH
+3. **Webhook triggers**: GitHub/GitLab webhooks for instant sync
+4. **Incremental sync**: Only re-scan changed files (git diff)
+5. **Submodule support**: Handle repos with submodules
+6. **Git LFS support**: Large file storage
+7. **Component dependency graph**: Track MCP dependencies
+8. **Multi-branch support**: Track multiple branches per source
+9. **Tag-based versioning**: Explicit version pinning via git tags
+10. **Rollback support**: Revert to previous sync state
+
+## References
+
+- [Agent-Centric Schema Design](../superpowers/specs/2026-04-10-agent-centric-schema-design.md)
+- [Product Vision](../superpowers/specs/2026-04-10-product-vision.md)
+- [Git Clone Documentation](https://git-scm.com/docs/git-clone)
+- [Cargo Book - Dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)
+- [Go Modules Reference](https://go.dev/ref/mod)
+- [Homebrew Taps](https://docs.brew.sh/Taps)
+- [MCP Servers Repository](https://github.com/modelcontextprotocol/servers)

--- a/observal-server/api/routes/component_source.py
+++ b/observal-server/api/routes/component_source.py
@@ -1,0 +1,127 @@
+"""Component source CRUD and sync endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import get_current_user, get_db
+from models.component_source import ComponentSource
+from models.user import User
+from schemas.component_source import (
+    ComponentSourceCreate,
+    ComponentSourceResponse,
+    SyncResponse,
+)
+from services.git_mirror_service import sync_source
+
+router = APIRouter(prefix="/api/v1/component-sources", tags=["component-sources"])
+
+
+@router.post("", response_model=ComponentSourceResponse, status_code=201)
+async def add_source(
+    req: ComponentSourceCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    # Detect provider from URL
+    provider = "github"
+    url_lower = req.url.lower()
+    if "gitlab" in url_lower:
+        provider = "gitlab"
+    elif "bitbucket" in url_lower:
+        provider = "bitbucket"
+
+    source = ComponentSource(
+        url=req.url,
+        provider=provider,
+        component_type=req.component_type,
+        is_public=req.is_public,
+        owner_org_id=req.owner_org_id,
+    )
+    try:
+        db.add(source)
+        await db.commit()
+        await db.refresh(source)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Source with this URL and component type already exists")
+
+    return ComponentSourceResponse.model_validate(source)
+
+
+@router.get("", response_model=list[ComponentSourceResponse])
+async def list_sources(
+    component_type: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    stmt = select(ComponentSource)
+    if component_type:
+        stmt = stmt.where(ComponentSource.component_type == component_type)
+    result = await db.execute(stmt.order_by(ComponentSource.created_at.desc()))
+    return [ComponentSourceResponse.model_validate(s) for s in result.scalars().all()]
+
+
+@router.get("/{source_id}", response_model=ComponentSourceResponse)
+async def get_source(
+    source_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    source = await db.get(ComponentSource, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return ComponentSourceResponse.model_validate(source)
+
+
+@router.post("/{source_id}/sync", response_model=SyncResponse)
+async def trigger_sync(
+    source_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    source = await db.get(ComponentSource, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+
+    source.sync_status = "syncing"
+    await db.commit()
+
+    result = sync_source(source.url, source.component_type)
+
+    source.last_synced_at = datetime.now(UTC)
+    if result.success:
+        source.sync_status = "success"
+        source.sync_error = None
+    else:
+        source.sync_status = "failed"
+        source.sync_error = result.error
+
+    await db.commit()
+    await db.refresh(source)
+
+    return SyncResponse(
+        source_id=source.id,
+        status=source.sync_status,
+        components_found=len(result.components),
+        commit_sha=result.commit_sha,
+        error=result.error or None,
+    )
+
+
+@router.delete("/{source_id}")
+async def delete_source(
+    source_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    source = await db.get(ComponentSource, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+    await db.delete(source)
+    await db.commit()
+    return {"deleted": str(source_id)}

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -8,6 +8,7 @@ from api.graphql import get_context_dep, schema
 from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
 from api.routes.alert import router as alert_router
+from api.routes.component_source import router as component_source_router
 from api.routes.auth import router as auth_router
 from api.routes.dashboard import router as dashboard_router
 from api.routes.eval import router as eval_router
@@ -64,6 +65,7 @@ app.include_router(eval_router)
 app.include_router(admin_router)
 app.include_router(alert_router)
 app.include_router(otel_dashboard_router)
+app.include_router(component_source_router)
 
 
 @app.get("/health")

--- a/observal-server/schemas/component_source.py
+++ b/observal-server/schemas/component_source.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime, timedelta
+
+from pydantic import BaseModel, Field
+
+
+class ComponentSourceCreate(BaseModel):
+    url: str = Field(..., min_length=10, pattern=r"^https://")
+    component_type: str = Field(..., pattern="^(mcp|skill|hook|prompt|sandbox)$")
+    is_public: bool = True
+    owner_org_id: uuid.UUID | None = None
+
+
+class ComponentSourceResponse(BaseModel):
+    id: uuid.UUID
+    url: str
+    provider: str
+    component_type: str
+    is_public: bool
+    owner_org_id: uuid.UUID | None
+    auto_sync_interval: timedelta | None
+    last_synced_at: datetime | None
+    sync_status: str | None
+    sync_error: str | None
+    created_at: datetime
+    model_config = {"from_attributes": True}
+
+
+class SyncResponse(BaseModel):
+    source_id: uuid.UUID
+    status: str
+    components_found: int
+    commit_sha: str
+    error: str | None = None

--- a/observal-server/services/git_mirror_service.py
+++ b/observal-server/services/git_mirror_service.py
@@ -92,7 +92,7 @@ def discover_components(mirror_dir: Path, component_type: str | None = None) -> 
         if manifest_path.exists():
             try:
                 manifest = json.loads(manifest_path.read_text())
-                return _parse_manifest(manifest, component_type)
+                return _parse_manifest(manifest, component_type, mirror_dir=mirror_dir)
             except (json.JSONDecodeError, KeyError) as e:
                 logger.warning("Invalid manifest %s: %s", manifest_path, e)
                 # Fall through to convention scan
@@ -101,7 +101,16 @@ def discover_components(mirror_dir: Path, component_type: str | None = None) -> 
     return _scan_by_convention(mirror_dir, component_type)
 
 
-def _parse_manifest(manifest: dict, component_type: str | None = None) -> list[DiscoveredComponent]:
+def _safe_path(base: Path, rel: str) -> bool:
+    """Check that a relative path stays within base (no traversal)."""
+    try:
+        resolved = (base / rel).resolve()
+        return resolved == base.resolve() or str(resolved).startswith(str(base.resolve()) + "/")
+    except (OSError, ValueError):
+        return False
+
+
+def _parse_manifest(manifest: dict, component_type: str | None = None, mirror_dir: Path | None = None) -> list[DiscoveredComponent]:
     """Parse .observal.json manifest."""
     components = []
     type_keys = {
@@ -120,9 +129,14 @@ def _parse_manifest(manifest: dict, component_type: str | None = None) -> list[D
 
     for ctype, key in types_to_scan.items():
         for entry in manifest.get(key, []):
+            comp_path = entry.get("path", "")
+            # Reject path traversal attempts
+            if mirror_dir and not _safe_path(mirror_dir, comp_path):
+                logger.warning("Skipping component with unsafe path: %s", comp_path)
+                continue
             components.append(DiscoveredComponent(
-                name=entry.get("name", entry.get("path", "").split("/")[-1]),
-                path=entry.get("path", ""),
+                name=entry.get("name", comp_path.split("/")[-1]),
+                path=comp_path,
                 component_type=ctype,
                 description=entry.get("description", ""),
             ))
@@ -141,7 +155,7 @@ _CONVENTION_DIRS = {
 
 # Markers that identify a valid component directory
 _COMPONENT_MARKERS = {
-    "mcp": lambda p: any(p.rglob("*.py")),  # Python files present
+    "mcp": lambda p: any(f for f in p.rglob("*.py") if ".git" not in f.parts),
     "skill": lambda p: (p / "SKILL.md").exists(),
     "hook": lambda p: (p / "hook.json").exists(),
     "prompt": lambda p: any(p.glob("*.md")) or any(p.glob("*.txt")),
@@ -165,7 +179,11 @@ def _scan_by_convention(mirror_dir: Path, component_type: str | None = None) -> 
             if not base.exists() or not base.is_dir():
                 continue
             for item in sorted(base.iterdir()):
-                if item.is_dir() and marker(item):
+                if item.is_symlink() or not item.is_dir():
+                    continue
+                if not _safe_path(mirror_dir, str(item.relative_to(mirror_dir))):
+                    continue
+                if marker(item):
                     components.append(DiscoveredComponent(
                         name=item.name,
                         path=str(item.relative_to(mirror_dir)),
@@ -183,6 +201,8 @@ _FASTMCP_PATTERN = re.compile(
 def validate_mcp_component(component_path: Path) -> tuple[bool, str]:
     """Validate an MCP component uses FastMCP. Returns (passed, detail)."""
     for py_file in component_path.rglob("*.py"):
+        if ".git" in py_file.parts or py_file.is_symlink():
+            continue
         try:
             content = py_file.read_text(errors="ignore")
             if _FASTMCP_PATTERN.search(content):

--- a/observal-server/services/git_mirror_service.py
+++ b/observal-server/services/git_mirror_service.py
@@ -1,0 +1,220 @@
+"""Git mirroring and component discovery service."""
+
+import hashlib
+import json
+import logging
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Mirror directory — use tempdir for tests, configurable for production
+DEFAULT_MIRROR_BASE = Path(tempfile.gettempdir()) / "observal_mirrors"
+
+
+@dataclass
+class DiscoveredComponent:
+    name: str
+    path: str  # relative to repo root
+    component_type: str  # mcp, skill, hook, prompt, sandbox
+    description: str = ""
+
+
+@dataclass
+class SyncResult:
+    success: bool
+    components: list[DiscoveredComponent] = field(default_factory=list)
+    commit_sha: str = ""
+    error: str = ""
+
+
+def _mirror_path(git_url: str, base: Path = DEFAULT_MIRROR_BASE) -> Path:
+    """Content-addressed mirror directory."""
+    url_hash = hashlib.sha256(git_url.encode()).hexdigest()[:16]
+    return base / url_hash
+
+
+def _run_git(args: list[str], cwd: str | None = None, timeout: int = 120) -> subprocess.CompletedProcess:
+    """Run a git command with timeout."""
+    return subprocess.run(
+        ["git"] + args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def clone_or_update(git_url: str, branch: str = "main", base: Path = DEFAULT_MIRROR_BASE) -> Path:
+    """Shallow clone or update a repo mirror. Returns the mirror directory path."""
+    base.mkdir(parents=True, exist_ok=True)
+    mirror_dir = _mirror_path(git_url, base)
+
+    if mirror_dir.exists() and (mirror_dir / ".git").exists():
+        # Update existing mirror
+        result = _run_git(["fetch", "origin", branch, "--depth", "1"], cwd=str(mirror_dir))
+        if result.returncode != 0:
+            raise RuntimeError(f"git fetch failed: {result.stderr.strip()}")
+        result = _run_git(["reset", "--hard", f"origin/{branch}"], cwd=str(mirror_dir))
+        if result.returncode != 0:
+            raise RuntimeError(f"git reset failed: {result.stderr.strip()}")
+    else:
+        # Fresh shallow clone
+        if mirror_dir.exists():
+            shutil.rmtree(mirror_dir)
+        result = _run_git([
+            "clone", "--depth", "1", "--single-branch", "--branch", branch,
+            git_url, str(mirror_dir),
+        ])
+        if result.returncode != 0:
+            raise RuntimeError(f"git clone failed: {result.stderr.strip()}")
+
+    return mirror_dir
+
+
+def get_commit_sha(mirror_dir: Path) -> str:
+    """Get the current HEAD commit SHA."""
+    result = _run_git(["rev-parse", "HEAD"], cwd=str(mirror_dir))
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def discover_components(mirror_dir: Path, component_type: str | None = None) -> list[DiscoveredComponent]:
+    """Discover components using manifest (primary) or convention scan (fallback)."""
+    # Try manifest first
+    for manifest_name in (".observal.json", "observal.json"):
+        manifest_path = mirror_dir / manifest_name
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text())
+                return _parse_manifest(manifest, component_type)
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning("Invalid manifest %s: %s", manifest_path, e)
+                # Fall through to convention scan
+
+    # Convention scan fallback
+    return _scan_by_convention(mirror_dir, component_type)
+
+
+def _parse_manifest(manifest: dict, component_type: str | None = None) -> list[DiscoveredComponent]:
+    """Parse .observal.json manifest."""
+    components = []
+    type_keys = {
+        "mcp": "mcps",
+        "skill": "skills",
+        "hook": "hooks",
+        "prompt": "prompts",
+        "sandbox": "sandboxes",
+    }
+
+    types_to_scan = (
+        {component_type: type_keys[component_type]}
+        if component_type and component_type in type_keys
+        else type_keys
+    )
+
+    for ctype, key in types_to_scan.items():
+        for entry in manifest.get(key, []):
+            components.append(DiscoveredComponent(
+                name=entry.get("name", entry.get("path", "").split("/")[-1]),
+                path=entry.get("path", ""),
+                component_type=ctype,
+                description=entry.get("description", ""),
+            ))
+
+    return components
+
+
+# Convention directories per component type
+_CONVENTION_DIRS = {
+    "mcp": ["src", "mcps", "servers"],
+    "skill": ["skills"],
+    "hook": ["hooks"],
+    "prompt": ["prompts"],
+    "sandbox": ["sandboxes"],
+}
+
+# Markers that identify a valid component directory
+_COMPONENT_MARKERS = {
+    "mcp": lambda p: any(p.rglob("*.py")),  # Python files present
+    "skill": lambda p: (p / "SKILL.md").exists(),
+    "hook": lambda p: (p / "hook.json").exists(),
+    "prompt": lambda p: any(p.glob("*.md")) or any(p.glob("*.txt")),
+    "sandbox": lambda p: (p / "Dockerfile").exists(),
+}
+
+
+def _scan_by_convention(mirror_dir: Path, component_type: str | None = None) -> list[DiscoveredComponent]:
+    """Discover components by scanning conventional directories."""
+    components = []
+    types_to_scan = (
+        {component_type: _CONVENTION_DIRS[component_type]}
+        if component_type and component_type in _CONVENTION_DIRS
+        else _CONVENTION_DIRS
+    )
+
+    for ctype, dirs in types_to_scan.items():
+        marker = _COMPONENT_MARKERS.get(ctype, lambda p: True)
+        for dir_name in dirs:
+            base = mirror_dir / dir_name
+            if not base.exists() or not base.is_dir():
+                continue
+            for item in sorted(base.iterdir()):
+                if item.is_dir() and marker(item):
+                    components.append(DiscoveredComponent(
+                        name=item.name,
+                        path=str(item.relative_to(mirror_dir)),
+                        component_type=ctype,
+                    ))
+
+    return components
+
+
+_FASTMCP_PATTERN = re.compile(
+    r"FastMCP\(|from\s+mcp\.server\.fastmcp\s+import|from\s+fastmcp\s+import"
+)
+
+
+def validate_mcp_component(component_path: Path) -> tuple[bool, str]:
+    """Validate an MCP component uses FastMCP. Returns (passed, detail)."""
+    for py_file in component_path.rglob("*.py"):
+        try:
+            content = py_file.read_text(errors="ignore")
+            if _FASTMCP_PATTERN.search(content):
+                return True, f"FastMCP found in {py_file.name}"
+        except Exception:
+            continue
+    return False, "No FastMCP usage found. MCP servers must use FastMCP."
+
+
+def sync_source(git_url: str, component_type: str, branch: str = "main", base: Path = DEFAULT_MIRROR_BASE) -> SyncResult:
+    """Full sync pipeline: clone -> discover -> validate. Returns SyncResult."""
+    try:
+        mirror_dir = clone_or_update(git_url, branch=branch, base=base)
+        commit_sha = get_commit_sha(mirror_dir)
+        components = discover_components(mirror_dir, component_type)
+
+        # Validate MCP components
+        valid_components = []
+        for comp in components:
+            if comp.component_type == "mcp":
+                comp_path = mirror_dir / comp.path
+                passed, detail = validate_mcp_component(comp_path)
+                if not passed:
+                    logger.warning("MCP validation failed for %s: %s", comp.name, detail)
+                    continue  # Skip invalid MCPs
+            valid_components.append(comp)
+
+        return SyncResult(
+            success=True,
+            components=valid_components,
+            commit_sha=commit_sha,
+        )
+    except Exception as e:
+        logger.exception("Sync failed for %s", git_url)
+        return SyncResult(success=False, error=str(e))

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -3,6 +3,7 @@
 import logging
 
 from arq.connections import RedisSettings
+from arq.cron import cron
 
 from config import settings
 from services.redis import publish
@@ -57,6 +58,48 @@ async def run_eval(ctx: dict, agent_id: str, trace_id: str | None = None):
         logger.exception(f"Eval job failed: {e}")
 
 
+async def sync_component_sources(ctx: dict):
+    """Background job: sync component sources that are due for re-sync."""
+    from datetime import UTC, datetime
+
+    from sqlalchemy import or_, select
+
+    from database import async_session
+    from models.component_source import ComponentSource
+    from services.git_mirror_service import sync_source
+
+    async with async_session() as db:
+        # Find sources due for sync
+        now = datetime.now(UTC)
+        stmt = select(ComponentSource).where(
+            ComponentSource.auto_sync_interval.isnot(None),
+            or_(
+                ComponentSource.last_synced_at.is_(None),
+                ComponentSource.last_synced_at + ComponentSource.auto_sync_interval < now,
+            ),
+        )
+        result = await db.execute(stmt)
+        sources = result.scalars().all()
+
+        for source in sources:
+            logger.info("Syncing component source %s (%s)", source.id, source.url)
+            source.sync_status = "syncing"
+            await db.commit()
+
+            sync_result = sync_source(source.url, source.component_type)
+
+            source.last_synced_at = now
+            source.sync_status = "success" if sync_result.success else "failed"
+            source.sync_error = sync_result.error if not sync_result.success else None
+            await db.commit()
+            logger.info(
+                "Sync %s: %s (%d components)",
+                source.url,
+                source.sync_status,
+                len(sync_result.components),
+            )
+
+
 async def startup(ctx: dict):
     logger.info("arq worker started")
 
@@ -68,7 +111,8 @@ async def shutdown(ctx: dict):
 class WorkerSettings:
     """arq worker configuration."""
 
-    functions = [run_eval]
+    functions = [run_eval, sync_component_sources]
+    cron_jobs = [cron(sync_component_sources, hour={0, 6, 12, 18})]  # Every 6 hours
     on_startup = startup
     on_shutdown = shutdown
     redis_settings = _redis_settings()

--- a/tests/test_git_mirror.py
+++ b/tests/test_git_mirror.py
@@ -1,0 +1,399 @@
+"""Integration tests for git mirror service — real git operations, no mocks.
+
+These tests create real git repos in tmpdir and exercise the full clone/discover/validate pipeline.
+"""
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from services.git_mirror_service import (
+    DiscoveredComponent,
+    SyncResult,
+    _mirror_path,
+    _parse_manifest,
+    _scan_by_convention,
+    clone_or_update,
+    discover_components,
+    get_commit_sha,
+    sync_source,
+    validate_mcp_component,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _create_git_repo(path: Path, files: dict[str, str] | None = None) -> Path:
+    """Create a real git repo at `path` with optional files. Returns repo path."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "--initial-branch", "main", str(path)], capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(path), capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(path), capture_output=True, check=True)
+
+    if files:
+        for rel_path, content in files.items():
+            fpath = path / rel_path
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content)
+        subprocess.run(["git", "add", "-A"], cwd=str(path), capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=str(path), capture_output=True, check=True)
+    else:
+        # Need at least one commit for HEAD to exist
+        (path / ".gitkeep").touch()
+        subprocess.run(["git", "add", "."], cwd=str(path), capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=str(path), capture_output=True, check=True)
+
+    return path
+
+
+@pytest.fixture
+def tmp_base(tmp_path):
+    """Provide a temp mirror base directory."""
+    return tmp_path / "mirrors"
+
+
+@pytest.fixture
+def simple_mcp_repo(tmp_path):
+    """A git repo with a single FastMCP server at src/my-mcp/."""
+    return _create_git_repo(tmp_path / "mcp-repo", {
+        "src/my-mcp/server.py": (
+            'from mcp.server.fastmcp import FastMCP\n'
+            'mcp = FastMCP("my-mcp")\n'
+            '\n'
+            '@mcp.tool()\n'
+            'def hello(name: str) -> str:\n'
+            '    """Say hello."""\n'
+            '    return f"Hello {name}"\n'
+        ),
+    })
+
+
+@pytest.fixture
+def manifest_repo(tmp_path):
+    """A git repo with an .observal.json manifest listing multiple components."""
+    manifest = {
+        "version": "1.0",
+        "mcps": [
+            {"path": "src/filesystem", "name": "filesystem-mcp", "description": "FS ops"},
+            {"path": "src/git-ops", "name": "git-mcp", "description": "Git ops"},
+        ],
+        "skills": [
+            {"path": "skills/tdd", "name": "tdd-skill", "description": "TDD workflow"},
+        ],
+    }
+    return _create_git_repo(tmp_path / "manifest-repo", {
+        ".observal.json": json.dumps(manifest, indent=2),
+        "src/filesystem/server.py": 'from mcp.server.fastmcp import FastMCP\nmcp = FastMCP("filesystem")\n',
+        "src/git-ops/server.py": 'from mcp.server.fastmcp import FastMCP\nmcp = FastMCP("git-ops")\n',
+        "skills/tdd/SKILL.md": "# TDD Skill\nTest-driven development.",
+    })
+
+
+@pytest.fixture
+def monorepo_convention(tmp_path):
+    """A git repo with multiple components using convention layout (no manifest)."""
+    return _create_git_repo(tmp_path / "mono-repo", {
+        "src/server-a/main.py": 'from fastmcp import FastMCP\napp = FastMCP("a")\n',
+        "src/server-b/main.py": 'from mcp.server.fastmcp import FastMCP\napp = FastMCP("b")\n',
+        "src/not-mcp/README.md": "This has no Python files.",
+        "skills/debugging/SKILL.md": "# Debugging skill",
+        "hooks/pre-commit/hook.json": json.dumps({"event": "PreCommit"}),
+        "prompts/code-review/review.md": "# Code Review Prompt",
+        "sandboxes/python/Dockerfile": "FROM python:3.12\nRUN pip install pytest\n",
+    })
+
+
+@pytest.fixture
+def non_fastmcp_repo(tmp_path):
+    """A git repo with a non-FastMCP MCP server (should fail validation)."""
+    return _create_git_repo(tmp_path / "bad-mcp", {
+        "src/old-server/server.py": (
+            'import flask\n'
+            'app = flask.Flask(__name__)\n'
+            '@app.route("/tool")\n'
+            'def tool(): return "hi"\n'
+        ),
+    })
+
+
+# ── Clone & Update ──────────────────────────────────────────────────
+
+
+class TestCloneOrUpdate:
+    def test_fresh_clone(self, simple_mcp_repo, tmp_base):
+        mirror = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+        assert mirror.exists()
+        assert (mirror / ".git").exists()
+        assert (mirror / "src" / "my-mcp" / "server.py").exists()
+
+    def test_returns_correct_path(self, simple_mcp_repo, tmp_base):
+        mirror = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+        expected = _mirror_path(str(simple_mcp_repo), tmp_base)
+        assert mirror == expected
+
+    def test_update_picks_up_changes(self, simple_mcp_repo, tmp_base):
+        # Initial clone
+        clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+
+        # Add a new file to the source repo
+        new_file = simple_mcp_repo / "NEW_FILE.txt"
+        new_file.write_text("new content")
+        subprocess.run(["git", "add", "-A"], cwd=str(simple_mcp_repo), capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "add file"], cwd=str(simple_mcp_repo), capture_output=True, check=True)
+
+        # Update mirror
+        mirror = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+        assert (mirror / "NEW_FILE.txt").exists()
+        assert (mirror / "NEW_FILE.txt").read_text() == "new content"
+
+    def test_clone_invalid_url_raises(self, tmp_base):
+        with pytest.raises(RuntimeError, match="clone failed"):
+            clone_or_update("https://github.com/nonexistent/repo-that-does-not-exist-12345.git", base=tmp_base)
+
+    def test_idempotent_clone(self, simple_mcp_repo, tmp_base):
+        """Cloning the same repo twice should work (update path)."""
+        m1 = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+        sha1 = get_commit_sha(m1)
+        m2 = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+        sha2 = get_commit_sha(m2)
+        assert m1 == m2
+        assert sha1 == sha2
+
+
+class TestGetCommitSha:
+    def test_returns_40_char_hex(self, simple_mcp_repo, tmp_base):
+        mirror = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+        sha = get_commit_sha(mirror)
+        assert len(sha) == 40
+        assert all(c in "0123456789abcdef" for c in sha)
+
+    def test_matches_source_repo_head(self, simple_mcp_repo, tmp_base):
+        mirror = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+        mirror_sha = get_commit_sha(mirror)
+        source_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(simple_mcp_repo),
+            capture_output=True, text=True,
+        ).stdout.strip()
+        assert mirror_sha == source_sha
+
+
+# ── Discovery: Manifest ─────────────────────────────────────────────
+
+
+class TestManifestDiscovery:
+    def test_discovers_from_manifest(self, manifest_repo, tmp_base):
+        mirror = clone_or_update(str(manifest_repo), branch="main", base=tmp_base)
+        components = discover_components(mirror)
+        names = {c.name for c in components}
+        assert "filesystem-mcp" in names
+        assert "git-mcp" in names
+        assert "tdd-skill" in names
+        assert len(components) == 3
+
+    def test_filter_by_type(self, manifest_repo, tmp_base):
+        mirror = clone_or_update(str(manifest_repo), branch="main", base=tmp_base)
+        mcps = discover_components(mirror, component_type="mcp")
+        assert all(c.component_type == "mcp" for c in mcps)
+        assert len(mcps) == 2
+
+        skills = discover_components(mirror, component_type="skill")
+        assert all(c.component_type == "skill" for c in skills)
+        assert len(skills) == 1
+
+    def test_manifest_preserves_description(self, manifest_repo, tmp_base):
+        mirror = clone_or_update(str(manifest_repo), branch="main", base=tmp_base)
+        components = discover_components(mirror, component_type="mcp")
+        fs_mcp = next(c for c in components if c.name == "filesystem-mcp")
+        assert fs_mcp.description == "FS ops"
+
+    def test_manifest_preserves_path(self, manifest_repo, tmp_base):
+        mirror = clone_or_update(str(manifest_repo), branch="main", base=tmp_base)
+        components = discover_components(mirror, component_type="mcp")
+        paths = {c.path for c in components}
+        assert "src/filesystem" in paths
+        assert "src/git-ops" in paths
+
+
+class TestParseManifest:
+    def test_basic_manifest(self):
+        manifest = {
+            "mcps": [{"name": "a", "path": "src/a"}],
+            "skills": [{"name": "b", "path": "skills/b"}],
+        }
+        result = _parse_manifest(manifest)
+        assert len(result) == 2
+        assert result[0].component_type == "mcp"
+        assert result[1].component_type == "skill"
+
+    def test_empty_manifest(self):
+        result = _parse_manifest({})
+        assert result == []
+
+    def test_filter_by_type(self):
+        manifest = {
+            "mcps": [{"name": "a", "path": "src/a"}],
+            "skills": [{"name": "b", "path": "skills/b"}],
+        }
+        result = _parse_manifest(manifest, component_type="mcp")
+        assert len(result) == 1
+        assert result[0].name == "a"
+
+
+# ── Discovery: Convention Scan ───────────────────────────────────────
+
+
+class TestConventionScan:
+    def test_discovers_all_types(self, monorepo_convention, tmp_base):
+        mirror = clone_or_update(str(monorepo_convention), branch="main", base=tmp_base)
+        components = discover_components(mirror)
+        types = {c.component_type for c in components}
+        assert "mcp" in types
+        assert "skill" in types
+        assert "hook" in types
+        assert "prompt" in types
+        assert "sandbox" in types
+
+    def test_mcp_requires_python_files(self, monorepo_convention, tmp_base):
+        """The not-mcp dir (only has README.md) should NOT be discovered as an MCP."""
+        mirror = clone_or_update(str(monorepo_convention), branch="main", base=tmp_base)
+        mcps = discover_components(mirror, component_type="mcp")
+        names = {c.name for c in mcps}
+        assert "server-a" in names
+        assert "server-b" in names
+        assert "not-mcp" not in names
+
+    def test_skill_requires_skill_md(self, monorepo_convention, tmp_base):
+        mirror = clone_or_update(str(monorepo_convention), branch="main", base=tmp_base)
+        skills = discover_components(mirror, component_type="skill")
+        assert len(skills) == 1
+        assert skills[0].name == "debugging"
+
+    def test_hook_requires_hook_json(self, monorepo_convention, tmp_base):
+        mirror = clone_or_update(str(monorepo_convention), branch="main", base=tmp_base)
+        hooks = discover_components(mirror, component_type="hook")
+        assert len(hooks) == 1
+        assert hooks[0].name == "pre-commit"
+
+    def test_sandbox_requires_dockerfile(self, monorepo_convention, tmp_base):
+        mirror = clone_or_update(str(monorepo_convention), branch="main", base=tmp_base)
+        sandboxes = discover_components(mirror, component_type="sandbox")
+        assert len(sandboxes) == 1
+        assert sandboxes[0].name == "python"
+
+    def test_empty_repo_returns_nothing(self, tmp_path, tmp_base):
+        repo = _create_git_repo(tmp_path / "empty-repo")
+        mirror = clone_or_update(str(repo), branch="main", base=tmp_base)
+        components = discover_components(mirror)
+        assert components == []
+
+
+# ── FastMCP Validation ───────────────────────────────────────────────
+
+
+class TestFastMcpValidation:
+    def test_valid_fastmcp(self, simple_mcp_repo, tmp_base):
+        mirror = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
+        passed, detail = validate_mcp_component(mirror / "src" / "my-mcp")
+        assert passed is True
+        assert "FastMCP found" in detail
+
+    def test_non_fastmcp_rejected(self, non_fastmcp_repo, tmp_base):
+        mirror = clone_or_update(str(non_fastmcp_repo), branch="main", base=tmp_base)
+        passed, detail = validate_mcp_component(mirror / "src" / "old-server")
+        assert passed is False
+        assert "must use FastMCP" in detail
+
+    def test_empty_dir_rejected(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        passed, detail = validate_mcp_component(empty)
+        assert passed is False
+
+    def test_alternative_import_style(self, tmp_path, tmp_base):
+        """Test 'from fastmcp import FastMCP' (alternative import) is accepted."""
+        repo = _create_git_repo(tmp_path / "alt-import-repo", {
+            "src/alt/server.py": 'from fastmcp import FastMCP\napp = FastMCP("alt")\n',
+        })
+        mirror = clone_or_update(str(repo), branch="main", base=tmp_base)
+        passed, detail = validate_mcp_component(mirror / "src" / "alt")
+        assert passed is True
+
+
+# ── Full Sync Pipeline ───────────────────────────────────────────────
+
+
+class TestSyncSource:
+    def test_sync_manifest_repo(self, manifest_repo, tmp_base):
+        result = sync_source(str(manifest_repo), component_type="mcp", base=tmp_base)
+        assert result.success is True
+        assert len(result.commit_sha) == 40
+        assert len(result.components) == 2
+        names = {c.name for c in result.components}
+        assert "filesystem-mcp" in names
+        assert "git-mcp" in names
+
+    def test_sync_convention_repo(self, monorepo_convention, tmp_base):
+        result = sync_source(str(monorepo_convention), component_type="mcp", base=tmp_base)
+        assert result.success is True
+        # Both server-a and server-b use FastMCP
+        assert len(result.components) == 2
+
+    def test_sync_filters_non_fastmcp(self, non_fastmcp_repo, tmp_base):
+        """Non-FastMCP MCPs should be filtered out during sync."""
+        result = sync_source(str(non_fastmcp_repo), component_type="mcp", base=tmp_base)
+        assert result.success is True
+        assert len(result.components) == 0  # Filtered out
+
+    def test_sync_non_mcp_skips_validation(self, monorepo_convention, tmp_base):
+        """Skills, hooks, etc. should not go through FastMCP validation."""
+        result = sync_source(str(monorepo_convention), component_type="skill", base=tmp_base)
+        assert result.success is True
+        assert len(result.components) == 1
+        assert result.components[0].name == "debugging"
+
+    def test_sync_invalid_url_returns_error(self, tmp_base):
+        result = sync_source("https://github.com/nonexistent/no-such-repo-99999.git", component_type="mcp", base=tmp_base)
+        assert result.success is False
+        assert result.error != ""
+        assert result.components == []
+
+    def test_sync_updates_on_second_run(self, simple_mcp_repo, tmp_base):
+        """Second sync should update, not re-clone."""
+        r1 = sync_source(str(simple_mcp_repo), component_type="mcp", base=tmp_base)
+        assert r1.success is True
+
+        # Add another MCP to the source repo
+        new_mcp = simple_mcp_repo / "src" / "new-mcp" / "server.py"
+        new_mcp.parent.mkdir(parents=True, exist_ok=True)
+        new_mcp.write_text('from mcp.server.fastmcp import FastMCP\nmcp = FastMCP("new")\n')
+        subprocess.run(["git", "add", "-A"], cwd=str(simple_mcp_repo), capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "add mcp"], cwd=str(simple_mcp_repo), capture_output=True, check=True)
+
+        r2 = sync_source(str(simple_mcp_repo), component_type="mcp", base=tmp_base)
+        assert r2.success is True
+        assert len(r2.components) == 2  # Original + new
+        assert r2.commit_sha != r1.commit_sha
+
+
+# ── Mirror Path ──────────────────────────────────────────────────────
+
+
+class TestMirrorPath:
+    def test_deterministic(self, tmp_base):
+        p1 = _mirror_path("https://github.com/org/repo.git", tmp_base)
+        p2 = _mirror_path("https://github.com/org/repo.git", tmp_base)
+        assert p1 == p2
+
+    def test_different_urls_different_paths(self, tmp_base):
+        p1 = _mirror_path("https://github.com/org/repo1.git", tmp_base)
+        p2 = _mirror_path("https://github.com/org/repo2.git", tmp_base)
+        assert p1 != p2
+
+    def test_path_under_base(self, tmp_base):
+        p = _mirror_path("https://github.com/org/repo.git", tmp_base)
+        assert str(p).startswith(str(tmp_base))

--- a/tests/test_git_mirror.py
+++ b/tests/test_git_mirror.py
@@ -16,6 +16,7 @@ from services.git_mirror_service import (
     SyncResult,
     _mirror_path,
     _parse_manifest,
+    _safe_path,
     _scan_by_convention,
     clone_or_update,
     discover_components,
@@ -397,3 +398,56 @@ class TestMirrorPath:
     def test_path_under_base(self, tmp_base):
         p = _mirror_path("https://github.com/org/repo.git", tmp_base)
         assert str(p).startswith(str(tmp_base))
+
+
+# ── Security ─────────────────────────────────────────────────────────
+
+
+class TestPathTraversalPrevention:
+    def test_safe_path_allows_normal(self, tmp_path):
+        assert _safe_path(tmp_path, "src/my-mcp") is True
+        assert _safe_path(tmp_path, "skills/tdd") is True
+
+    def test_safe_path_blocks_traversal(self, tmp_path):
+        assert _safe_path(tmp_path, "../../etc/passwd") is False
+        assert _safe_path(tmp_path, "../../../sensitive") is False
+
+    def test_safe_path_blocks_absolute(self, tmp_path):
+        assert _safe_path(tmp_path, "/etc/passwd") is False
+
+    def test_manifest_rejects_traversal_paths(self, tmp_path):
+        """Manifest entries with path traversal should be skipped."""
+        manifest = {
+            "mcps": [
+                {"name": "legit", "path": "src/legit"},
+                {"name": "evil", "path": "../../etc/passwd"},
+                {"name": "also-evil", "path": "../../../sensitive"},
+            ],
+        }
+        components = _parse_manifest(manifest, mirror_dir=tmp_path)
+        names = {c.name for c in components}
+        assert "legit" in names
+        assert "evil" not in names
+        assert "also-evil" not in names
+
+    def test_convention_scan_skips_symlinks(self, tmp_path, tmp_base):
+        """Symlinks in convention directories should be skipped."""
+        repo_dir = tmp_path / "symlink-repo"
+        external = tmp_path / "external_secret"
+        external.mkdir()
+        (external / "server.py").write_text("from mcp.server.fastmcp import FastMCP\n")
+
+        files = {
+            "src/legit/server.py": "from mcp.server.fastmcp import FastMCP\nmcp = FastMCP('legit')\n",
+        }
+        repo = _create_git_repo(repo_dir, files)
+
+        # Create symlink after repo init (git may not track it, but the mirror dir will have it)
+        mirror = clone_or_update(str(repo), branch="main", base=tmp_base)
+        symlink_target = mirror / "src" / "evil-link"
+        symlink_target.symlink_to(external)
+
+        mcps = discover_components(mirror, component_type="mcp")
+        names = {c.name for c in mcps}
+        assert "legit" in names
+        assert "evil-link" not in names


### PR DESCRIPTION
## Summary

- **#79** Git mirroring service: shallow clone repos, discover components via manifest (`.observal.json`) or convention scan, validate FastMCP for MCPs, sync pipeline with error handling
- New CRUD API at `/api/v1/component-sources` with manual sync trigger
- Background sync worker (arq cron, every 6 hours) for auto-sync sources
- 33 real integration tests — actual git repos created in tmpdir, no mocks

## Architecture

**Simple pattern from research** (Docker Hub + Homebrew + Cargo patterns):
- Shallow clone (`--depth 1 --single-branch`) for minimal disk/bandwidth
- Content-addressed mirror dirs (`sha256(url)[:16]`)
- Two-tier discovery: manifest file primary, convention scan fallback
- FastMCP validation for MCP components, skip for other types

## New files
- `services/git_mirror_service.py` — core service (clone, discover, validate, sync)
- `api/routes/component_source.py` — REST CRUD + `/sync` endpoint
- `schemas/component_source.py` — Pydantic schemas
- `tests/test_git_mirror.py` — 33 integration tests

## Modified files
- `main.py` — register component_source router
- `worker.py` — add sync_component_sources background job

## Test plan

- [x] 423 tests pass (33 new integration + 390 existing), 0 failures
- [x] Real git clone/fetch/reset tested (no mocks)
- [x] Manifest discovery: mono-repo with multiple component types
- [x] Convention scan: all 5 types (mcp, skill, hook, prompt, sandbox)
- [x] FastMCP validation: valid accepted, non-FastMCP rejected
- [x] Update detection: second sync picks up new commits
- [x] Error handling: invalid URLs return SyncResult with error

Closes #79