### PR TITLE
fix: remove FastMCP enforcement, support all MCP frameworks

### DIFF
--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -90,15 +90,6 @@ async def approve(
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    if listing_type == "mcp" and not listing.fastmcp_validated:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Cannot approve: MCP server has not passed FastMCP validation. "
-                "Server must use FastMCP (from mcp.server.fastmcp import FastMCP). "
-                "See: https://github.com/jlowin/fastmcp"
-            ),
-        )
     listing.status = ListingStatus.approved
     await db.commit()
     await db.refresh(listing)

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -27,7 +27,7 @@ class McpListing(Base):
     category: Mapped[str] = mapped_column(String(100), nullable=False)
     owner: Mapped[str] = mapped_column(String(255), nullable=False)
     transport: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    fastmcp_validated: Mapped[bool] = mapped_column(Boolean, default=False)
+    mcp_validated: Mapped[bool] = mapped_column(Boolean, default=False)
     tools_schema: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     supported_ides: Mapped[list] = mapped_column(JSON, default=list)
     setup_instructions: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/observal-server/schemas/mcp.py
+++ b/observal-server/schemas/mcp.py
@@ -44,7 +44,7 @@ class McpListingResponse(BaseModel):
     supported_ides: list[str]
     setup_instructions: str | None
     changelog: str | None
-    fastmcp_validated: bool = False
+    mcp_validated: bool = False
     status: ListingStatus
     rejection_reason: str | None = None
     submitted_by: uuid.UUID

--- a/observal-server/services/agent_resolver.py
+++ b/observal-server/services/agent_resolver.py
@@ -83,7 +83,7 @@ def _extract_extra(listing, component_type: str) -> dict:
         return {
             "transport": getattr(listing, "transport", None),
             "tools_schema": getattr(listing, "tools_schema", None),
-            "fastmcp_validated": getattr(listing, "fastmcp_validated", False),
+            "mcp_validated": getattr(listing, "mcp_validated", False),
             "setup_instructions": getattr(listing, "setup_instructions", None),
         }
     if component_type == "skill":

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import re
 import shutil
 import tempfile
@@ -12,6 +13,20 @@ from models.mcp import McpListing, McpValidationResult
 
 ALLOWED_SCHEMES = {"https", "http"}
 BLOCKED_SCHEMES = {"file", "ftp", "ssh", "git"}
+
+# Patterns that indicate an MCP server implementation (Python files)
+_PYTHON_MCP_PATTERN = re.compile(
+    r"FastMCP\("           # FastMCP framework
+    r"|@mcp\.server"       # standard MCP SDK decorator
+    r"|from\s+mcp\.server\s+import\s+Server"  # standard MCP SDK Server import
+    r"|from\s+mcp\s+import"   # any MCP SDK usage
+    r"|import\s+mcp\b"        # any MCP SDK usage
+    r"|McpServer\("           # common custom class name
+    r"|MCPServer\("           # common custom class name (alt casing)
+    r"|@app\.tool\b"          # common tool decorator
+    r"|@server\.tool\b"       # common tool decorator
+    r"|Server\(\s*name\s*="   # Server(name=...) pattern
+)
 
 
 def _validate_git_url(url: str) -> str | None:
@@ -36,6 +51,50 @@ def _validate_git_url(url: str) -> str | None:
     return None
 
 
+def _detect_non_python_mcp(tmp_dir: str) -> str | None:
+    """Check for non-Python MCP frameworks. Returns framework name or None."""
+    root = Path(tmp_dir)
+
+    # Check package.json for @modelcontextprotocol/sdk (TypeScript/JS)
+    pkg_json = root / "package.json"
+    if pkg_json.exists():
+        try:
+            data = json.loads(pkg_json.read_text(errors="ignore"))
+            all_deps = {}
+            all_deps.update(data.get("dependencies", {}))
+            all_deps.update(data.get("devDependencies", {}))
+            if "@modelcontextprotocol/sdk" in all_deps:
+                return "typescript-mcp-sdk"
+        except Exception:
+            pass
+
+    # Check Go files for mcp-go imports
+    for go_file in root.rglob("*.go"):
+        try:
+            content = go_file.read_text(errors="ignore")
+            if "mcp-go" in content or "mcp_go" in content:
+                return "go-mcp-sdk"
+        except Exception:
+            continue
+
+    return None
+
+
+def _extract_repo_name(git_url: str, tmp_dir: str) -> str:
+    """Extract a usable name from the git URL or directory name as fallback."""
+    try:
+        parsed = urlparse(git_url)
+        path = parsed.path.rstrip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        name = path.rsplit("/", 1)[-1]
+        if name:
+            return name
+    except Exception:
+        pass
+    return Path(tmp_dir).name or "unknown"
+
+
 async def run_validation(listing: McpListing, db: AsyncSession):
     tmp_dir = tempfile.mkdtemp(prefix="observal_")
     try:
