### PR TITLE
docs: rewrite README and AGENTS.md to current state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,42 @@ Observal is an agent-centric registry and observability platform for AI coding a
 
 All API routes accept either UUID or name for path parameters. Admin review controls public registry visibility only. Submitters can install and use their own items immediately without approval.
 
-The web frontend is a Next.js 16 / React 19 app in `web/`. It uses three route groups: `(auth)` for login, `(registry)` for the public-facing agent browser and component library, and `(admin)` for the admin dashboard, traces, eval, review, and user management. It uses shadcn/ui components, Recharts for charts, TanStack Query for data fetching, and TanStack Table for sortable/filterable tables. Shared API response types live in `web/src/lib/types.ts`. The GraphQL API at `/api/v1/graphql` is the read layer for telemetry data; REST endpoints serve everything else.
+The MCP validator supports multiple frameworks: FastMCP, standard MCP SDK (Python), TypeScript SDK (`@modelcontextprotocol/sdk`), and Go SDK (`mcp-go`). There is no framework enforcement — all MCP implementations are accepted.
+
+The web frontend is a Next.js 16 / React 19 app in `web/`. It uses three route groups: `(auth)` for login, `(registry)` for the public-facing agent browser, component library, and agent builder, and `(admin)` for the admin dashboard, traces, eval, review, and user management. The frontend has a custom OKLCH design system with 5 themes (light, dark, midnight, forest, sunset), three typefaces (Archivo for display, Albert Sans for body, JetBrains Mono for code), and a 4pt spacing scale. It uses shadcn/ui components, Recharts for charts, TanStack Query for data fetching, and TanStack Table for sortable/filterable tables. Shared API response types live in `web/src/lib/types.ts`. The GraphQL API at `/api/v1/graphql` is the read layer for telemetry data; REST endpoints serve everything else.
+
+## CLI structure
+
+The CLI is organized into nested command groups:
+
+```
+observal
+├── pull                     # install complete agent (primary workflow)
+├── scan                     # detect and instrument IDE configs
+├── use / profile            # swap IDE configs from git-hosted profiles
+├── auth                     # init, login, logout, whoami, status
+├── config                   # show, set, path, alias, aliases
+├── registry                 # component registry parent group
+│   ├── mcp                  #   submit, list, show, install, delete
+│   ├── skill                #   submit, list, show, install, delete
+│   ├── hook                 #   submit, list, show, install, delete
+│   ├── prompt               #   submit, list, show, install, render, delete
+│   └── sandbox              #   submit, list, show, install, delete
+├── agent                    # create, list, show, install, delete, init, add, build, publish
+├── ops                      # observability commands
+│   ├── overview, metrics, top, traces, spans
+│   ├── rate, feedback
+│   └── telemetry            #   status, test
+├── admin                    # admin commands
+│   ├── settings, set, users
+│   ├── penalties, penalty-set, weights, weight-set
+│   ├── review               #   list, show, approve, reject
+│   └── eval                 #   run, scorecards, show, compare, aggregate
+├── self                     # upgrade, downgrade
+└── doctor                   # diagnose IDE settings compatibility
+```
+
+Deprecated root-level aliases exist for backward compatibility (e.g. `observal submit` → `observal registry mcp submit`, `observal upgrade` → `observal self upgrade`). These are hidden from `--help` and print deprecation warnings.
 
 ## Commands
 
@@ -21,9 +56,9 @@ make logs                # tail logs
 
 # CLI (installed via uv)
 uv tool install --editable .
-observal init            # first-run admin setup
-observal whoami          # check auth
-observal status          # server health check
+observal auth init       # first-run admin setup
+observal auth whoami     # check auth
+observal auth status     # server health check
 
 # Linting
 make lint                # ruff check
@@ -58,8 +93,8 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 - `api/routes/telemetry.py` : `POST /ingest` (batch traces/spans/scores) + legacy `/events` + `POST /hooks` (raw IDE hook JSON)
 - `api/routes/dashboard.py` : MCP metrics, agent metrics, overview stats, top items, trends
 - `api/routes/feedback.py` : Ratings with dual-write to PostgreSQL + ClickHouse scores table
