### PR TITLE
feat(auth): invite codes and auto-bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ make logs                # tail logs
 
 # CLI (installed via uv)
 uv tool install --editable .
-observal auth init       # first-run admin setup
+observal auth login      # auto-creates admin on fresh server, or login
 observal auth whoami     # check auth
 observal auth status     # server health check
 
@@ -82,7 +82,7 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 - `worker.py` : arq WorkerSettings; background eval jobs consume from Redis queue
 - `api/deps.py` : auth dependency (`get_current_user` via X-API-Key header), DB session injection, `resolve_listing` (name-or-UUID resolver used by all routes)
 - `api/graphql.py` : Strawberry schema: Query (traces, spans, metrics) + Subscription (traceCreated, spanCreated); DataLoaders for ClickHouse batch queries
-- `api/routes/auth.py` : init, login, whoami
+- `api/routes/auth.py` : bootstrap (auto-admin), login, whoami, invite codes (create/redeem/list)
 - `api/routes/mcp.py` : MCP server CRUD; submit triggers async validation pipeline
 - `api/routes/agent.py` : Agent CRUD with goal templates, component linking via agent_components table
 - `api/routes/skill.py` : Skill CRUD; install generates SessionStart/End hook config
@@ -100,7 +100,8 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 
 ### Models (`observal-server/models/`)
 
-- `user.py` : User with UserRole enum (admin, developer, user); API key is hashed with SECRET_KEY
+- `user.py` : User with UserRole enum (admin, developer, user); API key is hashed with SHA-256
+- `invite.py` : InviteCode model — short codes (OBS-XXXXXX) for user onboarding, with expiry and one-time use tracking
 - `mcp.py` : McpListing, McpValidationResult, McpDownload; ListingStatus enum (shared by all models)
 - `agent.py` : Agent, AgentGoalTemplate, AgentGoalSection, AgentStatus enum
 - `alert.py` : AlertRule (metric threshold alerts with webhook URLs)
@@ -139,7 +140,7 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 ### CLI (`observal_cli/`)
 
 - `main.py` : Typer app wiring; creates `registry_app` parent group (mcp, skill, hook, prompt, sandbox), registers all command modules, adds deprecated backward-compat aliases
-- `cmd_auth.py` : `auth_app` subgroup: init, login, logout, whoami, status. Also `config_app` subgroup: show, set, path, alias, aliases. `register_deprecated_auth()` adds hidden root-level aliases
+- `cmd_auth.py` : `auth_app` subgroup: login (smart — auto-bootstrap on fresh server, supports --code for invite codes, --key for API keys), init (alias for login), logout, whoami, status. Also `config_app` subgroup: show, set, path, alias, aliases
 - `cmd_mcp.py` : `mcp_app` subgroup: submit (with --yes for non-interactive), list (--sort, --limit, --output), show, install (--raw), delete. `register_deprecated_mcp()` adds hidden root-level bare aliases (submit, list, show, install, delete)
 - `cmd_agent.py` : `agent_app` subgroup: create (--from-file), list, show, install, delete; authoring: init, add, build, publish
 - `cmd_skill.py` : `skill_app` subgroup: submit, list, show, install, delete
@@ -252,7 +253,7 @@ Three route groups organize the UI by access level:
 - Redis serves two purposes: pub/sub for GraphQL subscriptions (live trace/span events) and arq job queue for background eval runs.
 - The eval engine is pluggable. `LLMJudgeBackend` calls Bedrock or OpenAI-compatible endpoints. `FallbackBackend` returns deterministic scores when no LLM is configured. The 6 managed templates are prompt strings, not code.
 - Feedback dual-writes: when a user rates an MCP/agent, it writes to PostgreSQL (for the feedback API) AND ClickHouse scores table (for unified analytics). The ClickHouse write is best-effort.