@@ -45,7 +104,7 @@ async def run_validation(listing: McpListing, db: AsyncSession):
             return
 
         # Stage 2: Manifest Validation
-        await _manifest_validation(listing, db, entry_point)
+        await _manifest_validation(listing, db, entry_point, tmp_dir)
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
@@ -70,44 +129,65 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
         await db.commit()
         return None
 
-    pattern = re.compile(r"FastMCP\(|@mcp\.server")
+    # Try Python files first
     entry_point = None
     for py_file in Path(tmp_dir).rglob("*.py"):
         try:
             content = py_file.read_text(errors="ignore")
-            if pattern.search(content):
+            if _PYTHON_MCP_PATTERN.search(content):
                 entry_point = py_file
                 break
         except Exception:
             continue
 
-    if not entry_point:
-        listing.fastmcp_validated = False
+    if entry_point:
+        listing.mcp_validated = True
         db.add(
             McpValidationResult(
                 listing_id=listing.id,
                 stage="clone_and_inspect",
-                passed=False,
-                details="No FastMCP server found. Expected FastMCP() or @mcp.server in a .py file.",
+                passed=True,
+                details=f"Found MCP entry point: {entry_point.relative_to(tmp_dir)}",
+            )
+        )
+        await db.commit()
+        return entry_point
+
+    # Try non-Python MCP frameworks
+    non_python_framework = _detect_non_python_mcp(tmp_dir)
+    if non_python_framework:
+        listing.mcp_validated = True
+        db.add(
+            McpValidationResult(
+                listing_id=listing.id,
+                stage="clone_and_inspect",
+                passed=True,
+                details=f"Found non-Python MCP framework: {non_python_framework}",
             )
         )
         await db.commit()
         return None
 
-    listing.fastmcp_validated = True
+    # No known framework detected — still mark as validated but note unknown framework
+    listing.mcp_validated = True
     db.add(
         McpValidationResult(
             listing_id=listing.id,
             stage="clone_and_inspect",
             passed=True,
-            details=f"Found FastMCP entry point: {entry_point.relative_to(tmp_dir)}",
+            details=(
+                "No recognized MCP framework detected. "
+                "Marked as validated with framework: unknown. "
+                "Supported detection: FastMCP, MCP SDK (Python/TypeScript/Go), "
+                "and common MCP patterns."
+            ),
         )
     )
     await db.commit()
-    return entry_point
+    return None
 
 
-async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_point: Path):
+async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_point: Path, tmp_dir: str):
     issues = []
     tools_found = []
 
@@ -125,19 +205,38 @@ async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_poin
         await db.commit()
         return
 
-    # Extract server name from FastMCP() constructor
+    # Extract server name from FastMCP() or Server(name=...) constructor
     server_name = None
     for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # FastMCP("name") pattern
         if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
+            isinstance(node.func, ast.Name)
             and node.func.id == "FastMCP"
             and node.args
             and isinstance(node.args[0], ast.Constant)
         ):
             server_name = node.args[0].value
+            break
+        # Server(name="name") pattern
+        if isinstance(node.func, ast.Name) and node.func.id == "Server":
+            for kw in node.keywords:
+                if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                    server_name = kw.value.value
+                    break
+            if server_name:
+                break
+            # Server("name") positional
+            if node.args and isinstance(node.args[0], ast.Constant):
+                server_name = node.args[0].value
+                break
 
-    # Find @mcp.tool decorated functions
+    # Fallback to repo/directory name
+    if not server_name:
+        server_name = _extract_repo_name(listing.git_url, tmp_dir)
+
+    # Find @mcp.tool / @app.tool / @server.tool decorated functions
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
@@ -170,15 +269,15 @@ async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_poin
         issues.append(f"Server description too short ({len(listing.description)} chars, need 100+)")
 
     if not tools_found:
-        issues.append("No @mcp.tool decorated functions found")
+        issues.append("No @tool decorated functions found")
 
     passed = len(issues) == 0
-    details = f"Server: {server_name or 'unknown'}, Tools: {len(tools_found)}"
+    details = f"Server: {server_name}, Tools: {len(tools_found)}"
     if issues:
         details += "\nIssues:\n- " + "\n- ".join(issues)
 
     if not passed:
-        listing.fastmcp_validated = False
+        listing.mcp_validated = False
 
     db.add(
         McpValidationResult(
@@ -200,31 +299,54 @@ async def analyze_repo(git_url: str) -> dict:
     try:
         Repo.clone_from(git_url, tmp_dir, depth=1)
 
-        pattern = re.compile(r"FastMCP\(|@mcp\.server")
         entry_point = None
         for py_file in Path(tmp_dir).rglob("*.py"):
             try:
-                if pattern.search(py_file.read_text(errors="ignore")):
+                if _PYTHON_MCP_PATTERN.search(py_file.read_text(errors="ignore")):
                     entry_point = py_file
                     break
             except Exception:
                 continue
 
         if not entry_point:
-            return {"name": "", "description": "", "version": "0.1.0", "tools": []}
+            # Try non-Python detection; return repo name as fallback
+            non_python = _detect_non_python_mcp(tmp_dir)
+            name = _extract_repo_name(git_url, tmp_dir)
+            if non_python:
+                return {"name": name, "description": "", "version": "0.1.0", "tools": [], "framework": non_python}
+            return {"name": name, "description": "", "version": "0.1.0", "tools": []}
 
         tree = ast.parse(entry_point.read_text(errors="ignore"))
 
         server_name = ""
         server_desc = ""
         for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "FastMCP":
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            # FastMCP("name") pattern
+            if node.func.id == "FastMCP":
                 if node.args and isinstance(node.args[0], ast.Constant):
                     server_name = str(node.args[0].value)
-                # Check for description keyword arg
                 for kw in node.keywords:
                     if kw.arg == "description" and isinstance(kw.value, ast.Constant):
                         server_desc = str(kw.value.value)
+                if server_name:
+                    break
+            # Server(name="name") pattern
+            if node.func.id == "Server":
+                for kw in node.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        server_name = str(kw.value.value)
+                    if kw.arg == "description" and isinstance(kw.value, ast.Constant):
+                        server_desc = str(kw.value.value)
+                if not server_name and node.args and isinstance(node.args[0], ast.Constant):
+                    server_name = str(node.args[0].value)
+                if server_name:
+                    break
+
+        # Fallback to repo name
+        if not server_name:
+            server_name = _extract_repo_name(git_url, tmp_dir)
 
         tools = []
         for node in ast.walk(tree):

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -245,11 +245,11 @@ class TestExtractExtra:
         listing = MagicMock()
         listing.transport = "stdio"
         listing.tools_schema = {"tools": []}
-        listing.fastmcp_validated = True
+        listing.mcp_validated = True
         listing.setup_instructions = "pip install"
         extra = _extract_extra(listing, "mcp")
         assert extra["transport"] == "stdio"
-        assert extra["fastmcp_validated"] is True
+        assert extra["mcp_validated"] is True
         assert extra["tools_schema"] == {"tools": []}
 
     def test_skill_extra(self):
@@ -432,7 +432,7 @@ class TestResolveAgent:
         listing.description = "A good MCP"
         listing.transport = "stdio"
         listing.tools_schema = None
-        listing.fastmcp_validated = True
+        listing.mcp_validated = True
         listing.setup_instructions = None
 
         mock_result = MagicMock()
@@ -527,7 +527,7 @@ class TestResolveAgent:
         good_listing.description = ""
         good_listing.transport = None
         good_listing.tools_schema = None
-        good_listing.fastmcp_validated = True
+        good_listing.mcp_validated = True
         good_listing.setup_instructions = None
 
         # Return good listing for first call, None for second
@@ -650,7 +650,7 @@ class TestBuildAgentManifest:
                     git_url="https://github.com/org/repo.git", git_ref="abc123",
                     description="FS ops", order_index=0,
                     extra={"transport": "stdio", "tools_schema": None,
-                           "fastmcp_validated": True, "setup_instructions": None},
+                           "mcp_validated": True, "setup_instructions": None},
                 ),
             ],
         )

--- a/tests/test_schema_redesign.py
+++ b/tests/test_schema_redesign.py
@@ -126,10 +126,10 @@ class TestComponentTableUpdates:
         cols = {c.name for c in cls.__table__.columns}
         assert "git_ref" in cols, f"{model_name} missing git_ref"
 
-    def test_mcp_has_fastmcp_validated(self):
+    def test_mcp_has_mcp_validated(self):
         from models.mcp import McpListing
         cols = {c.name for c in McpListing.__table__.columns}
-        assert "fastmcp_validated" in cols
+        assert "mcp_validated" in cols
 
     def test_skill_link_table_removed(self):
         """AgentSkillLink should no longer exist — replaced by AgentComponent."""
@@ -405,33 +405,33 @@ class TestDownloadTracking:
         assert "request" in param_names
 
 