-- `api/routes/eval.py` : Run evals, list scorecards, compare versions
-- `api/routes/admin.py` : Enterprise settings CRUD, user management, role changes
+- `api/routes/eval.py` : Run evals, list scorecards, compare versions, aggregate stats
+- `api/routes/admin.py` : Enterprise settings CRUD, user management, role changes, penalty catalog, dimension weights
 - `api/routes/alert.py` : Alert rule CRUD (metric threshold alerts with webhook URLs)
 - `api/routes/scan.py` : `POST /api/v1/scan` bulk registration from IDE config scans; deduplicates by name
 
@@ -92,7 +127,7 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 - `sandbox_config_generator.py` : Wraps sandbox execution with `observal-sandbox-run` entry point
 - `skill_config_generator.py` : Emits SessionStart/End hooks for skill activation telemetry
 - `hook_config_generator.py` : Generates IDE-specific HTTP hook configs (Claude Code, Kiro, Cursor)
-- `mcp_validator.py` : 2-stage validation: clone+inspect (git clone, find entry point, parse AST for FastMCP tools) + manifest validation
+- `mcp_validator.py` : 2-stage validation: clone+inspect (git clone, find entry point, detect framework) + manifest validation. Detects FastMCP, standard MCP SDK (Python), TypeScript SDK, and Go SDK. No framework enforcement.
 - `eval_engine.py` : `EvalBackend` ABC; `LLMJudgeBackend` (Bedrock/OpenAI); `FallbackBackend` (deterministic); 6 managed prompt templates
 - `eval_service.py` : Orchestrates eval runs: fetch traces, run backend, create scorecards
 
@@ -103,16 +138,19 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 
 ### CLI (`observal_cli/`)
 
-- `main.py` : Typer app wiring; imports and registers all command modules
-- `cmd_auth.py` : init, login, logout, whoami, status, version; `config` subcommand (show, set, path, alias, aliases)
-- `cmd_mcp.py` : submit (with --yes for non-interactive), list (--sort, --limit, --output), show, install (--raw), delete
-- `cmd_agent.py` : create (--from-file), list, show, install, delete; new: pull, init, add, build, test, publish
-- `cmd_skill.py` : submit, list, show, install, delete
-- `cmd_hook.py` : submit, list, show, install, delete
-- `cmd_prompt.py` : submit, list, show, install, render, delete
-- `cmd_sandbox.py` : submit, list, show, install, delete
+- `main.py` : Typer app wiring; creates `registry_app` parent group (mcp, skill, hook, prompt, sandbox), registers all command modules, adds deprecated backward-compat aliases
+- `cmd_auth.py` : `auth_app` subgroup: init, login, logout, whoami, status. Also `config_app` subgroup: show, set, path, alias, aliases. `register_deprecated_auth()` adds hidden root-level aliases
+- `cmd_mcp.py` : `mcp_app` subgroup: submit (with --yes for non-interactive), list (--sort, --limit, --output), show, install (--raw), delete. `register_deprecated_mcp()` adds hidden root-level bare aliases (submit, list, show, install, delete)
+- `cmd_agent.py` : `agent_app` subgroup: create (--from-file), list, show, install, delete; authoring: init, add, build, publish
+- `cmd_skill.py` : `skill_app` subgroup: submit, list, show, install, delete
+- `cmd_hook.py` : `hook_app` subgroup: submit, list, show, install, delete
+- `cmd_prompt.py` : `prompt_app` subgroup: submit, list, show, install, render, delete
+- `cmd_sandbox.py` : `sandbox_app` subgroup: submit, list, show, install, delete
 - `cmd_scan.py` : `observal scan`: auto-detect IDE configs (Cursor, Kiro, VS Code, Claude Code, Gemini CLI), bulk-register MCPs, wrap with observal-shim; `--dry-run`, `--ide`, `--yes` flags
