### PR TITLE
feat: agent composition resolver and multi-component support (#80)

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -19,6 +19,7 @@ from schemas.agent import (
     AgentResponse,
     AgentSummary,
     AgentUpdateRequest,
+    ComponentLinkResponse,
     GoalSectionResponse,
     GoalTemplateResponse,
     McpLinkResponse,
@@ -51,7 +52,7 @@ async def _load_agent(db: AsyncSession, *where_clauses) -> Agent | None:
 
 
 def _agent_to_response(agent: Agent) -> AgentResponse:
-    # Build mcp_links from components with component_type='mcp'
+    # Build mcp_links from components with component_type='mcp' (backwards compat)
     mcp_components = [c for c in agent.components if c.component_type == "mcp"]
     mcp_links = [
         McpLinkResponse(
@@ -60,6 +61,17 @@ def _agent_to_response(agent: Agent) -> AgentResponse:
             order=comp.order_index,
         )
         for comp in mcp_components
+    ]
+    # Build full component_links for all types
+    component_links = [
+        ComponentLinkResponse(
+            component_type=comp.component_type,
+            component_id=comp.component_id,
+            version_ref=comp.version_ref,
+            order=comp.order_index,
+            config_override=comp.config_override,
+        )
+        for comp in agent.components
     ]
     goal_template = None
     if agent.goal_template:
@@ -73,6 +85,7 @@ def _agent_to_response(agent: Agent) -> AgentResponse:
 
     agent_dict = {c.key: getattr(agent, c.key) for c in Agent.__table__.columns}
     agent_dict["mcp_links"] = mcp_links
+    agent_dict["component_links"] = component_links
     agent_dict["goal_template"] = goal_template
     return AgentResponse(**agent_dict)
 
@@ -96,7 +109,25 @@ async def create_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    # If `components` is provided, it supersedes legacy `mcp_server_ids`
+    if req.components:
+        req.mcp_server_ids = []
+
+    # Validate legacy mcp_server_ids
     mcp_listings = await _validate_mcp_ids(req.mcp_server_ids, db)
+
+    # Validate new components field (component_type already validated by Pydantic Literal)
+    if req.components:
+        from services.agent_resolver import validate_component_ids
+        errors = await validate_component_ids(
+            [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
+            db,
+        )
+        if errors:
+            raise HTTPException(status_code=400, detail=[
+                {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                for e in errors
+            ])
 
     agent = Agent(
         name=req.name,
@@ -113,14 +144,29 @@ async def create_agent(
     db.add(agent)
     await db.flush()
 
-    for i, (mid, listing) in enumerate(zip(req.mcp_server_ids, mcp_listings)):
+    # Legacy: mcp_server_ids → AgentComponent(type=mcp)
+    order = 0
+    for mid, listing in zip(req.mcp_server_ids, mcp_listings):
         db.add(AgentComponent(
             agent_id=agent.id,
             component_type="mcp",
             component_id=mid,
             version_ref=listing.version,
-            order_index=i,
+            order_index=order,
         ))
+        order += 1
+
+    # New: components list with all types
+    for cref in req.components:
+        db.add(AgentComponent(
+            agent_id=agent.id,
+            component_type=cref.component_type,
+            component_id=cref.component_id,
+            version_ref="latest",
+            order_index=order,
+            config_override=cref.config_override,
+        ))
+        order += 1
 
     goal = AgentGoalTemplate(agent_id=agent.id, description=req.goal_template.description)
     db.add(goal)
@@ -192,9 +238,38 @@ async def update_agent(
     if req.external_mcps is not None:
         agent.external_mcps = [m.model_dump() for m in req.external_mcps]
 
-    if req.mcp_server_ids is not None:
+    if req.components is not None:
+        # New components field replaces ALL components (type validated by Pydantic Literal)
+        from services.agent_resolver import validate_component_ids
+        errors = await validate_component_ids(
+            [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
+            db,
+        )
+        if errors:
+            raise HTTPException(status_code=400, detail=[
+                {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                for e in errors
+            ])
+        # Remove ALL old components
+        old_comps = (
+            await db.execute(
+                select(AgentComponent).where(AgentComponent.agent_id == agent.id)
+            )
+        ).scalars().all()
+        for comp in old_comps:
+            await db.delete(comp)
+        for i, cref in enumerate(req.components):
+            db.add(AgentComponent(
+                agent_id=agent.id,
+                component_type=cref.component_type,
+                component_id=cref.component_id,
+                version_ref="latest",
+                order_index=i,
+                config_override=cref.config_override,
+            ))
+    elif req.mcp_server_ids is not None:
+        # Legacy: only update MCP components
         mcp_listings = await _validate_mcp_ids(req.mcp_server_ids, db)
-        # Remove old MCP components
         old_comps = (
             await db.execute(
                 select(AgentComponent).where(
@@ -262,7 +337,16 @@ async def install_agent(
         if not agent or agent.created_by != current_user.id:
             raise HTTPException(status_code=404, detail="Agent not found or not active")
 
-    snippet = generate_agent_config(agent, req.ide)
+    # Pre-load MCP listings for config generation
+    mcp_comp_ids = [c.component_id for c in agent.components if c.component_type == "mcp"]
+    mcp_listings_map = {}
+    if mcp_comp_ids:
+        mcp_rows = (await db.execute(
+            select(McpListing).where(McpListing.id.in_(mcp_comp_ids))
+        )).scalars().all()
+        mcp_listings_map = {l.id: l for l in mcp_rows}
+
+    snippet = generate_agent_config(agent, req.ide, mcp_listings=mcp_listings_map)
     from services.download_tracker import record_agent_download
     await record_agent_download(
         agent_id=agent.id,
@@ -289,6 +373,46 @@ async def agent_download_stats(
     from services.download_tracker import get_download_stats
     stats = await get_download_stats(agent.id, db)
     return stats
+
+
+@router.get("/{agent_id}/resolve")
+async def resolve_agent_components(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Resolve all components for an agent — validates they exist and are approved."""
+    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    from services.agent_resolver import resolve_agent
+    resolved = await resolve_agent(agent, db)
+    from services.agent_builder import build_composition_summary
+    return build_composition_summary(resolved)
+
+
+@router.get("/{agent_id}/manifest")
+async def get_agent_manifest(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Generate a portable agent manifest with all resolved components."""
+    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    from services.agent_resolver import resolve_agent
+    resolved = await resolve_agent(agent, db)
+    if not resolved.ok:
+        raise HTTPException(status_code=422, detail={
+            "message": "Agent has unresolvable components",
+            "errors": [
+                {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                for e in resolved.errors
+            ],
+        })
+    from services.agent_builder import build_agent_manifest
+    return build_agent_manifest(resolved)
 
 
 @router.delete("/{agent_id}")

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -1,9 +1,12 @@
 import uuid
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from models.agent import AgentStatus
+
+VALID_COMPONENT_TYPES = {"mcp", "skill", "hook", "prompt", "sandbox"}
 
 
 class GoalSectionRequest(BaseModel):
@@ -25,6 +28,16 @@ class ExternalMcp(BaseModel):
     url: str | None = None  # source URL for reference
 
 
+ComponentType = Literal["mcp", "skill", "hook", "prompt", "sandbox"]
+
+
+class ComponentRef(BaseModel):
+    """Reference to a registry component to include in an agent."""
+    component_type: ComponentType
+    component_id: uuid.UUID
+    config_override: dict | None = None
+
+
 class AgentCreateRequest(BaseModel):
     name: str
     version: str
@@ -34,7 +47,8 @@ class AgentCreateRequest(BaseModel):
     model_name: str
     model_config_json: dict = {}
     supported_ides: list[str] = []
-    mcp_server_ids: list[uuid.UUID] = []
+    mcp_server_ids: list[uuid.UUID] = []  # kept for backwards compat
+    components: list[ComponentRef] = []  # new: all component types
     external_mcps: list[ExternalMcp] = []
     goal_template: GoalTemplateRequest
 
@@ -48,7 +62,8 @@ class AgentUpdateRequest(BaseModel):
     model_name: str | None = None
     model_config_json: dict | None = None
     supported_ides: list[str] | None = None
-    mcp_server_ids: list[uuid.UUID] | None = None
+    mcp_server_ids: list[uuid.UUID] | None = None  # kept for backwards compat
+    components: list[ComponentRef] | None = None  # new: all component types
     external_mcps: list[ExternalMcp] | None = None
     goal_template: GoalTemplateRequest | None = None
 
@@ -74,6 +89,16 @@ class McpLinkResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class ComponentLinkResponse(BaseModel):
+    """A component attached to an agent."""
+    component_type: str
+    component_id: uuid.UUID
+    version_ref: str
+    order: int
+    config_override: dict | None = None
+    model_config = {"from_attributes": True}
+
+
 class AgentResponse(BaseModel):
     id: uuid.UUID
     name: str
@@ -90,6 +115,7 @@ class AgentResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     mcp_links: list[McpLinkResponse] = []
+    component_links: list[ComponentLinkResponse] = []
     goal_template: GoalTemplateResponse | None = None
 
     model_config = {"from_attributes": True}

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -1,66 +1,142 @@
-"""Agent builder — composes resolved components into a portable agent manifest."""
+"""Agent builder — composes resolved components into portable agent manifests.
+
+Generates IDE-specific agent files from a ResolvedAgent:
+- Claude Code: .claude/rules/<name>.md (markdown) + MCP JSON config
+- Cursor: .cursor/rules/<name>.md (markdown) + .cursor/mcp.json
+- Gemini CLI: GEMINI.md (markdown) + MCP JSON config
+- Kiro: ~/.kiro/agents/<name>.json (JSON)
+- VSCode: .vscode/rules/<name>.md + .vscode/mcp.json
+- Codex: AGENTS.md (markdown)
+- GitHub Copilot: .github/copilot-instructions.md (markdown)
+"""
 
 import logging
+from typing import Literal
+
+from pydantic import BaseModel, Field, computed_field
 
 from services.agent_resolver import ResolvedAgent, ResolvedComponent
 
 logger = logging.getLogger(__name__)
 
 
-def build_agent_manifest(resolved: ResolvedAgent) -> dict:
-    """Build a portable agent manifest from a fully resolved agent.
-
-    Returns a dict that represents the agent.yaml structure:
-    {
-      "name": "code-reviewer",
-      "version": "1.0.0",
-      "components": {
-        "mcps": [...],
-        "skills": [...],
-        "hooks": [...],
-        "prompts": [...],
-        "sandboxes": [...],
-      },
-      "errors": [...]  # only if resolution had errors
-    }
-    """
-    manifest: dict = {
-        "name": resolved.agent_name,
-        "version": resolved.agent_version,
-        "components": {},
-    }
-
-    type_keys = {
-        "mcp": "mcps",
-        "skill": "skills",
-        "hook": "hooks",
-        "prompt": "prompts",
-        "sandbox": "sandboxes",
-    }
-
-    for ctype, key in type_keys.items():
-        typed_comps = resolved.components_by_type(ctype)
-        if typed_comps:
-            manifest["components"][key] = [
-                _component_to_manifest_entry(c) for c in typed_comps
-            ]
-
-    if resolved.errors:
-        manifest["errors"] = [
-            {
-                "component_type": e.component_type,
-                "component_id": str(e.component_id),
-                "reason": e.reason,
-            }
-            for e in resolved.errors
-        ]
-
-    return manifest
+# ── Manifest Pydantic Models ────────────────────────────────────────
 
 
-def _component_to_manifest_entry(comp: ResolvedComponent) -> dict:
-    """Convert a resolved component to its manifest representation."""
-    entry: dict = {
+class ManifestComponent(BaseModel):
+    """A single component entry in the agent manifest."""
+    name: str
+    version: str
+    git_url: str
+    description: str = ""
+    order: int = 0
+    git_ref: str | None = None
+    config_override: dict | None = None
+    # MCP-specific
+    transport: str | None = None
+    tools: dict | None = None
+    # Skill-specific
+    slash_command: str | None = None
+    task_type: str | None = None
+    # Hook-specific
+    event: str | None = None
+    execution_mode: str | None = None
+    priority: int | None = None
+    # Prompt-specific
+    template: str | None = None
+    variables: list[str] | None = None
+    # Sandbox-specific
+    image: str | None = None
+    runtime_type: str | None = None
+    resource_limits: dict | None = None
+
+    def model_dump_compact(self) -> dict:
+        """Dump only non-None fields for clean manifest output."""
+        return {k: v for k, v in self.model_dump().items() if v is not None}
+
+
+class ManifestComponents(BaseModel):
+    """All components grouped by type."""
+    mcps: list[ManifestComponent] = Field(default_factory=list)
+    skills: list[ManifestComponent] = Field(default_factory=list)
+    hooks: list[ManifestComponent] = Field(default_factory=list)
+    prompts: list[ManifestComponent] = Field(default_factory=list)
+    sandboxes: list[ManifestComponent] = Field(default_factory=list)
+
+    def model_dump_compact(self) -> dict:
+        """Only include non-empty component lists."""
+        result = {}
+        for key, items in [
+            ("mcps", self.mcps), ("skills", self.skills),
+            ("hooks", self.hooks), ("prompts", self.prompts),
+            ("sandboxes", self.sandboxes),
+        ]:
+            if items:
+                result[key] = [c.model_dump_compact() for c in items]
+        return result
+
+
+class ManifestError(BaseModel):
+    component_type: str
+    component_id: str
+    reason: str
+
+
+class AgentManifest(BaseModel):
+    """Portable agent manifest — the canonical representation of a composed agent."""
+    name: str
+    version: str
+    components: ManifestComponents = Field(default_factory=ManifestComponents)
+    errors: list[ManifestError] = Field(default_factory=list)
+
+    def model_dump_compact(self) -> dict:
+        """Clean manifest output (no empty lists, no None values)."""
+        result: dict = {
+            "name": self.name,
+            "version": self.version,
+            "components": self.components.model_dump_compact(),
+        }
+        if self.errors:
+            result["errors"] = [e.model_dump() for e in self.errors]
+        return result
+
+
+class CompositionSummary(BaseModel):
+    """Lightweight summary of agent composition for API responses."""
+    agent_id: str
+    agent_name: str
+    agent_version: str
+    resolved: bool
+    component_counts: dict[str, int] = Field(default_factory=dict)
+    components: dict[str, list[dict]] = Field(default_factory=dict)
+    errors: list[ManifestError] = Field(default_factory=list)
+
+
+# ── IDE Agent File Models ───────────────────────────────────────────
+
+
+class AgentFile(BaseModel):
+    """A single file to write for IDE agent installation."""
+    path: str
+    content: str | dict
+    format: Literal["markdown", "json", "toml"] = "json"
+
+
+class IdeAgentConfig(BaseModel):
+    """Complete IDE-specific agent configuration output."""
+    ide: str
+    files: list[AgentFile] = Field(default_factory=list)
+    mcp_servers: dict = Field(default_factory=dict)
+    env: dict[str, str] = Field(default_factory=dict)
+    setup_commands: list[list[str]] = Field(default_factory=list)
+
+
+# ── Builder Functions ───────────────────────────────────────────────
+
+
+def _resolved_to_manifest_component(comp: ResolvedComponent) -> ManifestComponent:
+    """Convert a ResolvedComponent to a ManifestComponent."""
+    kwargs: dict = {
         "name": comp.name,
         "version": comp.version,
         "git_url": comp.git_url,
@@ -68,42 +144,45 @@ def _component_to_manifest_entry(comp: ResolvedComponent) -> dict:
         "order": comp.order_index,
     }
     if comp.git_ref:
-        entry["git_ref"] = comp.git_ref
+        kwargs["git_ref"] = comp.git_ref
     if comp.config_override:
-        entry["config_override"] = comp.config_override
+        kwargs["config_override"] = comp.config_override
 
-    # Carry through type-specific fields that matter for installation
+    # Type-specific fields from extra
     if comp.component_type == "mcp":
         if comp.extra.get("transport"):
-            entry["transport"] = comp.extra["transport"]
+            kwargs["transport"] = comp.extra["transport"]
         if comp.extra.get("tools_schema"):
-            entry["tools"] = comp.extra["tools_schema"]
+            kwargs["tools"] = comp.extra["tools_schema"]
     elif comp.component_type == "skill":
         if comp.extra.get("slash_command"):
-            entry["slash_command"] = comp.extra["slash_command"]
+            kwargs["slash_command"] = comp.extra["slash_command"]
         if comp.extra.get("task_type"):
-            entry["task_type"] = comp.extra["task_type"]
+            kwargs["task_type"] = comp.extra["task_type"]
     elif comp.component_type == "hook":
-        entry["event"] = comp.extra.get("event", "")
-        entry["execution_mode"] = comp.extra.get("execution_mode", "async")
-        entry["priority"] = comp.extra.get("priority", 100)
+        kwargs["event"] = comp.extra.get("event", "")
+        kwargs["execution_mode"] = comp.extra.get("execution_mode", "async")
+        kwargs["priority"] = comp.extra.get("priority", 100)
     elif comp.component_type == "prompt":
         if comp.extra.get("template"):
-            entry["template"] = comp.extra["template"]
+            kwargs["template"] = comp.extra["template"]
         if comp.extra.get("variables"):
-            entry["variables"] = comp.extra["variables"]
+            kwargs["variables"] = comp.extra["variables"]
     elif comp.component_type == "sandbox":
-        entry["image"] = comp.extra.get("image", "")
-        entry["runtime_type"] = comp.extra.get("runtime_type", "")
+        kwargs["image"] = comp.extra.get("image", "")
+        kwargs["runtime_type"] = comp.extra.get("runtime_type", "")
         if comp.extra.get("resource_limits"):
-            entry["resource_limits"] = comp.extra["resource_limits"]
+            kwargs["resource_limits"] = comp.extra["resource_limits"]
 
-    return entry
+    return ManifestComponent(**kwargs)
 
 
-def build_composition_summary(resolved: ResolvedAgent) -> dict:
-    """Build a lightweight summary of the agent's composition for API responses."""
-    type_keys = {
+def build_agent_manifest(resolved: ResolvedAgent) -> dict:
+    """Build a portable agent manifest from a fully resolved agent.
+
+    Returns a clean dict with only populated fields.
+    """
+    type_map = {
         "mcp": "mcps",
         "skill": "skills",
         "hook": "hooks",
@@ -111,36 +190,64 @@ def build_composition_summary(resolved: ResolvedAgent) -> dict:
         "sandbox": "sandboxes",
     }
 
-    summary: dict = {
-        "agent_id": str(resolved.agent_id),
-        "agent_name": resolved.agent_name,
-        "agent_version": resolved.agent_version,
-        "resolved": resolved.ok,
-        "component_counts": {},
-        "components": {},
-    }
-
-    for ctype, key in type_keys.items():
+    grouped: dict[str, list[ManifestComponent]] = {}
+    for ctype, key in type_map.items():
         typed = resolved.components_by_type(ctype)
         if typed:
-            summary["component_counts"][ctype] = len(typed)
-            summary["components"][key] = [
-                {
-                    "name": c.name,
-                    "version": c.version,
-                    "order": c.order_index,
-                }
+            grouped[key] = [_resolved_to_manifest_component(c) for c in typed]
+
+    manifest = AgentManifest(
+        name=resolved.agent_name,
+        version=resolved.agent_version,
+        components=ManifestComponents(**grouped),
+        errors=[
+            ManifestError(
+                component_type=e.component_type,
+                component_id=str(e.component_id),
+                reason=e.reason,
+            )
+            for e in resolved.errors
+        ],
+    )
+    return manifest.model_dump_compact()
+
+
+def build_composition_summary(resolved: ResolvedAgent) -> dict:
+    """Build a lightweight summary of the agent's composition for API responses."""
+    type_map = {
+        "mcp": "mcps",
+        "skill": "skills",
+        "hook": "hooks",
+        "prompt": "prompts",
+        "sandbox": "sandboxes",
+    }
+
+    component_counts: dict[str, int] = {}
+    components_by_key: dict[str, list[dict]] = {}
+
+    for ctype, key in type_map.items():
+        typed = resolved.components_by_type(ctype)
+        if typed:
+            component_counts[ctype] = len(typed)
+            components_by_key[key] = [
+                {"name": c.name, "version": c.version, "order": c.order_index}
                 for c in typed
             ]
 
-    if resolved.errors:
-        summary["errors"] = [
-            {
-                "component_type": e.component_type,
-                "component_id": str(e.component_id),
-                "reason": e.reason,
-            }
+    summary = CompositionSummary(
+        agent_id=str(resolved.agent_id),
+        agent_name=resolved.agent_name,
+        agent_version=resolved.agent_version,
+        resolved=resolved.ok,
+        component_counts=component_counts,
+        components=components_by_key,
+        errors=[
+            ManifestError(
+                component_type=e.component_type,
+                component_id=str(e.component_id),
+                reason=e.reason,
+            )
             for e in resolved.errors
-        ]
-
-    return summary
+        ],
+    )
+    return summary.model_dump(exclude_none=True)

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -11,9 +11,10 @@ Generates IDE-specific agent files from a ResolvedAgent:
 """
 
 import logging
+import re
 from typing import Literal
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field
 
 from services.agent_resolver import ResolvedAgent, ResolvedComponent
 
@@ -86,6 +87,9 @@ class AgentManifest(BaseModel):
     """Portable agent manifest — the canonical representation of a composed agent."""
     name: str
     version: str
+    prompt: str = ""
+    description: str = ""
+    model_name: str = ""
     components: ManifestComponents = Field(default_factory=ManifestComponents)
     errors: list[ManifestError] = Field(default_factory=list)
 
@@ -96,6 +100,12 @@ class AgentManifest(BaseModel):
             "version": self.version,
             "components": self.components.model_dump_compact(),
         }
+        if self.prompt:
+            result["prompt"] = self.prompt
+        if self.description:
+            result["description"] = self.description
+        if self.model_name:
+            result["model_name"] = self.model_name
         if self.errors:
             result["errors"] = [e.model_dump() for e in self.errors]
         return result
@@ -199,6 +209,9 @@ def build_agent_manifest(resolved: ResolvedAgent) -> dict:
     manifest = AgentManifest(
         name=resolved.agent_name,
         version=resolved.agent_version,
+        prompt=resolved.agent_prompt,
+        description=resolved.agent_description,
+        model_name=resolved.model_name,
         components=ManifestComponents(**grouped),
         errors=[
             ManifestError(
@@ -251,3 +264,277 @@ def build_composition_summary(resolved: ResolvedAgent) -> dict:
         ],
     )
     return summary.model_dump(exclude_none=True)
+
+
+# ── IDE Agent File Generation ──────────────────────────────────────
+
+_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _sanitize_name(name: str) -> str:
+    if _SAFE_NAME_RE.match(name):
+        return name
+    return re.sub(r"[^a-zA-Z0-9_-]", "-", name)
+
+
+def _build_mcp_entries(manifest: AgentManifest) -> dict:
+    """Build MCP server config entries from manifest components."""
+    entries = {}
+    for mcp in manifest.components.mcps:
+        shim_args = ["--mcp-id", mcp.name, "--", "python", "-m", mcp.name]
+        entries[mcp.name] = {
+            "command": "observal-shim",
+            "args": shim_args,
+            "env": {},
+        }
+    return entries
+
+
+def _build_rules_markdown(manifest: AgentManifest) -> str:
+    """Build markdown rules content from the agent manifest."""
+    sections = []
+
+    if manifest.prompt:
+        sections.append(manifest.prompt)
+
+    # Component summary sections
+    if manifest.components.mcps:
+        lines = ["## MCP Servers", ""]
+        for mcp in manifest.components.mcps:
+            desc = f" — {mcp.description}" if mcp.description else ""
+            lines.append(f"- **{mcp.name}** v{mcp.version}{desc}")
+        sections.append("\n".join(lines))
+
+    if manifest.components.skills:
+        lines = ["## Skills", ""]
+        for skill in manifest.components.skills:
+            cmd = f" (`/{skill.slash_command}`)" if skill.slash_command else ""
+            lines.append(f"- **{skill.name}** v{skill.version}{cmd}")
+        sections.append("\n".join(lines))
+
+    if manifest.components.hooks:
+        lines = ["## Hooks", ""]
+        for hook in manifest.components.hooks:
+            lines.append(f"- **{hook.name}** on `{hook.event}` ({hook.execution_mode})")
+        sections.append("\n".join(lines))
+
+    if manifest.components.prompts:
+        lines = ["## Prompts", ""]
+        for prompt in manifest.components.prompts:
+            lines.append(f"- **{prompt.name}** v{prompt.version}")
+        sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)
+
+
+def _generate_claude_code(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate Claude Code agent config (.claude/rules/<name>.md + MCP commands)."""
+    safe_name = _sanitize_name(manifest.name)
+    mcp_entries = _build_mcp_entries(manifest)
+    rules_content = _build_rules_markdown(manifest)
+
+    setup_commands = []
+    for name, cfg in mcp_entries.items():
+        cmd = cfg.get("command", "observal-shim")
+        args = cfg.get("args", [])
+        setup_commands.append(["claude", "mcp", "add", name, "--", cmd, *args])
+
+    return IdeAgentConfig(
+        ide="claude-code",
+        files=[
+            AgentFile(
+                path=f".claude/rules/{safe_name}.md",
+                content=rules_content,
+                format="markdown",
+            ),
+        ],
+        mcp_servers=mcp_entries,
+        env={
+            "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+            "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+        },
+        setup_commands=setup_commands,
+    )
+
+
+def _generate_cursor(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate Cursor agent config (.cursor/rules/<name>.md + .cursor/mcp.json)."""
+    safe_name = _sanitize_name(manifest.name)
+    mcp_entries = _build_mcp_entries(manifest)
+    rules_content = _build_rules_markdown(manifest)
+
+    return IdeAgentConfig(
+        ide="cursor",
+        files=[
+            AgentFile(
+                path=f".cursor/rules/{safe_name}.md",
+                content=rules_content,
+                format="markdown",
+            ),
+            AgentFile(
+                path=".cursor/mcp.json",
+                content={"mcpServers": mcp_entries},
+                format="json",
+            ),
+        ],
+        mcp_servers=mcp_entries,
+    )
+
+
+def _generate_vscode(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate VS Code agent config (.vscode/rules/<name>.md + .vscode/mcp.json)."""
+    safe_name = _sanitize_name(manifest.name)
+    mcp_entries = _build_mcp_entries(manifest)
+    rules_content = _build_rules_markdown(manifest)
+
+    return IdeAgentConfig(
+        ide="vscode",
+        files=[
+            AgentFile(
+                path=f".vscode/rules/{safe_name}.md",
+                content=rules_content,
+                format="markdown",
+            ),
+            AgentFile(
+                path=".vscode/mcp.json",
+                content={"mcpServers": mcp_entries},
+                format="json",
+            ),
+        ],
+        mcp_servers=mcp_entries,
+    )
+
+
+def _generate_gemini_cli(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate Gemini CLI agent config (GEMINI.md + MCP JSON)."""
+    mcp_entries = _build_mcp_entries(manifest)
+    rules_content = _build_rules_markdown(manifest)
+
+    return IdeAgentConfig(
+        ide="gemini-cli",
+        files=[
+            AgentFile(
+                path="GEMINI.md",
+                content=rules_content,
+                format="markdown",
+            ),
+        ],
+        mcp_servers=mcp_entries,
+        env={
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+            "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+        },
+    )
+
+
+def _generate_kiro(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate Kiro agent config (~/.kiro/agents/<name>.json)."""
+    safe_name = _sanitize_name(manifest.name)
+    mcp_entries = _build_mcp_entries(manifest)
+
+    kiro_agent = {
+        "name": safe_name,
+        "description": manifest.description[:200] if manifest.description else "",
+        "prompt": manifest.prompt,
+        "mcpServers": mcp_entries,
+        "tools": [f"@{n}" for n in mcp_entries] + ["read", "write", "shell"],
+        "hooks": {},
+        "includeMcpJson": True,
+        "model": manifest.model_name or "default",
+    }
+
+    return IdeAgentConfig(
+        ide="kiro",
+        files=[
+            AgentFile(
+                path=f"~/.kiro/agents/{safe_name}.json",
+                content=kiro_agent,
+                format="json",
+            ),
+        ],
+        mcp_servers=mcp_entries,
+    )
+
+
+def _generate_codex(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate Codex agent config (AGENTS.md + ~/.codex/config.toml)."""
+    rules_content = _build_rules_markdown(manifest)
+
+    toml_snippet = (
+        "[otel]\n"
+        'environment = "production"\n'
+        "log_user_prompt = true\n"
+        "\n"
+        "[otel.exporter.otlp-http]\n"
+        'endpoint = "http://localhost:4318/v1/logs"\n'
+        'protocol = "http"\n'
+        "\n"
+        "[otel.trace_exporter.otlp-http]\n"
+        'endpoint = "http://localhost:4318/v1/traces"\n'
+        'protocol = "http"\n'
+    )
+
+    return IdeAgentConfig(
+        ide="codex",
+        files=[
+            AgentFile(
+                path="AGENTS.md",
+                content=rules_content,
+                format="markdown",
+            ),
+            AgentFile(
+                path="~/.codex/config.toml",
+                content=toml_snippet,
+                format="toml",
+            ),
+        ],
+    )
+
+
+def _generate_copilot(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate GitHub Copilot agent config (.github/copilot-instructions.md)."""
+    rules_content = _build_rules_markdown(manifest)
+
+    return IdeAgentConfig(
+        ide="copilot",
+        files=[
+            AgentFile(
+                path=".github/copilot-instructions.md",
+                content=rules_content,
+                format="markdown",
+            ),
+        ],
+    )
+
+
+_IDE_GENERATORS = {
+    "claude-code": _generate_claude_code,
+    "claude_code": _generate_claude_code,
+    "cursor": _generate_cursor,
+    "vscode": _generate_vscode,
+    "gemini-cli": _generate_gemini_cli,
+    "gemini_cli": _generate_gemini_cli,
+    "kiro": _generate_kiro,
+    "codex": _generate_codex,
+    "copilot": _generate_copilot,
+}
+
+SUPPORTED_IDES = list({
+    "claude-code", "cursor", "vscode", "gemini-cli",
+    "kiro", "codex", "copilot",
+})
+
+
+def generate_ide_agent_files(manifest: AgentManifest, ide: str) -> IdeAgentConfig:
+    """Generate IDE-specific agent files from a portable agent manifest.
+
+    This is the universal entry point — takes a Pydantic AgentManifest
+    and produces the correct file layout for any supported IDE.
+    """
+    generator = _IDE_GENERATORS.get(ide)
+    if generator is None:
+        raise ValueError(
+            f"Unsupported IDE: {ide!r}. Supported: {', '.join(SUPPORTED_IDES)}"
+        )
+    return generator(manifest)

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -1,0 +1,146 @@
+"""Agent builder — composes resolved components into a portable agent manifest."""
+
+import logging
+
+from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
+logger = logging.getLogger(__name__)
+
+
+def build_agent_manifest(resolved: ResolvedAgent) -> dict:
+    """Build a portable agent manifest from a fully resolved agent.
+
+    Returns a dict that represents the agent.yaml structure:
+    {
+      "name": "code-reviewer",
+      "version": "1.0.0",
+      "components": {
+        "mcps": [...],
+        "skills": [...],
+        "hooks": [...],
+        "prompts": [...],
+        "sandboxes": [...],
+      },
+      "errors": [...]  # only if resolution had errors
+    }
+    """
+    manifest: dict = {
+        "name": resolved.agent_name,
+        "version": resolved.agent_version,
+        "components": {},
+    }
+
+    type_keys = {
+        "mcp": "mcps",
+        "skill": "skills",
+        "hook": "hooks",
+        "prompt": "prompts",
+        "sandbox": "sandboxes",
+    }
+
+    for ctype, key in type_keys.items():
+        typed_comps = resolved.components_by_type(ctype)
+        if typed_comps:
+            manifest["components"][key] = [
+                _component_to_manifest_entry(c) for c in typed_comps
+            ]
+
+    if resolved.errors:
+        manifest["errors"] = [
+            {
+                "component_type": e.component_type,
+                "component_id": str(e.component_id),
+                "reason": e.reason,
+            }
+            for e in resolved.errors
+        ]
+
+    return manifest
+
+
+def _component_to_manifest_entry(comp: ResolvedComponent) -> dict:
+    """Convert a resolved component to its manifest representation."""
+    entry: dict = {
+        "name": comp.name,
+        "version": comp.version,
+        "git_url": comp.git_url,
+        "description": comp.description,
+        "order": comp.order_index,
+    }
+    if comp.git_ref:
+        entry["git_ref"] = comp.git_ref
+    if comp.config_override:
+        entry["config_override"] = comp.config_override
+
+    # Carry through type-specific fields that matter for installation
+    if comp.component_type == "mcp":
+        if comp.extra.get("transport"):
+            entry["transport"] = comp.extra["transport"]
+        if comp.extra.get("tools_schema"):
+            entry["tools"] = comp.extra["tools_schema"]
+    elif comp.component_type == "skill":
+        if comp.extra.get("slash_command"):
+            entry["slash_command"] = comp.extra["slash_command"]
+        if comp.extra.get("task_type"):
+            entry["task_type"] = comp.extra["task_type"]
+    elif comp.component_type == "hook":
+        entry["event"] = comp.extra.get("event", "")
+        entry["execution_mode"] = comp.extra.get("execution_mode", "async")
+        entry["priority"] = comp.extra.get("priority", 100)
+    elif comp.component_type == "prompt":
+        if comp.extra.get("template"):
+            entry["template"] = comp.extra["template"]
+        if comp.extra.get("variables"):
+            entry["variables"] = comp.extra["variables"]
+    elif comp.component_type == "sandbox":
+        entry["image"] = comp.extra.get("image", "")
+        entry["runtime_type"] = comp.extra.get("runtime_type", "")
+        if comp.extra.get("resource_limits"):
+            entry["resource_limits"] = comp.extra["resource_limits"]
+
+    return entry
+
+
+def build_composition_summary(resolved: ResolvedAgent) -> dict:
+    """Build a lightweight summary of the agent's composition for API responses."""
+    type_keys = {
+        "mcp": "mcps",
+        "skill": "skills",
+        "hook": "hooks",
+        "prompt": "prompts",
+        "sandbox": "sandboxes",
+    }
+
+    summary: dict = {
+        "agent_id": str(resolved.agent_id),
+        "agent_name": resolved.agent_name,
+        "agent_version": resolved.agent_version,
+        "resolved": resolved.ok,
+        "component_counts": {},
+        "components": {},
+    }
+
+    for ctype, key in type_keys.items():
+        typed = resolved.components_by_type(ctype)
+        if typed:
+            summary["component_counts"][ctype] = len(typed)
+            summary["components"][key] = [
+                {
+                    "name": c.name,
+                    "version": c.version,
+                    "order": c.order_index,
+                }
+                for c in typed
+            ]
+
+    if resolved.errors:
+        summary["errors"] = [
+            {
+                "component_type": e.component_type,
+                "component_id": str(e.component_id),
+                "reason": e.reason,
+            }
+            for e in resolved.errors
+        ]
+
+    return summary

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -25,12 +25,21 @@ def _inject_agent_id(mcp_config: dict, agent_id: str):
             cfg["env"]["OBSERVAL_AGENT_ID"] = agent_id
 
 
-def _build_mcp_configs(agent: Agent, ide: str, observal_url: str) -> dict:
-    """Build MCP server configs from registry links + external MCPs."""
-    mcp_configs = {}
+def _build_mcp_configs(agent: Agent, ide: str, observal_url: str, mcp_listings: dict | None = None) -> dict:
+    """Build MCP server configs from registry components + external MCPs.
 
-    for link in agent.mcp_links:
-        listing = link.mcp_listing
+    Args:
+        mcp_listings: optional {component_id: McpListing} map. When provided,
+            used to look up MCP listings for each component. The install route
+            pre-loads these to avoid N+1 queries in a sync context.
+    """
+    mcp_configs = {}
+    mcp_listings = mcp_listings or {}
+
+    for comp in agent.components:
+        if comp.component_type != "mcp":
+            continue
+        listing = mcp_listings.get(comp.component_id)
         if not listing:
             continue
         cfg = generate_config(listing, ide, observal_url=observal_url)
@@ -54,10 +63,19 @@ def _build_mcp_configs(agent: Agent, ide: str, observal_url: str) -> dict:
     return mcp_configs
 
 
-def generate_agent_config(agent: Agent, ide: str, observal_url: str = "http://localhost:8000") -> dict:
-    """Generate IDE-specific config for an agent."""
+def generate_agent_config(
+    agent: Agent,
+    ide: str,
+    observal_url: str = "http://localhost:8000",
+    mcp_listings: dict | None = None,
+) -> dict:
+    """Generate IDE-specific config for an agent.
+
+    Args:
+        mcp_listings: optional {component_id: McpListing} map pre-loaded by caller.
+    """
     safe_name = _sanitize_name(agent.name)
-    mcp_configs = _build_mcp_configs(agent, ide, observal_url)
+    mcp_configs = _build_mcp_configs(agent, ide, observal_url, mcp_listings=mcp_listings)
 
     if ide == "kiro":
         # Kiro agent JSON: drop into ~/.kiro/agents/<name>.json

--- a/observal-server/services/agent_resolver.py
+++ b/observal-server/services/agent_resolver.py
@@ -2,8 +2,9 @@
 
 import logging
 import uuid
-from dataclasses import dataclass, field
+from typing import Literal
 
+from pydantic import BaseModel, Field, computed_field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,6 +18,8 @@ from models.skill import SkillListing
 
 logger = logging.getLogger(__name__)
 
+ComponentType = Literal["mcp", "skill", "hook", "prompt", "sandbox"]
+
 # Maps component_type string to its ORM model
 _LISTING_MODELS: dict[str, type] = {
     "mcp": McpListing,
@@ -27,40 +30,42 @@ _LISTING_MODELS: dict[str, type] = {
 }
 
 
-@dataclass
-class ResolvedComponent:
+class ResolvedComponent(BaseModel):
     """A fully resolved component with its listing data."""
-    component_type: str
+    model_config = {"frozen": True}
+
+    component_type: ComponentType
     component_id: uuid.UUID
     name: str
     version: str
     git_url: str
-    git_ref: str
-    description: str
-    order_index: int
+    git_ref: str = ""
+    description: str = ""
+    order_index: int = 0
     config_override: dict | None = None
     listing_status: str = ""
-    # Type-specific fields carried through for config generation
-    extra: dict = field(default_factory=dict)
+    extra: dict = Field(default_factory=dict)
 
 
-@dataclass
-class ResolutionError:
+class ResolutionError(BaseModel):
     """A single resolution failure."""
+    model_config = {"frozen": True}
+
     component_type: str
     component_id: uuid.UUID
     reason: str
 
 
-@dataclass
-class ResolvedAgent:
+class ResolvedAgent(BaseModel):
     """Complete resolution result for an agent."""
+
     agent_id: uuid.UUID
     agent_name: str
     agent_version: str
-    components: list[ResolvedComponent] = field(default_factory=list)
-    errors: list[ResolutionError] = field(default_factory=list)
+    components: list[ResolvedComponent] = Field(default_factory=list)
+    errors: list[ResolutionError] = Field(default_factory=list)
 
+    @computed_field
     @property
     def ok(self) -> bool:
         return len(self.errors) == 0
@@ -125,16 +130,13 @@ async def resolve_agent(
     Looks up each AgentComponent's listing in the correct table,
     validates status, and returns a ResolvedAgent with full details.
     """
-    result = ResolvedAgent(
-        agent_id=agent.id,
-        agent_name=agent.name,
-        agent_version=agent.version,
-    )
+    components: list[ResolvedComponent] = []
+    errors: list[ResolutionError] = []
 
     for comp in agent.components:
         model = _LISTING_MODELS.get(comp.component_type)
         if model is None:
-            result.errors.append(ResolutionError(
+            errors.append(ResolutionError(
                 component_type=comp.component_type,
                 component_id=comp.component_id,
                 reason=f"Unknown component type: {comp.component_type}",
@@ -145,7 +147,7 @@ async def resolve_agent(
         listing = (await db.execute(stmt)).scalar_one_or_none()
 
         if listing is None:
-            result.errors.append(ResolutionError(
+            errors.append(ResolutionError(
                 component_type=comp.component_type,
                 component_id=comp.component_id,
                 reason=f"{comp.component_type} listing {comp.component_id} not found",
@@ -153,14 +155,14 @@ async def resolve_agent(
             continue
 
         if require_approved and listing.status != ListingStatus.approved:
-            result.errors.append(ResolutionError(
+            errors.append(ResolutionError(
                 component_type=comp.component_type,
                 component_id=comp.component_id,
                 reason=f"{comp.component_type} '{listing.name}' is not approved (status: {listing.status.value})",
             ))
             continue
 
-        result.components.append(ResolvedComponent(
+        components.append(ResolvedComponent(
             component_type=comp.component_type,
             component_id=comp.component_id,
             name=listing.name,
@@ -174,7 +176,13 @@ async def resolve_agent(
             extra=_extract_extra(listing, comp.component_type),
         ))
 
-    return result
+    return ResolvedAgent(
+        agent_id=agent.id,
+        agent_name=agent.name,
+        agent_version=agent.version,
+        components=components,
+        errors=errors,
+    )
 
 
 async def validate_component_ids(
@@ -192,11 +200,19 @@ async def validate_component_ids(
     for ref in components:
         ctype = ref.get("component_type", "")
         cid = ref.get("component_id")
+        if cid is None:
+            errors.append(ResolutionError(
+                component_type=ctype,
+                component_id=uuid.UUID(int=0),
+                reason=f"Missing component_id for {ctype}",
+            ))
+            continue
+
         model = _LISTING_MODELS.get(ctype)
         if model is None:
             errors.append(ResolutionError(
                 component_type=ctype,
-                component_id=cid or uuid.UUID(int=0),
+                component_id=cid,
                 reason=f"Unknown component type: {ctype}",
             ))
             continue

--- a/observal-server/services/agent_resolver.py
+++ b/observal-server/services/agent_resolver.py
@@ -62,6 +62,9 @@ class ResolvedAgent(BaseModel):
     agent_id: uuid.UUID
     agent_name: str
     agent_version: str
+    agent_prompt: str = ""
+    agent_description: str = ""
+    model_name: str = ""
     components: list[ResolvedComponent] = Field(default_factory=list)
     errors: list[ResolutionError] = Field(default_factory=list)
 
@@ -180,6 +183,9 @@ async def resolve_agent(
         agent_id=agent.id,
         agent_name=agent.name,
         agent_version=agent.version,
+        agent_prompt=agent.prompt or "",
+        agent_description=agent.description or "",
+        model_name=agent.model_name or "",
         components=components,
         errors=errors,
     )

--- a/observal-server/services/agent_resolver.py
+++ b/observal-server/services/agent_resolver.py
@@ -1,0 +1,222 @@
+"""Agent composition resolver — looks up and validates all components for an agent."""
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.agent import Agent
+from models.agent_component import AgentComponent
+from models.hook import HookListing
+from models.mcp import ListingStatus, McpListing
+from models.prompt import PromptListing
+from models.sandbox import SandboxListing
+from models.skill import SkillListing
+
+logger = logging.getLogger(__name__)
+
+# Maps component_type string to its ORM model
+_LISTING_MODELS: dict[str, type] = {
+    "mcp": McpListing,
+    "skill": SkillListing,
+    "hook": HookListing,
+    "prompt": PromptListing,
+    "sandbox": SandboxListing,
+}
+
+
+@dataclass
+class ResolvedComponent:
+    """A fully resolved component with its listing data."""
+    component_type: str
+    component_id: uuid.UUID
+    name: str
+    version: str
+    git_url: str
+    git_ref: str
+    description: str
+    order_index: int
+    config_override: dict | None = None
+    listing_status: str = ""
+    # Type-specific fields carried through for config generation
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class ResolutionError:
+    """A single resolution failure."""
+    component_type: str
+    component_id: uuid.UUID
+    reason: str
+
+
+@dataclass
+class ResolvedAgent:
+    """Complete resolution result for an agent."""
+    agent_id: uuid.UUID
+    agent_name: str
+    agent_version: str
+    components: list[ResolvedComponent] = field(default_factory=list)
+    errors: list[ResolutionError] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return len(self.errors) == 0
+
+    def components_by_type(self, component_type: str) -> list[ResolvedComponent]:
+        return [c for c in self.components if c.component_type == component_type]
+
+
+def _extract_extra(listing, component_type: str) -> dict:
+    """Pull type-specific fields from a listing into a flat dict for downstream use."""
+    if component_type == "mcp":
+        return {
+            "transport": getattr(listing, "transport", None),
+            "tools_schema": getattr(listing, "tools_schema", None),
+            "fastmcp_validated": getattr(listing, "fastmcp_validated", False),
+            "setup_instructions": getattr(listing, "setup_instructions", None),
+        }
+    if component_type == "skill":
+        return {
+            "skill_path": getattr(listing, "skill_path", "/"),
+            "task_type": getattr(listing, "task_type", ""),
+            "slash_command": getattr(listing, "slash_command", None),
+            "triggers": getattr(listing, "triggers", None),
+            "has_scripts": getattr(listing, "has_scripts", False),
+            "is_power": getattr(listing, "is_power", False),
+            "mcp_server_config": getattr(listing, "mcp_server_config", None),
+        }
+    if component_type == "hook":
+        return {
+            "event": getattr(listing, "event", ""),
+            "execution_mode": getattr(listing, "execution_mode", "async"),
+            "priority": getattr(listing, "priority", 100),
+            "handler_type": getattr(listing, "handler_type", ""),
+            "handler_config": getattr(listing, "handler_config", {}),
+            "scope": getattr(listing, "scope", "agent"),
+        }
+    if component_type == "prompt":
+        return {
+            "template": getattr(listing, "template", ""),
+            "variables": getattr(listing, "variables", []),
+            "category": getattr(listing, "category", ""),
+        }
+    if component_type == "sandbox":
+        return {
+            "runtime_type": getattr(listing, "runtime_type", ""),
+            "image": getattr(listing, "image", ""),
+            "resource_limits": getattr(listing, "resource_limits", {}),
+            "network_policy": getattr(listing, "network_policy", "none"),
+            "entrypoint": getattr(listing, "entrypoint", None),
+        }
+    return {}
+
+
+async def resolve_agent(
+    agent: Agent,
+    db: AsyncSession,
+    *,
+    require_approved: bool = True,
+) -> ResolvedAgent:
+    """Resolve all components for an agent.
+
+    Looks up each AgentComponent's listing in the correct table,
+    validates status, and returns a ResolvedAgent with full details.
+    """
+    result = ResolvedAgent(
+        agent_id=agent.id,
+        agent_name=agent.name,
+        agent_version=agent.version,
+    )
+
+    for comp in agent.components:
+        model = _LISTING_MODELS.get(comp.component_type)
+        if model is None:
+            result.errors.append(ResolutionError(
+                component_type=comp.component_type,
+                component_id=comp.component_id,
+                reason=f"Unknown component type: {comp.component_type}",
+            ))
+            continue
+
+        stmt = select(model).where(model.id == comp.component_id)
+        listing = (await db.execute(stmt)).scalar_one_or_none()
+
+        if listing is None:
+            result.errors.append(ResolutionError(
+                component_type=comp.component_type,
+                component_id=comp.component_id,
+                reason=f"{comp.component_type} listing {comp.component_id} not found",
+            ))
+            continue
+
+        if require_approved and listing.status != ListingStatus.approved:
+            result.errors.append(ResolutionError(
+                component_type=comp.component_type,
+                component_id=comp.component_id,
+                reason=f"{comp.component_type} '{listing.name}' is not approved (status: {listing.status.value})",
+            ))
+            continue
+
+        result.components.append(ResolvedComponent(
+            component_type=comp.component_type,
+            component_id=comp.component_id,
+            name=listing.name,
+            version=listing.version,
+            git_url=listing.git_url,
+            git_ref=listing.git_ref or "",
+            description=listing.description,
+            order_index=comp.order_index,
+            config_override=comp.config_override,
+            listing_status=listing.status.value,
+            extra=_extract_extra(listing, comp.component_type),
+        ))
+
+    return result
+
+
+async def validate_component_ids(
+    components: list[dict],
+    db: AsyncSession,
+    *,
+    require_approved: bool = True,
+) -> list[ResolutionError]:
+    """Validate a list of component references before attaching them to an agent.
+
+    Each dict should have 'component_type' and 'component_id' keys.
+    Returns a list of errors (empty if all valid).
+    """
+    errors = []
+    for ref in components:
+        ctype = ref.get("component_type", "")
+        cid = ref.get("component_id")
+        model = _LISTING_MODELS.get(ctype)
+        if model is None:
+            errors.append(ResolutionError(
+                component_type=ctype,
+                component_id=cid or uuid.UUID(int=0),
+                reason=f"Unknown component type: {ctype}",
+            ))
+            continue
+
+        stmt = select(model).where(model.id == cid)
+        listing = (await db.execute(stmt)).scalar_one_or_none()
+
+        if listing is None:
+            errors.append(ResolutionError(
+                component_type=ctype,
+                component_id=cid,
+                reason=f"{ctype} listing {cid} not found",
+            ))
+            continue
+
+        if require_approved and listing.status != ListingStatus.approved:
+            errors.append(ResolutionError(
+                component_type=ctype,
+                component_id=cid,
+                reason=f"{ctype} '{listing.name}' is not approved (status: {listing.status.value})",
+            ))
+
+    return errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     "typer",
     "httpx",
     "rich",
-    
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [project.scripts]
@@ -70,3 +71,11 @@ indent-style = "space"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[dependency-groups]
+dev = [
+    "fastapi>=0.135.3",
+    "pydantic>=2.12.5",
+    "pydantic-settings>=2.13.1",
+    "sqlalchemy>=2.0.49",
+]

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -1,0 +1,876 @@
+"""Tests for agent composition and resolver (issue #80).
+
+Tests the resolver service, builder service, schema updates,
+and route endpoints for multi-component agent composition.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ── Schema Tests ────────────────────────────────────────────────────
+
+
+class TestComponentRefSchema:
+    def test_component_ref_fields(self):
+        from schemas.agent import ComponentRef
+        ref = ComponentRef(component_type="mcp", component_id=uuid.uuid4())
+        assert ref.component_type == "mcp"
+        assert ref.config_override is None
+
+    def test_component_ref_with_override(self):
+        from schemas.agent import ComponentRef
+        cid = uuid.uuid4()
+        ref = ComponentRef(
+            component_type="skill",
+            component_id=cid,
+            config_override={"key": "value"},
+        )
+        assert ref.component_type == "skill"
+        assert ref.component_id == cid
+        assert ref.config_override == {"key": "value"}
+
+    def test_valid_component_types_constant(self):
+        from schemas.agent import VALID_COMPONENT_TYPES
+        assert VALID_COMPONENT_TYPES == {"mcp", "skill", "hook", "prompt", "sandbox"}
+
+    def test_component_ref_rejects_invalid_type(self):
+        from pydantic import ValidationError
+        from schemas.agent import ComponentRef
+        with pytest.raises(ValidationError):
+            ComponentRef(component_type="invalid", component_id=uuid.uuid4())
+
+
+class TestComponentLinkResponseSchema:
+    def test_component_link_response_fields(self):
+        from schemas.agent import ComponentLinkResponse
+        resp = ComponentLinkResponse(
+            component_type="hook",
+            component_id=uuid.uuid4(),
+            version_ref="1.0.0",
+            order=0,
+        )
+        assert resp.component_type == "hook"
+        assert resp.version_ref == "1.0.0"
+        assert resp.config_override is None
+
+
+class TestAgentCreateRequestWithComponents:
+    def test_create_request_accepts_components(self):
+        from schemas.agent import AgentCreateRequest, ComponentRef, GoalTemplateRequest, GoalSectionRequest
+        cid = uuid.uuid4()
+        req = AgentCreateRequest(
+            name="test-agent",
+            version="1.0.0",
+            owner="test",
+            model_name="claude-sonnet-4-6",
+            components=[
+                ComponentRef(component_type="mcp", component_id=cid),
+                ComponentRef(component_type="skill", component_id=uuid.uuid4()),
+            ],
+            goal_template=GoalTemplateRequest(
+                description="test",
+                sections=[GoalSectionRequest(name="s1")],
+            ),
+        )
+        assert len(req.components) == 2
+        assert req.components[0].component_type == "mcp"
+
+    def test_create_request_backwards_compat(self):
+        """mcp_server_ids should still work."""
+        from schemas.agent import AgentCreateRequest, GoalTemplateRequest, GoalSectionRequest
+        req = AgentCreateRequest(
+            name="legacy-agent",
+            version="1.0.0",
+            owner="test",
+            model_name="claude-sonnet-4-6",
+            mcp_server_ids=[uuid.uuid4()],
+            goal_template=GoalTemplateRequest(
+                description="test",
+                sections=[GoalSectionRequest(name="s1")],
+            ),
+        )
+        assert len(req.mcp_server_ids) == 1
+        assert len(req.components) == 0
+
+    def test_create_request_both_fields(self):
+        """Both mcp_server_ids and components can coexist."""
+        from schemas.agent import AgentCreateRequest, ComponentRef, GoalTemplateRequest, GoalSectionRequest
+        req = AgentCreateRequest(
+            name="dual-agent",
+            version="1.0.0",
+            owner="test",
+            model_name="claude-sonnet-4-6",
+            mcp_server_ids=[uuid.uuid4()],
+            components=[
+                ComponentRef(component_type="skill", component_id=uuid.uuid4()),
+            ],
+            goal_template=GoalTemplateRequest(
+                description="test",
+                sections=[GoalSectionRequest(name="s1")],
+            ),
+        )
+        assert len(req.mcp_server_ids) == 1
+        assert len(req.components) == 1
+
+
+class TestAgentUpdateRequestWithComponents:
+    def test_update_request_components_optional(self):
+        from schemas.agent import AgentUpdateRequest
+        req = AgentUpdateRequest()
+        assert req.components is None
+
+    def test_update_request_with_components(self):
+        from schemas.agent import AgentUpdateRequest, ComponentRef
+        req = AgentUpdateRequest(
+            components=[
+                ComponentRef(component_type="mcp", component_id=uuid.uuid4()),
+                ComponentRef(component_type="hook", component_id=uuid.uuid4()),
+            ],
+        )
+        assert len(req.components) == 2
+
+
+class TestAgentResponseWithComponentLinks:
+    def test_response_has_component_links(self):
+        from schemas.agent import AgentResponse
+        fields = AgentResponse.model_fields
+        assert "component_links" in fields
+        assert "mcp_links" in fields  # backwards compat
+
+
+# ── Resolver Service Tests ──────────────────────────────────────────
+
+
+class TestResolvedAgentDataclass:
+    def test_ok_when_no_errors(self):
+        from services.agent_resolver import ResolvedAgent
+        ra = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="test",
+            agent_version="1.0",
+        )
+        assert ra.ok is True
+
+    def test_not_ok_when_errors(self):
+        from services.agent_resolver import ResolvedAgent, ResolutionError
+        ra = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="test",
+            agent_version="1.0",
+            errors=[ResolutionError(
+                component_type="mcp",
+                component_id=uuid.uuid4(),
+                reason="not found",
+            )],
+        )
+        assert ra.ok is False
+
+    def test_components_by_type(self):
+        from services.agent_resolver import ResolvedAgent, ResolvedComponent
+        cid1 = uuid.uuid4()
+        cid2 = uuid.uuid4()
+        cid3 = uuid.uuid4()
+        ra = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="test",
+            agent_version="1.0",
+            components=[
+                ResolvedComponent(
+                    component_type="mcp", component_id=cid1, name="mcp1",
+                    version="1.0", git_url="url", git_ref="abc",
+                    description="", order_index=0,
+                ),
+                ResolvedComponent(
+                    component_type="skill", component_id=cid2, name="skill1",
+                    version="1.0", git_url="url", git_ref="abc",
+                    description="", order_index=1,
+                ),
+                ResolvedComponent(
+                    component_type="mcp", component_id=cid3, name="mcp2",
+                    version="2.0", git_url="url", git_ref="def",
+                    description="", order_index=2,
+                ),
+            ],
+        )
+        mcps = ra.components_by_type("mcp")
+        assert len(mcps) == 2
+        assert mcps[0].name == "mcp1"
+        assert mcps[1].name == "mcp2"
+
+        skills = ra.components_by_type("skill")
+        assert len(skills) == 1
+        assert skills[0].name == "skill1"
+
+        hooks = ra.components_by_type("hook")
+        assert len(hooks) == 0
+
+
+class TestListingModelMap:
+    def test_all_types_mapped(self):
+        from services.agent_resolver import _LISTING_MODELS
+        assert set(_LISTING_MODELS.keys()) == {"mcp", "skill", "hook", "prompt", "sandbox"}
+
+    def test_mcp_maps_to_mcp_listing(self):
+        from models.mcp import McpListing
+        from services.agent_resolver import _LISTING_MODELS
+        assert _LISTING_MODELS["mcp"] is McpListing
+
+    def test_skill_maps_to_skill_listing(self):
+        from models.skill import SkillListing
+        from services.agent_resolver import _LISTING_MODELS
+        assert _LISTING_MODELS["skill"] is SkillListing
+
+    def test_hook_maps_to_hook_listing(self):
+        from models.hook import HookListing
+        from services.agent_resolver import _LISTING_MODELS
+        assert _LISTING_MODELS["hook"] is HookListing
+
+    def test_prompt_maps_to_prompt_listing(self):
+        from models.prompt import PromptListing
+        from services.agent_resolver import _LISTING_MODELS
+        assert _LISTING_MODELS["prompt"] is PromptListing
+
+    def test_sandbox_maps_to_sandbox_listing(self):
+        from models.sandbox import SandboxListing
+        from services.agent_resolver import _LISTING_MODELS
+        assert _LISTING_MODELS["sandbox"] is SandboxListing
+
+
+class TestExtractExtra:
+    def test_mcp_extra(self):
+        from services.agent_resolver import _extract_extra
+        listing = MagicMock()
+        listing.transport = "stdio"
+        listing.tools_schema = {"tools": []}
+        listing.fastmcp_validated = True
+        listing.setup_instructions = "pip install"
+        extra = _extract_extra(listing, "mcp")
+        assert extra["transport"] == "stdio"
+        assert extra["fastmcp_validated"] is True
+        assert extra["tools_schema"] == {"tools": []}
+
+    def test_skill_extra(self):
+        from services.agent_resolver import _extract_extra
+        listing = MagicMock()
+        listing.skill_path = "/skills/tdd"
+        listing.task_type = "development"
+        listing.slash_command = "/tdd"
+        listing.triggers = {"on": "test"}
+        listing.has_scripts = True
+        listing.is_power = False
+        listing.mcp_server_config = None
+        extra = _extract_extra(listing, "skill")
+        assert extra["skill_path"] == "/skills/tdd"
+        assert extra["slash_command"] == "/tdd"
+        assert extra["has_scripts"] is True
+
+    def test_hook_extra(self):
+        from services.agent_resolver import _extract_extra
+        listing = MagicMock()
+        listing.event = "PreCommit"
+        listing.execution_mode = "sync"
+        listing.priority = 50
+        listing.handler_type = "script"
+        listing.handler_config = {"cmd": "lint"}
+        listing.scope = "agent"
+        extra = _extract_extra(listing, "hook")
+        assert extra["event"] == "PreCommit"
+        assert extra["priority"] == 50
+
+    def test_prompt_extra(self):
+        from services.agent_resolver import _extract_extra
+        listing = MagicMock()
+        listing.template = "Review this code: {{code}}"
+        listing.variables = ["code"]
+        listing.category = "review"
+        extra = _extract_extra(listing, "prompt")
+        assert extra["template"] == "Review this code: {{code}}"
+        assert extra["variables"] == ["code"]
+
+    def test_sandbox_extra(self):
+        from services.agent_resolver import _extract_extra
+        listing = MagicMock()
+        listing.runtime_type = "docker"
+        listing.image = "python:3.12"
+        listing.resource_limits = {"cpu": "1", "memory": "512m"}
+        listing.network_policy = "none"
+        listing.entrypoint = "/bin/sh"
+        extra = _extract_extra(listing, "sandbox")
+        assert extra["image"] == "python:3.12"
+        assert extra["runtime_type"] == "docker"
+
+    def test_unknown_type_returns_empty(self):
+        from services.agent_resolver import _extract_extra
+        extra = _extract_extra(MagicMock(), "nonexistent")
+        assert extra == {}
+
+
+class TestResolveAgent:
+    @pytest.mark.asyncio
+    async def test_resolve_empty_agent(self):
+        from services.agent_resolver import resolve_agent
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "empty-agent"
+        agent.version = "1.0.0"
+        agent.components = []
+        db = AsyncMock()
+
+        resolved = await resolve_agent(agent, db)
+        assert resolved.ok is True
+        assert resolved.components == []
+        assert resolved.errors == []
+
+    @pytest.mark.asyncio
+    async def test_resolve_unknown_component_type(self):
+        from services.agent_resolver import resolve_agent
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "bad-type-agent"
+        agent.version = "1.0.0"
+
+        comp = MagicMock()
+        comp.component_type = "nonexistent_type"
+        comp.component_id = uuid.uuid4()
+        agent.components = [comp]
+
+        db = AsyncMock()
+        resolved = await resolve_agent(agent, db)
+        assert resolved.ok is False
+        assert len(resolved.errors) == 1
+        assert "Unknown component type" in resolved.errors[0].reason
+
+    @pytest.mark.asyncio
+    async def test_resolve_missing_listing(self):
+        from services.agent_resolver import resolve_agent
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "missing-listing-agent"
+        agent.version = "1.0.0"
+
+        comp = MagicMock()
+        comp.component_type = "mcp"
+        comp.component_id = uuid.uuid4()
+        agent.components = [comp]
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        resolved = await resolve_agent(agent, db)
+        assert resolved.ok is False
+        assert "not found" in resolved.errors[0].reason
+
+    @pytest.mark.asyncio
+    async def test_resolve_unapproved_listing(self):
+        from models.mcp import ListingStatus
+        from services.agent_resolver import resolve_agent
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "unapproved-agent"
+        agent.version = "1.0.0"
+
+        comp = MagicMock()
+        comp.component_type = "mcp"
+        comp.component_id = uuid.uuid4()
+        agent.components = [comp]
+
+        listing = MagicMock()
+        listing.status = ListingStatus.pending
+        listing.name = "pending-mcp"
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = listing
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        resolved = await resolve_agent(agent, db)
+        assert resolved.ok is False
+        assert "not approved" in resolved.errors[0].reason
+
+    @pytest.mark.asyncio
+    async def test_resolve_approved_listing(self):
+        from models.mcp import ListingStatus
+        from services.agent_resolver import resolve_agent
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "good-agent"
+        agent.version = "1.0.0"
+
+        comp = MagicMock()
+        comp.component_type = "mcp"
+        comp.component_id = uuid.uuid4()
+        comp.order_index = 0
+        comp.config_override = None
+        agent.components = [comp]
+
+        listing = MagicMock()
+        listing.status = ListingStatus.approved
+        listing.name = "good-mcp"
+        listing.version = "2.0.0"
+        listing.git_url = "https://github.com/org/repo.git"
+        listing.git_ref = "abc123"
+        listing.description = "A good MCP"
+        listing.transport = "stdio"
+        listing.tools_schema = None
+        listing.fastmcp_validated = True
+        listing.setup_instructions = None
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = listing
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        resolved = await resolve_agent(agent, db)
+        assert resolved.ok is True
+        assert len(resolved.components) == 1
+        assert resolved.components[0].name == "good-mcp"
+        assert resolved.components[0].version == "2.0.0"
+        assert resolved.components[0].git_ref == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_resolve_skip_approval_check(self):
+        """When require_approved=False, unapproved listings should resolve."""
+        from models.mcp import ListingStatus
+        from services.agent_resolver import resolve_agent
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "draft-agent"
+        agent.version = "0.1.0"
+
+        comp = MagicMock()
+        comp.component_type = "skill"
+        comp.component_id = uuid.uuid4()
+        comp.order_index = 0
+        comp.config_override = None
+        agent.components = [comp]
+
+        listing = MagicMock()
+        listing.status = ListingStatus.pending
+        listing.name = "pending-skill"
+        listing.version = "1.0.0"
+        listing.git_url = "https://github.com/org/skill.git"
+        listing.git_ref = None
+        listing.description = "A pending skill"
+        listing.skill_path = "/"
+        listing.task_type = "dev"
+        listing.slash_command = None
+        listing.triggers = None
+        listing.has_scripts = False
+        listing.is_power = False
+        listing.mcp_server_config = None
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = listing
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        resolved = await resolve_agent(agent, db, require_approved=False)
+        assert resolved.ok is True
+        assert len(resolved.components) == 1
+        assert resolved.components[0].name == "pending-skill"
+
+    @pytest.mark.asyncio
+    async def test_resolve_mixed_success_and_failure(self):
+        """An agent with both valid and invalid components."""
+        from models.mcp import ListingStatus
+        from services.agent_resolver import resolve_agent
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "mixed-agent"
+        agent.version = "1.0.0"
+
+        good_comp = MagicMock()
+        good_comp.component_type = "mcp"
+        good_comp.component_id = uuid.uuid4()
+        good_comp.order_index = 0
+        good_comp.config_override = None
+
+        bad_comp = MagicMock()
+        bad_comp.component_type = "mcp"
+        bad_comp.component_id = uuid.uuid4()
+        bad_comp.order_index = 1
+
+        agent.components = [good_comp, bad_comp]
+
+        good_listing = MagicMock()
+        good_listing.status = ListingStatus.approved
+        good_listing.name = "good-mcp"
+        good_listing.version = "1.0"
+        good_listing.git_url = "url"
+        good_listing.git_ref = "abc"
+        good_listing.description = ""
+        good_listing.transport = None
+        good_listing.tools_schema = None
+        good_listing.fastmcp_validated = True
+        good_listing.setup_instructions = None
+
+        # Return good listing for first call, None for second
+        mock_result_good = MagicMock()
+        mock_result_good.scalar_one_or_none.return_value = good_listing
+        mock_result_bad = MagicMock()
+        mock_result_bad.scalar_one_or_none.return_value = None
+
+        db = AsyncMock()
+        db.execute.side_effect = [mock_result_good, mock_result_bad]
+
+        resolved = await resolve_agent(agent, db)
+        assert resolved.ok is False
+        assert len(resolved.components) == 1
+        assert len(resolved.errors) == 1
+
+
+class TestValidateComponentIds:
+    @pytest.mark.asyncio
+    async def test_validate_empty_list(self):
+        from services.agent_resolver import validate_component_ids
+        db = AsyncMock()
+        errors = await validate_component_ids([], db)
+        assert errors == []
+
+    @pytest.mark.asyncio
+    async def test_validate_unknown_type(self):
+        from services.agent_resolver import validate_component_ids
+        db = AsyncMock()
+        errors = await validate_component_ids(
+            [{"component_type": "unknown", "component_id": uuid.uuid4()}],
+            db,
+        )
+        assert len(errors) == 1
+        assert "Unknown component type" in errors[0].reason
+
+    @pytest.mark.asyncio
+    async def test_validate_missing_component(self):
+        from services.agent_resolver import validate_component_ids
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        errors = await validate_component_ids(
+            [{"component_type": "mcp", "component_id": uuid.uuid4()}],
+            db,
+        )
+        assert len(errors) == 1
+        assert "not found" in errors[0].reason
+
+    @pytest.mark.asyncio
+    async def test_validate_unapproved_component(self):
+        from models.mcp import ListingStatus
+        from services.agent_resolver import validate_component_ids
+        listing = MagicMock()
+        listing.status = ListingStatus.pending
+        listing.name = "pending-mcp"
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = listing
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        errors = await validate_component_ids(
+            [{"component_type": "mcp", "component_id": uuid.uuid4()}],
+            db,
+        )
+        assert len(errors) == 1
+        assert "not approved" in errors[0].reason
+
+    @pytest.mark.asyncio
+    async def test_validate_approved_component(self):
+        from models.mcp import ListingStatus
+        from services.agent_resolver import validate_component_ids
+        listing = MagicMock()
+        listing.status = ListingStatus.approved
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = listing
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        errors = await validate_component_ids(
+            [{"component_type": "mcp", "component_id": uuid.uuid4()}],
+            db,
+        )
+        assert errors == []
+
+
+# ── Builder Service Tests ───────────────────────────────────────────
+
+
+class TestBuildAgentManifest:
+    def test_empty_agent_manifest(self):
+        from services.agent_builder import build_agent_manifest
+        from services.agent_resolver import ResolvedAgent
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="empty",
+            agent_version="1.0.0",
+        )
+        manifest = build_agent_manifest(resolved)
+        assert manifest["name"] == "empty"
+        assert manifest["version"] == "1.0.0"
+        assert manifest["components"] == {}
+        assert "errors" not in manifest
+
+    def test_manifest_with_mcps(self):
+        from services.agent_builder import build_agent_manifest
+        from services.agent_resolver import ResolvedAgent, ResolvedComponent
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="mcp-agent",
+            agent_version="1.0.0",
+            components=[
+                ResolvedComponent(
+                    component_type="mcp", component_id=uuid.uuid4(),
+                    name="filesystem-mcp", version="2.0.0",
+                    git_url="https://github.com/org/repo.git", git_ref="abc123",
+                    description="FS ops", order_index=0,
+                    extra={"transport": "stdio", "tools_schema": None,
+                           "fastmcp_validated": True, "setup_instructions": None},
+                ),
+            ],
+        )
+        manifest = build_agent_manifest(resolved)
+        assert "mcps" in manifest["components"]
+        assert len(manifest["components"]["mcps"]) == 1
+        mcp = manifest["components"]["mcps"][0]
+        assert mcp["name"] == "filesystem-mcp"
+        assert mcp["version"] == "2.0.0"
+        assert mcp["git_ref"] == "abc123"
+        assert mcp["transport"] == "stdio"
+
+    def test_manifest_with_all_types(self):
+        from services.agent_builder import build_agent_manifest
+        from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
+        def _comp(ctype, name, order, **extra_kw):
+            return ResolvedComponent(
+                component_type=ctype, component_id=uuid.uuid4(),
+                name=name, version="1.0", git_url="url", git_ref="ref",
+                description=f"{name} desc", order_index=order,
+                extra=extra_kw,
+            )
+
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="full-agent",
+            agent_version="2.0.0",
+            components=[
+                _comp("mcp", "fs-mcp", 0, transport="stdio"),
+                _comp("skill", "tdd", 1, task_type="dev", slash_command="/tdd"),
+                _comp("hook", "pre-commit", 2, event="PreCommit",
+                      execution_mode="sync", priority=50),
+                _comp("prompt", "review", 3, template="Review: {{code}}",
+                      variables=["code"]),
+                _comp("sandbox", "python", 4, image="python:3.12",
+                      runtime_type="docker", resource_limits={"cpu": "1"}),
+            ],
+        )
+        manifest = build_agent_manifest(resolved)
+        assert set(manifest["components"].keys()) == {"mcps", "skills", "hooks", "prompts", "sandboxes"}
+        assert len(manifest["components"]["mcps"]) == 1
+        assert len(manifest["components"]["skills"]) == 1
+        assert len(manifest["components"]["hooks"]) == 1
+        assert len(manifest["components"]["prompts"]) == 1
+        assert len(manifest["components"]["sandboxes"]) == 1
+
+    def test_manifest_includes_errors(self):
+        from services.agent_builder import build_agent_manifest
+        from services.agent_resolver import ResolvedAgent, ResolutionError
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="error-agent",
+            agent_version="1.0.0",
+            errors=[
+                ResolutionError(
+                    component_type="mcp",
+                    component_id=uuid.uuid4(),
+                    reason="not found",
+                ),
+            ],
+        )
+        manifest = build_agent_manifest(resolved)
+        assert "errors" in manifest
+        assert len(manifest["errors"]) == 1
+        assert manifest["errors"][0]["reason"] == "not found"
+
+    def test_manifest_hook_fields(self):
+        from services.agent_builder import build_agent_manifest
+        from services.agent_resolver import ResolvedAgent, ResolvedComponent
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="hook-agent",
+            agent_version="1.0.0",
+            components=[
+                ResolvedComponent(
+                    component_type="hook", component_id=uuid.uuid4(),
+                    name="pre-commit-lint", version="1.0",
+                    git_url="url", git_ref="ref", description="Lint hook",
+                    order_index=0,
+                    extra={"event": "PreCommit", "execution_mode": "sync", "priority": 10},
+                ),
+            ],
+        )
+        manifest = build_agent_manifest(resolved)
+        hook = manifest["components"]["hooks"][0]
+        assert hook["event"] == "PreCommit"
+        assert hook["execution_mode"] == "sync"
+        assert hook["priority"] == 10
+
+    def test_manifest_sandbox_fields(self):
+        from services.agent_builder import build_agent_manifest
+        from services.agent_resolver import ResolvedAgent, ResolvedComponent
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="sandbox-agent",
+            agent_version="1.0.0",
+            components=[
+                ResolvedComponent(
+                    component_type="sandbox", component_id=uuid.uuid4(),
+                    name="python-sandbox", version="1.0",
+                    git_url="url", git_ref="ref", description="",
+                    order_index=0,
+                    extra={
+                        "image": "python:3.12",
+                        "runtime_type": "docker",
+                        "resource_limits": {"cpu": "1", "memory": "512m"},
+                    },
+                ),
+            ],
+        )
+        manifest = build_agent_manifest(resolved)
+        sandbox = manifest["components"]["sandboxes"][0]
+        assert sandbox["image"] == "python:3.12"
+        assert sandbox["runtime_type"] == "docker"
+        assert sandbox["resource_limits"]["memory"] == "512m"
+
+    def test_manifest_with_config_override(self):
+        from services.agent_builder import build_agent_manifest
+        from services.agent_resolver import ResolvedAgent, ResolvedComponent
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="override-agent",
+            agent_version="1.0.0",
+            components=[
+                ResolvedComponent(
+                    component_type="mcp", component_id=uuid.uuid4(),
+                    name="db-mcp", version="1.0",
+                    git_url="url", git_ref="ref", description="",
+                    order_index=0,
+                    config_override={"env": {"DB_URL": "postgres://..."}},
+                    extra={},
+                ),
+            ],
+        )
+        manifest = build_agent_manifest(resolved)
+        mcp = manifest["components"]["mcps"][0]
+        assert mcp["config_override"] == {"env": {"DB_URL": "postgres://..."}}
+
+
+class TestBuildCompositionSummary:
+    def test_summary_resolved_flag(self):
+        from services.agent_builder import build_composition_summary
+        from services.agent_resolver import ResolvedAgent
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="ok-agent",
+            agent_version="1.0",
+        )
+        summary = build_composition_summary(resolved)
+        assert summary["resolved"] is True
+
+    def test_summary_not_resolved_with_errors(self):
+        from services.agent_builder import build_composition_summary
+        from services.agent_resolver import ResolvedAgent, ResolutionError
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="bad-agent",
+            agent_version="1.0",
+            errors=[ResolutionError("mcp", uuid.uuid4(), "missing")],
+        )
+        summary = build_composition_summary(resolved)
+        assert summary["resolved"] is False
+        assert "errors" in summary
+
+    def test_summary_component_counts(self):
+        from services.agent_builder import build_composition_summary
+        from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
+        def _comp(ctype, name, order):
+            return ResolvedComponent(
+                component_type=ctype, component_id=uuid.uuid4(),
+                name=name, version="1.0", git_url="u", git_ref="r",
+                description="", order_index=order,
+            )
+
+        resolved = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="counted-agent",
+            agent_version="1.0",
+            components=[
+                _comp("mcp", "a", 0),
+                _comp("mcp", "b", 1),
+                _comp("skill", "c", 2),
+            ],
+        )
+        summary = build_composition_summary(resolved)
+        assert summary["component_counts"]["mcp"] == 2
+        assert summary["component_counts"]["skill"] == 1
+        assert "hook" not in summary["component_counts"]
+
+
+# ── Route Schema Integration Tests ──────────────────────────────────
+
+
+class TestComponentLinkResponseInAgentResponse:
+    def test_agent_response_has_component_links_field(self):
+        """AgentResponse schema must include component_links."""
+        from schemas.agent import AgentResponse
+        assert "component_links" in AgentResponse.model_fields
+        assert "mcp_links" in AgentResponse.model_fields  # backwards compat
+
+    def test_component_link_response_serializes(self):
+        from schemas.agent import ComponentLinkResponse
+        cid = uuid.uuid4()
+        link = ComponentLinkResponse(
+            component_type="skill",
+            component_id=cid,
+            version_ref="2.0",
+            order=1,
+            config_override={"key": "val"},
+        )
+        data = link.model_dump()
+        assert data["component_type"] == "skill"
+        assert data["component_id"] == cid
+        assert data["config_override"] == {"key": "val"}
+
+    def test_component_link_response_no_override(self):
+        from schemas.agent import ComponentLinkResponse
+        link = ComponentLinkResponse(
+            component_type="mcp",
+            component_id=uuid.uuid4(),
+            version_ref="1.0",
+            order=0,
+        )
+        assert link.config_override is None
+
+
+class TestResolverAndBuilderModulesImportable:
+    def test_resolver_module_importable(self):
+        from services.agent_resolver import (
+            ResolvedAgent, ResolvedComponent, ResolutionError,
+            resolve_agent, validate_component_ids, _LISTING_MODELS,
+        )
+        assert callable(resolve_agent)
+        assert callable(validate_component_ids)
+        assert len(_LISTING_MODELS) == 5
+
+    def test_builder_module_importable(self):
+        from services.agent_builder import (
+            build_agent_manifest, build_composition_summary,
+        )
+        assert callable(build_agent_manifest)
+        assert callable(build_composition_summary)

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -316,6 +316,9 @@ class TestResolveAgent:
         agent.id = uuid.uuid4()
         agent.name = "empty-agent"
         agent.version = "1.0.0"
+        agent.prompt = "Test prompt"
+        agent.description = "Test desc"
+        agent.model_name = "test-model"
         agent.components = []
         db = AsyncMock()
 
@@ -331,6 +334,9 @@ class TestResolveAgent:
         agent.id = uuid.uuid4()
         agent.name = "bad-type-agent"
         agent.version = "1.0.0"
+        agent.prompt = ""
+        agent.description = ""
+        agent.model_name = ""
 
         comp = MagicMock()
         comp.component_type = "nonexistent_type"
@@ -350,6 +356,9 @@ class TestResolveAgent:
         agent.id = uuid.uuid4()
         agent.name = "missing-listing-agent"
         agent.version = "1.0.0"
+        agent.prompt = ""
+        agent.description = ""
+        agent.model_name = ""
 
         comp = MagicMock()
         comp.component_type = "mcp"
@@ -373,6 +382,9 @@ class TestResolveAgent:
         agent.id = uuid.uuid4()
         agent.name = "unapproved-agent"
         agent.version = "1.0.0"
+        agent.prompt = ""
+        agent.description = ""
+        agent.model_name = ""
 
         comp = MagicMock()
         comp.component_type = "mcp"
@@ -400,6 +412,9 @@ class TestResolveAgent:
         agent.id = uuid.uuid4()
         agent.name = "good-agent"
         agent.version = "1.0.0"
+        agent.prompt = "Agent prompt"
+        agent.description = "Agent desc"
+        agent.model_name = "test-model"
 
         comp = MagicMock()
         comp.component_type = "mcp"
@@ -441,6 +456,9 @@ class TestResolveAgent:
         agent.id = uuid.uuid4()
         agent.name = "draft-agent"
         agent.version = "0.1.0"
+        agent.prompt = ""
+        agent.description = ""
+        agent.model_name = ""
 
         comp = MagicMock()
         comp.component_type = "skill"
@@ -483,6 +501,9 @@ class TestResolveAgent:
         agent.id = uuid.uuid4()
         agent.name = "mixed-agent"
         agent.version = "1.0.0"
+        agent.prompt = ""
+        agent.description = ""
+        agent.model_name = ""
 
         good_comp = MagicMock()
         good_comp.component_type = "mcp"
@@ -965,6 +986,311 @@ class TestResolverAndBuilderModulesImportable:
     def test_builder_module_importable(self):
         from services.agent_builder import (
             build_agent_manifest, build_composition_summary,
+            generate_ide_agent_files, SUPPORTED_IDES,
         )
         assert callable(build_agent_manifest)
         assert callable(build_composition_summary)
+        assert callable(generate_ide_agent_files)
+        assert "claude-code" in SUPPORTED_IDES
+        assert "copilot" in SUPPORTED_IDES
+
+
+class TestGenerateIdeAgentFiles:
+    """Tests for universal IDE agent file generation from AgentManifest."""
+
+    def _make_manifest(self, **overrides):
+        from services.agent_builder import (
+            AgentManifest, ManifestComponent, ManifestComponents,
+        )
+        defaults = {
+            "name": "test-agent",
+            "version": "1.0",
+            "prompt": "You are a helpful coding assistant.",
+            "description": "A test agent for unit testing.",
+            "model_name": "claude-sonnet-4-20250514",
+            "components": ManifestComponents(
+                mcps=[
+                    ManifestComponent(
+                        name="github-mcp", version="2.0", git_url="https://github.com/example/mcp",
+                        description="GitHub integration MCP server",
+                    ),
+                    ManifestComponent(
+                        name="postgres-mcp", version="1.5", git_url="https://github.com/example/pg",
+                        description="PostgreSQL query MCP",
+                    ),
+                ],
+                skills=[
+                    ManifestComponent(
+                        name="code-review", version="1.0", git_url="https://github.com/example/cr",
+                        slash_command="review",
+                    ),
+                ],
+            ),
+        }
+        defaults.update(overrides)
+        return AgentManifest(**defaults)
+
+    # ── Claude Code ────────────────────────────────────────────
+
+    def test_claude_code_generates_rules_file(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "claude-code")
+        assert config.ide == "claude-code"
+        rules_files = [f for f in config.files if f.format == "markdown"]
+        assert len(rules_files) == 1
+        assert rules_files[0].path == ".claude/rules/test-agent.md"
+        assert "You are a helpful coding assistant." in rules_files[0].content
+
+    def test_claude_code_mcp_setup_commands(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "claude-code")
+        assert len(config.setup_commands) == 2
+        assert config.setup_commands[0][:3] == ["claude", "mcp", "add"]
+        assert "github-mcp" in config.setup_commands[0]
+
+    def test_claude_code_env_includes_telemetry(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "claude-code")
+        assert "CLAUDE_CODE_ENABLE_TELEMETRY" in config.env
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" in config.env
+
+    def test_claude_code_underscore_alias(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "claude_code")
+        assert config.ide == "claude-code"
+
+    # ── Cursor ─────────────────────────────────────────────────
+
+    def test_cursor_generates_rules_and_mcp_json(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "cursor")
+        assert config.ide == "cursor"
+        assert len(config.files) == 2
+        rules = [f for f in config.files if f.format == "markdown"][0]
+        mcp_json = [f for f in config.files if f.format == "json"][0]
+        assert rules.path == ".cursor/rules/test-agent.md"
+        assert mcp_json.path == ".cursor/mcp.json"
+        assert "mcpServers" in mcp_json.content
+        assert "github-mcp" in mcp_json.content["mcpServers"]
+
+    # ── VS Code ────────────────────────────────────────────────
+
+    def test_vscode_generates_rules_and_mcp_json(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "vscode")
+        assert config.ide == "vscode"
+        rules = [f for f in config.files if f.format == "markdown"][0]
+        mcp_json = [f for f in config.files if f.format == "json"][0]
+        assert rules.path == ".vscode/rules/test-agent.md"
+        assert mcp_json.path == ".vscode/mcp.json"
+
+    # ── Gemini CLI ─────────────────────────────────────────────
+
+    def test_gemini_cli_generates_gemini_md(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "gemini-cli")
+        assert config.ide == "gemini-cli"
+        md_files = [f for f in config.files if f.format == "markdown"]
+        assert len(md_files) == 1
+        assert md_files[0].path == "GEMINI.md"
+        assert "You are a helpful coding assistant." in md_files[0].content
+
+    def test_gemini_cli_env_includes_otel(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "gemini-cli")
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" in config.env
+
+    def test_gemini_cli_underscore_alias(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "gemini_cli")
+        assert config.ide == "gemini-cli"
+
+    # ── Kiro ───────────────────────────────────────────────────
+
+    def test_kiro_generates_agent_json(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "kiro")
+        assert config.ide == "kiro"
+        assert len(config.files) == 1
+        agent_file = config.files[0]
+        assert agent_file.path == "~/.kiro/agents/test-agent.json"
+        assert agent_file.format == "json"
+        content = agent_file.content
+        assert content["name"] == "test-agent"
+        assert content["prompt"] == "You are a helpful coding assistant."
+        assert "mcpServers" in content
+        assert "github-mcp" in content["mcpServers"]
+        assert "@github-mcp" in content["tools"]
+        assert content["model"] == "claude-sonnet-4-20250514"
+
+    # ── Codex ──────────────────────────────────────────────────
+
+    def test_codex_generates_agents_md_and_config_toml(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "codex")
+        assert config.ide == "codex"
+        assert len(config.files) == 2
+        md_file = [f for f in config.files if f.format == "markdown"][0]
+        toml_file = [f for f in config.files if f.format == "toml"][0]
+        assert md_file.path == "AGENTS.md"
+        assert toml_file.path == "~/.codex/config.toml"
+        assert "[otel]" in toml_file.content
+
+    # ── GitHub Copilot ─────────────────────────────────────────
+
+    def test_copilot_generates_instructions_md(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "copilot")
+        assert config.ide == "copilot"
+        assert len(config.files) == 1
+        md = config.files[0]
+        assert md.path == ".github/copilot-instructions.md"
+        assert md.format == "markdown"
+        assert "You are a helpful coding assistant." in md.content
+
+    # ── Rules markdown content ─────────────────────────────────
+
+    def test_rules_markdown_includes_component_sections(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "cursor")
+        rules = [f for f in config.files if f.format == "markdown"][0]
+        content = rules.content
+        assert "## MCP Servers" in content
+        assert "**github-mcp**" in content
+        assert "**postgres-mcp**" in content
+        assert "## Skills" in content
+        assert "**code-review**" in content
+        assert "`/review`" in content
+
+    def test_rules_markdown_empty_prompt(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest(prompt="")
+        config = generate_ide_agent_files(manifest, "copilot")
+        content = config.files[0].content
+        # Should still have component sections
+        assert "## MCP Servers" in content
+
+    def test_rules_markdown_no_components(self):
+        from services.agent_builder import AgentManifest, ManifestComponents
+        from services.agent_builder import generate_ide_agent_files
+        manifest = AgentManifest(
+            name="bare-agent",
+            version="1.0",
+            prompt="Just a prompt, no components.",
+            components=ManifestComponents(),
+        )
+        config = generate_ide_agent_files(manifest, "copilot")
+        content = config.files[0].content
+        assert "Just a prompt, no components." in content
+        assert "## MCP Servers" not in content
+
+    # ── MCP entries ────────────────────────────────────────────
+
+    def test_mcp_entries_use_observal_shim(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "cursor")
+        for name, entry in config.mcp_servers.items():
+            assert entry["command"] == "observal-shim"
+            assert "--mcp-id" in entry["args"]
+
+    def test_no_mcps_produces_empty_servers(self):
+        from services.agent_builder import (
+            AgentManifest, ManifestComponent, ManifestComponents,
+            generate_ide_agent_files,
+        )
+        manifest = AgentManifest(
+            name="no-mcp-agent",
+            version="1.0",
+            prompt="Agent without MCPs.",
+            components=ManifestComponents(
+                skills=[ManifestComponent(name="s", version="1.0", git_url="url")],
+            ),
+        )
+        config = generate_ide_agent_files(manifest, "claude-code")
+        assert config.mcp_servers == {}
+        assert config.setup_commands == []
+
+    # ── Name sanitization ──────────────────────────────────────
+
+    def test_name_with_spaces_gets_sanitized(self):
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest(name="My Cool Agent!")
+        config = generate_ide_agent_files(manifest, "claude-code")
+        rules = config.files[0]
+        assert "My Cool Agent!" not in rules.path
+        assert "My-Cool-Agent-" in rules.path
+
+    # ── Unsupported IDE ────────────────────────────────────────
+
+    def test_unsupported_ide_raises_value_error(self):
+        import pytest
+        from services.agent_builder import generate_ide_agent_files
+        manifest = self._make_manifest()
+        with pytest.raises(ValueError, match="Unsupported IDE"):
+            generate_ide_agent_files(manifest, "notepad")
+
+    # ── Hooks in markdown ──────────────────────────────────────
+
+    def test_hooks_appear_in_rules_markdown(self):
+        from services.agent_builder import (
+            AgentManifest, ManifestComponent, ManifestComponents,
+            generate_ide_agent_files,
+        )
+        manifest = AgentManifest(
+            name="hook-agent",
+            version="1.0",
+            prompt="Agent with hooks.",
+            components=ManifestComponents(
+                hooks=[
+                    ManifestComponent(
+                        name="lint-hook", version="1.0", git_url="url",
+                        event="pre_commit", execution_mode="sync",
+                    ),
+                ],
+            ),
+        )
+        config = generate_ide_agent_files(manifest, "gemini-cli")
+        content = config.files[0].content
+        assert "## Hooks" in content
+        assert "**lint-hook**" in content
+        assert "`pre_commit`" in content
+
+    # ── All supported IDEs produce valid output ────────────────
+
+    def test_all_supported_ides_produce_output(self):
+        from services.agent_builder import generate_ide_agent_files, SUPPORTED_IDES
+        manifest = self._make_manifest()
+        for ide in SUPPORTED_IDES:
+            config = generate_ide_agent_files(manifest, ide)
+            assert config.ide is not None
+            assert len(config.files) > 0
+
+    # ── Manifest with prompt/description round-trips ───────────
+
+    def test_manifest_compact_includes_prompt_and_description(self):
+        manifest = self._make_manifest()
+        compact = manifest.model_dump_compact()
+        assert compact["prompt"] == "You are a helpful coding assistant."
+        assert compact["description"] == "A test agent for unit testing."
+        assert compact["model_name"] == "claude-sonnet-4-20250514"
+
+    def test_manifest_compact_omits_empty_prompt(self):
+        manifest = self._make_manifest(prompt="", description="", model_name="")
+        compact = manifest.model_dump_compact()
+        assert "prompt" not in compact
+        assert "description" not in compact
+        assert "model_name" not in compact

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -789,7 +789,7 @@ class TestBuildCompositionSummary:
             agent_id=uuid.uuid4(),
             agent_name="bad-agent",
             agent_version="1.0",
-            errors=[ResolutionError("mcp", uuid.uuid4(), "missing")],
+            errors=[ResolutionError(component_type="mcp", component_id=uuid.uuid4(), reason="missing")],
         )
         summary = build_composition_summary(resolved)
         assert summary["resolved"] is False
@@ -856,6 +856,100 @@ class TestComponentLinkResponseInAgentResponse:
             order=0,
         )
         assert link.config_override is None
+
+
+class TestPydanticValidation:
+    """Verify Pydantic validation on resolver/builder models."""
+
+    def test_resolved_component_is_frozen(self):
+        from services.agent_resolver import ResolvedComponent
+        comp = ResolvedComponent(
+            component_type="mcp", component_id=uuid.uuid4(),
+            name="test", version="1.0", git_url="url",
+        )
+        with pytest.raises(Exception):
+            comp.name = "changed"
+
+    def test_resolution_error_is_frozen(self):
+        from services.agent_resolver import ResolutionError
+        err = ResolutionError(
+            component_type="mcp", component_id=uuid.uuid4(), reason="test",
+        )
+        with pytest.raises(Exception):
+            err.reason = "changed"
+
+    def test_resolved_agent_serializes_to_dict(self):
+        from services.agent_resolver import ResolvedAgent
+        ra = ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="test",
+            agent_version="1.0",
+        )
+        data = ra.model_dump()
+        assert data["agent_name"] == "test"
+        assert data["ok"] is True
+
+    def test_resolved_component_rejects_invalid_type(self):
+        from pydantic import ValidationError
+        from services.agent_resolver import ResolvedComponent
+        with pytest.raises(ValidationError):
+            ResolvedComponent(
+                component_type="invalid_type", component_id=uuid.uuid4(),
+                name="bad", version="1.0", git_url="url",
+            )
+
+    def test_manifest_component_dump_compact(self):
+        from services.agent_builder import ManifestComponent
+        comp = ManifestComponent(
+            name="test-mcp", version="1.0", git_url="url",
+            description="desc", transport="stdio",
+        )
+        dumped = comp.model_dump_compact()
+        assert "transport" in dumped
+        assert "image" not in dumped  # None fields excluded
+        assert "slash_command" not in dumped
+
+    def test_agent_manifest_model_validates(self):
+        from services.agent_builder import AgentManifest, ManifestComponent, ManifestComponents
+        manifest = AgentManifest(
+            name="my-agent",
+            version="2.0",
+            components=ManifestComponents(
+                mcps=[ManifestComponent(name="a", version="1.0", git_url="url")],
+            ),
+        )
+        assert manifest.name == "my-agent"
+        assert len(manifest.components.mcps) == 1
+        compact = manifest.model_dump_compact()
+        assert compact["components"]["mcps"][0]["name"] == "a"
+        assert "skills" not in compact["components"]
+
+    def test_ide_agent_config_model(self):
+        from services.agent_builder import AgentFile, IdeAgentConfig
+        config = IdeAgentConfig(
+            ide="claude-code",
+            files=[
+                AgentFile(path=".claude/rules/test.md", content="# Rules", format="markdown"),
+                AgentFile(path=".mcp.json", content={"mcpServers": {}}, format="json"),
+            ],
+            env={"OTEL_ENDPOINT": "http://localhost:4318"},
+        )
+        assert len(config.files) == 2
+        assert config.files[0].format == "markdown"
+        assert config.files[1].format == "json"
+
+    def test_composition_summary_model(self):
+        from services.agent_builder import CompositionSummary
+        summary = CompositionSummary(
+            agent_id=str(uuid.uuid4()),
+            agent_name="test",
+            agent_version="1.0",
+            resolved=True,
+            component_counts={"mcp": 2, "skill": 1},
+        )
+        data = summary.model_dump()
+        assert data["resolved"] is True
+        assert data["component_counts"]["mcp"] == 2
 
 
 class TestResolverAndBuilderModulesImportable:

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -52,6 +61,79 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4d/d8123a4e0bcd583d5cfc8ddae0bbe29c67aab96711be331a7cc935a35966/greenlet-3.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267", size = 235045, upload-time = "2026-04-08T17:04:05.072Z" },
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
 ]
 
 [[package]]
@@ -101,6 +183,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -127,15 +218,179 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "rich" },
     { name = "typer" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "fastapi" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "sqlalchemy" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "httpx" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "rich" },
     { name = "typer" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "sqlalchemy", specifier = ">=2.0.49" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
 ]
 
 [[package]]
@@ -145,6 +400,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -170,6 +463,72 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/b5/e3617cc67420f8f403efebd7b043128f94775e57e5b84e7255203390ceae/sqlalchemy-2.0.49-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5070135e1b7409c4161133aa525419b0062088ed77c92b1da95366ec5cbebbe", size = 2159126, upload-time = "2026-04-03T16:50:13.242Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9b/91ca80403b17cd389622a642699e5f6564096b698e7cdcbcbb6409898bc4/sqlalchemy-2.0.49-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ac7a3e245fd0310fd31495eb61af772e637bdf7d88ee81e7f10a3f271bff014", size = 3315509, upload-time = "2026-04-03T16:54:49.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/61/0722511d98c54de95acb327824cb759e8653789af2b1944ab1cc69d32565/sqlalchemy-2.0.49-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d4e5a0ceba319942fa6b585cf82539288a61e314ef006c1209f734551ab9536", size = 3315014, upload-time = "2026-04-03T16:56:56.376Z" },
+    { url = "https://files.pythonhosted.org/packages/46/55/d514a653ffeb4cebf4b54c47bec32ee28ad89d39fafba16eeed1d81dccd5/sqlalchemy-2.0.49-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3ddcb27fb39171de36e207600116ac9dfd4ae46f86c82a9bf3934043e80ebb88", size = 3267388, upload-time = "2026-04-03T16:54:51.272Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/16/0dcc56cb6d3335c1671a2258f5d2cb8267c9a2260e27fde53cbfb1b3540a/sqlalchemy-2.0.49-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:32fe6a41ad97302db2931f05bb91abbcc65b5ce4c675cd44b972428dd2947700", size = 3289602, upload-time = "2026-04-03T16:56:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6c/f8ab6fb04470a133cd80608db40aa292e6bae5f162c3a3d4ab19544a67af/sqlalchemy-2.0.49-cp311-cp311-win32.whl", hash = "sha256:46d51518d53edfbe0563662c96954dc8fcace9832332b914375f45a99b77cc9a", size = 2119044, upload-time = "2026-04-03T17:00:53.455Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/55a6d627d04b6ebb290693681d7683c7da001eddf90b60cfcc41ee907978/sqlalchemy-2.0.49-cp311-cp311-win_amd64.whl", hash = "sha256:951d4a210744813be63019f3df343bf233b7432aadf0db54c75802247330d3af", size = 2143642, upload-time = "2026-04-03T17:00:54.769Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -191,4 +550,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]


### PR DESCRIPTION
## Summary
- **agent_resolver.py**: Resolves all 5 component types (MCP, skill, hook, prompt, sandbox) from DB via polymorphic `_LISTING_MODELS` map, validates approval status, extracts type-specific fields
- **agent_builder.py**: Composes resolved components into portable agent manifest (`agent.yaml` format) and lightweight composition summaries
- **Schema updates**: `ComponentRef` with `Literal` type validation, `ComponentLinkResponse`, extended `AgentCreateRequest`/`UpdateRequest` with `components` field (backwards compat with `mcp_server_ids`)
- **Route updates**: Multi-component create/update, `GET /resolve` and `GET /manifest` endpoints (both authenticated), fix `agent_config_generator.py` broken `mcp_links` reference
- **53 tests** covering resolver, builder, schemas, Pydantic validation, and edge cases

## Code reviewer fixes applied
- Fixed critical crash: `agent.mcp_links` AttributeError in install endpoint → pre-load MCP listings map
- Added authentication to `/resolve` and `/manifest` endpoints
- Prevented duplicate MCP IntegrityError when both `mcp_server_ids` and `components` provided
- Added `Literal` type validation on `ComponentRef.component_type` (rejects invalid types at schema level)

## Test plan
- [x] 53 tests pass (`uv run pytest tests/test_agent_composition.py`)
- [x] Existing tests unaffected (103/107 pass, 4 pre-existing env failures)
- [ ] Manual: create agent with mixed component types via API
- [ ] Manual: resolve/manifest endpoints return correct data