-class TestFastMcpEnforcement:
-    """Tests for FastMCP validation enforcement (#92)."""
+class TestMcpValidationField:
+    """Tests for MCP validation field (#92)."""
 
-    def test_mcp_has_fastmcp_validated_field(self):
+    def test_mcp_has_mcp_validated_field(self):
         from models.mcp import McpListing
-        assert hasattr(McpListing, "fastmcp_validated")
+        assert hasattr(McpListing, "mcp_validated")
 
-    def test_fastmcp_validated_defaults_false(self):
+    def test_mcp_validated_defaults_false(self):
         from models.mcp import McpListing
-        col = McpListing.__table__.columns["fastmcp_validated"]
+        col = McpListing.__table__.columns["mcp_validated"]
         # default is False
         assert col.default.arg is False
 
     @pytest.mark.asyncio
-    async def test_approve_blocks_non_fastmcp(self):
-        """Review approve should reject MCPs that haven't passed FastMCP validation."""
+    async def test_approve_allows_non_validated_mcp(self):
+        """Review approve should allow MCPs regardless of validation status."""
         from unittest.mock import AsyncMock, MagicMock
         from api.routes.review import approve
         from models.mcp import ListingStatus
         from models.user import UserRole
 
-        # Create a mock MCP listing with fastmcp_validated=False
+        # Create a mock MCP listing with mcp_validated=False
         listing = MagicMock()
         listing.id = uuid.uuid4()
         listing.name = "test-mcp"
         listing.status = ListingStatus.pending
-        listing.fastmcp_validated = False
+        listing.mcp_validated = False
 
         mock_db = AsyncMock()
         mock_user = MagicMock()
@@ -442,18 +442,15 @@ class TestFastMcpEnforcement:
         original_find = review_mod._find_listing
         review_mod._find_listing = AsyncMock(return_value=("mcp", listing))
 
-        from fastapi import HTTPException
         try:
-            with pytest.raises(HTTPException) as exc_info:
-                await approve(str(listing.id), mock_db, mock_user)
-            assert exc_info.value.status_code == 400
-            assert "FastMCP" in exc_info.value.detail
+            result = await approve(str(listing.id), mock_db, mock_user)
+            assert result["status"] == "approved"
         finally:
             review_mod._find_listing = original_find
 
     @pytest.mark.asyncio
-    async def test_approve_allows_fastmcp_validated(self):
-        """Review approve should allow MCPs that passed FastMCP validation."""
+    async def test_approve_allows_validated_mcp(self):
+        """Review approve should allow MCPs that passed validation."""
         from unittest.mock import AsyncMock, MagicMock
         from api.routes.review import approve
         from models.mcp import ListingStatus
@@ -463,7 +460,7 @@ class TestFastMcpEnforcement:
         listing.id = uuid.uuid4()
         listing.name = "validated-mcp"
         listing.status = ListingStatus.pending
-        listing.fastmcp_validated = True
+        listing.mcp_validated = True
 
         mock_db = AsyncMock()
         mock_user = MagicMock()
@@ -481,7 +478,7 @@ class TestFastMcpEnforcement:
 
     @pytest.mark.asyncio
     async def test_approve_non_mcp_not_affected(self):
-        """Non-MCP listings should not be affected by FastMCP check."""
+        """Non-MCP listings should not be affected by validation check."""
         from unittest.mock import AsyncMock, MagicMock
         from api.routes.review import approve
         from models.mcp import ListingStatus
@@ -491,7 +488,6 @@ class TestFastMcpEnforcement:
         listing.id = uuid.uuid4()
         listing.name = "test-skill"
         listing.status = ListingStatus.pending
-        # Skills don't have fastmcp_validated
 
         mock_db = AsyncMock()
         mock_user = MagicMock()


### PR DESCRIPTION
## Summary
- Remove the hard approval gate that blocked non-FastMCP MCP servers from being approved
- Rename `fastmcp_validated` → `mcp_validated` across models, schemas, services, and tests
- Expand pattern detection to support: FastMCP, standard MCP SDK (`Server`, `from mcp`), custom classes (`McpServer`/`MCPServer`), TypeScript (`@modelcontextprotocol/sdk`), Go (`mcp-go`), and unknown frameworks (accepted, not blocked)
- Server name extraction works for both `FastMCP("name")` and `Server(name="name")`, falls back to repo name

## Test plan
- [x] All 547 tests pass
- [ ] Submit a non-FastMCP MCP server and verify it can be approved
- [ ] Submit a TypeScript MCP and verify detection works
- [ ] Verify existing FastMCP servers still validate correctly