-- `cmd_ops.py` : review, telemetry, dashboard (overview, metrics --watch, top), feedback, eval (run, scorecards, show, compare), admin, traces, spans, upgrade/downgrade
+- `cmd_pull.py` : `observal pull`: fetch agent config from server, write IDE files (rules, MCP config, agent files) to disk; `--dry-run`, `--dir` flags; merges MCP configs with existing files
+- `cmd_profile.py` : `observal use` + `observal profile`: swap IDE configs from git-hosted profiles; clones/caches profiles, backs up current config, restores via `observal use default`
+- `cmd_ops.py` : `ops_app` subgroup: overview, metrics (--watch), top, traces, spans, rate, feedback. Contains `telemetry_app` (status, test). Also `admin_app` subgroup: settings, set, users, penalties, penalty-set, weights, weight-set. Contains `review_app` (list, show, approve, reject) and `eval_app` (run, scorecards, show, compare, aggregate). Also `self_app` subgroup: upgrade, downgrade. `register_deprecated_ops/admin/lifecycle()` add hidden root-level aliases
+- `cmd_doctor.py` : `doctor_app`: diagnose IDE settings for Observal compatibility; checks Observal config, server connectivity, IDE configs (Claude Code, Kiro, Cursor, Gemini CLI), env vars, Docker availability, entry points; `--ide` to target specific IDE, `--fix` to show suggested fixes
 - `client.py` : httpx wrapper with get/post/put/delete/health; contextual error messages per status code
 - `config.py` : ~/.observal/config.json management; alias system (@name -> UUID resolution)
 - `render.py` : Shared Rich rendering: status badges, relative timestamps, IDE color tags, star ratings, kv panels, spinners
@@ -150,6 +188,8 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 
 ### Web Frontend (`web/`)
 
+**Design system:** OKLCH color space with 5 themes (light, dark, midnight, forest, sunset). Typography: Archivo (display/headings), Albert Sans (body), JetBrains Mono (code). 4pt base spacing scale. Motion tokens for animations. Defined in `globals.css`.
+
 Three route groups organize the UI by access level:
 
 **`(auth)/`** - Login and initialization
@@ -159,6 +199,7 @@ Three route groups organize the UI by access level:
 - `page.tsx` : Registry home with search, trending agents, top rated
 - `agents/page.tsx` : Agent list table with search and filters
 - `agents/[id]/page.tsx` : Agent detail with pull command box
+- `agents/builder/page.tsx` : Agent builder with two-column layout, component selector tabs, goal template editor, live YAML preview, publish action
 - `components/page.tsx` : Tabbed component browser (MCPs, skills, hooks, prompts, sandboxes)
 - `components/[id]/page.tsx` : Component detail view
 
@@ -178,13 +219,20 @@ Three route groups organize the UI by access level:
 - `src/hooks/use-api.ts` : TanStack Query hooks for every endpoint (queries + mutations)
 - `src/hooks/use-auth.ts` : Auth guard hook (checks API key exists)
 - `src/hooks/use-admin-guard.ts` : Admin role check hook
+- `src/hooks/use-mobile.ts` : Mobile viewport detection
 - `src/components/layouts/auth-guard.tsx` : Auth guard wrapper
 - `src/components/layouts/admin-guard.tsx` : Admin guard wrapper
+- `src/components/layouts/dashboard-shell.tsx` : Dashboard layout shell
+- `src/components/layouts/page-header.tsx` : Page header with breadcrumbs
 - `src/components/nav/registry-sidebar.tsx` : Unified sidebar with conditional admin section
 - `src/components/nav/command-menu.tsx` : Command palette (Cmd+K)
-- `src/components/dashboard/` : Reusable stat cards, trend charts, bar lists, heatmap, time range select, no-data/error states
+- `src/components/nav/nav-user.tsx` : User profile menu
+- `src/components/shared/skeleton-layouts.tsx` : Reusable skeletons (TableSkeleton, CardSkeleton, DetailSkeleton, ChartSkeleton)
+- `src/components/shared/error-state.tsx` : Reusable error display with retry
+- `src/components/shared/empty-state.tsx` : Icon + title + description + CTA
+- `src/components/dashboard/` : Stat cards, trend charts, bar lists, heatmap, time range select, no-data/error states
 - `src/components/traces/` : Trace list, trace detail, span tree with collapsible thread lines
-- `src/components/registry/` : Agent card, pull command with IDE selector
+- `src/components/registry/` : Agent card, component card, pull command with IDE selector, install dialog, metrics panel, feedback list, status badge
 - `src/components/eval/` : Eval-specific components
 
 ### Demo (`demo/`)