-- Auth is API key based. Keys are hashed with SECRET_KEY before storage. The `X-API-Key` header is checked on every authenticated request via `get_current_user` dependency.
+- Auth is API key based. Keys are SHA-256 hashed before storage. The `X-API-Key` header is checked on every authenticated request via `get_current_user` dependency. User onboarding uses short invite codes (OBS-XXXXXX) — admin generates a code, new user redeems it to get an API key. Fresh servers auto-bootstrap an admin account on first `observal auth login` (zero prompts). The `/health` endpoint returns `initialized: bool` so the CLI knows whether to bootstrap or prompt for credentials.
 - Install routes use an owner fallback: try approved first, then allow the submitter to install their own pending/rejected items. This lets `observal scan` work. Items are auto-registered as pending and immediately usable by the submitter.
 - The CLI stores config in `~/.observal/config.json`. Aliases are in `~/.observal/aliases.json`. Both are plain JSON. All API path parameters accept UUID or name; the server resolves names via `resolve_listing()` in `deps.py`.
 - All CLI list/show commands support `--output table|json|plain`. Use `--output json` for scripting. Use `--raw` on install commands to pipe config directly to files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,10 @@ docker compose up --build -d
 cd ..
 
 uv tool install --editable .
-observal init
+observal auth login
 ```
 
-The API starts at http://localhost:8000.
+The API starts at http://localhost:8000. On a fresh server, `auth login` auto-creates an admin account.
 
 ### Frontend
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cp .env.example .env          # edit with your values
 
 cd docker && docker compose up --build -d && cd ..
 uv tool install --editable .
-observal auth init             # create admin account
+observal auth login            # auto-creates admin on fresh server
 ```
 
 Already have MCP servers in your IDE? Instrument them in one command:
@@ -102,11 +102,16 @@ observal profile                     # show active profile and backup info
 <summary><strong>Authentication</strong> &mdash; <code>observal auth</code></summary>
 
 ```bash
-observal auth init             # first-time setup (connect to team or create admin)
-observal auth login             # login with API key
-observal auth logout            # clear saved credentials
-observal auth whoami            # show current user
-observal auth status            # check server connectivity and health
+observal auth login            # auto-creates admin on fresh server, or login with key
+observal auth logout           # clear saved credentials
+observal auth whoami           # show current user
+observal auth status           # check server connectivity and health
+```
+
+For CI/scripts, use environment variables:
+```bash
+export OBSERVAL_SERVER_URL=http://localhost:8000
+export OBSERVAL_API_KEY=<your-key>
 ```
 
 </details>
@@ -169,6 +174,10 @@ observal ops telemetry test
 <summary><strong>Admin</strong> &mdash; <code>observal admin</code></summary>
 
 ```bash
+# Invite team members
+observal admin invite              # generate invite code (e.g. OBS-A7X9B2)
+observal admin invites             # list all invite codes
+
 # Settings and users
 observal admin settings
 observal admin set <key> <value>
@@ -247,9 +256,12 @@ For detailed setup, eval engine configuration, environment variables, and troubl
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/api/v1/auth/init` | First-run admin setup |
+| `POST` | `/api/v1/auth/bootstrap` | Auto-create admin on fresh server |
 | `POST` | `/api/v1/auth/login` | Login with API key |
 | `GET` | `/api/v1/auth/whoami` | Current user info |
+| `POST` | `/api/v1/auth/invite` | Create invite code (admin) |
+| `POST` | `/api/v1/auth/redeem` | Redeem invite code → get API key |
+| `GET` | `/api/v1/auth/invites` | List invite codes (admin) |
 
 ### Registry (per type: mcps, agents, skills, hooks, prompts, sandboxes)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -43,10 +43,29 @@ Install the CLI and run first-time setup:
 ```bash
 cd ..
 uv tool install --editable .
-observal init
+observal auth login
 ```
 
