### PR TITLE
added GitHub Actions CI pipeline (soft-launch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,140 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Observal CI — runs on every PR targeting main and on pushes to main.
+#
+# Soft-launch mode:
+#   The `lint` and `web-lint` jobs use `continue-on-error: true` so pre-existing
+#   violations in the current codebase don't block merges. They still run and
+#   surface warnings in the PR checks UI — use those reports to burn down the
+#   backlog in follow-up PRs. Once the repo is clean, remove `continue-on-error`
+#   and add those jobs to the required status checks list below.
+#
+# Recommended branch-protection rules (Settings → Branches → main):
+#   Required status checks (initial soft-launch set):
+#     • test (3.11)
+#     • test (3.12)
+#     • test (3.13)
+#     • docker-build
+#   Required status checks (after soft-launch, once lint backlog is clean):
+#     • lint
+#     • web-lint
+#   Require a pull request before merging
+#   Require approvals: 1
+#   Do not allow bypassing the above settings
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# ── Job 1: Python lint ────────────────────────────────────────────────────────
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    # Soft-launch: don't block merges on pre-existing ruff violations.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: ruff check
+        run: uv run --with ruff==0.9.10 ruff check .
+
+      - name: ruff format --check
+        run: uv run --with ruff==0.9.10 ruff format --check .
+
+# ── Job 2: Python tests (matrix) ─────────────────────────────────────────────
+  test:
+    name: test (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Run pytest
+        run: |
+          cd observal-server
+          uv run \
+            --python ${{ matrix.python-version }} \
+            --with pytest \
+            --with pytest-asyncio \
+            --with pyyaml \
+            --with typer \
+            --with rich \
+            pytest ../tests/ -q
+
+# ── Job 3: Next.js lint + typecheck ──────────────────────────────────────────
+  web-lint:
+    name: web-lint
+    runs-on: ubuntu-latest
+    # Soft-launch: don't block merges on pre-existing ESLint errors.
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: ESLint
+        run: pnpm run lint
+
+      - name: TypeScript typecheck
+        run: pnpm run typecheck
+
+# ── Job 4: Docker build ───────────────────────────────────────────────────────
+  docker-build:
+    name: docker-build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docker
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # docker-compose.yml references env_file: ../.env — create a stub so
+      # the build doesn't fail on a missing file.
+      - name: Create stub .env
+        run: touch ../.env
+
+      - name: Build images
+        run: docker compose build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Observal
 
+<a href="https://github.com/BlazeUp-AI/Observal/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/BlazeUp-AI/Observal/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
+
 Contributions of all kinds are welcome: bug fixes, new features, documentation improvements.
 
 ## Fork and Clone

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python">
   <img src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" alt="Status">
-  <a href="https://github.com/BlazeUp-AI/Observal/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/BlazeUp-AI/Observal/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python">
   <img src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" alt="Status">
+  <a href="https://github.com/BlazeUp-AI/Observal/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/BlazeUp-AI/Observal/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
 </p>
 
 ---

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.4",


### PR DESCRIPTION
Adds a basic CI workflow so PRs get checked automatically.

 What's in it
- `.github/workflows/ci.yml` — 4 jobs that run on every PR to main:
  - `lint` — ruff check + format
  - `test` — pytest on Python 3.11, 3.12, 3.13
  - `web-lint` — eslint + tsc on the Next.js app
  - `docker-build` — verifies `docker compose build` works
- `typecheck` script added to `web/package.json`
- CI badge added to the README

Note on soft-launch :
`lint` and `web-lint` have `continue-on-error: true` for now. The current codebase has a bunch of pre-existing ruff and eslint violations, and I didn't want to mix a giant cleanup diff into this PR. The jobs still run and show warnings — once we clean up the backlog in follow-ups, we can flip them to strict and add them to branch protection.

## Todo after merge
- Set up branch protection (see comment at top of `ci.yml`)
- Clean up ruff + eslint backlog
- Flip lint jobs to strict