@@ -208,7 +256,9 @@ Three route groups organize the UI by access level:
 - Install routes use an owner fallback: try approved first, then allow the submitter to install their own pending/rejected items. This lets `observal scan` work. Items are auto-registered as pending and immediately usable by the submitter.
 - The CLI stores config in `~/.observal/config.json`. Aliases are in `~/.observal/aliases.json`. Both are plain JSON. All API path parameters accept UUID or name; the server resolves names via `resolve_listing()` in `deps.py`.
 - All CLI list/show commands support `--output table|json|plain`. Use `--output json` for scripting. Use `--raw` on install commands to pipe config directly to files.
+- The CLI uses nested Typer subgroups. Deprecated root-level aliases are registered as hidden commands that print deprecation warnings and delegate to the canonical implementation functions (`_impl` pattern). The `register_deprecated_*` functions in each module handle this.
 - Ruff is the Python linter and formatter. Line length is 120. Pre-commit hooks enforce it.
 - The `B008` ruff rule is suppressed because Typer requires function calls in argument defaults (`typer.Option(...)`, `typer.Argument(...)`).
 - The data model is agent-centric. Agents bundle components (MCPs, skills, hooks, prompts, sandboxes) via `agent_components`, a polymorphic junction table with NO foreign key on `component_id` (allows cross-type references). Agent downloads are deduplicated by `(user_id)` and `(fingerprint)` unique constraints; component downloads are not deduplicated. All components support organization ownership via `is_private` + `owner_org_id` fields. Git-based versioning: components require `git_url` + `git_ref` for reproducible installs.
+- The web frontend uses OKLCH color space for perceptually uniform theming. 5 themes are defined in `globals.css` using CSS custom properties. Theme switching is handled by `theme-switcher.tsx`. The design system uses a 4pt spacing scale, semantic color tokens (background, foreground, card, border, primary, secondary, accent, destructive, success, warning, info), and motion tokens for animations.
 - The web frontend proxies all API calls through Next.js rewrites (`/api/v1/*` -> backend). The backend URL is configured via `NEXT_PUBLIC_API_URL` env var (defaults to `http://localhost:8000`). Auth state (API key, user role) is stored in localStorage. Role-based access is enforced client-side via AuthGuard and AdminGuard components, not Next.js middleware.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python">
   <img src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" alt="Status">
+  <a href="https://github.com/BlazeUp-AI/Observal/stargazers"><img src="https://img.shields.io/github/stars/BlazeUp-AI/Observal?style=flat-square" alt="Stars"></a>
 </p>
+
+> If you find Observal useful, please consider giving it a star. It helps others discover the project and keeps development going.
 
 ---
 
-Observal is a self-hosted agent registry and observability platform. Discover, publish, and pull complete AI coding agents bundled with their MCP servers, skills, hooks, prompts, and sandboxes. Every component emits telemetry into ClickHouse so you can measure what's actually working.
+Observal is a **self-hosted agent registry and observability platform**. Think Docker Hub for AI agents. Discover, publish, and pull complete AI coding agents bundled with their MCP servers, skills, hooks, prompts, and sandboxes. Every component emits telemetry into ClickHouse so you can measure what's actually working.
 
-It works with Cursor, Kiro, Claude Code, Gemini CLI, VS Code, Codex CLI, and GitHub Copilot.
+Works with **Cursor**, **Kiro**, **Claude Code**, **Gemini CLI**, **VS Code**, **Codex CLI**, and **GitHub Copilot**.
 
 ## Quick Start
 
@@ -27,14 +30,14 @@ cp .env.example .env          # edit with your values
 
 cd docker && docker compose up --build -d && cd ..
 uv tool install --editable .
-observal init                  # create admin account
+observal auth init             # create admin account
 ```
 
 Already have MCP servers in your IDE? Instrument them in one command:
 
 ```bash
 observal scan                  # auto-detect, register, and instrument everything
