### PR TITLE
refactor: nest CLI commands into registry and self groups

### DIFF
--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -17,218 +17,311 @@ from observal_cli.render import (
     status_badge,
 )
 
+_DEPRECATION_TPL = (
+    "[yellow]Warning:[/yellow] [dim]`observal {old}` is deprecated. "
+    "Use `observal {new}` instead.[/dim]\n"
+)
 
-def register_mcp(app: typer.Typer):
+mcp_app = typer.Typer(help="MCP server registry commands")
 
-    @app.command()
-    def submit(
+
+# ── Implementation functions (shared by canonical + deprecated) ──
+
+
+def _submit_impl(git_url, name, category, yes):
+    with spinner("Analyzing repository..."):
+        try:
+            prefill = client.post("/api/v1/mcps/analyze", {"git_url": git_url})
+        except (Exception, SystemExit):
+            rprint("[yellow]Could not analyze repo: fill in details manually.[/yellow]")
+            prefill = {}
+
+    if prefill.get("tools"):
+        rprint(f"\n[bold]Detected {len(prefill['tools'])} tools:[/bold]")
+        for t in prefill["tools"][:10]:
+            rprint(f"  [cyan]•[/cyan] {t.get('name', '?')}: {t.get('description', '')[:60]}")
+        if len(prefill["tools"]) > 10:
+            rprint(f"  [dim]...and {len(prefill['tools']) - 10} more[/dim]")
+        rprint()
+
+    _name = name or (prefill.get("name", "") if yes else typer.prompt("Name", default=prefill.get("name", "")))
+    _version = (
+        prefill.get("version", "0.1.0") if yes else typer.prompt("Version", default=prefill.get("version", "0.1.0"))
+    )
+    _category = category or ("general" if yes else typer.prompt("Category"))
+    _desc = (
+        prefill.get("description", "")
+        if yes
+        else typer.prompt("Description", default=prefill.get("description", ""))
+    )
+    _owner = typer.prompt("Owner / Team") if not yes else "default"
+
+    ide_choices = ["vscode", "cursor", "kiro", "claude_code", "gemini_cli"]
+    if not yes:
+        rprint(f"[dim]IDEs: {', '.join(ide_choices)}[/dim]")
+        ides_input = typer.prompt("Supported IDEs (comma-separated)", default=",".join(ide_choices))
+    else:
+        ides_input = ",".join(ide_choices)
+    supported_ides = [i.strip() for i in ides_input.split(",") if i.strip()]
+
+    _setup = "" if yes else typer.prompt("Setup instructions", default="")
+    _changelog = "Initial release" if yes else typer.prompt("Changelog", default="Initial release")
+
+    with spinner("Submitting..."):
+        result = client.post(
+            "/api/v1/mcps/submit",
+            {
+                "git_url": git_url,
+                "name": _name,
+                "version": _version,
+                "category": _category,
+                "description": _desc,
+                "owner": _owner,
+                "supported_ides": supported_ides,
+                "setup_instructions": _setup,
+                "changelog": _changelog,
+            },
+        )
+    rprint(f"\n[green]✓ Submitted![/green] ID: [bold]{result['id']}[/bold]")
+    rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
+
+
+def _list_impl(category, search, limit, sort, output):
+    params = {}
+    if category:
+        params["category"] = category
+    if search:
+        params["search"] = search
+
+    with spinner("Fetching MCP servers..."):
+        data = client.get("/api/v1/mcps", params=params)
+
+    if not data:
+        rprint("[dim]No MCP servers found.[/dim]")
+        return
+
+    # Sort
+    key_map = {"name": "name", "category": "category", "version": "version"}
+    sk = key_map.get(sort, "name")
+    data = sorted(data, key=lambda x: x.get(sk, ""))[:limit]
+
+    # Cache IDs for numeric shorthand
+    config.save_last_results(data)
+
+    if output == "json":
+        output_json(data)
+        return
+
+    if output == "plain":
+        for item in data:
+            rprint(f"{item['id']}  {item['name']}  v{item.get('version', '?')}  [{item.get('category', '')}]")
+        return
+
+    table = Table(title=f"MCP Servers ({len(data)})", show_lines=False, padding=(0, 1))
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Name", style="bold cyan", no_wrap=True)
+    table.add_column("Version", style="green")
+    table.add_column("Category")
+    table.add_column("Owner", style="dim")
+    table.add_column("IDEs")
+    table.add_column("ID", style="dim", max_width=12)
+    for i, item in enumerate(data, 1):
+        table.add_row(
+            str(i),
+            item["name"],
+            item.get("version", ""),
+            item.get("category", ""),
+            item.get("owner", ""),
+            ide_tags(item.get("supported_ides", [])),
+            str(item["id"])[:8] + "…",
+        )
+    console.print(table)
+
+
+def _show_impl(mcp_id, output):
+    resolved = config.resolve_alias(mcp_id)
+    with spinner():
+        item = client.get(f"/api/v1/mcps/{resolved}")
+
+    if output == "json":
+        output_json(item)
+        return
+
+    console.print(
+        kv_panel(
+            f"{item['name']} v{item.get('version', '?')}",
+            [
+                ("Status", status_badge(item.get("status", ""))),
+                ("Category", item.get("category", "N/A")),
+                ("Owner", item.get("owner", "N/A")),
+                ("Description", item.get("description", "")),
+                ("IDEs", ide_tags(item.get("supported_ides", []))),
+                ("Git", f"[link={item.get('git_url', '')}]{item.get('git_url', 'N/A')}[/link]"),
+                ("Setup", item.get("setup_instructions") or "[dim]none[/dim]"),
+                ("Changelog", item.get("changelog") or "[dim]none[/dim]"),
+                ("Created", relative_time(item.get("created_at"))),
+                ("ID", f"[dim]{item['id']}[/dim]"),
+            ],
+            border_style="cyan",
+        )
+    )
+
+    if item.get("validation_results"):
+        rprint("\n[bold]Validation:[/bold]")
+        for v in item["validation_results"]:
+            icon = "[green]✓[/green]" if v["passed"] else "[red]✗[/red]"
+            rprint(f"  {icon} {v['stage']}: {v.get('details', '') or 'passed'}")
+
+
+def _install_impl(mcp_id, ide, raw):
+    import json as _json
+
+    resolved = config.resolve_alias(mcp_id)
+    with spinner(f"Generating {ide} config..."):
+        result = client.post(f"/api/v1/mcps/{resolved}/install", {"ide": ide})
+
+    snippet = result.get("config_snippet", {})
+    if raw:
+        print(_json.dumps(snippet, indent=2))
+        return
+
+    _IDE_CONFIG_PATHS = {
+        "kiro": ".kiro/settings/mcp.json",
+        "cursor": ".cursor/mcp.json",
+        "vscode": ".vscode/mcp.json",
+        "claude-code": "(run the command below)",
+        "claude_code": "(run the command below)",
+        "gemini-cli": ".gemini/settings.json",
+        "gemini_cli": ".gemini/settings.json",
+    }
+
+    rprint(f"\n[bold]Config for {ide}:[/bold]\n")
+    console.print_json(_json.dumps(snippet, indent=2))
+    config_path = _IDE_CONFIG_PATHS.get(ide, "")
+    if config_path and not config_path.startswith("("):
+        rprint(f"\n[dim]Add to:[/dim] [bold]{config_path}[/bold]")
+        rprint(f"[dim]Or pipe:[/dim] observal install {mcp_id} --ide {ide} --raw > {config_path}")
+
+
+def _delete_impl(mcp_id, yes):
+    resolved = config.resolve_alias(mcp_id)
+    if not yes:
+        with spinner():
+            item = client.get(f"/api/v1/mcps/{resolved}")
+        if not typer.confirm(f"Delete [bold]{item['name']}[/bold] ({resolved})?"):
+            raise typer.Abort()
+    with spinner("Deleting..."):
+        client.delete(f"/api/v1/mcps/{resolved}")
+    rprint(f"[green]✓ Deleted {resolved}[/green]")
+
+
+# ── Canonical commands (on mcp_app) ─────────────────────────
+
+
+@mcp_app.command()
+def submit(
+    git_url: str = typer.Argument(..., help="Git repository URL"),
+    name: str = typer.Option(None, "--name", "-n", help="Skip name prompt"),
+    category: str = typer.Option(None, "--category", "-c", help="Skip category prompt"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Accept defaults from repo analysis"),
+):
+    """Submit an MCP server for review."""
+    _submit_impl(git_url, name, category, yes)
+
+
+@mcp_app.command(name="list")
+def list_mcps(
+    category: str | None = typer.Option(None, "--category", "-c", help="Filter by category"),
+    search: str | None = typer.Option(None, "--search", "-s", help="Search by name/description"),
+    limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
+    sort: str = typer.Option("name", "--sort", help="Sort by: name, category, version"),
+    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+):
+    """List approved MCP servers."""
+    _list_impl(category, search, limit, sort, output)
+
+
+@mcp_app.command()
+def show(
+    mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    output: str = typer.Option("table", "--output", "-o", help="Output: table, json"),
+):
+    """Show full details of an MCP server."""
+    _show_impl(mcp_id, output)
+
+
+@mcp_app.command()
+def install(
+    mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    ide: str = typer.Option(..., "--ide", "-i", help="Target IDE"),
+    raw: bool = typer.Option(False, "--raw", help="Output raw JSON only (for piping)"),
+):
+    """Get install config snippet for an MCP server."""
+    _install_impl(mcp_id, ide, raw)
+
+
+@mcp_app.command(name="delete")
+def delete_mcp(
+    mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+):
+    """Delete an MCP server."""
+    _delete_impl(mcp_id, yes)
+
+
+# ── Deprecated root-level aliases ────────────────────────────
+
+
+def register_deprecated_mcp(app: typer.Typer):
+    """Register deprecated bare root-level MCP commands (submit, list, show, install, delete)."""
+
+    @app.command(name="submit", hidden=True)
+    def deprecated_submit(
         git_url: str = typer.Argument(..., help="Git repository URL"),
         name: str = typer.Option(None, "--name", "-n", help="Skip name prompt"),
         category: str = typer.Option(None, "--category", "-c", help="Skip category prompt"),
         yes: bool = typer.Option(False, "--yes", "-y", help="Accept defaults from repo analysis"),
     ):
-        """Submit an MCP server for review."""
-        with spinner("Analyzing repository..."):
-            try:
-                prefill = client.post("/api/v1/mcps/analyze", {"git_url": git_url})
-            except (Exception, SystemExit):
-                rprint("[yellow]Could not analyze repo: fill in details manually.[/yellow]")
-                prefill = {}
+        """(Deprecated) Use `observal registry mcp submit` instead."""
+        rprint(_DEPRECATION_TPL.format(old="submit", new="registry mcp submit"))
+        _submit_impl(git_url, name, category, yes)
 
-        if prefill.get("tools"):
-            rprint(f"\n[bold]Detected {len(prefill['tools'])} tools:[/bold]")
-            for t in prefill["tools"][:10]:
-                rprint(f"  [cyan]•[/cyan] {t.get('name', '?')}: {t.get('description', '')[:60]}")
-            if len(prefill["tools"]) > 10:
-                rprint(f"  [dim]...and {len(prefill['tools']) - 10} more[/dim]")
-            rprint()
-
-        _name = name or (prefill.get("name", "") if yes else typer.prompt("Name", default=prefill.get("name", "")))
-        _version = (
-            prefill.get("version", "0.1.0") if yes else typer.prompt("Version", default=prefill.get("version", "0.1.0"))
-        )
-        _category = category or ("general" if yes else typer.prompt("Category"))
-        _desc = (
-            prefill.get("description", "")
-            if yes
-            else typer.prompt("Description", default=prefill.get("description", ""))
-        )
-        _owner = typer.prompt("Owner / Team") if not yes else "default"
-
-        ide_choices = ["vscode", "cursor", "kiro", "claude_code", "gemini_cli"]
-        if not yes:
-            rprint(f"[dim]IDEs: {', '.join(ide_choices)}[/dim]")
-            ides_input = typer.prompt("Supported IDEs (comma-separated)", default=",".join(ide_choices))
-        else:
-            ides_input = ",".join(ide_choices)
-        supported_ides = [i.strip() for i in ides_input.split(",") if i.strip()]
-
-        _setup = "" if yes else typer.prompt("Setup instructions", default="")
-        _changelog = "Initial release" if yes else typer.prompt("Changelog", default="Initial release")
-
-        with spinner("Submitting..."):
-            result = client.post(
-                "/api/v1/mcps/submit",
-                {
-                    "git_url": git_url,
-                    "name": _name,
-                    "version": _version,
-                    "category": _category,
-                    "description": _desc,
-                    "owner": _owner,
-                    "supported_ides": supported_ides,
-                    "setup_instructions": _setup,
-                    "changelog": _changelog,
-                },
-            )
-        rprint(f"\n[green]✓ Submitted![/green] ID: [bold]{result['id']}[/bold]")
-        rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
-
-    @app.command(name="list")
-    def list_mcps(
+    @app.command(name="list", hidden=True)
+    def deprecated_list(
         category: str | None = typer.Option(None, "--category", "-c", help="Filter by category"),
         search: str | None = typer.Option(None, "--search", "-s", help="Search by name/description"),
         limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
         sort: str = typer.Option("name", "--sort", help="Sort by: name, category, version"),
         output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
     ):
-        """List approved MCP servers."""
-        params = {}
-        if category:
-            params["category"] = category
-        if search:
-            params["search"] = search
+        """(Deprecated) Use `observal registry mcp list` instead."""
+        rprint(_DEPRECATION_TPL.format(old="list", new="registry mcp list"))
+        _list_impl(category, search, limit, sort, output)
 
-        with spinner("Fetching MCP servers..."):
-            data = client.get("/api/v1/mcps", params=params)
-
-        if not data:
-            rprint("[dim]No MCP servers found.[/dim]")
-            return
-
-        # Sort
-        key_map = {"name": "name", "category": "category", "version": "version"}
-        sk = key_map.get(sort, "name")
-        data = sorted(data, key=lambda x: x.get(sk, ""))[:limit]
-
-        # Cache IDs for numeric shorthand (observal show 1, observal install 2 --ide kiro)
-        config.save_last_results(data)
-
-        if output == "json":
-            output_json(data)
-            return
-
-        if output == "plain":
-            for item in data:
-                rprint(f"{item['id']}  {item['name']}  v{item.get('version', '?')}  [{item.get('category', '')}]")
-            return
-
-        table = Table(title=f"MCP Servers ({len(data)})", show_lines=False, padding=(0, 1))
-        table.add_column("#", style="dim", width=3)
-        table.add_column("Name", style="bold cyan", no_wrap=True)
-        table.add_column("Version", style="green")
-        table.add_column("Category")
-        table.add_column("Owner", style="dim")
-        table.add_column("IDEs")
-        table.add_column("ID", style="dim", max_width=12)
-        for i, item in enumerate(data, 1):
-            table.add_row(
-                str(i),
-                item["name"],
-                item.get("version", ""),
-                item.get("category", ""),
-                item.get("owner", ""),
-                ide_tags(item.get("supported_ides", [])),
-                str(item["id"])[:8] + "…",
-            )
-        console.print(table)
-
-    @app.command()
-    def show(
+    @app.command(name="show", hidden=True)
+    def deprecated_show(
         mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
         output: str = typer.Option("table", "--output", "-o", help="Output: table, json"),
     ):
-        """Show full details of an MCP server."""
-        resolved = config.resolve_alias(mcp_id)
-        with spinner():
-            item = client.get(f"/api/v1/mcps/{resolved}")
+        """(Deprecated) Use `observal registry mcp show` instead."""
+        rprint(_DEPRECATION_TPL.format(old="show", new="registry mcp show"))
+        _show_impl(mcp_id, output)
 
-        if output == "json":
-            output_json(item)
-            return
-
-        console.print(
-            kv_panel(
-                f"{item['name']} v{item.get('version', '?')}",
-                [
-                    ("Status", status_badge(item.get("status", ""))),
-                    ("Category", item.get("category", "N/A")),
-                    ("Owner", item.get("owner", "N/A")),
-                    ("Description", item.get("description", "")),
-                    ("IDEs", ide_tags(item.get("supported_ides", []))),
-                    ("Git", f"[link={item.get('git_url', '')}]{item.get('git_url', 'N/A')}[/link]"),
-                    ("Setup", item.get("setup_instructions") or "[dim]none[/dim]"),
-                    ("Changelog", item.get("changelog") or "[dim]none[/dim]"),
-                    ("Created", relative_time(item.get("created_at"))),
-                    ("ID", f"[dim]{item['id']}[/dim]"),
-                ],
-                border_style="cyan",
-            )
-        )
-
-        if item.get("validation_results"):
-            rprint("\n[bold]Validation:[/bold]")
-            for v in item["validation_results"]:
-                icon = "[green]✓[/green]" if v["passed"] else "[red]✗[/red]"
-                rprint(f"  {icon} {v['stage']}: {v.get('details', '') or 'passed'}")
-
-    @app.command()
-    def install(
+    @app.command(name="install", hidden=True)
+    def deprecated_install(
         mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
         ide: str = typer.Option(..., "--ide", "-i", help="Target IDE"),
         raw: bool = typer.Option(False, "--raw", help="Output raw JSON only (for piping)"),
     ):
-        """Get install config snippet for an MCP server."""
-        import json as _json
+        """(Deprecated) Use `observal registry mcp install` instead."""
+        rprint(_DEPRECATION_TPL.format(old="install", new="registry mcp install"))
+        _install_impl(mcp_id, ide, raw)
 
-        resolved = config.resolve_alias(mcp_id)
-        with spinner(f"Generating {ide} config..."):
-            result = client.post(f"/api/v1/mcps/{resolved}/install", {"ide": ide})
-
-        snippet = result.get("config_snippet", {})
-        if raw:
-            print(_json.dumps(snippet, indent=2))
-            return
-
-        _IDE_CONFIG_PATHS = {
-            "kiro": ".kiro/settings/mcp.json",
-            "cursor": ".cursor/mcp.json",
-            "vscode": ".vscode/mcp.json",
-            "claude-code": "(run the command below)",
-            "claude_code": "(run the command below)",
-            "gemini-cli": ".gemini/settings.json",
-            "gemini_cli": ".gemini/settings.json",
-        }
-
-        rprint(f"\n[bold]Config for {ide}:[/bold]\n")
-        console.print_json(_json.dumps(snippet, indent=2))
-        config_path = _IDE_CONFIG_PATHS.get(ide, "")
-        if config_path and not config_path.startswith("("):
-            rprint(f"\n[dim]Add to:[/dim] [bold]{config_path}[/bold]")
-            rprint(f"[dim]Or pipe:[/dim] observal install {mcp_id} --ide {ide} --raw > {config_path}")
-
-    @app.command(name="delete")
-    def delete_mcp(
+    @app.command(name="delete", hidden=True)
+    def deprecated_delete(
         mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
     ):
-        """Delete an MCP server."""
-        resolved = config.resolve_alias(mcp_id)
-        if not yes:
-            with spinner():
-                item = client.get(f"/api/v1/mcps/{resolved}")
-            if not typer.confirm(f"Delete [bold]{item['name']}[/bold] ({resolved})?"):
-                raise typer.Abort()
-        with spinner("Deleting..."):
-            client.delete(f"/api/v1/mcps/{resolved}")
-        rprint(f"[green]✓ Deleted {resolved}[/green]")
+        """(Deprecated) Use `observal registry mcp delete` instead."""
+        rprint(_DEPRECATION_TPL.format(old="delete", new="registry mcp delete"))
+        _delete_impl(mcp_id, yes)

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -902,7 +902,15 @@ def _spans_impl(trace_id, output):
     console.print(table)
 
 
-# ── Upgrade / Downgrade (stays at root) ─────────────────
+# ═══════════════════════════════════════════════════════════
+# self_app — CLI self-management commands
+# ═══════════════════════════════════════════════════════════
+
+self_app = typer.Typer(
+    name="self",
+    help="CLI self-management commands (upgrade, downgrade)",
+    no_args_is_help=True,
+)
 
 
 def _upgrade_impl():
@@ -931,16 +939,31 @@ def _downgrade_impl():
     rprint("[dim]Track: https://github.com/BlazeUp-AI/Observal/issues/19[/dim]")
 
 
-def register_lifecycle(app: typer.Typer):
+@self_app.command()
+def upgrade():
+    """Upgrade observal CLI to the latest version."""
+    _upgrade_impl()
 
-    @app.command()
-    def upgrade():
-        """Upgrade observal CLI to the latest version."""
+
+@self_app.command()
+def downgrade():
+    """Downgrade observal CLI to a previous version."""
+    _downgrade_impl()
+
+
+def register_deprecated_lifecycle(app: typer.Typer):
+    """Register deprecated root-level upgrade/downgrade aliases."""
+
+    @app.command(name="upgrade", hidden=True)
+    def deprecated_upgrade():
+        """(Deprecated) Use `observal self upgrade` instead."""
+        rprint(_DEPRECATION_TPL.format(old="upgrade", new="self upgrade"))
         _upgrade_impl()
 
-    @app.command()
-    def downgrade():
-        """Downgrade observal CLI to a previous version."""
+    @app.command(name="downgrade", hidden=True)
+    def deprecated_downgrade():
+        """(Deprecated) Use `observal self downgrade` instead."""
+        rprint(_DEPRECATION_TPL.format(old="downgrade", new="self downgrade"))
         _downgrade_impl()
 
 

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -14,8 +14,6 @@ from rich.table import Table
 from observal_cli import client
 from observal_cli.render import console, spinner
 
-scan_app = typer.Typer(help="Scan and instrument existing IDE configs")
-
 # IDE config file locations (relative to project root)
 _IDE_MCP_CONFIGS = {
     "cursor": ".cursor/mcp.json",
@@ -80,7 +78,6 @@ def _backup_config(config_path: Path) -> Path:
 
 
 def register_scan(app: typer.Typer):
-    app.add_typer(scan_app, name="scan")
 
     @app.command(name="scan")
     def scan(

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -43,23 +43,40 @@ def main(
 from observal_cli.cmd_agent import agent_app
 from observal_cli.cmd_auth import auth_app, register_config, register_deprecated_auth
 from observal_cli.cmd_doctor import doctor_app
-from observal_cli.cmd_hook import register_hook
-from observal_cli.cmd_mcp import register_mcp
+from observal_cli.cmd_hook import hook_app
+from observal_cli.cmd_mcp import mcp_app, register_deprecated_mcp
 from observal_cli.cmd_ops import (
     admin_app,
     ops_app,
     register_deprecated_admin,
+    register_deprecated_lifecycle,
     register_deprecated_ops,
-    register_lifecycle,
+    self_app,
 )
 from observal_cli.cmd_profile import register_use
-from observal_cli.cmd_prompt import register_prompt
+from observal_cli.cmd_prompt import prompt_app
 from observal_cli.cmd_pull import register_pull
-from observal_cli.cmd_sandbox import register_sandbox
+from observal_cli.cmd_sandbox import sandbox_app
 from observal_cli.cmd_scan import register_scan
-from observal_cli.cmd_skill import register_skill
+from observal_cli.cmd_skill import skill_app
 
-# ── Auth subgroup (new canonical location) ────────────────
+# ═══════════════════════════════════════════════════════════
+# registry_app — Component registry parent group
+# ═══════════════════════════════════════════════════════════
+
+registry_app = typer.Typer(
+    name="registry",
+    help="Component registry (MCPs, skills, hooks, prompts, sandboxes)",
+    no_args_is_help=True,
+)
+
+registry_app.add_typer(mcp_app, name="mcp")
+registry_app.add_typer(skill_app, name="skill")
+registry_app.add_typer(hook_app, name="hook")
+registry_app.add_typer(prompt_app, name="prompt")
+registry_app.add_typer(sandbox_app, name="sandbox")
+
+# ── Auth subgroup (canonical) ────────────────────────────
 app.add_typer(auth_app, name="auth")
 
 # ── Deprecated root-level auth aliases (backward compat) ──
@@ -67,25 +84,41 @@ register_deprecated_auth(app)
 
 # ── Primary user workflows (root) ─────────────────────────
 register_config(app)
-register_mcp(app)
-register_skill(app)
-register_hook(app)
-register_prompt(app)
-register_sandbox(app)
 register_pull(app)
 register_scan(app)
 register_use(app)
-register_lifecycle(app)
 
 # ── Subgroups ─────────────────────────────────────────────
+app.add_typer(registry_app, name="registry")
 app.add_typer(agent_app, name="agent")
 app.add_typer(ops_app, name="ops")
 app.add_typer(admin_app, name="admin")
+app.add_typer(self_app, name="self")
 app.add_typer(doctor_app, name="doctor")
 
-# ── Deprecated root-level ops/admin aliases ───────────────
+# ═══════════════════════════════════════════════════════════
+# Deprecated root-level aliases (hidden, print deprecation)
+# ═══════════════════════════════════════════════════════════
+
+# Deprecated bare MCP commands at root (submit, list, show, install, delete)
+register_deprecated_mcp(app)
+
+# Deprecated root-level ops/admin aliases
 register_deprecated_ops(app)
 register_deprecated_admin(app)
+
+# Deprecated root-level upgrade/downgrade
+register_deprecated_lifecycle(app)
+
+
+# Deprecated root-level component subgroup aliases
+# (observal skill → observal registry skill, etc.)
+# Register the real apps as hidden at root for backward compatibility.
+# Commands still work, they're just hidden from --help.
+app.add_typer(skill_app, name="skill", hidden=True)
+app.add_typer(hook_app, name="hook", hidden=True)
+app.add_typer(prompt_app, name="prompt", hidden=True)
+app.add_typer(sandbox_app, name="sandbox", hidden=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Creates `observal registry` parent group containing all 5 component types (mcp, skill, hook, prompt, sandbox) as nested subgroups
- Converts bare root-level MCP commands (submit, list, show, install, delete) into proper `mcp_app` Typer subgroup under registry
- Creates `observal self` group for CLI lifecycle commands (upgrade, downgrade)
- All old command paths still work via hidden deprecated aliases for backward compatibility

## New CLI structure
```
observal registry mcp submit/list/show/install/delete
observal registry skill submit/list/show/install/delete
observal registry hook submit/list/show/install/delete
observal registry prompt submit/list/show/install/delete/render
observal registry sandbox submit/list/show/install/delete
observal self upgrade/downgrade
```

## Files changed
- `observal_cli/cmd_mcp.py` — refactored from `register_mcp(app)` to `mcp_app` Typer subgroup with `_impl` functions shared between canonical and deprecated commands
- `observal_cli/cmd_ops.py` — extracted `self_app` for upgrade/downgrade, added `register_deprecated_lifecycle`
- `observal_cli/cmd_scan.py` — removed unused empty `scan_app` subgroup
- `observal_cli/main.py` — created `registry_app` parent, rewired all imports, added hidden backward-compat aliases

## Test plan
- [x] `observal --help` shows clean top-level with registry, self, agent, ops, admin, doctor groups
- [x] `observal registry --help` shows mcp, skill, hook, prompt, sandbox subgroups
- [x] `observal registry mcp --help` shows submit, list, show, install, delete commands
- [x] `observal self --help` shows upgrade, downgrade
- [x] Deprecated paths still work: `observal skill list`, `observal upgrade`, `observal submit`
- [x] All 35 CLI tests pass