### PR TITLE
feat: Phase 2 — public registry frontend and agent builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - name: DCO Check
         uses: christophebedard/dco-check@0.5.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: DCO Check
-        uses: tim-actions/dco@master
+        uses: christophebedard/dco-check@0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -43,6 +43,7 @@ def require_role(*roles: UserRole):
 async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_status=None):
     """Resolve a listing by UUID or name."""
     import uuid as _uuid
+
     if isinstance(identifier, _uuid.UUID):
         stmt = select(model).where(model.id == identifier)
     else:

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -176,7 +176,9 @@ async def list_penalties(
     _require_admin(current_user)
     from models.scoring import PenaltyDefinition
 
-    result = await db.execute(select(PenaltyDefinition).order_by(PenaltyDefinition.dimension, PenaltyDefinition.event_name))
+    result = await db.execute(
+        select(PenaltyDefinition).order_by(PenaltyDefinition.dimension, PenaltyDefinition.event_name)
+    )
     return [
         {
             "id": str(p.id),
@@ -240,11 +242,13 @@ async def list_weights(
     # Merge with defaults
     weights = []
     for dim, default_weight in DEFAULT_DIMENSION_WEIGHTS.items():
-        weights.append({
-            "dimension": dim.value,
-            "weight": db_weights.get(dim.value, default_weight),
-            "is_custom": dim.value in db_weights,
-        })
+        weights.append(
+            {
+                "dimension": dim.value,
+                "weight": db_weights.get(dim.value, default_weight),
+                "is_custom": dim.value in db_weights,
+            }
+        )
     return weights
 
 

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -2,7 +2,7 @@ import uuid
 import uuid as _uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -19,10 +19,13 @@ from schemas.agent import (
     AgentResponse,
     AgentSummary,
     AgentUpdateRequest,
+    AgentValidateRequest,
     ComponentLinkResponse,
     GoalSectionResponse,
     GoalTemplateResponse,
     McpLinkResponse,
+    ValidationIssue,
+    ValidationResult,
 )
 from services.agent_config_generator import generate_agent_config
 
@@ -193,11 +196,47 @@ async def list_agents(
     search: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
 ):
-    stmt = select(Agent).where(Agent.status == AgentStatus.active)
+    from models.feedback import Feedback
+
+    stmt = (
+        select(Agent)
+        .where(Agent.status == AgentStatus.active)
+        .options(selectinload(Agent.components))
+    )
     if search:
         stmt = stmt.where(Agent.name.ilike(f"%{search}%") | Agent.description.ilike(f"%{search}%"))
     result = await db.execute(stmt.order_by(Agent.created_at.desc()))
-    return [AgentSummary.model_validate(a) for a in result.scalars().all()]
+    agents = result.scalars().all()
+
+    # Batch-fetch average ratings
+    agent_ids = [a.id for a in agents]
+    rating_map: dict[uuid.UUID, float] = {}
+    if agent_ids:
+        rows = await db.execute(
+            select(Feedback.listing_id, func.avg(Feedback.rating))
+            .where(Feedback.listing_id.in_(agent_ids), Feedback.listing_type == "agent")
+            .group_by(Feedback.listing_id)
+        )
+        rating_map = {r[0]: round(float(r[1]), 2) for r in rows.all()}
+
+    return [
+        AgentSummary(
+            id=a.id,
+            name=a.name,
+            version=a.version,
+            description=a.description,
+            owner=a.owner,
+            model_name=a.model_name,
+            supported_ides=a.supported_ides,
+            status=a.status,
+            download_count=a.download_count,
+            average_rating=rating_map.get(a.id),
+            component_count=len(a.components),
+            created_at=a.created_at,
+            updated_at=a.updated_at,
+        )
+        for a in agents
+    ]
 
 
 @router.get("/{agent_id}", response_model=AgentResponse)
@@ -365,7 +404,6 @@ async def install_agent(
 async def agent_download_stats(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
 ):
     agent = await _load_agent(db, _agent_id_clause(agent_id))
     if not agent:
@@ -413,6 +451,34 @@ async def get_agent_manifest(
         })
     from services.agent_builder import build_agent_manifest
     return build_agent_manifest(resolved)
+
+
+@router.post("/validate", response_model=ValidationResult)
+async def validate_agent_composition(
+    req: AgentValidateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Validate a set of components for compatibility before publishing an agent."""
+    if not req.components:
+        return ValidationResult(valid=True, issues=[])
+
+    from services.agent_resolver import validate_component_ids
+
+    errors = await validate_component_ids(
+        [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
+        db,
+    )
+    issues = [
+        ValidationIssue(
+            severity="error",
+            component_type=e.component_type,
+            component_id=e.component_id,
+            message=e.reason,
+        )
+        for e in errors
+    ]
+    return ValidationResult(valid=len(issues) == 0, issues=issues)
 
 
 @router.delete("/{agent_id}")

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -122,15 +122,19 @@ async def create_agent(
     # Validate new components field (component_type already validated by Pydantic Literal)
     if req.components:
         from services.agent_resolver import validate_component_ids
+
         errors = await validate_component_ids(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
             db,
         )
         if errors:
-            raise HTTPException(status_code=400, detail=[
-                {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
-                for e in errors
-            ])
+            raise HTTPException(
+                status_code=400,
+                detail=[
+                    {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                    for e in errors
+                ],
+            )
 
     agent = Agent(
         name=req.name,
@@ -150,25 +154,29 @@ async def create_agent(
     # Legacy: mcp_server_ids → AgentComponent(type=mcp)
     order = 0
     for mid, listing in zip(req.mcp_server_ids, mcp_listings, strict=False):
-        db.add(AgentComponent(
-            agent_id=agent.id,
-            component_type="mcp",
-            component_id=mid,
-            version_ref=listing.version,
-            order_index=order,
-        ))
+        db.add(
+            AgentComponent(
+                agent_id=agent.id,
+                component_type="mcp",
+                component_id=mid,
+                version_ref=listing.version,
+                order_index=order,
+            )
+        )
         order += 1
 
     # New: components list with all types
     for cref in req.components:
-        db.add(AgentComponent(
-            agent_id=agent.id,
-            component_type=cref.component_type,
-            component_id=cref.component_id,
-            version_ref="latest",
-            order_index=order,
-            config_override=cref.config_override,
-        ))
+        db.add(
+            AgentComponent(
+                agent_id=agent.id,
+                component_type=cref.component_type,
+                component_id=cref.component_id,
+                version_ref="latest",
+                order_index=order,
+                config_override=cref.config_override,
+            )
+        )
         order += 1
 
     goal = AgentGoalTemplate(agent_id=agent.id, description=req.goal_template.description)
@@ -198,11 +206,7 @@ async def list_agents(
 ):
     from models.feedback import Feedback
 
-    stmt = (
-        select(Agent)
-        .where(Agent.status == AgentStatus.active)
-        .options(selectinload(Agent.components))
-    )
+    stmt = select(Agent).where(Agent.status == AgentStatus.active).options(selectinload(Agent.components))
     if search:
         stmt = stmt.where(Agent.name.ilike(f"%{search}%") | Agent.description.ilike(f"%{search}%"))
     result = await db.execute(stmt.order_by(Agent.created_at.desc()))
@@ -280,53 +284,63 @@ async def update_agent(
     if req.components is not None:
         # New components field replaces ALL components (type validated by Pydantic Literal)
         from services.agent_resolver import validate_component_ids
+
         errors = await validate_component_ids(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
             db,
         )
         if errors:
-            raise HTTPException(status_code=400, detail=[
-                {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
-                for e in errors
-            ])
+            raise HTTPException(
+                status_code=400,
+                detail=[
+                    {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                    for e in errors
+                ],
+            )
         # Remove ALL old components
         old_comps = (
-            await db.execute(
-                select(AgentComponent).where(AgentComponent.agent_id == agent.id)
-            )
-        ).scalars().all()
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+        )
         for comp in old_comps:
             await db.delete(comp)
         for i, cref in enumerate(req.components):
-            db.add(AgentComponent(
-                agent_id=agent.id,
-                component_type=cref.component_type,
-                component_id=cref.component_id,
-                version_ref="latest",
-                order_index=i,
-                config_override=cref.config_override,
-            ))
+            db.add(
+                AgentComponent(
+                    agent_id=agent.id,
+                    component_type=cref.component_type,
+                    component_id=cref.component_id,
+                    version_ref="latest",
+                    order_index=i,
+                    config_override=cref.config_override,
+                )
+            )
     elif req.mcp_server_ids is not None:
         # Legacy: only update MCP components
         mcp_listings = await _validate_mcp_ids(req.mcp_server_ids, db)
         old_comps = (
-            await db.execute(
-                select(AgentComponent).where(
-                    AgentComponent.agent_id == agent.id,
-                    AgentComponent.component_type == "mcp",
+            (
+                await db.execute(
+                    select(AgentComponent).where(
+                        AgentComponent.agent_id == agent.id,
+                        AgentComponent.component_type == "mcp",
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for comp in old_comps:
             await db.delete(comp)
         for i, (mid, listing) in enumerate(zip(req.mcp_server_ids, mcp_listings, strict=False)):
-            db.add(AgentComponent(
-                agent_id=agent.id,
-                component_type="mcp",
-                component_id=mid,
-                version_ref=listing.version,
-                order_index=i,
-            ))
+            db.add(
+                AgentComponent(
+                    agent_id=agent.id,
+                    component_type="mcp",
+                    component_id=mid,
+                    version_ref=listing.version,
+                    order_index=i,
+                )
+            )
 
     if req.goal_template is not None:
         if agent.goal_template:
@@ -380,13 +394,12 @@ async def install_agent(
     mcp_comp_ids = [c.component_id for c in agent.components if c.component_type == "mcp"]
     mcp_listings_map = {}
     if mcp_comp_ids:
-        mcp_rows = (await db.execute(
-            select(McpListing).where(McpListing.id.in_(mcp_comp_ids))
-        )).scalars().all()
+        mcp_rows = (await db.execute(select(McpListing).where(McpListing.id.in_(mcp_comp_ids)))).scalars().all()
         mcp_listings_map = {row.id: row for row in mcp_rows}
 
     snippet = generate_agent_config(agent, req.ide, mcp_listings=mcp_listings_map)
     from services.download_tracker import record_agent_download
+
     await record_agent_download(
         agent_id=agent.id,
         user_id=current_user.id,
@@ -409,6 +422,7 @@ async def agent_download_stats(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     from services.download_tracker import get_download_stats
+
     stats = await get_download_stats(agent.id, db)
     return stats
 
@@ -424,8 +438,10 @@ async def resolve_agent_components(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     from services.agent_resolver import resolve_agent
+
     resolved = await resolve_agent(agent, db)
     from services.agent_builder import build_composition_summary
+
     return build_composition_summary(resolved)
 
 
@@ -440,16 +456,21 @@ async def get_agent_manifest(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     from services.agent_resolver import resolve_agent
+
     resolved = await resolve_agent(agent, db)
     if not resolved.ok:
-        raise HTTPException(status_code=422, detail={
-            "message": "Agent has unresolvable components",
-            "errors": [
-                {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
-                for e in resolved.errors
-            ],
-        })
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "Agent has unresolvable components",
+                "errors": [
+                    {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                    for e in resolved.errors
+                ],
+            },
+        )
     from services.agent_builder import build_agent_manifest
+
     return build_agent_manifest(resolved)
 
 
@@ -507,7 +528,9 @@ async def delete_agent(
         await db.delete(r)
     for r in (await db.execute(select(EvalRun).where(EvalRun.agent_id == agent.id))).scalars().all():
         await db.delete(r)
-    for r in (await db.execute(select(AgentDownloadRecord).where(AgentDownloadRecord.agent_id == agent.id))).scalars().all():
+    for r in (
+        (await db.execute(select(AgentDownloadRecord).where(AgentDownloadRecord.agent_id == agent.id))).scalars().all()
+    ):
         await db.delete(r)
     # AgentComponent, AgentGoalTemplate, AgentGoalSection handled by cascade="all, delete-orphan"
 

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -149,7 +149,7 @@ async def create_agent(
 
     # Legacy: mcp_server_ids → AgentComponent(type=mcp)
     order = 0
-    for mid, listing in zip(req.mcp_server_ids, mcp_listings):
+    for mid, listing in zip(req.mcp_server_ids, mcp_listings, strict=False):
         db.add(AgentComponent(
             agent_id=agent.id,
             component_type="mcp",
@@ -319,7 +319,7 @@ async def update_agent(
         ).scalars().all()
         for comp in old_comps:
             await db.delete(comp)
-        for i, (mid, listing) in enumerate(zip(req.mcp_server_ids, mcp_listings)):
+        for i, (mid, listing) in enumerate(zip(req.mcp_server_ids, mcp_listings, strict=False)):
             db.add(AgentComponent(
                 agent_id=agent.id,
                 component_type="mcp",
@@ -383,7 +383,7 @@ async def install_agent(
         mcp_rows = (await db.execute(
             select(McpListing).where(McpListing.id.in_(mcp_comp_ids))
         )).scalars().all()
-        mcp_listings_map = {l.id: l for l in mcp_rows}
+        mcp_listings_map = {row.id: row for row in mcp_rows}
 
     snippet = generate_agent_config(agent, req.ide, mcp_listings=mcp_listings_map)
     from services.download_tracker import record_agent_download

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -20,6 +20,7 @@ from schemas.dashboard import (
     IdeBreakdown,
     IdeUsage,
     LatencyCell,
+    LeaderboardItem,
     McpMetrics,
     OverviewStats,
     RagasDimensionScore,
@@ -33,6 +34,7 @@ from schemas.dashboard import (
     TokenByEntity,
     TokenStats,
     TokenTimePoint,
+    TopAgentItem,
     TopItem,
     TrendPoint,
     UnannotatedTrace,
@@ -162,7 +164,6 @@ async def agent_metrics(
 async def overview_stats(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
 ):
     total_mcps = (
         await db.scalar(select(func.count(McpListing.id)).where(McpListing.status == ListingStatus.approved)) or 0
@@ -188,7 +189,7 @@ async def overview_stats(
 
 
 @router.get("/overview/top-mcps", response_model=list[TopItem])
-async def top_mcps(db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)):
+async def top_mcps(db: AsyncSession = Depends(get_db)):
     result = await db.execute(
         select(McpDownload.listing_id, func.count(McpDownload.id).label("cnt"), McpListing.name)
         .join(McpListing, McpDownload.listing_id == McpListing.id)
@@ -199,16 +200,138 @@ async def top_mcps(db: AsyncSession = Depends(get_db), current_user: User = Depe
     return [TopItem(id=row.listing_id, name=row.name, value=row.cnt) for row in result.all()]
 
 
-@router.get("/overview/top-agents", response_model=list[TopItem])
-async def top_agents(db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)):
+@router.get("/overview/top-agents", response_model=list[TopAgentItem])
+async def top_agents(
+    limit: int = Query(6, le=50),
+    db: AsyncSession = Depends(get_db),
+):
     result = await db.execute(
-        select(AgentDownloadRecord.agent_id, func.count(AgentDownloadRecord.id).label("cnt"), Agent.name)
+        select(
+            AgentDownloadRecord.agent_id,
+            func.count(AgentDownloadRecord.id).label("cnt"),
+            Agent.name,
+            Agent.description,
+            Agent.owner,
+            Agent.version,
+        )
         .join(Agent, AgentDownloadRecord.agent_id == Agent.id)
-        .group_by(AgentDownloadRecord.agent_id, Agent.name)
+        .where(Agent.status == AgentStatus.active)
+        .group_by(AgentDownloadRecord.agent_id, Agent.name, Agent.description, Agent.owner, Agent.version)
         .order_by(func.count(AgentDownloadRecord.id).desc())
-        .limit(5)
+        .limit(limit)
     )
-    return [TopItem(id=row.agent_id, name=row.name, value=row.cnt) for row in result.all()]
+    rows = result.all()
+
+    # Batch-fetch average ratings
+    agent_ids = [r.agent_id for r in rows]
+    rating_map: dict[uuid.UUID, float] = {}
+    if agent_ids:
+        from models.feedback import Feedback
+
+        rating_rows = await db.execute(
+            select(Feedback.listing_id, func.avg(Feedback.rating))
+            .where(Feedback.listing_id.in_(agent_ids), Feedback.listing_type == "agent")
+            .group_by(Feedback.listing_id)
+        )
+        rating_map = {r[0]: round(float(r[1]), 2) for r in rating_rows.all()}
+
+    return [
+        TopAgentItem(
+            id=row.agent_id,
+            name=row.name,
+            description=row.description or "",
+            owner=row.owner or "",
+            version=row.version or "",
+            download_count=row.cnt,
+            average_rating=rating_map.get(row.agent_id),
+        )
+        for row in rows
+    ]
+
+
+@router.get("/overview/leaderboard", response_model=list[LeaderboardItem])
+async def agent_leaderboard(
+    window: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
+    limit: int = Query(20, le=50),
+    db: AsyncSession = Depends(get_db),
+):
+    """Public leaderboard of agents ranked by downloads within a time window."""
+    from models.feedback import Feedback
+
+    stmt = (
+        select(
+            AgentDownloadRecord.agent_id,
+            func.count(AgentDownloadRecord.id).label("cnt"),
+            Agent.name,
+            Agent.description,
+            Agent.owner,
+            Agent.version,
+        )
+        .join(Agent, AgentDownloadRecord.agent_id == Agent.id)
+        .where(Agent.status == AgentStatus.active)
+    )
+    if window != "all":
+        days = _RANGE_MAP.get(window, 7)
+        stmt = stmt.where(
+            AgentDownloadRecord.installed_at >= dt.now(UTC) - timedelta(days=days)
+        )
+    stmt = (
+        stmt
+        .group_by(AgentDownloadRecord.agent_id, Agent.name, Agent.description, Agent.owner, Agent.version)
+        .order_by(func.count(AgentDownloadRecord.id).desc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    # Batch-fetch average ratings
+    agent_ids = [r.agent_id for r in rows]
+    rating_map: dict[uuid.UUID, float] = {}
+    if agent_ids:
+        rating_rows = await db.execute(
+            select(Feedback.listing_id, func.avg(Feedback.rating))
+            .where(Feedback.listing_id.in_(agent_ids), Feedback.listing_type == "agent")
+            .group_by(Feedback.listing_id)
+        )
+        rating_map = {r[0]: round(float(r[1]), 2) for r in rating_rows.all()}
+
+    # Also include agents with no downloads if window=all and we have fewer than limit
+    if window == "all" and len(rows) < limit:
+        existing_ids = {r.agent_id for r in rows}
+        extra_stmt = (
+            select(Agent)
+            .where(Agent.status == AgentStatus.active, Agent.id.notin_(existing_ids))
+            .order_by(Agent.created_at.desc())
+            .limit(limit - len(rows))
+        )
+        extra = (await db.execute(extra_stmt)).scalars().all()
+        extra_items = [
+            LeaderboardItem(
+                id=a.id,
+                name=a.name,
+                description=a.description or "",
+                owner=a.owner or "",
+                version=a.version or "",
+                download_count=0,
+                average_rating=rating_map.get(a.id),
+            )
+            for a in extra
+        ]
+    else:
+        extra_items = []
+
+    return [
+        LeaderboardItem(
+            id=row.agent_id,
+            name=row.name,
+            description=row.description or "",
+            owner=row.owner or "",
+            version=row.version or "",
+            download_count=row.cnt,
+            average_rating=rating_map.get(row.agent_id),
+        )
+        for row in rows
+    ] + extra_items
 
 
 @router.get("/overview/trends", response_model=list[TrendPoint])

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -107,7 +107,9 @@ async def agent_metrics(
     from models.eval import Scorecard
     from services.score_aggregator import ScoreAggregator
 
-    dl_count = await db.scalar(select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)) or 0
+    dl_count = (
+        await db.scalar(select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)) or 0
+    )
 
     rows = await _ch_json(
         "SELECT "
@@ -124,10 +126,7 @@ async def agent_metrics(
 
     # Fetch recent scorecards for dimension breakdown
     sc_result = await db.execute(
-        select(Scorecard)
-        .where(Scorecard.agent_id == agent_id)
-        .order_by(Scorecard.evaluated_at.desc())
-        .limit(100)
+        select(Scorecard).where(Scorecard.agent_id == agent_id).order_by(Scorecard.evaluated_at.desc()).limit(100)
     )
     scorecards = sc_result.scalars().all()
     dimension_averages = None
@@ -272,12 +271,9 @@ async def agent_leaderboard(
     )
     if window != "all":
         days = _RANGE_MAP.get(window, 7)
-        stmt = stmt.where(
-            AgentDownloadRecord.installed_at >= dt.now(UTC) - timedelta(days=days)
-        )
+        stmt = stmt.where(AgentDownloadRecord.installed_at >= dt.now(UTC) - timedelta(days=days))
     stmt = (
-        stmt
-        .group_by(AgentDownloadRecord.agent_id, Agent.name, Agent.description, Agent.owner, Agent.version)
+        stmt.group_by(AgentDownloadRecord.agent_id, Agent.name, Agent.description, Agent.owner, Agent.version)
         .order_by(func.count(AgentDownloadRecord.id).desc())
         .limit(limit)
     )
@@ -418,10 +414,19 @@ async def token_stats(
     agent_ids = [r["agent_id"] for r in by_agent_rows if r.get("agent_id")]
     agent_names: dict[str, str] = {}
     if agent_ids:
-        rows = (await db.execute(select(Agent.id, Agent.name).where(Agent.id.in_([uuid.UUID(a) for a in agent_ids])))).all()
+        rows = (
+            await db.execute(select(Agent.id, Agent.name).where(Agent.id.in_([uuid.UUID(a) for a in agent_ids])))
+        ).all()
         agent_names = {str(r.id): r.name for r in rows}
     by_agent = [
-        TokenByEntity(id=r["agent_id"], name=agent_names.get(r["agent_id"], ""), input=int(r["input"]), output=int(r["output"]), total=int(r["total"]), traces=int(r["traces"]))
+        TokenByEntity(
+            id=r["agent_id"],
+            name=agent_names.get(r["agent_id"], ""),
+            input=int(r["input"]),
+            output=int(r["output"]),
+            total=int(r["total"]),
+            traces=int(r["traces"]),
+        )
         for r in by_agent_rows
     ]
 
@@ -440,10 +445,21 @@ async def token_stats(
     mcp_ids = [r["mcp_id"] for r in by_mcp_rows if r.get("mcp_id")]
     mcp_names: dict[str, str] = {}
     if mcp_ids:
-        rows = (await db.execute(select(McpListing.id, McpListing.name).where(McpListing.id.in_([uuid.UUID(m) for m in mcp_ids])))).all()
+        rows = (
+            await db.execute(
+                select(McpListing.id, McpListing.name).where(McpListing.id.in_([uuid.UUID(m) for m in mcp_ids]))
+            )
+        ).all()
         mcp_names = {str(r.id): r.name for r in rows}
     by_mcp = [
-        TokenByEntity(id=r["mcp_id"], name=mcp_names.get(r["mcp_id"], ""), input=int(r["input"]), output=int(r["output"]), total=int(r["total"]), traces=int(r["traces"]))
+        TokenByEntity(
+            id=r["mcp_id"],
+            name=mcp_names.get(r["mcp_id"], ""),
+            input=int(r["input"]),
+            output=int(r["output"]),
+            total=int(r["total"]),
+            traces=int(r["traces"]),
+        )
         for r in by_mcp_rows
     ]
 
@@ -455,7 +471,9 @@ async def token_stats(
         f"FROM spans FINAL WHERE project_id = 'default' AND is_deleted = 0 {time_filter} "
         "GROUP BY date ORDER BY date"
     )
-    over_time = [TokenTimePoint(date=str(r["date"]), input=int(r["input"]), output=int(r["output"])) for r in over_time_rows]
+    over_time = [
+        TokenTimePoint(date=str(r["date"]), input=int(r["input"]), output=int(r["output"])) for r in over_time_rows
+    ]
 
     return TokenStats(
         total_input=total_input,
@@ -678,9 +696,11 @@ async def graphrag_ragas_scores(
     """Get previously computed RAGAS scores. If graphrag_id is provided, scoped to that GraphRAG; otherwise aggregate."""
     if graphrag_id:
         from services.ragas_eval import get_ragas_scores
+
         avgs = await get_ragas_scores(graphrag_id)
     else:
         from services.ragas_eval import get_ragas_aggregate
+
         avgs = await get_ragas_aggregate()
 
     return RagasScores(

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -1,4 +1,3 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -1,4 +1,3 @@
-import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -1,4 +1,3 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -1,4 +1,3 @@
-import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -152,15 +152,15 @@ async def otel_stats():
         "count() AS total_spans "
         "FROM otel_traces"
     )
-    l = log_rows[0] if log_rows else {}
-    t = trace_rows[0] if trace_rows else {}
+    log = log_rows[0] if log_rows else {}
+    tr = trace_rows[0] if trace_rows else {}
     return {
-        "total_sessions": int(l.get("total_sessions", 0)),
-        "total_prompts": int(l.get("total_prompts", 0)),
-        "total_api_requests": int(l.get("total_api_requests", 0)),
-        "total_tool_calls": int(l.get("total_tool_calls", 0)),
-        "total_input_tokens": int(l.get("total_input_tokens", 0)),
-        "total_output_tokens": int(l.get("total_output_tokens", 0)),
-        "total_traces": int(t.get("total_traces", 0)),
-        "total_spans": int(t.get("total_spans", 0)),
+        "total_sessions": int(log.get("total_sessions", 0)),
+        "total_prompts": int(log.get("total_prompts", 0)),
+        "total_api_requests": int(log.get("total_api_requests", 0)),
+        "total_tool_calls": int(log.get("total_tool_calls", 0)),
+        "total_input_tokens": int(log.get("total_input_tokens", 0)),
+        "total_output_tokens": int(log.get("total_output_tokens", 0)),
+        "total_traces": int(tr.get("total_traces", 0)),
+        "total_spans": int(tr.get("total_spans", 0)),
     }

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -117,20 +117,24 @@ async def get_trace(trace_id: str):
         timestamps = r.get("event_timestamps") or []
         attrs = r.get("event_attributes") or []
         for i in range(len(names)):
-            events.append({
-                "name": names[i],
-                "timestamp": timestamps[i] if i < len(timestamps) else None,
-                "attributes": attrs[i] if i < len(attrs) else {},
-            })
-        spans.append({
-            "span_id": r["span_id"],
-            "parent_span_id": r["parent_span_id"],
-            "span_name": r["span_name"],
-            "duration_ns": r["duration_ns"],
-            "status_code": r["status_code"],
-            "span_attributes": r["span_attributes"],
-            "events": events,
-        })
+            events.append(
+                {
+                    "name": names[i],
+                    "timestamp": timestamps[i] if i < len(timestamps) else None,
+                    "attributes": attrs[i] if i < len(attrs) else {},
+                }
+            )
+        spans.append(
+            {
+                "span_id": r["span_id"],
+                "parent_span_id": r["parent_span_id"],
+                "span_name": r["span_name"],
+                "duration_ns": r["duration_ns"],
+                "status_code": r["status_code"],
+                "span_attributes": r["span_attributes"],
+                "events": events,
+            }
+        )
     return spans
 
 
@@ -147,10 +151,7 @@ async def otel_stats():
         "FROM otel_logs"
     )
     trace_rows = await _ch_json(
-        "SELECT "
-        "count(DISTINCT TraceId) AS total_traces, "
-        "count() AS total_spans "
-        "FROM otel_traces"
+        "SELECT count(DISTINCT TraceId) AS total_traces, count() AS total_spans FROM otel_traces"
     )
     log = log_rows[0] if log_rows else {}
     tr = trace_rows[0] if trace_rows else {}

--- a/observal-server/api/routes/otlp.py
+++ b/observal-server/api/routes/otlp.py
@@ -141,7 +141,12 @@ def _convert_resource_spans(body: dict) -> tuple[list[dict], list[dict]]:
                     status = _STATUS_MAP.get(status_code, "success")
                     error_msg = span.get("status", {}).get("message") if status == "error" else None
 
-                    user_id = all_attrs.get("user.id") or all_attrs.get("user.email") or all_attrs.get("user.account_uuid") or "otlp"
+                    user_id = (
+                        all_attrs.get("user.id")
+                        or all_attrs.get("user.email")
+                        or all_attrs.get("user.account_uuid")
+                        or "otlp"
+                    )
                     session_id = all_attrs.get("session.id")
 
                     # GenAI semantic conventions
@@ -245,41 +250,45 @@ def _process_span_events(
 
             if event_name in ("claude_code.user_prompt", "user_prompt"):
                 # Captured as trace input via log handler; also emit a span
-                spans_out.append({
-                    "span_id": uuid.uuid4().hex,
-                    "trace_id": trace_id,
-                    "parent_span_id": parent_span_id,
-                    "project_id": DEFAULT_PROJECT,
-                    "user_id": user_id,
-                    "type": "user_prompt",
-                    "name": "user_prompt",
-                    "input": event_attrs.get("prompt") or event_attrs.get("content"),
-                    "start_time": dt,
-                    "end_time": dt,
-                    "status": "success",
-                    "ide": ide,
-                    "environment": "default",
-                    "metadata": {},
-                })
+                spans_out.append(
+                    {
+                        "span_id": uuid.uuid4().hex,
+                        "trace_id": trace_id,
+                        "parent_span_id": parent_span_id,
+                        "project_id": DEFAULT_PROJECT,
+                        "user_id": user_id,
+                        "type": "user_prompt",
+                        "name": "user_prompt",
+                        "input": event_attrs.get("prompt") or event_attrs.get("content"),
+                        "start_time": dt,
+                        "end_time": dt,
+                        "status": "success",
+                        "ide": ide,
+                        "environment": "default",
+                        "metadata": {},
+                    }
+                )
             elif event_name in ("claude_code.tool_result", "tool_result"):
                 dur = _safe_int(event_attrs.get("duration_ms"))
-                spans_out.append({
-                    "span_id": uuid.uuid4().hex,
-                    "trace_id": trace_id,
-                    "parent_span_id": parent_span_id,
-                    "project_id": DEFAULT_PROJECT,
-                    "user_id": user_id,
-                    "type": "tool_result",
-                    "name": event_attrs.get("tool_name", "tool"),
-                    "output": event_attrs.get("result"),
-                    "start_time": dt,
-                    "end_time": dt,
-                    "latency_ms": dur,
-                    "status": "success" if event_attrs.get("success", "true") == "true" else "error",
-                    "ide": ide,
-                    "environment": "default",
-                    "metadata": {},
-                })
+                spans_out.append(
+                    {
+                        "span_id": uuid.uuid4().hex,
+                        "trace_id": trace_id,
+                        "parent_span_id": parent_span_id,
+                        "project_id": DEFAULT_PROJECT,
+                        "user_id": user_id,
+                        "type": "tool_result",
+                        "name": event_attrs.get("tool_name", "tool"),
+                        "output": event_attrs.get("result"),
+                        "start_time": dt,
+                        "end_time": dt,
+                        "latency_ms": dur,
+                        "status": "success" if event_attrs.get("success", "true") == "true" else "error",
+                        "ide": ide,
+                        "environment": "default",
+                        "metadata": {},
+                    }
+                )
             elif event_name in ("claude_code.api_request", "api_request"):
                 tok_in = _safe_int(event_attrs.get("input_tokens"))
                 tok_out = _safe_int(event_attrs.get("output_tokens"))
@@ -287,26 +296,28 @@ def _process_span_events(
                 meta: dict[str, str] = {}
                 if event_attrs.get("model"):
                     meta["model"] = event_attrs["model"]
-                spans_out.append({
-                    "span_id": uuid.uuid4().hex,
-                    "trace_id": trace_id,
-                    "parent_span_id": parent_span_id,
-                    "project_id": DEFAULT_PROJECT,
-                    "user_id": user_id,
-                    "type": "llm",
-                    "name": event_attrs.get("model", "api_request"),
-                    "start_time": dt,
-                    "end_time": dt,
-                    "latency_ms": _safe_int(event_attrs.get("duration_ms")),
-                    "status": "success",
-                    "ide": ide,
-                    "environment": "default",
-                    "metadata": meta,
-                    "token_count_input": tok_in,
-                    "token_count_output": tok_out,
-                    "token_count_total": tok_total,
-                    "cost": _safe_float(event_attrs.get("cost")),
-                })
+                spans_out.append(
+                    {
+                        "span_id": uuid.uuid4().hex,
+                        "trace_id": trace_id,
+                        "parent_span_id": parent_span_id,
+                        "project_id": DEFAULT_PROJECT,
+                        "user_id": user_id,
+                        "type": "llm",
+                        "name": event_attrs.get("model", "api_request"),
+                        "start_time": dt,
+                        "end_time": dt,
+                        "latency_ms": _safe_int(event_attrs.get("duration_ms")),
+                        "status": "success",
+                        "ide": ide,
+                        "environment": "default",
+                        "metadata": meta,
+                        "token_count_input": tok_in,
+                        "token_count_output": tok_out,
+                        "token_count_total": tok_total,
+                        "cost": _safe_float(event_attrs.get("cost")),
+                    }
+                )
         except Exception:
             logger.warning("Failed to process span event %s", event.get("name"), exc_info=True)
 
@@ -333,11 +344,18 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                     log_attrs = _extract_attrs(rec.get("attributes", []))
                     all_attrs = {**res_attrs, **log_attrs}
                     event_name = all_attrs.get("event.name", "")
-                    print(f"OTLP log: event_name={event_name!r}, all_attr_keys={list(all_attrs.keys())[:15]}", flush=True)
+                    print(
+                        f"OTLP log: event_name={event_name!r}, all_attr_keys={list(all_attrs.keys())[:15]}", flush=True
+                    )
                     time_nano = rec.get("timeUnixNano", "0")
                     dt = _nanos_to_dt(time_nano) if int(time_nano) > 0 else _now_ms()
 
-                    user_id = all_attrs.get("user.id") or all_attrs.get("user.email") or all_attrs.get("user.account_uuid") or "otlp"
+                    user_id = (
+                        all_attrs.get("user.id")
+                        or all_attrs.get("user.email")
+                        or all_attrs.get("user.account_uuid")
+                        or "otlp"
+                    )
                     session_id = all_attrs.get("session.id")
                     prompt_id = all_attrs.get("prompt.id")
                     # Use prompt_id as trace grouping key, fall back to a new UUID
@@ -347,8 +365,22 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                     body_text = body_val.get("stringValue", "") if isinstance(body_val, dict) else str(body_val)
 
                     if event_name in ("claude_code.user_prompt", "user_prompt"):
-                        prompt_text = all_attrs.get("prompt") or body_text or all_attrs.get("content") or all_attrs.get("prompt_length")
-                        logger.info("OTLP user_prompt: prompt_text=%s, body_text=%s, attrs=%s", repr(prompt_text)[:200], repr(body_text)[:200], {k: repr(v)[:80] for k, v in all_attrs.items() if k.startswith("prompt") or k == "event.name"})
+                        prompt_text = (
+                            all_attrs.get("prompt")
+                            or body_text
+                            or all_attrs.get("content")
+                            or all_attrs.get("prompt_length")
+                        )
+                        logger.info(
+                            "OTLP user_prompt: prompt_text=%s, body_text=%s, attrs=%s",
+                            repr(prompt_text)[:200],
+                            repr(body_text)[:200],
+                            {
+                                k: repr(v)[:80]
+                                for k, v in all_attrs.items()
+                                if k.startswith("prompt") or k == "event.name"
+                            },
+                        )
                         # Create or update trace with user prompt as input
                         if trace_id not in prompt_traces:
                             prompt_traces[trace_id] = {
@@ -385,22 +417,24 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                                 "tags": [],
                             }
                         dur = _safe_int(all_attrs.get("duration_ms"))
-                        spans.append({
-                            "span_id": uuid.uuid4().hex,
-                            "trace_id": trace_id,
-                            "project_id": DEFAULT_PROJECT,
-                            "user_id": user_id,
-                            "type": "tool_result",
-                            "name": all_attrs.get("tool_name", "tool"),
-                            "output": body_text or all_attrs.get("result"),
-                            "start_time": dt,
-                            "end_time": dt,
-                            "latency_ms": dur,
-                            "status": "success" if all_attrs.get("success", "true") == "true" else "error",
-                            "ide": ide,
-                            "environment": "default",
-                            "metadata": {},
-                        })
+                        spans.append(
+                            {
+                                "span_id": uuid.uuid4().hex,
+                                "trace_id": trace_id,
+                                "project_id": DEFAULT_PROJECT,
+                                "user_id": user_id,
+                                "type": "tool_result",
+                                "name": all_attrs.get("tool_name", "tool"),
+                                "output": body_text or all_attrs.get("result"),
+                                "start_time": dt,
+                                "end_time": dt,
+                                "latency_ms": dur,
+                                "status": "success" if all_attrs.get("success", "true") == "true" else "error",
+                                "ide": ide,
+                                "environment": "default",
+                                "metadata": {},
+                            }
+                        )
 
                     elif event_name in ("claude_code.api_request", "api_request"):
                         if trace_id not in prompt_traces:
@@ -419,53 +453,67 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                             }
                         tok_in = _safe_int(all_attrs.get("input_tokens"))
                         tok_out = _safe_int(all_attrs.get("output_tokens"))
-                        tok_total = (tok_in or 0) + (tok_out or 0) if (tok_in is not None or tok_out is not None) else None
+                        tok_total = (
+                            (tok_in or 0) + (tok_out or 0) if (tok_in is not None or tok_out is not None) else None
+                        )
                         meta: dict[str, str] = {}
                         if all_attrs.get("model"):
                             meta["model"] = all_attrs["model"]
-                        spans.append({
-                            "span_id": uuid.uuid4().hex,
-                            "trace_id": trace_id,
-                            "project_id": DEFAULT_PROJECT,
-                            "user_id": user_id,
-                            "type": "llm",
-                            "name": all_attrs.get("model", "api_request"),
-                            "start_time": dt,
-                            "end_time": dt,
-                            "latency_ms": _safe_int(all_attrs.get("duration_ms")),
-                            "status": "success",
-                            "ide": ide,
-                            "environment": "default",
-                            "metadata": meta,
-                            "token_count_input": tok_in,
-                            "token_count_output": tok_out,
-                            "token_count_total": tok_total,
-                            "cost": _safe_float(all_attrs.get("cost")),
-                        })
+                        spans.append(
+                            {
+                                "span_id": uuid.uuid4().hex,
+                                "trace_id": trace_id,
+                                "project_id": DEFAULT_PROJECT,
+                                "user_id": user_id,
+                                "type": "llm",
+                                "name": all_attrs.get("model", "api_request"),
+                                "start_time": dt,
+                                "end_time": dt,
+                                "latency_ms": _safe_int(all_attrs.get("duration_ms")),
+                                "status": "success",
+                                "ide": ide,
+                                "environment": "default",
+                                "metadata": meta,
+                                "token_count_input": tok_in,
+                                "token_count_output": tok_out,
+                                "token_count_total": tok_total,
+                                "cost": _safe_float(all_attrs.get("cost")),
+                            }
+                        )
                     else:
                         # Generic log record → span
-                        spans.append({
-                            "span_id": uuid.uuid4().hex,
-                            "trace_id": trace_id,
-                            "project_id": DEFAULT_PROJECT,
-                            "user_id": user_id,
-                            "type": "log",
-                            "name": event_name or "log",
-                            "input": body_text or None,
-                            "start_time": dt,
-                            "end_time": dt,
-                            "status": "success",
-                            "ide": ide,
-                            "environment": "default",
-                            "metadata": {"severity": str(rec.get("severityNumber", ""))} if rec.get("severityNumber") else {},
-                        })
+                        spans.append(
+                            {
+                                "span_id": uuid.uuid4().hex,
+                                "trace_id": trace_id,
+                                "project_id": DEFAULT_PROJECT,
+                                "user_id": user_id,
+                                "type": "log",
+                                "name": event_name or "log",
+                                "input": body_text or None,
+                                "start_time": dt,
+                                "end_time": dt,
+                                "status": "success",
+                                "ide": ide,
+                                "environment": "default",
+                                "metadata": {"severity": str(rec.get("severityNumber", ""))}
+                                if rec.get("severityNumber")
+                                else {},
+                            }
+                        )
                 except Exception:
                     logger.warning("Failed to convert OTLP log record", exc_info=True)
 
     traces = list(prompt_traces.values())
-    print(f"OTLP logs converted: {len(traces)} traces, {len(spans)} spans, prompt_traces_keys={list(prompt_traces.keys())[:5]}", flush=True)
+    print(
+        f"OTLP logs converted: {len(traces)} traces, {len(spans)} spans, prompt_traces_keys={list(prompt_traces.keys())[:5]}",
+        flush=True,
+    )
     if traces:
-        print(f"OTLP first trace: name={traces[0].get('name')}, input={repr(traces[0].get('input'))[:100]}, session={traces[0].get('session_id')}", flush=True)
+        print(
+            f"OTLP first trace: name={traces[0].get('name')}, input={repr(traces[0].get('input'))[:100]}, session={traces[0].get('session_id')}",
+            flush=True,
+        )
     return traces, spans
 
 
@@ -483,7 +531,11 @@ async def otlp_traces(request: Request):
         body = await request.json()
     except Exception:
         logger.warning("OTLP /v1/traces: malformed JSON body")
-        return Response(content=json.dumps({"partialSuccess": {"rejectedSpans": 1, "errorMessage": "malformed JSON"}}), status_code=400, media_type="application/json")
+        return Response(
+            content=json.dumps({"partialSuccess": {"rejectedSpans": 1, "errorMessage": "malformed JSON"}}),
+            status_code=400,
+            media_type="application/json",
+        )
 
     try:
         trace_rows, span_rows = _convert_resource_spans(body)
@@ -521,17 +573,32 @@ async def otlp_logs(request: Request):
         body = await request.json()
     except Exception:
         logger.warning("OTLP /v1/logs: malformed JSON body")
-        return Response(content=json.dumps({"partialSuccess": {"rejectedLogRecords": 1, "errorMessage": "malformed JSON"}}), status_code=400, media_type="application/json")
+        return Response(
+            content=json.dumps({"partialSuccess": {"rejectedLogRecords": 1, "errorMessage": "malformed JSON"}}),
+            status_code=400,
+            media_type="application/json",
+        )
 
     rl_count = len(body.get("resourceLogs", []))
-    total_recs = sum(len(rec) for rl in body.get("resourceLogs", []) for sl in rl.get("scopeLogs", []) for rec in [sl.get("logRecords", [])])
+    total_recs = sum(
+        len(rec)
+        for rl in body.get("resourceLogs", [])
+        for sl in rl.get("scopeLogs", [])
+        for rec in [sl.get("logRecords", [])]
+    )
     print(f"OTLP /v1/logs: {rl_count} resourceLogs, {total_recs} total records", flush=True)
     if rl_count > 0:
         sample = body["resourceLogs"][0]
-        print(f"OTLP /v1/logs sample resource attrs: {[a.get('key') for a in sample.get('resource', {}).get('attributes', [])][:10]}", flush=True)
+        print(
+            f"OTLP /v1/logs sample resource attrs: {[a.get('key') for a in sample.get('resource', {}).get('attributes', [])][:10]}",
+            flush=True,
+        )
         for sl in sample.get("scopeLogs", []):
             for rec in sl.get("logRecords", [])[:3]:
-                print(f"OTLP /v1/logs sample record: body={repr(rec.get('body', {}))[:200]}, attrs={[a.get('key') for a in rec.get('attributes', [])][:15]}", flush=True)
+                print(
+                    f"OTLP /v1/logs sample record: body={repr(rec.get('body', {}))[:200]}, attrs={[a.get('key') for a in rec.get('attributes', [])][:15]}",
+                    flush=True,
+                )
 
     try:
         trace_rows, span_rows = _convert_resource_logs(body)
@@ -569,7 +636,11 @@ async def otlp_metrics(request: Request):
         body = await request.json()
     except Exception:
         logger.warning("OTLP /v1/metrics: malformed JSON body")
-        return Response(content=json.dumps({"partialSuccess": {"rejectedDataPoints": 1, "errorMessage": "malformed JSON"}}), status_code=400, media_type="application/json")
+        return Response(
+            content=json.dumps({"partialSuccess": {"rejectedDataPoints": 1, "errorMessage": "malformed JSON"}}),
+            status_code=400,
+            media_type="application/json",
+        )
 
     span_rows: list[dict] = []
     now = _now_ms()
@@ -597,25 +668,31 @@ async def otlp_metrics(request: Request):
                         if val is None:
                             continue
                         meta = {"metric_name": name, **dp_attrs}
-                        tok_in = _safe_int(dp_attrs.get("gen_ai.usage.input_tokens")) if "token" in name.lower() else None
-                        tok_out = _safe_int(dp_attrs.get("gen_ai.usage.output_tokens")) if "token" in name.lower() else None
-                        span_rows.append({
-                            "span_id": uuid.uuid4().hex,
-                            "trace_id": uuid.uuid4().hex,
-                            "project_id": DEFAULT_PROJECT,
-                            "user_id": user_id,
-                            "type": "metric",
-                            "name": name,
-                            "start_time": now,
-                            "end_time": now,
-                            "status": "success",
-                            "ide": ide,
-                            "environment": "default",
-                            "metadata": {k: str(v) for k, v in meta.items()},
-                            "token_count_input": tok_in,
-                            "token_count_output": tok_out,
-                            "cost": _safe_float(dp_attrs.get("cost")),
-                        })
+                        tok_in = (
+                            _safe_int(dp_attrs.get("gen_ai.usage.input_tokens")) if "token" in name.lower() else None
+                        )
+                        tok_out = (
+                            _safe_int(dp_attrs.get("gen_ai.usage.output_tokens")) if "token" in name.lower() else None
+                        )
+                        span_rows.append(
+                            {
+                                "span_id": uuid.uuid4().hex,
+                                "trace_id": uuid.uuid4().hex,
+                                "project_id": DEFAULT_PROJECT,
+                                "user_id": user_id,
+                                "type": "metric",
+                                "name": name,
+                                "start_time": now,
+                                "end_time": now,
+                                "status": "success",
+                                "ide": ide,
+                                "environment": "default",
+                                "metadata": {k: str(v) for k, v in meta.items()},
+                                "token_count_input": tok_in,
+                                "token_count_output": tok_out,
+                                "cost": _safe_float(dp_attrs.get("cost")),
+                            }
+                        )
                 except Exception:
                     logger.warning("Failed to convert OTLP metric %s", metric.get("name"), exc_info=True)
 

--- a/observal-server/api/routes/otlp.py
+++ b/observal-server/api/routes/otlp.py
@@ -333,7 +333,7 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                     log_attrs = _extract_attrs(rec.get("attributes", []))
                     all_attrs = {**res_attrs, **log_attrs}
                     event_name = all_attrs.get("event.name", "")
-                    print(f"OTLP log: event_name={repr(event_name)}, all_attr_keys={list(all_attrs.keys())[:15]}", flush=True)
+                    print(f"OTLP log: event_name={event_name!r}, all_attr_keys={list(all_attrs.keys())[:15]}", flush=True)
                     time_nano = rec.get("timeUnixNano", "0")
                     dt = _nanos_to_dt(time_nano) if int(time_nano) > 0 else _now_ms()
 

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -120,22 +120,26 @@ async def render_prompt(
 
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     try:
-        await insert_spans([{
-            "span_id": str(uuid.uuid4()),
-            "trace_id": str(uuid.uuid4()),
-            "type": "prompt_render",
-            "name": f"render:{listing.name}",
-            "start_time": now,
-            "end_time": now,
-            "latency_ms": 0,
-            "status": "success",
-            "project_id": "default",
-            "user_id": str(current_user.id),
-            "variables_provided": len(req.variables),
-            "template_tokens": len(listing.template.split()),
-            "rendered_tokens": len(rendered.split()),
-            "metadata": {},
-        }])
+        await insert_spans(
+            [
+                {
+                    "span_id": str(uuid.uuid4()),
+                    "trace_id": str(uuid.uuid4()),
+                    "type": "prompt_render",
+                    "name": f"render:{listing.name}",
+                    "start_time": now,
+                    "end_time": now,
+                    "latency_ms": 0,
+                    "status": "success",
+                    "project_id": "default",
+                    "user_id": str(current_user.id),
+                    "variables_provided": len(req.variables),
+                    "template_tokens": len(listing.template.split()),
+                    "rendered_tokens": len(rendered.split()),
+                    "metadata": {},
+                }
+            ]
+        )
     except Exception:
         pass
 
@@ -154,9 +158,7 @@ async def delete_prompt(
     if listing.submitted_by != current_user.id and current_user.role.value != "admin":
         raise HTTPException(status_code=403, detail="Not authorized")
 
-    for r in (
-        await db.execute(select(PromptDownload).where(PromptDownload.listing_id == listing.id))
-    ).scalars().all():
+    for r in (await db.execute(select(PromptDownload).where(PromptDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
     await db.delete(listing)

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -1,4 +1,3 @@
-import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
@@ -33,13 +32,16 @@ async def _find_listing(listing_id: str, db: AsyncSession):
     """Try each listing model to find the listing by id or name."""
     import uuid as _uuid
     if isinstance(listing_id, _uuid.UUID):
-        clause_fn = lambda model: model.id == listing_id
+        def clause_fn(model):
+            return model.id == listing_id
     else:
         try:
             uid = _uuid.UUID(listing_id)
-            clause_fn = lambda model: model.id == uid
+            def clause_fn(model):
+                return model.id == uid
         except ValueError:
-            clause_fn = lambda model: model.name == listing_id
+            def clause_fn(model):
+                return model.name == listing_id
     for listing_type, model in LISTING_MODELS.items():
         result = await db.execute(select(model).where(clause_fn(model)))
         listing = result.scalar_one_or_none()

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -1,4 +1,3 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,17 +30,22 @@ def _require_admin(user: User):
 async def _find_listing(listing_id: str, db: AsyncSession):
     """Try each listing model to find the listing by id or name."""
     import uuid as _uuid
+
     if isinstance(listing_id, _uuid.UUID):
+
         def clause_fn(model):
             return model.id == listing_id
     else:
         try:
             uid = _uuid.UUID(listing_id)
+
             def clause_fn(model):
                 return model.id == uid
         except ValueError:
+
             def clause_fn(model):
                 return model.name == listing_id
+
     for listing_type, model in LISTING_MODELS.items():
         result = await db.execute(select(model).where(clause_fn(model)))
         listing = result.scalar_one_or_none()
@@ -65,7 +69,16 @@ async def list_pending(
             select(model).where(model.status == ListingStatus.pending).order_by(model.created_at.desc())
         )
         for r in result.scalars().all():
-            items.append({"type": listing_type, "id": str(r.id), "name": r.name, "status": r.status.value, "submitted_by": str(r.submitted_by), "created_at": r.created_at.isoformat()})
+            items.append(
+                {
+                    "type": listing_type,
+                    "id": str(r.id),
+                    "name": r.name,
+                    "status": r.status.value,
+                    "submitted_by": str(r.submitted_by),
+                    "created_at": r.created_at.isoformat(),
+                }
+            )
     return items
 
 
@@ -79,7 +92,14 @@ async def get_review(
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    return {"type": listing_type, "id": str(listing.id), "name": listing.name, "status": listing.status.value, "submitted_by": str(listing.submitted_by), "created_at": listing.created_at.isoformat()}
+    return {
+        "type": listing_type,
+        "id": str(listing.id),
+        "name": listing.name,
+        "status": listing.status.value,
+        "submitted_by": str(listing.submitted_by),
+        "created_at": listing.created_at.isoformat(),
+    }
 
 
 @router.post("/{listing_id}/approve")

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -1,4 +1,3 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -57,9 +56,7 @@ async def list_sandboxes(
     if runtime_type:
         stmt = stmt.where(SandboxListing.runtime_type == runtime_type)
     if search:
-        stmt = stmt.where(
-            SandboxListing.name.ilike(f"%{search}%") | SandboxListing.description.ilike(f"%{search}%")
-        )
+        stmt = stmt.where(SandboxListing.name.ilike(f"%{search}%") | SandboxListing.description.ilike(f"%{search}%"))
     result = await db.execute(stmt.order_by(SandboxListing.created_at.desc()))
     return [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
 
@@ -107,8 +104,8 @@ async def delete_sandbox(
         raise HTTPException(status_code=403, detail="Not authorized")
 
     for r in (
-        await db.execute(select(SandboxDownload).where(SandboxDownload.listing_id == listing.id))
-    ).scalars().all():
+        (await db.execute(select(SandboxDownload).where(SandboxDownload.listing_id == listing.id))).scalars().all()
+    ):
         await db.delete(r)
 
     await db.delete(listing)

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -1,4 +1,3 @@
-import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -1,4 +1,3 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -1,4 +1,3 @@
-import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -45,7 +45,7 @@ async def ingest(
         try:
             rows = []
             for t in batch.traces:
-                    rows.append(
+                rows.append(
                     {
                         "trace_id": t.trace_id,
                         "parent_trace_id": t.parent_trace_id,

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -8,8 +8,8 @@ from api.graphql import get_context_dep, schema
 from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
 from api.routes.alert import router as alert_router
-from api.routes.component_source import router as component_source_router
 from api.routes.auth import router as auth_router
+from api.routes.component_source import router as component_source_router
 from api.routes.dashboard import router as dashboard_router
 from api.routes.eval import router as eval_router
 from api.routes.feedback import router as feedback_router
@@ -20,9 +20,9 @@ from api.routes.otlp import router as otlp_router
 from api.routes.prompt import router as prompt_router
 from api.routes.review import router as review_router
 from api.routes.sandbox import router as sandbox_router
+from api.routes.scan import router as scan_router
 from api.routes.skill import router as skill_router
 from api.routes.telemetry import router as telemetry_router
-from api.routes.scan import router as scan_router
 from database import engine
 from models import Base
 from services.clickhouse import init_clickhouse

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -45,8 +45,7 @@ class Agent(Base):
     )
 
     components: Mapped[list["AgentComponent"]] = relationship(
-        back_populates="agent", lazy="selectin", order_by="AgentComponent.order_index",
-        cascade="all, delete-orphan"
+        back_populates="agent", lazy="selectin", order_by="AgentComponent.order_index", cascade="all, delete-orphan"
     )
     goal_template: Mapped["AgentGoalTemplate | None"] = relationship(
         back_populates="agent", lazy="selectin", uselist=False, cascade="all, delete-orphan"

--- a/observal-server/models/agent_component.py
+++ b/observal-server/models/agent_component.py
@@ -11,8 +11,7 @@ from models.base import Base
 class AgentComponent(Base):
     __tablename__ = "agent_components"
     __table_args__ = (
-        UniqueConstraint("agent_id", "component_type", "component_id",
-                         name="uq_agent_components_agent_type_component"),
+        UniqueConstraint("agent_id", "component_type", "component_id", name="uq_agent_components_agent_type_component"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/observal-server/models/alert.py
+++ b/observal-server/models/alert.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime
 
 from sqlalchemy import DateTime, Float, String, func
 from sqlalchemy.orm import Mapped, mapped_column

--- a/observal-server/models/component_source.py
+++ b/observal-server/models/component_source.py
@@ -10,9 +10,7 @@ from models.base import Base
 
 class ComponentSource(Base):
     __tablename__ = "component_sources"
-    __table_args__ = (
-        UniqueConstraint("url", "component_type", name="uq_component_sources_url_type"),
-    )
+    __table_args__ = (UniqueConstraint("url", "component_type", name="uq_component_sources_url_type"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     url: Mapped[str] = mapped_column(Text, nullable=False)

--- a/observal-server/models/component_source.py
+++ b/observal-server/models/component_source.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import DateTime, ForeignKey, Interval, String, Text, UniqueConstraint, Boolean
+from sqlalchemy import Boolean, DateTime, ForeignKey, Interval, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 

--- a/observal-server/models/download.py
+++ b/observal-server/models/download.py
@@ -21,9 +21,7 @@ class AgentDownloadRecord(Base):
     agent_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
     )
-    user_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
-    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     fingerprint: Mapped[str | None] = mapped_column(Text, nullable=True)
     source: Mapped[str] = mapped_column(String(50), nullable=False)
     ide: Mapped[str | None] = mapped_column(String(50), nullable=True)

--- a/observal-server/models/exporter_config.py
+++ b/observal-server/models/exporter_config.py
@@ -10,14 +10,10 @@ from models.base import Base
 
 class ExporterConfig(Base):
     __tablename__ = "exporter_configs"
-    __table_args__ = (
-        UniqueConstraint("org_id", "exporter_type", name="uq_exporter_configs_org_type"),
-    )
+    __table_args__ = (UniqueConstraint("org_id", "exporter_type", name="uq_exporter_configs_org_type"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    org_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
-    )
+    org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True)
     exporter_type: Mapped[str] = mapped_column(String(50), nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     config: Mapped[dict] = mapped_column(JSON, nullable=False)

--- a/observal-server/models/sandbox.py
+++ b/observal-server/models/sandbox.py
@@ -47,9 +47,7 @@ class SandboxDownload(Base):
     __tablename__ = "sandbox_downloads"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    listing_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("sandbox_listings.id"), nullable=False
-    )
+    listing_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("sandbox_listings.id"), nullable=False)
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     ide: Mapped[str] = mapped_column(String(50), nullable=False)
     downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/observal-server/models/user.py
+++ b/observal-server/models/user.py
@@ -23,7 +23,5 @@ class User(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.user)
     api_key_hash: Mapped[str] = mapped_column(String(64), nullable=False)
-    org_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
-    )
+    org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -130,7 +130,28 @@ class AgentSummary(BaseModel):
     model_name: str
     supported_ides: list[str]
     status: AgentStatus
+    download_count: int = 0
+    average_rating: float | None = None
+    component_count: int = 0
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
     model_config = {"from_attributes": True}
+
+
+class AgentValidateRequest(BaseModel):
+    components: list[ComponentRef] = []
+
+
+class ValidationIssue(BaseModel):
+    severity: Literal["error", "warning"]
+    component_type: str | None = None
+    component_id: uuid.UUID | None = None
+    message: str
+
+
+class ValidationResult(BaseModel):
+    valid: bool
+    issues: list[ValidationIssue] = []
 
 
 class AgentInstallRequest(BaseModel):

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -33,6 +33,7 @@ ComponentType = Literal["mcp", "skill", "hook", "prompt", "sandbox"]
 
 class ComponentRef(BaseModel):
     """Reference to a registry component to include in an agent."""
+
     component_type: ComponentType
     component_id: uuid.UUID
     config_override: dict | None = None
@@ -91,6 +92,7 @@ class McpLinkResponse(BaseModel):
 
 class ComponentLinkResponse(BaseModel):
     """A component attached to an agent."""
+
     component_type: str
     component_id: uuid.UUID
     version_ref: str

--- a/observal-server/schemas/dashboard.py
+++ b/observal-server/schemas/dashboard.py
@@ -47,6 +47,21 @@ class TopItem(BaseModel):
     value: float
 
 
+class TopAgentItem(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str = ""
+    owner: str = ""
+    version: str = ""
+    download_count: int = 0
+    average_rating: float | None = None
+
+
+class LeaderboardItem(TopAgentItem):
+    """Same as TopAgentItem — used by the leaderboard endpoint."""
+    pass
+
+
 class TrendPoint(BaseModel):
     date: str
     submissions: int

--- a/observal-server/schemas/dashboard.py
+++ b/observal-server/schemas/dashboard.py
@@ -59,6 +59,7 @@ class TopAgentItem(BaseModel):
 
 class LeaderboardItem(TopAgentItem):
     """Same as TopAgentItem — used by the leaderboard endpoint."""
+
     pass
 
 
@@ -69,6 +70,7 @@ class TrendPoint(BaseModel):
 
 
 # --- Token usage ---
+
 
 class TokenByEntity(BaseModel):
     id: str
@@ -97,6 +99,7 @@ class TokenStats(BaseModel):
 
 # --- IDE usage ---
 
+
 class IdeBreakdown(BaseModel):
     ide: str
     traces: int
@@ -110,6 +113,7 @@ class IdeUsage(BaseModel):
 
 
 # --- Sandbox metrics ---
+
 
 class SandboxRun(BaseModel):
     span_id: str
@@ -142,6 +146,7 @@ class SandboxStats(BaseModel):
 
 # --- GraphRAG metrics ---
 
+
 class RelevanceBucket(BaseModel):
     bucket: str
     count: int
@@ -169,6 +174,7 @@ class GraphRagStats(BaseModel):
 
 
 # --- RAGAS evaluation ---
+
 
 class RagasDimensionScore(BaseModel):
     avg: float | None
@@ -209,6 +215,7 @@ class RagasEvalRequest(BaseModel):
 
 # --- Latency heatmap ---
 
+
 class LatencyCell(BaseModel):
     name: str
     hour: str
@@ -218,6 +225,7 @@ class LatencyCell(BaseModel):
 
 
 # --- Unannotated traces ---
+
 
 class UnannotatedTrace(BaseModel):
     trace_id: str

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 class ManifestComponent(BaseModel):
     """A single component entry in the agent manifest."""
+
     name: str
     version: str
     git_url: str
@@ -58,6 +59,7 @@ class ManifestComponent(BaseModel):
 
 class ManifestComponents(BaseModel):
     """All components grouped by type."""
+
     mcps: list[ManifestComponent] = Field(default_factory=list)
     skills: list[ManifestComponent] = Field(default_factory=list)
     hooks: list[ManifestComponent] = Field(default_factory=list)
@@ -68,8 +70,10 @@ class ManifestComponents(BaseModel):
         """Only include non-empty component lists."""
         result = {}
         for key, items in [
-            ("mcps", self.mcps), ("skills", self.skills),
-            ("hooks", self.hooks), ("prompts", self.prompts),
+            ("mcps", self.mcps),
+            ("skills", self.skills),
+            ("hooks", self.hooks),
+            ("prompts", self.prompts),
             ("sandboxes", self.sandboxes),
         ]:
             if items:
@@ -85,6 +89,7 @@ class ManifestError(BaseModel):
 
 class AgentManifest(BaseModel):
     """Portable agent manifest — the canonical representation of a composed agent."""
+
     name: str
     version: str
     prompt: str = ""
@@ -113,6 +118,7 @@ class AgentManifest(BaseModel):
 
 class CompositionSummary(BaseModel):
     """Lightweight summary of agent composition for API responses."""
+
     agent_id: str
     agent_name: str
     agent_version: str
@@ -127,6 +133,7 @@ class CompositionSummary(BaseModel):
 
 class AgentFile(BaseModel):
     """A single file to write for IDE agent installation."""
+
     path: str
     content: str | dict
     format: Literal["markdown", "json", "toml"] = "json"
@@ -134,6 +141,7 @@ class AgentFile(BaseModel):
 
 class IdeAgentConfig(BaseModel):
     """Complete IDE-specific agent configuration output."""
+
     ide: str
     files: list[AgentFile] = Field(default_factory=list)
     mcp_servers: dict = Field(default_factory=dict)
@@ -242,10 +250,7 @@ def build_composition_summary(resolved: ResolvedAgent) -> dict:
         typed = resolved.components_by_type(ctype)
         if typed:
             component_counts[ctype] = len(typed)
-            components_by_key[key] = [
-                {"name": c.name, "version": c.version, "order": c.order_index}
-                for c in typed
-            ]
+            components_by_key[key] = [{"name": c.name, "version": c.version, "order": c.order_index} for c in typed]
 
     summary = CompositionSummary(
         agent_id=str(resolved.agent_id),
@@ -520,10 +525,17 @@ _IDE_GENERATORS = {
     "copilot": _generate_copilot,
 }
 
-SUPPORTED_IDES = list({
-    "claude-code", "cursor", "vscode", "gemini-cli",
-    "kiro", "codex", "copilot",
-})
+SUPPORTED_IDES = list(
+    {
+        "claude-code",
+        "cursor",
+        "vscode",
+        "gemini-cli",
+        "kiro",
+        "codex",
+        "copilot",
+    }
+)
 
 
 def generate_ide_agent_files(manifest: AgentManifest, ide: str) -> IdeAgentConfig:
@@ -534,7 +546,5 @@ def generate_ide_agent_files(manifest: AgentManifest, ide: str) -> IdeAgentConfi
     """
     generator = _IDE_GENERATORS.get(ide)
     if generator is None:
-        raise ValueError(
-            f"Unsupported IDE: {ide!r}. Supported: {', '.join(SUPPORTED_IDES)}"
-        )
+        raise ValueError(f"Unsupported IDE: {ide!r}. Supported: {', '.join(SUPPORTED_IDES)}")
     return generator(manifest)

--- a/observal-server/services/agent_resolver.py
+++ b/observal-server/services/agent_resolver.py
@@ -31,6 +31,7 @@ _LISTING_MODELS: dict[str, type] = {
 
 class ResolvedComponent(BaseModel):
     """A fully resolved component with its listing data."""
+
     model_config = {"frozen": True}
 
     component_type: ComponentType
@@ -48,6 +49,7 @@ class ResolvedComponent(BaseModel):
 
 class ResolutionError(BaseModel):
     """A single resolution failure."""
+
     model_config = {"frozen": True}
 
     component_type: str
@@ -138,45 +140,53 @@ async def resolve_agent(
     for comp in agent.components:
         model = _LISTING_MODELS.get(comp.component_type)
         if model is None:
-            errors.append(ResolutionError(
-                component_type=comp.component_type,
-                component_id=comp.component_id,
-                reason=f"Unknown component type: {comp.component_type}",
-            ))
+            errors.append(
+                ResolutionError(
+                    component_type=comp.component_type,
+                    component_id=comp.component_id,
+                    reason=f"Unknown component type: {comp.component_type}",
+                )
+            )
             continue
 
         stmt = select(model).where(model.id == comp.component_id)
         listing = (await db.execute(stmt)).scalar_one_or_none()
 
         if listing is None:
-            errors.append(ResolutionError(
-                component_type=comp.component_type,
-                component_id=comp.component_id,
-                reason=f"{comp.component_type} listing {comp.component_id} not found",
-            ))
+            errors.append(
+                ResolutionError(
+                    component_type=comp.component_type,
+                    component_id=comp.component_id,
+                    reason=f"{comp.component_type} listing {comp.component_id} not found",
+                )
+            )
             continue
 
         if require_approved and listing.status != ListingStatus.approved:
-            errors.append(ResolutionError(
-                component_type=comp.component_type,
-                component_id=comp.component_id,
-                reason=f"{comp.component_type} '{listing.name}' is not approved (status: {listing.status.value})",
-            ))
+            errors.append(
+                ResolutionError(
+                    component_type=comp.component_type,
+                    component_id=comp.component_id,
+                    reason=f"{comp.component_type} '{listing.name}' is not approved (status: {listing.status.value})",
+                )
+            )
             continue
 
-        components.append(ResolvedComponent(
-            component_type=comp.component_type,
-            component_id=comp.component_id,
-            name=listing.name,
-            version=listing.version,
-            git_url=listing.git_url,
-            git_ref=listing.git_ref or "",
-            description=listing.description,
-            order_index=comp.order_index,
-            config_override=comp.config_override,
-            listing_status=listing.status.value,
-            extra=_extract_extra(listing, comp.component_type),
-        ))
+        components.append(
+            ResolvedComponent(
+                component_type=comp.component_type,
+                component_id=comp.component_id,
+                name=listing.name,
+                version=listing.version,
+                git_url=listing.git_url,
+                git_ref=listing.git_ref or "",
+                description=listing.description,
+                order_index=comp.order_index,
+                config_override=comp.config_override,
+                listing_status=listing.status.value,
+                extra=_extract_extra(listing, comp.component_type),
+            )
+        )
 
     return ResolvedAgent(
         agent_id=agent.id,
@@ -206,38 +216,46 @@ async def validate_component_ids(
         ctype = ref.get("component_type", "")
         cid = ref.get("component_id")
         if cid is None:
-            errors.append(ResolutionError(
-                component_type=ctype,
-                component_id=uuid.UUID(int=0),
-                reason=f"Missing component_id for {ctype}",
-            ))
+            errors.append(
+                ResolutionError(
+                    component_type=ctype,
+                    component_id=uuid.UUID(int=0),
+                    reason=f"Missing component_id for {ctype}",
+                )
+            )
             continue
 
         model = _LISTING_MODELS.get(ctype)
         if model is None:
-            errors.append(ResolutionError(
-                component_type=ctype,
-                component_id=cid,
-                reason=f"Unknown component type: {ctype}",
-            ))
+            errors.append(
+                ResolutionError(
+                    component_type=ctype,
+                    component_id=cid,
+                    reason=f"Unknown component type: {ctype}",
+                )
+            )
             continue
 
         stmt = select(model).where(model.id == cid)
         listing = (await db.execute(stmt)).scalar_one_or_none()
 
         if listing is None:
-            errors.append(ResolutionError(
-                component_type=ctype,
-                component_id=cid,
-                reason=f"{ctype} listing {cid} not found",
-            ))
+            errors.append(
+                ResolutionError(
+                    component_type=ctype,
+                    component_id=cid,
+                    reason=f"{ctype} listing {cid} not found",
+                )
+            )
             continue
 
         if require_approved and listing.status != ListingStatus.approved:
-            errors.append(ResolutionError(
-                component_type=ctype,
-                component_id=cid,
-                reason=f"{ctype} '{listing.name}' is not approved (status: {listing.status.value})",
-            ))
+            errors.append(
+                ResolutionError(
+                    component_type=ctype,
+                    component_id=cid,
+                    reason=f"{ctype} '{listing.name}' is not approved (status: {listing.status.value})",
+                )
+            )
 
     return errors

--- a/observal-server/services/agent_resolver.py
+++ b/observal-server/services/agent_resolver.py
@@ -9,7 +9,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.agent import Agent
-from models.agent_component import AgentComponent
 from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
 from models.prompt import PromptListing

--- a/observal-server/services/download_tracker.py
+++ b/observal-server/services/download_tracker.py
@@ -8,10 +8,10 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-logger = logging.getLogger(__name__)
-
 from models.agent import Agent
 from models.download import AgentDownloadRecord, ComponentDownloadRecord
+
+logger = logging.getLogger(__name__)
 
 
 def _anonymous_fingerprint(request: Request) -> str:

--- a/observal-server/services/download_tracker.py
+++ b/observal-server/services/download_tracker.py
@@ -89,6 +89,8 @@ async def _update_agent_counts(agent_id: uuid.UUID, db: AsyncSession) -> None:
 
 async def get_download_stats(agent_id: uuid.UUID, db: AsyncSession) -> dict:
     """Get download statistics for an agent."""
+    from datetime import timedelta
+
     total = await db.scalar(
         select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)
     ) or 0
@@ -96,6 +98,15 @@ async def get_download_stats(agent_id: uuid.UUID, db: AsyncSession) -> dict:
         select(func.count(func.distinct(AgentDownloadRecord.user_id))).where(
             AgentDownloadRecord.agent_id == agent_id,
             AgentDownloadRecord.user_id.isnot(None),
+        )
+    ) or 0
+
+    # Recent 7-day downloads
+    cutoff = datetime.now(UTC) - timedelta(days=7)
+    recent_7d = await db.scalar(
+        select(func.count(AgentDownloadRecord.id)).where(
+            AgentDownloadRecord.agent_id == agent_id,
+            AgentDownloadRecord.installed_at >= cutoff,
         )
     ) or 0
 
@@ -108,7 +119,9 @@ async def get_download_stats(agent_id: uuid.UUID, db: AsyncSession) -> dict:
     sources = {r.source: r.cnt for r in source_rows.all()}
 
     return {
+        "total": total,
         "total_downloads": total,
         "unique_users": unique,
+        "recent_7d": recent_7d,
         "sources": sources,
     }

--- a/observal-server/services/download_tracker.py
+++ b/observal-server/services/download_tracker.py
@@ -60,27 +60,32 @@ async def record_component_download(
     db: AsyncSession,
 ) -> None:
     """Record a component download (not deduplicated)."""
-    db.add(ComponentDownloadRecord(
-        component_type=component_type,
-        component_id=component_id,
-        version_ref=version_ref,
-        agent_id=agent_id,
-        source=source,
-    ))
+    db.add(
+        ComponentDownloadRecord(
+            component_type=component_type,
+            component_id=component_id,
+            version_ref=version_ref,
+            agent_id=agent_id,
+            source=source,
+        )
+    )
     await db.flush()
 
 
 async def _update_agent_counts(agent_id: uuid.UUID, db: AsyncSession) -> None:
     """Recompute download_count and unique_users for an agent."""
-    total = await db.scalar(
-        select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)
-    ) or 0
-    unique = await db.scalar(
-        select(func.count(func.distinct(AgentDownloadRecord.user_id))).where(
-            AgentDownloadRecord.agent_id == agent_id,
-            AgentDownloadRecord.user_id.isnot(None),
+    total = (
+        await db.scalar(select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)) or 0
+    )
+    unique = (
+        await db.scalar(
+            select(func.count(func.distinct(AgentDownloadRecord.user_id))).where(
+                AgentDownloadRecord.agent_id == agent_id,
+                AgentDownloadRecord.user_id.isnot(None),
+            )
         )
-    ) or 0
+        or 0
+    )
     agent = await db.get(Agent, agent_id)
     if agent:
         agent.download_count = total
@@ -91,24 +96,30 @@ async def get_download_stats(agent_id: uuid.UUID, db: AsyncSession) -> dict:
     """Get download statistics for an agent."""
     from datetime import timedelta
 
-    total = await db.scalar(
-        select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)
-    ) or 0
-    unique = await db.scalar(
-        select(func.count(func.distinct(AgentDownloadRecord.user_id))).where(
-            AgentDownloadRecord.agent_id == agent_id,
-            AgentDownloadRecord.user_id.isnot(None),
+    total = (
+        await db.scalar(select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)) or 0
+    )
+    unique = (
+        await db.scalar(
+            select(func.count(func.distinct(AgentDownloadRecord.user_id))).where(
+                AgentDownloadRecord.agent_id == agent_id,
+                AgentDownloadRecord.user_id.isnot(None),
+            )
         )
-    ) or 0
+        or 0
+    )
 
     # Recent 7-day downloads
     cutoff = datetime.now(UTC) - timedelta(days=7)
-    recent_7d = await db.scalar(
-        select(func.count(AgentDownloadRecord.id)).where(
-            AgentDownloadRecord.agent_id == agent_id,
-            AgentDownloadRecord.installed_at >= cutoff,
+    recent_7d = (
+        await db.scalar(
+            select(func.count(AgentDownloadRecord.id)).where(
+                AgentDownloadRecord.agent_id == agent_id,
+                AgentDownloadRecord.installed_at >= cutoff,
+            )
         )
-    ) or 0
+        or 0
+    )
 
     # Source breakdown
     source_rows = await db.execute(

--- a/observal-server/services/eval_service.py
+++ b/observal-server/services/eval_service.py
@@ -254,9 +254,7 @@ async def run_structured_eval(
     aggregator = ScoreAggregator()
 
     # Phase 1: Structural scoring (always runs)
-    structural_penalties = structural_scorer.score_tool_efficiency(
-        spans, str(agent.id)
-    )
+    structural_penalties = structural_scorer.score_tool_efficiency(spans, str(agent.id))
     structural_penalties += structural_scorer.score_tool_failures(spans)
 
     # Attach penalty amounts from catalog
@@ -275,13 +273,10 @@ async def run_structured_eval(
             if agent.goal_template:
                 goal_desc = agent.goal_template.description
                 required_sections = [
-                    {"name": s.name, "grounding_required": s.grounding_required}
-                    for s in agent.goal_template.sections
+                    {"name": s.name, "grounding_required": s.grounding_required} for s in agent.goal_template.sections
                 ]
             if required_sections:
-                slm_penalties += await slm_scorer.score_goal_completion(
-                    trace, spans, goal_desc, required_sections
-                )
+                slm_penalties += await slm_scorer.score_goal_completion(trace, spans, goal_desc, required_sections)
 
             # Factual grounding
             slm_penalties += await slm_scorer.score_factual_grounding(trace, spans)

--- a/observal-server/services/git_mirror_service.py
+++ b/observal-server/services/git_mirror_service.py
@@ -41,7 +41,7 @@ def _mirror_path(git_url: str, base: Path = DEFAULT_MIRROR_BASE) -> Path:
 def _run_git(args: list[str], cwd: str | None = None, timeout: int = 120) -> subprocess.CompletedProcess:
     """Run a git command with timeout."""
     return subprocess.run(
-        ["git"] + args,
+        ["git", *args],
         cwd=cwd,
         capture_output=True,
         text=True,

--- a/observal-server/services/git_mirror_service.py
+++ b/observal-server/services/git_mirror_service.py
@@ -66,10 +66,18 @@ def clone_or_update(git_url: str, branch: str = "main", base: Path = DEFAULT_MIR
         # Fresh shallow clone
         if mirror_dir.exists():
             shutil.rmtree(mirror_dir)
-        result = _run_git([
-            "clone", "--depth", "1", "--single-branch", "--branch", branch,
-            git_url, str(mirror_dir),
-        ])
+        result = _run_git(
+            [
+                "clone",
+                "--depth",
+                "1",
+                "--single-branch",
+                "--branch",
+                branch,
+                git_url,
+                str(mirror_dir),
+            ]
+        )
         if result.returncode != 0:
             raise RuntimeError(f"git clone failed: {result.stderr.strip()}")
 
@@ -110,7 +118,9 @@ def _safe_path(base: Path, rel: str) -> bool:
         return False
 
 
-def _parse_manifest(manifest: dict, component_type: str | None = None, mirror_dir: Path | None = None) -> list[DiscoveredComponent]:
+def _parse_manifest(
+    manifest: dict, component_type: str | None = None, mirror_dir: Path | None = None
+) -> list[DiscoveredComponent]:
     """Parse .observal.json manifest."""
     components = []
     type_keys = {
@@ -122,9 +132,7 @@ def _parse_manifest(manifest: dict, component_type: str | None = None, mirror_di
     }
 
     types_to_scan = (
-        {component_type: type_keys[component_type]}
-        if component_type and component_type in type_keys
-        else type_keys
+        {component_type: type_keys[component_type]} if component_type and component_type in type_keys else type_keys
     )
 
     for ctype, key in types_to_scan.items():
@@ -134,12 +142,14 @@ def _parse_manifest(manifest: dict, component_type: str | None = None, mirror_di
             if mirror_dir and not _safe_path(mirror_dir, comp_path):
                 logger.warning("Skipping component with unsafe path: %s", comp_path)
                 continue
-            components.append(DiscoveredComponent(
-                name=entry.get("name", comp_path.split("/")[-1]),
-                path=comp_path,
-                component_type=ctype,
-                description=entry.get("description", ""),
-            ))
+            components.append(
+                DiscoveredComponent(
+                    name=entry.get("name", comp_path.split("/")[-1]),
+                    path=comp_path,
+                    component_type=ctype,
+                    description=entry.get("description", ""),
+                )
+            )
 
     return components
 
@@ -184,18 +194,18 @@ def _scan_by_convention(mirror_dir: Path, component_type: str | None = None) -> 
                 if not _safe_path(mirror_dir, str(item.relative_to(mirror_dir))):
                     continue
                 if marker(item):
-                    components.append(DiscoveredComponent(
-                        name=item.name,
-                        path=str(item.relative_to(mirror_dir)),
-                        component_type=ctype,
-                    ))
+                    components.append(
+                        DiscoveredComponent(
+                            name=item.name,
+                            path=str(item.relative_to(mirror_dir)),
+                            component_type=ctype,
+                        )
+                    )
 
     return components
 
 
-_FASTMCP_PATTERN = re.compile(
-    r"FastMCP\(|from\s+mcp\.server\.fastmcp\s+import|from\s+fastmcp\s+import"
-)
+_FASTMCP_PATTERN = re.compile(r"FastMCP\(|from\s+mcp\.server\.fastmcp\s+import|from\s+fastmcp\s+import")
 
 
 def validate_mcp_component(component_path: Path) -> tuple[bool, str]:
@@ -212,7 +222,9 @@ def validate_mcp_component(component_path: Path) -> tuple[bool, str]:
     return False, "No FastMCP usage found. MCP servers must use FastMCP."
 
 
-def sync_source(git_url: str, component_type: str, branch: str = "main", base: Path = DEFAULT_MIRROR_BASE) -> SyncResult:
+def sync_source(
+    git_url: str, component_type: str, branch: str = "main", base: Path = DEFAULT_MIRROR_BASE
+) -> SyncResult:
     """Full sync pipeline: clone -> discover -> validate. Returns SyncResult."""
     try:
         mirror_dir = clone_or_update(git_url, branch=branch, base=base)

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -16,16 +16,16 @@ BLOCKED_SCHEMES = {"file", "ftp", "ssh", "git"}
 
 # Patterns that indicate an MCP server implementation (Python files)
 _PYTHON_MCP_PATTERN = re.compile(
-    r"FastMCP\("           # FastMCP framework
-    r"|@mcp\.server"       # standard MCP SDK decorator
+    r"FastMCP\("  # FastMCP framework
+    r"|@mcp\.server"  # standard MCP SDK decorator
     r"|from\s+mcp\.server\s+import\s+Server"  # standard MCP SDK Server import
-    r"|from\s+mcp\s+import"   # any MCP SDK usage
-    r"|import\s+mcp\b"        # any MCP SDK usage
-    r"|McpServer\("           # common custom class name
-    r"|MCPServer\("           # common custom class name (alt casing)
-    r"|@app\.tool\b"          # common tool decorator
-    r"|@server\.tool\b"       # common tool decorator
-    r"|Server\(\s*name\s*="   # Server(name=...) pattern
+    r"|from\s+mcp\s+import"  # any MCP SDK usage
+    r"|import\s+mcp\b"  # any MCP SDK usage
+    r"|McpServer\("  # common custom class name
+    r"|MCPServer\("  # common custom class name (alt casing)
+    r"|@app\.tool\b"  # common tool decorator
+    r"|@server\.tool\b"  # common tool decorator
+    r"|Server\(\s*name\s*="  # Server(name=...) pattern
 )
 
 

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -238,7 +238,7 @@ async def _manifest_validation(listing: McpListing, db: AsyncSession, entry_poin
 
     # Find @mcp.tool / @app.tool / @server.tool decorated functions
     for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             continue
         is_tool = any(
             (isinstance(d, ast.Attribute) and d.attr == "tool")
@@ -350,7 +350,7 @@ async def analyze_repo(git_url: str) -> dict:
 
         tools = []
         for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 continue
             is_tool = any(
                 (isinstance(d, ast.Attribute) and d.attr == "tool")

--- a/observal-server/services/ragas_eval.py
+++ b/observal-server/services/ragas_eval.py
@@ -230,23 +230,25 @@ async def run_ragas_on_graphrag(
             span_result[dim] = dim_result.get("score", 0.0)
             span_result[f"{dim}_reason"] = dim_result.get("reason", "")
 
-            scores_to_insert.append({
-                "score_id": str(uuid.uuid4()),
-                "trace_id": span["trace_id"],
-                "span_id": span["span_id"],
-                "project_id": project_id,
-                "mcp_id": None,
-                "agent_id": None,
-                "user_id": "system",
-                "name": f"ragas_{dim}",
-                "source": "ragas_eval",
-                "data_type": "numeric",
-                "value": dim_result.get("score", 0.0),
-                "comment": dim_result.get("reason", ""),
-                "eval_template_id": f"ragas-{dim}",
-                "metadata": {"graphrag_id": graphrag_id},
-                "timestamp": now,
-            })
+            scores_to_insert.append(
+                {
+                    "score_id": str(uuid.uuid4()),
+                    "trace_id": span["trace_id"],
+                    "span_id": span["span_id"],
+                    "project_id": project_id,
+                    "mcp_id": None,
+                    "agent_id": None,
+                    "user_id": "system",
+                    "name": f"ragas_{dim}",
+                    "source": "ragas_eval",
+                    "data_type": "numeric",
+                    "value": dim_result.get("score", 0.0),
+                    "comment": dim_result.get("reason", ""),
+                    "eval_template_id": f"ragas-{dim}",
+                    "metadata": {"graphrag_id": graphrag_id},
+                    "timestamp": now,
+                }
+            )
 
         all_scores.append(span_result)
 

--- a/observal-server/services/ragas_eval.py
+++ b/observal-server/services/ragas_eval.py
@@ -18,13 +18,12 @@ References:
 Content was rephrased for compliance with licensing restrictions.
 """
 
-import json
 import logging
 import uuid
 from datetime import UTC, datetime
 
-from services.clickhouse import insert_scores, query_spans
-from services.eval_engine import _call_model, _extract_json, get_backend
+from services.clickhouse import insert_scores
+from services.eval_engine import _call_model
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +192,7 @@ async def run_ragas_on_graphrag(
     Returns:
         Dict with per-span scores and aggregate averages.
     """
-    from services.clickhouse import _query, _escape
+    from services.clickhouse import _escape, _query
 
     ground_truths = ground_truths or {}
 
@@ -276,7 +275,7 @@ async def get_ragas_scores(
     project_id: str = "default",
 ) -> dict:
     """Fetch previously computed RAGAS scores from ClickHouse."""
-    from services.clickhouse import _query, _escape
+    from services.clickhouse import _escape, _query
 
     averages = {}
     for dim in RAGAS_DIMENSIONS:
@@ -306,7 +305,7 @@ async def get_ragas_scores(
 
 async def get_ragas_aggregate(project_id: str = "default") -> dict:
     """Fetch aggregate RAGAS scores across all GraphRAGs."""
-    from services.clickhouse import _query, _escape
+    from services.clickhouse import _escape, _query
 
     averages = {}
     for dim in RAGAS_DIMENSIONS:

--- a/observal-server/services/score_aggregator.py
+++ b/observal-server/services/score_aggregator.py
@@ -100,10 +100,7 @@ class ScoreAggregator:
             dimension_scores[dim.value] = score
 
         # Weighted composite
-        composite = sum(
-            dimension_scores[dim.value] * weights.get(dim, 0)
-            for dim in ScoringDimension
-        )
+        composite = sum(dimension_scores[dim.value] * weights.get(dim, 0) for dim in ScoringDimension)
         composite = max(0, min(100, composite))
 
         # Display score (0-10)
@@ -163,8 +160,13 @@ class ScoreAggregator:
         """
         if not scorecards:
             return {
-                "mean": 0, "std": 0, "ci_low": 0, "ci_high": 0,
-                "dimension_averages": {}, "drift_alert": False, "trend": [],
+                "mean": 0,
+                "std": 0,
+                "ci_low": 0,
+                "ci_high": 0,
+                "dimension_averages": {},
+                "drift_alert": False,
+                "trend": [],
             }
 
         recent = scorecards[:window_size]
@@ -180,11 +182,7 @@ class ScoreAggregator:
         # Per-dimension averages
         dim_avgs: dict[str, float] = {}
         for dim in ScoringDimension:
-            scores = [
-                s.get("dimension_scores", {}).get(dim.value, 0)
-                for s in recent
-                if s.get("dimension_scores")
-            ]
+            scores = [s.get("dimension_scores", {}).get(dim.value, 0) for s in recent if s.get("dimension_scores")]
             dim_avgs[dim.value] = round(sum(scores) / len(scores), 2) if scores else 0
 
         # Find weakest dimension
@@ -193,7 +191,7 @@ class ScoreAggregator:
         # Drift alert: compare recent mean to 30-day baseline
         drift_alert = False
         if len(scorecards) > window_size:
-            baseline = scorecards[window_size: window_size + 50]
+            baseline = scorecards[window_size : window_size + 50]
             if baseline:
                 baseline_composites = [s.get("composite_score", 0) for s in baseline]
                 baseline_mean = sum(baseline_composites) / len(baseline_composites)
@@ -203,10 +201,7 @@ class ScoreAggregator:
                     drift_alert = True
 
         # Trend data
-        trend = [
-            {"timestamp": s.get("evaluated_at", ""), "composite": s.get("composite_score", 0)}
-            for s in recent
-        ]
+        trend = [{"timestamp": s.get("evaluated_at", ""), "composite": s.get("composite_score", 0)} for s in recent]
 
         return {
             "mean": round(mean, 2),
@@ -251,28 +246,23 @@ class ScoreAggregator:
 
             if dim == ScoringDimension.goal_completion:
                 recommendations.append(
-                    f"Improve goal completion (score: {score:.0f}). "
-                    f"Issues: {', '.join(unique_names[:3])}."
+                    f"Improve goal completion (score: {score:.0f}). Issues: {', '.join(unique_names[:3])}."
                 )
             elif dim == ScoringDimension.tool_efficiency:
                 recommendations.append(
-                    f"Improve tool efficiency (score: {score:.0f}). "
-                    f"Issues: {', '.join(unique_names[:3])}."
+                    f"Improve tool efficiency (score: {score:.0f}). Issues: {', '.join(unique_names[:3])}."
                 )
             elif dim == ScoringDimension.tool_failures:
                 recommendations.append(
-                    f"Reduce tool failures (score: {score:.0f}). "
-                    f"Issues: {', '.join(unique_names[:3])}."
+                    f"Reduce tool failures (score: {score:.0f}). Issues: {', '.join(unique_names[:3])}."
                 )
             elif dim == ScoringDimension.factual_grounding:
                 recommendations.append(
-                    f"Improve factual grounding (score: {score:.0f}). "
-                    f"Issues: {', '.join(unique_names[:3])}."
+                    f"Improve factual grounding (score: {score:.0f}). Issues: {', '.join(unique_names[:3])}."
                 )
             elif dim == ScoringDimension.thought_process:
                 recommendations.append(
-                    f"Improve thought process (score: {score:.0f}). "
-                    f"Issues: {', '.join(unique_names[:3])}."
+                    f"Improve thought process (score: {score:.0f}). Issues: {', '.join(unique_names[:3])}."
                 )
 
         return recommendations

--- a/observal-server/services/slm_scorer.py
+++ b/observal-server/services/slm_scorer.py
@@ -92,8 +92,7 @@ class SLMScorer:
         agent_output = trace.get("output") or ""
         tool_results = _extract_tool_results(spans)
         sections_text = "\n".join(
-            f"- {s.get('name', 'Unknown')}"
-            + (" [grounding required]" if s.get("grounding_required") else "")
+            f"- {s.get('name', 'Unknown')}" + (" [grounding required]" if s.get("grounding_required") else "")
             for s in required_sections
         )
 
@@ -113,26 +112,32 @@ class SLMScorer:
             section_name = section.get("section_name", "")
 
             if status == "missing":
-                penalties.append({
-                    "event_name": "missing_required_section",
-                    "dimension": ScoringDimension.goal_completion,
-                    "evidence": f"Section '{section_name}' is missing. {evidence}",
-                    "trace_event_index": None,
-                })
+                penalties.append(
+                    {
+                        "event_name": "missing_required_section",
+                        "dimension": ScoringDimension.goal_completion,
+                        "evidence": f"Section '{section_name}' is missing. {evidence}",
+                        "trace_event_index": None,
+                    }
+                )
             elif status == "stub":
-                penalties.append({
-                    "event_name": "empty_stub_section",
-                    "dimension": ScoringDimension.goal_completion,
-                    "evidence": f"Section '{section_name}' contains only stub content. {evidence}",
-                    "trace_event_index": None,
-                })
+                penalties.append(
+                    {
+                        "event_name": "empty_stub_section",
+                        "dimension": ScoringDimension.goal_completion,
+                        "evidence": f"Section '{section_name}' contains only stub content. {evidence}",
+                        "trace_event_index": None,
+                    }
+                )
             elif status == "ungrounded":
-                penalties.append({
-                    "event_name": "ungrounded_section",
-                    "dimension": ScoringDimension.goal_completion,
-                    "evidence": f"Section '{section_name}' is not grounded in tool results. {evidence}",
-                    "trace_event_index": None,
-                })
+                penalties.append(
+                    {
+                        "event_name": "ungrounded_section",
+                        "dimension": ScoringDimension.goal_completion,
+                        "evidence": f"Section '{section_name}' is not grounded in tool results. {evidence}",
+                        "trace_event_index": None,
+                    }
+                )
 
         return penalties
 
@@ -165,12 +170,14 @@ class SLMScorer:
             status = claim.get("status", "grounded")
             event_name = status_to_event.get(status)
             if event_name:
-                penalties.append({
-                    "event_name": event_name,
-                    "dimension": ScoringDimension.factual_grounding,
-                    "evidence": f"Claim: '{claim.get('claim', '')}'. {claim.get('evidence', '')}",
-                    "trace_event_index": None,
-                })
+                penalties.append(
+                    {
+                        "event_name": event_name,
+                        "dimension": ScoringDimension.factual_grounding,
+                        "evidence": f"Claim: '{claim.get('claim', '')}'. {claim.get('evidence', '')}",
+                        "trace_event_index": None,
+                    }
+                )
 
         return penalties
 
@@ -197,12 +204,14 @@ class SLMScorer:
         for finding in result.get("findings", []):
             event_name = finding.get("type", "")
             if event_name in valid_types:
-                penalties.append({
-                    "event_name": event_name,
-                    "dimension": ScoringDimension.thought_process,
-                    "evidence": f"{finding.get('description', '')} Evidence: {finding.get('evidence', '')}",
-                    "trace_event_index": None,
-                })
+                penalties.append(
+                    {
+                        "event_name": event_name,
+                        "dimension": ScoringDimension.thought_process,
+                        "evidence": f"{finding.get('description', '')} Evidence: {finding.get('evidence', '')}",
+                        "trace_event_index": None,
+                    }
+                )
 
         return penalties
 
@@ -223,6 +232,7 @@ class SLMScorer:
     async def _call_model_direct(self, prompt: str) -> dict:
         """Direct model call for structured JSON responses."""
         from services.eval_service import call_eval_model
+
         try:
             result = await call_eval_model(prompt)
             if result:

--- a/observal-server/services/structural_scorer.py
+++ b/observal-server/services/structural_scorer.py
@@ -39,19 +39,19 @@ class StructuralScorer:
         # Detected when non-tool spans contain assertion patterns but the trace
         # has zero tool calls to back them up.
         if len(tool_call_spans) == 0 and len(non_tool_spans) > 0:
-            has_assertions = any(
-                _span_asserts_external_state(s) for s in non_tool_spans
-            )
+            has_assertions = any(_span_asserts_external_state(s) for s in non_tool_spans)
             if has_assertions:
-                penalties.append({
-                    "event_name": "ungrounded_claims",
-                    "dimension": ScoringDimension.tool_efficiency,
-                    "evidence": (
-                        f"Agent {agent_id} made assertions about external state "
-                        f"but trace contains 0 tool call spans to ground them."
-                    ),
-                    "trace_event_index": None,
-                })
+                penalties.append(
+                    {
+                        "event_name": "ungrounded_claims",
+                        "dimension": ScoringDimension.tool_efficiency,
+                        "evidence": (
+                            f"Agent {agent_id} made assertions about external state "
+                            f"but trace contains 0 tool call spans to ground them."
+                        ),
+                        "trace_event_index": None,
+                    }
+                )
                 return penalties
 
         # Duplicate tool calls: same tool name + same input hash
@@ -59,15 +59,17 @@ class StructuralScorer:
         for idx, span in enumerate(tool_call_spans):
             key = _span_dedup_key(span)
             if key in seen:
-                penalties.append({
-                    "event_name": "duplicate_tool_call",
-                    "dimension": ScoringDimension.tool_efficiency,
-                    "evidence": (
-                        f"Duplicate call to '{span.get('name', '')}' with same params. "
-                        f"First at index {seen[key]}, duplicate at index {idx}."
-                    ),
-                    "trace_event_index": idx,
-                })
+                penalties.append(
+                    {
+                        "event_name": "duplicate_tool_call",
+                        "dimension": ScoringDimension.tool_efficiency,
+                        "evidence": (
+                            f"Duplicate call to '{span.get('name', '')}' with same params. "
+                            f"First at index {seen[key]}, duplicate at index {idx}."
+                        ),
+                        "trace_event_index": idx,
+                    }
+                )
             else:
                 seen[key] = idx
 
@@ -79,7 +81,7 @@ class StructuralScorer:
             if not output:
                 continue
             global_idx = spans.index(span) if span in spans else -1
-            subsequent = spans[global_idx + 1:] if global_idx >= 0 else []
+            subsequent = spans[global_idx + 1 :] if global_idx >= 0 else []
             if not subsequent:
                 continue  # last span — nothing can reference it
             referenced = False
@@ -89,15 +91,17 @@ class StructuralScorer:
                     referenced = True
                     break
             if not referenced:
-                penalties.append({
-                    "event_name": "unused_tool_result",
-                    "dimension": ScoringDimension.tool_efficiency,
-                    "evidence": (
-                        f"Tool '{span.get('name', '')}' (span {span.get('span_id', '')}) "
-                        f"produced output but no subsequent span references it."
-                    ),
-                    "trace_event_index": idx,
-                })
+                penalties.append(
+                    {
+                        "event_name": "unused_tool_result",
+                        "dimension": ScoringDimension.tool_efficiency,
+                        "evidence": (
+                            f"Tool '{span.get('name', '')}' (span {span.get('span_id', '')}) "
+                            f"produced output but no subsequent span references it."
+                        ),
+                        "trace_event_index": idx,
+                    }
+                )
 
         return penalties
 
@@ -123,44 +127,50 @@ class StructuralScorer:
 
             # Timeout detection
             if is_timeout:
-                penalties.append({
-                    "event_name": "tool_call_timeout",
-                    "dimension": ScoringDimension.tool_failures,
-                    "evidence": (
-                        f"Tool '{span.get('name', '')}' (span {span.get('span_id', '')}) "
-                        f"took {latency}ms, exceeding {self.timeout_ms}ms threshold."
-                    ),
-                    "trace_event_index": idx,
-                })
+                penalties.append(
+                    {
+                        "event_name": "tool_call_timeout",
+                        "dimension": ScoringDimension.tool_failures,
+                        "evidence": (
+                            f"Tool '{span.get('name', '')}' (span {span.get('span_id', '')}) "
+                            f"took {latency}ms, exceeding {self.timeout_ms}ms threshold."
+                        ),
+                        "trace_event_index": idx,
+                    }
+                )
             elif is_error:
                 # Check for retry success
                 key = _span_dedup_key(span)
                 retried = False
-                for later_idx, later_span in enumerate(tool_call_spans[idx + 1:], idx + 1):
+                for later_idx, later_span in enumerate(tool_call_spans[idx + 1 :], idx + 1):
                     if _span_dedup_key(later_span) == key:
                         later_status = later_span.get("status", "success")
                         if later_status != "error" and not later_span.get("error"):
                             retried = True
-                            penalties.append({
-                                "event_name": "tool_call_retry_success",
-                                "dimension": ScoringDimension.tool_failures,
-                                "evidence": (
-                                    f"Tool '{span.get('name', '')}' failed at index {idx} "
-                                    f"but succeeded on retry at index {later_idx}."
-                                ),
-                                "trace_event_index": idx,
-                            })
+                            penalties.append(
+                                {
+                                    "event_name": "tool_call_retry_success",
+                                    "dimension": ScoringDimension.tool_failures,
+                                    "evidence": (
+                                        f"Tool '{span.get('name', '')}' failed at index {idx} "
+                                        f"but succeeded on retry at index {later_idx}."
+                                    ),
+                                    "trace_event_index": idx,
+                                }
+                            )
                             break
                 if not retried:
-                    penalties.append({
-                        "event_name": "tool_call_error",
-                        "dimension": ScoringDimension.tool_failures,
-                        "evidence": (
-                            f"Tool '{span.get('name', '')}' (span {span.get('span_id', '')}) "
-                            f"returned error: {str(error or status)[:200]}"
-                        ),
-                        "trace_event_index": idx,
-                    })
+                    penalties.append(
+                        {
+                            "event_name": "tool_call_error",
+                            "dimension": ScoringDimension.tool_failures,
+                            "evidence": (
+                                f"Tool '{span.get('name', '')}' (span {span.get('span_id', '')}) "
+                                f"returned error: {str(error or status)[:200]}"
+                            ),
+                            "trace_event_index": idx,
+                        }
+                    )
 
         # Ignored tool failure: error span followed by non-tool span
         # (candidate for SLM confirmation)
@@ -174,20 +184,22 @@ class StructuralScorer:
                 # Check no retry anywhere later
                 has_retry = any(
                     _span_dedup_key(s) == key
-                    for s in tool_call_spans[tool_call_spans.index(span) + 1:]
+                    for s in tool_call_spans[tool_call_spans.index(span) + 1 :]
                     if s is not span
                 )
                 if not has_retry:
-                    penalties.append({
-                        "event_name": "ignored_tool_failure",
-                        "dimension": ScoringDimension.tool_failures,
-                        "evidence": (
-                            f"Tool '{span.get('name', '')}' failed at span {span.get('span_id', '')}, "
-                            f"but agent continued with '{next_span.get('type', '')}' span without "
-                            f"retry or acknowledgment. (SLM confirmation recommended)"
-                        ),
-                        "trace_event_index": idx,
-                    })
+                    penalties.append(
+                        {
+                            "event_name": "ignored_tool_failure",
+                            "dimension": ScoringDimension.tool_failures,
+                            "evidence": (
+                                f"Tool '{span.get('name', '')}' failed at span {span.get('span_id', '')}, "
+                                f"but agent continued with '{next_span.get('type', '')}' span without "
+                                f"retry or acknowledgment. (SLM confirmation recommended)"
+                            ),
+                            "trace_event_index": idx,
+                        }
+                    )
 
         return penalties
 

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -317,10 +317,9 @@ def agent_init(
     dir_path = Path(directory)
     yaml_path = dir_path / YAML_FILE
 
-    if yaml_path.exists():
-        if not typer.confirm(f"{YAML_FILE} already exists in {dir_path}. Overwrite?"):
-            rprint("[yellow]Aborted.[/yellow]")
-            raise typer.Exit(code=1)
+    if yaml_path.exists() and not typer.confirm(f"{YAML_FILE} already exists in {dir_path}. Overwrite?"):
+        rprint("[yellow]Aborted.[/yellow]")
+        raise typer.Exit(code=1)
 
     name = typer.prompt("Agent name")
     version = typer.prompt("Version", default="1.0.0")
@@ -405,8 +404,8 @@ def agent_build(
         ctype = comp["component_type"]
         cid = comp["component_id"]
         # API convention: plural resource name
-        _PLURAL = {"mcp": "mcps", "skill": "skills", "hook": "hooks", "prompt": "prompts", "sandbox": "sandboxes"}
-        endpoint = f"/api/v1/{_PLURAL[ctype]}/{cid}"
+        plural = {"mcp": "mcps", "skill": "skills", "hook": "hooks", "prompt": "prompts", "sandbox": "sandboxes"}
+        endpoint = f"/api/v1/{plural[ctype]}/{cid}"
         try:
             with spinner(f"Checking {ctype} {cid[:8]}..."):
                 client.get(endpoint)

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -45,6 +45,7 @@ def _save_agent_yaml(directory: Path, data: dict) -> None:
     with open(path, "w") as f:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
+
 agent_app = typer.Typer(help="Agent registry commands")
 
 
@@ -261,7 +262,9 @@ def agent_install(
         rprint(f"[bold]Save to:[/bold] {agent_file['path']}")
         rprint()
         console.print_json(_json.dumps(agent_file["content"], indent=2))
-        rprint(f"\n[dim]Or pipe:[/dim] observal agent install {agent_id} --ide {ide} --raw | jq .agent_file.content > {agent_file['path']}")
+        rprint(
+            f"\n[dim]Or pipe:[/dim] observal agent install {agent_id} --ide {ide} --raw | jq .agent_file.content > {agent_file['path']}"
+        )
         return
 
     # Rules file

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import json as _json
-import os
 import shutil
-import sys
 from pathlib import Path
 
 import httpx
@@ -43,7 +41,7 @@ def init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
         rprint(f"[red]x Connection failed.[/red] Is the server running at {server_url}?")
         raise typer.Exit(1)
     except Exception as e:
-        rprint(f"[red]x Server error:[/red] {str(e)}")
+        rprint(f"[red]x Server error:[/red] {e!s}")
         raise typer.Exit(1)
 
     rprint("[green]Connected to server[/green]\n")

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -48,8 +48,7 @@ def init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
 
     # 2. Smart Detection: Determine if we are a Developer (Connect) or Admin (Setup)
     setup_choice = typer.prompt(
-        "Are you connecting to an existing team (C) or setting up a brand new server (N)?",
-        default="C"
+        "Are you connecting to an existing team (C) or setting up a brand new server (N)?", default="C"
     )
 
     if setup_choice.lower().startswith("c"):
@@ -106,6 +105,7 @@ def logout():
     if config.CONFIG_FILE.exists():
         # Read strictly from disk to avoid mixing with env variables
         import json
+
         raw_cfg = json.loads(config.CONFIG_FILE.read_text())
 
         # Remove the key and save directly
@@ -227,6 +227,7 @@ def register_deprecated_auth(app: typer.Typer):
 
 # ── Helper functions ────────────────────────────────────────
 
+
 def _do_login(server_url: str, api_key: str | None = None):
     api_key = api_key or typer.prompt("API Key", hide_input=True)
     try:
@@ -319,7 +320,9 @@ def _configure_claude_code(server_url: str, api_key: str):
         if not claude_exists:
             return
 
-        if not typer.confirm("\nDetected Claude Code installation.\nConfigure Claude Code telemetry -> Observal?", default=True):
+        if not typer.confirm(
+            "\nDetected Claude Code installation.\nConfigure Claude Code telemetry -> Observal?", default=True
+        ):
             return
 
         settings = {}
@@ -328,7 +331,9 @@ def _configure_claude_code(server_url: str, api_key: str):
                 try:
                     settings = _json.load(f)
                 except _json.JSONDecodeError:
-                    rprint(f"[yellow]Warning: Could not parse {claude_settings_file}. A new file will be created.[/yellow]")
+                    rprint(
+                        f"[yellow]Warning: Could not parse {claude_settings_file}. A new file will be created.[/yellow]"
+                    )
                     pass  # Will create a new file
 
         # Prepare OTEL config

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -59,6 +59,7 @@ IDE_CONFIGS = {
 
 # ── Check functions ──────────────────────────────────────
 
+
 def _load_json(path: Path) -> dict | None:
     try:
         return json.loads(path.read_text())
@@ -129,7 +130,9 @@ def _check_kiro(path: Path, data: dict, issues: list, warnings: list):
     """Check Kiro CLI/IDE settings for Observal conflicts."""
     # Telemetry disabled
     if data.get("telemetry.enabled") is False or data.get("telemetry", {}).get("enabled") is False:
-        warnings.append(f"{path}: Kiro telemetry is disabled. This does not affect Observal, but may indicate a preference against data collection.")
+        warnings.append(
+            f"{path}: Kiro telemetry is disabled. This does not affect Observal, but may indicate a preference against data collection."
+        )
 
     # MCP init timeout too low
     mcp_timeout = data.get("mcp.initTimeout") or data.get("mcp", {}).get("initTimeout")
@@ -189,6 +192,7 @@ def _check_mcp_json(path: Path, data: dict, issues: list, warnings: list):
 
 # ── Observal config checks ──────────────────────────────
 
+
 def _check_observal_config(issues: list, warnings: list):
     """Check Observal's own config."""
     config_path = Path.home() / ".observal" / "config.json"
@@ -212,6 +216,7 @@ def _check_observal_config(issues: list, warnings: list):
     if server_url:
         try:
             import httpx
+
             resp = httpx.get(f"{server_url}/health", timeout=5)
             if resp.status_code != 200:
                 issues.append(f"Observal server at {server_url} returned status {resp.status_code}.")
@@ -220,6 +225,7 @@ def _check_observal_config(issues: list, warnings: list):
 
 
 # ── Environment checks ───────────────────────────────────
+
 
 def _check_environment(issues: list, warnings: list):
     """Check environment variables."""
@@ -239,6 +245,7 @@ def _check_environment(issues: list, warnings: list):
 
 
 # ── Main doctor command ──────────────────────────────────
+
 
 @doctor_app.callback(invoke_without_command=True)
 def doctor(

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -78,8 +78,12 @@ def hook_list(
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
-            str(i), item["name"], item.get("version", ""), item.get("owner", ""),
-            status_badge(item.get("status", "")), str(item["id"])[:8] + "…",
+            str(i),
+            item["name"],
+            item.get("version", ""),
+            item.get("owner", ""),
+            status_badge(item.get("status", "")),
+            str(item["id"])[:8] + "…",
         )
     console.print(table)
 
@@ -96,19 +100,21 @@ def hook_show(
     if output == "json":
         output_json(item)
         return
-    console.print(kv_panel(
-        f"{item['name']} v{item.get('version', '?')}",
-        [
-            ("Status", status_badge(item.get("status", ""))),
-            ("Event", item.get("event", "N/A")),
-            ("Handler Type", item.get("handler_type", "N/A")),
-            ("Owner", item.get("owner", "N/A")),
-            ("Description", item.get("description", "")),
-            ("Created", relative_time(item.get("created_at"))),
-            ("ID", f"[dim]{item['id']}[/dim]"),
-        ],
-        border_style="yellow",
-    ))
+    console.print(
+        kv_panel(
+            f"{item['name']} v{item.get('version', '?')}",
+            [
+                ("Status", status_badge(item.get("status", ""))),
+                ("Event", item.get("event", "N/A")),
+                ("Handler Type", item.get("handler_type", "N/A")),
+                ("Owner", item.get("owner", "N/A")),
+                ("Description", item.get("description", "")),
+                ("Created", relative_time(item.get("created_at"))),
+                ("ID", f"[dim]{item['id']}[/dim]"),
+            ],
+            border_style="yellow",
+        )
+    )
 
 
 @hook_app.command(name="install")

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -185,7 +185,7 @@ def _install_impl(mcp_id, ide, raw):
         print(_json.dumps(snippet, indent=2))
         return
 
-    _IDE_CONFIG_PATHS = {
+    ide_config_paths = {
         "kiro": ".kiro/settings/mcp.json",
         "cursor": ".cursor/mcp.json",
         "vscode": ".vscode/mcp.json",
@@ -197,7 +197,7 @@ def _install_impl(mcp_id, ide, raw):
 
     rprint(f"\n[bold]Config for {ide}:[/bold]\n")
     console.print_json(_json.dumps(snippet, indent=2))
-    config_path = _IDE_CONFIG_PATHS.get(ide, "")
+    config_path = ide_config_paths.get(ide, "")
     if config_path and not config_path.startswith("("):
         rprint(f"\n[dim]Add to:[/dim] [bold]{config_path}[/bold]")
         rprint(f"[dim]Or pipe:[/dim] observal install {mcp_id} --ide {ide} --raw > {config_path}")

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -18,8 +18,7 @@ from observal_cli.render import (
 )
 
 _DEPRECATION_TPL = (
-    "[yellow]Warning:[/yellow] [dim]`observal {old}` is deprecated. "
-    "Use `observal {new}` instead.[/dim]\n"
+    "[yellow]Warning:[/yellow] [dim]`observal {old}` is deprecated. Use `observal {new}` instead.[/dim]\n"
 )
 
 mcp_app = typer.Typer(help="MCP server registry commands")
@@ -50,9 +49,7 @@ def _submit_impl(git_url, name, category, yes):
     )
     _category = category or ("general" if yes else typer.prompt("Category"))
     _desc = (
-        prefill.get("description", "")
-        if yes
-        else typer.prompt("Description", default=prefill.get("description", ""))
+        prefill.get("description", "") if yes else typer.prompt("Description", default=prefill.get("description", ""))
     )
     _owner = typer.prompt("Owner / Team") if not yes else "default"
 

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -20,8 +20,7 @@ from observal_cli.render import (
 )
 
 _DEPRECATION_TPL = (
-    "[yellow]Warning:[/yellow] [dim]`observal {old}` is deprecated. "
-    "Use `observal {new}` instead.[/dim]\n"
+    "[yellow]Warning:[/yellow] [dim]`observal {old}` is deprecated. Use `observal {new}` instead.[/dim]\n"
 )
 
 # ═══════════════════════════════════════════════════════════
@@ -192,9 +191,7 @@ def _metrics_impl(item_id, item_type, output, watch):
             rprint("\n  [bold]Agent Metrics[/bold]")
             rprint(f"  Interactions:   {total}")
             rprint(f"  Downloads:      {data.get('total_downloads', 0)}")
-            rprint(
-                f"  Acceptance:     [{'green' if rate > 0.7 else 'yellow' if rate > 0.4 else 'red'}]{rate:.1%}[/]"
-            )
+            rprint(f"  Acceptance:     [{'green' if rate > 0.7 else 'yellow' if rate > 0.4 else 'red'}]{rate:.1%}[/]")
             rprint(f"  Avg tool calls: {data.get('avg_tool_calls', 0)}")
             rprint(f"  Avg latency:    {(data.get('avg_latency_ms') or 0):.0f}ms")
         else:
@@ -443,7 +440,17 @@ def eval_show(
         table.add_column("Bar", width=30)
         for dim_name, dim_score in dim_scores.items():
             ds = float(dim_score)
-            dc = "green" if ds >= 85 else "blue" if ds >= 70 else "yellow" if ds >= 55 else "#ff8c00" if ds >= 40 else "red"
+            dc = (
+                "green"
+                if ds >= 85
+                else "blue"
+                if ds >= 70
+                else "yellow"
+                if ds >= 55
+                else "#ff8c00"
+                if ds >= 40
+                else "red"
+            )
             bar_len = int(ds / 100 * 25)
             bar = f"[{dc}]{'█' * bar_len}[/{dc}][dim]{'░' * (25 - bar_len)}[/dim]"
             table.add_row(dim_name, f"[{dc}]{ds:.0f}[/{dc}]", bar)
@@ -576,7 +583,17 @@ def eval_aggregate(
         table.add_column("Bar", width=30)
         for dim, avg in sorted(dim_avgs.items()):
             ds = float(avg)
-            dc = "green" if ds >= 85 else "blue" if ds >= 70 else "yellow" if ds >= 55 else "#ff8c00" if ds >= 40 else "red"
+            dc = (
+                "green"
+                if ds >= 85
+                else "blue"
+                if ds >= 70
+                else "yellow"
+                if ds >= 55
+                else "#ff8c00"
+                if ds >= 40
+                else "red"
+            )
             bar_len = int(ds / 100 * 25)
             bar = f"[{dc}]{'█' * bar_len}[/{dc}][dim]{'░' * (25 - bar_len)}[/dim]"
             table.add_row(dim, f"[{dc}]{ds:.0f}[/{dc}]", bar)
@@ -676,7 +693,9 @@ def admin_penalty_set(
 
     with spinner("Updating penalty..."):
         result = client.put(f"/api/v1/admin/penalties/{match['id']}", body)
-    rprint(f"[green]Updated {result.get('event_name', penalty_name)}: amount={result.get('amount')}, active={result.get('is_active')}[/green]")
+    rprint(
+        f"[green]Updated {result.get('event_name', penalty_name)}: amount={result.get('amount')}, active={result.get('is_active')}[/green]"
+    )
 
 
 @admin_app.command(name="weights")

--- a/observal_cli/cmd_profile.py
+++ b/observal_cli/cmd_profile.py
@@ -75,11 +75,16 @@ def _backup_current(label: str) -> Path:
             backed_up.append(rel_path)
 
     if backed_up:
-        (backup_path / "manifest.json").write_text(json.dumps({
-            "label": label,
-            "timestamp": ts,
-            "files": backed_up,
-        }, indent=2))
+        (backup_path / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "label": label,
+                    "timestamp": ts,
+                    "files": backed_up,
+                },
+                indent=2,
+            )
+        )
 
     return backup_path
 

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -20,7 +20,9 @@ def register_prompt(app: typer.Typer):
 
 @prompt_app.command(name="submit")
 def prompt_submit(
-    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file or read template from file"),
+    from_file: str | None = typer.Option(
+        None, "--from-file", "-f", help="Create from JSON file or read template from file"
+    ),
 ):
     """Submit a new prompt for review."""
     if from_file:
@@ -86,8 +88,12 @@ def prompt_list(
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
-            str(i), item["name"], item.get("version", ""), item.get("owner", ""),
-            status_badge(item.get("status", "")), str(item["id"])[:8] + "…",
+            str(i),
+            item["name"],
+            item.get("version", ""),
+            item.get("owner", ""),
+            status_badge(item.get("status", "")),
+            str(item["id"])[:8] + "…",
         )
     console.print(table)
 
@@ -104,18 +110,20 @@ def prompt_show(
     if output == "json":
         output_json(item)
         return
-    console.print(kv_panel(
-        f"{item['name']} v{item.get('version', '?')}",
-        [
-            ("Status", status_badge(item.get("status", ""))),
-            ("Category", item.get("category", "N/A")),
-            ("Owner", item.get("owner", "N/A")),
-            ("Description", item.get("description", "")),
-            ("Created", relative_time(item.get("created_at"))),
-            ("ID", f"[dim]{item['id']}[/dim]"),
-        ],
-        border_style="cyan",
-    ))
+    console.print(
+        kv_panel(
+            f"{item['name']} v{item.get('version', '?')}",
+            [
+                ("Status", status_badge(item.get("status", ""))),
+                ("Category", item.get("category", "N/A")),
+                ("Owner", item.get("owner", "N/A")),
+                ("Description", item.get("description", "")),
+                ("Created", relative_time(item.get("created_at"))),
+                ("ID", f"[dim]{item['id']}[/dim]"),
+            ],
+            border_style="cyan",
+        )
+    )
     if item.get("template"):
         rprint(f"\n[bold]Template:[/bold]\n[dim]{item['template']}[/dim]")
 

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -9,7 +9,7 @@ import typer
 from rich import print as rprint
 
 from observal_cli import client, config
-from observal_cli.render import console, spinner
+from observal_cli.render import spinner
 
 
 def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> str:

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -60,11 +60,12 @@ def _resolve_path(raw_path: str, target_dir: Path) -> Path:
 
 
 def register_pull(app: typer.Typer):
-
     @app.command("pull")
     def pull(
         agent_id: str = typer.Argument(..., help="Agent ID, name, row number, or @alias"),
-        ide: str = typer.Option(..., "--ide", "-i", help="Target IDE (cursor, vscode, claude-code, gemini-cli, kiro, codex, copilot)"),
+        ide: str = typer.Option(
+            ..., "--ide", "-i", help="Target IDE (cursor, vscode, claude-code, gemini-cli, kiro, codex, copilot)"
+        ),
         directory: str = typer.Option(".", "--dir", "-d", help="Target directory for written files"),
         dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Preview files without writing"),
     ):
@@ -125,7 +126,9 @@ def register_pull(app: typer.Typer):
         if dry_run:
             rprint("\n[bold yellow]Dry run[/bold yellow] — no files written:\n")
         else:
-            rprint(f"\n[bold green]Pulled {ide} config[/bold green] ({len(written)} file{'s' if len(written) != 1 else ''}):\n")
+            rprint(
+                f"\n[bold green]Pulled {ide} config[/bold green] ({len(written)} file{'s' if len(written) != 1 else ''}):\n"
+            )
 
         for path, status in written:
             style = "dim" if dry_run else "green"

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -75,8 +75,12 @@ def sandbox_list(
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
-            str(i), item["name"], item.get("version", ""), item.get("owner", ""),
-            status_badge(item.get("status", "")), str(item["id"])[:8] + "…",
+            str(i),
+            item["name"],
+            item.get("version", ""),
+            item.get("owner", ""),
+            status_badge(item.get("status", "")),
+            str(item["id"])[:8] + "…",
         )
     console.print(table)
 
@@ -93,19 +97,21 @@ def sandbox_show(
     if output == "json":
         output_json(item)
         return
-    console.print(kv_panel(
-        f"{item['name']} v{item.get('version', '?')}",
-        [
-            ("Status", status_badge(item.get("status", ""))),
-            ("Runtime", item.get("runtime_type", "N/A")),
-            ("Image", item.get("image", "N/A")),
-            ("Owner", item.get("owner", "N/A")),
-            ("Description", item.get("description", "")),
-            ("Created", relative_time(item.get("created_at"))),
-            ("ID", f"[dim]{item['id']}[/dim]"),
-        ],
-        border_style="red",
-    ))
+    console.print(
+        kv_panel(
+            f"{item['name']} v{item.get('version', '?')}",
+            [
+                ("Status", status_badge(item.get("status", ""))),
+                ("Runtime", item.get("runtime_type", "N/A")),
+                ("Image", item.get("image", "N/A")),
+                ("Owner", item.get("owner", "N/A")),
+                ("Description", item.get("description", "")),
+                ("Created", relative_time(item.get("created_at"))),
+                ("ID", f"[dim]{item['id']}[/dim]"),
+            ],
+            border_style="red",
+        )
+    )
 
 
 @sandbox_app.command(name="install")

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -76,7 +76,6 @@ def _backup_config(config_path: Path) -> Path:
 
 
 def register_scan(app: typer.Typer):
-
     @app.command(name="scan")
     def scan(
         project_dir: str = typer.Argument(".", help="Project directory to scan"),
@@ -213,6 +212,8 @@ def register_scan(app: typer.Typer):
                 config_path.write_text(json.dumps(config, indent=2) + "\n")
                 rprint(f"  [dim]Backup: {backup.name}[/dim]")
 
-        rprint(f"\n[green]✓ Done![/green] Registered {total_registered} items, instrumented {total_shimmed} with telemetry.")
+        rprint(
+            f"\n[green]✓ Done![/green] Registered {total_registered} items, instrumented {total_shimmed} with telemetry."
+        )
         rprint("[dim]Your existing tools still work exactly the same — observal-shim is transparent.[/dim]")
         rprint("[dim]Telemetry flows to Observal even without admin approval.[/dim]")

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -48,9 +48,7 @@ def _is_already_shimmed(entry: dict) -> bool:
     args = entry.get("args", [])
     if cmd == "observal-shim" or "observal-shim" in cmd:
         return True
-    if any("observal-shim" in str(a) for a in args):
-        return True
-    return False
+    return bool(any("observal-shim" in str(a) for a in args))
 
 
 def _wrap_with_shim(entry: dict, mcp_id: str) -> dict:
@@ -193,7 +191,7 @@ def register_scan(app: typer.Typer):
 
             # Rewrite config files
             configs_to_update: dict[str, dict] = {}  # path -> full config
-            for name, entry, config_path in items:
+            for name, _entry, config_path in items:
                 mcp_id = id_map.get(name)
                 if not mcp_id:
                     continue

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -79,8 +79,12 @@ def skill_list(
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
-            str(i), item["name"], item.get("version", ""), item.get("owner", ""),
-            status_badge(item.get("status", "")), str(item["id"])[:8] + "…",
+            str(i),
+            item["name"],
+            item.get("version", ""),
+            item.get("owner", ""),
+            status_badge(item.get("status", "")),
+            str(item["id"])[:8] + "…",
         )
     console.print(table)
 
@@ -97,20 +101,22 @@ def skill_show(
     if output == "json":
         output_json(item)
         return
-    console.print(kv_panel(
-        f"{item['name']} v{item.get('version', '?')}",
-        [
-            ("Status", status_badge(item.get("status", ""))),
-            ("Task Type", item.get("task_type", "N/A")),
-            ("Owner", item.get("owner", "N/A")),
-            ("Git URL", item.get("git_url", "N/A")),
-            ("Description", item.get("description", "")),
-            ("Target Agents", ", ".join(item.get("target_agents", [])) or "N/A"),
-            ("Created", relative_time(item.get("created_at"))),
-            ("ID", f"[dim]{item['id']}[/dim]"),
-        ],
-        border_style="green",
-    ))
+    console.print(
+        kv_panel(
+            f"{item['name']} v{item.get('version', '?')}",
+            [
+                ("Status", status_badge(item.get("status", ""))),
+                ("Task Type", item.get("task_type", "N/A")),
+                ("Owner", item.get("owner", "N/A")),
+                ("Git URL", item.get("git_url", "N/A")),
+                ("Description", item.get("description", "")),
+                ("Target Agents", ", ".join(item.get("target_agents", [])) or "N/A"),
+                ("Created", relative_time(item.get("created_at"))),
+                ("ID", f"[dim]{item['id']}[/dim]"),
+            ],
+            border_style="green",
+        )
+    )
 
 
 @skill_app.command(name="install")

--- a/observal_cli/config.py
+++ b/observal_cli/config.py
@@ -19,24 +19,24 @@ def load() -> dict:
     cfg = dict(DEFAULTS)
     if CONFIG_FILE.exists():
         cfg.update(json.loads(CONFIG_FILE.read_text()))
-        
+
     # Environment variable overrides (No login required if these are set)
     if env_url := os.environ.get("OBSERVAL_SERVER_URL"):
         cfg["server_url"] = env_url
     if env_key := os.environ.get("OBSERVAL_API_KEY"):
         cfg["api_key"] = env_key
-        
+
     return cfg
 
 def save(data: dict):
     """Save config to disk (safely ignoring environment variables)."""
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    
+
     # Read strictly from disk so we don't accidentally save env vars
     existing = {}
     if CONFIG_FILE.exists():
         existing = json.loads(CONFIG_FILE.read_text())
-        
+
     existing.update(data)
     CONFIG_FILE.write_text(json.dumps(existing, indent=2))
 

--- a/observal_cli/config.py
+++ b/observal_cli/config.py
@@ -14,6 +14,7 @@ DEFAULTS = {
     "api_key": "",
 }
 
+
 def load() -> dict:
     """Load config from disk and apply environment variable overrides."""
     cfg = dict(DEFAULTS)
@@ -28,6 +29,7 @@ def load() -> dict:
 
     return cfg
 
+
 def save(data: dict):
     """Save config to disk (safely ignoring environment variables)."""
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -40,13 +42,16 @@ def save(data: dict):
     existing.update(data)
     CONFIG_FILE.write_text(json.dumps(existing, indent=2))
 
+
 def get_or_exit() -> dict:
     cfg = load()
     if not cfg.get("server_url") or not cfg.get("api_key"):
         import typer
         from rich import print as rprint
 
-        rprint("[red]Not configured.[/red] Run [bold]observal init[/bold], [bold]observal login[/bold], or set the [bold]OBSERVAL_API_KEY[/bold] environment variable.")
+        rprint(
+            "[red]Not configured.[/red] Run [bold]observal init[/bold], [bold]observal login[/bold], or set the [bold]OBSERVAL_API_KEY[/bold] environment variable."
+        )
         raise typer.Exit(1)
     return cfg
 

--- a/observal_cli/sandbox_runner.py
+++ b/observal_cli/sandbox_runner.py
@@ -44,6 +44,7 @@ def run_sandbox(sandbox_id: str, image: str, command: str | None = None, timeout
     except ImportError:
         import typer
         from rich import print as rprint
+
         rprint("[red]Docker SDK not found.[/red] Please install via: pip install observal-cli[sandbox]")
         raise typer.Exit(1)
 
@@ -133,26 +134,30 @@ def run_sandbox(sandbox_id: str, image: str, command: str | None = None, timeout
             api_key = api_key or cfg.get("api_key", "")
             server_url = server_url or cfg.get("server_url", "")
 
-        _send_span(server_url, api_key, {
-            "span_id": str(uuid.uuid4()),
-            "trace_id": str(uuid.uuid4()),
-            "parent_span_id": None,
-            "type": "sandbox_exec",
-            "name": f"sandbox:{image}",
-            "method": "",
-            "input": json.dumps({"image": image, "command": command, "sandbox_id": sandbox_id}),
-            "output": None,
-            "error": str(e),
-            "start_time": start_time,
-            "end_time": _now_iso(),
-            "latency_ms": wall_ms,
-            "status": "error",
-            "ide": "",
-            "metadata": {},
-            "container_id": None,
-            "exit_code": -1,
-            "oom_killed": False,
-        })
+        _send_span(
+            server_url,
+            api_key,
+            {
+                "span_id": str(uuid.uuid4()),
+                "trace_id": str(uuid.uuid4()),
+                "parent_span_id": None,
+                "type": "sandbox_exec",
+                "name": f"sandbox:{image}",
+                "method": "",
+                "input": json.dumps({"image": image, "command": command, "sandbox_id": sandbox_id}),
+                "output": None,
+                "error": str(e),
+                "start_time": start_time,
+                "end_time": _now_iso(),
+                "latency_ms": wall_ms,
+                "status": "error",
+                "ide": "",
+                "metadata": {},
+                "container_id": None,
+                "exit_code": -1,
+                "oom_killed": False,
+            },
+        )
         sys.exit(1)
     finally:
         if container:
@@ -191,13 +196,16 @@ def main():
             i += 2
         elif args[i] == "--":
             # Everything after: is the command
-            command = " ".join(args[i + 1:])
+            command = " ".join(args[i + 1 :])
             break
         else:
             i += 1
 
     if not image:
-        print("Usage: observal-sandbox-run --sandbox-id <id> --image <image> [--command <cmd>] [--timeout <s>]", file=sys.stderr)
+        print(
+            "Usage: observal-sandbox-run --sandbox-id <id> --image <image> [--command <cmd>] [--timeout <s>]",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     run_sandbox(sandbox_id, image, command, timeout, env)

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -8,6 +8,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 # ── Schema Tests ────────────────────────────────────────────────────
 
@@ -985,7 +986,7 @@ class TestPydanticValidation:
             version="1.0",
             git_url="url",
         )
-        with pytest.raises((TypeError, AttributeError)):
+        with pytest.raises((TypeError, AttributeError, ValidationError)):
             comp.name = "changed"
 
     def test_resolution_error_is_frozen(self):
@@ -996,7 +997,7 @@ class TestPydanticValidation:
             component_id=uuid.uuid4(),
             reason="test",
         )
-        with pytest.raises((TypeError, AttributeError)):
+        with pytest.raises((TypeError, AttributeError, ValidationError)):
             err.reason = "changed"
 
     def test_resolved_agent_serializes_to_dict(self):

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -15,12 +15,14 @@ import pytest
 class TestComponentRefSchema:
     def test_component_ref_fields(self):
         from schemas.agent import ComponentRef
+
         ref = ComponentRef(component_type="mcp", component_id=uuid.uuid4())
         assert ref.component_type == "mcp"
         assert ref.config_override is None
 
     def test_component_ref_with_override(self):
         from schemas.agent import ComponentRef
+
         cid = uuid.uuid4()
         ref = ComponentRef(
             component_type="skill",
@@ -33,12 +35,14 @@ class TestComponentRefSchema:
 
     def test_valid_component_types_constant(self):
         from schemas.agent import VALID_COMPONENT_TYPES
+
         assert {"mcp", "skill", "hook", "prompt", "sandbox"} == VALID_COMPONENT_TYPES
 
     def test_component_ref_rejects_invalid_type(self):
         from pydantic import ValidationError
 
         from schemas.agent import ComponentRef
+
         with pytest.raises(ValidationError):
             ComponentRef(component_type="invalid", component_id=uuid.uuid4())
 
@@ -46,6 +50,7 @@ class TestComponentRefSchema:
 class TestComponentLinkResponseSchema:
     def test_component_link_response_fields(self):
         from schemas.agent import ComponentLinkResponse
+
         resp = ComponentLinkResponse(
             component_type="hook",
             component_id=uuid.uuid4(),
@@ -60,6 +65,7 @@ class TestComponentLinkResponseSchema:
 class TestAgentCreateRequestWithComponents:
     def test_create_request_accepts_components(self):
         from schemas.agent import AgentCreateRequest, ComponentRef, GoalSectionRequest, GoalTemplateRequest
+
         cid = uuid.uuid4()
         req = AgentCreateRequest(
             name="test-agent",
@@ -81,6 +87,7 @@ class TestAgentCreateRequestWithComponents:
     def test_create_request_backwards_compat(self):
         """mcp_server_ids should still work."""
         from schemas.agent import AgentCreateRequest, GoalSectionRequest, GoalTemplateRequest
+
         req = AgentCreateRequest(
             name="legacy-agent",
             version="1.0.0",
@@ -98,6 +105,7 @@ class TestAgentCreateRequestWithComponents:
     def test_create_request_both_fields(self):
         """Both mcp_server_ids and components can coexist."""
         from schemas.agent import AgentCreateRequest, ComponentRef, GoalSectionRequest, GoalTemplateRequest
+
         req = AgentCreateRequest(
             name="dual-agent",
             version="1.0.0",
@@ -119,11 +127,13 @@ class TestAgentCreateRequestWithComponents:
 class TestAgentUpdateRequestWithComponents:
     def test_update_request_components_optional(self):
         from schemas.agent import AgentUpdateRequest
+
         req = AgentUpdateRequest()
         assert req.components is None
 
     def test_update_request_with_components(self):
         from schemas.agent import AgentUpdateRequest, ComponentRef
+
         req = AgentUpdateRequest(
             components=[
                 ComponentRef(component_type="mcp", component_id=uuid.uuid4()),
@@ -136,6 +146,7 @@ class TestAgentUpdateRequestWithComponents:
 class TestAgentResponseWithComponentLinks:
     def test_response_has_component_links(self):
         from schemas.agent import AgentResponse
+
         fields = AgentResponse.model_fields
         assert "component_links" in fields
         assert "mcp_links" in fields  # backwards compat
@@ -147,6 +158,7 @@ class TestAgentResponseWithComponentLinks:
 class TestResolvedAgentDataclass:
     def test_ok_when_no_errors(self):
         from services.agent_resolver import ResolvedAgent
+
         ra = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="test",
@@ -156,20 +168,24 @@ class TestResolvedAgentDataclass:
 
     def test_not_ok_when_errors(self):
         from services.agent_resolver import ResolutionError, ResolvedAgent
+
         ra = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="test",
             agent_version="1.0",
-            errors=[ResolutionError(
-                component_type="mcp",
-                component_id=uuid.uuid4(),
-                reason="not found",
-            )],
+            errors=[
+                ResolutionError(
+                    component_type="mcp",
+                    component_id=uuid.uuid4(),
+                    reason="not found",
+                )
+            ],
         )
         assert ra.ok is False
 
     def test_components_by_type(self):
         from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
         cid1 = uuid.uuid4()
         cid2 = uuid.uuid4()
         cid3 = uuid.uuid4()
@@ -179,19 +195,34 @@ class TestResolvedAgentDataclass:
             agent_version="1.0",
             components=[
                 ResolvedComponent(
-                    component_type="mcp", component_id=cid1, name="mcp1",
-                    version="1.0", git_url="url", git_ref="abc",
-                    description="", order_index=0,
+                    component_type="mcp",
+                    component_id=cid1,
+                    name="mcp1",
+                    version="1.0",
+                    git_url="url",
+                    git_ref="abc",
+                    description="",
+                    order_index=0,
                 ),
                 ResolvedComponent(
-                    component_type="skill", component_id=cid2, name="skill1",
-                    version="1.0", git_url="url", git_ref="abc",
-                    description="", order_index=1,
+                    component_type="skill",
+                    component_id=cid2,
+                    name="skill1",
+                    version="1.0",
+                    git_url="url",
+                    git_ref="abc",
+                    description="",
+                    order_index=1,
                 ),
                 ResolvedComponent(
-                    component_type="mcp", component_id=cid3, name="mcp2",
-                    version="2.0", git_url="url", git_ref="def",
-                    description="", order_index=2,
+                    component_type="mcp",
+                    component_id=cid3,
+                    name="mcp2",
+                    version="2.0",
+                    git_url="url",
+                    git_ref="def",
+                    description="",
+                    order_index=2,
                 ),
             ],
         )
@@ -211,37 +242,44 @@ class TestResolvedAgentDataclass:
 class TestListingModelMap:
     def test_all_types_mapped(self):
         from services.agent_resolver import _LISTING_MODELS
+
         assert set(_LISTING_MODELS.keys()) == {"mcp", "skill", "hook", "prompt", "sandbox"}
 
     def test_mcp_maps_to_mcp_listing(self):
         from models.mcp import McpListing
         from services.agent_resolver import _LISTING_MODELS
+
         assert _LISTING_MODELS["mcp"] is McpListing
 
     def test_skill_maps_to_skill_listing(self):
         from models.skill import SkillListing
         from services.agent_resolver import _LISTING_MODELS
+
         assert _LISTING_MODELS["skill"] is SkillListing
 
     def test_hook_maps_to_hook_listing(self):
         from models.hook import HookListing
         from services.agent_resolver import _LISTING_MODELS
+
         assert _LISTING_MODELS["hook"] is HookListing
 
     def test_prompt_maps_to_prompt_listing(self):
         from models.prompt import PromptListing
         from services.agent_resolver import _LISTING_MODELS
+
         assert _LISTING_MODELS["prompt"] is PromptListing
 
     def test_sandbox_maps_to_sandbox_listing(self):
         from models.sandbox import SandboxListing
         from services.agent_resolver import _LISTING_MODELS
+
         assert _LISTING_MODELS["sandbox"] is SandboxListing
 
 
 class TestExtractExtra:
     def test_mcp_extra(self):
         from services.agent_resolver import _extract_extra
+
         listing = MagicMock()
         listing.transport = "stdio"
         listing.tools_schema = {"tools": []}
@@ -254,6 +292,7 @@ class TestExtractExtra:
 
     def test_skill_extra(self):
         from services.agent_resolver import _extract_extra
+
         listing = MagicMock()
         listing.skill_path = "/skills/tdd"
         listing.task_type = "development"
@@ -269,6 +308,7 @@ class TestExtractExtra:
 
     def test_hook_extra(self):
         from services.agent_resolver import _extract_extra
+
         listing = MagicMock()
         listing.event = "PreCommit"
         listing.execution_mode = "sync"
@@ -282,6 +322,7 @@ class TestExtractExtra:
 
     def test_prompt_extra(self):
         from services.agent_resolver import _extract_extra
+
         listing = MagicMock()
         listing.template = "Review this code: {{code}}"
         listing.variables = ["code"]
@@ -292,6 +333,7 @@ class TestExtractExtra:
 
     def test_sandbox_extra(self):
         from services.agent_resolver import _extract_extra
+
         listing = MagicMock()
         listing.runtime_type = "docker"
         listing.image = "python:3.12"
@@ -304,6 +346,7 @@ class TestExtractExtra:
 
     def test_unknown_type_returns_empty(self):
         from services.agent_resolver import _extract_extra
+
         extra = _extract_extra(MagicMock(), "nonexistent")
         assert extra == {}
 
@@ -312,6 +355,7 @@ class TestResolveAgent:
     @pytest.mark.asyncio
     async def test_resolve_empty_agent(self):
         from services.agent_resolver import resolve_agent
+
         agent = MagicMock()
         agent.id = uuid.uuid4()
         agent.name = "empty-agent"
@@ -330,6 +374,7 @@ class TestResolveAgent:
     @pytest.mark.asyncio
     async def test_resolve_unknown_component_type(self):
         from services.agent_resolver import resolve_agent
+
         agent = MagicMock()
         agent.id = uuid.uuid4()
         agent.name = "bad-type-agent"
@@ -352,6 +397,7 @@ class TestResolveAgent:
     @pytest.mark.asyncio
     async def test_resolve_missing_listing(self):
         from services.agent_resolver import resolve_agent
+
         agent = MagicMock()
         agent.id = uuid.uuid4()
         agent.name = "missing-listing-agent"
@@ -378,6 +424,7 @@ class TestResolveAgent:
     async def test_resolve_unapproved_listing(self):
         from models.mcp import ListingStatus
         from services.agent_resolver import resolve_agent
+
         agent = MagicMock()
         agent.id = uuid.uuid4()
         agent.name = "unapproved-agent"
@@ -408,6 +455,7 @@ class TestResolveAgent:
     async def test_resolve_approved_listing(self):
         from models.mcp import ListingStatus
         from services.agent_resolver import resolve_agent
+
         agent = MagicMock()
         agent.id = uuid.uuid4()
         agent.name = "good-agent"
@@ -452,6 +500,7 @@ class TestResolveAgent:
         """When require_approved=False, unapproved listings should resolve."""
         from models.mcp import ListingStatus
         from services.agent_resolver import resolve_agent
+
         agent = MagicMock()
         agent.id = uuid.uuid4()
         agent.name = "draft-agent"
@@ -497,6 +546,7 @@ class TestResolveAgent:
         """An agent with both valid and invalid components."""
         from models.mcp import ListingStatus
         from services.agent_resolver import resolve_agent
+
         agent = MagicMock()
         agent.id = uuid.uuid4()
         agent.name = "mixed-agent"
@@ -549,6 +599,7 @@ class TestValidateComponentIds:
     @pytest.mark.asyncio
     async def test_validate_empty_list(self):
         from services.agent_resolver import validate_component_ids
+
         db = AsyncMock()
         errors = await validate_component_ids([], db)
         assert errors == []
@@ -556,6 +607,7 @@ class TestValidateComponentIds:
     @pytest.mark.asyncio
     async def test_validate_unknown_type(self):
         from services.agent_resolver import validate_component_ids
+
         db = AsyncMock()
         errors = await validate_component_ids(
             [{"component_type": "unknown", "component_id": uuid.uuid4()}],
@@ -567,6 +619,7 @@ class TestValidateComponentIds:
     @pytest.mark.asyncio
     async def test_validate_missing_component(self):
         from services.agent_resolver import validate_component_ids
+
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = None
         db = AsyncMock()
@@ -583,6 +636,7 @@ class TestValidateComponentIds:
     async def test_validate_unapproved_component(self):
         from models.mcp import ListingStatus
         from services.agent_resolver import validate_component_ids
+
         listing = MagicMock()
         listing.status = ListingStatus.pending
         listing.name = "pending-mcp"
@@ -603,6 +657,7 @@ class TestValidateComponentIds:
     async def test_validate_approved_component(self):
         from models.mcp import ListingStatus
         from services.agent_resolver import validate_component_ids
+
         listing = MagicMock()
         listing.status = ListingStatus.approved
 
@@ -625,6 +680,7 @@ class TestBuildAgentManifest:
     def test_empty_agent_manifest(self):
         from services.agent_builder import build_agent_manifest
         from services.agent_resolver import ResolvedAgent
+
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="empty",
@@ -639,18 +695,27 @@ class TestBuildAgentManifest:
     def test_manifest_with_mcps(self):
         from services.agent_builder import build_agent_manifest
         from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="mcp-agent",
             agent_version="1.0.0",
             components=[
                 ResolvedComponent(
-                    component_type="mcp", component_id=uuid.uuid4(),
-                    name="filesystem-mcp", version="2.0.0",
-                    git_url="https://github.com/org/repo.git", git_ref="abc123",
-                    description="FS ops", order_index=0,
-                    extra={"transport": "stdio", "tools_schema": None,
-                           "mcp_validated": True, "setup_instructions": None},
+                    component_type="mcp",
+                    component_id=uuid.uuid4(),
+                    name="filesystem-mcp",
+                    version="2.0.0",
+                    git_url="https://github.com/org/repo.git",
+                    git_ref="abc123",
+                    description="FS ops",
+                    order_index=0,
+                    extra={
+                        "transport": "stdio",
+                        "tools_schema": None,
+                        "mcp_validated": True,
+                        "setup_instructions": None,
+                    },
                 ),
             ],
         )
@@ -669,9 +734,14 @@ class TestBuildAgentManifest:
 
         def _comp(ctype, name, order, **extra_kw):
             return ResolvedComponent(
-                component_type=ctype, component_id=uuid.uuid4(),
-                name=name, version="1.0", git_url="url", git_ref="ref",
-                description=f"{name} desc", order_index=order,
+                component_type=ctype,
+                component_id=uuid.uuid4(),
+                name=name,
+                version="1.0",
+                git_url="url",
+                git_ref="ref",
+                description=f"{name} desc",
+                order_index=order,
                 extra=extra_kw,
             )
 
@@ -682,12 +752,9 @@ class TestBuildAgentManifest:
             components=[
                 _comp("mcp", "fs-mcp", 0, transport="stdio"),
                 _comp("skill", "tdd", 1, task_type="dev", slash_command="/tdd"),
-                _comp("hook", "pre-commit", 2, event="PreCommit",
-                      execution_mode="sync", priority=50),
-                _comp("prompt", "review", 3, template="Review: {{code}}",
-                      variables=["code"]),
-                _comp("sandbox", "python", 4, image="python:3.12",
-                      runtime_type="docker", resource_limits={"cpu": "1"}),
+                _comp("hook", "pre-commit", 2, event="PreCommit", execution_mode="sync", priority=50),
+                _comp("prompt", "review", 3, template="Review: {{code}}", variables=["code"]),
+                _comp("sandbox", "python", 4, image="python:3.12", runtime_type="docker", resource_limits={"cpu": "1"}),
             ],
         )
         manifest = build_agent_manifest(resolved)
@@ -701,6 +768,7 @@ class TestBuildAgentManifest:
     def test_manifest_includes_errors(self):
         from services.agent_builder import build_agent_manifest
         from services.agent_resolver import ResolutionError, ResolvedAgent
+
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="error-agent",
@@ -721,15 +789,20 @@ class TestBuildAgentManifest:
     def test_manifest_hook_fields(self):
         from services.agent_builder import build_agent_manifest
         from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="hook-agent",
             agent_version="1.0.0",
             components=[
                 ResolvedComponent(
-                    component_type="hook", component_id=uuid.uuid4(),
-                    name="pre-commit-lint", version="1.0",
-                    git_url="url", git_ref="ref", description="Lint hook",
+                    component_type="hook",
+                    component_id=uuid.uuid4(),
+                    name="pre-commit-lint",
+                    version="1.0",
+                    git_url="url",
+                    git_ref="ref",
+                    description="Lint hook",
                     order_index=0,
                     extra={"event": "PreCommit", "execution_mode": "sync", "priority": 10},
                 ),
@@ -744,15 +817,20 @@ class TestBuildAgentManifest:
     def test_manifest_sandbox_fields(self):
         from services.agent_builder import build_agent_manifest
         from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="sandbox-agent",
             agent_version="1.0.0",
             components=[
                 ResolvedComponent(
-                    component_type="sandbox", component_id=uuid.uuid4(),
-                    name="python-sandbox", version="1.0",
-                    git_url="url", git_ref="ref", description="",
+                    component_type="sandbox",
+                    component_id=uuid.uuid4(),
+                    name="python-sandbox",
+                    version="1.0",
+                    git_url="url",
+                    git_ref="ref",
+                    description="",
                     order_index=0,
                     extra={
                         "image": "python:3.12",
@@ -771,15 +849,20 @@ class TestBuildAgentManifest:
     def test_manifest_with_config_override(self):
         from services.agent_builder import build_agent_manifest
         from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="override-agent",
             agent_version="1.0.0",
             components=[
                 ResolvedComponent(
-                    component_type="mcp", component_id=uuid.uuid4(),
-                    name="db-mcp", version="1.0",
-                    git_url="url", git_ref="ref", description="",
+                    component_type="mcp",
+                    component_id=uuid.uuid4(),
+                    name="db-mcp",
+                    version="1.0",
+                    git_url="url",
+                    git_ref="ref",
+                    description="",
                     order_index=0,
                     config_override={"env": {"DB_URL": "postgres://..."}},
                     extra={},
@@ -795,6 +878,7 @@ class TestBuildCompositionSummary:
     def test_summary_resolved_flag(self):
         from services.agent_builder import build_composition_summary
         from services.agent_resolver import ResolvedAgent
+
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="ok-agent",
@@ -806,6 +890,7 @@ class TestBuildCompositionSummary:
     def test_summary_not_resolved_with_errors(self):
         from services.agent_builder import build_composition_summary
         from services.agent_resolver import ResolutionError, ResolvedAgent
+
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="bad-agent",
@@ -822,9 +907,14 @@ class TestBuildCompositionSummary:
 
         def _comp(ctype, name, order):
             return ResolvedComponent(
-                component_type=ctype, component_id=uuid.uuid4(),
-                name=name, version="1.0", git_url="u", git_ref="r",
-                description="", order_index=order,
+                component_type=ctype,
+                component_id=uuid.uuid4(),
+                name=name,
+                version="1.0",
+                git_url="u",
+                git_ref="r",
+                description="",
+                order_index=order,
             )
 
         resolved = ResolvedAgent(
@@ -850,11 +940,13 @@ class TestComponentLinkResponseInAgentResponse:
     def test_agent_response_has_component_links_field(self):
         """AgentResponse schema must include component_links."""
         from schemas.agent import AgentResponse
+
         assert "component_links" in AgentResponse.model_fields
         assert "mcp_links" in AgentResponse.model_fields  # backwards compat
 
     def test_component_link_response_serializes(self):
         from schemas.agent import ComponentLinkResponse
+
         cid = uuid.uuid4()
         link = ComponentLinkResponse(
             component_type="skill",
@@ -870,6 +962,7 @@ class TestComponentLinkResponseInAgentResponse:
 
     def test_component_link_response_no_override(self):
         from schemas.agent import ComponentLinkResponse
+
         link = ComponentLinkResponse(
             component_type="mcp",
             component_id=uuid.uuid4(),
@@ -884,23 +977,31 @@ class TestPydanticValidation:
 
     def test_resolved_component_is_frozen(self):
         from services.agent_resolver import ResolvedComponent
+
         comp = ResolvedComponent(
-            component_type="mcp", component_id=uuid.uuid4(),
-            name="test", version="1.0", git_url="url",
+            component_type="mcp",
+            component_id=uuid.uuid4(),
+            name="test",
+            version="1.0",
+            git_url="url",
         )
         with pytest.raises((TypeError, AttributeError)):
             comp.name = "changed"
 
     def test_resolution_error_is_frozen(self):
         from services.agent_resolver import ResolutionError
+
         err = ResolutionError(
-            component_type="mcp", component_id=uuid.uuid4(), reason="test",
+            component_type="mcp",
+            component_id=uuid.uuid4(),
+            reason="test",
         )
         with pytest.raises((TypeError, AttributeError)):
             err.reason = "changed"
 
     def test_resolved_agent_serializes_to_dict(self):
         from services.agent_resolver import ResolvedAgent
+
         ra = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="test",
@@ -914,17 +1015,25 @@ class TestPydanticValidation:
         from pydantic import ValidationError
 
         from services.agent_resolver import ResolvedComponent
+
         with pytest.raises(ValidationError):
             ResolvedComponent(
-                component_type="invalid_type", component_id=uuid.uuid4(),
-                name="bad", version="1.0", git_url="url",
+                component_type="invalid_type",
+                component_id=uuid.uuid4(),
+                name="bad",
+                version="1.0",
+                git_url="url",
             )
 
     def test_manifest_component_dump_compact(self):
         from services.agent_builder import ManifestComponent
+
         comp = ManifestComponent(
-            name="test-mcp", version="1.0", git_url="url",
-            description="desc", transport="stdio",
+            name="test-mcp",
+            version="1.0",
+            git_url="url",
+            description="desc",
+            transport="stdio",
         )
         dumped = comp.model_dump_compact()
         assert "transport" in dumped
@@ -933,6 +1042,7 @@ class TestPydanticValidation:
 
     def test_agent_manifest_model_validates(self):
         from services.agent_builder import AgentManifest, ManifestComponent, ManifestComponents
+
         manifest = AgentManifest(
             name="my-agent",
             version="2.0",
@@ -948,6 +1058,7 @@ class TestPydanticValidation:
 
     def test_ide_agent_config_model(self):
         from services.agent_builder import AgentFile, IdeAgentConfig
+
         config = IdeAgentConfig(
             ide="claude-code",
             files=[
@@ -962,6 +1073,7 @@ class TestPydanticValidation:
 
     def test_composition_summary_model(self):
         from services.agent_builder import CompositionSummary
+
         summary = CompositionSummary(
             agent_id=str(uuid.uuid4()),
             agent_name="test",
@@ -981,6 +1093,7 @@ class TestResolverAndBuilderModulesImportable:
             resolve_agent,
             validate_component_ids,
         )
+
         assert callable(resolve_agent)
         assert callable(validate_component_ids)
         assert len(_LISTING_MODELS) == 5
@@ -992,6 +1105,7 @@ class TestResolverAndBuilderModulesImportable:
             build_composition_summary,
             generate_ide_agent_files,
         )
+
         assert callable(build_agent_manifest)
         assert callable(build_composition_summary)
         assert callable(generate_ide_agent_files)
@@ -1008,6 +1122,7 @@ class TestGenerateIdeAgentFiles:
             ManifestComponent,
             ManifestComponents,
         )
+
         defaults = {
             "name": "test-agent",
             "version": "1.0",
@@ -1017,17 +1132,23 @@ class TestGenerateIdeAgentFiles:
             "components": ManifestComponents(
                 mcps=[
                     ManifestComponent(
-                        name="github-mcp", version="2.0", git_url="https://github.com/example/mcp",
+                        name="github-mcp",
+                        version="2.0",
+                        git_url="https://github.com/example/mcp",
                         description="GitHub integration MCP server",
                     ),
                     ManifestComponent(
-                        name="postgres-mcp", version="1.5", git_url="https://github.com/example/pg",
+                        name="postgres-mcp",
+                        version="1.5",
+                        git_url="https://github.com/example/pg",
                         description="PostgreSQL query MCP",
                     ),
                 ],
                 skills=[
                     ManifestComponent(
-                        name="code-review", version="1.0", git_url="https://github.com/example/cr",
+                        name="code-review",
+                        version="1.0",
+                        git_url="https://github.com/example/cr",
                         slash_command="review",
                     ),
                 ],
@@ -1040,6 +1161,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_claude_code_generates_rules_file(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "claude-code")
         assert config.ide == "claude-code"
@@ -1050,6 +1172,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_claude_code_mcp_setup_commands(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "claude-code")
         assert len(config.setup_commands) == 2
@@ -1058,6 +1181,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_claude_code_env_includes_telemetry(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "claude-code")
         assert "CLAUDE_CODE_ENABLE_TELEMETRY" in config.env
@@ -1065,6 +1189,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_claude_code_underscore_alias(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "claude_code")
         assert config.ide == "claude-code"
@@ -1073,6 +1198,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_cursor_generates_rules_and_mcp_json(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "cursor")
         assert config.ide == "cursor"
@@ -1088,6 +1214,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_vscode_generates_rules_and_mcp_json(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "vscode")
         assert config.ide == "vscode"
@@ -1100,6 +1227,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_gemini_cli_generates_gemini_md(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "gemini-cli")
         assert config.ide == "gemini-cli"
@@ -1110,12 +1238,14 @@ class TestGenerateIdeAgentFiles:
 
     def test_gemini_cli_env_includes_otel(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "gemini-cli")
         assert "OTEL_EXPORTER_OTLP_ENDPOINT" in config.env
 
     def test_gemini_cli_underscore_alias(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "gemini_cli")
         assert config.ide == "gemini-cli"
@@ -1124,6 +1254,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_kiro_generates_agent_json(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "kiro")
         assert config.ide == "kiro"
@@ -1143,6 +1274,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_codex_generates_agents_md_and_config_toml(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "codex")
         assert config.ide == "codex"
@@ -1157,6 +1289,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_copilot_generates_instructions_md(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "copilot")
         assert config.ide == "copilot"
@@ -1170,6 +1303,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_rules_markdown_includes_component_sections(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "cursor")
         rules = next(f for f in config.files if f.format == "markdown")
@@ -1183,6 +1317,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_rules_markdown_empty_prompt(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest(prompt="")
         config = generate_ide_agent_files(manifest, "copilot")
         content = config.files[0].content
@@ -1191,6 +1326,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_rules_markdown_no_components(self):
         from services.agent_builder import AgentManifest, ManifestComponents, generate_ide_agent_files
+
         manifest = AgentManifest(
             name="bare-agent",
             version="1.0",
@@ -1206,6 +1342,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_mcp_entries_use_observal_shim(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "cursor")
         for name, entry in config.mcp_servers.items():
@@ -1219,6 +1356,7 @@ class TestGenerateIdeAgentFiles:
             ManifestComponents,
             generate_ide_agent_files,
         )
+
         manifest = AgentManifest(
             name="no-mcp-agent",
             version="1.0",
@@ -1235,6 +1373,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_name_with_spaces_gets_sanitized(self):
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest(name="My Cool Agent!")
         config = generate_ide_agent_files(manifest, "claude-code")
         rules = config.files[0]
@@ -1247,6 +1386,7 @@ class TestGenerateIdeAgentFiles:
         import pytest
 
         from services.agent_builder import generate_ide_agent_files
+
         manifest = self._make_manifest()
         with pytest.raises(ValueError, match="Unsupported IDE"):
             generate_ide_agent_files(manifest, "notepad")
@@ -1260,6 +1400,7 @@ class TestGenerateIdeAgentFiles:
             ManifestComponents,
             generate_ide_agent_files,
         )
+
         manifest = AgentManifest(
             name="hook-agent",
             version="1.0",
@@ -1267,8 +1408,11 @@ class TestGenerateIdeAgentFiles:
             components=ManifestComponents(
                 hooks=[
                     ManifestComponent(
-                        name="lint-hook", version="1.0", git_url="url",
-                        event="pre_commit", execution_mode="sync",
+                        name="lint-hook",
+                        version="1.0",
+                        git_url="url",
+                        event="pre_commit",
+                        execution_mode="sync",
                     ),
                 ],
             ),
@@ -1283,6 +1427,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_all_supported_ides_produce_output(self):
         from services.agent_builder import SUPPORTED_IDES, generate_ide_agent_files
+
         manifest = self._make_manifest()
         for ide in SUPPORTED_IDES:
             config = generate_ide_agent_files(manifest, ide)

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-
 # ── Schema Tests ────────────────────────────────────────────────────
 
 
@@ -34,10 +33,11 @@ class TestComponentRefSchema:
 
     def test_valid_component_types_constant(self):
         from schemas.agent import VALID_COMPONENT_TYPES
-        assert VALID_COMPONENT_TYPES == {"mcp", "skill", "hook", "prompt", "sandbox"}
+        assert {"mcp", "skill", "hook", "prompt", "sandbox"} == VALID_COMPONENT_TYPES
 
     def test_component_ref_rejects_invalid_type(self):
         from pydantic import ValidationError
+
         from schemas.agent import ComponentRef
         with pytest.raises(ValidationError):
             ComponentRef(component_type="invalid", component_id=uuid.uuid4())
@@ -59,7 +59,7 @@ class TestComponentLinkResponseSchema:
 
 class TestAgentCreateRequestWithComponents:
     def test_create_request_accepts_components(self):
-        from schemas.agent import AgentCreateRequest, ComponentRef, GoalTemplateRequest, GoalSectionRequest
+        from schemas.agent import AgentCreateRequest, ComponentRef, GoalSectionRequest, GoalTemplateRequest
         cid = uuid.uuid4()
         req = AgentCreateRequest(
             name="test-agent",
@@ -80,7 +80,7 @@ class TestAgentCreateRequestWithComponents:
 
     def test_create_request_backwards_compat(self):
         """mcp_server_ids should still work."""
-        from schemas.agent import AgentCreateRequest, GoalTemplateRequest, GoalSectionRequest
+        from schemas.agent import AgentCreateRequest, GoalSectionRequest, GoalTemplateRequest
         req = AgentCreateRequest(
             name="legacy-agent",
             version="1.0.0",
@@ -97,7 +97,7 @@ class TestAgentCreateRequestWithComponents:
 
     def test_create_request_both_fields(self):
         """Both mcp_server_ids and components can coexist."""
-        from schemas.agent import AgentCreateRequest, ComponentRef, GoalTemplateRequest, GoalSectionRequest
+        from schemas.agent import AgentCreateRequest, ComponentRef, GoalSectionRequest, GoalTemplateRequest
         req = AgentCreateRequest(
             name="dual-agent",
             version="1.0.0",
@@ -155,7 +155,7 @@ class TestResolvedAgentDataclass:
         assert ra.ok is True
 
     def test_not_ok_when_errors(self):
-        from services.agent_resolver import ResolvedAgent, ResolutionError
+        from services.agent_resolver import ResolutionError, ResolvedAgent
         ra = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="test",
@@ -700,7 +700,7 @@ class TestBuildAgentManifest:
 
     def test_manifest_includes_errors(self):
         from services.agent_builder import build_agent_manifest
-        from services.agent_resolver import ResolvedAgent, ResolutionError
+        from services.agent_resolver import ResolutionError, ResolvedAgent
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="error-agent",
@@ -805,7 +805,7 @@ class TestBuildCompositionSummary:
 
     def test_summary_not_resolved_with_errors(self):
         from services.agent_builder import build_composition_summary
-        from services.agent_resolver import ResolvedAgent, ResolutionError
+        from services.agent_resolver import ResolutionError, ResolvedAgent
         resolved = ResolvedAgent(
             agent_id=uuid.uuid4(),
             agent_name="bad-agent",
@@ -888,7 +888,7 @@ class TestPydanticValidation:
             component_type="mcp", component_id=uuid.uuid4(),
             name="test", version="1.0", git_url="url",
         )
-        with pytest.raises(Exception):
+        with pytest.raises((TypeError, AttributeError)):
             comp.name = "changed"
 
     def test_resolution_error_is_frozen(self):
@@ -896,7 +896,7 @@ class TestPydanticValidation:
         err = ResolutionError(
             component_type="mcp", component_id=uuid.uuid4(), reason="test",
         )
-        with pytest.raises(Exception):
+        with pytest.raises((TypeError, AttributeError)):
             err.reason = "changed"
 
     def test_resolved_agent_serializes_to_dict(self):
@@ -912,6 +912,7 @@ class TestPydanticValidation:
 
     def test_resolved_component_rejects_invalid_type(self):
         from pydantic import ValidationError
+
         from services.agent_resolver import ResolvedComponent
         with pytest.raises(ValidationError):
             ResolvedComponent(
@@ -976,8 +977,9 @@ class TestPydanticValidation:
 class TestResolverAndBuilderModulesImportable:
     def test_resolver_module_importable(self):
         from services.agent_resolver import (
-            ResolvedAgent, ResolvedComponent, ResolutionError,
-            resolve_agent, validate_component_ids, _LISTING_MODELS,
+            _LISTING_MODELS,
+            resolve_agent,
+            validate_component_ids,
         )
         assert callable(resolve_agent)
         assert callable(validate_component_ids)
@@ -985,8 +987,10 @@ class TestResolverAndBuilderModulesImportable:
 
     def test_builder_module_importable(self):
         from services.agent_builder import (
-            build_agent_manifest, build_composition_summary,
-            generate_ide_agent_files, SUPPORTED_IDES,
+            SUPPORTED_IDES,
+            build_agent_manifest,
+            build_composition_summary,
+            generate_ide_agent_files,
         )
         assert callable(build_agent_manifest)
         assert callable(build_composition_summary)
@@ -1000,7 +1004,9 @@ class TestGenerateIdeAgentFiles:
 
     def _make_manifest(self, **overrides):
         from services.agent_builder import (
-            AgentManifest, ManifestComponent, ManifestComponents,
+            AgentManifest,
+            ManifestComponent,
+            ManifestComponents,
         )
         defaults = {
             "name": "test-agent",
@@ -1071,8 +1077,8 @@ class TestGenerateIdeAgentFiles:
         config = generate_ide_agent_files(manifest, "cursor")
         assert config.ide == "cursor"
         assert len(config.files) == 2
-        rules = [f for f in config.files if f.format == "markdown"][0]
-        mcp_json = [f for f in config.files if f.format == "json"][0]
+        rules = next(f for f in config.files if f.format == "markdown")
+        mcp_json = next(f for f in config.files if f.format == "json")
         assert rules.path == ".cursor/rules/test-agent.md"
         assert mcp_json.path == ".cursor/mcp.json"
         assert "mcpServers" in mcp_json.content
@@ -1085,8 +1091,8 @@ class TestGenerateIdeAgentFiles:
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "vscode")
         assert config.ide == "vscode"
-        rules = [f for f in config.files if f.format == "markdown"][0]
-        mcp_json = [f for f in config.files if f.format == "json"][0]
+        rules = next(f for f in config.files if f.format == "markdown")
+        mcp_json = next(f for f in config.files if f.format == "json")
         assert rules.path == ".vscode/rules/test-agent.md"
         assert mcp_json.path == ".vscode/mcp.json"
 
@@ -1141,8 +1147,8 @@ class TestGenerateIdeAgentFiles:
         config = generate_ide_agent_files(manifest, "codex")
         assert config.ide == "codex"
         assert len(config.files) == 2
-        md_file = [f for f in config.files if f.format == "markdown"][0]
-        toml_file = [f for f in config.files if f.format == "toml"][0]
+        md_file = next(f for f in config.files if f.format == "markdown")
+        toml_file = next(f for f in config.files if f.format == "toml")
         assert md_file.path == "AGENTS.md"
         assert toml_file.path == "~/.codex/config.toml"
         assert "[otel]" in toml_file.content
@@ -1166,7 +1172,7 @@ class TestGenerateIdeAgentFiles:
         from services.agent_builder import generate_ide_agent_files
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "cursor")
-        rules = [f for f in config.files if f.format == "markdown"][0]
+        rules = next(f for f in config.files if f.format == "markdown")
         content = rules.content
         assert "## MCP Servers" in content
         assert "**github-mcp**" in content
@@ -1184,8 +1190,7 @@ class TestGenerateIdeAgentFiles:
         assert "## MCP Servers" in content
 
     def test_rules_markdown_no_components(self):
-        from services.agent_builder import AgentManifest, ManifestComponents
-        from services.agent_builder import generate_ide_agent_files
+        from services.agent_builder import AgentManifest, ManifestComponents, generate_ide_agent_files
         manifest = AgentManifest(
             name="bare-agent",
             version="1.0",
@@ -1209,7 +1214,9 @@ class TestGenerateIdeAgentFiles:
 
     def test_no_mcps_produces_empty_servers(self):
         from services.agent_builder import (
-            AgentManifest, ManifestComponent, ManifestComponents,
+            AgentManifest,
+            ManifestComponent,
+            ManifestComponents,
             generate_ide_agent_files,
         )
         manifest = AgentManifest(
@@ -1238,6 +1245,7 @@ class TestGenerateIdeAgentFiles:
 
     def test_unsupported_ide_raises_value_error(self):
         import pytest
+
         from services.agent_builder import generate_ide_agent_files
         manifest = self._make_manifest()
         with pytest.raises(ValueError, match="Unsupported IDE"):
@@ -1247,7 +1255,9 @@ class TestGenerateIdeAgentFiles:
 
     def test_hooks_appear_in_rules_markdown(self):
         from services.agent_builder import (
-            AgentManifest, ManifestComponent, ManifestComponents,
+            AgentManifest,
+            ManifestComponent,
+            ManifestComponents,
             generate_ide_agent_files,
         )
         manifest = AgentManifest(
@@ -1272,7 +1282,7 @@ class TestGenerateIdeAgentFiles:
     # ── All supported IDEs produce valid output ────────────────
 
     def test_all_supported_ides_produce_output(self):
-        from services.agent_builder import generate_ide_agent_files, SUPPORTED_IDES
+        from services.agent_builder import SUPPORTED_IDES, generate_ide_agent_files
         manifest = self._make_manifest()
         for ide in SUPPORTED_IDES:
             config = generate_ide_agent_files(manifest, ide)

--- a/tests/test_git_mirror.py
+++ b/tests/test_git_mirror.py
@@ -4,27 +4,21 @@ These tests create real git repos in tmpdir and exercise the full clone/discover
 """
 
 import json
-import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 
 import pytest
 
 from services.git_mirror_service import (
-    DiscoveredComponent,
-    SyncResult,
     _mirror_path,
     _parse_manifest,
     _safe_path,
-    _scan_by_convention,
     clone_or_update,
     discover_components,
     get_commit_sha,
     sync_source,
     validate_mcp_component,
 )
-
 
 # ── Helpers ─────────────────────────────────────────────────────────
 

--- a/tests/test_git_mirror.py
+++ b/tests/test_git_mirror.py
@@ -55,17 +55,20 @@ def tmp_base(tmp_path):
 @pytest.fixture
 def simple_mcp_repo(tmp_path):
     """A git repo with a single FastMCP server at src/my-mcp/."""
-    return _create_git_repo(tmp_path / "mcp-repo", {
-        "src/my-mcp/server.py": (
-            'from mcp.server.fastmcp import FastMCP\n'
-            'mcp = FastMCP("my-mcp")\n'
-            '\n'
-            '@mcp.tool()\n'
-            'def hello(name: str) -> str:\n'
-            '    """Say hello."""\n'
-            '    return f"Hello {name}"\n'
-        ),
-    })
+    return _create_git_repo(
+        tmp_path / "mcp-repo",
+        {
+            "src/my-mcp/server.py": (
+                "from mcp.server.fastmcp import FastMCP\n"
+                'mcp = FastMCP("my-mcp")\n'
+                "\n"
+                "@mcp.tool()\n"
+                "def hello(name: str) -> str:\n"
+                '    """Say hello."""\n'
+                '    return f"Hello {name}"\n'
+            ),
+        },
+    )
 
 
 @pytest.fixture
@@ -81,39 +84,45 @@ def manifest_repo(tmp_path):
             {"path": "skills/tdd", "name": "tdd-skill", "description": "TDD workflow"},
         ],
     }
-    return _create_git_repo(tmp_path / "manifest-repo", {
-        ".observal.json": json.dumps(manifest, indent=2),
-        "src/filesystem/server.py": 'from mcp.server.fastmcp import FastMCP\nmcp = FastMCP("filesystem")\n',
-        "src/git-ops/server.py": 'from mcp.server.fastmcp import FastMCP\nmcp = FastMCP("git-ops")\n',
-        "skills/tdd/SKILL.md": "# TDD Skill\nTest-driven development.",
-    })
+    return _create_git_repo(
+        tmp_path / "manifest-repo",
+        {
+            ".observal.json": json.dumps(manifest, indent=2),
+            "src/filesystem/server.py": 'from mcp.server.fastmcp import FastMCP\nmcp = FastMCP("filesystem")\n',
+            "src/git-ops/server.py": 'from mcp.server.fastmcp import FastMCP\nmcp = FastMCP("git-ops")\n',
+            "skills/tdd/SKILL.md": "# TDD Skill\nTest-driven development.",
+        },
+    )
 
 
 @pytest.fixture
 def monorepo_convention(tmp_path):
     """A git repo with multiple components using convention layout (no manifest)."""
-    return _create_git_repo(tmp_path / "mono-repo", {
-        "src/server-a/main.py": 'from fastmcp import FastMCP\napp = FastMCP("a")\n',
-        "src/server-b/main.py": 'from mcp.server.fastmcp import FastMCP\napp = FastMCP("b")\n',
-        "src/not-mcp/README.md": "This has no Python files.",
-        "skills/debugging/SKILL.md": "# Debugging skill",
-        "hooks/pre-commit/hook.json": json.dumps({"event": "PreCommit"}),
-        "prompts/code-review/review.md": "# Code Review Prompt",
-        "sandboxes/python/Dockerfile": "FROM python:3.12\nRUN pip install pytest\n",
-    })
+    return _create_git_repo(
+        tmp_path / "mono-repo",
+        {
+            "src/server-a/main.py": 'from fastmcp import FastMCP\napp = FastMCP("a")\n',
+            "src/server-b/main.py": 'from mcp.server.fastmcp import FastMCP\napp = FastMCP("b")\n',
+            "src/not-mcp/README.md": "This has no Python files.",
+            "skills/debugging/SKILL.md": "# Debugging skill",
+            "hooks/pre-commit/hook.json": json.dumps({"event": "PreCommit"}),
+            "prompts/code-review/review.md": "# Code Review Prompt",
+            "sandboxes/python/Dockerfile": "FROM python:3.12\nRUN pip install pytest\n",
+        },
+    )
 
 
 @pytest.fixture
 def non_fastmcp_repo(tmp_path):
     """A git repo with a non-FastMCP MCP server (should fail validation)."""
-    return _create_git_repo(tmp_path / "bad-mcp", {
-        "src/old-server/server.py": (
-            'import flask\n'
-            'app = flask.Flask(__name__)\n'
-            '@app.route("/tool")\n'
-            'def tool(): return "hi"\n'
-        ),
-    })
+    return _create_git_repo(
+        tmp_path / "bad-mcp",
+        {
+            "src/old-server/server.py": (
+                'import flask\napp = flask.Flask(__name__)\n@app.route("/tool")\ndef tool(): return "hi"\n'
+            ),
+        },
+    )
 
 
 # ── Clone & Update ──────────────────────────────────────────────────
@@ -171,8 +180,10 @@ class TestGetCommitSha:
         mirror = clone_or_update(str(simple_mcp_repo), branch="main", base=tmp_base)
         mirror_sha = get_commit_sha(mirror)
         source_sha = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=str(simple_mcp_repo),
-            capture_output=True, text=True,
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(simple_mcp_repo),
+            capture_output=True,
+            text=True,
         ).stdout.strip()
         assert mirror_sha == source_sha
 
@@ -311,9 +322,12 @@ class TestFastMcpValidation:
 
     def test_alternative_import_style(self, tmp_path, tmp_base):
         """Test 'from fastmcp import FastMCP' (alternative import) is accepted."""
-        repo = _create_git_repo(tmp_path / "alt-import-repo", {
-            "src/alt/server.py": 'from fastmcp import FastMCP\napp = FastMCP("alt")\n',
-        })
+        repo = _create_git_repo(
+            tmp_path / "alt-import-repo",
+            {
+                "src/alt/server.py": 'from fastmcp import FastMCP\napp = FastMCP("alt")\n',
+            },
+        )
         mirror = clone_or_update(str(repo), branch="main", base=tmp_base)
         passed, detail = validate_mcp_component(mirror / "src" / "alt")
         assert passed is True
@@ -352,7 +366,9 @@ class TestSyncSource:
         assert result.components[0].name == "debugging"
 
     def test_sync_invalid_url_returns_error(self, tmp_base):
-        result = sync_source("https://github.com/nonexistent/no-such-repo-99999.git", component_type="mcp", base=tmp_base)
+        result = sync_source(
+            "https://github.com/nonexistent/no-such-repo-99999.git", component_type="mcp", base=tmp_base
+        )
         assert result.success is False
         assert result.error != ""
         assert result.components == []

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -3,15 +3,27 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+import re
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-import pytest
+import typer
+import yaml
 from typer.testing import CliRunner
 
 from observal_cli.main import app as cli_app
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI escape codes from text."""
+    return _ANSI_RE.sub("", text)
 
 # ── Helpers ──────────────────────────────────────────────────
 
@@ -439,17 +451,16 @@ class TestPullHelp:
     def test_help_flag(self):
         result = runner.invoke(cli_app, ["pull", "--help"])
         assert result.exit_code == 0
-        assert "Fetch agent config" in result.output
-        assert "--ide" in result.output
-        assert "--dir" in result.output
-        assert "--dry-run" in result.output
+        out = _plain(result.output)
+        assert "Fetch agent config" in out
+        assert "--ide" in out
+        assert "--dir" in out
+        assert "--dry-run" in out
 
 
 # ═══════════════════════════════════════════════════════════════
 # Agent authoring CLI tests
 # ═══════════════════════════════════════════════════════════════
-
-import yaml
 
 
 def _make_agent_yaml(tmp_path: Path, **overrides) -> Path:

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -25,6 +25,7 @@ def _plain(text: str) -> str:
     """Strip ANSI escape codes from text."""
     return _ANSI_RE.sub("", text)
 
+
 # ── Helpers ──────────────────────────────────────────────────
 
 _FAKE_CONFIG = {"server_url": "http://localhost:8000", "api_key": "test-key"}
@@ -41,6 +42,7 @@ def _patch_post(return_value: dict):
 
 
 # ── Fixtures for common server responses ─────────────────────
+
 
 def _cursor_snippet() -> dict:
     return {
@@ -73,11 +75,7 @@ def _vscode_snippet() -> dict:
             },
             "mcp_config": {
                 "path": ".vscode/mcp.json",
-                "content": {
-                    "mcpServers": {
-                        "vscode-srv": {"command": "node", "args": ["server.js"]}
-                    }
-                },
+                "content": {"mcpServers": {"vscode-srv": {"command": "node", "args": ["server.js"]}}},
             },
         }
     }
@@ -90,12 +88,8 @@ def _claude_code_snippet() -> dict:
                 "path": ".claude/rules/my-agent.md",
                 "content": "# Claude Code Agent\n",
             },
-            "mcp_config": {
-                "name": {"command": "observal-mcp", "args": ["--agent", "abc"]}
-            },
-            "mcp_setup_commands": [
-                ["claude", "mcp", "add", "observal-mcp", "--", "observal-mcp", "--agent", "abc"]
-            ],
+            "mcp_config": {"name": {"command": "observal-mcp", "args": ["--agent", "abc"]}},
+            "mcp_setup_commands": [["claude", "mcp", "add", "observal-mcp", "--", "observal-mcp", "--agent", "abc"]],
             "otlp_env": {
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
                 "OTEL_SERVICE_NAME": "my-agent",
@@ -113,11 +107,7 @@ def _gemini_snippet() -> dict:
             },
             "mcp_config": {
                 "path": ".gemini/mcp.json",
-                "content": {
-                    "mcpServers": {
-                        "gemini-srv": {"command": "python", "args": ["serve.py"]}
-                    }
-                },
+                "content": {"mcpServers": {"gemini-srv": {"command": "python", "args": ["serve.py"]}}},
             },
         }
     }
@@ -324,11 +314,9 @@ class TestPullMcpMerge:
         """Pre-existing mcpServers should not be overwritten."""
         mcp_path = tmp_path / ".cursor" / "mcp.json"
         mcp_path.parent.mkdir(parents=True)
-        mcp_path.write_text(json.dumps({
-            "mcpServers": {
-                "existing-server": {"command": "old-cmd", "args": ["--old"]}
-            }
-        }, indent=2))
+        mcp_path.write_text(
+            json.dumps({"mcpServers": {"existing-server": {"command": "old-cmd", "args": ["--old"]}}}, indent=2)
+        )
 
         with _patch_config(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path)])
@@ -345,11 +333,7 @@ class TestPullMcpMerge:
         """If the incoming server has the same name, it should update."""
         mcp_path = tmp_path / ".cursor" / "mcp.json"
         mcp_path.parent.mkdir(parents=True)
-        mcp_path.write_text(json.dumps({
-            "mcpServers": {
-                "my-server": {"command": "old", "args": []}
-            }
-        }, indent=2))
+        mcp_path.write_text(json.dumps({"mcpServers": {"my-server": {"command": "old", "args": []}}}, indent=2))
 
         with _patch_config(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path)])
@@ -433,9 +417,11 @@ class TestPullEdgeCases:
 
     def test_resolve_alias_is_called(self, tmp_path: Path):
         """The command should call config.resolve_alias for the agent_id."""
-        with _patch_config(), \
-             _patch_post(_codex_snippet()), \
-             patch("observal_cli.cmd_pull.config.resolve_alias", return_value="real-uuid") as mock_resolve:
+        with (
+            _patch_config(),
+            _patch_post(_codex_snippet()),
+            patch("observal_cli.cmd_pull.config.resolve_alias", return_value="real-uuid") as mock_resolve,
+        ):
             result = runner.invoke(cli_app, ["pull", "@myagent", "--ide", "codex", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -572,9 +558,12 @@ class TestAgentAdd:
 
     def test_prevents_duplicate_component(self, tmp_path: Path):
         """Adding the same component twice exits non-zero."""
-        _make_agent_yaml(tmp_path, components=[
-            {"component_type": "skill", "component_id": "abc-123"},
-        ])
+        _make_agent_yaml(
+            tmp_path,
+            components=[
+                {"component_type": "skill", "component_id": "abc-123"},
+            ],
+        )
         result = runner.invoke(
             cli_app,
             ["agent", "add", "skill", "abc-123", "--dir", str(tmp_path)],
@@ -595,10 +584,13 @@ class TestAgentAdd:
 class TestAgentBuild:
     def test_validates_components_against_server(self, tmp_path: Path):
         """Components are validated via GET calls; output shows results."""
-        _make_agent_yaml(tmp_path, components=[
-            {"component_type": "mcp", "component_id": "id-1"},
-            {"component_type": "skill", "component_id": "id-2"},
-        ])
+        _make_agent_yaml(
+            tmp_path,
+            components=[
+                {"component_type": "mcp", "component_id": "id-1"},
+                {"component_type": "skill", "component_id": "id-2"},
+            ],
+        )
 
         def mock_get(path, **kwargs):
             return {"id": "id-1", "name": "test"}
@@ -613,9 +605,12 @@ class TestAgentBuild:
 
     def test_reports_invalid_components(self, tmp_path: Path):
         """Components that fail GET show as errors."""
-        _make_agent_yaml(tmp_path, components=[
-            {"component_type": "mcp", "component_id": "bad-id"},
-        ])
+        _make_agent_yaml(
+            tmp_path,
+            components=[
+                {"component_type": "mcp", "component_id": "bad-id"},
+            ],
+        )
 
         def mock_get(path, **kwargs):
             raise typer.Exit(code=1)
@@ -666,9 +661,7 @@ class TestAgentPublish:
         search_results = [{"id": "existing-uuid", "name": "test-agent"}]
         put_result = {"id": "existing-uuid", "name": "test-agent"}
 
-        with _patch_config(), \
-             _patch_get(search_results) as mock_get_fn, \
-             _patch_put(put_result) as mock_put_fn:
+        with _patch_config(), _patch_get(search_results) as mock_get_fn, _patch_put(put_result) as mock_put_fn:
             result = runner.invoke(
                 cli_app,
                 ["agent", "publish", "--dir", str(tmp_path), "--update"],

--- a/tests/test_ragas_eval.py
+++ b/tests/test_ragas_eval.py
@@ -87,7 +87,12 @@ class TestContextRecall:
     @pytest.mark.asyncio
     @patch("services.ragas_eval._call_model", new_callable=AsyncMock)
     async def test_returns_score(self, mock_call):
-        mock_call.return_value = {"statements_total": 4, "statements_attributed": 3, "score": 0.75, "reason": "1 missing"}
+        mock_call.return_value = {
+            "statements_total": 4,
+            "statements_attributed": 3,
+            "score": 0.75,
+            "reason": "1 missing",
+        }
         result = await _eval_context_recall("ground truth", "context")
         assert result["score"] == 0.75
 

--- a/tests/test_registry_types.py
+++ b/tests/test_registry_types.py
@@ -14,6 +14,7 @@ from models.user import User, UserRole
 
 # ── Helpers ──────────────────────────────────────────────
 
+
 def _user(**kw):
     u = MagicMock(spec=User)
     u.id = kw.get("id", uuid.uuid4())
@@ -70,39 +71,48 @@ def _scalar_result(val):
 # 1. TestModels
 # ═══════════════════════════════════════════════════════════
 
+
 class TestModels:
     """Test that all 6 listing + download + link models have correct table names and reuse ListingStatus."""
 
     def test_skill_listing_tablename(self):
         from models.skill import SkillListing
+
         assert SkillListing.__tablename__ == "skill_listings"
 
     def test_hook_listing_tablename(self):
         from models.hook import HookListing
+
         assert HookListing.__tablename__ == "hook_listings"
 
     def test_prompt_listing_tablename(self):
         from models.prompt import PromptListing
+
         assert PromptListing.__tablename__ == "prompt_listings"
 
     def test_sandbox_listing_tablename(self):
         from models.sandbox import SandboxListing
+
         assert SandboxListing.__tablename__ == "sandbox_listings"
 
     def test_skill_download_tablename(self):
         from models.skill import SkillDownload
+
         assert SkillDownload.__tablename__ == "skill_downloads"
 
     def test_hook_download_tablename(self):
         from models.hook import HookDownload
+
         assert HookDownload.__tablename__ == "hook_downloads"
 
     def test_prompt_download_tablename(self):
         from models.prompt import PromptDownload
+
         assert PromptDownload.__tablename__ == "prompt_downloads"
 
     def test_sandbox_download_tablename(self):
         from models.sandbox import SandboxDownload
+
         assert SandboxDownload.__tablename__ == "sandbox_downloads"
 
     def test_listing_status_reused_not_redefined(self):
@@ -119,12 +129,14 @@ class TestModels:
 
     def test_submission_model_tablename(self):
         from models.submission import Submission
+
         assert Submission.__tablename__ == "submissions"
 
 
 # ═══════════════════════════════════════════════════════════
 # 2. TestSchemas
 # ═══════════════════════════════════════════════════════════
+
 
 class TestSchemas:
     """Validate pydantic schemas for all 6 types."""
@@ -133,34 +145,46 @@ class TestSchemas:
 
     def test_skill_submit_valid(self):
         from schemas.skill import SkillSubmitRequest
+
         r = SkillSubmitRequest(name="s", version="1.0", description="desc", owner="o", task_type="code-review")
         assert r.skill_path == "/"
 
     def test_hook_submit_valid(self):
         from schemas.hook import HookSubmitRequest
-        r = HookSubmitRequest(name="h", version="1.0", description="desc", owner="o", event="pre_tool_call", handler_type="script")
+
+        r = HookSubmitRequest(
+            name="h", version="1.0", description="desc", owner="o", event="pre_tool_call", handler_type="script"
+        )
         assert r.execution_mode == "async"
         assert r.priority == 100
 
     def test_prompt_submit_valid(self):
         from schemas.prompt import PromptSubmitRequest
-        r = PromptSubmitRequest(name="p", version="1.0", description="desc", owner="o", category="c", template="Hello {{ name }}")
+
+        r = PromptSubmitRequest(
+            name="p", version="1.0", description="desc", owner="o", category="c", template="Hello {{ name }}"
+        )
         assert r.variables == []
 
     def test_sandbox_submit_valid(self):
         from schemas.sandbox import SandboxSubmitRequest
-        r = SandboxSubmitRequest(name="sb", version="1.0", description="desc", owner="o", runtime_type="docker", image="python:3.11")
+
+        r = SandboxSubmitRequest(
+            name="sb", version="1.0", description="desc", owner="o", runtime_type="docker", image="python:3.11"
+        )
         assert r.network_policy == "none"
 
     # ── SubmitRequest missing required fields ──
 
     def test_hook_submit_missing_event(self):
         from schemas.hook import HookSubmitRequest
+
         with pytest.raises(ValueError):
             HookSubmitRequest(name="h", version="1.0", description="d", owner="o", handler_type="script")
 
     def test_sandbox_submit_missing_image(self):
         from schemas.sandbox import SandboxSubmitRequest
+
         with pytest.raises(ValueError):
             SandboxSubmitRequest(name="sb", version="1.0", description="d", owner="o", runtime_type="docker")
 
@@ -169,15 +193,28 @@ class TestSchemas:
     def _ns(self, **kw):
         """SimpleNamespace works with pydantic from_attributes (MagicMock.name conflicts)."""
         from types import SimpleNamespace
+
         return SimpleNamespace(**kw)
 
     def test_prompt_response_from_attrs(self):
         from schemas.prompt import PromptListingResponse
+
         obj = self._ns(
-            id=uuid.uuid4(), name="p", version="1.0", description="d", owner="o",
-            category="c", template="hi", variables=[], tags=[], supported_ides=[],
-            status=ListingStatus.approved, rejection_reason=None,
-            submitted_by=uuid.uuid4(), created_at=datetime.now(UTC), updated_at=datetime.now(UTC),
+            id=uuid.uuid4(),
+            name="p",
+            version="1.0",
+            description="d",
+            owner="o",
+            category="c",
+            template="hi",
+            variables=[],
+            tags=[],
+            supported_ides=[],
+            status=ListingStatus.approved,
+            rejection_reason=None,
+            submitted_by=uuid.uuid4(),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         r = PromptListingResponse.model_validate(obj, from_attributes=True)
         assert r.status == ListingStatus.approved
@@ -186,11 +223,13 @@ class TestSchemas:
 
     def test_prompt_render_request(self):
         from schemas.prompt import PromptRenderRequest
+
         r = PromptRenderRequest(variables={"name": "world"})
         assert r.variables["name"] == "world"
 
     def test_prompt_render_response(self):
         from schemas.prompt import PromptRenderResponse
+
         r = PromptRenderResponse(listing_id=uuid.uuid4(), rendered="Hello world")
         assert "world" in r.rendered
 
@@ -199,21 +238,25 @@ class TestSchemas:
 # 3. TestRoutes
 # ═══════════════════════════════════════════════════════════
 
+
 class TestSkillRoutes:
     @pytest.mark.asyncio
     async def test_submit_calls_db_add_and_commit(self):
         from api.routes.skill import router
+
         app, db, user = _app_with(router)
 
         def _refresh(obj):
             obj.id = uuid.uuid4()
             obj.created_at = datetime.now(UTC)
             obj.updated_at = datetime.now(UTC)
+
         db.refresh = AsyncMock(side_effect=_refresh)
 
         # The route passes archive_url to SkillListing but the model lacks that column.
         # Patch SkillListing.__init__ to accept and ignore unknown kwargs.
         from models.skill import SkillListing
+
         _orig_init = SkillListing.__init__
 
         def _patched_init(self, **kwargs):
@@ -222,9 +265,10 @@ class TestSkillRoutes:
 
         with patch.object(SkillListing, "__init__", _patched_init):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.post("/api/v1/skills/submit", json={
-                    "name": "s", "version": "1.0", "description": "d", "owner": "o", "task_type": "review"
-                })
+                r = await ac.post(
+                    "/api/v1/skills/submit",
+                    json={"name": "s", "version": "1.0", "description": "d", "owner": "o", "task_type": "review"},
+                )
         assert r.status_code == 200
         db.add.assert_called_once()
         assert r.json()["status"] == "pending"
@@ -232,6 +276,7 @@ class TestSkillRoutes:
     @pytest.mark.asyncio
     async def test_get_missing_returns_404(self):
         from api.routes.skill import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -241,6 +286,7 @@ class TestSkillRoutes:
     @pytest.mark.asyncio
     async def test_delete_missing_returns_404(self):
         from api.routes.skill import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -250,6 +296,7 @@ class TestSkillRoutes:
     @pytest.mark.asyncio
     async def test_install_approved_returns_config(self):
         from api.routes.skill import router
+
         app, db, user = _app_with(router)
         listing = _listing_mock(None, status=ListingStatus.approved)
         db.execute = AsyncMock(return_value=_scalar_result(listing))
@@ -263,19 +310,28 @@ class TestHookRoutes:
     @pytest.mark.asyncio
     async def test_submit_calls_db_add_and_commit(self):
         from api.routes.hook import router
+
         app, db, user = _app_with(router)
 
         def _refresh(obj):
             obj.id = uuid.uuid4()
             obj.created_at = datetime.now(UTC)
             obj.updated_at = datetime.now(UTC)
+
         db.refresh = AsyncMock(side_effect=_refresh)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-            r = await ac.post("/api/v1/hooks/submit", json={
-                "name": "h", "version": "1.0", "description": "d", "owner": "o",
-                "event": "pre_tool_call", "handler_type": "script",
-            })
+            r = await ac.post(
+                "/api/v1/hooks/submit",
+                json={
+                    "name": "h",
+                    "version": "1.0",
+                    "description": "d",
+                    "owner": "o",
+                    "event": "pre_tool_call",
+                    "handler_type": "script",
+                },
+            )
         assert r.status_code == 200
         db.add.assert_called_once()
         assert r.json()["status"] == "pending"
@@ -283,6 +339,7 @@ class TestHookRoutes:
     @pytest.mark.asyncio
     async def test_get_missing_returns_404(self):
         from api.routes.hook import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -292,6 +349,7 @@ class TestHookRoutes:
     @pytest.mark.asyncio
     async def test_delete_missing_returns_404(self):
         from api.routes.hook import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -301,6 +359,7 @@ class TestHookRoutes:
     @pytest.mark.asyncio
     async def test_install_approved_returns_config(self):
         from api.routes.hook import router
+
         app, db, user = _app_with(router)
         listing = _listing_mock(None, status=ListingStatus.approved)
         db.execute = AsyncMock(return_value=_scalar_result(listing))
@@ -314,19 +373,28 @@ class TestPromptRoutes:
     @pytest.mark.asyncio
     async def test_submit_calls_db_add_and_commit(self):
         from api.routes.prompt import router
+
         app, db, user = _app_with(router)
 
         def _refresh(obj):
             obj.id = uuid.uuid4()
             obj.created_at = datetime.now(UTC)
             obj.updated_at = datetime.now(UTC)
+
         db.refresh = AsyncMock(side_effect=_refresh)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-            r = await ac.post("/api/v1/prompts/submit", json={
-                "name": "p", "version": "1.0", "description": "d", "owner": "o",
-                "category": "c", "template": "Hello {{ name }}",
-            })
+            r = await ac.post(
+                "/api/v1/prompts/submit",
+                json={
+                    "name": "p",
+                    "version": "1.0",
+                    "description": "d",
+                    "owner": "o",
+                    "category": "c",
+                    "template": "Hello {{ name }}",
+                },
+            )
         assert r.status_code == 200
         db.add.assert_called_once()
         assert r.json()["status"] == "pending"
@@ -334,6 +402,7 @@ class TestPromptRoutes:
     @pytest.mark.asyncio
     async def test_get_missing_returns_404(self):
         from api.routes.prompt import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -343,6 +412,7 @@ class TestPromptRoutes:
     @pytest.mark.asyncio
     async def test_delete_missing_returns_404(self):
         from api.routes.prompt import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -352,6 +422,7 @@ class TestPromptRoutes:
     @pytest.mark.asyncio
     async def test_install_approved_returns_config(self):
         from api.routes.prompt import router
+
         app, db, user = _app_with(router)
         listing = _listing_mock(None, status=ListingStatus.approved)
         db.execute = AsyncMock(return_value=_scalar_result(listing))
@@ -363,8 +434,11 @@ class TestPromptRoutes:
     @pytest.mark.asyncio
     async def test_render_substitutes_variables(self):
         from api.routes.prompt import router
+
         app, db, user = _app_with(router)
-        listing = _listing_mock(None, status=ListingStatus.approved, template="Hello {{ name }}, welcome to {{ place }}")
+        listing = _listing_mock(
+            None, status=ListingStatus.approved, template="Hello {{ name }}, welcome to {{ place }}"
+        )
         db.execute = AsyncMock(return_value=_scalar_result(listing))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(
@@ -377,6 +451,7 @@ class TestPromptRoutes:
     @pytest.mark.asyncio
     async def test_render_missing_returns_404(self):
         from api.routes.prompt import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -388,19 +463,28 @@ class TestSandboxRoutes:
     @pytest.mark.asyncio
     async def test_submit_calls_db_add_and_commit(self):
         from api.routes.sandbox import router
+
         app, db, user = _app_with(router)
 
         def _refresh(obj):
             obj.id = uuid.uuid4()
             obj.created_at = datetime.now(UTC)
             obj.updated_at = datetime.now(UTC)
+
         db.refresh = AsyncMock(side_effect=_refresh)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-            r = await ac.post("/api/v1/sandboxes/submit", json={
-                "name": "sb", "version": "1.0", "description": "d", "owner": "o",
-                "runtime_type": "docker", "image": "python:3.11",
-            })
+            r = await ac.post(
+                "/api/v1/sandboxes/submit",
+                json={
+                    "name": "sb",
+                    "version": "1.0",
+                    "description": "d",
+                    "owner": "o",
+                    "runtime_type": "docker",
+                    "image": "python:3.11",
+                },
+            )
         assert r.status_code == 200
         db.add.assert_called_once()
         assert r.json()["status"] == "pending"
@@ -408,6 +492,7 @@ class TestSandboxRoutes:
     @pytest.mark.asyncio
     async def test_get_missing_returns_404(self):
         from api.routes.sandbox import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -417,6 +502,7 @@ class TestSandboxRoutes:
     @pytest.mark.asyncio
     async def test_delete_missing_returns_404(self):
         from api.routes.sandbox import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -426,6 +512,7 @@ class TestSandboxRoutes:
     @pytest.mark.asyncio
     async def test_install_approved_returns_config(self):
         from api.routes.sandbox import router
+
         app, db, user = _app_with(router)
         listing = _listing_mock(None, status=ListingStatus.approved)
         db.execute = AsyncMock(return_value=_scalar_result(listing))
@@ -439,10 +526,12 @@ class TestSandboxRoutes:
 # 4. TestUnifiedReview
 # ═══════════════════════════════════════════════════════════
 
+
 class TestUnifiedReview:
     @pytest.mark.asyncio
     async def test_list_pending_returns_empty(self):
         from api.routes.review import router
+
         app, db, _ = _app_with(router)
         empty = MagicMock()
         empty.scalars.return_value.all.return_value = []
@@ -454,6 +543,7 @@ class TestUnifiedReview:
     @pytest.mark.asyncio
     async def test_list_pending_requires_admin(self):
         from api.routes.review import router
+
         user = _user(role=UserRole.developer)
         app, db, _ = _app_with(router, user=user)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -463,6 +553,7 @@ class TestUnifiedReview:
     @pytest.mark.asyncio
     async def test_approve_not_found(self):
         from api.routes.review import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -472,6 +563,7 @@ class TestUnifiedReview:
     @pytest.mark.asyncio
     async def test_reject_not_found(self):
         from api.routes.review import router
+
         app, db, _ = _app_with(router)
         db.execute = AsyncMock(return_value=_scalar_result(None))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -481,6 +573,7 @@ class TestUnifiedReview:
     @pytest.mark.asyncio
     async def test_approve_changes_status(self):
         from api.routes.review import router
+
         app, db, _ = _app_with(router)
         listing = _listing_mock(None, status=ListingStatus.pending)
         db.execute = AsyncMock(return_value=_scalar_result(listing))
@@ -493,6 +586,7 @@ class TestUnifiedReview:
     @pytest.mark.asyncio
     async def test_reject_sets_reason(self):
         from api.routes.review import router
+
         app, db, _ = _app_with(router)
         listing = _listing_mock(None, status=ListingStatus.pending)
         db.execute = AsyncMock(return_value=_scalar_result(listing))
@@ -505,6 +599,7 @@ class TestUnifiedReview:
 
     def test_listing_models_dict_has_all_types(self):
         from api.routes.review import LISTING_MODELS
+
         for t in ("mcp", "skill", "hook", "prompt", "sandbox"):
             assert t in LISTING_MODELS
 
@@ -513,27 +608,32 @@ class TestUnifiedReview:
 # 5. TestFeedbackExtension
 # ═══════════════════════════════════════════════════════════
 
+
 class TestFeedbackExtension:
     """Verify the feedback schema accepts all 6 new listing types."""
 
     @pytest.mark.parametrize("lt", ["mcp", "agent", "skill", "hook", "prompt", "sandbox"])
     def test_feedback_schema_accepts_new_types(self, lt):
         from schemas.feedback import FeedbackCreateRequest
+
         req = FeedbackCreateRequest(listing_id=uuid.uuid4(), listing_type=lt, rating=4)
         assert req.listing_type == lt
 
     def test_feedback_schema_rejects_invalid_type(self):
         from schemas.feedback import FeedbackCreateRequest
+
         with pytest.raises(ValueError):
             FeedbackCreateRequest(listing_id=uuid.uuid4(), listing_type="invalid", rating=4)
 
     def test_feedback_schema_rejects_rating_out_of_range(self):
         from schemas.feedback import FeedbackCreateRequest
+
         with pytest.raises(ValueError):
             FeedbackCreateRequest(listing_id=uuid.uuid4(), listing_type="tool", rating=6)
 
     def test_feedback_schema_accepts_mcp_and_agent(self):
         from schemas.feedback import FeedbackCreateRequest
+
         for lt in ("mcp", "agent"):
             req = FeedbackCreateRequest(listing_id=uuid.uuid4(), listing_type=lt, rating=3)
             assert req.listing_type == lt
@@ -542,6 +642,7 @@ class TestFeedbackExtension:
 # ═══════════════════════════════════════════════════════════
 # 6. TestCLICommands
 # ═══════════════════════════════════════════════════════════
+
 
 class TestCLICommands:
     """Verify CLI command groups exist with expected subcommands."""
@@ -553,10 +654,12 @@ class TestCLICommands:
 
     def test_skill_app_exists(self):
         from observal_cli.cmd_skill import skill_app
+
         assert skill_app is not None
 
     def test_skill_app_has_subcommands(self):
         from observal_cli.cmd_skill import skill_app
+
         names = self._get_command_names(skill_app)
         for cmd in ("submit", "list", "show", "install", "delete"):
             assert cmd in names, f"skill missing '{cmd}' subcommand"

--- a/tests/test_schema_redesign.py
+++ b/tests/test_schema_redesign.py
@@ -8,10 +8,12 @@ import pytest
 class TestOrganizationModel:
     def test_organization_tablename(self):
         from models.organization import Organization
+
         assert Organization.__tablename__ == "organizations"
 
     def test_organization_has_required_columns(self):
         from models.organization import Organization
+
         cols = {c.name for c in Organization.__table__.columns}
         assert "id" in cols
         assert "name" in cols
@@ -21,9 +23,11 @@ class TestOrganizationModel:
 
     def test_organization_slug_is_unique(self):
         from models.organization import Organization
+
         slug_col = Organization.__table__.c.slug
         assert slug_col.unique or any(
-            uc for uc in Organization.__table__.constraints
+            uc
+            for uc in Organization.__table__.constraints
             if hasattr(uc, "columns") and "slug" in [c.name for c in uc.columns]
         )
 
@@ -31,11 +35,13 @@ class TestOrganizationModel:
 class TestUserOrgField:
     def test_user_has_org_id(self):
         from models.user import User
+
         cols = {c.name for c in User.__table__.columns}
         assert "org_id" in cols
 
     def test_user_org_id_is_nullable(self):
         from models.user import User
+
         org_col = User.__table__.c.org_id
         assert org_col.nullable is True
 
@@ -43,23 +49,34 @@ class TestUserOrgField:
 class TestComponentSourceModel:
     def test_component_source_tablename(self):
         from models.component_source import ComponentSource
+
         assert ComponentSource.__tablename__ == "component_sources"
 
     def test_component_source_has_required_columns(self):
         from models.component_source import ComponentSource
+
         cols = {c.name for c in ComponentSource.__table__.columns}
-        required = {"id", "url", "provider", "component_type", "is_public", "owner_org_id",
-                    "auto_sync_interval", "last_synced_at", "sync_status", "sync_error",
-                    "created_at", "updated_at"}
+        required = {
+            "id",
+            "url",
+            "provider",
+            "component_type",
+            "is_public",
+            "owner_org_id",
+            "auto_sync_interval",
+            "last_synced_at",
+            "sync_status",
+            "sync_error",
+            "created_at",
+            "updated_at",
+        }
         assert required.issubset(cols)
 
     def test_component_source_url_type_unique(self):
         from models.component_source import ComponentSource
+
         table = ComponentSource.__table__
-        unique_constraints = [
-            uc for uc in table.constraints
-            if hasattr(uc, "columns") and len(uc.columns) == 2
-        ]
+        unique_constraints = [uc for uc in table.constraints if hasattr(uc, "columns") and len(uc.columns) == 2]
         col_sets = [frozenset(c.name for c in uc.columns) for uc in unique_constraints]
         assert frozenset({"url", "component_type"}) in col_sets
 
@@ -67,59 +84,75 @@ class TestComponentSourceModel:
 class TestComponentTableUpdates:
     """All component tables must have: is_private, owner_org_id, download_count, unique_agents."""
 
-    @pytest.mark.parametrize("model_path,model_name", [
-        ("models.mcp", "McpListing"),
-        ("models.skill", "SkillListing"),
-        ("models.hook", "HookListing"),
-        ("models.prompt", "PromptListing"),
-        ("models.sandbox", "SandboxListing"),
-    ])
+    @pytest.mark.parametrize(
+        "model_path,model_name",
+        [
+            ("models.mcp", "McpListing"),
+            ("models.skill", "SkillListing"),
+            ("models.hook", "HookListing"),
+            ("models.prompt", "PromptListing"),
+            ("models.sandbox", "SandboxListing"),
+        ],
+    )
     def test_component_has_org_fields(self, model_path, model_name):
         import importlib
+
         mod = importlib.import_module(model_path)
         cls = getattr(mod, model_name)
         cols = {c.name for c in cls.__table__.columns}
         assert "is_private" in cols, f"{model_name} missing is_private"
         assert "owner_org_id" in cols, f"{model_name} missing owner_org_id"
 
-    @pytest.mark.parametrize("model_path,model_name", [
-        ("models.mcp", "McpListing"),
-        ("models.skill", "SkillListing"),
-        ("models.hook", "HookListing"),
-        ("models.prompt", "PromptListing"),
-        ("models.sandbox", "SandboxListing"),
-    ])
+    @pytest.mark.parametrize(
+        "model_path,model_name",
+        [
+            ("models.mcp", "McpListing"),
+            ("models.skill", "SkillListing"),
+            ("models.hook", "HookListing"),
+            ("models.prompt", "PromptListing"),
+            ("models.sandbox", "SandboxListing"),
+        ],
+    )
     def test_component_has_download_counts(self, model_path, model_name):
         import importlib
+
         mod = importlib.import_module(model_path)
         cls = getattr(mod, model_name)
         cols = {c.name for c in cls.__table__.columns}
         assert "download_count" in cols, f"{model_name} missing download_count"
         assert "unique_agents" in cols, f"{model_name} missing unique_agents"
 
-    @pytest.mark.parametrize("model_path,model_name", [
-        ("models.mcp", "McpListing"),
-        ("models.skill", "SkillListing"),
-        ("models.hook", "HookListing"),
-        ("models.prompt", "PromptListing"),
-        ("models.sandbox", "SandboxListing"),
-    ])
+    @pytest.mark.parametrize(
+        "model_path,model_name",
+        [
+            ("models.mcp", "McpListing"),
+            ("models.skill", "SkillListing"),
+            ("models.hook", "HookListing"),
+            ("models.prompt", "PromptListing"),
+            ("models.sandbox", "SandboxListing"),
+        ],
+    )
     def test_component_has_git_url(self, model_path, model_name):
         import importlib
+
         mod = importlib.import_module(model_path)
         cls = getattr(mod, model_name)
         cols = {c.name for c in cls.__table__.columns}
         assert "git_url" in cols, f"{model_name} missing git_url"
 
-    @pytest.mark.parametrize("model_path,model_name", [
-        ("models.mcp", "McpListing"),
-        ("models.skill", "SkillListing"),
-        ("models.hook", "HookListing"),
-        ("models.prompt", "PromptListing"),
-        ("models.sandbox", "SandboxListing"),
-    ])
+    @pytest.mark.parametrize(
+        "model_path,model_name",
+        [
+            ("models.mcp", "McpListing"),
+            ("models.skill", "SkillListing"),
+            ("models.hook", "HookListing"),
+            ("models.prompt", "PromptListing"),
+            ("models.sandbox", "SandboxListing"),
+        ],
+    )
     def test_component_has_git_ref(self, model_path, model_name):
         import importlib
+
         mod = importlib.import_module(model_path)
         cls = getattr(mod, model_name)
         cols = {c.name for c in cls.__table__.columns}
@@ -127,74 +160,91 @@ class TestComponentTableUpdates:
 
     def test_mcp_has_mcp_validated(self):
         from models.mcp import McpListing
+
         cols = {c.name for c in McpListing.__table__.columns}
         assert "mcp_validated" in cols
 
     def test_skill_link_table_removed(self):
         """AgentSkillLink should no longer exist — replaced by AgentComponent."""
         from models import skill
+
         assert not hasattr(skill, "AgentSkillLink")
 
     def test_hook_link_table_removed(self):
         """AgentHookLink should no longer exist — replaced by AgentComponent."""
         from models import hook
+
         assert not hasattr(hook, "AgentHookLink")
 
 
 class TestAgentModelUpdate:
     def test_agent_has_org_fields(self):
         from models.agent import Agent
+
         cols = {c.name for c in Agent.__table__.columns}
         assert "is_private" in cols
         assert "owner_org_id" in cols
 
     def test_agent_has_git_url(self):
         from models.agent import Agent
+
         cols = {c.name for c in Agent.__table__.columns}
         assert "git_url" in cols
 
     def test_agent_has_download_metrics(self):
         from models.agent import Agent
+
         cols = {c.name for c in Agent.__table__.columns}
         assert "download_count" in cols
         assert "unique_users" in cols
 
     def test_agent_git_url_is_nullable(self):
         from models.agent import Agent
+
         git_col = Agent.__table__.c.git_url
         assert git_col.nullable is True
 
     def test_agent_mcp_link_removed(self):
         """AgentMcpLink should no longer exist — replaced by AgentComponent."""
         from models import agent
+
         assert not hasattr(agent, "AgentMcpLink")
 
 
 class TestAgentComponentModel:
     def test_agent_component_tablename(self):
         from models.agent_component import AgentComponent
+
         assert AgentComponent.__tablename__ == "agent_components"
 
     def test_agent_component_has_required_columns(self):
         from models.agent_component import AgentComponent
+
         cols = {c.name for c in AgentComponent.__table__.columns}
-        required = {"id", "agent_id", "component_type", "component_id",
-                    "version_ref", "order_index", "config_override", "created_at"}
+        required = {
+            "id",
+            "agent_id",
+            "component_type",
+            "component_id",
+            "version_ref",
+            "order_index",
+            "config_override",
+            "created_at",
+        }
         assert required.issubset(cols)
 
     def test_agent_component_has_unique_constraint(self):
         from models.agent_component import AgentComponent
+
         table = AgentComponent.__table__
-        unique_constraints = [
-            uc for uc in table.constraints
-            if hasattr(uc, "columns") and len(uc.columns) == 3
-        ]
+        unique_constraints = [uc for uc in table.constraints if hasattr(uc, "columns") and len(uc.columns) == 3]
         col_sets = [frozenset(c.name for c in uc.columns) for uc in unique_constraints]
         assert frozenset({"agent_id", "component_type", "component_id"}) in col_sets
 
     def test_agent_component_no_fk_on_component_id(self):
         """component_id should NOT have a FK constraint (polymorphic, future flexibility)."""
         from models.agent_component import AgentComponent
+
         col = AgentComponent.__table__.c.component_id
         fks = col.foreign_keys
         assert len(fks) == 0, "component_id should have no FK constraints"
@@ -203,10 +253,12 @@ class TestAgentComponentModel:
 class TestDownloadModels:
     def test_agent_download_tablename(self):
         from models.download import AgentDownloadRecord
+
         assert AgentDownloadRecord.__tablename__ == "agent_download_records"
 
     def test_agent_download_has_required_columns(self):
         from models.download import AgentDownloadRecord
+
         cols = {c.name for c in AgentDownloadRecord.__table__.columns}
         required = {"id", "agent_id", "user_id", "fingerprint", "source", "ide", "installed_at"}
         assert required.issubset(cols)
@@ -214,45 +266,44 @@ class TestDownloadModels:
     def test_agent_download_user_id_nullable(self):
         """user_id nullable for anonymous users (fingerprint used instead)."""
         from models.download import AgentDownloadRecord
+
         col = AgentDownloadRecord.__table__.c.user_id
         assert col.nullable is True
 
     def test_agent_download_has_unique_constraints(self):
         from models.download import AgentDownloadRecord
+
         table = AgentDownloadRecord.__table__
-        unique_constraints = [
-            uc for uc in table.constraints
-            if hasattr(uc, "columns") and len(uc.columns) == 2
-        ]
+        unique_constraints = [uc for uc in table.constraints if hasattr(uc, "columns") and len(uc.columns) == 2]
         col_sets = [frozenset(c.name for c in uc.columns) for uc in unique_constraints]
         assert frozenset({"agent_id", "user_id"}) in col_sets
         assert frozenset({"agent_id", "fingerprint"}) in col_sets
 
     def test_component_download_tablename(self):
         from models.download import ComponentDownloadRecord
+
         assert ComponentDownloadRecord.__tablename__ == "component_download_records"
 
     def test_component_download_has_required_columns(self):
         from models.download import ComponentDownloadRecord
+
         cols = {c.name for c in ComponentDownloadRecord.__table__.columns}
-        required = {"id", "component_type", "component_id", "version_ref",
-                    "agent_id", "source", "downloaded_at"}
+        required = {"id", "component_type", "component_id", "version_ref", "agent_id", "source", "downloaded_at"}
         assert required.issubset(cols)
 
     def test_component_download_no_unique_constraint(self):
         """Component downloads are NOT deduplicated — count every agent pull."""
         from models.download import ComponentDownloadRecord
+
         table = ComponentDownloadRecord.__table__
         # Should only have PK constraint
-        non_pk_unique = [
-            uc for uc in table.constraints
-            if hasattr(uc, "columns") and len(uc.columns) > 1
-        ]
+        non_pk_unique = [uc for uc in table.constraints if hasattr(uc, "columns") and len(uc.columns) > 1]
         assert len(non_pk_unique) == 0, "component_download_records should have no multi-column unique constraints"
 
     def test_component_download_no_fk_on_component_id(self):
         """component_id should NOT have a FK constraint (polymorphic)."""
         from models.download import ComponentDownloadRecord
+
         col = ComponentDownloadRecord.__table__.c.component_id
         fks = col.foreign_keys
         assert len(fks) == 0
@@ -261,21 +312,21 @@ class TestDownloadModels:
 class TestExporterConfigModel:
     def test_exporter_config_tablename(self):
         from models.exporter_config import ExporterConfig
+
         assert ExporterConfig.__tablename__ == "exporter_configs"
 
     def test_exporter_config_has_required_columns(self):
         from models.exporter_config import ExporterConfig
+
         cols = {c.name for c in ExporterConfig.__table__.columns}
         required = {"id", "org_id", "exporter_type", "enabled", "config", "created_at", "updated_at"}
         assert required.issubset(cols)
 
     def test_exporter_config_unique_per_org(self):
         from models.exporter_config import ExporterConfig
+
         table = ExporterConfig.__table__
-        unique_constraints = [
-            uc for uc in table.constraints
-            if hasattr(uc, "columns") and len(uc.columns) == 2
-        ]
+        unique_constraints = [uc for uc in table.constraints if hasattr(uc, "columns") and len(uc.columns) == 2]
         col_sets = [frozenset(c.name for c in uc.columns) for uc in unique_constraints]
         assert frozenset({"org_id", "exporter_type"}) in col_sets
 
@@ -284,12 +335,14 @@ class TestRemovedTypes:
     def test_tool_listing_not_importable(self):
         """ToolListing should no longer exist in models.__init__."""
         import models
+
         assert not hasattr(models, "ToolListing")
         assert not hasattr(models, "ToolDownload")
 
     def test_graphrag_listing_not_importable(self):
         """GraphRagListing should no longer exist in models.__init__."""
         import models
+
         assert not hasattr(models, "GraphRagListing")
         assert not hasattr(models, "GraphRagDownload")
 
@@ -303,6 +356,7 @@ class TestRemovedTypes:
             ExporterConfig,
             Organization,
         )
+
         assert Organization.__tablename__ == "organizations"
         assert ComponentSource.__tablename__ == "component_sources"
         assert AgentComponent.__tablename__ == "agent_components"
@@ -314,11 +368,13 @@ class TestRemovedTypes:
 class TestFeedbackSubmissionUpdates:
     def test_feedback_listing_type_wider(self):
         from models.feedback import Feedback
+
         col = Feedback.__table__.c.listing_type
         assert col.type.length >= 50
 
     def test_submission_listing_type_wider(self):
         from models.submission import Submission
+
         col = Submission.__table__.c.listing_type
         assert col.type.length >= 50
 
@@ -372,22 +428,24 @@ class TestDownloadTracking:
 
     def test_download_record_model_constraints(self):
         from models.download import AgentDownloadRecord
-        constraints = {c.name for c in AgentDownloadRecord.__table__.constraints if hasattr(c, 'name') and c.name}
+
+        constraints = {c.name for c in AgentDownloadRecord.__table__.constraints if hasattr(c, "name") and c.name}
         assert "uq_agent_downloads_agent_user" in constraints
         assert "uq_agent_downloads_agent_fingerprint" in constraints
 
     def test_component_download_not_deduplicated(self):
         """ComponentDownloadRecord should have no multi-column unique constraints."""
         from models.download import ComponentDownloadRecord
+
         unique_constraints = [
-            c for c in ComponentDownloadRecord.__table__.constraints
-            if hasattr(c, 'columns') and len(c.columns) > 1
+            c for c in ComponentDownloadRecord.__table__.constraints if hasattr(c, "columns") and len(c.columns) > 1
         ]
         # Only the PK constraint, no multi-column uniques
         assert len(unique_constraints) == 0
 
     def test_agent_has_download_count_fields(self):
         from models.agent import Agent
+
         assert hasattr(Agent, "download_count")
         assert hasattr(Agent, "unique_users")
         col_dl = Agent.__table__.columns["download_count"]
@@ -402,6 +460,7 @@ class TestDownloadTracking:
             record_agent_download,
             record_component_download,
         )
+
         assert callable(record_agent_download)
         assert callable(record_component_download)
         assert callable(get_download_stats)
@@ -412,6 +471,7 @@ class TestDownloadTracking:
         import inspect
 
         from api.routes.agent import install_agent
+
         sig = inspect.signature(install_agent)
         param_names = list(sig.parameters.keys())
         assert "request" in param_names
@@ -422,10 +482,12 @@ class TestMcpValidationField:
 
     def test_mcp_has_mcp_validated_field(self):
         from models.mcp import McpListing
+
         assert hasattr(McpListing, "mcp_validated")
 
     def test_mcp_validated_defaults_false(self):
         from models.mcp import McpListing
+
         col = McpListing.__table__.columns["mcp_validated"]
         # default is False
         assert col.default.arg is False
@@ -452,6 +514,7 @@ class TestMcpValidationField:
 
         # Patch _find_listing to return our mock
         import api.routes.review as review_mod
+
         original_find = review_mod._find_listing
         review_mod._find_listing = AsyncMock(return_value=("mcp", listing))
 
@@ -481,6 +544,7 @@ class TestMcpValidationField:
         mock_user.role = UserRole.admin
 
         import api.routes.review as review_mod
+
         original_find = review_mod._find_listing
         review_mod._find_listing = AsyncMock(return_value=("mcp", listing))
 
@@ -509,6 +573,7 @@ class TestMcpValidationField:
         mock_user.role = UserRole.admin
 
         import api.routes.review as review_mod
+
         original_find = review_mod._find_listing
         review_mod._find_listing = AsyncMock(return_value=("skill", listing))
 

--- a/tests/test_schema_redesign.py
+++ b/tests/test_schema_redesign.py
@@ -1,7 +1,6 @@
 """Tests for the agent-centric schema redesign."""
 
 import uuid
-from datetime import UTC, datetime
 
 import pytest
 
@@ -297,8 +296,12 @@ class TestRemovedTypes:
     def test_new_models_importable(self):
         """All new models should be importable from models package."""
         from models import (
-            Organization, ComponentSource, AgentComponent,
-            AgentDownloadRecord, ComponentDownloadRecord, ExporterConfig,
+            AgentComponent,
+            AgentDownloadRecord,
+            ComponentDownloadRecord,
+            ComponentSource,
+            ExporterConfig,
+            Organization,
         )
         assert Organization.__tablename__ == "organizations"
         assert ComponentSource.__tablename__ == "component_sources"
@@ -325,6 +328,7 @@ class TestDownloadTracking:
 
     def test_anonymous_fingerprint_deterministic(self):
         from unittest.mock import MagicMock
+
         from services.download_tracker import _anonymous_fingerprint
 
         request = MagicMock()
@@ -338,6 +342,7 @@ class TestDownloadTracking:
 
     def test_anonymous_fingerprint_varies_by_ip(self):
         from unittest.mock import MagicMock
+
         from services.download_tracker import _anonymous_fingerprint
 
         req1 = MagicMock()
@@ -352,6 +357,7 @@ class TestDownloadTracking:
 
     def test_anonymous_fingerprint_varies_by_ua(self):
         from unittest.mock import MagicMock
+
         from services.download_tracker import _anonymous_fingerprint
 
         req1 = MagicMock()
@@ -390,7 +396,12 @@ class TestDownloadTracking:
         assert col_uu.default.arg == 0
 
     def test_download_tracker_module_exists(self):
-        from services.download_tracker import record_agent_download, record_component_download, get_download_stats, _anonymous_fingerprint
+        from services.download_tracker import (
+            _anonymous_fingerprint,
+            get_download_stats,
+            record_agent_download,
+            record_component_download,
+        )
         assert callable(record_agent_download)
         assert callable(record_component_download)
         assert callable(get_download_stats)
@@ -399,6 +410,7 @@ class TestDownloadTracking:
     def test_install_agent_route_accepts_request(self):
         """The install_agent endpoint should accept a Request parameter for fingerprinting."""
         import inspect
+
         from api.routes.agent import install_agent
         sig = inspect.signature(install_agent)
         param_names = list(sig.parameters.keys())
@@ -422,6 +434,7 @@ class TestMcpValidationField:
     async def test_approve_allows_non_validated_mcp(self):
         """Review approve should allow MCPs regardless of validation status."""
         from unittest.mock import AsyncMock, MagicMock
+
         from api.routes.review import approve
         from models.mcp import ListingStatus
         from models.user import UserRole
@@ -452,6 +465,7 @@ class TestMcpValidationField:
     async def test_approve_allows_validated_mcp(self):
         """Review approve should allow MCPs that passed validation."""
         from unittest.mock import AsyncMock, MagicMock
+
         from api.routes.review import approve
         from models.mcp import ListingStatus
         from models.user import UserRole
@@ -480,6 +494,7 @@ class TestMcpValidationField:
     async def test_approve_non_mcp_not_affected(self):
         """Non-MCP listings should not be affected by validation check."""
         from unittest.mock import AsyncMock, MagicMock
+
         from api.routes.review import approve
         from models.mcp import ListingStatus
         from models.user import UserRole

--- a/tests/test_score_aggregator.py
+++ b/tests/test_score_aggregator.py
@@ -51,8 +51,18 @@ class TestComputeScorecard:
 
     def test_penalties_reduce_score(self):
         penalties = [
-            {"event_name": "duplicate_tool_call", "dimension": ScoringDimension.tool_efficiency, "amount": -5, "evidence": "dup"},
-            {"event_name": "tool_call_error", "dimension": ScoringDimension.tool_failures, "amount": -10, "evidence": "err"},
+            {
+                "event_name": "duplicate_tool_call",
+                "dimension": ScoringDimension.tool_efficiency,
+                "amount": -5,
+                "evidence": "dup",
+            },
+            {
+                "event_name": "tool_call_error",
+                "dimension": ScoringDimension.tool_failures,
+                "amount": -10,
+                "evidence": "err",
+            },
         ]
         sc = self.aggregator.compute_scorecard(
             structural_penalties=penalties,
@@ -70,12 +80,42 @@ class TestComputeScorecard:
 
     def test_score_floors_at_zero(self):
         penalties = [
-            {"event_name": "contradicts_source", "dimension": ScoringDimension.factual_grounding, "amount": -25, "evidence": "e1"},
-            {"event_name": "numeric_mismatch", "dimension": ScoringDimension.factual_grounding, "amount": -20, "evidence": "e2"},
-            {"event_name": "hallucinated_entity", "dimension": ScoringDimension.factual_grounding, "amount": -20, "evidence": "e3"},
-            {"event_name": "ungrounded_claim", "dimension": ScoringDimension.factual_grounding, "amount": -15, "evidence": "e4"},
-            {"event_name": "ungrounded_claim", "dimension": ScoringDimension.factual_grounding, "amount": -15, "evidence": "e5"},
-            {"event_name": "hallucinated_entity", "dimension": ScoringDimension.factual_grounding, "amount": -20, "evidence": "e6"},
+            {
+                "event_name": "contradicts_source",
+                "dimension": ScoringDimension.factual_grounding,
+                "amount": -25,
+                "evidence": "e1",
+            },
+            {
+                "event_name": "numeric_mismatch",
+                "dimension": ScoringDimension.factual_grounding,
+                "amount": -20,
+                "evidence": "e2",
+            },
+            {
+                "event_name": "hallucinated_entity",
+                "dimension": ScoringDimension.factual_grounding,
+                "amount": -20,
+                "evidence": "e3",
+            },
+            {
+                "event_name": "ungrounded_claim",
+                "dimension": ScoringDimension.factual_grounding,
+                "amount": -15,
+                "evidence": "e4",
+            },
+            {
+                "event_name": "ungrounded_claim",
+                "dimension": ScoringDimension.factual_grounding,
+                "amount": -15,
+                "evidence": "e5",
+            },
+            {
+                "event_name": "hallucinated_entity",
+                "dimension": ScoringDimension.factual_grounding,
+                "amount": -20,
+                "evidence": "e6",
+            },
         ]
         sc = self.aggregator.compute_scorecard(
             structural_penalties=[],
@@ -103,8 +143,18 @@ class TestComputeScorecard:
 
     def test_recommendations_generated(self):
         penalties = [
-            {"event_name": "tool_call_error", "dimension": ScoringDimension.tool_failures, "amount": -10, "evidence": "err"},
-            {"event_name": "tool_call_timeout", "dimension": ScoringDimension.tool_failures, "amount": -8, "evidence": "timeout"},
+            {
+                "event_name": "tool_call_error",
+                "dimension": ScoringDimension.tool_failures,
+                "amount": -10,
+                "evidence": "err",
+            },
+            {
+                "event_name": "tool_call_timeout",
+                "dimension": ScoringDimension.tool_failures,
+                "amount": -8,
+                "evidence": "timeout",
+            },
         ]
         sc = self.aggregator.compute_scorecard(
             structural_penalties=penalties,
@@ -119,7 +169,12 @@ class TestComputeScorecard:
 
     def test_bottleneck_identifies_worst(self):
         penalties = [
-            {"event_name": "missing_required_section", "dimension": ScoringDimension.goal_completion, "amount": -25, "evidence": "e"},
+            {
+                "event_name": "missing_required_section",
+                "dimension": ScoringDimension.goal_completion,
+                "amount": -25,
+                "evidence": "e",
+            },
         ]
         sc = self.aggregator.compute_scorecard(
             structural_penalties=[],
@@ -142,7 +197,19 @@ class TestAgentAggregate:
         assert result["drift_alert"] is False
 
     def test_single_scorecard(self):
-        scorecards = [{"composite_score": 80, "dimension_scores": {"goal_completion": 90, "tool_efficiency": 70, "tool_failures": 80, "factual_grounding": 85, "thought_process": 75}, "evaluated_at": "2026-01-01"}]
+        scorecards = [
+            {
+                "composite_score": 80,
+                "dimension_scores": {
+                    "goal_completion": 90,
+                    "tool_efficiency": 70,
+                    "tool_failures": 80,
+                    "factual_grounding": 85,
+                    "thought_process": 75,
+                },
+                "evaluated_at": "2026-01-01",
+            }
+        ]
         result = self.aggregator.compute_agent_aggregate(scorecards)
         assert result["mean"] == 80
         assert result["std"] == 0
@@ -162,8 +229,13 @@ class TestAgentAggregate:
 
     def test_drift_detection(self):
         # Recent scores much higher than baseline (baseline has variance)
-        recent = [{"composite_score": 95, "dimension_scores": {}, "evaluated_at": f"2026-02-{i:02d}"} for i in range(1, 51)]
-        baseline = [{"composite_score": 45 + (i % 10), "dimension_scores": {}, "evaluated_at": f"2026-01-{i:02d}"} for i in range(1, 51)]
+        recent = [
+            {"composite_score": 95, "dimension_scores": {}, "evaluated_at": f"2026-02-{i:02d}"} for i in range(1, 51)
+        ]
+        baseline = [
+            {"composite_score": 45 + (i % 10), "dimension_scores": {}, "evaluated_at": f"2026-01-{i:02d}"}
+            for i in range(1, 51)
+        ]
         result = self.aggregator.compute_agent_aggregate(recent + baseline)
         assert result["drift_alert"] is True
 

--- a/tests/test_slm_scorer.py
+++ b/tests/test_slm_scorer.py
@@ -15,7 +15,14 @@ def _make_backend(response: dict):
 
 
 def _tool_span(name="tool_a", output="result", span_id="s1", status="success", input_data=""):
-    return {"type": "tool_call", "name": name, "output": output, "span_id": span_id, "status": status, "input": input_data}
+    return {
+        "type": "tool_call",
+        "name": name,
+        "output": output,
+        "span_id": span_id,
+        "status": status,
+        "input": input_data,
+    }
 
 
 def _reasoning_span(input_data="thinking...", span_id="r1"):
@@ -60,9 +67,7 @@ class TestGoalCompletion:
         backend = _make_backend({})
         scorer = SLMScorer(backend)
         llm_response = {
-            "sections": [
-                {"section_name": "Summary", "status": "missing", "evidence": "Not found in output"}
-            ]
+            "sections": [{"section_name": "Summary", "status": "missing", "evidence": "Not found in output"}]
         }
         with patch.object(scorer, "_call_model_direct", new_callable=AsyncMock, return_value=llm_response):
             penalties = await scorer.score_goal_completion(
@@ -78,11 +83,7 @@ class TestGoalCompletion:
     async def test_stub_section(self):
         backend = _make_backend({})
         scorer = SLMScorer(backend)
-        llm_response = {
-            "sections": [
-                {"section_name": "Analysis", "status": "stub", "evidence": "Only contains TODO"}
-            ]
-        }
+        llm_response = {"sections": [{"section_name": "Analysis", "status": "stub", "evidence": "Only contains TODO"}]}
         with patch.object(scorer, "_call_model_direct", new_callable=AsyncMock, return_value=llm_response):
             penalties = await scorer.score_goal_completion(
                 trace={"output": "Analysis: TODO"},
@@ -98,9 +99,7 @@ class TestGoalCompletion:
         backend = _make_backend({})
         scorer = SLMScorer(backend)
         llm_response = {
-            "sections": [
-                {"section_name": "Data", "status": "ungrounded", "evidence": "No tool results support this"}
-            ]
+            "sections": [{"section_name": "Data", "status": "ungrounded", "evidence": "No tool results support this"}]
         }
         with patch.object(scorer, "_call_model_direct", new_callable=AsyncMock, return_value=llm_response):
             penalties = await scorer.score_goal_completion(
@@ -116,11 +115,7 @@ class TestGoalCompletion:
     async def test_present_section_no_penalty(self):
         backend = _make_backend({})
         scorer = SLMScorer(backend)
-        llm_response = {
-            "sections": [
-                {"section_name": "Summary", "status": "present", "evidence": "Well written"}
-            ]
-        }
+        llm_response = {"sections": [{"section_name": "Summary", "status": "present", "evidence": "Well written"}]}
         with patch.object(scorer, "_call_model_direct", new_callable=AsyncMock, return_value=llm_response):
             penalties = await scorer.score_goal_completion(
                 trace={"output": "Summary: good content"},
@@ -134,9 +129,7 @@ class TestGoalCompletion:
     async def test_no_sections_returns_empty(self):
         backend = _make_backend({})
         scorer = SLMScorer(backend)
-        penalties = await scorer.score_goal_completion(
-            trace={"output": "output"}, spans=[], required_sections=[]
-        )
+        penalties = await scorer.score_goal_completion(trace={"output": "output"}, spans=[], required_sections=[])
         assert penalties == []
 
 
@@ -147,7 +140,12 @@ class TestFactualGrounding:
         scorer = SLMScorer(backend)
         llm_response = {
             "claims": [
-                {"claim": "Revenue is $10M", "status": "ungrounded", "evidence": "No data source", "source_span_id": None}
+                {
+                    "claim": "Revenue is $10M",
+                    "status": "ungrounded",
+                    "evidence": "No data source",
+                    "source_span_id": None,
+                }
             ]
         }
         with patch.object(scorer, "_call_model_direct", new_callable=AsyncMock, return_value=llm_response):
@@ -164,7 +162,12 @@ class TestFactualGrounding:
         scorer = SLMScorer(backend)
         llm_response = {
             "claims": [
-                {"claim": "Revenue is $10M", "status": "contradicted", "evidence": "Source says $5M", "source_span_id": "s1"}
+                {
+                    "claim": "Revenue is $10M",
+                    "status": "contradicted",
+                    "evidence": "Source says $5M",
+                    "source_span_id": "s1",
+                }
             ]
         }
         with patch.object(scorer, "_call_model_direct", new_callable=AsyncMock, return_value=llm_response):
@@ -220,11 +223,7 @@ class TestThoughtProcess:
     async def test_invalid_finding_type_ignored(self):
         backend = _make_backend({})
         scorer = SLMScorer(backend)
-        llm_response = {
-            "findings": [
-                {"type": "unknown_type", "description": "Something", "evidence": "X"}
-            ]
-        }
+        llm_response = {"findings": [{"type": "unknown_type", "description": "Something", "evidence": "X"}]}
         with patch.object(scorer, "_call_model_direct", new_callable=AsyncMock, return_value=llm_response):
             penalties = await scorer.score_thought_process(
                 spans=[_tool_span()],

--- a/tests/test_structural_scorer.py
+++ b/tests/test_structural_scorer.py
@@ -1,10 +1,11 @@
 """Unit tests for the structural scorer (rule-based, no LLM)."""
 
-
 from services.structural_scorer import StructuralScorer, _span_dedup_key
 
 
-def _tool_span(name="tool_a", input_data="input1", output="result", status="success", latency_ms=100, span_id="s1", error=None):
+def _tool_span(
+    name="tool_a", input_data="input1", output="result", status="success", latency_ms=100, span_id="s1", error=None
+):
     """Helper to create a mock tool call span."""
     return {
         "type": "tool_call",

--- a/tests/test_structural_scorer.py
+++ b/tests/test_structural_scorer.py
@@ -1,7 +1,7 @@
 """Unit tests for the structural scorer (rule-based, no LLM)."""
 
 
-from services.structural_scorer import StructuralScorer, _span_dedup_key, _span_asserts_external_state
+from services.structural_scorer import StructuralScorer, _span_dedup_key
 
 
 def _tool_span(name="tool_a", input_data="input1", output="result", status="success", latency_ms=100, span_id="s1", error=None):

--- a/tests/test_telemetry_collection.py
+++ b/tests/test_telemetry_collection.py
@@ -48,7 +48,9 @@ class TestSandboxRunner:
 
         _send_span("http://localhost:8000", "key", {"test": True})  # should not raise
 
-    def _run_with_mock_docker(self, mock_container, sandbox_id="test-id", image="alpine:latest", command=None, timeout=300):
+    def _run_with_mock_docker(
+        self, mock_container, sandbox_id="test-id", image="alpine:latest", command=None, timeout=300
+    ):
         """Helper: run sandbox with mocked Docker SDK, return (exit_code, span_sent)."""
         mock_client = MagicMock()
         mock_client.containers.run.return_value = mock_container
@@ -63,6 +65,7 @@ class TestSandboxRunner:
             import importlib
 
             import observal_cli.sandbox_runner as sr
+
             importlib.reload(sr)
 
             original_send = sr._send_span

--- a/tests/test_telemetry_collection.py
+++ b/tests/test_telemetry_collection.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ── Sandbox Runner ──────────────────────────────────────────────────
 
 
@@ -62,6 +61,7 @@ class TestSandboxRunner:
 
         with patch.dict("sys.modules", {"docker": mock_docker}):
             import importlib
+
             import observal_cli.sandbox_runner as sr
             importlib.reload(sr)
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.4",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@chenglou/pretext':
         specifier: ^0.0.4
         version: 0.0.4
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -232,6 +241,28 @@ packages:
 
   '@chenglou/pretext@0.0.4':
     resolution: {integrity: sha512-FnPAFMid1/p1j2V2gRPUVBarGUIb2PhkkC9YNnTOfPtTDgHKh8siO8PP9pCxpFfYlcodWPJpE1UbSHGQqt8pQQ==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -3061,6 +3092,31 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@chenglou/pretext@0.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@emnapi/core@1.9.2':
     dependencies:

--- a/web/src/app/(admin)/dashboard/page.tsx
+++ b/web/src/app/(admin)/dashboard/page.tsx
@@ -67,7 +67,7 @@ export default function DashboardPage() {
   const { data: sessions, isLoading: sessionsLoading } = useOtelSessions();
 
   const recentSessions = (sessions ?? []).slice(0, 8);
-  const totalDownloads = topAgents?.reduce((s: number, a: { name: string; value: number }) => s + a.value, 0) ?? 0;
+  const totalDownloads = topAgents?.reduce((s: number, a: { download_count: number }) => s + a.download_count, 0) ?? 0;
 
   return (
     <>
@@ -222,7 +222,7 @@ export default function DashboardPage() {
                 />
               ) : (
                 <div className="rounded-md border border-border p-3">
-                  <TopDownloadsBar items={topAgents.slice(0, 8)} />
+                  <TopDownloadsBar items={topAgents.slice(0, 8).map((a: any) => ({ name: a.name, value: a.download_count ?? a.value ?? 0 }))} />
                 </div>
               )}
             </section>

--- a/web/src/app/(admin)/dashboard/page.tsx
+++ b/web/src/app/(admin)/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Bot, Activity, TrendingUp, TrendingDown, Minus, Download } from "lucide-react";
 import { useOverviewStats, useRegistryList, useTopAgents, useOtelSessions } from "@/hooks/use-api";
+import type { RegistryItem, OtelSession, TopAgentItem } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
@@ -125,7 +126,7 @@ export default function DashboardPage() {
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {(agents ?? []).slice(0, 10).map((a: any) => (
+                      {(agents ?? []).slice(0, 10).map((a: RegistryItem) => (
                         <TableRow key={a.id} className="group">
                           <TableCell className="py-1.5">
                             <Link
@@ -136,7 +137,7 @@ export default function DashboardPage() {
                             </Link>
                           </TableCell>
                           <TableCell className="py-1.5 text-xs text-muted-foreground font-[family-name:var(--font-mono)]">
-                            {a.version ?? "-"}
+                            {String(a.version ?? "-")}
                           </TableCell>
                           <TableCell className="py-1.5">
                             <Badge
@@ -181,7 +182,7 @@ export default function DashboardPage() {
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {recentSessions.map((s: any) => (
+                      {recentSessions.map((s: OtelSession) => (
                         <TableRow key={s.session_id} className="group">
                           <TableCell className="py-1.5">
                             <Link
@@ -222,7 +223,7 @@ export default function DashboardPage() {
                 />
               ) : (
                 <div className="rounded-md border border-border p-3">
-                  <TopDownloadsBar items={topAgents.slice(0, 8).map((a: any) => ({ name: a.name, value: a.download_count ?? a.value ?? 0 }))} />
+                  <TopDownloadsBar items={topAgents.slice(0, 8).map((a: TopAgentItem) => ({ name: a.name, value: a.download_count ?? 0 }))} />
                 </div>
               )}
             </section>

--- a/web/src/app/(admin)/eval/[agentId]/page.tsx
+++ b/web/src/app/(admin)/eval/[agentId]/page.tsx
@@ -3,6 +3,7 @@
 import { use } from "react";
 import { FlaskConical } from "lucide-react";
 import { useEvalScorecards, useEvalAggregate, useRegistryItem, useEvalRun, useEvalPenalties } from "@/hooks/use-api";
+import type { RegistryItem, Scorecard } from "@/lib/types";
 import { AgentAggregateChart } from "@/components/dashboard/agent-aggregate-chart";
 import { DimensionRadar } from "@/components/dashboard/dimension-radar";
 import { PenaltyAccordion } from "@/components/dashboard/penalty-accordion";
@@ -13,7 +14,7 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
 import { PageHeader } from "@/components/layouts/page-header";
-import { DetailSkeleton, TableSkeleton, ChartSkeleton } from "@/components/shared/skeleton-layouts";
+import { TableSkeleton, ChartSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 
@@ -42,9 +43,9 @@ export default function EvalDetailPage({ params }: { params: Promise<{ agentId: 
   const { data: aggregate, isLoading: aggLoading } = useEvalAggregate(agentId);
   const runEval = useEvalRun();
 
-  const a = agent as any;
+  const a = agent as RegistryItem | undefined;
   const cards = scorecards ?? [];
-  const latest = cards[0] as any;
+  const latest = cards[0] as Scorecard | undefined;
 
   const { data: latestPenalties } = useEvalPenalties(latest?.id);
 
@@ -118,7 +119,7 @@ export default function EvalDetailPage({ params }: { params: Promise<{ agentId: 
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {cards.map((sc: any) => (
+                      {cards.map((sc: Scorecard) => (
                         <TableRow key={sc.id}>
                           <TableCell className="py-1.5 text-xs tabular-nums">
                             {sc.created_at ? new Date(sc.created_at).toLocaleDateString() : "-"}

--- a/web/src/app/(admin)/eval/page.tsx
+++ b/web/src/app/(admin)/eval/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { FlaskConical, Play } from "lucide-react";
 import { useRegistryList, useEvalScorecards, useEvalRun } from "@/hooks/use-api";
-import { Badge } from "@/components/ui/badge";
+import type { RegistryItem, Scorecard } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/layouts/page-header";
 import { CardSkeleton } from "@/components/shared/skeleton-layouts";
@@ -19,11 +19,11 @@ function gradeColor(grade: string | undefined): string {
   return "bg-destructive/15 text-destructive";
 }
 
-function AgentEvalCard({ agent }: { agent: any }) {
+function AgentEvalCard({ agent }: { agent: RegistryItem }) {
   const { data: scorecards } = useEvalScorecards(agent.id);
   const runEval = useEvalRun();
 
-  const latest = (scorecards ?? [])[0] as any;
+  const latest = (scorecards ?? [])[0] as Scorecard | undefined;
   const evalCount = (scorecards ?? []).length;
 
   return (
@@ -108,7 +108,7 @@ export default function EvalPage() {
           />
         ) : (
           <div className="animate-in stagger-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {(agents ?? []).map((a: any) => (
+            {(agents ?? []).map((a: RegistryItem) => (
               <AgentEvalCard key={a.id} agent={a} />
             ))}
           </div>

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { CheckCircle2, X } from "lucide-react";
 import { useReviewList, useReviewAction } from "@/hooks/use-api";
+import type { ReviewItem } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -12,7 +13,7 @@ import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 
 function ReviewCard({ item, onApprove, onReject }: {
-  item: any;
+  item: ReviewItem;
   onApprove: (id: string) => void;
   onReject: (id: string, reason: string) => void;
 }) {
@@ -56,7 +57,7 @@ function ReviewCard({ item, onApprove, onReject }: {
 
       <div className="text-xs text-muted-foreground">
         {item.submitted_at || item.created_at
-          ? new Date(item.submitted_at ?? item.created_at).toLocaleDateString()
+          ? new Date((item.submitted_at ?? item.created_at)!).toLocaleDateString()
           : ""}
       </div>
 
@@ -146,7 +147,7 @@ export default function ReviewPage() {
           />
         ) : (
           <div className="animate-in grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {(items ?? []).map((item: any) => (
+            {(items ?? []).map((item: ReviewItem) => (
               <ReviewCard
                 key={item.id}
                 item={item}

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { Settings } from "lucide-react";
 import { useAdminSettings } from "@/hooks/use-api";
+import type { AdminSetting } from "@/lib/types";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -11,7 +12,7 @@ export default function SettingsPage() {
   const { data: settings, isLoading, isError, error, refetch } = useAdminSettings();
 
   const entries: [string, unknown][] = Array.isArray(settings)
-    ? settings.map((s: any) => [s.key, s.value])
+    ? settings.map((s: AdminSetting) => [s.key, s.value])
     : Object.entries(settings ?? {});
 
   return (

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { use, useState, useCallback } from "react";
+import { use, useState, useCallback, useMemo } from "react";
 import { useOtelSession } from "@/hooks/use-api";
+import type { OtelSessionData, RawOtelEvent } from "@/lib/types";
 import { FileText, ChevronDown, ChevronRight, ChevronsUpDown } from "lucide-react";
 import { PageHeader } from "@/components/layouts/page-header";
 import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
@@ -39,7 +40,7 @@ function EventRow({
   isExpanded,
   onToggle,
 }: {
-  event: any;
+  event: RawOtelEvent;
   isExpanded: boolean;
   onToggle: () => void;
 }) {
@@ -77,8 +78,8 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
   const { id } = use(params);
   const { data, isLoading, isError, error, refetch } = useOtelSession(id);
 
-  const session = data as any;
-  const events: any[] = session?.events ?? [];
+  const session = data as OtelSessionData;
+  const events: RawOtelEvent[] = useMemo(() => session?.events ?? [], [session]);
 
   const [expandedSet, setExpandedSet] = useState<Set<number>>(new Set());
 
@@ -101,7 +102,7 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
       }
       return new Set(events.map((_, i) => i));
     });
-  }, [events.length]);
+  }, [events]);
 
   const allExpanded = expandedSet.size === events.length && events.length > 0;
 
@@ -169,7 +170,7 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
                     {allExpanded ? "Collapse all" : "Expand all"}
                   </Button>
                 </div>
-                {events.map((evt: any, i: number) => (
+                {events.map((evt: RawOtelEvent, i: number) => (
                   <div key={i}>
                     <EventRow
                       event={evt}

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Activity, Search, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
@@ -101,16 +101,14 @@ export default function TracesPage() {
 
   // Debounced search
   const [searchValue, setSearchValue] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const handleSearch = useCallback(
-    (() => {
-      let timeout: ReturnType<typeof setTimeout>;
-      return (value: string) => {
-        setSearchValue(value);
-        clearTimeout(timeout);
-        timeout = setTimeout(() => setGlobalFilter(value), 300);
-      };
-    })(),
-    [],
+    (value: string) => {
+      setSearchValue(value);
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => setGlobalFilter(value), 300);
+    },
+    [setGlobalFilter],
   );
 
   return (

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -2,6 +2,7 @@
 
 import { Users } from "lucide-react";
 import { useAdminUsers } from "@/hooks/use-api";
+import type { AdminUser } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
@@ -57,7 +58,7 @@ export default function UsersPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {(users ?? []).map((u: any) => (
+                {(users ?? []).map((u: AdminUser) => (
                   <TableRow key={u.id}>
                     <TableCell className="py-1.5">
                       <span className="text-sm font-medium">{u.name ?? u.username ?? "-"}</span>

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   useFeedback,
   useFeedbackSummary,
 } from "@/hooks/use-api";
+import type { FeedbackItem } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
 import { StatusBadge } from "@/components/registry/status-badge";
 import { ReviewForm } from "@/components/registry/review-form";
@@ -30,6 +31,33 @@ import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { compactNumber } from "@/lib/utils";
+
+interface AgentDetail {
+  name: string;
+  status?: string;
+  version?: string;
+  owner?: string;
+  description?: string;
+  model_name?: string;
+  download_count?: number;
+  component_links?: ComponentLink[];
+  mcp_links?: ComponentLink[];
+  goal_template?: {
+    description?: string;
+    sections?: { name: string; description?: string }[];
+  };
+  [key: string]: unknown;
+}
+
+interface ComponentLink {
+  mcp_name?: string;
+  component_name?: string;
+  name?: string;
+  component_type?: string;
+  component_id?: string;
+  mcp_id?: string;
+  status?: string;
+}
 
 export default function AgentDetailPage({
   params,
@@ -56,8 +84,9 @@ export default function AgentDetailPage({
     typeof window !== "undefined" &&
     !!localStorage.getItem("observal_api_key");
 
-  const a = agent as any;
-  const components = a?.component_links ?? a?.mcp_links ?? [];
+  // `a` mirrors `agent` with extended fields; always guarded by `!agent` below
+  const a = agent as unknown as AgentDetail | undefined;
+  const components: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];
   const goalTemplate = a?.goal_template;
   const agentName = a?.name ?? id.slice(0, 8);
   const totalDownloads = downloadData?.total ?? a?.download_count;
@@ -81,7 +110,7 @@ export default function AgentDetailPage({
           <DetailSkeleton />
         ) : isError ? (
           <ErrorState message={error?.message} onRetry={() => refetch()} />
-        ) : !agent ? (
+        ) : !a ? (
           <ErrorState message="Agent not found" />
         ) : (
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-8 items-start">
@@ -194,7 +223,7 @@ export default function AgentDetailPage({
                         </p>
                       )}
                       {goalTemplate.sections?.map(
-                        (sec: any, i: number) => (
+                        (sec: { name: string; description?: string }, i: number) => (
                           <div key={i} className="space-y-1">
                             <h4 className="text-sm font-medium text-foreground">
                               {sec.name}
@@ -226,7 +255,7 @@ export default function AgentDetailPage({
                     />
                   ) : (
                     <div className="space-y-2">
-                      {components.map((comp: any, i: number) => {
+                      {components.map((comp: ComponentLink, i: number) => {
                         const compName =
                           comp.mcp_name ??
                           comp.component_name ??
@@ -303,7 +332,7 @@ export default function AgentDetailPage({
                     />
                   ) : (
                     <div className="space-y-4">
-                      {feedbackItems.map((fb: any) => (
+                      {feedbackItems.map((fb: FeedbackItem) => (
                         <div
                           key={fb.id}
                           className="rounded-md border border-border p-4 space-y-2"
@@ -359,7 +388,7 @@ export default function AgentDetailPage({
                       Add the following to your IDE configuration to use this
                       agent directly.
                     </p>
-                    <ConfigSnippet agentName={a.name} agentId={id} />
+                    <ConfigSnippet agentName={a.name} />
                   </div>
                 </TabsContent>
               </Tabs>
@@ -448,10 +477,8 @@ export default function AgentDetailPage({
 
 function ConfigSnippet({
   agentName,
-  agentId,
 }: {
   agentName: string;
-  agentId: string;
 }) {
   const [copied, setCopied] = useState(false);
 

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -2,12 +2,25 @@
 
 import { use } from "react";
 import Link from "next/link";
-import { ArrowDownToLine, Puzzle, Star, Check, Copy, Terminal } from "lucide-react";
+import {
+  ArrowDownToLine,
+  Puzzle,
+  Star,
+  Check,
+  Copy,
+  Users,
+} from "lucide-react";
 import { useState, useCallback } from "react";
 import { toast } from "sonner";
-import { useRegistryItem, useAgentDownloads } from "@/hooks/use-api";
+import {
+  useRegistryItem,
+  useAgentDownloads,
+  useFeedback,
+  useFeedbackSummary,
+} from "@/hooks/use-api";
 import { PullCommand } from "@/components/registry/pull-command";
 import { StatusBadge } from "@/components/registry/status-badge";
+import { ReviewForm } from "@/components/registry/review-form";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -32,12 +45,25 @@ export default function AgentDetailPage({
     refetch,
   } = useRegistryItem("agents", id);
   const { data: downloadData } = useAgentDownloads(id);
+  const { data: feedbackItems, refetch: refetchFeedback } = useFeedback(
+    "agent",
+    id,
+  );
+  const { data: feedbackSummary, refetch: refetchSummary } =
+    useFeedbackSummary(id);
+
+  const isAuthenticated =
+    typeof window !== "undefined" &&
+    !!localStorage.getItem("observal_api_key");
 
   const a = agent as any;
   const components = a?.component_links ?? a?.mcp_links ?? [];
   const goalTemplate = a?.goal_template;
   const agentName = a?.name ?? id.slice(0, 8);
-  const totalDownloads = downloadData?.total ?? a?.downloads;
+  const totalDownloads = downloadData?.total ?? a?.download_count;
+  const uniqueUsers = downloadData?.unique_users;
+  const avgRating = feedbackSummary?.average_rating;
+  const totalReviews = feedbackSummary?.total_reviews ?? 0;
 
   return (
     <>
@@ -86,7 +112,7 @@ export default function AgentDetailPage({
                 )}
               </div>
 
-              {/* Stats row (mobile only -- desktop shows in sidebar) */}
+              {/* Stats row (mobile only) */}
               <div className="flex items-center gap-6 text-sm text-muted-foreground lg:hidden">
                 {totalDownloads != null && (
                   <span className="inline-flex items-center gap-1.5">
@@ -98,6 +124,12 @@ export default function AgentDetailPage({
                   <Puzzle className="h-4 w-4" />
                   {components.length} components
                 </span>
+                {avgRating != null && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <Star className="h-4 w-4" />
+                    {avgRating.toFixed(1)}
+                  </span>
+                )}
               </div>
 
               {/* Pull command (mobile only) */}
@@ -114,6 +146,14 @@ export default function AgentDetailPage({
                     {components.length > 0 && (
                       <span className="ml-1.5 text-[10px] bg-muted px-1.5 py-0.5 rounded-full">
                         {components.length}
+                      </span>
+                    )}
+                  </TabsTrigger>
+                  <TabsTrigger value="reviews">
+                    Reviews
+                    {totalReviews > 0 && (
+                      <span className="ml-1.5 text-[10px] bg-muted px-1.5 py-0.5 rounded-full">
+                        {totalReviews}
                       </span>
                     )}
                   </TabsTrigger>
@@ -192,10 +232,8 @@ export default function AgentDetailPage({
                           comp.component_name ??
                           comp.name ??
                           "-";
-                        const compType =
-                          comp.component_type ?? "mcp";
-                        const compId =
-                          comp.component_id ?? comp.mcp_id;
+                        const compType = comp.component_type ?? "mcp";
+                        const compId = comp.component_id ?? comp.mcp_id;
                         const content = (
                           <div
                             className={[
@@ -234,6 +272,68 @@ export default function AgentDetailPage({
                           <div key={i}>{content}</div>
                         );
                       })}
+                    </div>
+                  )}
+                </TabsContent>
+
+                <TabsContent value="reviews" className="mt-6 space-y-6">
+                  {isAuthenticated && (
+                    <>
+                      <ReviewForm
+                        listingId={id}
+                        listingType="agent"
+                        onSuccess={() => {
+                          refetchFeedback();
+                          refetchSummary();
+                        }}
+                      />
+                      <Separator />
+                    </>
+                  )}
+
+                  {!feedbackItems || feedbackItems.length === 0 ? (
+                    <EmptyState
+                      icon={Star}
+                      title="No reviews yet"
+                      description={
+                        isAuthenticated
+                          ? "Be the first to review this agent."
+                          : "Log in to leave a review."
+                      }
+                    />
+                  ) : (
+                    <div className="space-y-4">
+                      {feedbackItems.map((fb: any) => (
+                        <div
+                          key={fb.id}
+                          className="rounded-md border border-border p-4 space-y-2"
+                        >
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-1">
+                              {Array.from({ length: 5 }).map((_, i) => (
+                                <Star
+                                  key={i}
+                                  className={`h-3.5 w-3.5 ${
+                                    i < fb.stars
+                                      ? "fill-current text-amber-500"
+                                      : "text-muted-foreground/30"
+                                  }`}
+                                />
+                              ))}
+                            </div>
+                            <span className="text-xs text-muted-foreground">
+                              {fb.username ?? fb.user ?? "Anonymous"}
+                              {fb.created_at &&
+                                ` · ${new Date(fb.created_at).toLocaleDateString()}`}
+                            </span>
+                          </div>
+                          {fb.comment && (
+                            <p className="text-sm text-muted-foreground leading-relaxed">
+                              {fb.comment}
+                            </p>
+                          )}
+                        </div>
+                      ))}
                     </div>
                   )}
                 </TabsContent>
@@ -282,6 +382,31 @@ export default function AgentDetailPage({
                       </span>
                       <span className="font-mono font-medium">
                         {compactNumber(totalDownloads)}
+                      </span>
+                    </div>
+                  )}
+                  {uniqueUsers != null && uniqueUsers > 0 && (
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="inline-flex items-center gap-2 text-muted-foreground">
+                        <Users className="h-3.5 w-3.5" />
+                        Unique users
+                      </span>
+                      <span className="font-mono font-medium">
+                        {compactNumber(uniqueUsers)}
+                      </span>
+                    </div>
+                  )}
+                  {avgRating != null && (
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="inline-flex items-center gap-2 text-muted-foreground">
+                        <Star className="h-3.5 w-3.5" />
+                        Rating
+                      </span>
+                      <span className="font-mono font-medium">
+                        {avgRating.toFixed(1)}{" "}
+                        <span className="text-xs text-muted-foreground font-normal">
+                          ({totalReviews})
+                        </span>
                       </span>
                     </div>
                   )}

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
   Search,
@@ -9,6 +9,7 @@ import {
   Trash2,
   Loader2,
   ArrowRight,
+  ShieldCheck,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
@@ -25,9 +26,14 @@ import {
   TabsContent,
 } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/layouts/page-header";
-import { useRegistryList } from "@/hooks/use-api";
+import { useRegistryList, useAgentValidation } from "@/hooks/use-api";
+import { useAuthGuard } from "@/hooks/use-auth";
 import { registry, type RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
+import type { ValidationResult } from "@/lib/types";
+import { SortableComponentList } from "@/components/builder/sortable-component-list";
+import { ValidationPanel } from "@/components/builder/validation-panel";
+import { PreviewPanel } from "@/components/builder/preview-panel";
 
 const COMPONENT_TYPES: { value: RegistryType; label: string }[] = [
   { value: "mcps", label: "MCPs" },
@@ -131,60 +137,18 @@ function ComponentPicker({
   );
 }
 
-function PreviewPanel({
-  name,
-  description,
-  selectedComponents,
-  goalSections,
-}: {
-  name: string;
-  description: string;
-  selectedComponents: Record<string, RegistryItem[]>;
-  goalSections: GoalSection[];
-}) {
-  const lines: string[] = [];
-
-  lines.push(`name: ${name || "(untitled)"}`);
-  if (description) {
-    lines.push(`description: |`);
-    description.split("\n").forEach((l) => lines.push(`  ${l}`));
-  }
-
-  const hasComponents = Object.values(selectedComponents).some(
-    (arr) => arr.length > 0,
-  );
-  if (hasComponents) {
-    lines.push("");
-    lines.push("components:");
-    for (const [type, items] of Object.entries(selectedComponents)) {
-      if (items.length === 0) continue;
-      lines.push(`  ${type}:`);
-      items.forEach((item) => lines.push(`    - ${item.name}`));
-    }
-  }
-
-  const nonEmptyGoals = goalSections.filter((s) => s.title || s.content);
-  if (nonEmptyGoals.length > 0) {
-    lines.push("");
-    lines.push("goal:");
-    nonEmptyGoals.forEach((section) => {
-      lines.push(`  ${section.title || "(section)"}:`);
-      if (section.content) {
-        section.content
-          .split("\n")
-          .forEach((l) => lines.push(`    ${l}`));
-      }
-    });
-  }
-
-  return (
-    <pre className="min-h-[200px] whitespace-pre-wrap rounded-md border bg-muted/30 p-4 text-sm leading-relaxed font-[family-name:var(--font-mono)] text-foreground/80">
-      {lines.join("\n")}
-    </pre>
-  );
-}
+const TYPE_MAP: Record<string, string> = {
+  mcps: "mcp",
+  skills: "skill",
+  hooks: "hook",
+  prompts: "prompt",
+  sandboxes: "sandbox",
+};
 
 export default function AgentBuilderPage() {
+  // Require auth for builder
+  const { ready } = useAuthGuard();
+
   const router = useRouter();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -207,6 +171,12 @@ export default function AgentBuilderPage() {
     { id: generateId(), title: "", content: "" },
   ]);
 
+  // Validation
+  const validation = useAgentValidation();
+  const [validationResult, setValidationResult] =
+    useState<ValidationResult | null>(null);
+  const validateTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
   // Compute selected IDs for quick lookup
   const selectedIds = useMemo(() => {
     const ids = new Set<string>();
@@ -215,6 +185,39 @@ export default function AgentBuilderPage() {
     );
     return ids;
   }, [selectedComponents]);
+
+  // Debounced validation on component changes
+  useEffect(() => {
+    if (validateTimerRef.current) clearTimeout(validateTimerRef.current);
+
+    const allComponents = Object.entries(selectedComponents).flatMap(
+      ([type, items]) =>
+        items.map((item) => ({
+          component_type: TYPE_MAP[type] ?? type,
+          component_id: item.id,
+        })),
+    );
+
+    if (allComponents.length === 0) {
+      setValidationResult(null);
+      return;
+    }
+
+    validateTimerRef.current = setTimeout(() => {
+      validation.mutate(
+        { components: allComponents },
+        {
+          onSuccess: (result) => setValidationResult(result),
+          onError: () =>
+            setValidationResult({ valid: false, issues: [{ severity: "error", message: "Validation request failed" }] }),
+        },
+      );
+    }, 500);
+
+    return () => {
+      if (validateTimerRef.current) clearTimeout(validateTimerRef.current);
+    };
+  }, [selectedComponents]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleToggle = useCallback(
     (type: string) => (item: RegistryItem) => {
@@ -238,6 +241,20 @@ export default function AgentBuilderPage() {
       [type]: (prev[type] ?? []).filter((c) => c.id !== id),
     }));
   }, []);
+
+  const handleReorder = useCallback(
+    (type: string) => (items: { id: string; name: string }[]) => {
+      setSelectedComponents((prev) => {
+        // Preserve the full RegistryItem objects, just reorder
+        const current = prev[type] ?? [];
+        const ordered = items
+          .map((item) => current.find((c) => c.id === item.id))
+          .filter(Boolean) as RegistryItem[];
+        return { ...prev, [type]: ordered };
+      });
+    },
+    [],
+  );
 
   const addGoalSection = useCallback(() => {
     setGoalSections((prev) => [
@@ -302,6 +319,8 @@ export default function AgentBuilderPage() {
     }
   }
 
+  if (!ready) return null;
+
   return (
     <>
       <PageHeader
@@ -360,7 +379,7 @@ export default function AgentBuilderPage() {
                 </h3>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Select the MCPs, skills, hooks, prompts, and sandboxes for
-                  this agent.
+                  this agent. Drag to reorder.
                 </p>
               </div>
 
@@ -392,32 +411,27 @@ export default function AgentBuilderPage() {
                       onToggle={handleToggle(ct.value)}
                     />
 
-                    {/* Selected badges */}
+                    {/* Sortable selected list */}
                     {(selectedComponents[ct.value] ?? []).length > 0 && (
-                      <div className="mt-3 flex flex-wrap gap-1.5">
-                        {(selectedComponents[ct.value] ?? []).map((item) => (
-                          <Badge
-                            key={item.id}
-                            variant="secondary"
-                            className="gap-1 pr-1"
-                          >
-                            {item.name}
-                            <button
-                              type="button"
-                              onClick={() =>
-                                removeComponent(ct.value, item.id)
-                              }
-                              className="ml-0.5 rounded-sm p-0.5 transition-colors hover:bg-foreground/10"
-                            >
-                              <X className="h-3 w-3" />
-                            </button>
-                          </Badge>
-                        ))}
+                      <div className="mt-3">
+                        <SortableComponentList
+                          items={(selectedComponents[ct.value] ?? []).map(
+                            (item) => ({ id: item.id, name: item.name }),
+                          )}
+                          onReorder={handleReorder(ct.value)}
+                          onRemove={(id) => removeComponent(ct.value, id)}
+                        />
                       </div>
                     )}
                   </TabsContent>
                 ))}
               </Tabs>
+
+              {/* Validation */}
+              <ValidationPanel
+                result={validationResult}
+                isValidating={validation.isPending}
+              />
             </section>
 
             <Separator />
@@ -446,7 +460,7 @@ export default function AgentBuilderPage() {
               </div>
 
               <div className="space-y-3">
-                {goalSections.map((section, i) => (
+                {goalSections.map((section) => (
                   <div
                     key={section.id}
                     className="rounded-md border bg-muted/20 p-4 space-y-3"
@@ -497,7 +511,7 @@ export default function AgentBuilderPage() {
             <Separator />
 
             {/* Publish */}
-            <div className="animate-in stagger-3">
+            <div className="flex items-center gap-3 animate-in stagger-3">
               <Button
                 onClick={handlePublish}
                 disabled={publishing || !name.trim()}
@@ -516,19 +530,17 @@ export default function AgentBuilderPage() {
           {/* Right column: Preview */}
           <aside className="w-full lg:w-1/3 animate-in stagger-1">
             <div className="sticky top-28 space-y-3">
-              <h3 className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                Preview
-              </h3>
-              <Card>
-                <CardContent className="p-0">
-                  <PreviewPanel
-                    name={name}
-                    description={description}
-                    selectedComponents={selectedComponents}
-                    goalSections={goalSections}
-                  />
-                </CardContent>
-              </Card>
+              <PreviewPanel
+                name={name}
+                description={description}
+                selectedComponents={Object.fromEntries(
+                  Object.entries(selectedComponents).map(([k, v]) =>
+                    [k, v.map((item) => ({ id: item.id, name: item.name }))]
+                  ),
+                )}
+                goalSections={goalSections}
+                validationResult={validationResult}
+              />
             </div>
           </aside>
         </div>

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -4,21 +4,17 @@ import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
   Search,
-  X,
   Plus,
   Trash2,
   Loader2,
   ArrowRight,
-  ShieldCheck,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   Tabs,
   TabsList,
@@ -444,7 +440,7 @@ export default function AgentBuilderPage() {
                     Goal Template
                   </h3>
                   <p className="mt-1 text-xs text-muted-foreground">
-                    Define the agent's objective in structured sections.
+                    Define the agent&apos;s objective in structured sections.
                   </p>
                 </div>
                 <Button

--- a/web/src/app/(registry)/agents/leaderboard/page.tsx
+++ b/web/src/app/(registry)/agents/leaderboard/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  Trophy,
+  ArrowDownToLine,
+  Star,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { EmptyState } from "@/components/shared/empty-state";
+import { useLeaderboard } from "@/hooks/use-api";
+import { compactNumber } from "@/lib/utils";
+import type { LeaderboardWindow } from "@/lib/types";
+
+export default function LeaderboardPage() {
+  const [window, setWindow] = useState<LeaderboardWindow>("7d");
+  const { data: leaderboard, isLoading } = useLeaderboard(window, 50);
+
+  return (
+    <>
+      <PageHeader
+        title="Leaderboard"
+        breadcrumbs={[
+          { label: "Registry", href: "/" },
+          { label: "Agents", href: "/agents" },
+          { label: "Leaderboard" },
+        ]}
+      />
+
+      <div className="p-6 lg:p-8 max-w-[1200px] space-y-6">
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <p className="text-sm text-muted-foreground">
+            Agents ranked by downloads within the selected time window.
+          </p>
+          <Tabs
+            value={window}
+            onValueChange={(v) => setWindow(v as LeaderboardWindow)}
+          >
+            <TabsList>
+              <TabsTrigger value="24h">24h</TabsTrigger>
+              <TabsTrigger value="7d">7 days</TabsTrigger>
+              <TabsTrigger value="30d">30 days</TabsTrigger>
+              <TabsTrigger value="all">All time</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+
+        {isLoading ? (
+          <TableSkeleton rows={10} cols={5} />
+        ) : !leaderboard || leaderboard.length === 0 ? (
+          <EmptyState
+            icon={Trophy}
+            title="No rankings yet"
+            description="Install agents via the CLI or web UI to populate the leaderboard."
+          />
+        ) : (
+          <div className="space-y-1 animate-in">
+            {/* Header */}
+            <div className="flex items-center gap-4 px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              <span className="w-8 text-right">#</span>
+              <span className="flex-1">Agent</span>
+              <span className="w-24 text-right">Downloads</span>
+              <span className="w-16 text-right">Rating</span>
+              <span className="w-20 text-right">Version</span>
+            </div>
+
+            {leaderboard.map((item, i) => (
+              <Link
+                key={item.id}
+                href={`/agents/${item.id}`}
+                className="flex items-center gap-4 rounded-md px-3 py-3 transition-colors hover:bg-accent/40 group"
+              >
+                <span
+                  className={`w-8 text-right font-mono font-semibold ${
+                    i < 3 ? "text-foreground" : "text-muted-foreground"
+                  }`}
+                >
+                  {i + 1}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <span className="text-sm font-medium truncate block group-hover:underline underline-offset-4">
+                    {item.name}
+                  </span>
+                  <span className="text-xs text-muted-foreground/70 truncate block">
+                    {item.owner}
+                    {item.description && ` — ${item.description}`}
+                  </span>
+                </div>
+                <span className="w-24 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground font-mono">
+                  <ArrowDownToLine className="h-3 w-3" />
+                  {compactNumber(item.download_count)}
+                </span>
+                <span className="w-16 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground">
+                  {item.average_rating != null ? (
+                    <>
+                      <Star className="h-3 w-3" />
+                      {item.average_rating.toFixed(1)}
+                    </>
+                  ) : (
+                    "-"
+                  )}
+                </span>
+                <span className="w-20 text-right">
+                  {item.version ? (
+                    <Badge
+                      variant="secondary"
+                      className="text-[10px] px-1.5 py-0"
+                    >
+                      {item.version}
+                    </Badge>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">-</span>
+                  )}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -14,7 +14,6 @@ import {
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { useRegistryList } from "@/hooks/use-api";
 import {
   Table,
@@ -30,11 +29,11 @@ import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { StatusBadge } from "@/components/registry/status-badge";
 import { AgentCard } from "@/components/registry/agent-card";
+import { compactNumber } from "@/lib/utils";
 import {
   useReactTable,
   getCoreRowModel,
   getSortedRowModel,
-  getFilteredRowModel,
   flexRender,
   type ColumnDef,
   type SortingState,
@@ -78,7 +77,7 @@ const columns: ColumnDef<any>[] = [
     ),
   },
   {
-    accessorKey: "downloads",
+    accessorKey: "download_count",
     header: ({ column }) => (
       <button
         className="inline-flex items-center gap-1.5 hover:text-foreground transition-colors"
@@ -89,13 +88,15 @@ const columns: ColumnDef<any>[] = [
       </button>
     ),
     cell: ({ row }) => (
-      <span className="text-muted-foreground text-sm">
-        {row.original.downloads ?? "-"}
+      <span className="text-muted-foreground text-sm font-mono">
+        {row.original.download_count != null
+          ? compactNumber(row.original.download_count)
+          : "-"}
       </span>
     ),
   },
   {
-    accessorKey: "score",
+    accessorKey: "average_rating",
     header: ({ column }) => (
       <button
         className="inline-flex items-center gap-1.5 hover:text-foreground transition-colors"
@@ -107,7 +108,9 @@ const columns: ColumnDef<any>[] = [
     ),
     cell: ({ row }) => (
       <span className="text-muted-foreground text-sm">
-        {row.original.score != null ? row.original.score.toFixed(1) : "-"}
+        {row.original.average_rating != null
+          ? row.original.average_rating.toFixed(1)
+          : "-"}
       </span>
     ),
   },
@@ -161,7 +164,6 @@ export default function AgentListPage() {
   const [sorting, setSorting] = useState<SortingState>([]);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // Debounce search
   useEffect(() => {
     timerRef.current = setTimeout(() => {
       setDebouncedSearch(search);
@@ -320,12 +322,10 @@ export default function AgentListPage() {
                 description={agent.description}
                 owner={agent.owner}
                 version={agent.version}
-                downloads={agent.downloads}
-                score={agent.score}
+                downloads={agent.download_count}
+                score={agent.average_rating ?? undefined}
                 status={agent.status}
-                component_count={
-                  agent.component_links?.length ?? agent.mcp_links?.length
-                }
+                component_count={agent.component_count}
                 className={`animate-in stagger-${Math.min(i + 1, 5)}`}
               />
             ))}

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -35,20 +35,22 @@ import {
   getCoreRowModel,
   getSortedRowModel,
   flexRender,
+  type Column,
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
+import type { RegistryItem } from "@/lib/types";
 
 type ViewMode = "table" | "grid";
 
-function SortIcon({ column }: { column: any }) {
+function SortIcon({ column }: { column: Column<RegistryItem> }) {
   const sorted = column.getIsSorted();
   if (sorted === "asc") return <ArrowUp className="h-3 w-3" />;
   if (sorted === "desc") return <ArrowDown className="h-3 w-3" />;
   return <ArrowUpDown className="h-3 w-3 opacity-40" />;
 }
 
-const columns: ColumnDef<any>[] = [
+const columns: ColumnDef<RegistryItem>[] = [
   {
     accessorKey: "name",
     header: ({ column }) => (
@@ -90,7 +92,7 @@ const columns: ColumnDef<any>[] = [
     cell: ({ row }) => (
       <span className="text-muted-foreground text-sm font-mono">
         {row.original.download_count != null
-          ? compactNumber(row.original.download_count)
+          ? compactNumber(row.original.download_count as number)
           : "-"}
       </span>
     ),
@@ -109,7 +111,7 @@ const columns: ColumnDef<any>[] = [
     cell: ({ row }) => (
       <span className="text-muted-foreground text-sm">
         {row.original.average_rating != null
-          ? row.original.average_rating.toFixed(1)
+          ? (row.original.average_rating as number).toFixed(1)
           : "-"}
       </span>
     ),
@@ -119,7 +121,7 @@ const columns: ColumnDef<any>[] = [
     header: "Version",
     cell: ({ row }) => (
       <span className="text-muted-foreground text-sm font-mono">
-        {row.original.version ?? "-"}
+        {(row.original.version as string | undefined) ?? "-"}
       </span>
     ),
   },
@@ -314,18 +316,18 @@ export default function AgentListPage() {
                 "repeat(auto-fill, minmax(min(320px, 100%), 1fr))",
             }}
           >
-            {filtered.map((agent: any, i: number) => (
+            {filtered.map((agent: RegistryItem, i: number) => (
               <AgentCard
                 key={agent.id}
                 id={agent.id}
                 name={agent.name}
-                description={agent.description}
-                owner={agent.owner}
-                version={agent.version}
-                downloads={agent.download_count}
-                score={agent.average_rating ?? undefined}
+                description={agent.description as string | undefined}
+                owner={agent.owner as string | undefined}
+                version={agent.version as string | undefined}
+                downloads={agent.download_count as number | undefined}
+                score={(agent.average_rating as number | null) ?? undefined}
                 status={agent.status}
-                component_count={agent.component_count}
+                component_count={agent.component_count as number | undefined}
                 className={`animate-in stagger-${Math.min(i + 1, 5)}`}
               />
             ))}

--- a/web/src/app/(registry)/components/[id]/page.tsx
+++ b/web/src/app/(registry)/components/[id]/page.tsx
@@ -15,8 +15,7 @@ export default function ComponentDetailPage({ params }: { params: Promise<{ id: 
   const type = (searchParams.get("type") ?? "mcps") as RegistryType;
   const { data: item, isLoading, isError, error, refetch } = useRegistryItem(type, id);
 
-  const c = item as any;
-  const componentName = c?.name ?? id.slice(0, 8);
+  const componentName = item?.name ?? id.slice(0, 8);
 
   return (
     <>
@@ -40,17 +39,17 @@ export default function ComponentDetailPage({ params }: { params: Promise<{ id: 
             <div className="space-y-1">
               <div className="flex items-center gap-2 flex-wrap">
                 <Badge variant="outline">{type.replace(/s$/, "")}</Badge>
-                {c.status && <Badge variant={c.status === "approved" ? "default" : "secondary"}>{c.status}</Badge>}
+                {item.status && <Badge variant={item.status === "approved" ? "default" : "secondary"}>{item.status}</Badge>}
               </div>
             </div>
 
-            {c.description && <p className="text-sm">{c.description}</p>}
+            {item.description && <p className="text-sm">{item.description}</p>}
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-              {c.version && <div><span className="text-muted-foreground">Version:</span> {c.version}</div>}
-              {c.git_url && <div><span className="text-muted-foreground">Source:</span> <a href={c.git_url} className="underline" target="_blank" rel="noopener noreferrer">{c.git_url}</a></div>}
-              {c.transport && <div><span className="text-muted-foreground">Transport:</span> {c.transport}</div>}
-              {c.created_at && <div><span className="text-muted-foreground">Created:</span> {new Date(c.created_at).toLocaleDateString()}</div>}
+              {"version" in item && item.version != null && <div><span className="text-muted-foreground">Version:</span> {String(item.version)}</div>}
+              {"git_url" in item && item.git_url != null && <div><span className="text-muted-foreground">Source:</span> <a href={String(item.git_url)} className="underline" target="_blank" rel="noopener noreferrer">{String(item.git_url)}</a></div>}
+              {"transport" in item && item.transport != null && <div><span className="text-muted-foreground">Transport:</span> {String(item.transport)}</div>}
+              {item.created_at && <div><span className="text-muted-foreground">Created:</span> {new Date(item.created_at).toLocaleDateString()}</div>}
             </div>
           </>
         )}

--- a/web/src/app/(registry)/components/page.tsx
+++ b/web/src/app/(registry)/components/page.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { useRegistryList } from "@/hooks/use-api";
 import type { RegistryType } from "@/lib/api";
+import type { RegistryItem } from "@/lib/types";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
@@ -51,7 +52,7 @@ function ComponentTable({ type, search }: { type: RegistryType; search: string }
           </TableRow>
         </TableHeader>
         <TableBody>
-          {items.map((item: any) => (
+          {items.map((item: RegistryItem) => (
             <TableRow key={item.id}>
               <TableCell>
                 <Link href={`/components/${item.id}?type=${type}`} className="font-medium hover:underline">

--- a/web/src/app/(registry)/layout.tsx
+++ b/web/src/app/(registry)/layout.tsx
@@ -2,7 +2,7 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { RegistrySidebar } from "@/components/nav/registry-sidebar";
 import { CommandMenu } from "@/components/nav/command-menu";
 import { Toaster } from "@/components/ui/sonner";
-import { AuthGuard } from "@/components/layouts/auth-guard";
+import { OptionalAuthGuard } from "@/components/layouts/auth-guard";
 
 export default function RegistryLayout({
   children,
@@ -10,13 +10,13 @@ export default function RegistryLayout({
   children: React.ReactNode;
 }) {
   return (
-    <AuthGuard>
+    <OptionalAuthGuard>
       <SidebarProvider>
         <RegistrySidebar />
         <SidebarInset>{children}</SidebarInset>
         <CommandMenu />
         <Toaster visibleToasts={1} />
       </SidebarProvider>
-    </AuthGuard>
+    </OptionalAuthGuard>
   );
 }

--- a/web/src/app/(registry)/page.tsx
+++ b/web/src/app/(registry)/page.tsx
@@ -1,21 +1,44 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
-import { Search, TrendingUp, Clock, Check, Copy, Terminal } from "lucide-react";
+import { useState, useCallback } from "react";
+import Link from "next/link";
+import {
+  Search,
+  TrendingUp,
+  Clock,
+  Check,
+  Copy,
+  Terminal,
+  Trophy,
+  ArrowRight,
+  ArrowDownToLine,
+  Star,
+} from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { AgentCard } from "@/components/registry/agent-card";
-import { useRegistryList, useTopAgents } from "@/hooks/use-api";
+import {
+  useRegistryList,
+  useTopAgents,
+  useOverviewStats,
+  useLeaderboard,
+} from "@/hooks/use-api";
 import { useRouter } from "next/navigation";
 import { PageHeader } from "@/components/layouts/page-header";
-import { CardSkeleton } from "@/components/shared/skeleton-layouts";
+import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+import { compactNumber } from "@/lib/utils";
+import type { LeaderboardWindow, TopAgentItem } from "@/lib/types";
 
 export default function RegistryHome() {
   const [search, setSearch] = useState("");
   const [heroCopied, setHeroCopied] = useState(false);
+  const [leaderboardWindow, setLeaderboardWindow] =
+    useState<LeaderboardWindow>("7d");
   const router = useRouter();
   const {
     data: agents,
@@ -25,6 +48,9 @@ export default function RegistryHome() {
     refetch: refetchAgents,
   } = useRegistryList("agents");
   const { data: topAgents, isLoading: topLoading } = useTopAgents();
+  const { data: stats } = useOverviewStats();
+  const { data: leaderboard, isLoading: leaderboardLoading } =
+    useLeaderboard(leaderboardWindow, 10);
 
   function handleSearch(e: React.FormEvent) {
     e.preventDefault();
@@ -40,9 +66,8 @@ export default function RegistryHome() {
     setTimeout(() => setHeroCopied(false), 2000);
   }, []);
 
-  const trending = topAgents?.slice(0, 6) ?? [];
+  const trending = (topAgents ?? []).slice(0, 6);
   const recentlyAdded = (agents ?? [])
-    .filter((a: any) => a.status === "approved")
     .sort((a: any, b: any) => {
       const da = a.created_at ? new Date(a.created_at).getTime() : 0;
       const db = b.created_at ? new Date(b.created_at).getTime() : 0;
@@ -69,6 +94,26 @@ export default function RegistryHome() {
               agents across your team.
             </p>
           </div>
+
+          {/* Stats bar */}
+          {stats && (
+            <div className="flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="font-mono font-medium text-foreground">
+                {stats.total_agents}
+              </span>{" "}
+              agents
+              <span className="text-border">·</span>
+              <span className="font-mono font-medium text-foreground">
+                {stats.total_mcps}
+              </span>{" "}
+              components
+              <span className="text-border">·</span>
+              <span className="font-mono font-medium text-foreground">
+                {stats.total_users}
+              </span>{" "}
+              engineers
+            </div>
+          )}
 
           {/* Search bar */}
           <form onSubmit={handleSearch} className="relative max-w-lg">
@@ -131,12 +176,13 @@ export default function RegistryHome() {
                   "repeat(auto-fill, minmax(min(320px, 100%), 1fr))",
               }}
             >
-              {trending.map((item: any, i: number) => (
+              {trending.map((item: TopAgentItem, i: number) => (
                 <AgentCard
                   key={item.id}
                   id={item.id}
                   name={item.name}
-                  downloads={item.value}
+                  downloads={item.download_count}
+                  score={item.average_rating ?? undefined}
                   description={item.description}
                   owner={item.owner}
                   version={item.version}
@@ -147,8 +193,94 @@ export default function RegistryHome() {
           )}
         </section>
 
-        {/* Recently Added */}
+        {/* Leaderboard */}
         <section className="animate-in stagger-2 space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Trophy className="h-4 w-4 text-muted-foreground" />
+              <h2 className="text-sm font-semibold font-display uppercase tracking-wider text-muted-foreground">
+                Leaderboard
+              </h2>
+            </div>
+            <Link
+              href="/agents/leaderboard"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              View all <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+
+          <Tabs
+            value={leaderboardWindow}
+            onValueChange={(v) =>
+              setLeaderboardWindow(v as LeaderboardWindow)
+            }
+          >
+            <TabsList>
+              <TabsTrigger value="24h">24h</TabsTrigger>
+              <TabsTrigger value="7d">7d</TabsTrigger>
+              <TabsTrigger value="30d">30d</TabsTrigger>
+              <TabsTrigger value="all">All time</TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          {leaderboardLoading ? (
+            <TableSkeleton rows={5} cols={4} />
+          ) : !leaderboard || leaderboard.length === 0 ? (
+            <EmptyState
+              icon={Trophy}
+              title="No leaderboard data"
+              description="Install agents to see rankings appear here."
+            />
+          ) : (
+            <div className="space-y-1">
+              {leaderboard.map((item, i) => (
+                <Link
+                  key={item.id}
+                  href={`/agents/${item.id}`}
+                  className="flex items-center gap-4 rounded-md px-3 py-2.5 transition-colors hover:bg-accent/40"
+                >
+                  <span className="w-6 text-right text-sm font-mono font-medium text-muted-foreground">
+                    {i + 1}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-medium truncate block">
+                      {item.name}
+                    </span>
+                    {item.owner && (
+                      <span className="text-xs text-muted-foreground/70">
+                        {item.owner}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-4 shrink-0 text-xs text-muted-foreground">
+                    <span className="inline-flex items-center gap-1">
+                      <ArrowDownToLine className="h-3 w-3" />
+                      {compactNumber(item.download_count)}
+                    </span>
+                    {item.average_rating != null && (
+                      <span className="inline-flex items-center gap-1">
+                        <Star className="h-3 w-3" />
+                        {item.average_rating.toFixed(1)}
+                      </span>
+                    )}
+                    {item.version && (
+                      <Badge
+                        variant="secondary"
+                        className="text-[10px] px-1.5 py-0"
+                      >
+                        {item.version}
+                      </Badge>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Recently Added */}
+        <section className="animate-in stagger-3 space-y-4">
           <div className="flex items-center gap-2">
             <Clock className="h-4 w-4 text-muted-foreground" />
             <h2 className="text-sm font-semibold font-display uppercase tracking-wider text-muted-foreground">
@@ -166,7 +298,7 @@ export default function RegistryHome() {
             <EmptyState
               icon={Clock}
               title="No agents yet"
-              description="Approved agents will appear here. Submit your first agent to get started."
+              description="Agents will appear here once published. Submit your first agent to get started."
               actionLabel="Browse Agents"
               actionHref="/agents"
             />
@@ -186,11 +318,9 @@ export default function RegistryHome() {
                   description={agent.description}
                   owner={agent.owner}
                   version={agent.version}
-                  score={agent.score}
-                  component_count={
-                    agent.component_links?.length ??
-                    agent.mcp_links?.length
-                  }
+                  downloads={agent.download_count}
+                  score={agent.average_rating ?? undefined}
+                  component_count={agent.component_count}
                   className={`animate-in stagger-${Math.min(i + 1, 5)}`}
                 />
               ))}

--- a/web/src/app/(registry)/page.tsx
+++ b/web/src/app/(registry)/page.tsx
@@ -18,7 +18,7 @@ import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AgentCard } from "@/components/registry/agent-card";
 import {
   useRegistryList,
@@ -32,7 +32,7 @@ import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layout
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { compactNumber } from "@/lib/utils";
-import type { LeaderboardWindow, TopAgentItem } from "@/lib/types";
+import type { LeaderboardWindow, TopAgentItem, RegistryItem } from "@/lib/types";
 
 export default function RegistryHome() {
   const [search, setSearch] = useState("");
@@ -68,7 +68,7 @@ export default function RegistryHome() {
 
   const trending = (topAgents ?? []).slice(0, 6);
   const recentlyAdded = (agents ?? [])
-    .sort((a: any, b: any) => {
+    .sort((a: RegistryItem, b: RegistryItem) => {
       const da = a.created_at ? new Date(a.created_at).getTime() : 0;
       const db = b.created_at ? new Date(b.created_at).getTime() : 0;
       return db - da;
@@ -310,17 +310,17 @@ export default function RegistryHome() {
                   "repeat(auto-fill, minmax(min(320px, 100%), 1fr))",
               }}
             >
-              {recentlyAdded.map((agent: any, i: number) => (
+              {recentlyAdded.map((agent: RegistryItem, i: number) => (
                 <AgentCard
                   key={agent.id}
                   id={agent.id}
                   name={agent.name}
-                  description={agent.description}
-                  owner={agent.owner}
-                  version={agent.version}
-                  downloads={agent.download_count}
-                  score={agent.average_rating ?? undefined}
-                  component_count={agent.component_count}
+                  description={agent.description as string | undefined}
+                  owner={agent.owner as string | undefined}
+                  version={agent.version as string | undefined}
+                  downloads={agent.download_count as number | undefined}
+                  score={(agent.average_rating as number | null) ?? undefined}
+                  component_count={agent.component_count as number | undefined}
                   className={`animate-in stagger-${Math.min(i + 1, 5)}`}
                 />
               ))}

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { CheckCircle2, XCircle } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import type { ValidationResult } from "@/lib/types";
+
+interface PreviewPanelProps {
+  name: string;
+  description: string;
+  selectedComponents: Record<string, { id: string; name: string }[]>;
+  goalSections: { id: string; title: string; content: string }[];
+  validationResult: ValidationResult | null;
+}
+
+export function PreviewPanel({
+  name,
+  description,
+  selectedComponents,
+  goalSections,
+  validationResult,
+}: PreviewPanelProps) {
+  const lines: string[] = [];
+
+  lines.push(`name: ${name || "(untitled)"}`);
+  if (description) {
+    lines.push(`description: |`);
+    description.split("\n").forEach((l) => lines.push(`  ${l}`));
+  }
+
+  const hasComponents = Object.values(selectedComponents).some(
+    (arr) => arr.length > 0,
+  );
+  if (hasComponents) {
+    lines.push("");
+    lines.push("components:");
+    for (const [type, items] of Object.entries(selectedComponents)) {
+      if (items.length === 0) continue;
+      lines.push(`  ${type}:`);
+      items.forEach((item) => lines.push(`    - ${item.name}`));
+    }
+  }
+
+  const nonEmptyGoals = goalSections.filter((s) => s.title || s.content);
+  if (nonEmptyGoals.length > 0) {
+    lines.push("");
+    lines.push("goal:");
+    nonEmptyGoals.forEach((section) => {
+      lines.push(`  ${section.title || "(section)"}:`);
+      if (section.content) {
+        section.content
+          .split("\n")
+          .forEach((l) => lines.push(`    ${l}`));
+      }
+    });
+  }
+
+  const errorCount = validationResult
+    ? validationResult.issues.filter((i) => i.severity === "error").length
+    : 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          Preview
+        </h3>
+        {validationResult && (
+          <span className="inline-flex items-center gap-1 text-xs">
+            {validationResult.valid ? (
+              <>
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+                <span className="text-emerald-600 dark:text-emerald-400">
+                  Valid
+                </span>
+              </>
+            ) : (
+              <>
+                <XCircle className="h-3.5 w-3.5 text-destructive" />
+                <span className="text-destructive">
+                  {errorCount} {errorCount === 1 ? "error" : "errors"}
+                </span>
+              </>
+            )}
+          </span>
+        )}
+      </div>
+      <Card>
+        <CardContent className="p-0">
+          <pre className="min-h-[200px] whitespace-pre-wrap rounded-md border bg-muted/30 p-4 text-sm leading-relaxed font-[family-name:var(--font-mono)] text-foreground/80">
+            {lines.join("\n")}
+          </pre>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/components/builder/sortable-component-list.tsx
+++ b/web/src/components/builder/sortable-component-list.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, X } from "lucide-react";
+
+interface SortableComponentListProps {
+  items: { id: string; name: string }[];
+  onReorder: (items: { id: string; name: string }[]) => void;
+  onRemove: (id: string) => void;
+}
+
+function SortableItem({
+  item,
+  onRemove,
+}: {
+  item: { id: string; name: string };
+  onRemove: (id: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm"
+    >
+      <button
+        type="button"
+        className="text-muted-foreground cursor-grab"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <span className="min-w-0 flex-1 truncate">{item.name}</span>
+      <button
+        type="button"
+        onClick={() => onRemove(item.id)}
+        className="text-muted-foreground hover:text-destructive transition-colors"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+export function SortableComponentList({
+  items,
+  onReorder,
+  onRemove,
+}: SortableComponentListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  if (items.length === 0) return null;
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = items.findIndex((i) => i.id === active.id);
+      const newIndex = items.findIndex((i) => i.id === over.id);
+      onReorder(arrayMove(items, oldIndex, newIndex));
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={items.map((i) => i.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="space-y-1.5">
+          {items.map((item) => (
+            <SortableItem key={item.id} item={item} onRemove={onRemove} />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/web/src/components/builder/validation-panel.tsx
+++ b/web/src/components/builder/validation-panel.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { AlertCircle, AlertTriangle, CheckCircle2 } from "lucide-react";
+import type { ValidationResult } from "@/lib/types";
+
+interface ValidationPanelProps {
+  result: ValidationResult | null;
+  isValidating: boolean;
+}
+
+export function ValidationPanel({ result, isValidating }: ValidationPanelProps) {
+  if (isValidating) {
+    return (
+      <div className="rounded-md border p-3 text-sm text-muted-foreground">
+        Validating...
+      </div>
+    );
+  }
+
+  if (!result) return null;
+
+  const errors = result.issues.filter((i) => i.severity === "error");
+  const warnings = result.issues.filter((i) => i.severity === "warning");
+
+  if (result.valid && errors.length === 0 && warnings.length === 0) {
+    return (
+      <div className="rounded-md border border-success/50 bg-success/5 p-3 text-sm space-y-2">
+        <div className="flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
+          <CheckCircle2 className="h-4 w-4" />
+          <span>All components valid</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {errors.length > 0 && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/5 p-3 text-sm space-y-2">
+          {errors.map((error, idx) => (
+            <div
+              key={idx}
+              className="flex items-start gap-2 text-destructive"
+            >
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{error.message}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {warnings.length > 0 && (
+        <div className="rounded-md border border-warning/50 bg-warning/5 p-3 text-sm space-y-2">
+          {warnings.map((warning, idx) => (
+            <div
+              key={idx}
+              className="flex items-start gap-2 text-amber-600 dark:text-amber-400"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{warning.message}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/dashboard/bar-list.tsx
+++ b/web/src/components/dashboard/bar-list.tsx
@@ -2,8 +2,6 @@
 
 import { useState, type ReactNode } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
-import { cn } from "@/lib/utils";
-
 interface BarListItem {
   name: ReactNode;
   value: number;

--- a/web/src/components/layouts/auth-guard.tsx
+++ b/web/src/components/layouts/auth-guard.tsx
@@ -1,8 +1,18 @@
 "use client";
-import { useAuthGuard } from "@/hooks/use-auth";
+import { useAuthGuard, useOptionalAuth } from "@/hooks/use-auth";
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const { ready } = useAuthGuard();
+  if (!ready) return null;
+  return <>{children}</>;
+}
+
+/**
+ * Allows unauthenticated browsing — renders children regardless of auth state.
+ * Resolves role for authenticated users so sidebar can show/hide admin items.
+ */
+export function OptionalAuthGuard({ children }: { children: React.ReactNode }) {
+  const { ready } = useOptionalAuth();
   if (!ready) return null;
   return <>{children}</>;
 }

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Bot,
   Blocks,
   Hammer,
+  Trophy,
   LayoutDashboard,
   Activity,
   FlaskConical,
@@ -31,11 +32,12 @@ import {
 } from "lucide-react";
 import { getUserRole } from "@/lib/api";
 
-const registryNav = [
+const registryNav: { title: string; href: string; icon: typeof Home; requiresAuth?: boolean }[] = [
   { title: "Home", href: "/", icon: Home },
   { title: "Agents", href: "/agents", icon: Bot },
+  { title: "Leaderboard", href: "/agents/leaderboard", icon: Trophy },
   { title: "Components", href: "/components", icon: Blocks },
-  { title: "Builder", href: "/agents/builder", icon: Hammer },
+  { title: "Builder", href: "/agents/builder", icon: Hammer, requiresAuth: true },
 ];
 
 const adminNav = [
@@ -56,11 +58,16 @@ export function RegistrySidebar() {
   const pathname = usePathname();
   const role = getUserRole();
   const isAdmin = role === "admin";
+  const isAuthenticated = typeof window !== "undefined" && !!localStorage.getItem("observal_api_key");
 
   function isActive(href: string) {
     if (href === "/") return pathname === "/";
     return pathname.startsWith(href);
   }
+
+  const visibleRegistryNav = registryNav.filter(
+    (item) => !item.requiresAuth || isAuthenticated,
+  );
 
   return (
     <Sidebar collapsible="icon">
@@ -78,7 +85,7 @@ export function RegistrySidebar() {
           </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {registryNav.map((item) => (
+              {visibleRegistryNav.map((item) => (
                 <SidebarMenuItem key={item.href}>
                   <SidebarMenuButton asChild isActive={isActive(item.href)}>
                     <Link href={item.href}>
@@ -92,7 +99,7 @@ export function RegistrySidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {isAdmin && (
+        {isAuthenticated && isAdmin && (
           <SidebarGroup>
             <SidebarGroupLabel className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
               Admin

--- a/web/src/components/registry/review-form.tsx
+++ b/web/src/components/registry/review-form.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { Star, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useSubmitFeedback } from "@/hooks/use-api";
+
+interface ReviewFormProps {
+  listingId: string;
+  listingType?: string;
+  onSuccess?: () => void;
+}
+
+export function ReviewForm({
+  listingId,
+  listingType = "agent",
+  onSuccess,
+}: ReviewFormProps) {
+  const [rating, setRating] = useState(0);
+  const [hoveredStar, setHoveredStar] = useState(0);
+  const [comment, setComment] = useState("");
+
+  const mutation = useSubmitFeedback();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (rating === 0) return;
+
+    mutation.mutate(
+      {
+        listing_type: listingType,
+        listing_id: listingId,
+        stars: rating,
+        comment: comment.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          setRating(0);
+          setComment("");
+          onSuccess?.();
+        },
+      },
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <h4 className="text-sm font-semibold font-[family-name:var(--font-display)]">
+        Leave a Review
+      </h4>
+
+      <div className="flex items-center gap-1">
+        {[1, 2, 3, 4, 5].map((star) => {
+          const filled = star <= (hoveredStar || rating);
+          return (
+            <button
+              key={star}
+              type="button"
+              className="p-0.5 transition-colors"
+              onClick={() => setRating(star)}
+              onMouseEnter={() => setHoveredStar(star)}
+              onMouseLeave={() => setHoveredStar(0)}
+            >
+              <Star
+                className={
+                  filled
+                    ? "h-5 w-5 fill-current text-amber-500"
+                    : "h-5 w-5 text-muted-foreground"
+                }
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      <Textarea
+        placeholder="Optional comment"
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        rows={3}
+        className="resize-none"
+      />
+
+      <Button
+        type="submit"
+        size="sm"
+        disabled={rating === 0 || mutation.isPending}
+      >
+        {mutation.isPending ? (
+          <>
+            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+            Submitting
+          </>
+        ) : (
+          "Submit Review"
+        )}
+      </Button>
+    </form>
+  );
+}

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -404,7 +404,7 @@ SidebarMenuBadge.displayName = "SidebarMenuBadge"
 
 const SidebarMenuSkeleton = React.forwardRef<HTMLDivElement, React.ComponentProps<"div"> & { showIcon?: boolean }>(
   ({ className, showIcon = false, ...props }, ref) => {
-    const width = React.useMemo(() => `${Math.floor(Math.random() * 40) + 50}%`, [])
+    const width = "70%"
     return (
       <div ref={ref} data-sidebar="menu-skeleton" className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)} {...props}>
         {showIcon && <Skeleton className="size-4 rounded-md" />}

--- a/web/src/hooks/use-admin-guard.ts
+++ b/web/src/hooks/use-admin-guard.ts
@@ -5,16 +5,16 @@ import { getUserRole } from "@/lib/api";
 
 export function useAdminGuard() {
   const router = useRouter();
-  const [ready, setReady] = useState(false);
+  const [ready] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return getUserRole() === "admin";
+  });
 
   useEffect(() => {
-    const role = getUserRole();
-    if (role !== "admin") {
+    if (!ready) {
       router.replace("/");
-      return;
     }
-    setReady(true);
-  }, [router]);
+  }, [ready, router]);
 
   return ready;
 }

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -4,7 +4,6 @@ import {
   useQuery,
   useMutation,
   useQueryClient,
-  type UseQueryOptions,
 } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -19,6 +19,7 @@ import {
   graphql,
   type RegistryType,
 } from "@/lib/api";
+import type { LeaderboardWindow } from "@/lib/types";
 
 // ── Dashboard ───────────────────────────────────────────────────────
 
@@ -30,8 +31,8 @@ export function useTopMcps() {
   return useQuery({ queryKey: ["overview", "top-mcps"], queryFn: dashboard.topMcps });
 }
 
-export function useTopAgents() {
-  return useQuery({ queryKey: ["overview", "top-agents"], queryFn: dashboard.topAgents });
+export function useTopAgents(limit?: number) {
+  return useQuery({ queryKey: ["overview", "top-agents", limit], queryFn: () => dashboard.topAgents(limit) });
 }
 
 export function useTrends(range?: string) {
@@ -269,6 +270,27 @@ export function useEvalAggregate(agentId: string) {
     queryKey: ["eval-aggregate", agentId],
     queryFn: () => eval_.aggregate(agentId),
     enabled: !!agentId,
+  });
+}
+
+export function useLeaderboard(window?: LeaderboardWindow, limit?: number) {
+  return useQuery({
+    queryKey: ["leaderboard", window, limit],
+    queryFn: () => dashboard.leaderboard(window, limit),
+  });
+}
+
+export function useAgentValidation() {
+  return useMutation({
+    mutationFn: registry.validate,
+  });
+}
+
+export function useFeedbackSummary(listingId: string | undefined) {
+  return useQuery({
+    queryKey: ["feedback", "summary", listingId],
+    enabled: !!listingId,
+    queryFn: () => feedback.summary(listingId!),
   });
 }
 

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -6,8 +6,16 @@ import { auth, setUserRole, getUserRole } from "@/lib/api";
 export function useAuthGuard() {
   const router = useRouter();
   const pathname = usePathname();
-  const [ready, setReady] = useState(false);
-  const [role, setRole] = useState<string | null>(null);
+  const [ready, setReady] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const key = localStorage.getItem("observal_api_key");
+    if (!key) return true;
+    return !!getUserRole();
+  });
+  const [role, setRole] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    return getUserRole();
+  });
 
   useEffect(() => {
     const key = localStorage.getItem("observal_api_key");
@@ -16,14 +24,13 @@ export function useAuthGuard() {
       return;
     }
     if (!key) {
-      setReady(true);
+      // Already ready from initial state
       return;
     }
 
     const cached = getUserRole();
     if (cached) {
-      setRole(cached);
-      setReady(true);
+      // Already ready from initial state
       return;
     }
 
@@ -45,22 +52,31 @@ export function useAuthGuard() {
  * Does NOT redirect to login.
  */
 export function useOptionalAuth() {
-  const [ready, setReady] = useState(false);
-  const [role, setRole] = useState<string | null>(null);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [ready, setReady] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const key = localStorage.getItem("observal_api_key");
+    if (!key) return true;
+    return !!getUserRole();
+  });
+  const [role, setRole] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    return getUserRole();
+  });
+  const [isAuthenticated, setIsAuthenticated] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return !!getUserRole();
+  });
 
   useEffect(() => {
     const key = localStorage.getItem("observal_api_key");
     if (!key) {
-      setReady(true);
+      // Already ready from initial state
       return;
     }
 
     const cached = getUserRole();
     if (cached) {
-      setRole(cached);
-      setIsAuthenticated(true);
-      setReady(true);
+      // Already ready from initial state
       return;
     }
 

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -38,3 +38,42 @@ export function useAuthGuard() {
 
   return { ready, role };
 }
+
+/**
+ * Optional auth — resolves immediately for unauthenticated users.
+ * Authenticated users get their role resolved via whoami.
+ * Does NOT redirect to login.
+ */
+export function useOptionalAuth() {
+  const [ready, setReady] = useState(false);
+  const [role, setRole] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const key = localStorage.getItem("observal_api_key");
+    if (!key) {
+      setReady(true);
+      return;
+    }
+
+    const cached = getUserRole();
+    if (cached) {
+      setRole(cached);
+      setIsAuthenticated(true);
+      setReady(true);
+      return;
+    }
+
+    auth.whoami().then((user) => {
+      setUserRole(user.role);
+      setRole(user.role);
+      setIsAuthenticated(true);
+      setReady(true);
+    }).catch(() => {
+      // API key invalid — treat as unauthenticated
+      setReady(true);
+    });
+  }, []);
+
+  return { ready, role, isAuthenticated };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,12 +1,14 @@
 import type {
   OverviewStats,
   TopItem,
+  TopAgentItem,
   TrendPoint,
   OtelStats,
   OtelTrace,
   OtelSessionData,
   TokenStats,
   FeedbackItem,
+  FeedbackSummary,
   Scorecard,
   TracePenalty,
   AgentAggregate,
@@ -17,6 +19,9 @@ import type {
   TelemetryStatus,
   ReviewItem,
   RegistryItem,
+  LeaderboardItem,
+  LeaderboardWindow,
+  ValidationResult,
 } from "./types";
 
 const API = "/api/v1";
@@ -131,7 +136,9 @@ export const registry = {
     get<unknown>(`/${type}/${id}/metrics`),
   resolve: (id: string) => get<unknown>(`/agents/${id}/resolve`),
   downloads: (id: string) =>
-    get<{ total: number; recent_7d: number }>(`/agents/${id}/downloads`),
+    get<{ total: number; unique_users: number; recent_7d: number }>(`/agents/${id}/downloads`),
+  validate: (body: { components: { component_type: string; component_id: string }[] }) =>
+    post<ValidationResult>("/agents/validate", body),
 };
 
 // ── Review ──────────────────────────────────────────────────────────
@@ -156,7 +163,14 @@ export const telemetry = {
 export const dashboard = {
   stats: (range?: string) => get<OverviewStats>(`/overview/stats${range ? `?range=${range}` : ''}`),
   topMcps: () => get<TopItem[]>("/overview/top-mcps"),
-  topAgents: () => get<TopItem[]>("/overview/top-agents"),
+  topAgents: (limit?: number) => get<TopAgentItem[]>(`/overview/top-agents${limit ? `?limit=${limit}` : ''}`),
+  leaderboard: (window?: LeaderboardWindow, limit?: number) => {
+    const params = new URLSearchParams();
+    if (window) params.set("window", window);
+    if (limit) params.set("limit", String(limit));
+    const qs = params.toString();
+    return get<LeaderboardItem[]>(`/overview/leaderboard${qs ? `?${qs}` : ''}`);
+  },
   trends: (range?: string) => get<TrendPoint[]>(`/overview/trends${range ? `?range=${range}` : ''}`),
   mcpMetrics: (id: string) => get<unknown>(`/mcps/${id}/metrics`),
   agentMetrics: (id: string) => get<unknown>(`/agents/${id}/metrics`),
@@ -178,7 +192,7 @@ export const feedback = {
     comment?: string;
   }) => post<FeedbackItem>("/feedback", body),
   get: (type: string, id: string) => get<FeedbackItem[]>(`/feedback/${type}/${id}`),
-  summary: (id: string) => get<unknown>(`/feedback/summary/${id}`),
+  summary: (id: string) => get<FeedbackSummary>(`/feedback/summary/${id}`),
 };
 
 // ── Eval ────────────────────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -90,6 +90,39 @@ export interface RegistryItem {
   [key: string]: unknown;
 }
 
+// ── Agent enriched types ────────────────────────────────────────────
+
+export interface TopAgentItem {
+  id: string;
+  name: string;
+  description: string;
+  owner: string;
+  version: string;
+  download_count: number;
+  average_rating: number | null;
+}
+
+export type LeaderboardItem = TopAgentItem;
+export type LeaderboardWindow = "24h" | "7d" | "30d" | "all";
+
+export interface FeedbackSummary {
+  listing_id: string;
+  average_rating: number;
+  total_reviews: number;
+}
+
+export interface ValidationIssue {
+  severity: "error" | "warning";
+  component_type?: string;
+  component_id?: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  issues: ValidationIssue[];
+}
+
 // ── Review ──────────────────────────────────────────────────────────
 
 export interface ReviewItem {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -182,6 +182,7 @@ export interface Scorecard {
   composite_score?: number;
   display_score?: number;
   grade?: string;
+  overall_grade?: string;
   scoring_recommendations?: string[];
   penalty_count?: number;
 }


### PR DESCRIPTION
## Summary

- **Public browsing**: Registry pages now work without authentication via `OptionalAuthGuard`. All employees on the self-hosted instance can browse agents, leaderboard, and component details without logging in. Write operations (builder, reviews) still require auth.
- **Agent Builder enhancements (#84)**: Drag-drop component reordering via `@dnd-kit`, live validation panel with debounced API calls, extracted YAML preview panel with validation status indicator, auth-gated builder page.
- **Public Agent Registry frontend (#85)**: Home page with stats bar, trending agents, inline leaderboard section, and recently added. Agent list with enriched download/rating columns. Agent detail with Reviews tab (star rating form + feedback list) and enhanced sidebar stats. Full leaderboard page with time window tabs (24h/7d/30d/all).
- **Backend**: Enriched `AgentSummary` with `download_count`, `average_rating`, `component_count`, timestamps. New `GET /overview/leaderboard` endpoint. `POST /agents/validate` for live validation. Removed auth from browse endpoints. Enhanced download stats with `recent_7d`.

### New pages
| Route | Description |
|-------|-------------|
| `/agents/leaderboard` | Ranked agents by downloads with time windows |
| `/agents/builder` | Enhanced builder with drag-drop, live validation |

### New components
| Component | Purpose |
|-----------|---------|
| `SortableComponentList` | Drag-drop reorderable component list |
| `ValidationPanel` | Live validation error/warning display |
| `PreviewPanel` | YAML preview with validation status |
| `ReviewForm` | Star rating + comment submission |
| `OptionalAuthGuard` | Allows unauthenticated browsing |

Closes #84, closes #85

## Test plan

- [ ] `npm run build` passes with zero errors
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] Browse `/` without auth — stats bar, trending, leaderboard, recently added render
- [ ] Browse `/agents` without auth — table/grid views with download and rating columns
- [ ] Browse `/agents/leaderboard` — time window tabs switch data, ranked list renders
- [ ] Browse `/agents/{id}` — Reviews tab shows form (when authed) and feedback list, sidebar shows rating
- [ ] `/agents/builder` redirects to login when not authenticated
- [ ] Builder: drag-drop reorder works, validation panel shows live errors, preview updates
- [ ] Review form: star selection, comment, submit works when authenticated