-observal pull <agent-id> --ide cursor  # install a complete agent
+observal pull <agent> --ide cursor  # install a complete agent
 ```
 
 This detects MCP servers from your IDE config files, registers them with Observal, and wraps them with `observal-shim` for telemetry without breaking your existing setup. A timestamped backup is created automatically.
@@ -52,9 +55,9 @@ Without answers, teams can't improve their agents. They guess, ship changes, and
 
 ## How It Works
 
-Observal is a registry for AI agents. Each agent bundles MCP servers, skills, hooks, prompts, and sandboxes into a single installable package. Run `observal pull <agent-id>` to install a complete agent with all its components.
+Observal is a registry for AI agents. Each agent bundles MCP servers, skills, hooks, prompts, and sandboxes into a single installable package. Run `observal pull <agent>` to install a complete agent with all its components.
 
-A transparent shim (`observal-shim` for stdio, `observal-proxy` for HTTP) intercepts traffic without modifying it, pairs requests with responses into spans, and streams them to ClickHouse. The shim is injected automatically when you install an agent or component - no code changes required. You can also run `observal scan` to automatically detect and instrument your existing IDE setup.
+A transparent shim (`observal-shim` for stdio, `observal-proxy` for HTTP) intercepts traffic without modifying it, pairs requests with responses into spans, and streams them to ClickHouse. The shim is injected automatically when you install an agent or component — no code changes required. You can also run `observal scan` to automatically detect and instrument your existing IDE setup.
 
 ```
 IDE  <-->  observal-shim  <-->  MCP Server / Sandbox
@@ -74,14 +77,14 @@ Observal manages 6 component types that agents bundle together:
 
 | Registry Type | What It Is | What Observal Measures |
 |--------------|-----------|----------------------|
-| Agents | AI agent configurations that bundle components (MCPs, skills, hooks, prompts, sandboxes) | Interaction count, acceptance rate, tool call efficiency, version comparison |
-| MCP Servers | Model Context Protocol servers that expose tools to agents | Call volume, latency, error rates, schema compliance, FastMCP validation |
-| Skills | Portable instruction packages (SKILL.md) that agents load on demand | Activation frequency, error rate correlation, session duration impact |
-| Hooks | Lifecycle callbacks that fire at specific points during agent sessions | Execution count, block rate, latency overhead |
-| Prompts | Managed prompt templates with variable substitution | Render count, token expansion, downstream success rate |
-| Sandbox Exec | Docker execution environments for code running and testing | CPU/memory/disk, exit codes, OOM rate, timeout rate |
+| **Agents** | AI agent configurations that bundle components | Interaction count, acceptance rate, tool call efficiency, version comparison |
+| **MCP Servers** | Model Context Protocol servers that expose tools to agents | Call volume, latency, error rates, schema compliance |
+| **Skills** | Portable instruction packages (SKILL.md) that agents load on demand | Activation frequency, error rate correlation, session duration impact |
+| **Hooks** | Lifecycle callbacks that fire at specific points during agent sessions | Execution count, block rate, latency overhead |
+| **Prompts** | Managed prompt templates with variable substitution | Render count, token expansion, downstream success rate |
+| **Sandbox Exec** | Docker execution environments for code running and testing | CPU/memory/disk, exit codes, OOM rate, timeout rate |
 
-Every type emits telemetry into ClickHouse. Every type gets metrics, feedback, and eval scores. Admin review controls visibility in the public registry, but you can use your own items and collect telemetry immediately, no approval needed.
+Every type emits telemetry into ClickHouse. Every type gets metrics, feedback, and eval scores. Admin review controls visibility in the public registry, but you can use your own items and collect telemetry immediately — no approval needed.
 
 ## IDE Support
 
@@ -99,6 +102,153 @@ Config generation and telemetry collection work across all major agentic IDEs:
 | VS Code | Yes | Yes | - | - | Yes | Yes | - |
 
 IDEs with **Native OTel** support send full distributed traces, user prompts, LLM token usage, and tool execution telemetry directly to Observal via OpenTelemetry. This is configured automatically when you run `observal install`. IDEs without native OTel support use the `observal-shim` transparent proxy for MCP tool call telemetry.
