### PR TITLE
fix: overhaul web UI — skeletons, errors, breadcrumbs, toasts

### DIFF
--- a/web/src/app/(admin)/dashboard/page.tsx
+++ b/web/src/app/(admin)/dashboard/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import Link from "next/link";
+import { LayoutDashboard, Bot, Activity } from "lucide-react";
 import { useOverviewStats, useRegistryList, useTopAgents, useOtelSessions } from "@/hooks/use-api";
 import { Badge } from "@/components/ui/badge";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 function StatCard({ label, value }: { label: string; value: string | number }) {
   return (
@@ -17,77 +22,115 @@ function StatCard({ label, value }: { label: string; value: string | number }) {
 }
 
 export default function DashboardPage() {
-  const { data: stats } = useOverviewStats();
-  const { data: agents } = useRegistryList("agents");
+  const { data: stats, isLoading: statsLoading, isError: statsError, error: statsErr, refetch: refetchStats } = useOverviewStats();
+  const { data: agents, isLoading: agentsLoading, isError: agentsError, error: agentsErr, refetch: refetchAgents } = useRegistryList("agents");
   const { data: topAgents } = useTopAgents();
-  const { data: sessions } = useOtelSessions();
+  const { data: sessions, isLoading: sessionsLoading } = useOtelSessions();
 
   const recentSessions = (sessions ?? []).slice(0, 10);
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-8">
-      <h1 className="text-xl font-semibold">Dashboard</h1>
+    <>
+      <PageHeader
+        title="Dashboard"
+        breadcrumbs={[
+          { label: "Dashboard" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-8">
+        {statsLoading ? (
+          <CardSkeleton count={4} />
+        ) : statsError ? (
+          <ErrorState message={statsErr?.message} onRetry={() => refetchStats()} />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <StatCard label="Agents Deployed" value={stats?.total_agents ?? 0} />
+            <StatCard label="Total Downloads" value={topAgents?.reduce((s: number, a: any) => s + a.value, 0) ?? 0} />
+            <StatCard label="Users" value={stats?.total_users ?? 0} />
+            <StatCard label="Components" value={stats?.total_mcps ?? 0} />
+          </div>
+        )}
 
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <StatCard label="Agents Deployed" value={stats?.total_agents ?? 0} />
-        <StatCard label="Total Downloads" value={topAgents?.reduce((s: number, a: any) => s + a.value, 0) ?? 0} />
-        <StatCard label="Users" value={stats?.total_users ?? 0} />
-        <StatCard label="Components" value={stats?.total_mcps ?? 0} />
-      </div>
+        <section>
+          <h2 className="text-sm font-medium text-muted-foreground mb-3">Agents</h2>
+          {agentsLoading ? (
+            <TableSkeleton rows={5} cols={4} />
+          ) : agentsError ? (
+            <ErrorState message={agentsErr?.message} onRetry={() => refetchAgents()} />
+          ) : (agents ?? []).length === 0 ? (
+            <EmptyState
+              icon={Bot}
+              title="No agents deployed"
+              description="Agents will appear here once they are submitted to the registry."
+              actionLabel="Browse Registry"
+              actionHref="/agents"
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Version</TableHead>
+                    <TableHead>Model</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {(agents ?? []).slice(0, 20).map((a: any) => (
+                    <TableRow key={a.id}>
+                      <TableCell>
+                        <Link href={`/agents/${a.id}`} className="font-medium hover:underline">{a.name}</Link>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">{a.version ?? "-"}</TableCell>
+                      <TableCell className="text-muted-foreground">{a.model_name ?? "-"}</TableCell>
+                      <TableCell>
+                        <Badge variant={a.status === "approved" ? "default" : "secondary"}>{a.status}</Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </section>
 
-      <section>
-        <h2 className="text-sm font-medium text-muted-foreground mb-3">Agents</h2>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Version</TableHead>
-              <TableHead>Model</TableHead>
-              <TableHead>Status</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {(agents ?? []).slice(0, 20).map((a: any) => (
-              <TableRow key={a.id}>
-                <TableCell>
-                  <Link href={`/agents/${a.id}`} className="font-medium hover:underline">{a.name}</Link>
-                </TableCell>
-                <TableCell className="text-muted-foreground">{a.version ?? "-"}</TableCell>
-                <TableCell className="text-muted-foreground">{a.model_name ?? "-"}</TableCell>
-                <TableCell>
-                  <Badge variant={a.status === "approved" ? "default" : "secondary"}>{a.status}</Badge>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </section>
-
-      {recentSessions.length > 0 && (
         <section>
           <h2 className="text-sm font-medium text-muted-foreground mb-3">Recent Traces</h2>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Session</TableHead>
-                <TableHead>Service</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {recentSessions.map((s: any) => (
-                <TableRow key={s.session_id}>
-                  <TableCell>
-                    <Link href={`/traces/${s.session_id}`} className="font-mono text-xs hover:underline">
-                      {s.session_id.slice(0, 12)}...
-                    </Link>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">{s.service_name ?? "-"}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          {sessionsLoading ? (
+            <TableSkeleton rows={5} cols={2} />
+          ) : recentSessions.length === 0 ? (
+            <EmptyState
+              icon={Activity}
+              title="No traces yet"
+              description="Traces will appear here once telemetry data is collected."
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Session</TableHead>
+                    <TableHead>Service</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {recentSessions.map((s: any) => (
+                    <TableRow key={s.session_id}>
+                      <TableCell>
+                        <Link href={`/traces/${s.session_id}`} className="font-mono text-xs hover:underline">
+                          {s.session_id.slice(0, 12)}...
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">{s.service_name ?? "-"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
         </section>
-      )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/web/src/app/(admin)/eval/[agentId]/page.tsx
+++ b/web/src/app/(admin)/eval/[agentId]/page.tsx
@@ -1,121 +1,145 @@
 "use client";
 
 import { use } from "react";
+import { FlaskConical } from "lucide-react";
 import { useEvalScorecards, useEvalAggregate, useRegistryItem, useEvalRun, useEvalPenalties } from "@/hooks/use-api";
 import { AgentAggregateChart } from "@/components/dashboard/agent-aggregate-chart";
 import { DimensionRadar } from "@/components/dashboard/dimension-radar";
 import { PenaltyAccordion } from "@/components/dashboard/penalty-accordion";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import Link from "next/link";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { DetailSkeleton, TableSkeleton, ChartSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function EvalDetailPage({ params }: { params: Promise<{ agentId: string }> }) {
   const { agentId } = use(params);
   const { data: agent } = useRegistryItem("agents", agentId);
-  const { data: scorecards, isLoading } = useEvalScorecards(agentId);
-  const { data: aggregate } = useEvalAggregate(agentId);
+  const { data: scorecards, isLoading, isError, error, refetch } = useEvalScorecards(agentId);
+  const { data: aggregate, isLoading: aggLoading } = useEvalAggregate(agentId);
   const runEval = useEvalRun();
 
   const a = agent as any;
   const cards = scorecards ?? [];
   const latest = cards[0];
 
-  // Fetch penalties for the latest scorecard
   const { data: latestPenalties } = useEvalPenalties(latest?.id);
 
-  return (
-    <div className="p-6 max-w-5xl mx-auto space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Link href="/eval" className="text-sm text-muted-foreground hover:text-foreground">Eval</Link>
-          <span className="text-muted-foreground">/</span>
-          <h1 className="text-lg font-semibold">{a?.name ?? agentId.slice(0, 8)}</h1>
-        </div>
-        <Button
-          size="sm"
-          onClick={() => runEval.mutate({ agentId })}
-          disabled={runEval.isPending}
-        >
-          {runEval.isPending ? "Running..." : "Run Eval"}
-        </Button>
-      </div>
+  const agentName = a?.name ?? agentId.slice(0, 8);
 
-      {aggregate && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <div>
-            <h2 className="text-sm font-medium text-muted-foreground mb-3">Score Over Time</h2>
-            <AgentAggregateChart data={aggregate} />
+  return (
+    <>
+      <PageHeader
+        title={agentName}
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Eval", href: "/eval" },
+          { label: agentName },
+        ]}
+        actionButtonsRight={
+          <Button
+            size="sm"
+            onClick={() => runEval.mutate({ agentId })}
+            disabled={runEval.isPending}
+          >
+            {runEval.isPending ? "Running..." : "Run Eval"}
+          </Button>
+        }
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-6">
+        {aggLoading ? (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <ChartSkeleton />
+            <ChartSkeleton />
           </div>
-          {latest?.dimension_scores && (
+        ) : aggregate ? (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <div>
-              <h2 className="text-sm font-medium text-muted-foreground mb-3">Latest Dimensions</h2>
-              <DimensionRadar dimensionScores={latest.dimension_scores} />
+              <h2 className="text-sm font-medium text-muted-foreground mb-3">Score Over Time</h2>
+              <AgentAggregateChart data={aggregate} />
+            </div>
+            {latest?.dimension_scores && (
+              <div>
+                <h2 className="text-sm font-medium text-muted-foreground mb-3">Latest Dimensions</h2>
+                <DimensionRadar dimensionScores={latest.dimension_scores} />
+              </div>
+            )}
+          </div>
+        ) : null}
+
+        {latest && (
+          <section>
+            <h2 className="text-sm font-medium text-muted-foreground mb-3">Latest Scorecard</h2>
+            <div className="border border-border rounded-sm p-4 space-y-2">
+              <div className="flex items-center gap-3">
+                {latest.grade && <Badge variant="default">{latest.grade}</Badge>}
+                {latest.display_score != null && <span className="text-sm font-mono">{latest.display_score.toFixed(1)}/10</span>}
+                {latest.version && <span className="text-xs text-muted-foreground">v{latest.version}</span>}
+              </div>
+              {(latest.scoring_recommendations ?? []).length > 0 && (
+                <ul className="text-xs text-muted-foreground space-y-1">
+                  {(latest.scoring_recommendations ?? []).map((r: string, i: number) => (
+                    <li key={i}>{r}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </section>
+        )}
+
+        {latestPenalties && latestPenalties.length > 0 && (
+          <section>
+            <h2 className="text-sm font-medium text-muted-foreground mb-3">Penalties</h2>
+            <PenaltyAccordion penalties={latestPenalties} />
+          </section>
+        )}
+
+        <section>
+          <h2 className="text-sm font-medium text-muted-foreground mb-3">Scorecard History</h2>
+          {isLoading ? (
+            <TableSkeleton rows={5} cols={5} />
+          ) : isError ? (
+            <ErrorState message={error?.message} onRetry={() => refetch()} />
+          ) : cards.length === 0 ? (
+            <EmptyState
+              icon={FlaskConical}
+              title="No scorecards yet"
+              description="Run an eval to generate scores for this agent."
+              onAction={() => runEval.mutate({ agentId })}
+              actionLabel="Run Eval"
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Version</TableHead>
+                    <TableHead>Score</TableHead>
+                    <TableHead>Grade</TableHead>
+                    <TableHead>Penalties</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {cards.map((sc: any) => (
+                    <TableRow key={sc.id}>
+                      <TableCell className="text-xs">{sc.created_at ? new Date(sc.created_at).toLocaleDateString() : "-"}</TableCell>
+                      <TableCell className="text-muted-foreground">{sc.version ?? "-"}</TableCell>
+                      <TableCell className="font-mono">{sc.display_score?.toFixed(1) ?? sc.overall_score?.toFixed(1) ?? "-"}</TableCell>
+                      <TableCell><Badge variant="outline">{sc.grade ?? sc.overall_grade ?? "-"}</Badge></TableCell>
+                      <TableCell className="text-muted-foreground">{sc.penalty_count ?? 0}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
             </div>
           )}
-        </div>
-      )}
-
-      {latest && (
-        <section>
-          <h2 className="text-sm font-medium text-muted-foreground mb-3">Latest Scorecard</h2>
-          <div className="border border-border rounded-sm p-4 space-y-2">
-            <div className="flex items-center gap-3">
-              {latest.grade && <Badge variant="default">{latest.grade}</Badge>}
-              {latest.display_score != null && <span className="text-sm font-mono">{latest.display_score.toFixed(1)}/10</span>}
-              {latest.version && <span className="text-xs text-muted-foreground">v{latest.version}</span>}
-            </div>
-            {(latest.scoring_recommendations ?? []).length > 0 && (
-              <ul className="text-xs text-muted-foreground space-y-1">
-                {(latest.scoring_recommendations ?? []).map((r: string, i: number) => (
-                  <li key={i}>{r}</li>
-                ))}
-              </ul>
-            )}
-          </div>
         </section>
-      )}
-
-      {latestPenalties && latestPenalties.length > 0 && (
-        <section>
-          <h2 className="text-sm font-medium text-muted-foreground mb-3">Penalties</h2>
-          <PenaltyAccordion penalties={latestPenalties} />
-        </section>
-      )}
-
-      <section>
-        <h2 className="text-sm font-medium text-muted-foreground mb-3">Scorecard History</h2>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Date</TableHead>
-              <TableHead>Version</TableHead>
-              <TableHead>Score</TableHead>
-              <TableHead>Grade</TableHead>
-              <TableHead>Penalties</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
-              <TableRow><TableCell colSpan={5} className="text-center text-muted-foreground">Loading...</TableCell></TableRow>
-            ) : cards.length === 0 ? (
-              <TableRow><TableCell colSpan={5} className="text-center text-muted-foreground">No scorecards yet. Run an eval to generate scores.</TableCell></TableRow>
-            ) : (
-              cards.map((sc: any) => (
-                <TableRow key={sc.id}>
-                  <TableCell className="text-xs">{sc.created_at ? new Date(sc.created_at).toLocaleDateString() : "-"}</TableCell>
-                  <TableCell className="text-muted-foreground">{sc.version ?? "-"}</TableCell>
-                  <TableCell className="font-mono">{sc.display_score?.toFixed(1) ?? sc.overall_score?.toFixed(1) ?? "-"}</TableCell>
-                  <TableCell><Badge variant="outline">{sc.grade ?? sc.overall_grade ?? "-"}</Badge></TableCell>
-                  <TableCell className="text-muted-foreground">{sc.penalty_count ?? 0}</TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </section>
-    </div>
+      </div>
+    </>
   );
 }

--- a/web/src/app/(admin)/eval/page.tsx
+++ b/web/src/app/(admin)/eval/page.tsx
@@ -1,45 +1,68 @@
 "use client";
 
 import Link from "next/link";
+import { FlaskConical } from "lucide-react";
 import { useRegistryList } from "@/hooks/use-api";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function EvalPage() {
-  const { data: agents, isLoading } = useRegistryList("agents");
+  const { data: agents, isLoading, isError, error, refetch } = useRegistryList("agents");
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <h1 className="text-xl font-semibold">Eval</h1>
-      <p className="text-sm text-muted-foreground">Select an agent to view evaluation scores and run evals.</p>
+    <>
+      <PageHeader
+        title="Eval"
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Eval" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-4">
+        <p className="text-sm text-muted-foreground">Select an agent to view evaluation scores and run evals.</p>
 
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Agent</TableHead>
-            <TableHead>Version</TableHead>
-            <TableHead>Model</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading ? (
-            <TableRow><TableCell colSpan={3} className="text-center text-muted-foreground">Loading...</TableCell></TableRow>
-          ) : (agents ?? []).length === 0 ? (
-            <TableRow><TableCell colSpan={3} className="text-center text-muted-foreground">No agents</TableCell></TableRow>
-          ) : (
-            (agents ?? []).map((a: any) => (
-              <TableRow key={a.id}>
-                <TableCell>
-                  <Link href={`/eval/${a.id}`} className="font-medium hover:underline">{a.name}</Link>
-                </TableCell>
-                <TableCell className="text-muted-foreground">{a.version ?? "-"}</TableCell>
-                <TableCell className="text-muted-foreground">{a.model_name ?? "-"}</TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </div>
+        {isLoading ? (
+          <TableSkeleton rows={5} cols={3} />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : (agents ?? []).length === 0 ? (
+          <EmptyState
+            icon={FlaskConical}
+            title="No agents to evaluate"
+            description="Submit an agent to the registry to run evaluations against it."
+            actionLabel="Browse Agents"
+            actionHref="/agents"
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Model</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(agents ?? []).map((a: any) => (
+                  <TableRow key={a.id}>
+                    <TableCell>
+                      <Link href={`/eval/${a.id}`} className="font-medium hover:underline">{a.name}</Link>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{a.version ?? "-"}</TableCell>
+                    <TableCell className="text-muted-foreground">{a.model_name ?? "-"}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -1,54 +1,83 @@
 "use client";
 
+import { ClipboardCheck } from "lucide-react";
 import { useReviewList, useReviewAction } from "@/hooks/use-api";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function ReviewPage() {
-  const { data: items, isLoading, refetch } = useReviewList();
+  const { data: items, isLoading, isError, error, refetch } = useReviewList();
   const approve = useReviewAction();
 
   async function handleApprove(id: string) {
     await approve.mutateAsync({ id, action: "approve" });
-    refetch();
+  }
+
+  async function handleReject(id: string) {
+    await approve.mutateAsync({ id, action: "reject" });
   }
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <h1 className="text-xl font-semibold">Review Queue</h1>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Type</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Actions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading ? (
-            <TableRow><TableCell colSpan={4} className="text-center text-muted-foreground">Loading...</TableCell></TableRow>
-          ) : (items ?? []).length === 0 ? (
-            <TableRow><TableCell colSpan={4} className="text-center text-muted-foreground">No pending reviews</TableCell></TableRow>
-          ) : (
-            (items ?? []).map((item: any) => (
-              <TableRow key={item.id}>
-                <TableCell className="font-medium">{item.name}</TableCell>
-                <TableCell><Badge variant="outline">{item.type ?? "-"}</Badge></TableCell>
-                <TableCell><Badge variant="secondary">{item.status}</Badge></TableCell>
-                <TableCell>
-                  <Button size="sm" variant="default" onClick={() => handleApprove(item.id)}>
-                    Approve
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </div>
+    <>
+      <PageHeader
+        title="Review Queue"
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Review" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-4">
+        {isLoading ? (
+          <TableSkeleton rows={5} cols={4} />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : (items ?? []).length === 0 ? (
+          <EmptyState
+            icon={ClipboardCheck}
+            title="No pending reviews"
+            description="All submissions have been reviewed. New items will appear here when agents or components are submitted."
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(items ?? []).map((item: any) => (
+                  <TableRow key={item.id}>
+                    <TableCell className="font-medium">{item.name}</TableCell>
+                    <TableCell><Badge variant="outline">{item.type ?? "-"}</Badge></TableCell>
+                    <TableCell><Badge variant="secondary">{item.status}</Badge></TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Button size="sm" variant="default" onClick={() => handleApprove(item.id)}>
+                          Approve
+                        </Button>
+                        <Button size="sm" variant="outline" onClick={() => handleReject(item.id)}>
+                          Reject
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -1,42 +1,63 @@
 "use client";
 
+import { Settings } from "lucide-react";
 import { useAdminSettings } from "@/hooks/use-api";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function SettingsPage() {
-  const { data: settings, isLoading } = useAdminSettings();
+  const { data: settings, isLoading, isError, error, refetch } = useAdminSettings();
 
   const entries = Array.isArray(settings)
     ? settings.map((s: any) => [s.key, s.value])
     : Object.entries(settings ?? {});
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <h1 className="text-xl font-semibold">Settings</h1>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Key</TableHead>
-            <TableHead>Value</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading ? (
-            <TableRow><TableCell colSpan={2} className="text-center text-muted-foreground">Loading...</TableCell></TableRow>
-          ) : entries.length === 0 ? (
-            <TableRow><TableCell colSpan={2} className="text-center text-muted-foreground">No settings</TableCell></TableRow>
-          ) : (
-            entries.map(([key, value]: any) => (
-              <TableRow key={key}>
-                <TableCell className="font-mono text-sm">{key}</TableCell>
-                <TableCell className="text-muted-foreground">{String(value)}</TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </div>
+    <>
+      <PageHeader
+        title="Settings"
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Settings" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-4">
+        {isLoading ? (
+          <TableSkeleton rows={5} cols={2} />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : entries.length === 0 ? (
+          <EmptyState
+            icon={Settings}
+            title="No settings configured"
+            description="System settings will appear here once they are configured."
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Key</TableHead>
+                  <TableHead>Value</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {entries.map(([key, value]: any) => (
+                  <TableRow key={key}>
+                    <TableCell className="font-mono text-sm">{key}</TableCell>
+                    <TableCell className="text-muted-foreground">{String(value)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -2,45 +2,64 @@
 
 import { use } from "react";
 import { useOtelSession } from "@/hooks/use-api";
-import Link from "next/link";
+import { FileText } from "lucide-react";
+import { PageHeader } from "@/components/layouts/page-header";
+import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function TraceDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { data, isLoading } = useOtelSession(id);
-
-  if (isLoading) return <div className="p-6 text-muted-foreground">Loading...</div>;
-  if (!data) return <div className="p-6 text-muted-foreground">Trace not found</div>;
+  const { data, isLoading, isError, error, refetch } = useOtelSession(id);
 
   const session = data as any;
-  const events = session.events ?? [];
+  const events = session?.events ?? [];
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <div className="flex items-center gap-3">
-        <Link href="/traces" className="text-sm text-muted-foreground hover:text-foreground">Traces</Link>
-        <span className="text-muted-foreground">/</span>
-        <h1 className="text-lg font-semibold font-mono">{id.slice(0, 16)}...</h1>
-      </div>
-
-      {session.service_name && (
-        <p className="text-sm text-muted-foreground">Service: {session.service_name}</p>
-      )}
-
-      <div className="space-y-2">
-        {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No events in this trace</p>
+    <>
+      <PageHeader
+        title={isLoading ? "Trace" : id.slice(0, 16) + "..."}
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Traces", href: "/traces" },
+          { label: id.slice(0, 12) + "..." },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-4">
+        {isLoading ? (
+          <DetailSkeleton />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : !data ? (
+          <ErrorState message="Trace not found" />
         ) : (
-          events.map((evt: any, i: number) => (
-            <div key={i} className="border border-border rounded-sm p-3 text-sm">
-              <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-                <span>{evt.event_name}</span>
-                {evt.timestamp && <span>{new Date(evt.timestamp).toLocaleTimeString()}</span>}
-              </div>
-              {evt.body && <pre className="text-xs font-mono whitespace-pre-wrap mt-1">{evt.body}</pre>}
+          <>
+            {session.service_name && (
+              <p className="text-sm text-muted-foreground">Service: {session.service_name}</p>
+            )}
+
+            <div className="space-y-2">
+              {events.length === 0 ? (
+                <EmptyState
+                  icon={FileText}
+                  title="No events in this trace"
+                  description="Events will appear here once spans are recorded for this session."
+                />
+              ) : (
+                events.map((evt: any, i: number) => (
+                  <div key={i} className="border border-border rounded-sm p-3 text-sm">
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
+                      <span>{evt.event_name}</span>
+                      {evt.timestamp && <span>{new Date(evt.timestamp).toLocaleTimeString()}</span>}
+                    </div>
+                    {evt.body && <pre className="text-xs font-mono whitespace-pre-wrap mt-1">{evt.body}</pre>}
+                  </div>
+                ))
+              )}
             </div>
-          ))
+          </>
         )}
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -1,43 +1,64 @@
 "use client";
 
 import Link from "next/link";
+import { Activity } from "lucide-react";
 import { useOtelSessions } from "@/hooks/use-api";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function TracesPage() {
-  const { data: sessions, isLoading } = useOtelSessions();
+  const { data: sessions, isLoading, isError, error, refetch } = useOtelSessions();
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <h1 className="text-xl font-semibold">Traces</h1>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Session ID</TableHead>
-            <TableHead>Service</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading ? (
-            <TableRow><TableCell colSpan={2} className="text-center text-muted-foreground">Loading...</TableCell></TableRow>
-          ) : (sessions ?? []).length === 0 ? (
-            <TableRow><TableCell colSpan={2} className="text-center text-muted-foreground">No traces</TableCell></TableRow>
-          ) : (
-            (sessions ?? []).map((s: any) => (
-              <TableRow key={s.session_id}>
-                <TableCell>
-                  <Link href={`/traces/${s.session_id}`} className="font-mono text-xs hover:underline">
-                    {s.session_id}
-                  </Link>
-                </TableCell>
-                <TableCell className="text-muted-foreground">{s.service_name ?? "-"}</TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </div>
+    <>
+      <PageHeader
+        title="Traces"
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Traces" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-4">
+        {isLoading ? (
+          <TableSkeleton rows={8} cols={2} />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : (sessions ?? []).length === 0 ? (
+          <EmptyState
+            icon={Activity}
+            title="No traces yet"
+            description="Traces will appear here once telemetry data is collected from your agents."
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Session ID</TableHead>
+                  <TableHead>Service</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(sessions ?? []).map((s: any) => (
+                  <TableRow key={s.session_id}>
+                    <TableCell>
+                      <Link href={`/traces/${s.session_id}`} className="font-mono text-xs hover:underline">
+                        {s.session_id}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{s.service_name ?? "-"}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -1,39 +1,62 @@
 "use client";
 
+import { Users } from "lucide-react";
 import { useAdminUsers } from "@/hooks/use-api";
 import { Badge } from "@/components/ui/badge";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function UsersPage() {
-  const { data: users, isLoading } = useAdminUsers();
+  const { data: users, isLoading, isError, error, refetch } = useAdminUsers();
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <h1 className="text-xl font-semibold">Users</h1>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Email</TableHead>
-            <TableHead>Role</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading ? (
-            <TableRow><TableCell colSpan={3} className="text-center text-muted-foreground">Loading...</TableCell></TableRow>
-          ) : (
-            (users ?? []).map((u: any) => (
-              <TableRow key={u.id}>
-                <TableCell className="font-medium">{u.name ?? u.username ?? "-"}</TableCell>
-                <TableCell className="text-muted-foreground">{u.email ?? "-"}</TableCell>
-                <TableCell><Badge variant={u.role === "admin" ? "default" : "secondary"}>{u.role}</Badge></TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </div>
+    <>
+      <PageHeader
+        title="Users"
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Users" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-4">
+        {isLoading ? (
+          <TableSkeleton rows={5} cols={3} />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : (users ?? []).length === 0 ? (
+          <EmptyState
+            icon={Users}
+            title="No users yet"
+            description="Users will appear here once they sign up or are added by an admin."
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Role</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(users ?? []).map((u: any) => (
+                  <TableRow key={u.id}>
+                    <TableCell className="font-medium">{u.name ?? u.username ?? "-"}</TableCell>
+                    <TableCell className="text-muted-foreground">{u.email ?? "-"}</TableCell>
+                    <TableCell><Badge variant={u.role === "admin" ? "default" : "secondary"}>{u.role}</Badge></TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Telescope, Eye, EyeOff, ArrowRight, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { auth, setApiKey, setUserRole } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,9 +26,12 @@ export default function LoginPage() {
       setApiKey(apiKey);
       const user = await auth.login({ api_key: apiKey });
       setUserRole(user.role);
+      toast.success("Signed in successfully");
       router.push("/");
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Invalid API key");
+      const msg = e instanceof Error ? e.message : "Invalid API key";
+      setError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }
@@ -40,9 +44,12 @@ export default function LoginPage() {
       const res = await auth.init({ email, name });
       setApiKey(res.api_key);
       setUserRole(res.user.role);
+      toast.success("Admin account created");
       router.push("/");
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Initialization failed");
+      const msg = e instanceof Error ? e.message : "Initialization failed";
+      setError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { use } from "react";
+import { Puzzle } from "lucide-react";
+import { toast } from "sonner";
 import { useRegistryItem } from "@/hooks/use-api";
 import { PullCommand } from "@/components/registry/pull-command";
 import { Badge } from "@/components/ui/badge";
@@ -13,83 +15,110 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function AgentDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { data: agent, isLoading } = useRegistryItem("agents", id);
-
-  if (isLoading) return <div className="p-6 text-muted-foreground">Loading...</div>;
-  if (!agent) return <div className="p-6 text-muted-foreground">Agent not found</div>;
+  const { data: agent, isLoading, isError, error, refetch } = useRegistryItem("agents", id);
 
   const a = agent as any;
-  const components = a.component_links ?? a.mcp_links ?? [];
-  const goalTemplate = a.goal_template;
+  const components = a?.component_links ?? a?.mcp_links ?? [];
+  const goalTemplate = a?.goal_template;
+  const agentName = a?.name ?? id.slice(0, 8);
 
   return (
-    <div className="p-6 max-w-4xl mx-auto space-y-6">
-      <div className="space-y-1">
-        <div className="flex items-center gap-2">
-          <h1 className="text-xl font-semibold">{a.name}</h1>
-          {a.version && <Badge variant="secondary">{a.version}</Badge>}
-          {a.status && <Badge variant={a.status === "approved" ? "default" : "outline"}>{a.status}</Badge>}
-        </div>
-        <div className="flex items-center gap-3 text-sm text-muted-foreground">
-          {a.model_name && <span>{a.model_name}</span>}
-          {a.owner && <span>{a.owner}</span>}
-        </div>
-      </div>
-
-      <PullCommand agentName={a.name} />
-
-      <Tabs defaultValue="overview">
-        <TabsList>
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="components">Components</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="overview" className="space-y-4 mt-4">
-          {a.description && <p className="text-sm">{a.description}</p>}
-          {goalTemplate && (
-            <div className="space-y-2">
-              <h3 className="text-sm font-medium">Goal Template</h3>
-              {goalTemplate.description && <p className="text-sm text-muted-foreground">{goalTemplate.description}</p>}
-              {goalTemplate.sections?.map((sec: any, i: number) => (
-                <div key={i} className="border border-border rounded-sm p-3">
-                  <p className="text-sm font-medium">{sec.name}</p>
-                  {sec.description && <p className="text-xs text-muted-foreground mt-1">{sec.description}</p>}
-                </div>
-              ))}
+    <>
+      <PageHeader
+        title={isLoading ? "Agent" : agentName}
+        breadcrumbs={[
+          { label: "Registry", href: "/" },
+          { label: "Agents", href: "/agents" },
+          { label: isLoading ? "..." : agentName },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-6">
+        {isLoading ? (
+          <DetailSkeleton />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : !agent ? (
+          <ErrorState message="Agent not found" />
+        ) : (
+          <>
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 flex-wrap">
+                {a.version && <Badge variant="secondary">{a.version}</Badge>}
+                {a.status && <Badge variant={a.status === "approved" ? "default" : "outline"}>{a.status}</Badge>}
+              </div>
+              <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                {a.model_name && <span>{a.model_name}</span>}
+                {a.owner && <span>{a.owner}</span>}
+              </div>
             </div>
-          )}
-        </TabsContent>
 
-        <TabsContent value="components" className="mt-4">
-          {components.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No components linked</p>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Status</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {components.map((comp: any, i: number) => (
-                  <TableRow key={i}>
-                    <TableCell>
-                      <Badge variant="outline">{comp.component_type ?? "mcp"}</Badge>
-                    </TableCell>
-                    <TableCell>{comp.mcp_name ?? comp.component_name ?? comp.name ?? "-"}</TableCell>
-                    <TableCell className="text-muted-foreground">{comp.status ?? "-"}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </TabsContent>
-      </Tabs>
-    </div>
+            <PullCommand agentName={a.name} />
+
+            <Tabs defaultValue="overview">
+              <TabsList>
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="components">Components</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="overview" className="space-y-4 mt-4">
+                {a.description && <p className="text-sm">{a.description}</p>}
+                {goalTemplate && (
+                  <div className="space-y-2">
+                    <h3 className="text-sm font-medium">Goal Template</h3>
+                    {goalTemplate.description && <p className="text-sm text-muted-foreground">{goalTemplate.description}</p>}
+                    {goalTemplate.sections?.map((sec: any, i: number) => (
+                      <div key={i} className="border border-border rounded-sm p-3">
+                        <p className="text-sm font-medium">{sec.name}</p>
+                        {sec.description && <p className="text-xs text-muted-foreground mt-1">{sec.description}</p>}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </TabsContent>
+
+              <TabsContent value="components" className="mt-4">
+                {components.length === 0 ? (
+                  <EmptyState
+                    icon={Puzzle}
+                    title="No components linked"
+                    description="This agent does not have any linked MCP servers or components."
+                  />
+                ) : (
+                  <div className="overflow-x-auto">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Type</TableHead>
+                          <TableHead>Name</TableHead>
+                          <TableHead>Status</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {components.map((comp: any, i: number) => (
+                          <TableRow key={i}>
+                            <TableCell>
+                              <Badge variant="outline">{comp.component_type ?? "mcp"}</Badge>
+                            </TableCell>
+                            <TableCell>{comp.mcp_name ?? comp.component_name ?? comp.name ?? "-"}</TableCell>
+                            <TableCell className="text-muted-foreground">{comp.status ?? "-"}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </TabsContent>
+            </Tabs>
+          </>
+        )}
+      </div>
+    </>
   );
 }

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Search } from "lucide-react";
+import { Search, Bot } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useRegistryList } from "@/hooks/use-api";
 import {
@@ -15,63 +15,84 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function AgentListPage() {
   const searchParams = useSearchParams();
   const initialSearch = searchParams.get("search") ?? "";
   const [search, setSearch] = useState(initialSearch);
-  const { data: agents, isLoading } = useRegistryList("agents", search ? { search } : undefined);
+  const { data: agents, isLoading, isError, error, refetch } = useRegistryList("agents", search ? { search } : undefined);
 
   const filtered = agents ?? [];
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <h1 className="text-xl font-semibold">Agents</h1>
+    <>
+      <PageHeader
+        title="Agents"
+        breadcrumbs={[
+          { label: "Registry", href: "/" },
+          { label: "Agents" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-4">
+        <div className="relative max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Filter agents..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
 
-      <div className="relative max-w-sm">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Filter agents..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="pl-9"
-        />
+        {isLoading ? (
+          <TableSkeleton rows={8} cols={5} />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : filtered.length === 0 ? (
+          <EmptyState
+            icon={Bot}
+            title="No agents found"
+            description={search ? `No agents match "${search}". Try a different search term.` : "No agents have been submitted yet. Be the first to submit one."}
+            actionLabel="Submit Your First Agent"
+            actionHref="/agents"
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Model</TableHead>
+                  <TableHead>Owner</TableHead>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((agent: any) => (
+                  <TableRow key={agent.id}>
+                    <TableCell>
+                      <Link href={`/agents/${agent.id}`} className="font-medium hover:underline">{agent.name}</Link>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{agent.model_name ?? "-"}</TableCell>
+                    <TableCell className="text-muted-foreground">{agent.owner ?? "-"}</TableCell>
+                    <TableCell className="text-muted-foreground">{agent.version ?? "-"}</TableCell>
+                    <TableCell>
+                      <Badge variant={agent.status === "approved" ? "default" : "secondary"}>
+                        {agent.status}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
       </div>
-
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Model</TableHead>
-            <TableHead>Owner</TableHead>
-            <TableHead>Version</TableHead>
-            <TableHead>Status</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading ? (
-            <TableRow><TableCell colSpan={5} className="text-center text-muted-foreground">Loading...</TableCell></TableRow>
-          ) : filtered.length === 0 ? (
-            <TableRow><TableCell colSpan={5} className="text-center text-muted-foreground">No agents found</TableCell></TableRow>
-          ) : (
-            filtered.map((agent: any) => (
-              <TableRow key={agent.id}>
-                <TableCell>
-                  <Link href={`/agents/${agent.id}`} className="font-medium hover:underline">{agent.name}</Link>
-                </TableCell>
-                <TableCell className="text-muted-foreground">{agent.model_name ?? "-"}</TableCell>
-                <TableCell className="text-muted-foreground">{agent.owner ?? "-"}</TableCell>
-                <TableCell className="text-muted-foreground">{agent.version ?? "-"}</TableCell>
-                <TableCell>
-                  <Badge variant={agent.status === "approved" ? "default" : "secondary"}>
-                    {agent.status}
-                  </Badge>
-                </TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </div>
+    </>
   );
 }

--- a/web/src/app/(registry)/components/[id]/page.tsx
+++ b/web/src/app/(registry)/components/[id]/page.tsx
@@ -5,43 +5,56 @@ import { useSearchParams } from "next/navigation";
 import { useRegistryItem } from "@/hooks/use-api";
 import type { RegistryType } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
-import Link from "next/link";
+import { PageHeader } from "@/components/layouts/page-header";
+import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
 
 export default function ComponentDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const searchParams = useSearchParams();
   const type = (searchParams.get("type") ?? "mcps") as RegistryType;
-  const { data: item, isLoading } = useRegistryItem(type, id);
-
-  if (isLoading) return <div className="p-6 text-muted-foreground">Loading...</div>;
-  if (!item) return <div className="p-6 text-muted-foreground">Component not found</div>;
+  const { data: item, isLoading, isError, error, refetch } = useRegistryItem(type, id);
 
   const c = item as any;
+  const componentName = c?.name ?? id.slice(0, 8);
 
   return (
-    <div className="p-6 max-w-4xl mx-auto space-y-6">
-      <div className="space-y-1">
-        <div className="flex items-center gap-2">
-          <h1 className="text-xl font-semibold">{c.name}</h1>
-          <Badge variant="outline">{type.replace(/s$/, "")}</Badge>
-          {c.status && <Badge variant={c.status === "approved" ? "default" : "secondary"}>{c.status}</Badge>}
-        </div>
-      </div>
+    <>
+      <PageHeader
+        title={isLoading ? "Component" : componentName}
+        breadcrumbs={[
+          { label: "Registry", href: "/" },
+          { label: "Components", href: "/components" },
+          { label: isLoading ? "..." : componentName },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-6">
+        {isLoading ? (
+          <DetailSkeleton />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : !item ? (
+          <ErrorState message="Component not found" />
+        ) : (
+          <>
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 flex-wrap">
+                <Badge variant="outline">{type.replace(/s$/, "")}</Badge>
+                {c.status && <Badge variant={c.status === "approved" ? "default" : "secondary"}>{c.status}</Badge>}
+              </div>
+            </div>
 
-      {c.description && <p className="text-sm">{c.description}</p>}
+            {c.description && <p className="text-sm">{c.description}</p>}
 
-      <div className="grid grid-cols-2 gap-4 text-sm">
-        {c.version && <div><span className="text-muted-foreground">Version:</span> {c.version}</div>}
-        {c.git_url && <div><span className="text-muted-foreground">Source:</span> <a href={c.git_url} className="underline" target="_blank" rel="noopener noreferrer">{c.git_url}</a></div>}
-        {c.transport && <div><span className="text-muted-foreground">Transport:</span> {c.transport}</div>}
-        {c.created_at && <div><span className="text-muted-foreground">Created:</span> {new Date(c.created_at).toLocaleDateString()}</div>}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+              {c.version && <div><span className="text-muted-foreground">Version:</span> {c.version}</div>}
+              {c.git_url && <div><span className="text-muted-foreground">Source:</span> <a href={c.git_url} className="underline" target="_blank" rel="noopener noreferrer">{c.git_url}</a></div>}
+              {c.transport && <div><span className="text-muted-foreground">Transport:</span> {c.transport}</div>}
+              {c.created_at && <div><span className="text-muted-foreground">Created:</span> {new Date(c.created_at).toLocaleDateString()}</div>}
+            </div>
+          </>
+        )}
       </div>
-
-      <div>
-        <Link href="/components" className="text-sm text-muted-foreground hover:text-foreground">
-          Back to components
-        </Link>
-      </div>
-    </div>
+    </>
   );
 }

--- a/web/src/app/(registry)/components/page.tsx
+++ b/web/src/app/(registry)/components/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { Search } from "lucide-react";
+import { Search, Puzzle } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -11,6 +11,10 @@ import type { RegistryType } from "@/lib/api";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 const TYPES: { value: RegistryType; label: string }[] = [
   { value: "mcps", label: "MCPs" },
@@ -21,41 +25,52 @@ const TYPES: { value: RegistryType; label: string }[] = [
 ];
 
 function ComponentTable({ type, search }: { type: RegistryType; search: string }) {
-  const { data, isLoading } = useRegistryList(type, search ? { search } : undefined);
+  const { data, isLoading, isError, error, refetch } = useRegistryList(type, search ? { search } : undefined);
   const items = data ?? [];
 
-  if (isLoading) return <p className="text-sm text-muted-foreground py-4">Loading...</p>;
-  if (items.length === 0) return <p className="text-sm text-muted-foreground py-4">No {type} found</p>;
+  if (isLoading) return <TableSkeleton rows={5} cols={3} />;
+  if (isError) return <ErrorState message={error?.message} onRetry={() => refetch()} />;
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        icon={Puzzle}
+        title={`No ${type} found`}
+        description={search ? `No ${type} match "${search}". Try a different search.` : `No ${type} have been registered yet.`}
+      />
+    );
+  }
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Name</TableHead>
-          <TableHead>Description</TableHead>
-          <TableHead>Status</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {items.map((item: any) => (
-          <TableRow key={item.id}>
-            <TableCell>
-              <Link href={`/components/${item.id}?type=${type}`} className="font-medium hover:underline">
-                {item.name}
-              </Link>
-            </TableCell>
-            <TableCell className="text-muted-foreground text-xs max-w-xs truncate">
-              {item.description ?? "-"}
-            </TableCell>
-            <TableCell>
-              <Badge variant={item.status === "approved" ? "default" : "secondary"}>
-                {item.status}
-              </Badge>
-            </TableCell>
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Description</TableHead>
+            <TableHead>Status</TableHead>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {items.map((item: any) => (
+            <TableRow key={item.id}>
+              <TableCell>
+                <Link href={`/components/${item.id}?type=${type}`} className="font-medium hover:underline">
+                  {item.name}
+                </Link>
+              </TableCell>
+              <TableCell className="text-muted-foreground text-xs max-w-xs truncate">
+                {item.description ?? "-"}
+              </TableCell>
+              <TableCell>
+                <Badge variant={item.status === "approved" ? "default" : "secondary"}>
+                  {item.status}
+                </Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 
@@ -63,31 +78,38 @@ export default function ComponentsPage() {
   const [search, setSearch] = useState("");
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <h1 className="text-xl font-semibold">Components</h1>
+    <>
+      <PageHeader
+        title="Components"
+        breadcrumbs={[
+          { label: "Registry", href: "/" },
+          { label: "Components" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-4">
+        <div className="relative max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search components..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
 
-      <div className="relative max-w-sm">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Search components..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="pl-9"
-        />
-      </div>
-
-      <Tabs defaultValue="mcps">
-        <TabsList>
+        <Tabs defaultValue="mcps">
+          <TabsList>
+            {TYPES.map((t) => (
+              <TabsTrigger key={t.value} value={t.value}>{t.label}</TabsTrigger>
+            ))}
+          </TabsList>
           {TYPES.map((t) => (
-            <TabsTrigger key={t.value} value={t.value}>{t.label}</TabsTrigger>
+            <TabsContent key={t.value} value={t.value} className="mt-4">
+              <ComponentTable type={t.value} search={search} />
+            </TabsContent>
           ))}
-        </TabsList>
-        {TYPES.map((t) => (
-          <TabsContent key={t.value} value={t.value} className="mt-4">
-            <ComponentTable type={t.value} search={search} />
-          </TabsContent>
-        ))}
-      </Tabs>
-    </div>
+        </Tabs>
+      </div>
+    </>
   );
 }

--- a/web/src/app/(registry)/page.tsx
+++ b/web/src/app/(registry)/page.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { useState } from "react";
-import { Search } from "lucide-react";
+import { Search, Bot, TrendingUp } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { AgentCard } from "@/components/registry/agent-card";
 import { useRegistryList, useTopAgents } from "@/hooks/use-api";
 import { useRouter } from "next/navigation";
+import { PageHeader } from "@/components/layouts/page-header";
+import { CardSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
 
 export default function RegistryHome() {
   const [search, setSearch] = useState("");
   const router = useRouter();
-  const { data: agents } = useRegistryList("agents");
-  const { data: topAgents } = useTopAgents();
+  const { data: agents, isLoading: agentsLoading, isError: agentsError, error: agentsErr, refetch: refetchAgents } = useRegistryList("agents");
+  const { data: topAgents, isLoading: topLoading } = useTopAgents();
 
   function handleSearch(e: React.FormEvent) {
     e.preventDefault();
@@ -26,57 +30,84 @@ export default function RegistryHome() {
     .slice(0, 6);
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Agent Registry</h1>
-        <p className="text-sm text-muted-foreground">
-          Browse, install, and evaluate agents across your team.
-        </p>
-      </div>
+    <>
+      <PageHeader
+        title="Agent Registry"
+        breadcrumbs={[
+          { label: "Registry" },
+        ]}
+      />
+      <div className="p-6 max-w-6xl mx-auto space-y-8">
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            Browse, install, and evaluate agents across your team.
+          </p>
+        </div>
 
-      <form onSubmit={handleSearch} className="relative max-w-lg">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Search agents..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="pl-9"
-        />
-      </form>
+        <form onSubmit={handleSearch} className="relative max-w-lg">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search agents..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </form>
 
-      {trending.length > 0 && (
         <section>
           <h2 className="text-sm font-medium text-muted-foreground mb-3">Trending</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-            {trending.map((item: any) => (
-              <AgentCard
-                key={item.id}
-                id={item.id}
-                name={item.name}
-                downloads={item.value}
-              />
-            ))}
-          </div>
+          {topLoading ? (
+            <CardSkeleton count={3} columns={3} />
+          ) : trending.length === 0 ? (
+            <EmptyState
+              icon={TrendingUp}
+              title="No trending agents"
+              description="Agents with the most downloads will appear here."
+            />
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {trending.map((item: any) => (
+                <AgentCard
+                  key={item.id}
+                  id={item.id}
+                  name={item.name}
+                  downloads={item.value}
+                />
+              ))}
+            </div>
+          )}
         </section>
-      )}
 
-      {topRated.length > 0 && (
         <section>
           <h2 className="text-sm font-medium text-muted-foreground mb-3">Top Rated</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-            {topRated.map((agent: any) => (
-              <AgentCard
-                key={agent.id}
-                id={agent.id}
-                name={agent.name}
-                description={agent.description}
-                model_name={agent.model_name}
-                owner={agent.owner}
-              />
-            ))}
-          </div>
+          {agentsLoading ? (
+            <CardSkeleton count={3} columns={3} />
+          ) : agentsError ? (
+            <ErrorState message={agentsErr?.message} onRetry={() => refetchAgents()} />
+          ) : topRated.length === 0 ? (
+            <EmptyState
+              icon={Bot}
+              title="No approved agents"
+              description="Approved agents will appear here. Submit your first agent to get started."
+              actionLabel="Submit an Agent"
+              actionHref="/agents"
+            />
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {topRated.map((agent: any) => (
+                <AgentCard
+                  key={agent.id}
+                  id={agent.id}
+                  name={agent.name}
+                  description={agent.description}
+                  model_name={agent.model_name}
+                  owner={agent.owner}
+                />
+              ))}
+            </div>
+          )}
         </section>
-      )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/web/src/components/registry/pull-command.tsx
+++ b/web/src/components/registry/pull-command.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -30,6 +31,7 @@ export function PullCommand({ agentName }: { agentName: string }) {
   function handleCopy() {
     navigator.clipboard.writeText(command);
     setCopied(true);
+    toast.success("Copied to clipboard");
     setTimeout(() => setCopied(false), 2000);
   }
 

--- a/web/src/components/shared/empty-state.tsx
+++ b/web/src/components/shared/empty-state.tsx
@@ -1,0 +1,46 @@
+import type { LucideIcon } from "lucide-react";
+import { Inbox } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  actionHref?: string;
+  onAction?: () => void;
+}
+
+export function EmptyState({
+  icon: Icon = Inbox,
+  title,
+  description,
+  actionLabel,
+  actionHref,
+  onAction,
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-md border border-dashed py-16">
+      <Icon className="h-10 w-10 text-muted-foreground/50" />
+      <p className="mt-4 text-sm font-medium">{title}</p>
+      {description && (
+        <p className="mt-1 max-w-sm text-center text-xs text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {actionLabel && (actionHref || onAction) && (
+        actionHref ? (
+          <a href={actionHref}>
+            <Button variant="outline" size="sm" className="mt-4">
+              {actionLabel}
+            </Button>
+          </a>
+        ) : (
+          <Button variant="outline" size="sm" className="mt-4" onClick={onAction}>
+            {actionLabel}
+          </Button>
+        )
+      )}
+    </div>
+  );
+}

--- a/web/src/components/shared/error-state.tsx
+++ b/web/src/components/shared/error-state.tsx
@@ -1,0 +1,24 @@
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ErrorStateProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export function ErrorState({ message, onRetry }: ErrorStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-destructive/30 py-16">
+      <AlertCircle className="h-10 w-10 text-destructive/60" />
+      <p className="mt-4 text-sm font-medium">Something went wrong</p>
+      <p className="mt-1 max-w-sm text-center text-xs text-muted-foreground">
+        {message ?? "Failed to load data. Check your connection and try again."}
+      </p>
+      {onRetry && (
+        <Button variant="outline" size="sm" className="mt-4" onClick={onRetry}>
+          <RefreshCw className="mr-1.5 h-3.5 w-3.5" /> Retry
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/shared/skeleton-layouts.tsx
+++ b/web/src/components/shared/skeleton-layouts.tsx
@@ -1,0 +1,73 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Skeleton for table-based list pages (traces, agents, users, review, etc.) */
+export function TableSkeleton({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
+  return (
+    <div className="space-y-3">
+      {/* Header row */}
+      <div className="flex gap-4">
+        {Array.from({ length: cols }).map((_, i) => (
+          <Skeleton key={`h-${i}`} className="h-4 flex-1" />
+        ))}
+      </div>
+      {/* Data rows */}
+      {Array.from({ length: rows }).map((_, r) => (
+        <div key={r} className="flex gap-4">
+          {Array.from({ length: cols }).map((_, c) => (
+            <Skeleton key={`${r}-${c}`} className="h-8 flex-1" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Skeleton for card grids (stat cards, agent cards, etc.) */
+export function CardSkeleton({ count = 4, columns = 4 }: { count?: number; columns?: 3 | 4 }) {
+  const gridClass =
+    columns === 3
+      ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+      : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4";
+  return (
+    <div className={gridClass}>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="border border-border rounded-sm p-4 space-y-2">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-7 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Skeleton for detail pages with a header area and content blocks */
+export function DetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+      <Skeleton className="h-12 w-full" />
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-5/6" />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton for chart / visualization areas */
+export function ChartSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={className}>
+      <Skeleton className="h-3 w-24 mb-3" />
+      <Skeleton className="h-48 w-full rounded-sm" />
+    </div>
+  );
+}

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -6,6 +6,7 @@ import {
   useQueryClient,
   type UseQueryOptions,
 } from "@tanstack/react-query";
+import { toast } from "sonner";
 import {
   auth,
   registry,
@@ -117,7 +118,13 @@ export function useReviewAction() {
       vars.action === "approve"
         ? review.approve(vars.id)
         : review.reject(vars.id, { reason: vars.reason ?? "" }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["review"] }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ["review"] });
+      toast.success(vars.action === "approve" ? "Submission approved" : "Submission rejected");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Review action failed");
+    },
   });
 }
 
@@ -128,7 +135,13 @@ export function useEvalRun() {
   return useMutation({
     mutationFn: (vars: { agentId: string; body?: unknown }) =>
       eval_.run(vars.agentId, vars.body),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["eval"] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["eval"] });
+      toast.success("Eval run started");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Eval run failed");
+    },
   });
 }
 
@@ -168,7 +181,13 @@ export function useSubmitFeedback() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: feedback.submit,
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["feedback"] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["feedback"] });
+      toast.success("Feedback submitted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to submit feedback");
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- **Loading states**: Replace all "Loading..." text with skeleton screens (TableSkeleton, CardSkeleton, DetailSkeleton, ChartSkeleton)
- **Error states**: Add ErrorState component with retry button to every page using TanStack Query
- **Empty states**: Replace plain text with EmptyState component (contextual icons, descriptions, CTA buttons)
- **Breadcrumbs**: Wire PageHeader with breadcrumb trails into all 13 pages
- **Toasts**: Add Sonner notifications for review approve/reject, eval run, feedback submit, clipboard copy, login
- **Responsive**: overflow-x-auto on all tables, consistent responsive grid classes
- **Spacing**: Standardize to max-w-6xl/p-6/gap-4 across all pages

3 new shared components, 16 files modified, zero new dependencies.

## Test plan
- [x] `next build` passes cleanly (15 routes, 0 errors)
- [ ] Verify skeleton screens appear during loading on dashboard, traces, agents pages
- [ ] Verify error state renders when API is down
- [ ] Verify empty states show on pages with no data
- [ ] Verify breadcrumbs navigate correctly
- [ ] Verify toasts fire on review approve, eval run, clipboard copy
- [ ] Verify tables scroll horizontally on narrow viewport