-`observal init` prompts for the server URL (defaults to http://localhost:8000), your admin email, and name. It creates the admin account and saves your API key to `~/.observal/config.json`.
+On a fresh server, `observal auth login` auto-detects that no users exist and bootstraps an admin account automatically — no prompts needed. Your credentials are saved to `~/.observal/config.json`.
+
+To invite team members:
+
+```bash
+observal admin invite              # prints a short code like OBS-A7X9B2
+```
+
+Share the code. They run:
+
+```bash
+observal auth login --code OBS-A7X9B2
+```
+
+For CI/scripts, use environment variables instead of interactive login:
+
+```bash
+export OBSERVAL_SERVER_URL=http://your-server:8000
+export OBSERVAL_API_KEY=<your-key>
+```
 
 You're ready to go. See the [README](README.md) for usage.
 
@@ -138,14 +157,15 @@ uv tool install --editable .
 This installs the `observal` command globally. Configure it to point at your local server:
 
 ```bash
-observal init
+observal auth login
 # Server URL: http://localhost:8000
 ```
 
-Your config is saved to `~/.observal/config.json`. You can also log in with an existing API key:
+On a fresh server this auto-creates an admin account. On an existing server, log in with an API key or invite code:
 
 ```bash
-observal login
+observal auth login --code OBS-XXXX    # invite code
+observal auth login --key <api-key>    # API key
 ```
 
 ## Eval Engine Setup
@@ -301,7 +321,7 @@ docker compose down -v
 docker compose up --build -d
 ```
 
-The `-v` flag removes the named volumes (`pgdata`, `chdata`), which deletes all data. After restarting, run `observal init` again to create a new admin account.
+The `-v` flag removes the named volumes (`pgdata`, `chdata`), which deletes all data. After restarting, run `observal auth login` again — it will auto-create a new admin account.
 
 ## Docker Details
 
@@ -350,7 +370,7 @@ The CLI cannot reach the API. Check that the Docker stack is up (`docker compose
 Another process is using port 8000, 3000, 5432, or 8123. Either stop the conflicting process or change the port mappings in `docker/docker-compose.yml`.
 
 **"System already initialized"**
-`observal init` was already run. Use `observal login` instead, or reset the database (see above).
+The server already has users. Use `observal auth login` with an API key or invite code, or reset the database (see above).
 
 **ClickHouse not receiving data**
 Check that `CLICKHOUSE_URL` in `.env` matches the credentials in the docker-compose ClickHouse environment. The default is `clickhouse://default:clickhouse@observal-clickhouse:8123/observal`.

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -1,5 +1,6 @@
 import hashlib
 import secrets
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select
@@ -7,8 +8,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_current_user, get_db
 from config import settings
+from models.invite import InviteCode
 from models.user import User, UserRole
-from schemas.auth import InitRequest, InitResponse, LoginRequest, UserResponse
+from schemas.auth import (
+    InitRequest,
+    InitResponse,
+    InviteCreateRequest,
+    InviteListResponse,
+    InviteRedeemRequest,
+    InviteResponse,
+    LoginRequest,
+    UserResponse,
+)
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 
@@ -35,6 +46,29 @@ async def init_admin(req: InitRequest, db: AsyncSession = Depends(get_db)):
     return InitResponse(user=UserResponse.model_validate(user), api_key=api_key)
 
 
+@router.post("/bootstrap", response_model=InitResponse)
+async def bootstrap(db: AsyncSession = Depends(get_db)):
+    """Auto-create admin account on a fresh server. No input needed."""
+    count = await db.scalar(select(func.count()).select_from(User))
+    if count and count > 0:
+        raise HTTPException(status_code=400, detail="System already initialized")
+
+    api_key = secrets.token_hex(settings.API_KEY_LENGTH)
+    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+
+    user = User(
+        email="admin@localhost",
+        name="admin",
+        role=UserRole.admin,
+        api_key_hash=key_hash,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    return InitResponse(user=UserResponse.model_validate(user), api_key=api_key)
+
+
 @router.post("/login", response_model=UserResponse)
 async def login(req: LoginRequest, db: AsyncSession = Depends(get_db)):
     key_hash = hashlib.sha256(req.api_key.encode()).hexdigest()
@@ -48,3 +82,88 @@ async def login(req: LoginRequest, db: AsyncSession = Depends(get_db)):
 @router.get("/whoami", response_model=UserResponse)
 async def whoami(current_user: User = Depends(get_current_user)):
     return UserResponse.model_validate(current_user)
+
+
+# ── Invite Codes ────────────────────────────────────────────
+
+
+@router.post("/invite", response_model=InviteResponse)
+async def create_invite(
+    req: InviteCreateRequest = InviteCreateRequest(),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Admin creates an invite code for a new user."""
+    if current_user.role != UserRole.admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    from datetime import timedelta
+
+    invite = InviteCode(
+        role=req.role,
+        created_by=current_user.id,
+        expires_at=datetime.now(UTC) + timedelta(days=req.expires_days),
+    )
+    db.add(invite)
+    await db.commit()
+    await db.refresh(invite)
+
+    return InviteResponse.model_validate(invite)
+
+
+@router.post("/redeem", response_model=InitResponse)
+async def redeem_invite(req: InviteRedeemRequest, db: AsyncSession = Depends(get_db)):
+    """Redeem an invite code to create an account and get an API key."""
+    code = req.code.strip().upper()
+
+    result = await db.execute(select(InviteCode).where(InviteCode.code == code))
+    invite = result.scalar_one_or_none()
+
+    if not invite:
+        raise HTTPException(status_code=404, detail="Invalid invite code")
+    if invite.used_by is not None:
+        raise HTTPException(status_code=400, detail="Invite code already used")
+    if invite.expires_at < datetime.now(UTC):
+        raise HTTPException(status_code=400, detail="Invite code expired")
+
+    # Generate user credentials
+    api_key = secrets.token_hex(settings.API_KEY_LENGTH)
+    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+
+    name = req.name or f"user-{code[-4:]}"
+    email = req.email or f"{name.lower().replace(' ', '-')}@localhost"
+
+    try:
+        role = UserRole(invite.role)
+    except ValueError:
+        role = UserRole.developer
+
+    user = User(
+        email=email,
+        name=name,
+        role=role,
+        api_key_hash=key_hash,
+    )
+    db.add(user)
+
+    # Mark invite as used
+    invite.used_by = user.id
+    invite.used_at = datetime.now(UTC)
+
+    await db.commit()
+    await db.refresh(user)
+
+    return InitResponse(user=UserResponse.model_validate(user), api_key=api_key)
+
+
+@router.get("/invites", response_model=list[InviteListResponse])
+async def list_invites(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Admin lists all invite codes."""
+    if current_user.role != UserRole.admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    result = await db.execute(select(InviteCode).order_by(InviteCode.created_at.desc()))
+    return [InviteListResponse.model_validate(i) for i in result.scalars().all()]

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -1,9 +1,12 @@
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.fastapi import GraphQLRouter
 
+from api.deps import get_db
 from api.graphql import get_context_dep, schema
 from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
@@ -25,6 +28,7 @@ from api.routes.skill import router as skill_router
 from api.routes.telemetry import router as telemetry_router
 from database import engine
 from models import Base
+from models.user import User
 from services.clickhouse import init_clickhouse
 from services.redis import close as close_redis
 
@@ -69,5 +73,6 @@ app.include_router(component_source_router)
 
 
 @app.get("/health")
-async def health():
-    return {"status": "ok"}
+async def health(db: AsyncSession = Depends(get_db)):
+    count = await db.scalar(select(func.count()).select_from(User))
+    return {"status": "ok", "initialized": (count or 0) > 0}

--- a/observal-server/models/__init__.py
+++ b/observal-server/models/__init__.py
@@ -9,6 +9,7 @@ from models.eval import EvalRun, EvalRunStatus, Scorecard, ScorecardDimension
 from models.exporter_config import ExporterConfig
 from models.feedback import Feedback
 from models.hook import HookDownload, HookListing
+from models.invite import InviteCode
 from models.mcp import ListingStatus, McpDownload, McpListing, McpValidationResult
 from models.organization import Organization
 from models.prompt import PromptDownload, PromptListing
@@ -48,6 +49,7 @@ __all__ = [
     "Feedback",
     "HookDownload",
     "HookListing",
+    "InviteCode",
     "ListingStatus",
     "McpDownload",
     "McpListing",

--- a/observal-server/models/invite.py
+++ b/observal-server/models/invite.py
@@ -1,0 +1,36 @@
+import secrets
+import string
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+
+# 8-char alphanumeric, prefixed with OBS-
+_CODE_CHARS = string.ascii_uppercase + string.digits
+_CODE_LENGTH = 6
+
+
+def _generate_code() -> str:
+    """Generate a short invite code like OBS-A7X9B2."""
+    body = "".join(secrets.choice(_CODE_CHARS) for _ in range(_CODE_LENGTH))
+    return f"OBS-{body}"
+
+
+class InviteCode(Base):
+    __tablename__ = "invite_codes"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    code: Mapped[str] = mapped_column(String(20), unique=True, nullable=False, default=_generate_code)
+    role: Mapped[str] = mapped_column(String(20), nullable=False, default="developer")
+    created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC) + timedelta(days=7),
+    )
+    used_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -15,6 +15,37 @@ class LoginRequest(BaseModel):
     api_key: str
 
 
+class InviteRedeemRequest(BaseModel):
+    code: str
+    name: str | None = None
+    email: str | None = None
+
+
+class InviteCreateRequest(BaseModel):
+    role: str = "developer"
+    expires_days: int = 7
+
+
+class InviteResponse(BaseModel):
+    code: str
+    role: str
+    expires_at: datetime
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class InviteListResponse(BaseModel):
+    code: str
+    role: str
+    created_at: datetime
+    expires_at: datetime
+    used_by: uuid.UUID | None = None
+    used_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
 class UserResponse(BaseModel):
     id: uuid.UUID
     email: str

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -283,7 +283,9 @@ def _do_invite_login(server_url: str, code: str, name: str | None = None):
         api_key = data["api_key"]
         user = data["user"]
         config.save({"server_url": server_url, "api_key": api_key})
-        rprint(f"[green]Account created! Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
+        rprint(
+            f"[green]Account created! Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]"
+        )
 
         _configure_claude_code(server_url, api_key)
 

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -28,92 +28,107 @@ config_app = typer.Typer(help="CLI configuration")
 
 
 @auth_app.command()
-def init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
-    """First-run setup: connect to a team server or initialize a new local server."""
-    server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
+def login(
+    server: str = typer.Option(None, "--server", "-s", help="Server URL"),
+    key: str = typer.Option(None, "--key", "-k", help="API key (skip prompt)"),
+    code: str = typer.Option(None, "--code", "-c", help="Invite code (e.g. OBS-A7X9B2)"),
+    name: str = typer.Option(None, "--name", "-n", help="Your name (used with invite code)"),
+):
+    """Connect to Observal.
 
-    # 1. Verify Connectivity First
+    On a fresh server: auto-creates admin, no prompts needed.
+    With an invite code: redeems it and creates your account.
+    On an existing server: logs in with an API key.
+    """
+    server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
+    server_url = server_url.rstrip("/")
+
+    # 1. Check connectivity + initialization state
     try:
-        with spinner("Checking server..."):
-            r = httpx.get(f"{server_url.rstrip('/')}/health", timeout=10)
+        with spinner("Connecting..."):
+            r = httpx.get(f"{server_url}/health", timeout=10)
             r.raise_for_status()
+            health_data = r.json()
     except httpx.ConnectError:
-        rprint(f"[red]x Connection failed.[/red] Is the server running at {server_url}?")
+        rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
         raise typer.Exit(1)
     except Exception as e:
-        rprint(f"[red]x Server error:[/red] {e!s}")
+        rprint(f"[red]Server error:[/red] {e!s}")
         raise typer.Exit(1)
 
-    rprint("[green]Connected to server[/green]\n")
+    initialized = health_data.get("initialized", True)
 
-    # 2. Smart Detection: Determine if we are a Developer (Connect) or Admin (Setup)
-    setup_choice = typer.prompt(
-        "Are you connecting to an existing team (C) or setting up a brand new server (N)?", default="C"
-    )
-
-    if setup_choice.lower().startswith("c"):
-        # --- DEVELOPER PATH (No Docker, just API Key) ---
-        api_key = typer.prompt("Your API Key", hide_input=True)
-        _do_login(server_url, api_key)
-
-    else:
-        # --- ADMIN PATH (Provisioning the first account) ---
-        admin_email = typer.prompt("Admin email")
-        admin_name = typer.prompt("Admin name")
+    # 2. Fresh server → auto-bootstrap admin
+    if not initialized:
+        rprint("[green]Connected.[/green] No users yet — creating admin account.\n")
         try:
-            with spinner("Creating admin account..."):
-                r = httpx.post(
-                    f"{server_url.rstrip('/')}/api/v1/auth/init",
-                    json={"email": admin_email, "name": admin_name},
-                    timeout=30,
-                )
+            with spinner("Bootstrapping..."):
+                r = httpx.post(f"{server_url}/api/v1/auth/bootstrap", timeout=30)
                 r.raise_for_status()
                 data = r.json()
 
-            config.save({"server_url": server_url, "api_key": data["api_key"]})
-            rprint(f"\n[green]Platform Initialized![/green] Config saved to [dim]{config.CONFIG_FILE}[/dim]")
-            rprint("\n[bold]Your Admin API key:[/bold]")
-            rprint(f"  {data['api_key']}")
-            rprint("\n[dim]Keep this safe. You can now invite developers via the Web UI.[/dim]")
+            api_key = data["api_key"]
+            user = data["user"]
+            config.save({"server_url": server_url, "api_key": api_key})
 
-            _configure_claude_code(server_url, data["api_key"])
+            rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [admin]")
+            rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]\n")
+            rprint("[bold]To invite team members:[/bold]")
+            rprint("  observal admin invite")
+            rprint("  [dim]Share the code — they run: observal auth login --code OBS-XXXX[/dim]")
+
+            _configure_claude_code(server_url, api_key)
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 400 and "already initialized" in e.response.text.lower():
-                rprint("\n[yellow]System is already initialized.[/yellow]")
-                rprint("Switching to login flow...")
-                api_key = typer.prompt("API Key", hide_input=True)
-                _do_login(server_url, api_key)
+                rprint("[yellow]Server was just initialized by someone else.[/yellow]")
+                _do_key_login(server_url, key)
             else:
-                rprint(f"[red]Error {e.response.status_code}: {e.response.text}[/red]")
+                rprint(f"[red]Bootstrap failed ({e.response.status_code}):[/red] {e.response.text}")
                 raise typer.Exit(1)
+        return
+
+    rprint("[green]Connected.[/green]\n")
+
+    # 3. Invite code → redeem
+    if code:
+        _do_invite_login(server_url, code, name)
+        return
+
+    # 4. No code provided → check if user wants to use one
+    if not key:
+        choice = typer.prompt("Login with [K]ey or [I]nvite code?", default="K")
+        if choice.strip().upper().startswith("I"):
+            invite_code = typer.prompt("Invite code")
+            invite_name = typer.prompt("Your name", default="")
+            _do_invite_login(server_url, invite_code, invite_name or None)
+            return
+
+    # 5. API key login
+    _do_key_login(server_url, key)
 
 
 @auth_app.command()
-def login(
-    server: str = typer.Option(None, "--server", "-s", help="Server URL (skips prompt)"),
-    key: str = typer.Option(None, "--key", "-k", help="API key (skips prompt)"),
+def init(
+    server: str = typer.Option(None, "--server", "-s", help="Server URL"),
 ):
-    """Login with an existing API key."""
-    server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
-    _do_login(server_url, key)
+    """First-run setup (alias for login)."""
+    login(server=server, key=None, code=None, name=None)
 
 
 @auth_app.command()
 def logout():
     """Clear saved credentials."""
     if config.CONFIG_FILE.exists():
-        # Read strictly from disk to avoid mixing with env variables
         import json
 
         raw_cfg = json.loads(config.CONFIG_FILE.read_text())
 
-        # Remove the key and save directly
         if "api_key" in raw_cfg:
             del raw_cfg["api_key"]
             config.CONFIG_FILE.write_text(json.dumps(raw_cfg, indent=2))
 
-        rprint("[green]Logged out (removed from disk).[/green]")
+        rprint("[green]Logged out.[/green]")
     else:
         rprint("[dim]No config to clear.[/dim]")
 
@@ -176,27 +191,27 @@ _DEPRECATION_MSG = "Deprecated: use 'observal auth {cmd}' instead"
 
 
 def _deprecation_notice(cmd_name: str):
-    """Print a deprecation warning for a root-level auth command."""
     rprint(f"[yellow]{_DEPRECATION_MSG.format(cmd=cmd_name)}[/yellow]\n")
 
 
 def register_deprecated_auth(app: typer.Typer):
-    """Register deprecated root-level aliases that delegate to auth subgroup commands."""
+    """Register deprecated root-level aliases."""
 
     @app.command(name="init", hidden=True)
     def deprecated_init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
-        """[Deprecated] Use 'observal auth init' instead."""
-        _deprecation_notice("init")
-        init(server=server)
+        """[Deprecated] Use 'observal auth login' instead."""
+        _deprecation_notice("login")
+        login(server=server, key=None, code=None, name=None)
 
     @app.command(name="login", hidden=True)
     def deprecated_login(
-        server: str = typer.Option(None, "--server", "-s", help="Server URL (skips prompt)"),
-        key: str = typer.Option(None, "--key", "-k", help="API key (skips prompt)"),
+        server: str = typer.Option(None, "--server", "-s", help="Server URL"),
+        key: str = typer.Option(None, "--key", "-k", help="API key"),
+        code: str = typer.Option(None, "--code", "-c", help="Invite code"),
     ):
         """[Deprecated] Use 'observal auth login' instead."""
         _deprecation_notice("login")
-        login(server=server, key=key)
+        login(server=server, key=key, code=code, name=None)
 
     @app.command(name="logout", hidden=True)
     def deprecated_logout():
@@ -228,12 +243,13 @@ def register_deprecated_auth(app: typer.Typer):
 # ── Helper functions ────────────────────────────────────────
 
 
-def _do_login(server_url: str, api_key: str | None = None):
+def _do_key_login(server_url: str, api_key: str | None = None):
+    """Authenticate with an API key."""
     api_key = api_key or typer.prompt("API Key", hide_input=True)
     try:
         with spinner("Authenticating..."):
             r = httpx.get(
-                f"{server_url.rstrip('/')}/api/v1/auth/whoami",
+                f"{server_url}/api/v1/auth/whoami",
                 headers={"X-API-Key": api_key},
                 timeout=30,
             )
@@ -246,6 +262,38 @@ def _do_login(server_url: str, api_key: str | None = None):
         raise typer.Exit(1)
     except httpx.HTTPStatusError:
         rprint("[red]Invalid API key.[/red]")
+        raise typer.Exit(1)
+
+
+def _do_invite_login(server_url: str, code: str, name: str | None = None):
+    """Redeem an invite code to create account and log in."""
+    payload: dict = {"code": code.strip()}
+    if name:
+        payload["name"] = name
+    try:
+        with spinner("Redeeming invite code..."):
+            r = httpx.post(
+                f"{server_url}/api/v1/auth/redeem",
+                json=payload,
+                timeout=30,
+            )
+            r.raise_for_status()
+            data = r.json()
+
+        api_key = data["api_key"]
+        user = data["user"]
+        config.save({"server_url": server_url, "api_key": api_key})
+        rprint(f"[green]Account created! Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
+
+        _configure_claude_code(server_url, api_key)
+
+    except httpx.HTTPStatusError as e:
+        detail = ""
+        try:
+            detail = e.response.json().get("detail", e.response.text)
+        except Exception:
+            detail = e.response.text
+        rprint(f"[red]Failed:[/red] {detail}")
         raise typer.Exit(1)
 
 
@@ -321,7 +369,8 @@ def _configure_claude_code(server_url: str, api_key: str):
             return
 
         if not typer.confirm(
-            "\nDetected Claude Code installation.\nConfigure Claude Code telemetry -> Observal?", default=True
+            "\nDetected Claude Code. Configure telemetry -> Observal?",
+            default=True,
         ):
             return
 
@@ -334,9 +383,7 @@ def _configure_claude_code(server_url: str, api_key: str):
                     rprint(
                         f"[yellow]Warning: Could not parse {claude_settings_file}. A new file will be created.[/yellow]"
                     )
-                    pass  # Will create a new file
 
-        # Prepare OTEL config
         otel_env = {
             "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
             "OTEL_METRICS_EXPORTER": "otlp",
@@ -345,8 +392,6 @@ def _configure_claude_code(server_url: str, api_key: str):
             "OTEL_EXPORTER_OTLP_HEADERS": f"Authorization=Bearer {api_key}",
         }
 
-        # Set endpoint based on server_url
-        # Assumes OTLP/gRPC is on port 4317 of the same host
         from urllib.parse import urlparse
 
         parsed_url = urlparse(server_url)
@@ -354,19 +399,16 @@ def _configure_claude_code(server_url: str, api_key: str):
         otel_endpoint = f"{scheme}://{parsed_url.hostname}:4317"
         otel_env["OTEL_EXPORTER_OTLP_ENDPOINT"] = otel_endpoint
 
-        # Merge with existing settings
         if "env" not in settings:
             settings["env"] = {}
         settings["env"].update(otel_env)
 
-        # Write back
         claude_dir.mkdir(exist_ok=True)
         with open(claude_settings_file, "w", encoding="utf-8") as f:
             _json.dump(settings, f, indent=2)
 
-        rprint(f"Updated [dim]{claude_settings_file}[/dim] -- Claude Code will send traces to Observal.")
-        rprint("\nYou're all set. Open Claude Code and traces will appear in the dashboard.")
+        rprint(f"Updated [dim]{claude_settings_file}[/dim] — telemetry will flow to Observal.")
 
     except Exception as e:
         rprint(f"\n[yellow]Could not configure Claude Code automatically: {e}[/yellow]")
-        rprint("Please see documentation for manual configuration.")
+        rprint("See documentation for manual configuration.")

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -753,6 +753,52 @@ def admin_users(output: str = typer.Option("table", "--output", "-o")):
     console.print(table)
 
 
+@admin_app.command(name="invite")
+def admin_invite(
+    role: str = typer.Option("developer", "--role", "-r", help="Role: developer, user, admin"),
+    expires: int = typer.Option(7, "--expires", "-e", help="Days until expiry"),
+):
+    """Generate an invite code for a new team member."""
+    with spinner("Creating invite code..."):
+        data = client.post("/api/v1/auth/invite", {"role": role, "expires_days": expires})
+    rprint(f"\n[bold green]Invite code:[/bold green]  [bold]{data['code']}[/bold]")
+    rprint(f"[dim]Role: {data['role']} | Expires: {data['expires_at'][:10]}[/dim]\n")
+    rprint("[dim]Share this code. They run:[/dim]")
+    rprint(f"  [bold]observal auth login --code {data['code']}[/bold]")
+
+
+@admin_app.command(name="invites")
+def admin_invites(output: str = typer.Option("table", "--output", "-o")):
+    """List all invite codes."""
+    with spinner():
+        data = client.get("/api/v1/auth/invites")
+    if output == "json":
+        output_json(data)
+        return
+    if not data:
+        rprint("[dim]No invite codes.[/dim]")
+        return
+    table = Table(title=f"Invite Codes ({len(data)})", show_lines=False, padding=(0, 1))
+    table.add_column("Code", style="bold cyan")
+    table.add_column("Role")
+    table.add_column("Created")
+    table.add_column("Expires")
+    table.add_column("Status")
+    for inv in data:
+        if inv.get("used_by"):
+            status_str = f"[green]used[/green] {inv.get('used_at', '')[:10]}"
+        else:
+            status_str = "[yellow]pending[/yellow]"
+        table.add_row(
+            inv["code"],
+            inv["role"],
+            inv["created_at"][:10],
+            inv["expires_at"][:10],
+            status_str,
+        )
+    console.print(table)
+
+
 # ── Traces / Spans (on ops_app) ─────────────────────────
 
 


### PR DESCRIPTION
## Summary

Replaces the clunky API key ceremony with a simple, frictionless auth system inspired by Slack/Discord/Tailscale invite codes.

**Before (5+ steps):**
1. `observal auth init` → "C or N?" → email? → name? → copies 64-char hex key
2. `observal auth login` → pastes key

**After:**
- **Fresh server:** `observal auth login` → auto-creates admin, zero prompts
- **New team member:** `observal auth login --code OBS-A7X9B2` → done
- **CI/scripts:** `OBSERVAL_API_KEY` env var (unchanged)

### Changes

- **InviteCode model** — short codes (`OBS-XXXXXX`), role assignment, 7-day expiry, one-time use
- **`POST /api/v1/auth/bootstrap`** — auto-create admin on fresh server (no input needed)
- **`POST /api/v1/auth/invite`** — admin generates invite code
- **`POST /api/v1/auth/redeem`** — redeem code → get API key + account
- **`GET /api/v1/auth/invites`** — admin lists all codes
- **`GET /health`** — now returns `initialized: bool`
- **CLI `auth login`** — single smart command: detects fresh server, supports `--code`, `--key`
- **`observal admin invite`** / **`admin invites`** — CLI commands for code management
- Updated README, SETUP.md, CONTRIBUTING.md, AGENTS.md

### Onboarding flow comparison

| Scenario | Old | New |
|---|---|---|
| Fresh server setup | 5+ prompts | 0 prompts |
| Invite new user | Create user → copy 64-char key → transmit | `admin invite` → share 10-char code |
| New user joins | Paste 64-char key | `--code OBS-A7X9B2` |
| CI/automation | env var | env var (same) |

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] 547 tests pass
- [ ] Docker compose up → `observal auth login` auto-bootstraps
- [ ] `observal admin invite` generates code
- [ ] New user redeems code with `--code`
- [ ] Expired/used codes are rejected
- [ ] Existing API key login still works