+
+## CLI Reference
+
+The CLI is organized into command groups. Run `observal --help` or `observal <group> --help` for full details.
+
+### Primary Workflows
+
+```bash
+observal pull <agent> --ide <ide>    # install a complete agent with all dependencies
+observal scan [--ide <ide>]          # detect and instrument existing IDE configs
+observal use <git-url|path>          # swap IDE configs to a git-hosted profile
+observal profile                     # show active profile and backup info
+```
+
+### Authentication (`observal auth`)
+
+```bash
+observal auth init             # first-time setup (connect to team or create admin)
+observal auth login             # login with API key
+observal auth logout            # clear saved credentials
+observal auth whoami            # show current user
+observal auth status            # check server connectivity and health
+```
+
+### Component Registry (`observal registry`)
+
+All 5 component types live under `observal registry <type>`. Each type supports the same core commands:
+
+```bash
+# MCP Servers
+observal registry mcp submit <git-url>
+observal registry mcp list [--category <cat>] [--search <term>]
+observal registry mcp show <id-or-name>
+observal registry mcp install <id-or-name> --ide <ide>
+observal registry mcp delete <id-or-name>
+
+# Skills
+observal registry skill submit [--from-file <path>]
+observal registry skill list [--task-type <type>] [--target-agent <agent>]
+observal registry skill show <id>
+observal registry skill install <id> --ide <ide>
+observal registry skill delete <id>
+
+# Hooks
+observal registry hook submit [--from-file <path>]
+observal registry hook list [--event <event>] [--scope <scope>]
+observal registry hook show <id>
+observal registry hook install <id> --ide <ide>
+observal registry hook delete <id>
+
+# Prompts
+observal registry prompt submit [--from-file <path>]
+observal registry prompt list [--category <cat>]
+observal registry prompt show <id>
+observal registry prompt render <id> --var key=value
+observal registry prompt install <id> --ide <ide>
+observal registry prompt delete <id>
+
+# Sandboxes
+observal registry sandbox submit [--from-file <path>]
+observal registry sandbox list [--runtime docker|lxc]
+observal registry sandbox show <id>
+observal registry sandbox install <id> --ide <ide>
+observal registry sandbox delete <id>
+```
+
+### Agent Authoring (`observal agent`)
+
+```bash
+# Browse and manage agents
+observal agent create              # interactive agent creation
+observal agent list [--search <term>]
+observal agent show <id>
+observal agent install <id> --ide <ide>
+observal agent delete <id>
+
+# Local YAML workflow
+observal agent init                # scaffold observal-agent.yaml
+observal agent add <type> <id>     # add component (mcp, skill, hook, prompt, sandbox)
+observal agent build               # validate against server (dry-run)
+observal agent publish             # submit to registry
+```
+
+### Observability (`observal ops`)
+
+```bash
+observal ops overview              # enterprise dashboard stats
+observal ops metrics <id> [--type mcp|agent] [--watch]
+observal ops top [--type mcp|agent]
+observal ops traces [--type <type>] [--mcp <id>] [--agent <id>]
+observal ops spans <trace-id>
+observal ops rate <id> --stars 5 [--type mcp|agent] [--comment "..."]
+observal ops feedback <id> [--type mcp|agent]
+observal ops telemetry status
+observal ops telemetry test
+```
+
+### Admin (`observal admin`)
+
+```bash
+# Settings and users
+observal admin settings
+observal admin set <key> <value>
+observal admin users
+
+# Review workflow
+observal admin review list
+observal admin review show <id>
+observal admin review approve <id>
+observal admin review reject <id> --reason "..."
+
+# Evaluation engine
+observal admin eval run <agent-id> [--trace <trace-id>]
+observal admin eval scorecards <agent-id> [--version "1.0.0"]
+observal admin eval show <scorecard-id>
+observal admin eval compare <agent-id> --a "1.0.0" --b "2.0.0"
+observal admin eval aggregate <agent-id> [--window 50]
+
+# Penalty and weight tuning
+observal admin penalties
+observal admin penalty-set <name> [--amount 10] [--active]
+observal admin weights
+observal admin weight-set <dimension> <weight>
+```
+
+### Configuration (`observal config`)
+
+```bash
+observal config show               # show current config
+observal config set <key> <value>  # set a config value
+observal config path               # show config file path
+observal config alias <name> <id>  # create @alias for an ID
+observal config aliases            # list all aliases
+```
+
+### Self-Management (`observal self`)
+
+```bash
+observal self upgrade              # upgrade CLI to latest version
+observal self downgrade            # downgrade to previous version
+```
+
+### Diagnostics (`observal doctor`)
+
+```bash
+observal doctor [--ide <ide>] [--fix]  # diagnose IDE settings compatibility
+```
 
 ## Tech Stack
 
