### PR TITLE
refactor: restructure CLI into auth, ops, admin groups

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json as _json
 import os
 import shutil
+import sys
 from pathlib import Path
 
 import httpx
@@ -14,150 +15,219 @@ from rich import print as rprint
 from observal_cli import client, config
 from observal_cli.render import console, kv_panel, spinner, status_badge
 
+# ── Auth subgroup ───────────────────────────────────────────
+
+auth_app = typer.Typer(
+    name="auth",
+    help="Authentication and account commands",
+    no_args_is_help=True,
+)
+
 config_app = typer.Typer(help="CLI configuration")
 
 
-def register_auth(app: typer.Typer):
-    """Register auth commands on the root app."""
+# ── Auth commands (registered on auth_app) ──────────────────
 
-    @app.command()
-    def init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
-        """First-run setup: connect to a team server or initialize a new local server."""
-        server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
-        
-        # 1. Verify Connectivity First
+
+@auth_app.command()
+def init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
+    """First-run setup: connect to a team server or initialize a new local server."""
+    server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
+
+    # 1. Verify Connectivity First
+    try:
+        with spinner("Checking server..."):
+            r = httpx.get(f"{server_url.rstrip('/')}/health", timeout=10)
+            r.raise_for_status()
+    except httpx.ConnectError:
+        rprint(f"[red]x Connection failed.[/red] Is the server running at {server_url}?")
+        raise typer.Exit(1)
+    except Exception as e:
+        rprint(f"[red]x Server error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+    rprint("[green]Connected to server[/green]\n")
+
+    # 2. Smart Detection: Determine if we are a Developer (Connect) or Admin (Setup)
+    setup_choice = typer.prompt(
+        "Are you connecting to an existing team (C) or setting up a brand new server (N)?",
+        default="C"
+    )
+
+    if setup_choice.lower().startswith("c"):
+        # --- DEVELOPER PATH (No Docker, just API Key) ---
+        api_key = typer.prompt("Your API Key", hide_input=True)
+        _do_login(server_url, api_key)
+
+    else:
+        # --- ADMIN PATH (Provisioning the first account) ---
+        admin_email = typer.prompt("Admin email")
+        admin_name = typer.prompt("Admin name")
         try:
-            with spinner("Checking server..."):
-                r = httpx.get(f"{server_url.rstrip('/')}/health", timeout=10)
+            with spinner("Creating admin account..."):
+                r = httpx.post(
+                    f"{server_url.rstrip('/')}/api/v1/auth/init",
+                    json={"email": admin_email, "name": admin_name},
+                    timeout=30,
+                )
                 r.raise_for_status()
-        except httpx.ConnectError:
-            rprint(f"[red]✗ Connection failed.[/red] Is the server running at {server_url}?")
-            raise typer.Exit(1)
-        except Exception as e:
-            rprint(f"[red]✗ Server error:[/red] {str(e)}")
-            raise typer.Exit(1)
+                data = r.json()
 
-        rprint("[green]✓ Connected to server[/green]\n")
+            config.save({"server_url": server_url, "api_key": data["api_key"]})
+            rprint(f"\n[green]Platform Initialized![/green] Config saved to [dim]{config.CONFIG_FILE}[/dim]")
+            rprint("\n[bold]Your Admin API key:[/bold]")
+            rprint(f"  {data['api_key']}")
+            rprint("\n[dim]Keep this safe. You can now invite developers via the Web UI.[/dim]")
 
-        # 2. Smart Detection: Determine if we are a Developer (Connect) or Admin (Setup)
-        setup_choice = typer.prompt(
-            "Are you connecting to an existing team (C) or setting up a brand new server (N)?", 
-            default="C"
+            _configure_claude_code(server_url, data["api_key"])
+
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 400 and "already initialized" in e.response.text.lower():
+                rprint("\n[yellow]System is already initialized.[/yellow]")
+                rprint("Switching to login flow...")
+                api_key = typer.prompt("API Key", hide_input=True)
+                _do_login(server_url, api_key)
+            else:
+                rprint(f"[red]Error {e.response.status_code}: {e.response.text}[/red]")
+                raise typer.Exit(1)
+
+
+@auth_app.command()
+def login(
+    server: str = typer.Option(None, "--server", "-s", help="Server URL (skips prompt)"),
+    key: str = typer.Option(None, "--key", "-k", help="API key (skips prompt)"),
+):
+    """Login with an existing API key."""
+    server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
+    _do_login(server_url, key)
+
+
+@auth_app.command()
+def logout():
+    """Clear saved credentials."""
+    if config.CONFIG_FILE.exists():
+        # Read strictly from disk to avoid mixing with env variables
+        import json
+        raw_cfg = json.loads(config.CONFIG_FILE.read_text())
+
+        # Remove the key and save directly
+        if "api_key" in raw_cfg:
+            del raw_cfg["api_key"]
+            config.CONFIG_FILE.write_text(json.dumps(raw_cfg, indent=2))
+
+        rprint("[green]Logged out (removed from disk).[/green]")
+    else:
+        rprint("[dim]No config to clear.[/dim]")
+
+
+@auth_app.command()
+def whoami(
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table, json"),
+):
+    """Show current authenticated user."""
+    with spinner("Checking..."):
+        user = client.get("/api/v1/auth/whoami")
+    if output == "json":
+        from observal_cli.render import output_json
+
+        output_json(user)
+        return
+    console.print(
+        kv_panel(
+            user["name"],
+            [
+                ("Email", user["email"]),
+                ("Role", status_badge(user.get("role", "user"))),
+                ("ID", f"[dim]{user['id']}[/dim]"),
+            ],
         )
+    )
 
-        if setup_choice.lower().startswith("c"):
-            # --- DEVELOPER PATH (No Docker, just API Key) ---
-            api_key = typer.prompt("Your API Key", hide_input=True)
-            _do_login(server_url, api_key)
-            
-        else:
-            # --- ADMIN PATH (Provisioning the first account) ---
-            admin_email = typer.prompt("Admin email")
-            admin_name = typer.prompt("Admin name")
-            try:
-                with spinner("Creating admin account..."):
-                    r = httpx.post(
-                        f"{server_url.rstrip('/')}/api/v1/auth/init",
-                        json={"email": admin_email, "name": admin_name},
-                        timeout=30,
-                    )
-                    r.raise_for_status()
-                    data = r.json()
-                    
-                config.save({"server_url": server_url, "api_key": data["api_key"]})
-                rprint(f"\n[green]✓ Platform Initialized![/green] Config saved to [dim]{config.CONFIG_FILE}[/dim]")
-                rprint("\n[bold]Your Admin API key:[/bold]")
-                rprint(f"  {data['api_key']}")
-                rprint("\n[dim]Keep this safe. You can now invite developers via the Web UI.[/dim]")
 
-                _configure_claude_code(server_url, data["api_key"])
-                
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code == 400 and "already initialized" in e.response.text.lower():
-                    rprint("\n[yellow]System is already initialized.[/yellow]")
-                    rprint("Switching to login flow...")
-                    api_key = typer.prompt("API Key", hide_input=True)
-                    _do_login(server_url, api_key)
-                else:
-                    rprint(f"[red]Error {e.response.status_code}: {e.response.text}[/red]")
-                    raise typer.Exit(1)
+@auth_app.command()
+def status():
+    """Check server connectivity and health."""
+    cfg = config.load()
+    url = cfg.get("server_url", "not set")
+    has_key = bool(cfg.get("api_key"))
+    ok, latency = client.health()
 
-    @app.command()
-    def login(
+    rprint(f"  Server:  {url}")
+    rprint(f"  API Key: {'[green]configured[/green]' if has_key else '[red]not set[/red]'}")
+    if ok:
+        color = "green" if latency < 200 else "yellow" if latency < 1000 else "red"
+        rprint(f"  Health:  [{color}]ok[/{color}] ({latency:.0f}ms)")
+    else:
+        rprint("  Health:  [red]unreachable[/red]")
+
+
+def version_callback():
+    """Show CLI version."""
+    from importlib.metadata import version as pkg_version
+
+    try:
+        v = pkg_version("observal-cli")
+    except Exception:
+        v = "dev"
+    rprint(f"observal [bold]{v}[/bold]")
+
+
+# ── Deprecated root-level wrappers ──────────────────────────
+
+_DEPRECATION_MSG = "Deprecated: use 'observal auth {cmd}' instead"
+
+
+def _deprecation_notice(cmd_name: str):
+    """Print a deprecation warning for a root-level auth command."""
+    rprint(f"[yellow]{_DEPRECATION_MSG.format(cmd=cmd_name)}[/yellow]\n")
+
+
+def register_deprecated_auth(app: typer.Typer):
+    """Register deprecated root-level aliases that delegate to auth subgroup commands."""
+
+    @app.command(name="init", hidden=True)
+    def deprecated_init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
+        """[Deprecated] Use 'observal auth init' instead."""
+        _deprecation_notice("init")
+        init(server=server)
+
+    @app.command(name="login", hidden=True)
+    def deprecated_login(
         server: str = typer.Option(None, "--server", "-s", help="Server URL (skips prompt)"),
         key: str = typer.Option(None, "--key", "-k", help="API key (skips prompt)"),
     ):
-        """Login with an existing API key."""
-        server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
-        _do_login(server_url, key)
+        """[Deprecated] Use 'observal auth login' instead."""
+        _deprecation_notice("login")
+        login(server=server, key=key)
 
-    @app.command()
-    def logout():
-        """Clear saved credentials."""
-        if config.CONFIG_FILE.exists():
-            # Read strictly from disk to avoid mixing with env variables
-            import json
-            raw_cfg = json.loads(config.CONFIG_FILE.read_text())
-            
-            # Remove the key and save directly
-            if "api_key" in raw_cfg:
-                del raw_cfg["api_key"]
-                config.CONFIG_FILE.write_text(json.dumps(raw_cfg, indent=2))
-                
-            rprint("[green]✓ Logged out (removed from disk).[/green]")
-        else:
-            rprint("[dim]No config to clear.[/dim]")
+    @app.command(name="logout", hidden=True)
+    def deprecated_logout():
+        """[Deprecated] Use 'observal auth logout' instead."""
+        _deprecation_notice("logout")
+        logout()
 
-    @app.command()
-    def whoami(
+    @app.command(name="whoami", hidden=True)
+    def deprecated_whoami(
         output: str = typer.Option("table", "--output", "-o", help="Output format: table, json"),
     ):
-        """Show current authenticated user."""
-        with spinner("Checking..."):
-            user = client.get("/api/v1/auth/whoami")
-        if output == "json":
-            from observal_cli.render import output_json
+        """[Deprecated] Use 'observal auth whoami' instead."""
+        _deprecation_notice("whoami")
+        whoami(output=output)
 
-            output_json(user)
-            return
-        console.print(
-            kv_panel(
-                user["name"],
-                [
-                    ("Email", user["email"]),
-                    ("Role", status_badge(user.get("role", "user"))),
-                    ("ID", f"[dim]{user['id']}[/dim]"),
-                ],
-            )
-        )
+    @app.command(name="status", hidden=True)
+    def deprecated_status():
+        """[Deprecated] Use 'observal auth status' instead."""
+        _deprecation_notice("status")
+        status()
 
-    @app.command()
-    def status():
-        """Check server connectivity and health."""
-        cfg = config.load()
-        url = cfg.get("server_url", "not set")
-        has_key = bool(cfg.get("api_key"))
-        ok, latency = client.health()
+    @app.command(name="version", hidden=True)
+    def deprecated_version():
+        """[Deprecated] Use 'observal --version' instead."""
+        rprint("[yellow]Deprecated: use 'observal --version' instead[/yellow]\n")
+        version_callback()
 
-        rprint(f"  Server:  {url}")
-        rprint(f"  API Key: {'[green]configured[/green]' if has_key else '[red]not set[/red]'}")
-        if ok:
-            color = "green" if latency < 200 else "yellow" if latency < 1000 else "red"
-            rprint(f"  Health:  [{color}]✓ ok[/{color}] ({latency:.0f}ms)")
-        else:
-            rprint("  Health:  [red]✗ unreachable[/red]")
 
-    @app.command()
-    def version():
-        """Show CLI version."""
-        from importlib.metadata import version as pkg_version
-
-        try:
-            v = pkg_version("observal-cli")
-        except Exception:
-            v = "dev"
-        rprint(f"observal [bold]{v}[/bold]")
-
+# ── Helper functions ────────────────────────────────────────
 
 def _do_login(server_url: str, api_key: str | None = None):
     api_key = api_key or typer.prompt("API Key", hide_input=True)
@@ -171,12 +241,12 @@ def _do_login(server_url: str, api_key: str | None = None):
             r.raise_for_status()
             user = r.json()
         config.save({"server_url": server_url, "api_key": api_key})
-        rprint(f"[green]✓ Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
+        rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
     except httpx.ConnectError:
-        rprint(f"[red]✗ Connection failed.[/red] Is the server running at {server_url}?")
+        rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
         raise typer.Exit(1)
     except httpx.HTTPStatusError:
-        rprint("[red]✗ Invalid API key.[/red]")
+        rprint("[red]Invalid API key.[/red]")
         raise typer.Exit(1)
 
 
@@ -202,7 +272,7 @@ def register_config(app: typer.Typer):
             config.save({key: value.lower() in ("true", "1", "yes")})
         else:
             config.save({key: value})
-        rprint(f"[green]✓ Set {key}[/green]")
+        rprint(f"[green]Set {key}[/green]")
 
     @config_app.command(name="path")
     def config_path():
@@ -219,12 +289,12 @@ def register_config(app: typer.Typer):
         if target:
             aliases[name] = target
             config.save_aliases(aliases)
-            rprint(f"[green]✓ @{name} → {target}[/green]")
+            rprint(f"[green]@{name} -> {target}[/green]")
         else:
             removed = aliases.pop(name, None)
             config.save_aliases(aliases)
             if removed:
-                rprint(f"[green]✓ Removed @{name}[/green]")
+                rprint(f"[green]Removed @{name}[/green]")
             else:
                 rprint(f"[yellow]Alias @{name} not found.[/yellow]")
 
@@ -236,7 +306,7 @@ def register_config(app: typer.Typer):
             rprint("[dim]No aliases set. Use: observal config alias <name> <id>[/dim]")
             return
         for name, target in sorted(aliases.items()):
-            rprint(f"  @{name} → [dim]{target}[/dim]")
+            rprint(f"  @{name} -> [dim]{target}[/dim]")
 
     app.add_typer(config_app, name="config")
 
@@ -251,7 +321,7 @@ def _configure_claude_code(server_url: str, api_key: str):
         if not claude_exists:
             return
 
-        if not typer.confirm("\nDetected Claude Code installation.\nConfigure Claude Code telemetry → Observal?", default=True):
+        if not typer.confirm("\nDetected Claude Code installation.\nConfigure Claude Code telemetry -> Observal?", default=True):
             return
 
         settings = {}
@@ -291,7 +361,7 @@ def _configure_claude_code(server_url: str, api_key: str):
         with open(claude_settings_file, "w", encoding="utf-8") as f:
             _json.dump(settings, f, indent=2)
 
-        rprint(f"✓ Updated [dim]{claude_settings_file}[/dim] — Claude Code will send traces to Observal.")
+        rprint(f"Updated [dim]{claude_settings_file}[/dim] -- Claude Code will send traces to Observal.")
         rprint("\nYou're all set. Open Claude Code and traces will appear in the dashboard.")
 
     except Exception as e:

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -19,6 +19,22 @@ from observal_cli.render import (
     status_badge,
 )
 
+_DEPRECATION_TPL = (
+    "[yellow]Warning:[/yellow] [dim]`observal {old}` is deprecated. "
+    "Use `observal {new}` instead.[/dim]\n"
+)
+
+# ═══════════════════════════════════════════════════════════
+# ops_app — Observability / operational commands group
+# ═══════════════════════════════════════════════════════════
+
+ops_app = typer.Typer(
+    name="ops",
+    help="Observability and operational commands (traces, telemetry, dashboard, feedback)",
+    no_args_is_help=True,
+)
+
+
 # ── Review ───────────────────────────────────────────────
 
 review_app = typer.Typer(help="Admin review commands")
@@ -131,165 +147,180 @@ def telemetry_test():
     rprint(f"[green]✓ Test event sent![/green] Ingested: {result.get('ingested', 0)}")
 
 
-# ── Dashboard ────────────────────────────────────────────
+# ── Dashboard (on ops_app) ──────────────────────────────
 
 
-def register_dashboard(app: typer.Typer):
-
-    @app.command(name="overview")
-    def overview(output: str = typer.Option("table", "--output", "-o")):
-        """Show enterprise overview stats."""
-        with spinner("Loading overview..."):
-            data = client.get("/api/v1/overview/stats")
-        if output == "json":
-            output_json(data)
-            return
-        rprint()
-        rprint(f"  [bold cyan]MCP Servers[/bold cyan]     {data.get('total_mcps', 0)}")
-        rprint(f"  [bold magenta]Agents[/bold magenta]          {data.get('total_agents', 0)}")
-        rprint(f"  [bold]Users[/bold]           {data.get('total_users', 0)}")
-        rprint(f"  [bold green]Tool calls[/bold green]      {data.get('total_tool_calls_today', 0)} today")
-        rprint(f"  [bold yellow]Interactions[/bold yellow]    {data.get('total_agent_interactions_today', 0)} today")
-        rprint()
-
-    @app.command(name="metrics")
-    def metrics(
-        item_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-        item_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
-        output: str = typer.Option("table", "--output", "-o"),
-        watch: bool = typer.Option(False, "--watch", "-w", help="Refresh every 5s"),
-    ):
-        """Show metrics for an MCP server or agent."""
-        resolved = config.resolve_alias(item_id)
-
-        def _fetch_and_print():
-            if item_type == "agent":
-                data = client.get(f"/api/v1/agents/{resolved}/metrics")
-                if output == "json":
-                    output_json(data)
-                    return
-                total = data.get("total_interactions", 0)
-                rate = data.get("acceptance_rate") or 0
-                rprint("\n  [bold]Agent Metrics[/bold]")
-                rprint(f"  Interactions:   {total}")
-                rprint(f"  Downloads:      {data.get('total_downloads', 0)}")
-                rprint(
-                    f"  Acceptance:     [{'green' if rate > 0.7 else 'yellow' if rate > 0.4 else 'red'}]{rate:.1%}[/]"
-                )
-                rprint(f"  Avg tool calls: {data.get('avg_tool_calls', 0)}")
-                rprint(f"  Avg latency:    {(data.get('avg_latency_ms') or 0):.0f}ms")
-            else:
-                data = client.get(f"/api/v1/mcps/{resolved}/metrics")
-                if output == "json":
-                    output_json(data)
-                    return
-                err_rate = data.get("error_rate") or 0
-                rprint("\n  [bold]MCP Metrics[/bold]")
-                rprint(f"  Downloads:  {data.get('total_downloads', 0)}")
-                rprint(f"  Total calls: {data.get('total_calls', 0)}")
-                rprint(
-                    f"  Error rate:  [{'red' if err_rate > 0.1 else 'yellow' if err_rate > 0.01 else 'green'}]{err_rate:.2%}[/]"
-                )
-                rprint(f"  Avg latency: {(data.get('avg_latency_ms') or 0):.0f}ms")
-                rprint(
-                    f"  Latency p50/p90/p99: {data.get('p50_latency_ms', 0)}/{data.get('p90_latency_ms', 0)}/{data.get('p99_latency_ms', 0)}ms"
-                )
-            rprint()
-
-        if watch:
-            try:
-                while True:
-                    console.clear()
-                    rprint(f"[dim]Watching metrics for {resolved} (Ctrl+C to stop)[/dim]")
-                    _fetch_and_print()
-                    time.sleep(5)
-            except KeyboardInterrupt:
-                rprint("\n[dim]Stopped.[/dim]")
-        else:
-            with spinner("Loading metrics..."):
-                pass
-            _fetch_and_print()
-
-    @app.command(name="top")
-    def top(
-        item_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
-        output: str = typer.Option("table", "--output", "-o"),
-    ):
-        """Show top MCP servers or agents by usage."""
-        endpoint = "/api/v1/overview/top-mcps" if item_type == "mcp" else "/api/v1/overview/top-agents"
-        with spinner():
-            data = client.get(endpoint)
-        if output == "json":
-            output_json(data)
-            return
-        if not data:
-            rprint(f"[dim]No {item_type} data yet.[/dim]")
-            return
-        label = "MCP Servers" if item_type == "mcp" else "Agents"
-        table = Table(title=f"Top {label}", show_lines=False, padding=(0, 1))
-        table.add_column("#", style="dim", width=3)
-        table.add_column("Name", style="bold")
-        table.add_column("Downloads", justify="right")
-        table.add_column("ID", style="dim", max_width=12)
-        for i, item in enumerate(data, 1):
-            table.add_row(str(i), item["name"], str(int(item["value"])), str(item["id"])[:8] + "…")
-        console.print(table)
+@ops_app.command(name="overview")
+def _overview(output: str = typer.Option("table", "--output", "-o")):
+    """Show enterprise overview stats."""
+    with spinner("Loading overview..."):
+        data = client.get("/api/v1/overview/stats")
+    if output == "json":
+        output_json(data)
+        return
+    rprint()
+    rprint(f"  [bold cyan]MCP Servers[/bold cyan]     {data.get('total_mcps', 0)}")
+    rprint(f"  [bold magenta]Agents[/bold magenta]          {data.get('total_agents', 0)}")
+    rprint(f"  [bold]Users[/bold]           {data.get('total_users', 0)}")
+    rprint(f"  [bold green]Tool calls[/bold green]      {data.get('total_tool_calls_today', 0)} today")
+    rprint(f"  [bold yellow]Interactions[/bold yellow]    {data.get('total_agent_interactions_today', 0)} today")
+    rprint()
 
 
-# ── Feedback ─────────────────────────────────────────────
+@ops_app.command(name="metrics")
+def _metrics(
+    item_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    item_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
+    output: str = typer.Option("table", "--output", "-o"),
+    watch: bool = typer.Option(False, "--watch", "-w", help="Refresh every 5s"),
+):
+    """Show metrics for an MCP server or agent."""
+    _metrics_impl(item_id, item_type, output, watch)
 
 
-def register_feedback(app: typer.Typer):
+def _metrics_impl(item_id, item_type, output, watch):
+    resolved = config.resolve_alias(item_id)
 
-    @app.command()
-    def rate(
-        listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-        stars: int = typer.Option(..., "--stars", "-s", min=1, max=5, help="Rating 1-5"),
-        listing_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
-        comment: str | None = typer.Option(None, "--comment", "-c"),
-    ):
-        """Rate an MCP server or agent."""
-        resolved = config.resolve_alias(listing_id)
-        with spinner("Submitting rating..."):
-            client.post(
-                "/api/v1/feedback",
-                {
-                    "listing_id": resolved,
-                    "listing_type": listing_type,
-                    "rating": stars,
-                    "comment": comment,
-                },
+    def _fetch_and_print():
+        if item_type == "agent":
+            data = client.get(f"/api/v1/agents/{resolved}/metrics")
+            if output == "json":
+                output_json(data)
+                return
+            total = data.get("total_interactions", 0)
+            rate = data.get("acceptance_rate") or 0
+            rprint("\n  [bold]Agent Metrics[/bold]")
+            rprint(f"  Interactions:   {total}")
+            rprint(f"  Downloads:      {data.get('total_downloads', 0)}")
+            rprint(
+                f"  Acceptance:     [{'green' if rate > 0.7 else 'yellow' if rate > 0.4 else 'red'}]{rate:.1%}[/]"
             )
-        rprint(f"[green]✓ Rated {star_rating(stars)}[/green]")
-
-    @app.command()
-    def feedback(
-        listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-        listing_type: str = typer.Option("mcp", "--type", "-t"),
-        output: str = typer.Option("table", "--output", "-o"),
-    ):
-        """Show feedback for an MCP server or agent."""
-        resolved = config.resolve_alias(listing_id)
-        with spinner():
-            data = client.get(f"/api/v1/feedback/{listing_type}/{resolved}")
-            summary = client.get(f"/api/v1/feedback/summary/{resolved}")
-
-        if output == "json":
-            output_json({"summary": summary, "reviews": data})
-            return
-
-        if not data:
-            rprint("[dim]No feedback yet.[/dim]")
-            return
-
-        avg = summary.get("average_rating", 0)
-        total = summary.get("total_reviews", 0)
-        rprint(f"\n  {star_rating(round(avg))} [bold]{avg:.1f}[/bold]/5 ({total} reviews)\n")
-        for fb in data:
-            stars_str = star_rating(fb.get("rating", 0))
-            comment = f"  {fb['comment']}" if fb.get("comment") else ""
-            rprint(f"  {stars_str}{comment}")
+            rprint(f"  Avg tool calls: {data.get('avg_tool_calls', 0)}")
+            rprint(f"  Avg latency:    {(data.get('avg_latency_ms') or 0):.0f}ms")
+        else:
+            data = client.get(f"/api/v1/mcps/{resolved}/metrics")
+            if output == "json":
+                output_json(data)
+                return
+            err_rate = data.get("error_rate") or 0
+            rprint("\n  [bold]MCP Metrics[/bold]")
+            rprint(f"  Downloads:  {data.get('total_downloads', 0)}")
+            rprint(f"  Total calls: {data.get('total_calls', 0)}")
+            rprint(
+                f"  Error rate:  [{'red' if err_rate > 0.1 else 'yellow' if err_rate > 0.01 else 'green'}]{err_rate:.2%}[/]"
+            )
+            rprint(f"  Avg latency: {(data.get('avg_latency_ms') or 0):.0f}ms")
+            rprint(
+                f"  Latency p50/p90/p99: {data.get('p50_latency_ms', 0)}/{data.get('p90_latency_ms', 0)}/{data.get('p99_latency_ms', 0)}ms"
+            )
         rprint()
+
+    if watch:
+        try:
+            while True:
+                console.clear()
+                rprint(f"[dim]Watching metrics for {resolved} (Ctrl+C to stop)[/dim]")
+                _fetch_and_print()
+                time.sleep(5)
+        except KeyboardInterrupt:
+            rprint("\n[dim]Stopped.[/dim]")
+    else:
+        with spinner("Loading metrics..."):
+            pass
+        _fetch_and_print()
+
+
+@ops_app.command(name="top")
+def _top(
+    item_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
+    output: str = typer.Option("table", "--output", "-o"),
+):
+    """Show top MCP servers or agents by usage."""
+    _top_impl(item_type, output)
+
+
+def _top_impl(item_type, output):
+    endpoint = "/api/v1/overview/top-mcps" if item_type == "mcp" else "/api/v1/overview/top-agents"
+    with spinner():
+        data = client.get(endpoint)
+    if output == "json":
+        output_json(data)
+        return
+    if not data:
+        rprint(f"[dim]No {item_type} data yet.[/dim]")
+        return
+    label = "MCP Servers" if item_type == "mcp" else "Agents"
+    table = Table(title=f"Top {label}", show_lines=False, padding=(0, 1))
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Name", style="bold")
+    table.add_column("Downloads", justify="right")
+    table.add_column("ID", style="dim", max_width=12)
+    for i, item in enumerate(data, 1):
+        table.add_row(str(i), item["name"], str(int(item["value"])), str(item["id"])[:8] + "…")
+    console.print(table)
+
+
+# ── Feedback (on ops_app) ────────────────────────────────
+
+
+@ops_app.command(name="rate")
+def _rate(
+    listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    stars: int = typer.Option(..., "--stars", "-s", min=1, max=5, help="Rating 1-5"),
+    listing_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
+    comment: str | None = typer.Option(None, "--comment", "-c"),
+):
+    """Rate an MCP server or agent."""
+    _rate_impl(listing_id, stars, listing_type, comment)
+
+
+def _rate_impl(listing_id, stars, listing_type, comment):
+    resolved = config.resolve_alias(listing_id)
+    with spinner("Submitting rating..."):
+        client.post(
+            "/api/v1/feedback",
+            {
+                "listing_id": resolved,
+                "listing_type": listing_type,
+                "rating": stars,
+                "comment": comment,
+            },
+        )
+    rprint(f"[green]✓ Rated {star_rating(stars)}[/green]")
+
+
+@ops_app.command(name="feedback")
+def _feedback(
+    listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    listing_type: str = typer.Option("mcp", "--type", "-t"),
+    output: str = typer.Option("table", "--output", "-o"),
+):
+    """Show feedback for an MCP server or agent."""
+    _feedback_impl(listing_id, listing_type, output)
+
+
+def _feedback_impl(listing_id, listing_type, output):
+    resolved = config.resolve_alias(listing_id)
+    with spinner():
+        data = client.get(f"/api/v1/feedback/{listing_type}/{resolved}")
+        summary = client.get(f"/api/v1/feedback/summary/{resolved}")
+
+    if output == "json":
+        output_json({"summary": summary, "reviews": data})
+        return
+
+    if not data:
+        rprint("[dim]No feedback yet.[/dim]")
+        return
+
+    avg = summary.get("average_rating", 0)
+    total = summary.get("total_reviews", 0)
+    rprint(f"\n  {star_rating(round(avg))} [bold]{avg:.1f}[/bold]/5 ({total} reviews)\n")
+    for fb in data:
+        stars_str = star_rating(fb.get("rating", 0))
+        comment = f"  {fb['comment']}" if fb.get("comment") else ""
+        rprint(f"  {stars_str}{comment}")
+    rprint()
 
 
 # ── Eval ─────────────────────────────────────────────────
@@ -703,168 +734,201 @@ def admin_users(output: str = typer.Option("table", "--output", "-o")):
     console.print(table)
 
 
-# ── Traces ───────────────────────────────────────────────
+# ── Traces / Spans (on ops_app) ─────────────────────────
 
 
-def register_traces(app: typer.Typer):
+@ops_app.command(name="traces")
+def _traces(
+    trace_type: str | None = typer.Option(None, "--type", "-t"),
+    mcp_id: str | None = typer.Option(None, "--mcp"),
+    agent_id: str | None = typer.Option(None, "--agent"),
+    limit: int = typer.Option(20, "--limit", "-n"),
+    output: str = typer.Option("table", "--output", "-o"),
+):
+    """List recent traces."""
+    _traces_impl(trace_type, mcp_id, agent_id, limit, output)
 
-    @app.command()
-    def traces(
-        trace_type: str | None = typer.Option(None, "--type", "-t"),
-        mcp_id: str | None = typer.Option(None, "--mcp"),
-        agent_id: str | None = typer.Option(None, "--agent"),
-        limit: int = typer.Option(20, "--limit", "-n"),
-        output: str = typer.Option("table", "--output", "-o"),
-    ):
-        """List recent traces."""
-        variables = {"limit": limit}
-        if trace_type:
-            variables["traceType"] = trace_type
-        if mcp_id:
-            variables["mcpId"] = config.resolve_alias(mcp_id)
-        if agent_id:
-            variables["agentId"] = config.resolve_alias(agent_id)
 
-        query = """query($traceType: String, $mcpId: String, $agentId: String, $limit: Int) {
-            traces(traceType: $traceType, mcpId: $mcpId, agentId: $agentId, limit: $limit) {
-                items {
-                    traceId traceType name mcpId agentId ide startTime
-                    metrics { totalSpans errorCount toolCallCount }
-                }
+def _traces_impl(trace_type, mcp_id, agent_id, limit, output):
+    variables = {"limit": limit}
+    if trace_type:
+        variables["traceType"] = trace_type
+    if mcp_id:
+        variables["mcpId"] = config.resolve_alias(mcp_id)
+    if agent_id:
+        variables["agentId"] = config.resolve_alias(agent_id)
+
+    query = """query($traceType: String, $mcpId: String, $agentId: String, $limit: Int) {
+        traces(traceType: $traceType, mcpId: $mcpId, agentId: $agentId, limit: $limit) {
+            items {
+                traceId traceType name mcpId agentId ide startTime
+                metrics { totalSpans errorCount toolCallCount }
             }
-        }"""
-        import httpx
+        }
+    }"""
+    import httpx
 
-        cfg = config.get_or_exit()
-        with spinner("Querying traces..."):
-            try:
-                r = httpx.post(
-                    f"{cfg['server_url'].rstrip('/')}/api/v1/graphql",
-                    json={"query": query, "variables": variables},
-                    timeout=30,
-                )
-                r.raise_for_status()
-                items = r.json().get("data", {}).get("traces", {}).get("items", [])
-            except Exception as e:
-                rprint(f"[red]Failed to query traces: {e}[/red]")
-                raise typer.Exit(1)
-
-        if output == "json":
-            output_json(items)
-            return
-
-        if not items:
-            rprint("[dim]No traces found.[/dim]")
-            return
-
-        table = Table(title=f"Traces ({len(items)})", show_lines=False, padding=(0, 1))
-        table.add_column("#", style="dim", width=3)
-        table.add_column("Trace ID", style="dim", max_width=14)
-        table.add_column("Type")
-        table.add_column("Name", no_wrap=True)
-        table.add_column("Ref", style="dim", max_width=16)
-        table.add_column("IDE")
-        table.add_column("Spans", justify="right")
-        table.add_column("Err", justify="right")
-        table.add_column("Tools", justify="right")
-        table.add_column("When")
-        for i, t in enumerate(items, 1):
-            m = t.get("metrics", {})
-            ref = t.get("mcpId") or t.get("agentId") or "--"
-            errs = m.get("errorCount", 0)
-            err_style = "red" if errs > 0 else ""
-            table.add_row(
-                str(i),
-                t["traceId"][:12] + "…",
-                t.get("traceType", ""),
-                t.get("name", "") or "--",
-                ref[:16],
-                t.get("ide", "") or "--",
-                str(m.get("totalSpans", 0)),
-                f"[{err_style}]{errs}[/{err_style}]" if err_style else str(errs),
-                str(m.get("toolCallCount", 0)),
-                relative_time(t.get("startTime")),
+    cfg = config.get_or_exit()
+    with spinner("Querying traces..."):
+        try:
+            r = httpx.post(
+                f"{cfg['server_url'].rstrip('/')}/api/v1/graphql",
+                json={"query": query, "variables": variables},
+                timeout=30,
             )
-        console.print(table)
-
-    @app.command()
-    def spans(
-        trace_id: str = typer.Argument(..., help="Trace ID"),
-        output: str = typer.Option("table", "--output", "-o"),
-    ):
-        """List spans for a trace."""
-        query = """query($traceId: String!) {
-            trace(traceId: $traceId) {
-                traceId name
-                spans {
-                    spanId type name method latencyMs status
-                    toolSchemaValid toolsAvailable
-                }
-            }
-        }"""
-        import httpx
-
-        cfg = config.get_or_exit()
-        with spinner("Querying spans..."):
-            try:
-                r = httpx.post(
-                    f"{cfg['server_url'].rstrip('/')}/api/v1/graphql",
-                    json={"query": query, "variables": {"traceId": trace_id}},
-                    timeout=30,
-                )
-                r.raise_for_status()
-                trace_data = r.json().get("data", {}).get("trace")
-            except Exception as e:
-                rprint(f"[red]Failed to query spans: {e}[/red]")
-                raise typer.Exit(1)
-
-        if not trace_data:
-            rprint(f"[yellow]Trace {trace_id} not found.[/yellow]")
+            r.raise_for_status()
+            items = r.json().get("data", {}).get("traces", {}).get("items", [])
+        except Exception as e:
+            rprint(f"[red]Failed to query traces: {e}[/red]")
             raise typer.Exit(1)
 
-        if output == "json":
-            output_json(trace_data)
-            return
+    if output == "json":
+        output_json(items)
+        return
 
-        rprint(f"\n[bold]Trace:[/bold] {trace_data['traceId']}: {trace_data.get('name', '')}\n")
+    if not items:
+        rprint("[dim]No traces found.[/dim]")
+        return
 
-        spans_data = trace_data.get("spans", [])
-        if not spans_data:
-            rprint("[dim]No spans.[/dim]")
-            return
+    table = Table(title=f"Traces ({len(items)})", show_lines=False, padding=(0, 1))
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Trace ID", style="dim", max_width=14)
+    table.add_column("Type")
+    table.add_column("Name", no_wrap=True)
+    table.add_column("Ref", style="dim", max_width=16)
+    table.add_column("IDE")
+    table.add_column("Spans", justify="right")
+    table.add_column("Err", justify="right")
+    table.add_column("Tools", justify="right")
+    table.add_column("When")
+    for i, t in enumerate(items, 1):
+        m = t.get("metrics", {})
+        ref = t.get("mcpId") or t.get("agentId") or "--"
+        errs = m.get("errorCount", 0)
+        err_style = "red" if errs > 0 else ""
+        table.add_row(
+            str(i),
+            t["traceId"][:12] + "…",
+            t.get("traceType", ""),
+            t.get("name", "") or "--",
+            ref[:16],
+            t.get("ide", "") or "--",
+            str(m.get("totalSpans", 0)),
+            f"[{err_style}]{errs}[/{err_style}]" if err_style else str(errs),
+            str(m.get("toolCallCount", 0)),
+            relative_time(t.get("startTime")),
+        )
+    console.print(table)
 
-        table = Table(show_lines=False, padding=(0, 1))
-        table.add_column("#", style="dim", width=3)
-        table.add_column("Span ID", style="dim", max_width=14)
-        table.add_column("Type")
-        table.add_column("Name", no_wrap=True)
-        table.add_column("Method")
-        table.add_column("Latency", justify="right")
-        table.add_column("Status")
-        table.add_column("Schema")
-        for i, s in enumerate(spans_data, 1):
-            schema = (
-                "[green]✓[/green]"
-                if s.get("toolSchemaValid") is True
-                else ("[red]✗[/red]" if s.get("toolSchemaValid") is False else "[dim]--[/dim]")
+
+@ops_app.command(name="spans")
+def _spans(
+    trace_id: str = typer.Argument(..., help="Trace ID"),
+    output: str = typer.Option("table", "--output", "-o"),
+):
+    """List spans for a trace."""
+    _spans_impl(trace_id, output)
+
+
+def _spans_impl(trace_id, output):
+    query = """query($traceId: String!) {
+        trace(traceId: $traceId) {
+            traceId name
+            spans {
+                spanId type name method latencyMs status
+                toolSchemaValid toolsAvailable
+            }
+        }
+    }"""
+    import httpx
+
+    cfg = config.get_or_exit()
+    with spinner("Querying spans..."):
+        try:
+            r = httpx.post(
+                f"{cfg['server_url'].rstrip('/')}/api/v1/graphql",
+                json={"query": query, "variables": {"traceId": trace_id}},
+                timeout=30,
             )
-            latency = f"{s['latencyMs']}ms" if s.get("latencyMs") else "--"
-            st = s.get("status", "")
-            st_display = f"[red]{st}[/red]" if st == "error" else f"[green]{st}[/green]" if st == "success" else st
-            table.add_row(
-                str(i),
-                s["spanId"][:12] + "…",
-                s.get("type", ""),
-                s.get("name", ""),
-                s.get("method", "") or "--",
-                latency,
-                st_display,
-                schema,
-            )
-        console.print(table)
+            r.raise_for_status()
+            trace_data = r.json().get("data", {}).get("trace")
+        except Exception as e:
+            rprint(f"[red]Failed to query spans: {e}[/red]")
+            raise typer.Exit(1)
+
+    if not trace_data:
+        rprint(f"[yellow]Trace {trace_id} not found.[/yellow]")
+        raise typer.Exit(1)
+
+    if output == "json":
+        output_json(trace_data)
+        return
+
+    rprint(f"\n[bold]Trace:[/bold] {trace_data['traceId']}: {trace_data.get('name', '')}\n")
+
+    spans_data = trace_data.get("spans", [])
+    if not spans_data:
+        rprint("[dim]No spans.[/dim]")
+        return
+
+    table = Table(show_lines=False, padding=(0, 1))
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Span ID", style="dim", max_width=14)
+    table.add_column("Type")
+    table.add_column("Name", no_wrap=True)
+    table.add_column("Method")
+    table.add_column("Latency", justify="right")
+    table.add_column("Status")
+    table.add_column("Schema")
+    for i, s in enumerate(spans_data, 1):
+        schema = (
+            "[green]✓[/green]"
+            if s.get("toolSchemaValid") is True
+            else ("[red]✗[/red]" if s.get("toolSchemaValid") is False else "[dim]--[/dim]")
+        )
+        latency = f"{s['latencyMs']}ms" if s.get("latencyMs") else "--"
+        st = s.get("status", "")
+        st_display = f"[red]{st}[/red]" if st == "error" else f"[green]{st}[/green]" if st == "success" else st
+        table.add_row(
+            str(i),
+            s["spanId"][:12] + "…",
+            s.get("type", ""),
+            s.get("name", ""),
+            s.get("method", "") or "--",
+            latency,
+            st_display,
+            schema,
+        )
+    console.print(table)
 
 
-# ── Upgrade / Downgrade ──────────────────────────────────
+# ── Upgrade / Downgrade (stays at root) ─────────────────
+
+
+def _upgrade_impl():
+    """Upgrade observal CLI to the latest version."""
+    import subprocess
+
+    with spinner("Upgrading..."):
+        result = subprocess.run(
+            ["uv", "tool", "upgrade", "observal-cli"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    if result.returncode == 0:
+        rprint("[green]✓ Upgraded![/green]")
+        if result.stdout.strip():
+            rprint(f"[dim]{result.stdout.strip()}[/dim]")
+    else:
+        rprint(f"[red]Upgrade failed:[/red] {result.stderr.strip()}")
+        raise typer.Exit(1)
+
+
+def _downgrade_impl():
+    """Downgrade observal CLI to a previous version."""
+    rprint("[yellow]WIP: not yet implemented.[/yellow]")
+    rprint("[dim]Track: https://github.com/BlazeUp-AI/Observal/issues/19[/dim]")
 
 
 def register_lifecycle(app: typer.Typer):
@@ -872,25 +936,209 @@ def register_lifecycle(app: typer.Typer):
     @app.command()
     def upgrade():
         """Upgrade observal CLI to the latest version."""
-        import subprocess
-
-        with spinner("Upgrading..."):
-            result = subprocess.run(
-                ["uv", "tool", "upgrade", "observal-cli"],
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-        if result.returncode == 0:
-            rprint("[green]✓ Upgraded![/green]")
-            if result.stdout.strip():
-                rprint(f"[dim]{result.stdout.strip()}[/dim]")
-        else:
-            rprint(f"[red]Upgrade failed:[/red] {result.stderr.strip()}")
-            raise typer.Exit(1)
+        _upgrade_impl()
 
     @app.command()
     def downgrade():
         """Downgrade observal CLI to a previous version."""
-        rprint("[yellow]WIP: not yet implemented.[/yellow]")
-        rprint("[dim]Track: https://github.com/BlazeUp-AI/Observal/issues/19[/dim]")
+        _downgrade_impl()
+
+
+# ═══════════════════════════════════════════════════════════
+# Wire sub-Typers into ops_app and admin_app
+# ═══════════════════════════════════════════════════════════
+
+# telemetry is a subgroup of ops
+ops_app.add_typer(telemetry_app, name="telemetry")
+
+# review and eval are subgroups of admin
+admin_app.add_typer(review_app, name="review")
+admin_app.add_typer(eval_app, name="eval")
+
+
+# ═══════════════════════════════════════════════════════════
+# Deprecated root-level aliases (hidden, print deprecation notice)
+# ═══════════════════════════════════════════════════════════
+
+
+def register_deprecated_ops(app: typer.Typer):
+    """Register backward-compat aliases at root level for commands now under `observal ops`."""
+
+    @app.command(name="traces", hidden=True)
+    def deprecated_traces(
+        trace_type: str | None = typer.Option(None, "--type", "-t"),
+        mcp_id: str | None = typer.Option(None, "--mcp"),
+        agent_id: str | None = typer.Option(None, "--agent"),
+        limit: int = typer.Option(20, "--limit", "-n"),
+        output: str = typer.Option("table", "--output", "-o"),
+    ):
+        """(Deprecated) Use `observal ops traces` instead."""
+        rprint(_DEPRECATION_TPL.format(old="traces", new="ops traces"))
+        _traces_impl(trace_type, mcp_id, agent_id, limit, output)
+
+    @app.command(name="spans", hidden=True)
+    def deprecated_spans(
+        trace_id: str = typer.Argument(..., help="Trace ID"),
+        output: str = typer.Option("table", "--output", "-o"),
+    ):
+        """(Deprecated) Use `observal ops spans` instead."""
+        rprint(_DEPRECATION_TPL.format(old="spans", new="ops spans"))
+        _spans_impl(trace_id, output)
+
+    @app.command(name="overview", hidden=True)
+    def deprecated_overview(output: str = typer.Option("table", "--output", "-o")):
+        """(Deprecated) Use `observal ops overview` instead."""
+        rprint(_DEPRECATION_TPL.format(old="overview", new="ops overview"))
+        _overview(output)
+
+    @app.command(name="metrics", hidden=True)
+    def deprecated_metrics(
+        item_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+        item_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
+        output: str = typer.Option("table", "--output", "-o"),
+        watch: bool = typer.Option(False, "--watch", "-w", help="Refresh every 5s"),
+    ):
+        """(Deprecated) Use `observal ops metrics` instead."""
+        rprint(_DEPRECATION_TPL.format(old="metrics", new="ops metrics"))
+        _metrics_impl(item_id, item_type, output, watch)
+
+    @app.command(name="top", hidden=True)
+    def deprecated_top(
+        item_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
+        output: str = typer.Option("table", "--output", "-o"),
+    ):
+        """(Deprecated) Use `observal ops top` instead."""
+        rprint(_DEPRECATION_TPL.format(old="top", new="ops top"))
+        _top_impl(item_type, output)
+
+    @app.command(name="rate", hidden=True)
+    def deprecated_rate(
+        listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+        stars: int = typer.Option(..., "--stars", "-s", min=1, max=5, help="Rating 1-5"),
+        listing_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
+        comment: str | None = typer.Option(None, "--comment", "-c"),
+    ):
+        """(Deprecated) Use `observal ops rate` instead."""
+        rprint(_DEPRECATION_TPL.format(old="rate", new="ops rate"))
+        _rate_impl(listing_id, stars, listing_type, comment)
+
+    @app.command(name="feedback", hidden=True)
+    def deprecated_feedback(
+        listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+        listing_type: str = typer.Option("mcp", "--type", "-t"),
+        output: str = typer.Option("table", "--output", "-o"),
+    ):
+        """(Deprecated) Use `observal ops feedback` instead."""
+        rprint(_DEPRECATION_TPL.format(old="feedback", new="ops feedback"))
+        _feedback_impl(listing_id, listing_type, output)
+
+
+def register_deprecated_admin(app: typer.Typer):
+    """Register backward-compat aliases at root level for commands now nested under `observal admin`."""
+
+    # `observal review` was a top-level Typer; now it's `observal admin review`.
+    # We add it as a hidden sub-Typer alias at root.
+    _deprecated_review = typer.Typer(help="(Deprecated) Use `observal admin review` instead.", hidden=True)
+
+    @_deprecated_review.callback(invoke_without_command=True)
+    def _review_deprecation_notice(ctx: typer.Context):
+        rprint(_DEPRECATION_TPL.format(old="review ...", new="admin review ..."))
+        if ctx.invoked_subcommand is None:
+            ctx.invoke(review_list)
+
+    @_deprecated_review.command(name="list")
+    def _dep_review_list(output: str = typer.Option("table", "--output", "-o")):
+        """(Deprecated) Use `observal admin review list`."""
+        review_list(output)
+
+    @_deprecated_review.command(name="show")
+    def _dep_review_show(review_id: str = typer.Argument(...), output: str = typer.Option("table", "--output", "-o")):
+        """(Deprecated) Use `observal admin review show`."""
+        review_show(review_id, output)
+
+    @_deprecated_review.command(name="approve")
+    def _dep_review_approve(review_id: str = typer.Argument(...)):
+        """(Deprecated) Use `observal admin review approve`."""
+        review_approve(review_id)
+
+    @_deprecated_review.command(name="reject")
+    def _dep_review_reject(
+        review_id: str = typer.Argument(...),
+        reason: str = typer.Option(..., "--reason", "-r", help="Rejection reason"),
+    ):
+        """(Deprecated) Use `observal admin review reject`."""
+        review_reject(review_id, reason)
+
+    app.add_typer(_deprecated_review, name="review")
+
+    # `observal telemetry` was a top-level Typer; now it's `observal ops telemetry`.
+    _deprecated_telemetry = typer.Typer(help="(Deprecated) Use `observal ops telemetry` instead.", hidden=True)
+
+    @_deprecated_telemetry.callback(invoke_without_command=True)
+    def _telemetry_deprecation_notice(ctx: typer.Context):
+        rprint(_DEPRECATION_TPL.format(old="telemetry ...", new="ops telemetry ..."))
+
+    @_deprecated_telemetry.command(name="status")
+    def _dep_telemetry_status():
+        """(Deprecated) Use `observal ops telemetry status`."""
+        telemetry_status()
+
+    @_deprecated_telemetry.command(name="test")
+    def _dep_telemetry_test():
+        """(Deprecated) Use `observal ops telemetry test`."""
+        telemetry_test()
+
+    app.add_typer(_deprecated_telemetry, name="telemetry")
+
+    # `observal eval` was a top-level Typer; now it's `observal admin eval`.
+    _deprecated_eval = typer.Typer(help="(Deprecated) Use `observal admin eval` instead.", hidden=True)
+
+    @_deprecated_eval.callback(invoke_without_command=True)
+    def _eval_deprecation_notice(ctx: typer.Context):
+        rprint(_DEPRECATION_TPL.format(old="eval ...", new="admin eval ..."))
+
+    @_deprecated_eval.command(name="run")
+    def _dep_eval_run(
+        agent_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+        trace_id: str | None = typer.Option(None, "--trace"),
+    ):
+        """(Deprecated) Use `observal admin eval run`."""
+        eval_run(agent_id, trace_id)
+
+    @_deprecated_eval.command(name="scorecards")
+    def _dep_eval_scorecards(
+        agent_id: str = typer.Argument(...),
+        version: str | None = typer.Option(None, "--version", "-v"),
+        output: str = typer.Option("table", "--output", "-o"),
+    ):
+        """(Deprecated) Use `observal admin eval scorecards`."""
+        eval_scorecards(agent_id, version, output)
+
+    @_deprecated_eval.command(name="show")
+    def _dep_eval_show(
+        scorecard_id: str = typer.Argument(...),
+        output: str = typer.Option("table", "--output", "-o"),
+    ):
+        """(Deprecated) Use `observal admin eval show`."""
+        eval_show(scorecard_id, output)
+
+    @_deprecated_eval.command(name="compare")
+    def _dep_eval_compare(
+        agent_id: str = typer.Argument(...),
+        version_a: str = typer.Option(..., "--a"),
+        version_b: str = typer.Option(..., "--b"),
+        output: str = typer.Option("table", "--output", "-o"),
+    ):
+        """(Deprecated) Use `observal admin eval compare`."""
+        eval_compare(agent_id, version_a, version_b, output)
+
+    @_deprecated_eval.command(name="aggregate")
+    def _dep_eval_aggregate(
+        agent_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+        window: int = typer.Option(50, "--window", "-w", help="Number of recent scorecards"),
+        output: str = typer.Option("table", "--output", "-o"),
+    ):
+        """(Deprecated) Use `observal admin eval aggregate`."""
+        eval_aggregate(agent_id, window, output)
+
+    app.add_typer(_deprecated_eval, name="eval")

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -1,6 +1,19 @@
 """Observal CLI: MCP Server & Agent Registry."""
 
+from typing import Optional
+
 import typer
+
+from observal_cli.cmd_auth import version_callback
+
+# ── Version callback for --version flag ───────────────────
+
+
+def _version_option(value: bool):
+    if value:
+        version_callback()
+        raise typer.Exit()
+
 
 app = typer.Typer(
     name="observal",
@@ -10,22 +23,34 @@ app = typer.Typer(
     pretty_exceptions_enable=False,
 )
 
+
+@app.callback()
+def main(
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        "-V",
+        help="Show CLI version and exit.",
+        callback=_version_option,
+        is_eager=True,
+    ),
+):
+    """Observal: MCP Server & Agent Registry CLI"""
+
+
 # ── Register command groups ──────────────────────────────
 
 from observal_cli.cmd_agent import agent_app
-from observal_cli.cmd_auth import register_auth, register_config
+from observal_cli.cmd_auth import auth_app, register_config, register_deprecated_auth
 from observal_cli.cmd_doctor import doctor_app
 from observal_cli.cmd_hook import register_hook
 from observal_cli.cmd_mcp import register_mcp
 from observal_cli.cmd_ops import (
     admin_app,
-    eval_app,
-    register_dashboard,
-    register_feedback,
+    ops_app,
+    register_deprecated_admin,
+    register_deprecated_ops,
     register_lifecycle,
-    register_traces,
-    review_app,
-    telemetry_app,
 )
 from observal_cli.cmd_profile import register_use
 from observal_cli.cmd_prompt import register_prompt
@@ -34,13 +59,15 @@ from observal_cli.cmd_sandbox import register_sandbox
 from observal_cli.cmd_scan import register_scan
 from observal_cli.cmd_skill import register_skill
 
-register_auth(app)
+# ── Auth subgroup (new canonical location) ────────────────
+app.add_typer(auth_app, name="auth")
+
+# ── Deprecated root-level auth aliases (backward compat) ──
+register_deprecated_auth(app)
+
+# ── Primary user workflows (root) ─────────────────────────
 register_config(app)
 register_mcp(app)
-register_dashboard(app)
-register_feedback(app)
-register_traces(app)
-register_lifecycle(app)
 register_skill(app)
 register_hook(app)
 register_prompt(app)
@@ -48,13 +75,17 @@ register_sandbox(app)
 register_pull(app)
 register_scan(app)
 register_use(app)
+register_lifecycle(app)
 
+# ── Subgroups ─────────────────────────────────────────────
 app.add_typer(agent_app, name="agent")
-app.add_typer(review_app, name="review")
-app.add_typer(telemetry_app, name="telemetry")
-app.add_typer(eval_app, name="eval")
+app.add_typer(ops_app, name="ops")
 app.add_typer(admin_app, name="admin")
 app.add_typer(doctor_app, name="doctor")
+
+# ── Deprecated root-level ops/admin aliases ───────────────
+register_deprecated_ops(app)
+register_deprecated_admin(app)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Group auth commands under `observal auth` (init, login, logout, whoami, status)
- Group observability under `observal ops` (traces, spans, telemetry, overview, metrics, top, rate, feedback)
- Nest review and eval under `observal admin` (review list/show/approve/reject, eval run/scorecards/show/compare/aggregate)
- Add `--version` / `-V` flag to root app
- All old root-level paths preserved as hidden deprecated aliases with yellow migration notices

## Test plan
- [x] All 547 tests pass
- [ ] `observal auth login` works
- [ ] `observal login` prints deprecation warning then works
- [ ] `observal ops traces` works
- [ ] `observal admin review list` works
- [ ] `observal --version` prints version