@@ -119,132 +269,6 @@ IDEs with **Native OTel** support send full distributed traces, user prompts, LL
 ## Setup & Configuration
 
 For detailed setup, eval engine configuration, environment variables, and troubleshooting, see [SETUP.md](SETUP.md).
-
-<details>
-<summary><strong>CLI Usage</strong></summary>
-
-### Authentication
-
-```bash
-observal init          # first-time admin setup
-observal login         # login with API key
-observal whoami        # check current user
-```
-
-### Quick Start with Existing Setup
-
-```bash
-observal scan              # detect and instrument all IDE configs in current directory
-observal scan --ide cursor # target specific IDE
-observal scan --dry-run    # preview changes without modifying files
-observal scan /path/to/project --yes  # non-interactive
-```
-
-### Agent Workflow
-
-```bash
-# Agent Workflow
-observal pull <agent-id> --ide <ide>    # install complete agent
-observal agent init <name>              # scaffold new agent
-observal agent add mcp <name@version>   # add component
-observal agent add skill <name>         # add skill
-observal agent build                    # generate agent.yaml
-observal agent test                     # run in sandbox
-observal agent publish                  # submit to registry
-
-# Component Sources
-observal registry add-source <git-url>  # add component source
-observal registry sync                  # trigger re-sync
-```
-
-### Registry Operations
-
-All component types follow the same pattern. All commands accept either an ID or a name.
-
-```bash
-# MCP Servers (ID or name works for all commands)
-observal submit <git-url>
-observal list [--category <cat>] [--search <term>]
-observal show <id-or-name>
-observal install <id-or-name> --ide <ide>
-
-# Agents
-observal agent create
-observal agent list [--search <term>]
-observal agent show <id>
-observal agent install <id> --ide <ide>
-
-# Skills
-observal skill submit <git-url-or-path>
-observal skill list [--task-type <type>] [--target-agent <agent>]
-observal skill install <id> --ide <ide>
-
-# Hooks
-observal hook submit
-observal hook list [--event <event>] [--scope <scope>]
-observal hook install <id> --ide <ide>
-
-# Prompts
-observal prompt submit [--from-file <path>]
-observal prompt list [--category <cat>]
-observal prompt render <id> --var key=value
-
-# Sandboxes
-observal sandbox submit
-observal sandbox list [--runtime docker|lxc]
-observal sandbox install <id> --ide <ide>
-```
-
-### Admin Review
-
-All registry types go through a single review workflow:
-
-```bash
-observal review list [--type mcp|agent|skill|hook|prompt|sandbox]
-observal review show <id>
-observal review approve <id>
-observal review reject <id> --reason "Missing documentation"
-```
-
-### Observability
-
-```bash
-# Telemetry status
-observal telemetry status
-
-# Metrics for any registry type
-observal metrics <id> --type mcp
-observal metrics <id> --type agent
-
-# Enterprise overview
-observal overview
-```
-
-### Evaluation
-
-```bash
-# Run eval on agent traces
-observal eval run <agent-id>
-
-# List and inspect scorecards
-observal eval scorecards <agent-id> [--version "1.0.0"]
-observal eval show <scorecard-id>
-
-# Compare versions
-observal eval compare <agent-id> --a "1.0.0" --b "2.0.0"
-```
-
-### Feedback
-
-```bash
-# Rate any registry item (1-5 stars)
-observal rate <id> --stars 5 --type mcp --comment "Works great"
-
-# View feedback
-observal feedback <id> --type mcp
-```
-
-</details>
 
 <details>
 <summary><strong>API Endpoints</strong></summary>
@@ -270,10 +294,6 @@ All `{id}` parameters accept either a UUID or a name.
 | `DELETE` | `/api/v1/{type}/{id}` | Delete |
 | `GET` | `/api/v1/{type}/{id}/metrics` | Metrics |
 | `POST` | `/api/v1/agents/{id}/pull` | Pull agent (installs all components) |
-| `GET` | `/api/v1/organizations` | List organizations |
-| `POST` | `/api/v1/organizations` | Create organization |
-| `GET` | `/api/v1/component-sources` | List component sources |
-| `POST` | `/api/v1/component-sources` | Add component source |
 
 ### Scan
 
@@ -306,6 +326,7 @@ All `{id}` parameters accept either a UUID or a name.
 | `GET` | `/api/v1/eval/agents/{id}/scorecards` | List scorecards |
 | `GET` | `/api/v1/eval/scorecards/{id}` | Scorecard details |
 | `GET` | `/api/v1/eval/agents/{id}/compare` | Compare versions |
+| `GET` | `/api/v1/eval/agents/{id}/aggregate` | Aggregate scoring stats |
 
 ### Feedback
 
@@ -324,15 +345,10 @@ All `{id}` parameters accept either a UUID or a name.
 | `GET` | `/api/v1/admin/users` | List users |
 | `POST` | `/api/v1/admin/users` | Create user |
 | `PUT` | `/api/v1/admin/users/{id}/role` | Change role |
-
-### Alerts
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/api/v1/alerts` | List alert rules |
-| `POST` | `/api/v1/alerts` | Create alert rule |
-| `PATCH` | `/api/v1/alerts/{id}` | Update alert status |
-| `DELETE` | `/api/v1/alerts/{id}` | Delete alert rule |
+| `GET` | `/api/v1/admin/penalties` | List penalty catalog |
+| `PUT` | `/api/v1/admin/penalties/{id}` | Modify penalty |
+| `GET` | `/api/v1/admin/weights` | Get dimension weights |
+| `PUT` | `/api/v1/admin/weights` | Set dimension weights |
 
 ### GraphQL
 
@@ -382,7 +398,7 @@ All tests mock external services. No Docker needed.
 
 ## Community
 
-Have a question, idea, or want to share what you've built? Head to [GitHub Discussions](https://github.com/BlazeUp-AI/Observal/discussions). Please use Discussions for questions instead of opening issues, issues are reserved for bug reports and feature requests.
+Have a question, idea, or want to share what you've built? Head to [GitHub Discussions](https://github.com/BlazeUp-AI/Observal/discussions). Please use Discussions for questions instead of opening issues — issues are reserved for bug reports and feature requests.
 
 ## Contributing
 
@@ -399,3 +415,15 @@ See [AGENTS.md](AGENTS.md) for internal codebase context useful when working wit
 ## License
 
 Apache License 2.0. See [LICENSE](LICENSE).
+
+## Star History
+
+If you find Observal useful, please star the repo — it helps others discover the project and motivates continued development.
+
+<a href="https://www.star-history.com/?repos=BlazeUp-AI%2FObserval&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=BlazeUp-AI/Observal&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=BlazeUp-AI/Observal&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=BlazeUp-AI/Observal&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
## Summary
- Rewrites README with current CLI command groups (registry, agent, ops, admin, self, config, doctor) and all subcommands documented
- Updates AGENTS.md with current codebase state: nested CLI structure, OKLCH design system, multi-framework MCP support, agent builder page, shared components
- Adds star history chart and star encouragement to README
- Adds stars badge to header

## Changes

**README.md:**
- CLI reference rewritten as organized command groups instead of flat list
- Moved CLI docs out of collapsed `<details>` section into main body
- Added missing API endpoints (aggregate, penalties, weights)
- Added star history section at bottom with chart widget

**AGENTS.md:**
- Full CLI command tree showing nested group hierarchy
- Documented deprecated alias pattern (`register_deprecated_*` + `_impl` functions)
- Updated all CLI module descriptions for new subgroup structure
- Added MCP validator multi-framework support details
- Added agent builder page, OKLCH design system, themes, fonts to frontend docs
- Added shared components (skeleton-layouts, error-state, empty-state)

## Test plan
- [x] All information verified against actual CLI `--help` output and codebase audit
- [x] No code changes, documentation only