### PR TITLE
feat: E2E overhaul — auth, traces, admin, registry UI

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -12,6 +12,10 @@ End-to-end integration tests that run against your **real local setup** — your
 ## Quick Start
 
 ```bash
+# Scan your real ~/.claude setup and register everything with Observal
+observal scan --home --yes
+
+# Or run the full E2E demo
 cd demo
 ./run_demo.sh
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       observal-db:
         condition: service_healthy
       observal-clickhouse:
-        condition: service_started
+        condition: service_healthy
       observal-redis:
         condition: service_healthy
     networks:
@@ -50,6 +50,11 @@ services:
       CLICKHOUSE_DB: observal
     volumes:
       - chdata:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - observal-net
 
@@ -105,13 +110,15 @@ services:
   observal-otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
     command: ["--config", "/etc/otelcol/config.yaml"]
+    restart: on-failure
     ports:
       - "4317:4317"
       - "4318:4318"
     volumes:
       - ../otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
     depends_on:
-      - observal-clickhouse
+      observal-clickhouse:
+        condition: service_healthy
     networks:
       - observal-net
 

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -16,10 +16,19 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 
 
 async def get_current_user(
-    x_api_key: str = Header(...),
+    x_api_key: str | None = Header(None),
+    authorization: str | None = Header(None),
     db: AsyncSession = Depends(get_db),
 ) -> User:
-    key_hash = hashlib.sha256(x_api_key.encode()).hexdigest()
+    # Try X-API-Key header first
+    api_key = x_api_key
+    # Fall back to Bearer token in Authorization header
+    if not api_key and authorization and authorization.startswith("Bearer "):
+        api_key = authorization.removeprefix("Bearer ").strip()
+    if not api_key:
+        raise HTTPException(status_code=401, detail="Missing API key")
+
+    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
     result = await db.execute(select(User).where(User.api_key_hash == key_hash))
     user = result.scalar_one_or_none()
     if not user:

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -54,13 +54,14 @@ async def _load_agent(db: AsyncSession, *where_clauses) -> Agent | None:
     return result.scalar_one_or_none()
 
 
-def _agent_to_response(agent: Agent) -> AgentResponse:
+def _agent_to_response(agent: Agent, name_map: dict[str, str] | None = None) -> AgentResponse:
+    name_map = name_map or {}
     # Build mcp_links from components with component_type='mcp' (backwards compat)
     mcp_components = [c for c in agent.components if c.component_type == "mcp"]
     mcp_links = [
         McpLinkResponse(
             mcp_listing_id=comp.component_id,
-            mcp_name="(component)",
+            mcp_name=name_map.get(str(comp.component_id), "(component)"),
             order=comp.order_index,
         )
         for comp in mcp_components
@@ -70,6 +71,7 @@ def _agent_to_response(agent: Agent) -> AgentResponse:
         ComponentLinkResponse(
             component_type=comp.component_type,
             component_id=comp.component_id,
+            component_name=name_map.get(str(comp.component_id), ""),
             version_ref=comp.version_ref,
             order=comp.order_index,
             config_override=comp.config_override,
@@ -91,6 +93,28 @@ def _agent_to_response(agent: Agent) -> AgentResponse:
     agent_dict["component_links"] = component_links
     agent_dict["goal_template"] = goal_template
     return AgentResponse(**agent_dict)
+
+
+async def _resolve_component_names(components: list, db: AsyncSession) -> dict[str, str]:
+    """Batch-resolve component_id → name for all component types."""
+    if not components:
+        return {}
+    from services.agent_resolver import _LISTING_MODELS
+
+    # Group component_ids by type
+    by_type: dict[str, list[uuid.UUID]] = {}
+    for comp in components:
+        by_type.setdefault(comp.component_type, []).append(comp.component_id)
+
+    name_map: dict[str, str] = {}
+    for comp_type, ids in by_type.items():
+        model = _LISTING_MODELS.get(comp_type)
+        if not model:
+            continue
+        rows = (await db.execute(select(model.id, model.name).where(model.id.in_(ids)))).all()
+        for row in rows:
+            name_map[str(row[0])] = row[1]
+    return name_map
 
 
 async def _validate_mcp_ids(mcp_ids: list[uuid.UUID], db: AsyncSession) -> list[McpListing]:
@@ -196,7 +220,8 @@ async def create_agent(
 
     await db.commit()
     agent = await _load_agent(db, Agent.id == agent.id)
-    return _agent_to_response(agent)
+    name_map = await _resolve_component_names(agent.components, db)
+    return _agent_to_response(agent, name_map)
 
 
 @router.get("", response_model=list[AgentSummary])
@@ -248,7 +273,8 @@ async def get_agent(agent_id: str, db: AsyncSession = Depends(get_db)):
     agent = await _load_agent(db, _agent_id_clause(agent_id))
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
-    return _agent_to_response(agent)
+    name_map = await _resolve_component_names(agent.components, db)
+    return _agent_to_response(agent, name_map)
 
 
 @router.put("/{agent_id}", response_model=AgentResponse)
@@ -373,7 +399,8 @@ async def update_agent(
 
     await db.commit()
     agent = await _load_agent(db, Agent.id == agent.id)
-    return _agent_to_response(agent)
+    name_map = await _resolve_component_names(agent.components, db)
+    return _agent_to_response(agent, name_map)
 
 
 @router.post("/{agent_id}/install", response_model=AgentInstallResponse)

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -18,10 +18,17 @@ from schemas.auth import (
     InviteRedeemRequest,
     InviteResponse,
     LoginRequest,
+    RegisterRequest,
     UserResponse,
 )
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
+
+
+def _generate_api_key() -> tuple[str, str]:
+    """Return (raw_key, sha256_hash)."""
+    raw = secrets.token_hex(settings.API_KEY_LENGTH)
+    return raw, hashlib.sha256(raw.encode()).hexdigest()
 
 
 @router.post("/init", response_model=InitResponse)
@@ -30,8 +37,7 @@ async def init_admin(req: InitRequest, db: AsyncSession = Depends(get_db)):
     if count and count > 0:
         raise HTTPException(status_code=400, detail="System already initialized")
 
-    api_key = secrets.token_hex(settings.API_KEY_LENGTH)
-    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+    api_key, key_hash = _generate_api_key()
 
     user = User(
         email=req.email,
@@ -39,6 +45,8 @@ async def init_admin(req: InitRequest, db: AsyncSession = Depends(get_db)):
         role=UserRole.admin,
         api_key_hash=key_hash,
     )
+    if req.password:
+        user.set_password(req.password)
     db.add(user)
     await db.commit()
     await db.refresh(user)
@@ -53,8 +61,7 @@ async def bootstrap(db: AsyncSession = Depends(get_db)):
     if count and count > 0:
         raise HTTPException(status_code=400, detail="System already initialized")
 
-    api_key = secrets.token_hex(settings.API_KEY_LENGTH)
-    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+    api_key, key_hash = _generate_api_key()
 
     user = User(
         email="admin@localhost",
@@ -69,14 +76,53 @@ async def bootstrap(db: AsyncSession = Depends(get_db)):
     return InitResponse(user=UserResponse.model_validate(user), api_key=api_key)
 
 
-@router.post("/login", response_model=UserResponse)
+@router.post("/register", response_model=InitResponse)
+async def register(req: RegisterRequest, db: AsyncSession = Depends(get_db)):
+    """Create a new account with email + password."""
+    existing = await db.execute(select(User).where(User.email == req.email))
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="Email already registered")
+
+    api_key, key_hash = _generate_api_key()
+
+    user = User(
+        email=req.email,
+        name=req.name,
+        role=UserRole.user,
+        api_key_hash=key_hash,
+    )
+    user.set_password(req.password)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    return InitResponse(user=UserResponse.model_validate(user), api_key=api_key)
+
+
+@router.post("/login", response_model=InitResponse)
 async def login(req: LoginRequest, db: AsyncSession = Depends(get_db)):
-    key_hash = hashlib.sha256(req.api_key.encode()).hexdigest()
-    result = await db.execute(select(User).where(User.api_key_hash == key_hash))
+    """Login with API key or email+password. Returns user info and API key."""
+    if req.api_key:
+        key_hash = hashlib.sha256(req.api_key.encode()).hexdigest()
+        result = await db.execute(select(User).where(User.api_key_hash == key_hash))
+        user = result.scalar_one_or_none()
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+        return InitResponse(user=UserResponse.model_validate(user), api_key=req.api_key)
+
+    # Email + password login
+    result = await db.execute(select(User).where(User.email == req.email))
     user = result.scalar_one_or_none()
-    if not user:
-        raise HTTPException(status_code=401, detail="Invalid API key")
-    return UserResponse.model_validate(user)
+    if not user or not user.verify_password(req.password):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    # Return the user's current API key (regenerate so they always have a fresh one)
+    api_key, key_hash = _generate_api_key()
+    user.api_key_hash = key_hash
+    await db.commit()
+    await db.refresh(user)
+
+    return InitResponse(user=UserResponse.model_validate(user), api_key=api_key)
 
 
 @router.get("/whoami", response_model=UserResponse)
@@ -127,8 +173,7 @@ async def redeem_invite(req: InviteRedeemRequest, db: AsyncSession = Depends(get
         raise HTTPException(status_code=400, detail="Invite code expired")
 
     # Generate user credentials
-    api_key = secrets.token_hex(settings.API_KEY_LENGTH)
-    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+    api_key, key_hash = _generate_api_key()
 
     name = req.name or f"user-{code[-4:]}"
     email = req.email or f"{name.lower().replace(' ', '-')}@localhost"

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -35,6 +35,8 @@ async def list_sessions():
         "sum(toUInt64OrZero(LogAttributes['output_tokens'])) AS total_output_tokens, "
         "sum(toUInt64OrZero(LogAttributes['cache_read_tokens'])) AS total_cache_read_tokens, "
         "anyIf(LogAttributes['model'], LogAttributes['model'] != '') AS model, "
+        "anyIf(LogAttributes['user.id'], LogAttributes['user.id'] != '') AS user_id, "
+        "anyIf(LogAttributes['terminal.type'], LogAttributes['terminal.type'] != '') AS terminal_type, "
         "any(ServiceName) AS service_name "
         "FROM otel_logs "
         "WHERE LogAttributes['session.id'] != '' "
@@ -140,6 +142,33 @@ async def get_trace(trace_id: str):
             }
         )
     return spans
+
+
+@router.get("/errors")
+async def list_errors():
+    """List recent error events (tool failures, stop failures, API errors)."""
+    rows = await _ch_json(
+        "SELECT "
+        "Timestamp AS timestamp, "
+        "if(LogAttributes['event.name'] != '', LogAttributes['event.name'], EventName) AS event_name, "
+        "Body AS body, "
+        "LogAttributes['session.id'] AS session_id, "
+        "LogAttributes['tool_name'] AS tool_name, "
+        "LogAttributes['error'] AS error, "
+        "LogAttributes['agent_id'] AS agent_id, "
+        "LogAttributes['agent_type'] AS agent_type, "
+        "LogAttributes['tool_input'] AS tool_input, "
+        "LogAttributes['tool_response'] AS tool_response, "
+        "LogAttributes['stop_reason'] AS stop_reason, "
+        "LogAttributes['user.id'] AS user_id "
+        "FROM otel_logs "
+        "WHERE LogAttributes['event.name'] IN "
+        "('hook_posttoolusefailure', 'hook_stopfailure', 'api_error') "
+        "OR EventName = 'api_error' "
+        "ORDER BY Timestamp DESC "
+        "LIMIT 200"
+    )
+    return rows
 
 
 @router.get("/stats")

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -1,8 +1,10 @@
+import json
 import logging
+from datetime import UTC, datetime
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
-from services.clickhouse import _escape, _query
+from services.clickhouse import _escape, _map_literal, _query
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/otel", tags=["otel-dashboard"])
@@ -28,8 +30,10 @@ async def list_sessions():
         "countIf(EventName = 'user_prompt' OR LogAttributes['event.name'] = 'user_prompt') AS prompt_count, "
         "countIf(LogAttributes['event.name'] = 'api_request') AS api_request_count, "
         "countIf(LogAttributes['event.name'] = 'tool_result') AS tool_result_count, "
+        "countIf(LogAttributes['event.name'] LIKE 'hook_%') AS hook_event_count, "
         "sum(toUInt64OrZero(LogAttributes['input_tokens'])) AS total_input_tokens, "
         "sum(toUInt64OrZero(LogAttributes['output_tokens'])) AS total_output_tokens, "
+        "sum(toUInt64OrZero(LogAttributes['cache_read_tokens'])) AS total_cache_read_tokens, "
         "anyIf(LogAttributes['model'], LogAttributes['model'] != '') AS model, "
         "any(ServiceName) AS service_name "
         "FROM otel_logs "
@@ -165,3 +169,206 @@ async def otel_stats():
         "total_traces": int(tr.get("total_traces", 0)),
         "total_spans": int(tr.get("total_spans", 0)),
     }
+
+
+# ── Hook ingestion (unauthenticated — Claude Code hooks fire from CLI) ──
+
+
+def _truncate(s: str, max_len: int = 64000) -> str:
+    """Truncate a string to fit in ClickHouse without blowing up storage."""
+    if len(s) <= max_len:
+        return s
+    return s[:max_len] + f"\n... [truncated, {len(s)} total chars]"
+
+
+def _safe_json(obj: object) -> str:
+    """Serialize to JSON string, falling back to str()."""
+    if obj is None:
+        return ""
+    if isinstance(obj, str):
+        return obj
+    try:
+        return json.dumps(obj, default=str)
+    except Exception:
+        return str(obj)
+
+
+@router.post("/hooks")
+async def ingest_hook(request: Request):
+    """Ingest hook events from Claude Code and store in otel_logs.
+
+    This is intentionally unauthenticated because Claude Code hooks fire
+    from the CLI and can't easily carry auth tokens.  The endpoint only
+    writes to ClickHouse — no destructive operations.
+    """
+    body = await request.json()
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+    hook_event = body.get("hook_event_name", "unknown")
+    session_id = body.get("session_id", "")
+    tool_name = body.get("tool_name", "")
+
+    # Build the attributes map that the frontend already reads
+    attrs: dict[str, str] = {
+        "session.id": session_id,
+        "event.name": f"hook_{hook_event.lower()}",
+        "hook_event": hook_event,
+        "tool_name": tool_name,
+    }
+
+    # ── Agent attribution (present on ALL events fired within a subagent) ──
+    if body.get("agent_id"):
+        attrs["agent_id"] = body["agent_id"]
+    if body.get("agent_type"):
+        attrs["agent_type"] = body["agent_type"]
+
+    # Capture full content — this is the Langfuse-equivalent visibility
+    tool_input_raw = body.get("tool_input")
+    tool_response_raw = body.get("tool_response")
+
+    if tool_input_raw is not None:
+        attrs["tool_input"] = _truncate(_safe_json(tool_input_raw))
+    if tool_response_raw is not None:
+        attrs["tool_response"] = _truncate(_safe_json(tool_response_raw))
+
+    # UserPromptSubmit — capture the actual user prompt
+    if hook_event == "UserPromptSubmit":
+        prompt_text = body.get("prompt") or body.get("user_prompt") or ""
+        if prompt_text:
+            attrs["tool_input"] = _truncate(prompt_text)
+            attrs["prompt_length"] = str(len(prompt_text))
+        attrs["tool_name"] = "user_prompt"
+
+    # SubagentStart — capture agent spawn
+    if hook_event == "SubagentStart":
+        if body.get("last_assistant_message"):
+            attrs["tool_input"] = _truncate(body["last_assistant_message"])
+
+    # SubagentStop — capture agent final output
+    if hook_event == "SubagentStop":
+        if body.get("last_assistant_message"):
+            attrs["tool_response"] = _truncate(body["last_assistant_message"])
+
+    # PostToolUseFailure — tool failure (critical for debugging)
+    if hook_event == "PostToolUseFailure":
+        if body.get("error"):
+            attrs["error"] = _truncate(str(body["error"]))
+
+    # Stop — session/turn end (command hook sends assistant response text)
+    if hook_event == "Stop":
+        if body.get("stop_reason"):
+            attrs["stop_reason"] = body["stop_reason"]
+        # If the stop hook captured Claude's response, mark it clearly
+        if tool_name == "assistant_response" and tool_response_raw:
+            attrs["event.name"] = "hook_assistant_response"
+
+    # StopFailure — API error on turn end
+    if hook_event == "StopFailure":
+        if body.get("error"):
+            attrs["error"] = _truncate(str(body["error"]))
+        if body.get("stop_reason"):
+            attrs["stop_reason"] = body["stop_reason"]
+
+    # SessionStart — session lifecycle
+    if hook_event == "SessionStart":
+        if body.get("resume"):
+            attrs["session_resumed"] = str(body["resume"])
+
+    # Notification
+    if hook_event == "Notification":
+        if body.get("message"):
+            attrs["tool_response"] = _truncate(str(body["message"]))
+        if body.get("title"):
+            attrs["notification_title"] = str(body["title"])
+
+    # TaskCreated / TaskCompleted
+    if hook_event in ("TaskCreated", "TaskCompleted"):
+        for field in ("task_id", "task_subject", "task_status"):
+            if body.get(field):
+                attrs[field] = str(body[field])
+
+    # PreCompact / PostCompact — context compaction
+    if hook_event in ("PreCompact", "PostCompact"):
+        if body.get("summary"):
+            attrs["tool_response"] = _truncate(str(body["summary"]))
+
+    # WorktreeCreate / WorktreeRemove
+    if hook_event in ("WorktreeCreate", "WorktreeRemove"):
+        if body.get("worktree_path"):
+            attrs["worktree_path"] = str(body["worktree_path"])
+        if body.get("branch"):
+            attrs["branch"] = str(body["branch"])
+
+    # Elicitation / ElicitationResult — MCP server interactions
+    if hook_event in ("Elicitation", "ElicitationResult"):
+        for field in ("mcp_server_name", "message", "response", "elicitation_id"):
+            if body.get(field):
+                key = "tool_input" if field == "message" else ("tool_response" if field == "response" else field)
+                attrs[key] = _truncate(str(body[field]))
+
+    # Extra context fields (present on most events)
+    if body.get("tool_use_id"):
+        attrs["tool_use_id"] = body["tool_use_id"]
+    if body.get("cwd"):
+        attrs["cwd"] = body["cwd"]
+    if body.get("permission_mode"):
+        attrs["permission_mode"] = body["permission_mode"]
+
+    # Build the Body as a readable summary
+    agent_prefix = f"[{attrs.get('agent_type', '')}] " if attrs.get("agent_id") else ""
+    if hook_event in ("PostToolUse", "PreToolUse"):
+        body_text = f"{agent_prefix}{hook_event}: {tool_name}"
+    elif hook_event == "PostToolUseFailure":
+        body_text = f"{agent_prefix}ToolFailure: {tool_name}"
+    elif hook_event == "UserPromptSubmit":
+        prompt_preview = (attrs.get("tool_input") or "")[:100]
+        body_text = f"Prompt: {prompt_preview}"
+    elif hook_event in ("SubagentStop", "SubagentStart"):
+        body_text = f"{hook_event}: {attrs.get('agent_type', 'unknown')}"
+    elif hook_event in ("Elicitation", "ElicitationResult"):
+        body_text = f"{hook_event}: {body.get('mcp_server_name', 'unknown')}"
+    elif hook_event == "Stop" and tool_name == "assistant_response":
+        preview = (attrs.get("tool_response") or "")[:100]
+        body_text = f"Response: {preview}"
+    elif hook_event == "Stop":
+        body_text = f"Stop: {body.get('stop_reason', 'end_turn')}"
+    elif hook_event == "StopFailure":
+        body_text = f"StopFailure: {attrs.get('error', 'unknown')[:80]}"
+    elif hook_event == "SessionStart":
+        resumed = " (resumed)" if attrs.get("session_resumed") == "True" else ""
+        body_text = f"SessionStart{resumed}"
+    elif hook_event == "Notification":
+        body_text = f"Notification: {attrs.get('notification_title', '')}"
+    elif hook_event in ("TaskCreated", "TaskCompleted"):
+        body_text = f"{hook_event}: {attrs.get('task_subject', '')[:60]}"
+    elif hook_event in ("PreCompact", "PostCompact"):
+        body_text = f"{hook_event}"
+    elif hook_event in ("WorktreeCreate", "WorktreeRemove"):
+        body_text = f"{hook_event}: {attrs.get('branch', '')}"
+    else:
+        body_text = f"{agent_prefix}hook: {hook_event}"
+
+    # Event name for the EventName column (used by list_sessions countIf)
+    event_name = attrs.get("event.name", f"hook_{hook_event.lower()}")
+
+    # INSERT into otel_logs
+    attr_map = _map_literal(attrs)
+    sql = (
+        "INSERT INTO otel_logs "
+        "(Timestamp, EventName, Body, LogAttributes, ServiceName, "
+        "SeverityText, SeverityNumber) VALUES "
+        f"('{_escape(now)}', '{_escape(event_name)}', "
+        f"'{_escape(body_text)}', {attr_map}, "
+        f"'observal-hooks', 'INFO', 9)"
+    )
+
+    try:
+        r = await _query(sql)
+        if r.status_code != 200:
+            logger.warning(f"Hook insert failed: {r.status_code} {r.text[:200]}")
+            return {"ingested": 0, "error": "insert failed"}
+    except Exception as e:
+        logger.warning(f"Hook insert failed: {e}")
+        return {"ingested": 0, "error": str(e)}
+
+    return {"ingested": 1, "session_id": session_id, "event": hook_event}

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -269,19 +269,16 @@ async def ingest_hook(request: Request):
         attrs["tool_name"] = "user_prompt"
 
     # SubagentStart — capture agent spawn
-    if hook_event == "SubagentStart":
-        if body.get("last_assistant_message"):
-            attrs["tool_input"] = _truncate(body["last_assistant_message"])
+    if hook_event == "SubagentStart" and body.get("last_assistant_message"):
+        attrs["tool_input"] = _truncate(body["last_assistant_message"])
 
     # SubagentStop — capture agent final output
-    if hook_event == "SubagentStop":
-        if body.get("last_assistant_message"):
-            attrs["tool_response"] = _truncate(body["last_assistant_message"])
+    if hook_event == "SubagentStop" and body.get("last_assistant_message"):
+        attrs["tool_response"] = _truncate(body["last_assistant_message"])
 
     # PostToolUseFailure — tool failure (critical for debugging)
-    if hook_event == "PostToolUseFailure":
-        if body.get("error"):
-            attrs["error"] = _truncate(str(body["error"]))
+    if hook_event == "PostToolUseFailure" and body.get("error"):
+        attrs["error"] = _truncate(str(body["error"]))
 
     # Stop — session/turn end (command hook sends assistant response text)
     if hook_event == "Stop":
@@ -304,9 +301,8 @@ async def ingest_hook(request: Request):
             attrs["stop_reason"] = body["stop_reason"]
 
     # SessionStart — session lifecycle
-    if hook_event == "SessionStart":
-        if body.get("resume"):
-            attrs["session_resumed"] = str(body["resume"])
+    if hook_event == "SessionStart" and body.get("resume"):
+        attrs["session_resumed"] = str(body["resume"])
 
     # Notification
     if hook_event == "Notification":
@@ -322,9 +318,8 @@ async def ingest_hook(request: Request):
                 attrs[field] = str(body[field])
 
     # PreCompact / PostCompact — context compaction
-    if hook_event in ("PreCompact", "PostCompact"):
-        if body.get("summary"):
-            attrs["tool_response"] = _truncate(str(body["summary"]))
+    if hook_event in ("PreCompact", "PostCompact") and body.get("summary"):
+        attrs["tool_response"] = _truncate(str(body["summary"]))
 
     # WorktreeCreate / WorktreeRemove
     if hook_event in ("WorktreeCreate", "WorktreeRemove"):

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -261,6 +261,11 @@ async def ingest_hook(request: Request):
         # If the stop hook captured Claude's response, mark it clearly
         if tool_name == "assistant_response" and tool_response_raw:
             attrs["event.name"] = "hook_assistant_response"
+            # Sequence metadata for interleaving with tool calls
+            if body.get("message_sequence") is not None:
+                attrs["message_sequence"] = str(body["message_sequence"])
+            if body.get("message_total") is not None:
+                attrs["message_total"] = str(body["message_total"])
 
     # StopFailure — API error on turn end
     if hook_event == "StopFailure":
@@ -328,8 +333,11 @@ async def ingest_hook(request: Request):
     elif hook_event in ("Elicitation", "ElicitationResult"):
         body_text = f"{hook_event}: {body.get('mcp_server_name', 'unknown')}"
     elif hook_event == "Stop" and tool_name == "assistant_response":
+        seq = attrs.get("message_sequence", "")
+        total = attrs.get("message_total", "")
+        seq_label = f" [{seq}/{total}]" if seq and total else ""
         preview = (attrs.get("tool_response") or "")[:100]
-        body_text = f"Response: {preview}"
+        body_text = f"Response{seq_label}: {preview}"
     elif hook_event == "Stop":
         body_text = f"Stop: {body.get('stop_reason', 'end_turn')}"
     elif hook_event == "StopFailure":

--- a/observal-server/api/routes/scan.py
+++ b/observal-server/api/routes/scan.py
@@ -1,4 +1,4 @@
-"""Bulk scan endpoint: register multiple items in one call."""
+"""Bulk scan endpoint: register multiple component types in one call."""
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -6,10 +6,16 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_current_user, get_db
+from models.agent import Agent, AgentGoalSection, AgentGoalTemplate
+from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
+from models.skill import SkillListing
 from models.user import User
 
 router = APIRouter(prefix="/api/v1/scan", tags=["scan"])
+
+
+# ── Request models ──────────────────────────────────────────
 
 
 class ScannedMcp(BaseModel):
@@ -18,21 +24,59 @@ class ScannedMcp(BaseModel):
     args: list[str] = []
     url: str | None = None
     env: dict[str, str] = {}
+    description: str = ""
+    source_plugin: str | None = None
+
+
+class ScannedSkill(BaseModel):
+    name: str
+    description: str = ""
+    source_plugin: str | None = None
+    task_type: str = "general"
+    skill_path: str = "/"
+
+
+class ScannedHook(BaseModel):
+    name: str
+    event: str
+    handler_type: str = "command"
+    handler_config: dict = {}
+    description: str = ""
+    source_plugin: str | None = None
+
+
+class ScannedAgent(BaseModel):
+    name: str
+    description: str = ""
+    model_name: str = ""
+    prompt: str = ""
+    source_file: str | None = None
 
 
 class ScanRequest(BaseModel):
     ide: str
     mcps: list[ScannedMcp] = []
+    skills: list[ScannedSkill] = []
+    hooks: list[ScannedHook] = []
+    agents: list[ScannedAgent] = []
+
+
+# ── Response models ─────────────────────────────────────────
 
 
 class RegisteredItem(BaseModel):
     name: str
     id: str
+    type: str  # "mcp", "skill", "hook", "agent"
     status: str  # "created" or "existing"
 
 
 class ScanResponse(BaseModel):
     registered: list[RegisteredItem] = []
+    summary: dict[str, int] = {}
+
+
+# ── Endpoint ────────────────────────────────────────────────
 
 
 @router.post("", response_model=ScanResponse)
@@ -42,29 +86,126 @@ async def bulk_scan(
     current_user: User = Depends(get_current_user),
 ):
     registered = []
+    counts: dict[str, int] = {"mcp": 0, "skill": 0, "hook": 0, "agent": 0}
+
+    owner = current_user.username if hasattr(current_user, "username") else str(current_user.id)
+
+    # ── MCPs ────────────────────────────────────────────
     for mcp in req.mcps:
-        # Check if already registered by name
         result = await db.execute(select(McpListing).where(McpListing.name == mcp.name))
         existing = result.scalar_one_or_none()
         if existing:
-            registered.append(RegisteredItem(name=mcp.name, id=str(existing.id), status="existing"))
+            registered.append(RegisteredItem(name=mcp.name, id=str(existing.id), type="mcp", status="existing"))
+            counts["mcp"] += 1
             continue
 
-        # Auto-register as pending (owner can install their own pending items)
         listing = McpListing(
             name=mcp.name,
             version="0.1.0",
             git_url=mcp.url or "",
-            description=f"Auto-registered from {req.ide} config",
+            description=mcp.description or f"Auto-scanned MCP from {req.ide}: {mcp.name}",
             category="scanned",
-            owner=current_user.username if hasattr(current_user, "username") else str(current_user.id),
+            owner=owner,
             supported_ides=[req.ide],
             status=ListingStatus.pending,
             submitted_by=current_user.id,
         )
         db.add(listing)
         await db.flush()
-        registered.append(RegisteredItem(name=mcp.name, id=str(listing.id), status="created"))
+        registered.append(RegisteredItem(name=mcp.name, id=str(listing.id), type="mcp", status="created"))
+        counts["mcp"] += 1
+
+    # ── Skills ──────────────────────────────────────────
+    for skill in req.skills:
+        result = await db.execute(select(SkillListing).where(SkillListing.name == skill.name))
+        existing = result.scalar_one_or_none()
+        if existing:
+            registered.append(RegisteredItem(name=skill.name, id=str(existing.id), type="skill", status="existing"))
+            counts["skill"] += 1
+            continue
+
+        listing = SkillListing(
+            name=skill.name,
+            version="0.1.0",
+            description=skill.description or f"Auto-scanned skill: {skill.name}",
+            owner=owner,
+            task_type=skill.task_type,
+            skill_path=skill.skill_path,
+            supported_ides=[req.ide],
+            status=ListingStatus.pending,
+            submitted_by=current_user.id,
+        )
+        db.add(listing)
+        await db.flush()
+        registered.append(RegisteredItem(name=skill.name, id=str(listing.id), type="skill", status="created"))
+        counts["skill"] += 1
+
+    # ── Hooks ───────────────────────────────────────────
+    for hook in req.hooks:
+        result = await db.execute(select(HookListing).where(HookListing.name == hook.name))
+        existing = result.scalar_one_or_none()
+        if existing:
+            registered.append(RegisteredItem(name=hook.name, id=str(existing.id), type="hook", status="existing"))
+            counts["hook"] += 1
+            continue
+
+        listing = HookListing(
+            name=hook.name,
+            version="0.1.0",
+            description=hook.description or f"Auto-scanned hook: {hook.name}",
+            owner=owner,
+            event=hook.event,
+            handler_type=hook.handler_type,
+            handler_config=hook.handler_config,
+            supported_ides=[req.ide],
+            status=ListingStatus.pending,
+            submitted_by=current_user.id,
+        )
+        db.add(listing)
+        await db.flush()
+        registered.append(RegisteredItem(name=hook.name, id=str(listing.id), type="hook", status="created"))
+        counts["hook"] += 1
+
+    # ── Agents ──────────────────────────────────────────
+    for agent in req.agents:
+        result = await db.execute(select(Agent).where(Agent.name == agent.name))
+        existing = result.scalar_one_or_none()
+        if existing:
+            registered.append(RegisteredItem(name=agent.name, id=str(existing.id), type="agent", status="existing"))
+            counts["agent"] += 1
+            continue
+
+        new_agent = Agent(
+            name=agent.name,
+            version="0.1.0",
+            description=agent.description or f"Auto-scanned agent: {agent.name}",
+            owner=owner,
+            prompt=agent.prompt or "",
+            model_name=agent.model_name or "sonnet-4-6",
+            supported_ides=[req.ide],
+            created_by=current_user.id,
+        )
+        db.add(new_agent)
+        await db.flush()
+
+        goal_template = AgentGoalTemplate(
+            agent_id=new_agent.id,
+            description=agent.description or f"Goal for {agent.name}",
+        )
+        db.add(goal_template)
+        await db.flush()
+
+        section = AgentGoalSection(
+            goal_template_id=goal_template.id,
+            name="default",
+            description="Default goal section",
+            order=0,
+        )
+        db.add(section)
+        await db.flush()
+
+        registered.append(RegisteredItem(name=agent.name, id=str(new_agent.id), type="agent", status="created"))
+        counts["agent"] += 1
 
     await db.commit()
-    return ScanResponse(registered=registered)
+    return ScanResponse(registered=registered, summary=counts)

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -33,10 +33,23 @@ from services.clickhouse import init_clickhouse
 from services.redis import close as close_redis
 
 
+async def _ensure_columns(conn):
+    """Add columns that may be missing on existing databases."""
+    from sqlalchemy import text
+
+    try:
+        await conn.execute(text(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255)"
+        ))
+    except Exception:
+        pass  # column already exists or DB doesn't support IF NOT EXISTS
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await _ensure_columns(conn)
     await init_clickhouse()
     yield
     await close_redis()

--- a/observal-server/models/user.py
+++ b/observal-server/models/user.py
@@ -1,4 +1,6 @@
 import enum
+import hashlib
+import os
 import uuid
 from datetime import UTC, datetime
 
@@ -23,5 +25,22 @@ class User(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.user)
     api_key_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+    def set_password(self, password: str) -> None:
+        salt = os.urandom(16)
+        key = hashlib.scrypt(password.encode(), salt=salt, n=16384, r=8, p=1, dklen=32)
+        self.password_hash = f"{salt.hex()}${key.hex()}"
+
+    def verify_password(self, password: str) -> bool:
+        if not self.password_hash:
+            return False
+        try:
+            salt_hex, key_hex = self.password_hash.split("$")
+            salt = bytes.fromhex(salt_hex)
+            key = hashlib.scrypt(password.encode(), salt=salt, n=16384, r=8, p=1, dklen=32)
+            return key.hex() == key_hex
+        except (ValueError, TypeError):
+            return False

--- a/observal-server/schemas/admin.py
+++ b/observal-server/schemas/admin.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 
 from pydantic import BaseModel
 
@@ -18,6 +19,7 @@ class UserAdminResponse(BaseModel):
     email: str
     name: str
     role: str
+    created_at: datetime | None = None
     model_config = {"from_attributes": True}
 
 

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -95,6 +95,7 @@ class ComponentLinkResponse(BaseModel):
 
     component_type: str
     component_id: uuid.UUID
+    component_name: str = ""
     version_ref: str
     order: int
     config_override: dict | None = None

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, model_validator
 
 from models.user import UserRole
 
@@ -9,10 +9,27 @@ from models.user import UserRole
 class InitRequest(BaseModel):
     email: EmailStr
     name: str
+    password: str | None = None
 
 
 class LoginRequest(BaseModel):
-    api_key: str
+    api_key: str | None = None
+    email: EmailStr | None = None
+    password: str | None = None
+
+    @model_validator(mode="after")
+    def _require_credentials(self):
+        has_key = bool(self.api_key)
+        has_password = bool(self.email and self.password)
+        if not has_key and not has_password:
+            raise ValueError("Provide api_key or email+password")
+        return self
+
+
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    name: str
+    password: str
 
 
 class InviteRedeemRequest(BaseModel):

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -360,6 +360,19 @@ def register_config(app: typer.Typer):
     app.add_typer(config_app, name="config")
 
 
+def _find_stop_hook_script() -> str | None:
+    """Locate the observal-stop-hook.sh script."""
+    # Check common locations
+    candidates = [
+        Path(__file__).parent / "hooks" / "observal-stop-hook.sh",
+        Path(shutil.which("observal-stop-hook.sh") or ""),
+    ]
+    for p in candidates:
+        if p.is_file():
+            return str(p.resolve())
+    return None
+
+
 def _configure_claude_code(server_url: str, api_key: str):
     """Check for Claude Code and offer to configure its telemetry."""
     claude_dir = Path.home() / ".claude"
@@ -405,11 +418,47 @@ def _configure_claude_code(server_url: str, api_key: str):
             settings["env"] = {}
         settings["env"].update(otel_env)
 
+        # ── Inject hooks for full content capture (prompts, tool I/O, MCP, agents) ──
+        hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
+        http_hook = [{"hooks": [{"type": "http", "url": hooks_url}]}]
+
+        # Stop uses a command hook to read the transcript for Claude's response text
+        stop_script = _find_stop_hook_script()
+        stop_hook = (
+            [{"hooks": [{"type": "command", "command": stop_script}]}]
+            if stop_script
+            else http_hook
+        )
+
+        settings["hooks"] = {
+            "SessionStart": http_hook,
+            "UserPromptSubmit": http_hook,
+            "PreToolUse": http_hook,
+            "PostToolUse": http_hook,
+            "PostToolUseFailure": http_hook,
+            "SubagentStart": http_hook,
+            "SubagentStop": http_hook,
+            "Stop": stop_hook,
+            "StopFailure": http_hook,
+            "Notification": http_hook,
+            "TaskCreated": http_hook,
+            "TaskCompleted": http_hook,
+            "PreCompact": http_hook,
+            "PostCompact": http_hook,
+            "WorktreeCreate": http_hook,
+            "WorktreeRemove": http_hook,
+            "Elicitation": http_hook,
+            "ElicitationResult": http_hook,
+        }
+
+        # Set the hooks URL env var so the stop script knows where to POST
+        settings["env"]["OBSERVAL_HOOKS_URL"] = hooks_url
+
         claude_dir.mkdir(exist_ok=True)
         with open(claude_settings_file, "w", encoding="utf-8") as f:
             _json.dump(settings, f, indent=2)
 
-        rprint(f"Updated [dim]{claude_settings_file}[/dim] — telemetry will flow to Observal.")
+        rprint(f"Updated [dim]{claude_settings_file}[/dim] — telemetry + hooks will flow to Observal.")
 
     except Exception as e:
         rprint(f"\n[yellow]Could not configure Claude Code automatically: {e}[/yellow]")

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -31,14 +31,17 @@ config_app = typer.Typer(help="CLI configuration")
 def login(
     server: str = typer.Option(None, "--server", "-s", help="Server URL"),
     key: str = typer.Option(None, "--key", "-k", help="API key (skip prompt)"),
+    email: str = typer.Option(None, "--email", "-e", help="Email (for password login)"),
+    password: str = typer.Option(None, "--password", "-p", help="Password (for password login)"),
     code: str = typer.Option(None, "--code", "-c", help="Invite code (e.g. OBS-A7X9B2)"),
-    name: str = typer.Option(None, "--name", "-n", help="Your name (used with invite code)"),
+    name: str = typer.Option(None, "--name", "-n", help="Your name (used with invite/register)"),
 ):
     """Connect to Observal.
 
     On a fresh server: auto-creates admin, no prompts needed.
+    With email+password: logs in with credentials.
     With an invite code: redeems it and creates your account.
-    On an existing server: logs in with an API key.
+    With --key: logs in with an API key.
     """
     server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
     server_url = server_url.rstrip("/")
@@ -90,22 +93,79 @@ def login(
 
     rprint("[green]Connected.[/green]\n")
 
-    # 3. Invite code → redeem
+    # 3. Email+password provided via flags → password login
+    if email and password:
+        _do_password_login(server_url, email, password)
+        return
+
+    # 4. API key provided via flag → key login
+    if key:
+        _do_key_login(server_url, key)
+        return
+
+    # 5. Invite code → redeem
     if code:
         _do_invite_login(server_url, code, name)
         return
 
-    # 4. No code provided → check if user wants to use one
-    if not key:
-        choice = typer.prompt("Login with [K]ey or [I]nvite code?", default="K")
-        if choice.strip().upper().startswith("I"):
-            invite_code = typer.prompt("Invite code")
-            invite_name = typer.prompt("Your name", default="")
-            _do_invite_login(server_url, invite_code, invite_name or None)
-            return
+    # 6. Interactive: choose method
+    choice = typer.prompt("Login with [E]mail, [K]ey, or [I]nvite code?", default="E")
+    ch = choice.strip().upper()
+    if ch.startswith("I"):
+        invite_code = typer.prompt("Invite code")
+        invite_name = typer.prompt("Your name", default="")
+        _do_invite_login(server_url, invite_code, invite_name or None)
+    elif ch.startswith("K"):
+        _do_key_login(server_url, None)
+    else:
+        login_email = email or typer.prompt("Email")
+        login_password = password or typer.prompt("Password", hide_input=True)
+        _do_password_login(server_url, login_email, login_password)
 
-    # 5. API key login
-    _do_key_login(server_url, key)
+
+@auth_app.command()
+def register(
+    server: str = typer.Option(None, "--server", "-s", help="Server URL"),
+    email: str = typer.Option(None, "--email", "-e", help="Email"),
+    password: str = typer.Option(None, "--password", "-p", help="Password"),
+    name: str = typer.Option(None, "--name", "-n", help="Your name"),
+):
+    """Create a new account with email + password."""
+    server_url = server or typer.prompt("Server URL", default="http://localhost:8000")
+    server_url = server_url.rstrip("/")
+    reg_email = email or typer.prompt("Email")
+    reg_name = name or typer.prompt("Name")
+    reg_password = password or typer.prompt("Password", hide_input=True)
+
+    try:
+        with spinner("Creating account..."):
+            r = httpx.post(
+                f"{server_url}/api/v1/auth/register",
+                json={"email": reg_email, "name": reg_name, "password": reg_password},
+                timeout=30,
+            )
+            r.raise_for_status()
+            data = r.json()
+
+        api_key = data["api_key"]
+        user = data["user"]
+        config.save({"server_url": server_url, "api_key": api_key})
+        rprint(f"[green]Account created! Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
+        rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]")
+
+        _configure_claude_code(server_url, api_key)
+
+    except httpx.HTTPStatusError as e:
+        detail = ""
+        try:
+            detail = e.response.json().get("detail", e.response.text)
+        except Exception:
+            detail = e.response.text
+        rprint(f"[red]Registration failed:[/red] {detail}")
+        raise typer.Exit(1)
+    except httpx.ConnectError:
+        rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
+        raise typer.Exit(1)
 
 
 @auth_app.command()
@@ -113,7 +173,7 @@ def init(
     server: str = typer.Option(None, "--server", "-s", help="Server URL"),
 ):
     """First-run setup (alias for login)."""
-    login(server=server, key=None, code=None, name=None)
+    login(server=server, key=None, email=None, password=None, code=None, name=None)
 
 
 @auth_app.command()
@@ -201,7 +261,7 @@ def register_deprecated_auth(app: typer.Typer):
     def deprecated_init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
         """[Deprecated] Use 'observal auth login' instead."""
         _deprecation_notice("login")
-        login(server=server, key=None, code=None, name=None)
+        login(server=server, key=None, email=None, password=None, code=None, name=None)
 
     @app.command(name="login", hidden=True)
     def deprecated_login(
@@ -211,7 +271,7 @@ def register_deprecated_auth(app: typer.Typer):
     ):
         """[Deprecated] Use 'observal auth login' instead."""
         _deprecation_notice("login")
-        login(server=server, key=key, code=code, name=None)
+        login(server=server, key=key, email=None, password=None, code=code, name=None)
 
     @app.command(name="logout", hidden=True)
     def deprecated_logout():
@@ -248,20 +308,55 @@ def _do_key_login(server_url: str, api_key: str | None = None):
     api_key = api_key or typer.prompt("API Key", hide_input=True)
     try:
         with spinner("Authenticating..."):
-            r = httpx.get(
-                f"{server_url}/api/v1/auth/whoami",
-                headers={"X-API-Key": api_key},
+            r = httpx.post(
+                f"{server_url}/api/v1/auth/login",
+                json={"api_key": api_key},
                 timeout=30,
             )
             r.raise_for_status()
-            user = r.json()
-        config.save({"server_url": server_url, "api_key": api_key})
+            data = r.json()
+        # Use the key returned by server (same key echoed back)
+        config.save({"server_url": server_url, "api_key": data.get("api_key", api_key)})
+        user = data.get("user", data)
         rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
     except httpx.ConnectError:
         rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
         raise typer.Exit(1)
     except httpx.HTTPStatusError:
         rprint("[red]Invalid API key.[/red]")
+        raise typer.Exit(1)
+
+
+def _do_password_login(server_url: str, email: str, password: str):
+    """Authenticate with email + password."""
+    try:
+        with spinner("Authenticating..."):
+            r = httpx.post(
+                f"{server_url}/api/v1/auth/login",
+                json={"email": email, "password": password},
+                timeout=30,
+            )
+            r.raise_for_status()
+            data = r.json()
+
+        api_key = data["api_key"]
+        user = data["user"]
+        config.save({"server_url": server_url, "api_key": api_key})
+        rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
+        rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]")
+
+        _configure_claude_code(server_url, api_key)
+
+    except httpx.ConnectError:
+        rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
+        raise typer.Exit(1)
+    except httpx.HTTPStatusError as e:
+        detail = ""
+        try:
+            detail = e.response.json().get("detail", e.response.text)
+        except Exception:
+            detail = e.response.text
+        rprint(f"[red]Login failed:[/red] {detail}")
         raise typer.Exit(1)
 
 

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -14,31 +15,331 @@ from rich.table import Table
 from observal_cli import client
 from observal_cli.render import console, spinner
 
-# IDE config file locations (relative to project root)
-_IDE_MCP_CONFIGS = {
+# ── IDE config file locations (relative to project root) ────
+
+_IDE_PROJECT_CONFIGS = {
     "cursor": ".cursor/mcp.json",
     "kiro": ".kiro/settings/mcp.json",
     "vscode": ".vscode/mcp.json",
-    "claude-code": ".claude/mcp.json",
     "gemini-cli": ".gemini/settings.json",
 }
 
 
-def _detect_ide(project_dir: Path) -> list[tuple[str, Path]]:
-    """Return list of (ide_name, config_path) for detected IDE configs."""
+# ── Data containers for discovered items ────────────────────
+
+
+class DiscoveredMcp:
+    def __init__(self, name: str, command: str | None, args: list[str], url: str | None, description: str, source: str):
+        self.name = name
+        self.command = command
+        self.args = args
+        self.url = url
+        self.description = description
+        self.source = source
+
+    def display_cmd(self) -> str:
+        if self.url:
+            return self.url[:60]
+        cmd = f"{self.command or '?'} {' '.join(self.args[:3])}"
+        return cmd[:60] + "..." if len(cmd) > 60 else cmd
+
+
+class DiscoveredSkill:
+    def __init__(self, name: str, description: str, source: str, task_type: str = "general"):
+        self.name = name
+        self.description = description
+        self.source = source
+        self.task_type = task_type
+
+
+class DiscoveredHook:
+    def __init__(self, name: str, event: str, handler_type: str, handler_config: dict, description: str, source: str):
+        self.name = name
+        self.event = event
+        self.handler_type = handler_type
+        self.handler_config = handler_config
+        self.description = description
+        self.source = source
+
+
+class DiscoveredAgent:
+    def __init__(self, name: str, description: str, model_name: str, prompt: str, source_file: str):
+        self.name = name
+        self.description = description
+        self.model_name = model_name
+        self.prompt = prompt
+        self.source_file = source_file
+
+
+# ── Claude Code ~/.claude scanner ───────────────────────────
+
+
+def _scan_claude_home(
+    claude_dir: Path,
+) -> tuple[list[DiscoveredMcp], list[DiscoveredSkill], list[DiscoveredHook], list[DiscoveredAgent]]:
+    """Scan ~/.claude for all component types using the real plugin system."""
+    mcps: list[DiscoveredMcp] = []
+    skills: list[DiscoveredSkill] = []
+    hooks: list[DiscoveredHook] = []
+    agents: list[DiscoveredAgent] = []
+
+    settings_file = claude_dir / "settings.json"
+    if not settings_file.exists():
+        return mcps, skills, hooks, agents
+
+    try:
+        settings = json.loads(settings_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return mcps, skills, hooks, agents
+
+    enabled_plugins = settings.get("enabledPlugins", {})
+    active_plugins = {name for name, enabled in enabled_plugins.items() if enabled}
+
+    # Load installed_plugins.json to get install paths
+    installed_file = claude_dir / "plugins" / "installed_plugins.json"
+    plugin_paths: dict[str, Path] = {}
+    if installed_file.exists():
+        try:
+            installed = json.loads(installed_file.read_text())
+            for plugin_key, entries in installed.get("plugins", {}).items():
+                if plugin_key in active_plugins and entries:
+                    install_path = entries[0].get("installPath")
+                    if install_path:
+                        plugin_paths[plugin_key] = Path(install_path)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Fallback: also scan plugin cache directly for active plugins
+    cache_dir = claude_dir / "plugins" / "cache"
+    if cache_dir.exists():
+        for plugin_key in active_plugins:
+            if plugin_key in plugin_paths:
+                continue
+            # Parse "name@marketplace" format
+            parts = plugin_key.split("@", 1)
+            name = parts[0]
+            marketplace = parts[1] if len(parts) > 1 else ""
+            # Try to find in cache
+            market_dir = cache_dir / marketplace / name if marketplace else cache_dir / name / name
+            if market_dir.exists():
+                # Pick latest version directory
+                versions = sorted(market_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True)
+                if versions:
+                    plugin_paths[plugin_key] = versions[0]
+
+    # Scan each active plugin directory
+    for plugin_key, plugin_dir in plugin_paths.items():
+        if not plugin_dir.is_dir():
+            continue
+
+        plugin_name = plugin_key.split("@")[0]
+
+        # Read plugin metadata
+        plugin_desc = f"Plugin: {plugin_name}"
+        plugin_json = plugin_dir / ".claude-plugin" / "plugin.json"
+        if plugin_json.exists():
+            try:
+                meta = json.loads(plugin_json.read_text())
+                plugin_desc = meta.get("description", plugin_desc)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        # ── Discover MCPs ───────────────────────────
+        mcp_file = plugin_dir / ".mcp.json"
+        if mcp_file.exists():
+            try:
+                mcp_data = json.loads(mcp_file.read_text())
+                servers = _extract_mcp_servers(mcp_data)
+                for srv_name, srv_config in servers.items():
+                    mcps.append(
+                        DiscoveredMcp(
+                            name=srv_name,
+                            command=srv_config.get("command"),
+                            args=srv_config.get("args", []),
+                            url=srv_config.get("url"),
+                            description=plugin_desc,
+                            source=f"plugin:{plugin_name}",
+                        )
+                    )
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        # ── Discover Skills ─────────────────────────
+        for skill_md in plugin_dir.rglob("SKILL.md"):
+            skill_name_part = skill_md.parent.name
+            # Unique name: plugin/skill
+            full_name = f"{plugin_name}/{skill_name_part}"
+            desc = ""
+            try:
+                content = skill_md.read_text()
+                desc = _parse_frontmatter_field(content, "description") or ""
+                # If no description in frontmatter, use first non-empty line after frontmatter
+                if not desc:
+                    desc = _first_content_line(content)
+            except OSError:
+                pass
+            skills.append(
+                DiscoveredSkill(
+                    name=full_name,
+                    description=desc or f"Skill from {plugin_name}",
+                    source=f"plugin:{plugin_name}",
+                )
+            )
+
+        # ── Discover Hooks ──────────────────────────
+        for hooks_file in plugin_dir.rglob("hooks.json"):
+            try:
+                hooks_data = json.loads(hooks_file.read_text())
+                hook_events = hooks_data.get("hooks", {})
+                for event_name, event_hooks in hook_events.items():
+                    hook_full_name = f"{plugin_name}/{event_name}"
+                    handler_type = "command"
+                    handler_config = {}
+                    if isinstance(event_hooks, list) and event_hooks:
+                        first = event_hooks[0]
+                        if isinstance(first, dict):
+                            inner = first.get("hooks", [first])
+                            if inner and isinstance(inner[0], dict):
+                                handler_type = inner[0].get("type", "command")
+                                handler_config = inner[0]
+                    hooks.append(
+                        DiscoveredHook(
+                            name=hook_full_name,
+                            event=event_name,
+                            handler_type=handler_type,
+                            handler_config=handler_config,
+                            description=f"Hook from {plugin_name}: {event_name}",
+                            source=f"plugin:{plugin_name}",
+                        )
+                    )
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    # ── Discover Agents from ~/.claude/agents/ ──────
+    agents_dir = claude_dir / "agents"
+    if agents_dir.is_dir():
+        for agent_md in sorted(agents_dir.glob("*.md")):
+            try:
+                content = agent_md.read_text()
+                name = agent_md.stem
+                model = _parse_frontmatter_field(content, "model") or ""
+                desc = _first_content_line(content)
+                prompt_body = _extract_body(content)
+                agents.append(
+                    DiscoveredAgent(
+                        name=name,
+                        description=desc or f"Agent: {name}",
+                        model_name=model,
+                        prompt=prompt_body,
+                        source_file=str(agent_md),
+                    )
+                )
+            except OSError:
+                pass
+
+    return mcps, skills, hooks, agents
+
+
+def _extract_mcp_servers(mcp_data: dict) -> dict[str, dict]:
+    """Extract server entries from .mcp.json, handling both formats.
+
+    Format 1 (bare): {"server-name": {"command": "...", "args": [...]}}
+    Format 2 (wrapped): {"mcpServers": {"server-name": {"command": "...", "args": [...]}}}
+    """
+    if "mcpServers" in mcp_data:
+        return mcp_data["mcpServers"]
+    # Bare format: every top-level key is a server name
+    servers = {}
+    for key, val in mcp_data.items():
+        if isinstance(val, dict) and ("command" in val or "url" in val or "type" in val):
+            servers[key] = val
+    return servers
+
+
+def _parse_frontmatter_field(content: str, field: str) -> str | None:
+    """Extract a field from YAML frontmatter (--- delimited)."""
+    match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return None
+    for line in match.group(1).splitlines():
+        if line.startswith(f"{field}:"):
+            val = line[len(field) + 1 :].strip().strip('"').strip("'")
+            return val
+    return None
+
+
+def _extract_body(content: str) -> str:
+    """Extract everything after YAML frontmatter."""
+    match = re.match(r"^---\s*\n.*?\n---\s*\n?", content, re.DOTALL)
+    if match:
+        return content[match.end():]
+    return content
+
+
+def _first_content_line(content: str) -> str:
+    """Get first non-empty, non-heading content line after frontmatter."""
+    in_frontmatter = False
+    past_frontmatter = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "---":
+            if not in_frontmatter:
+                in_frontmatter = True
+                continue
+            else:
+                past_frontmatter = True
+                continue
+        if not past_frontmatter and in_frontmatter:
+            continue
+        if past_frontmatter and stripped and not stripped.startswith("#"):
+            return stripped[:200]
+    return ""
+
+
+# ── Project-dir scanner (Cursor, VS Code, Kiro, Gemini) ────
+
+
+def _scan_project_dir(project_dir: Path, ide_filter: str | None) -> list[tuple[str, str, DiscoveredMcp, Path]]:
+    """Scan project directory for IDE MCP configs. Returns (ide, name, mcp, config_path) tuples."""
     found = []
-    for ide, rel in _IDE_MCP_CONFIGS.items():
-        p = project_dir / rel
-        if p.exists():
-            found.append((ide, p))
+    for ide, rel in _IDE_PROJECT_CONFIGS.items():
+        if ide_filter and ide != ide_filter:
+            continue
+        config_path = project_dir / rel
+        if not config_path.exists():
+            continue
+        try:
+            config = json.loads(config_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        servers = _parse_project_mcp_servers(config, ide)
+        for name, entry in servers.items():
+            if _is_already_shimmed(entry):
+                continue
+            found.append(
+                (
+                    ide,
+                    name,
+                    DiscoveredMcp(
+                        name=name,
+                        command=entry.get("command"),
+                        args=entry.get("args", []),
+                        url=entry.get("url"),
+                        description=f"MCP from {ide} config",
+                        source=f"ide:{ide}",
+                    ),
+                    config_path,
+                )
+            )
     return found
 
 
-def _parse_mcp_servers(config: dict, ide: str) -> dict[str, dict]:
-    """Extract mcpServers dict from IDE config, handling format differences."""
-    if ide == "gemini-cli":
-        return config.get("mcpServers", {})
-    # cursor, kiro, vscode, claude-code all use mcpServers at top level
+def _parse_project_mcp_servers(config: dict, ide: str) -> dict[str, dict]:
+    """Extract MCP servers dict from project-level IDE config."""
+    if ide == "vscode":
+        return config.get("servers", config.get("mcpServers", {}))
+    # cursor, kiro, gemini-cli all use mcpServers at top level
     return config.get("mcpServers", config.get("servers", {}))
 
 
@@ -54,8 +355,6 @@ def _is_already_shimmed(entry: dict) -> bool:
 def _wrap_with_shim(entry: dict, mcp_id: str) -> dict:
     """Wrap an MCP server entry with observal-shim for telemetry."""
     if entry.get("url"):
-        # HTTP transport — can't shim stdio, leave as-is for now
-        # The proxy approach would need observal-proxy, skip for scan
         return entry
 
     original_cmd = entry.get("command", "")
@@ -75,145 +374,298 @@ def _backup_config(config_path: Path) -> Path:
     return backup
 
 
+# ── CLI command ─────────────────────────────────────────────
+
+
 def register_scan(app: typer.Typer):
     @app.command(name="scan")
     def scan(
         project_dir: str = typer.Argument(".", help="Project directory to scan"),
         ide: str | None = typer.Option(None, "--ide", "-i", help="Target IDE (auto-detected if omitted)"),
-        dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show what would change without modifying files"),
+        home: bool = typer.Option(
+            False, "--home", help="Scan ~/.claude for Claude Code plugins, agents, skills, hooks"
+        ),
+        dry_run: bool = typer.Option(
+            False, "--dry-run", "-n", help="Show what would be registered without making changes"
+        ),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+        shim: bool = typer.Option(
+            False, "--shim", help="Rewrite project IDE configs to route MCPs through observal-shim"
+        ),
     ):
-        """Scan existing IDE configs, register items in Observal, and wrap with telemetry shims.
+        """Scan IDE configs and register discovered components with Observal.
 
-        Detects MCP servers from your IDE config files, registers them with Observal,
-        and rewrites configs to route through observal-shim for telemetry collection.
-        Your existing setup keeps working — the shim is transparent.
+        By default, scans the current project directory for Cursor, VS Code, Kiro,
+        and Gemini CLI MCP configs.
+
+        With --home, scans your ~/.claude directory to discover all installed
+        plugins, agents, skills, and hooks from your Claude Code setup.
         """
+        all_mcps: list[DiscoveredMcp] = []
+        all_skills: list[DiscoveredSkill] = []
+        all_hooks: list[DiscoveredHook] = []
+        all_agents: list[DiscoveredAgent] = []
+        project_mcp_entries: list[tuple[str, str, DiscoveredMcp, Path]] = []
+
+        # ── Scan ~/.claude if --home ────────────────
+        if home:
+            claude_dir = Path.home() / ".claude"
+            if not claude_dir.is_dir():
+                rprint("[red]~/.claude directory not found.[/red]")
+                raise typer.Exit(1)
+
+            with spinner("Scanning ~/.claude..."):
+                h_mcps, h_skills, h_hooks, h_agents = _scan_claude_home(claude_dir)
+            all_mcps.extend(h_mcps)
+            all_skills.extend(h_skills)
+            all_hooks.extend(h_hooks)
+            all_agents.extend(h_agents)
+
+        # ── Scan project directory ──────────────────
         root = Path(project_dir).resolve()
-        if not root.is_dir():
-            rprint(f"[red]Not a directory: {root}[/red]")
+        if root.is_dir():
+            project_mcp_entries = _scan_project_dir(root, ide)
+            # Add project MCPs to the list (dedup by name)
+            seen_names = {m.name for m in all_mcps}
+            for _ide, _name, mcp, _path in project_mcp_entries:
+                if mcp.name not in seen_names:
+                    all_mcps.append(mcp)
+                    seen_names.add(mcp.name)
+
+        total = len(all_mcps) + len(all_skills) + len(all_hooks) + len(all_agents)
+        if total == 0:
+            rprint("[yellow]No components found.[/yellow]")
+            if not home:
+                rprint("[dim]Tip: use --home to scan ~/.claude for Claude Code plugins and agents.[/dim]")
             raise typer.Exit(1)
 
-        # Detect IDEs
-        detected = _detect_ide(root)
-        if ide:
-            detected = [(i, p) for i, p in detected if i == ide]
+        # ── Display discovery results ───────────────
+        rprint(f"\n[bold]Discovered {total} components[/bold]\n")
 
-        if not detected:
-            rprint("[yellow]No IDE configs found.[/yellow]")
-            rprint(f"[dim]Looked for: {', '.join(_IDE_MCP_CONFIGS.values())}[/dim]")
-            raise typer.Exit(1)
+        if all_mcps:
+            tbl = Table(title=f"MCP Servers ({len(all_mcps)})", show_lines=False, padding=(0, 1))
+            tbl.add_column("Name", style="bold")
+            tbl.add_column("Command/URL", style="dim")
+            tbl.add_column("Source", style="cyan")
+            for m in all_mcps:
+                tbl.add_row(m.name, m.display_cmd(), m.source)
+            console.print(tbl)
+            rprint()
 
-        rprint(f"\n[bold]Scanning {root}[/bold]\n")
+        if all_skills:
+            # Show summary for skills (can be hundreds)
+            by_plugin: dict[str, int] = {}
+            for s in all_skills:
+                by_plugin[s.source] = by_plugin.get(s.source, 0) + 1
+            tbl = Table(title=f"Skills ({len(all_skills)})", show_lines=False, padding=(0, 1))
+            tbl.add_column("Source Plugin", style="cyan")
+            tbl.add_column("Count", style="bold", justify="right")
+            for src, count in sorted(by_plugin.items()):
+                tbl.add_row(src, str(count))
+            console.print(tbl)
+            rprint()
 
-        all_items = []  # (ide, name, entry, config_path)
-        for ide_name, config_path in detected:
-            try:
-                config = json.loads(config_path.read_text())
-            except (json.JSONDecodeError, OSError) as e:
-                rprint(f"[yellow]⚠ Could not parse {config_path}: {e}[/yellow]")
-                continue
+        if all_hooks:
+            tbl = Table(title=f"Hooks ({len(all_hooks)})", show_lines=False, padding=(0, 1))
+            tbl.add_column("Name", style="bold")
+            tbl.add_column("Event", style="cyan")
+            tbl.add_column("Source", style="dim")
+            for h in all_hooks:
+                tbl.add_row(h.name, h.event, h.source)
+            console.print(tbl)
+            rprint()
 
-            servers = _parse_mcp_servers(config, ide_name)
-            if not servers:
-                rprint(f"[dim]{ide_name}: no MCP servers found in {config_path}[/dim]")
-                continue
-
-            for name, entry in servers.items():
-                if _is_already_shimmed(entry):
-                    rprint(f"  [dim]⊘ {name} (already shimmed)[/dim]")
-                    continue
-                all_items.append((ide_name, name, entry, config_path))
-
-        if not all_items:
-            rprint("[green]✓ Nothing to do — all items already instrumented or no items found.[/green]")
-            return
-
-        # Show what we found
-        table = Table(title=f"Found {len(all_items)} MCP servers to instrument", show_lines=False, padding=(0, 1))
-        table.add_column("IDE", style="cyan")
-        table.add_column("Name", style="bold")
-        table.add_column("Command/URL", style="dim")
-        for ide_name, name, entry, _ in all_items:
-            cmd = entry.get("url") or f"{entry.get('command', '?')} {' '.join(entry.get('args', [])[:3])}"
-            if len(cmd) > 60:
-                cmd = cmd[:57] + "..."
-            table.add_row(ide_name, name, cmd)
-        console.print(table)
-        rprint()
+        if all_agents:
+            tbl = Table(title=f"Agents ({len(all_agents)})", show_lines=False, padding=(0, 1))
+            tbl.add_column("Name", style="bold")
+            tbl.add_column("Model", style="cyan")
+            tbl.add_column("Description", style="dim", max_width=60)
+            for a in all_agents:
+                tbl.add_row(a.name, a.model_name or "-", a.description[:60])
+            console.print(tbl)
+            rprint()
 
         if dry_run:
             rprint("[yellow]Dry run — no changes made.[/yellow]")
             return
 
-        if not yes and not typer.confirm("Register and instrument these items?"):
+        if not yes and not typer.confirm("Register these components with Observal?"):
             raise typer.Abort()
 
-        # Group by IDE for bulk registration
-        by_ide: dict[str, list[tuple[str, dict, Path]]] = {}
-        for ide_name, name, entry, config_path in all_items:
-            by_ide.setdefault(ide_name, []).append((name, entry, config_path))
+        # ── Register via bulk scan API ──────────────
+        scan_payload = {
+            "ide": "claude-code" if home else (ide or "auto"),
+            "mcps": [
+                {
+                    "name": m.name,
+                    "command": m.command,
+                    "args": m.args,
+                    "url": m.url,
+                    "description": m.description,
+                    "source_plugin": m.source,
+                }
+                for m in all_mcps
+            ],
+            "skills": [
+                {
+                    "name": s.name,
+                    "description": s.description,
+                    "source_plugin": s.source,
+                    "task_type": s.task_type,
+                }
+                for s in all_skills
+            ],
+            "hooks": [
+                {
+                    "name": h.name,
+                    "event": h.event,
+                    "handler_type": h.handler_type,
+                    "handler_config": h.handler_config,
+                    "description": h.description,
+                    "source_plugin": h.source,
+                }
+                for h in all_hooks
+            ],
+            "agents": [
+                {
+                    "name": a.name,
+                    "description": a.description,
+                    "model_name": a.model_name,
+                    "prompt": a.prompt,
+                    "source_file": a.source_file,
+                }
+                for a in all_agents
+            ],
+        }
 
-        total_registered = 0
-        total_shimmed = 0
+        with spinner(f"Registering {total} components..."):
+            try:
+                result = client.post("/api/v1/scan", scan_payload)
+            except (Exception, SystemExit) as e:
+                rprint(f"[red]Failed to register: {e}[/red]")
+                raise typer.Exit(1) from None
 
-        for ide_name, items in by_ide.items():
-            # Bulk register via /api/v1/scan
-            scan_payload = {
-                "ide": ide_name,
-                "mcps": [
-                    {
-                        "name": name,
-                        "command": entry.get("command"),
-                        "args": entry.get("args", []),
-                        "url": entry.get("url"),
-                        "env": entry.get("env", {}),
-                    }
-                    for name, entry, _ in items
-                ],
-            }
+        # Show registration results
+        new_count = 0
+        existing_count = 0
+        for reg in result.get("registered", []):
+            if reg["status"] == "created":
+                rprint(f"  [green]+ new[/green] [{reg['type']}] {reg['name']} -> {reg['id'][:8]}...")
+                new_count += 1
+            else:
+                rprint(f"  [dim]= existing[/dim] [{reg['type']}] {reg['name']}")
+                existing_count += 1
 
-            with spinner(f"Registering {len(items)} items for {ide_name}..."):
-                try:
-                    result = client.post("/api/v1/scan", scan_payload)
-                except (Exception, SystemExit) as e:
-                    rprint(f"[red]✗ Failed to register items for {ide_name}: {e}[/red]")
-                    continue
+        rprint(f"\n[green]Done![/green] {new_count} new, {existing_count} existing.")
 
-            # Build name -> id mapping
-            id_map = {}
-            for reg in result.get("registered", []):
-                id_map[reg["name"]] = reg["id"]
-                status_icon = "[green]✓ new[/green]" if reg["status"] == "created" else "[cyan]↻ existing[/cyan]"
-                rprint(f"  {status_icon} {reg['name']} → {reg['id'][:8]}…")
-                total_registered += 1
+        # ── Optionally shim project MCP configs ─────
+        if shim and project_mcp_entries:
+            id_map = {r["name"]: r["id"] for r in result.get("registered", []) if r["type"] == "mcp"}
+            shimmed_count = 0
+            configs_to_update: dict[str, dict] = {}
 
-            # Rewrite config files
-            configs_to_update: dict[str, dict] = {}  # path -> full config
-            for name, _entry, config_path in items:
+            for ide_name, name, _mcp, config_path in project_mcp_entries:
                 mcp_id = id_map.get(name)
                 if not mcp_id:
                     continue
-
                 path_str = str(config_path)
                 if path_str not in configs_to_update:
                     configs_to_update[path_str] = json.loads(config_path.read_text())
 
                 config = configs_to_update[path_str]
-                servers = _parse_mcp_servers(config, ide_name)
+                servers = _parse_project_mcp_servers(config, ide_name)
                 if name in servers and not _is_already_shimmed(servers[name]):
                     servers[name] = _wrap_with_shim(servers[name], mcp_id)
-                    total_shimmed += 1
+                    shimmed_count += 1
 
-            # Write updated configs
             for path_str, config in configs_to_update.items():
                 config_path = Path(path_str)
                 backup = _backup_config(config_path)
                 config_path.write_text(json.dumps(config, indent=2) + "\n")
                 rprint(f"  [dim]Backup: {backup.name}[/dim]")
 
-        rprint(
-            f"\n[green]✓ Done![/green] Registered {total_registered} items, instrumented {total_shimmed} with telemetry."
-        )
-        rprint("[dim]Your existing tools still work exactly the same — observal-shim is transparent.[/dim]")
-        rprint("[dim]Telemetry flows to Observal even without admin approval.[/dim]")
+            if shimmed_count:
+                rprint(f"[green]Shimmed {shimmed_count} MCP entries for telemetry.[/green]")
+
+        # ── Auto-inject hooks into ~/.claude/settings.json ─────
+        if home:
+            from observal_cli.config import load as _load_config
+
+            cfg = _load_config()
+            server_url = cfg.get("server_url", "http://localhost:8000").rstrip("/")
+            hooks_url = f"{server_url}/api/v1/otel/hooks"
+            http_hook = [{"hooks": [{"type": "http", "url": hooks_url}]}]
+
+            # Stop uses a command hook to read transcript for Claude's response
+            stop_script = Path(__file__).parent / "hooks" / "observal-stop-hook.sh"
+            stop_hook = (
+                [{"hooks": [{"type": "command", "command": str(stop_script.resolve())}]}]
+                if stop_script.is_file()
+                else http_hook
+            )
+
+            hooks_block = {
+                "SessionStart": http_hook,
+                "UserPromptSubmit": http_hook,
+                "PreToolUse": http_hook,
+                "PostToolUse": http_hook,
+                "PostToolUseFailure": http_hook,
+                "SubagentStart": http_hook,
+                "SubagentStop": http_hook,
+                "Stop": stop_hook,
+                "StopFailure": http_hook,
+                "Notification": http_hook,
+                "TaskCreated": http_hook,
+                "TaskCompleted": http_hook,
+                "PreCompact": http_hook,
+                "PostCompact": http_hook,
+                "WorktreeCreate": http_hook,
+                "WorktreeRemove": http_hook,
+                "Elicitation": http_hook,
+                "ElicitationResult": http_hook,
+            }
+
+            claude_settings = Path.home() / ".claude" / "settings.json"
+            try:
+                settings: dict = {}
+                if claude_settings.exists():
+                    settings = json.loads(claude_settings.read_text())
+
+                existing_hooks = settings.get("hooks", {})
+                needs_update = False
+
+                # Check if hooks already point to the right URL
+                for event_name, _entry in hooks_block.items():
+                    if event_name not in existing_hooks:
+                        needs_update = True
+                        break
+                    # Check URL or command matches
+                    existing_target = ""
+                    try:
+                        h = existing_hooks[event_name][0]["hooks"][0]
+                        existing_target = h.get("url") or h.get("command", "")
+                    except (KeyError, IndexError, TypeError):
+                        pass
+                    expected_target = hooks_block[event_name][0]["hooks"][0].get("url") or hooks_block[event_name][0]["hooks"][0].get("command", "")
+                    if existing_target != expected_target:
+                        needs_update = True
+                        break
+
+                if needs_update:
+                    settings["hooks"] = {**existing_hooks, **hooks_block}
+                    # Ensure the stop hook env var is set
+                    if "env" not in settings:
+                        settings["env"] = {}
+                    settings["env"]["OBSERVAL_HOOKS_URL"] = hooks_url
+                    claude_settings.write_text(json.dumps(settings, indent=2) + "\n")
+                    rprint(f"\n[green]Injected hooks config into {claude_settings}[/green]")
+                    rprint(f"[dim]Hooks endpoint: {hooks_url}[/dim]")
+                    rprint(
+                        "[dim]Captures: prompts, tool I/O, MCP responses, "
+                        "subagents, elicitations[/dim]"
+                    )
+                else:
+                    rprint(f"\n[dim]Hooks already configured -> {hooks_url}[/dim]")
+            except Exception as e:
+                rprint(f"\n[yellow]Could not auto-inject hooks: {e}[/yellow]")
+                rprint("[dim]Add hooks manually — see docs.[/dim]")

--- a/observal_cli/hooks/observal-stop-hook.sh
+++ b/observal_cli/hooks/observal-stop-hook.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# observal-stop-hook.sh — Claude Code Stop hook that captures ALL assistant
+# text responses from the current turn and sends them to Observal.
+#
+# The hook receives JSON on stdin with session_id, transcript_path, etc.
+# It reads the transcript JSONL backwards, collecting text from every
+# assistant message until it hits a user/system message (marking the
+# start of the turn), then POSTs the concatenated text to the hooks endpoint.
+
+set -eu
+# NOTE: no pipefail — tac|while causes SIGPIPE when while breaks early
+
+OBSERVAL_HOOKS_URL="${OBSERVAL_HOOKS_URL:-http://localhost:8000/api/v1/otel/hooks}"
+
+# Read hook payload from stdin
+PAYLOAD=$(cat)
+
+SESSION_ID=$(echo "$PAYLOAD" | jq -r '.session_id // ""')
+TRANSCRIPT_PATH=$(echo "$PAYLOAD" | jq -r '.transcript_path // ""')
+
+if [ -z "$SESSION_ID" ] || [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+# Collect ALL assistant text from the current turn (bottom-up until user msg).
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+# tac reads bottom-up. We collect every assistant message's text content
+# and stop when we hit a non-assistant message (user prompt = turn boundary).
+(tac "$TRANSCRIPT_PATH" || true) | while IFS= read -r line; do
+  # Detect message type
+  case "$line" in
+    *'"type":"assistant"'*)
+      TEXT=$(echo "$line" | jq -r \
+        '[.message.content[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null)
+      if [ -n "$TEXT" ]; then
+        # Prepend to tmpfile (since we're reading backwards)
+        if [ -s "$TMPFILE" ]; then
+          EXISTING=$(cat "$TMPFILE")
+          printf '%s\n\n%s' "$TEXT" "$EXISTING" > "$TMPFILE"
+        else
+          printf '%s' "$TEXT" > "$TMPFILE"
+        fi
+      fi
+      ;;
+    *'"type":"user"'*|*'"type":"human"'*)
+      # Hit a user message — this is the turn boundary, stop collecting
+      break
+      ;;
+    *)
+      # Skip system/tool_result/other non-assistant lines
+      continue
+      ;;
+  esac
+done
+
+LAST_RESPONSE=$(cat "$TMPFILE" 2>/dev/null || true)
+
+if [ -z "$LAST_RESPONSE" ]; then
+  exit 0
+fi
+
+# Truncate to 64KB
+LAST_RESPONSE=$(echo "$LAST_RESPONSE" | head -c 65536)
+
+# POST to Observal
+jq -n \
+  --arg session_id "$SESSION_ID" \
+  --arg response "$LAST_RESPONSE" \
+  '{
+    hook_event_name: "Stop",
+    session_id: $session_id,
+    tool_name: "assistant_response",
+    tool_response: $response
+  }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
+    -H "Content-Type: application/json" \
+    -d @- >/dev/null 2>&1
+
+exit 0

--- a/observal_cli/hooks/observal-stop-hook.sh
+++ b/observal_cli/hooks/observal-stop-hook.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# observal-stop-hook.sh — Claude Code Stop hook that captures ALL assistant
+# observal-stop-hook.sh — Claude Code Stop hook that captures assistant
 # text responses from the current turn and sends them to Observal.
 #
 # The hook receives JSON on stdin with session_id, transcript_path, etc.
-# It reads the transcript JSONL backwards, collecting text from every
-# assistant message until it hits a user/system message (marking the
-# start of the turn), then POSTs the concatenated text to the hooks endpoint.
+# It reads the transcript JSONL backwards, collecting each assistant
+# message as a separate event with sequence metadata, then POSTs them
+# individually to the hooks endpoint. This allows the UI to interleave
+# assistant "thinking" text between tool calls.
 
 set -eu
 # NOTE: no pipefail — tac|while causes SIGPIPE when while breaks early
@@ -22,26 +23,21 @@ if [ -z "$SESSION_ID" ] || [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH
   exit 0
 fi
 
-# Collect ALL assistant text from the current turn (bottom-up until user msg).
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
+# Collect assistant messages from the current turn (bottom-up until user msg).
+# Each assistant message becomes a separate event with a sequence number.
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
 
-# tac reads bottom-up. We collect every assistant message's text content
-# and stop when we hit a non-assistant message (user prompt = turn boundary).
+MSG_COUNT=0
+
 (tac "$TRANSCRIPT_PATH" || true) | while IFS= read -r line; do
-  # Detect message type
   case "$line" in
     *'"type":"assistant"'*)
       TEXT=$(echo "$line" | jq -r \
         '[.message.content[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null)
       if [ -n "$TEXT" ]; then
-        # Prepend to tmpfile (since we're reading backwards)
-        if [ -s "$TMPFILE" ]; then
-          EXISTING=$(cat "$TMPFILE")
-          printf '%s\n\n%s' "$TEXT" "$EXISTING" > "$TMPFILE"
-        else
-          printf '%s' "$TEXT" > "$TMPFILE"
-        fi
+        MSG_COUNT=$((MSG_COUNT + 1))
+        printf '%s' "$TEXT" > "$TMPDIR_WORK/msg_$MSG_COUNT"
       fi
       ;;
     *'"type":"user"'*|*'"type":"human"'*)
@@ -55,26 +51,39 @@ trap 'rm -f "$TMPFILE"' EXIT
   esac
 done
 
-LAST_RESPONSE=$(cat "$TMPFILE" 2>/dev/null || true)
-
-if [ -z "$LAST_RESPONSE" ]; then
+# Check if we collected anything
+MSG_FILES=$(ls "$TMPDIR_WORK"/msg_* 2>/dev/null | sort -t_ -k2 -n -r || true)
+if [ -z "$MSG_FILES" ]; then
   exit 0
 fi
 
-# Truncate to 64KB
-LAST_RESPONSE=$(echo "$LAST_RESPONSE" | head -c 65536)
+# Count total messages
+TOTAL=$(echo "$MSG_FILES" | wc -l | tr -d ' ')
 
-# POST to Observal
-jq -n \
-  --arg session_id "$SESSION_ID" \
-  --arg response "$LAST_RESPONSE" \
-  '{
-    hook_event_name: "Stop",
-    session_id: $session_id,
-    tool_name: "assistant_response",
-    tool_response: $response
-  }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
-    -H "Content-Type: application/json" \
-    -d @- >/dev/null 2>&1
+# Send each message as a separate event (in chronological order — reverse of collection)
+SEQ=0
+for f in $MSG_FILES; do
+  SEQ=$((SEQ + 1))
+  MSG_TEXT=$(cat "$f")
+
+  # Truncate to 64KB
+  MSG_TEXT=$(echo "$MSG_TEXT" | head -c 65536)
+
+  jq -n \
+    --arg session_id "$SESSION_ID" \
+    --arg response "$MSG_TEXT" \
+    --arg seq "$SEQ" \
+    --arg total "$TOTAL" \
+    '{
+      hook_event_name: "Stop",
+      session_id: $session_id,
+      tool_name: "assistant_response",
+      tool_response: $response,
+      message_sequence: ($seq | tonumber),
+      message_total: ($total | tonumber)
+    }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
+      -H "Content-Type: application/json" \
+      -d @- >/dev/null 2>&1
+done
 
 exit 0

--- a/web/src/app/(admin)/errors/page.tsx
+++ b/web/src/app/(admin)/errors/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState, useMemo, useCallback, useRef } from "react";
+import Link from "next/link";
+import { AlertTriangle, Search, ChevronDown, ChevronRight, Wrench, Bot, Square } from "lucide-react";
+import { useOtelErrors } from "@/hooks/use-api";
+import type { OtelErrorEvent } from "@/lib/types";
+import { PageHeader } from "@/components/layouts/page-header";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
+import { Input } from "@/components/ui/input";
+
+/* ── Helpers ─────────────────────────────────────────────── */
+
+type ErrorType = "tool_failure" | "stop_failure" | "api_error";
+
+function classifyError(event: OtelErrorEvent): ErrorType {
+  if (event.event_name === "hook_posttoolusefailure") return "tool_failure";
+  if (event.event_name === "hook_stopfailure") return "stop_failure";
+  return "api_error";
+}
+
+function errorTypeLabel(t: ErrorType): string {
+  switch (t) {
+    case "tool_failure": return "Tool Failure";
+    case "stop_failure": return "Stop Failure";
+    case "api_error": return "API Error";
+  }
+}
+
+function errorTypeColor(t: ErrorType): string {
+  switch (t) {
+    case "tool_failure": return "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20";
+    case "stop_failure": return "bg-red-500/10 text-red-500 border-red-500/20";
+    case "api_error": return "bg-rose-500/10 text-rose-500 border-rose-500/20";
+  }
+}
+
+function ErrorIcon({ type }: { type: ErrorType }) {
+  switch (type) {
+    case "tool_failure": return <Wrench className="h-3.5 w-3.5" />;
+    case "stop_failure": return <Square className="h-3.5 w-3.5" />;
+    case "api_error": return <AlertTriangle className="h-3.5 w-3.5" />;
+  }
+}
+
+/* ── Error row ───────────────────────────────────────────── */
+
+function ErrorRow({ event }: { event: OtelErrorEvent }) {
+  const [expanded, setExpanded] = useState(false);
+  const type = classifyError(event);
+  const colorCls = errorTypeColor(type);
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-start gap-2.5 w-full text-left py-2.5 px-3 hover:bg-muted/30 transition-colors"
+      >
+        {expanded
+          ? <ChevronDown className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+          : <ChevronRight className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />}
+        <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-medium border ${colorCls} shrink-0`}>
+          <ErrorIcon type={type} />
+          {errorTypeLabel(type)}
+        </span>
+        {event.tool_name && (
+          <span className="text-xs font-medium bg-muted px-1.5 py-0.5 rounded shrink-0">
+            {event.tool_name}
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground truncate flex-1">
+          {event.error || event.body || "Unknown error"}
+        </span>
+        {event.agent_type && (
+          <span className="text-[10px] bg-indigo-500/10 text-indigo-500 px-1.5 py-0.5 rounded shrink-0">
+            <Bot className="h-2.5 w-2.5 inline mr-0.5" />{event.agent_type}
+          </span>
+        )}
+        <span className="text-[10px] text-muted-foreground tabular-nums shrink-0 mt-0.5">
+          {new Date(event.timestamp).toLocaleString()}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border px-4 py-3 space-y-3 bg-muted/10">
+          {/* Error detail */}
+          {event.error && (
+            <div className="space-y-1">
+              <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Error</span>
+              <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-all bg-red-500/5 border border-red-500/20 rounded-md p-2.5 max-h-[200px] overflow-auto text-red-600 dark:text-red-400">
+                {event.error}
+              </pre>
+            </div>
+          )}
+
+          {/* Tool input that caused the error */}
+          {event.tool_input && (
+            <div className="space-y-1">
+              <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Tool Input</span>
+              <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-all bg-background/50 border border-border rounded-md p-2.5 max-h-[200px] overflow-auto">
+                {(() => {
+                  try { return JSON.stringify(JSON.parse(event.tool_input), null, 2); } catch { return event.tool_input; }
+                })()}
+              </pre>
+            </div>
+          )}
+
+          {/* Tool response (may contain error details) */}
+          {event.tool_response && (
+            <div className="space-y-1">
+              <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Tool Response</span>
+              <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-all bg-background/50 border border-border rounded-md p-2.5 max-h-[200px] overflow-auto">
+                {event.tool_response.substring(0, 2000)}
+              </pre>
+            </div>
+          )}
+
+          {/* Metadata */}
+          <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
+            <span>
+              Session:{" "}
+              <Link href={`/traces/${event.session_id}`} className="text-primary-accent hover:underline font-[family-name:var(--font-mono)]">
+                {event.session_id.slice(0, 12)}...
+              </Link>
+            </span>
+            {event.agent_type && <span>Agent: {event.agent_type}</span>}
+            {event.stop_reason && <span>Reason: {event.stop_reason}</span>}
+            {event.user_id && <span>User: {event.user_id.slice(0, 8)}...</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Page ─────────────────────────────────────────────────── */
+
+export default function ErrorsPage() {
+  const { data: errors, isLoading, isError, error, refetch } = useOtelErrors();
+
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState<ErrorType | "all">("all");
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  const handleSearch = useCallback((value: string) => {
+    setSearch(value);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setDebouncedSearch(value), 300);
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!errors) return [];
+    const q = debouncedSearch.toLowerCase();
+    return errors.filter((e) => {
+      if (typeFilter !== "all" && classifyError(e) !== typeFilter) return false;
+      if (q) {
+        const searchable = [e.tool_name, e.error, e.body, e.agent_type, e.session_id].join(" ").toLowerCase();
+        if (!searchable.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [errors, typeFilter, debouncedSearch]);
+
+  // Counts by type
+  const counts = useMemo(() => {
+    if (!errors) return { tool_failure: 0, stop_failure: 0, api_error: 0 };
+    const c = { tool_failure: 0, stop_failure: 0, api_error: 0 };
+    for (const e of errors) c[classifyError(e)]++;
+    return c;
+  }, [errors]);
+
+  return (
+    <>
+      <PageHeader
+        title="Errors"
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Errors" },
+        ]}
+      />
+      <div className="p-6 max-w-5xl mx-auto space-y-4">
+        {isLoading ? (
+          <TableSkeleton rows={6} cols={4} />
+        ) : isError ? (
+          <ErrorState message={error?.message} onRetry={() => refetch()} />
+        ) : (errors ?? []).length === 0 ? (
+          <EmptyState
+            icon={AlertTriangle}
+            title="No errors"
+            description="Error events from tool failures, API errors, and stop failures will appear here."
+          />
+        ) : (
+          <div className="animate-in space-y-4">
+            {/* Filters */}
+            <div className="flex items-center gap-3 flex-wrap">
+              <div className="relative max-w-sm flex-1">
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                <Input
+                  placeholder="Search errors, tools, sessions..."
+                  value={search}
+                  onChange={(e) => handleSearch(e.target.value)}
+                  className="pl-8 h-8 text-sm"
+                />
+              </div>
+              <div className="flex gap-1.5">
+                {(["all", "tool_failure", "stop_failure", "api_error"] as const).map((t) => {
+                  const active = typeFilter === t;
+                  const count = t === "all" ? (errors?.length ?? 0) : counts[t];
+                  const label = t === "all" ? "All" : errorTypeLabel(t);
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => setTypeFilter(t)}
+                      className={`px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors ${
+                        active
+                          ? "bg-foreground text-background border-foreground"
+                          : "bg-muted/50 text-muted-foreground border-border hover:bg-muted"
+                      }`}
+                    >
+                      {label} {count}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Error list */}
+            <div className="space-y-2">
+              {filtered.map((evt, i) => (
+                <ErrorRow key={`${evt.timestamp}-${i}`} event={evt} />
+              ))}
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              {filtered.length} of {errors?.length ?? 0} error{(errors?.length ?? 0) !== 1 ? "s" : ""}
+            </p>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -1,19 +1,137 @@
 "use client";
 
-import { Settings } from "lucide-react";
+import { useState, useCallback } from "react";
+import { Settings, Plus, Pencil, Trash2, Save, X, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { useAdminSettings } from "@/hooks/use-api";
 import type { AdminSetting } from "@/lib/types";
+import { admin } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
-import { EmptyState } from "@/components/shared/empty-state";
+
+function SettingRow({
+  setting,
+  onSaved,
+  onDeleted,
+}: {
+  setting: { key: string; value: string };
+  onSaved: () => void;
+  onDeleted: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(setting.value);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      await admin.updateSetting(setting.key, { value });
+      toast.success(`Updated ${setting.key}`);
+      setEditing(false);
+      onSaved();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [setting.key, value, onSaved]);
+
+  const handleDelete = useCallback(async () => {
+    setSaving(true);
+    try {
+      await admin.updateSetting(setting.key, { value: "" });
+      toast.success(`Deleted ${setting.key}`);
+      onDeleted();
+    } catch {
+      toast.error("Failed to delete");
+    } finally {
+      setSaving(false);
+    }
+  }, [setting.key, onDeleted]);
+
+  return (
+    <div className="flex items-start gap-4 py-3 border-b border-border last:border-b-0 group">
+      <span className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground shrink-0 min-w-[220px] pt-1.5 select-all">
+        {setting.key}
+      </span>
+      {editing ? (
+        <div className="flex items-center gap-2 flex-1">
+          <Input
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="h-8 text-sm flex-1"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSave();
+              if (e.key === "Escape") { setEditing(false); setValue(setting.value); }
+            }}
+            autoFocus
+          />
+          <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={handleSave} disabled={saving}>
+            {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+          </Button>
+          <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={() => { setEditing(false); setValue(setting.value); }}>
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 flex-1">
+          <span className="text-sm text-foreground break-all flex-1">{setting.value || <span className="text-muted-foreground italic">empty</span>}</span>
+          <div className="opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
+            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => setEditing(true)}>
+              <Pencil className="h-3 w-3 text-muted-foreground" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={handleDelete}>
+              <Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const DEFAULT_SETTINGS = [
+  { key: "telemetry.otlp_endpoint", description: "OpenTelemetry collector endpoint" },
+  { key: "telemetry.enabled", description: "Enable/disable telemetry collection" },
+  { key: "registry.auto_approve", description: "Auto-approve new submissions" },
+  { key: "registry.max_agents_per_user", description: "Maximum agents per user" },
+  { key: "eval.default_window_size", description: "Default eval window size" },
+  { key: "hooks.auth_required", description: "Require auth for hook endpoints" },
+];
 
 export default function SettingsPage() {
   const { data: settings, isLoading, isError, error, refetch } = useAdminSettings();
+  const [addingKey, setAddingKey] = useState("");
+  const [addingValue, setAddingValue] = useState("");
+  const [showAdd, setShowAdd] = useState(false);
+  const [saving, setSaving] = useState(false);
 
-  const entries: [string, unknown][] = Array.isArray(settings)
-    ? settings.map((s: AdminSetting) => [s.key, s.value])
-    : Object.entries(settings ?? {});
+  const entries: { key: string; value: string }[] = Array.isArray(settings)
+    ? settings.map((s: AdminSetting) => ({ key: s.key, value: s.value }))
+    : Object.entries(settings ?? {}).map(([k, v]) => ({ key: k, value: String(v) }));
+
+  const existingKeys = new Set(entries.map((e) => e.key));
+  const missingDefaults = DEFAULT_SETTINGS.filter((d) => !existingKeys.has(d.key));
+
+  const handleAdd = useCallback(async () => {
+    if (!addingKey.trim()) return;
+    setSaving(true);
+    try {
+      await admin.updateSetting(addingKey.trim(), { value: addingValue });
+      toast.success(`Added ${addingKey.trim()}`);
+      setAddingKey("");
+      setAddingValue("");
+      setShowAdd(false);
+      refetch();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to add setting");
+    } finally {
+      setSaving(false);
+    }
+  }, [addingKey, addingValue, refetch]);
 
   return (
     <>
@@ -23,35 +141,91 @@ export default function SettingsPage() {
           { label: "Dashboard", href: "/dashboard" },
           { label: "Settings" },
         ]}
+        actionButtonsRight={
+          <Button size="sm" variant="outline" onClick={() => setShowAdd(true)} className="h-8">
+            <Plus className="mr-1 h-3.5 w-3.5" /> Add Setting
+          </Button>
+        }
       />
-      <div className="p-6 max-w-6xl mx-auto space-y-4">
+      <div className="p-6 max-w-4xl mx-auto space-y-6">
         {isLoading ? (
           <TableSkeleton rows={5} cols={2} />
         ) : isError ? (
           <ErrorState message={error?.message} onRetry={() => refetch()} />
-        ) : entries.length === 0 ? (
-          <EmptyState
-            icon={Settings}
-            title="No settings configured"
-            description="System settings will appear here once they are configured."
-          />
         ) : (
-          <div className="animate-in space-y-0">
-            {entries.map(([key, value], i) => (
-              <div
-                key={key}
-                className={`flex items-start gap-6 py-3 ${
-                  i < entries.length - 1 ? "border-b border-border" : ""
-                }`}
-              >
-                <span className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground shrink-0 min-w-[180px] pt-0.5 select-all">
-                  {key}
-                </span>
-                <span className="text-sm text-foreground break-all">
-                  {String(value)}
-                </span>
+          <div className="animate-in space-y-6">
+            {/* Add new setting form */}
+            {showAdd && (
+              <div className="rounded-md border border-primary/30 bg-primary/5 p-4 space-y-3">
+                <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">New Setting</h4>
+                <div className="flex gap-3">
+                  <Input
+                    placeholder="setting.key"
+                    value={addingKey}
+                    onChange={(e) => setAddingKey(e.target.value)}
+                    className="h-8 text-sm max-w-[260px] font-[family-name:var(--font-mono)]"
+                    autoFocus
+                  />
+                  <Input
+                    placeholder="value"
+                    value={addingValue}
+                    onChange={(e) => setAddingValue(e.target.value)}
+                    className="h-8 text-sm flex-1"
+                    onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+                  />
+                  <Button size="sm" className="h-8" onClick={handleAdd} disabled={saving || !addingKey.trim()}>
+                    {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Save"}
+                  </Button>
+                  <Button size="sm" variant="ghost" className="h-8" onClick={() => setShowAdd(false)}>
+                    Cancel
+                  </Button>
+                </div>
               </div>
-            ))}
+            )}
+
+            {/* Current settings */}
+            {entries.length > 0 && (
+              <section>
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+                  Active Settings
+                </h3>
+                <div className="rounded-md border border-border bg-card px-4">
+                  {entries.map((s) => (
+                    <SettingRow key={s.key} setting={s} onSaved={() => refetch()} onDeleted={() => refetch()} />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Suggested defaults */}
+            {missingDefaults.length > 0 && (
+              <section>
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+                  Suggested Settings
+                </h3>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  {missingDefaults.map((d) => (
+                    <button
+                      key={d.key}
+                      type="button"
+                      onClick={() => { setAddingKey(d.key); setAddingValue(""); setShowAdd(true); }}
+                      className="text-left rounded-md border border-dashed border-border p-3 hover:bg-muted/30 transition-colors"
+                    >
+                      <span className="block text-xs font-[family-name:var(--font-mono)] text-foreground">{d.key}</span>
+                      <span className="block text-[11px] text-muted-foreground mt-0.5">{d.description}</span>
+                    </button>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {entries.length === 0 && !showAdd && (
+              <div className="text-center py-12">
+                <Settings className="h-8 w-8 text-muted-foreground/40 mx-auto mb-3" />
+                <h3 className="text-sm font-medium">No settings configured</h3>
+                <p className="text-xs text-muted-foreground mt-1">Click suggested settings below or add your own.</p>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -869,7 +869,8 @@ function TurnNode({ turn, index, expandedSet, onToggleEvent, activeFilters, sear
   const nodeKey = `turn-${index}`;
   const isOpen = expandedSet.has(nodeKey);
   const attrs = turn.promptEvent?.attributes ?? {};
-  const promptPreview = (attrs.tool_input || attrs.prompt_text || "").slice(0, 120);
+  const fullPrompt = attrs.tool_input || attrs.prompt_text || "";
+  const promptPreview = fullPrompt.slice(0, 80);
 
   const filteredTop = filterTurnEvents(turn.topLevelEvents, activeFilters, searchQuery);
   const hasMatchingAgents = turn.agents.some((a) => {
@@ -915,8 +916,8 @@ function TurnNode({ turn, index, expandedSet, onToggleEvent, activeFilters, sear
             </div>
           </div>
           {promptPreview && (
-            <p className="text-xs text-muted-foreground mt-1 truncate max-w-2xl">
-              {promptPreview}{(attrs.tool_input?.length ?? 0) > 120 ? "..." : ""}
+            <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-2xl">
+              {promptPreview}{fullPrompt.length > 80 ? "…" : ""}
             </p>
           )}
         </div>
@@ -930,6 +931,18 @@ function TurnNode({ turn, index, expandedSet, onToggleEvent, activeFilters, sear
       {/* Turn children */}
       {isOpen && (
         <div className="border-t border-border">
+          {/* Full user prompt */}
+          {fullPrompt && (
+            <div className="mx-3 mt-3 mb-2 rounded-md border border-purple-500/20 bg-purple-500/5 overflow-hidden">
+              <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-purple-500/10">
+                <MessageSquare className="h-3 w-3 text-purple-500" />
+                <span className="text-[11px] font-medium text-purple-600 dark:text-purple-400">User Prompt</span>
+              </div>
+              <div className="px-3 py-2.5 text-sm text-foreground whitespace-pre-wrap break-words leading-relaxed max-h-[300px] overflow-auto">
+                {fullPrompt}
+              </div>
+            </div>
+          )}
           {/* Top-level events (not inside any agent) */}
           {filteredTop.map((evt, i) => {
             const key = `turn-${index}-evt-${i}`;

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -721,6 +721,48 @@ function HookMetaGrid({ attrs }: { attrs: Record<string, string> }) {
   );
 }
 
+/* ── Assistant response block ──────────────────────────────── */
+
+function AssistantResponseBlock({ event }: { event: RawOtelEvent }) {
+  const [expanded, setExpanded] = useState(false);
+  const attrs = event.attributes ?? {};
+  const fullResponse = attrs.tool_response || "";
+  const seq = attrs.message_sequence;
+  const total = attrs.message_total;
+  const seqLabel = seq && total ? ` (${seq}/${total})` : "";
+  const lines = fullResponse.split("\n");
+  const isLong = lines.length > 15;
+  const shown = isLong && !expanded ? lines.slice(0, 15).join("\n") + "\n…" : fullResponse;
+
+  if (!fullResponse) return null;
+
+  return (
+    <div className="mx-3 mt-2 mb-3 rounded-md border border-violet-500/20 bg-violet-500/5 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-violet-500/10">
+        <Bot className="h-3 w-3 text-violet-500" />
+        <span className="text-[11px] font-medium text-violet-600 dark:text-violet-400">Assistant Response{seqLabel}</span>
+        {event.timestamp && (
+          <span className="ml-auto text-[10px] text-muted-foreground tabular-nums">
+            {new Date(event.timestamp).toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+      <div className="px-3 py-2.5 text-sm text-foreground whitespace-pre-wrap break-words leading-relaxed max-h-[400px] overflow-auto">
+        {shown}
+      </div>
+      {isLong && (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="w-full text-center py-1 text-[11px] text-violet-500 hover:underline border-t border-violet-500/10"
+        >
+          {expanded ? "Show less" : `Show all ${lines.length} lines`}
+        </button>
+      )}
+    </div>
+  );
+}
+
 /* ── Friendly event label ────────────────────────────────── */
 
 function eventLabel(evt: RawOtelEvent): string {
@@ -800,7 +842,23 @@ function AgentNode({ agent, expandedSet, onToggleEvent, activeFilters, searchQue
   const nodeKey = `agent-${agent.agentId}`;
   const isOpen = expandedSet.has(nodeKey);
   const filtered = filterTurnEvents(agent.events, activeFilters, searchQuery);
-  const totalInAgent = agent.events.length;
+
+  // Compute agent-level token stats
+  const agentTokens = useMemo(() => {
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let toolCount = 0;
+    for (const evt of agent.events) {
+      const en = getEventName(evt);
+      const a = evt.attributes ?? {};
+      if (en === "api_request") {
+        inputTokens += parseInt(a.input_tokens || "0", 10);
+        outputTokens += parseInt(a.output_tokens || "0", 10);
+      }
+      if (en === "hook_posttooluse" || en === "tool_result") toolCount++;
+    }
+    return { inputTokens, outputTokens, toolCount };
+  }, [agent.events]);
 
   if (filtered.length === 0 && activeFilters.size > 0) return null;
 
@@ -817,7 +875,11 @@ function AgentNode({ agent, expandedSet, onToggleEvent, activeFilters, searchQue
           : <ChevronRight className="h-3.5 w-3.5 text-indigo-500 shrink-0" />}
         <Users className="h-3.5 w-3.5 text-indigo-500 shrink-0" />
         <span className="text-xs font-semibold text-indigo-600 dark:text-indigo-400">{agent.agentType}</span>
-        <Badge variant="muted">{filtered.length} event{filtered.length !== 1 ? "s" : ""}</Badge>
+        <div className="flex items-center gap-1.5">
+          {agentTokens.toolCount > 0 && <Badge variant="muted"><Wrench className="h-2.5 w-2.5 mr-0.5 inline" />{agentTokens.toolCount}</Badge>}
+          {agentTokens.inputTokens > 0 && <Badge variant="muted">{formatTokens(agentTokens.inputTokens)} in</Badge>}
+          {agentTokens.outputTokens > 0 && <Badge variant="muted">{formatTokens(agentTokens.outputTokens)} out</Badge>}
+        </div>
         {agent.startEvent?.timestamp && (
           <span className="ml-auto text-[10px] text-muted-foreground tabular-nums shrink-0">
             {new Date(agent.startEvent.timestamp).toLocaleTimeString()}
@@ -845,9 +907,9 @@ function AgentNode({ agent, expandedSet, onToggleEvent, activeFilters, searchQue
               );
             })
           )}
-          {totalInAgent > filtered.length && activeFilters.size > 0 && (
+          {agent.events.length > filtered.length && activeFilters.size > 0 && (
             <p className="text-[10px] text-muted-foreground pl-4 py-1">
-              {totalInAgent - filtered.length} event{totalInAgent - filtered.length !== 1 ? "s" : ""} hidden by filters
+              {agent.events.length - filtered.length} event{agent.events.length - filtered.length !== 1 ? "s" : ""} hidden by filters
             </p>
           )}
         </div>
@@ -970,34 +1032,8 @@ function TurnNode({ turn, index, expandedSet, onToggleEvent, activeFilters, sear
             />
           ))}
 
-          {/* Response at the bottom of the turn */}
-          {turn.responseEvent && (() => {
-            const key = `turn-${index}-response`;
-            const respAttrs = turn.responseEvent.attributes ?? {};
-            const preview = (respAttrs.tool_response || "").slice(0, 200);
-            return (
-              <div>
-                <button
-                  type="button"
-                  onClick={() => onToggleEvent(key)}
-                  className="flex items-center gap-2 w-full text-left py-1.5 px-3 hover:bg-violet-500/5 transition-colors"
-                  style={{ paddingLeft: "32px" }}
-                >
-                  {expandedSet.has(key)
-                    ? <ChevronDown className="h-3 w-3 text-violet-500 shrink-0" />
-                    : <ChevronRight className="h-3 w-3 text-violet-500 shrink-0" />}
-                  <Bot className="h-3.5 w-3.5 text-violet-500 shrink-0" />
-                  <span className="text-xs font-medium text-violet-600 dark:text-violet-400 w-20 shrink-0">response</span>
-                  <span className="text-xs text-muted-foreground truncate flex-1">{preview}{preview.length >= 200 ? "..." : ""}</span>
-                </button>
-                {expandedSet.has(key) && turn.responseEvent && (
-                  <div style={{ paddingLeft: "20px" }}>
-                    <EventDetail event={turn.responseEvent} />
-                  </div>
-                )}
-              </div>
-            );
-          })()}
+          {/* Assistant response */}
+          {turn.responseEvent && <AssistantResponseBlock event={turn.responseEvent} />}
 
           {/* Turn end marker */}
           {turn.stopEvent && (

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -506,6 +506,125 @@ function EventSummary({ event }: { event: RawOtelEvent }) {
 
 /* ── Pretty JSON / content block ──────────────────────── */
 
+/* ── Simple line diff (no external dep) ─────────────────── */
+
+function computeLineDiff(oldStr: string, newStr: string): { type: "same" | "add" | "remove"; text: string }[] {
+  const oldLines = oldStr.split("\n");
+  const newLines = newStr.split("\n");
+
+  // Simple LCS-based diff for reasonable sizes (< 500 lines each)
+  // For very large diffs, fall back to showing old/new blocks
+  if (oldLines.length > 500 || newLines.length > 500) {
+    return [
+      ...oldLines.map((l) => ({ type: "remove" as const, text: l })),
+      ...newLines.map((l) => ({ type: "add" as const, text: l })),
+    ];
+  }
+
+  const m = oldLines.length;
+  const n = newLines.length;
+  // Build LCS table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = oldLines[i - 1] === newLines[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+  // Backtrack
+  const result: { type: "same" | "add" | "remove"; text: string }[] = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      result.push({ type: "same", text: oldLines[i - 1] });
+      i--; j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.push({ type: "add", text: newLines[j - 1] });
+      j--;
+    } else {
+      result.push({ type: "remove", text: oldLines[i - 1] });
+      i--;
+    }
+  }
+  result.reverse();
+  return result;
+}
+
+function DiffBlock({ filePath, oldStr, newStr }: { filePath: string; oldStr: string; newStr: string }) {
+  const [showFull, setShowFull] = useState(false);
+  const diff = useMemo(() => computeLineDiff(oldStr, newStr), [oldStr, newStr]);
+  const changedCount = diff.filter((d) => d.type !== "same").length;
+  const addCount = diff.filter((d) => d.type === "add").length;
+  const removeCount = diff.filter((d) => d.type === "remove").length;
+
+  // Collapse to context: show 3 lines around changes
+  const contextLines = 3;
+  const visible = showFull
+    ? diff
+    : diff.reduce<(typeof diff[0] | { type: "collapse"; count: number })[]>((acc, line, idx) => {
+        const nearChange = diff.slice(Math.max(0, idx - contextLines), Math.min(diff.length, idx + contextLines + 1)).some((d) => d.type !== "same");
+        if (nearChange || line.type !== "same") {
+          acc.push(line);
+        } else {
+          const prev = acc[acc.length - 1];
+          if (prev && "count" in prev) {
+            prev.count++;
+          } else {
+            acc.push({ type: "collapse", count: 1 });
+          }
+        }
+        return acc;
+      }, []);
+
+  // Line numbers
+  let oldLine = 1;
+  let newLine = 1;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Diff</span>
+        <span className="text-[11px] font-[family-name:var(--font-mono)] text-muted-foreground">{filePath.split("/").pop()}</span>
+        <span className="text-[11px] text-emerald-500">+{addCount}</span>
+        <span className="text-[11px] text-red-400">-{removeCount}</span>
+      </div>
+      <div className="text-xs font-[family-name:var(--font-mono)] border border-border rounded-md overflow-hidden max-h-[400px] overflow-auto">
+        {visible.map((line, idx) => {
+          if ("count" in line) {
+            return (
+              <div key={idx} className="px-2 py-0.5 text-muted-foreground bg-muted/30 text-center text-[10px]">
+                ··· {line.count} unchanged lines ···
+              </div>
+            );
+          }
+          const bgCls = line.type === "add" ? "bg-emerald-500/10" : line.type === "remove" ? "bg-red-500/10" : "";
+          const textCls = line.type === "add" ? "text-emerald-600 dark:text-emerald-400" : line.type === "remove" ? "text-red-400" : "text-foreground/60";
+          const prefix = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
+          const ln = line.type === "remove" ? oldLine : line.type === "add" ? newLine : oldLine;
+          if (line.type === "remove" || line.type === "same") oldLine++;
+          if (line.type === "add" || line.type === "same") newLine++;
+          return (
+            <div key={idx} className={`flex ${bgCls} hover:brightness-95`}>
+              <span className="w-8 shrink-0 text-right pr-1 text-muted-foreground/40 select-none">{ln}</span>
+              <span className={`px-1 select-none ${textCls}`}>{prefix}</span>
+              <span className={`whitespace-pre-wrap break-all ${textCls}`}>{line.text || " "}</span>
+            </div>
+          );
+        })}
+      </div>
+      {changedCount > 0 && !showFull && diff.length > 20 && (
+        <button type="button" onClick={() => setShowFull(true)} className="text-[11px] text-primary-accent hover:underline">
+          Show full diff ({diff.length} lines)
+        </button>
+      )}
+      {showFull && (
+        <button type="button" onClick={() => setShowFull(false)} className="text-[11px] text-primary-accent hover:underline">
+          Show context only
+        </button>
+      )}
+    </div>
+  );
+}
+
 function ContentBlock({ label, content }: { label: string; content: string }) {
   let display = content;
   let isJson = false;
@@ -542,10 +661,27 @@ function EventDetail({ event }: { event: RawOtelEvent }) {
   const eName = getEventName(event);
 
   if (isHookEvent(eName) && (attrs.tool_input || attrs.tool_response)) {
+    // Try to render a diff view for Edit tool events
+    const toolName = attrs.tool_name ?? "";
+    let diffView: React.ReactNode = null;
+
+    if (toolName === "Edit" && attrs.tool_input) {
+      try {
+        const parsed = JSON.parse(attrs.tool_input);
+        if (parsed.old_string && parsed.new_string) {
+          diffView = <DiffBlock filePath={parsed.file_path || "unknown"} oldStr={parsed.old_string} newStr={parsed.new_string} />;
+        }
+      } catch { /* not valid JSON, fall through */ }
+    }
+
     return (
       <div className="ml-6 mr-3 mb-2 mt-1 space-y-3">
-        {attrs.tool_input && <ContentBlock label="Input" content={attrs.tool_input} />}
-        {attrs.tool_response && <ContentBlock label="Response" content={attrs.tool_response} />}
+        {diffView || (
+          <>
+            {attrs.tool_input && <ContentBlock label="Input" content={attrs.tool_input} />}
+            {attrs.tool_response && <ContentBlock label="Response" content={attrs.tool_response} />}
+          </>
+        )}
         <HookMetaGrid attrs={attrs} />
       </div>
     );

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState, useCallback, useMemo } from "react";
+import { use, useState, useCallback, useMemo, createElement } from "react";
 import { useOtelSession } from "@/hooks/use-api";
 import type { OtelSessionData, RawOtelEvent } from "@/lib/types";
 import {
@@ -663,20 +663,22 @@ function EventDetail({ event }: { event: RawOtelEvent }) {
   if (isHookEvent(eName) && (attrs.tool_input || attrs.tool_response)) {
     // Try to render a diff view for Edit tool events
     const toolName = attrs.tool_name ?? "";
-    let diffView: React.ReactNode = null;
+    let diffView: { filePath: string; oldStr: string; newStr: string } | null = null;
 
     if (toolName === "Edit" && attrs.tool_input) {
       try {
         const parsed = JSON.parse(attrs.tool_input);
         if (parsed.old_string && parsed.new_string) {
-          diffView = <DiffBlock filePath={parsed.file_path || "unknown"} oldStr={parsed.old_string} newStr={parsed.new_string} />;
+          diffView = { filePath: parsed.file_path || "unknown", oldStr: parsed.old_string, newStr: parsed.new_string };
         }
       } catch { /* not valid JSON, fall through */ }
     }
 
     return (
       <div className="ml-6 mr-3 mb-2 mt-1 space-y-3">
-        {diffView || (
+        {diffView ? (
+          <DiffBlock filePath={diffView.filePath} oldStr={diffView.oldStr} newStr={diffView.newStr} />
+        ) : (
           <>
             {attrs.tool_input && <ContentBlock label="Input" content={attrs.tool_input} />}
             {attrs.tool_response && <ContentBlock label="Response" content={attrs.tool_response} />}
@@ -794,7 +796,7 @@ function LeafEvent({ event, isExpanded, onToggle, depth = 0 }: {
 }) {
   const eName = getEventName(event);
   const attrs = event.attributes ?? {};
-  const Icon = eventIcon(eName);
+  const icon = eventIcon(eName);
   const color = eventColor(eName);
 
   return (
@@ -808,7 +810,7 @@ function LeafEvent({ event, isExpanded, onToggle, depth = 0 }: {
         {isExpanded
           ? <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
           : <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />}
-        <Icon className={`h-3.5 w-3.5 shrink-0 ${color}`} />
+        {createElement(icon, { className: `h-3.5 w-3.5 shrink-0 ${color}` })}
         <span className="text-xs font-medium w-24 shrink-0 truncate">{eventLabel(event)}</span>
         {attrs.agent_id && (
           <span className="text-[10px] px-1 py-0.5 rounded bg-indigo-500/10 text-indigo-500 font-medium shrink-0">
@@ -935,10 +937,6 @@ function TurnNode({ turn, index, expandedSet, onToggleEvent, activeFilters, sear
   const promptPreview = fullPrompt.slice(0, 80);
 
   const filteredTop = filterTurnEvents(turn.topLevelEvents, activeFilters, searchQuery);
-  const hasMatchingAgents = turn.agents.some((a) => {
-    const agentFiltered = filterTurnEvents(a.events, activeFilters, searchQuery);
-    return agentFiltered.length > 0 || activeFilters.size === 0;
-  });
 
   // Count totals for the turn
   const toolCount = turn.allEvents.filter((e) => {

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -175,30 +175,70 @@ function deduplicateEvents(events: RawOtelEvent[]): RawOtelEvent[] {
   const hasHooks = events.some((e) => isHookEvent(getEventName(e)));
   if (!hasHooks) return events;
 
-  // Build a set of tool_use_ids covered by hooks
-  const hookToolUseIds = new Set<string>();
+  // OTEL tool_result events have rich metadata (duration_ms, success,
+  // tool_result_size_bytes) but NO tool_use_id. Hook PostToolUse events have
+  // rich content (tool_input, tool_response) and a tool_use_id.
+  // Merge strategy: match by tool_name + timestamp proximity (within 50ms).
+
+  // Index OTEL tool_result events by tool_name for proximity matching
+  const otelToolResults: { ts: number; attrs: Record<string, string>; matched: boolean }[] = [];
   for (const evt of events) {
     const eName = getEventName(evt);
-    const tuid = evt.attributes?.tool_use_id;
-    if (tuid && isHookEvent(eName)) hookToolUseIds.add(tuid);
+    if (eName === "tool_result") {
+      otelToolResults.push({
+        ts: new Date(evt.timestamp).getTime(),
+        attrs: evt.attributes ?? {},
+        matched: false,
+      });
+    }
   }
 
-  return events.filter((evt) => {
+  const result: RawOtelEvent[] = [];
+  for (const evt of events) {
     const eName = getEventName(evt);
 
-    // Remove OTEL user_prompt when we have hook_userpromptsubmit (hooks have full text)
-    if (eName === "user_prompt" && hasHooks) return false;
+    // Drop OTEL user_prompt when hooks have the richer version
+    if (eName === "user_prompt" && hasHooks) continue;
 
-    // Remove OTEL tool_decision/tool_result when hooks cover the same tool call
-    if (eName === "tool_decision" || eName === "tool_result") {
-      const tuid = evt.attributes?.tool_use_id;
-      if (tuid && hookToolUseIds.has(tuid)) return false;
-      // Even without matching tool_use_id, if hooks exist, they're richer
-      if (hasHooks) return false;
+    // Drop OTEL tool_decision / tool_result — their metadata gets merged into hooks below
+    if ((eName === "tool_decision" || eName === "tool_result") && hasHooks) continue;
+
+    // For hook PostToolUse, find the closest OTEL tool_result with same tool_name
+    // and merge its metadata (duration_ms, success, tool_result_size_bytes)
+    if (eName === "hook_posttooluse") {
+      const hookTs = new Date(evt.timestamp).getTime();
+      const hookTool = evt.attributes?.tool_name ?? "";
+
+      let bestIdx = -1;
+      let bestDiff = Infinity;
+      for (let i = 0; i < otelToolResults.length; i++) {
+        const o = otelToolResults[i];
+        if (o.matched) continue;
+        if (o.attrs.tool_name !== hookTool) continue;
+        const diff = Math.abs(o.ts - hookTs);
+        if (diff < bestDiff && diff <= 50) {
+          bestDiff = diff;
+          bestIdx = i;
+        }
+      }
+
+      if (bestIdx >= 0) {
+        otelToolResults[bestIdx].matched = true;
+        const otelAttrs = otelToolResults[bestIdx].attrs;
+        // Merge OTEL fields the hook doesn't have (don't overwrite hook's richer content)
+        const merged = { ...evt.attributes };
+        for (const [k, v] of Object.entries(otelAttrs)) {
+          if (!merged[k] || merged[k] === "") merged[k] = v;
+        }
+        result.push({ ...evt, attributes: merged });
+        continue;
+      }
     }
 
-    return true;
-  });
+    result.push(evt);
+  }
+
+  return result;
 }
 
 function buildEventTree(events: RawOtelEvent[]): { turns: Turn[]; preSessionEvents: RawOtelEvent[] } {
@@ -378,9 +418,13 @@ function EventSummary({ event }: { event: RawOtelEvent }) {
   }
 
   if (eName === "hook_posttooluse" || eName === "hook_pretooluse") {
+    const success = attrs.success !== undefined ? attrs.success === "true" : undefined;
     return (
       <div className="flex items-center gap-3 flex-wrap">
-        <Badge variant={eName === "hook_posttooluse" ? "success" : "muted"}>{attrs.tool_name || "?"}</Badge>
+        <Badge variant={success === false ? "warning" : eName === "hook_posttooluse" ? "success" : "muted"}>{attrs.tool_name || "?"}</Badge>
+        {attrs.duration_ms && <Stat label="" value={formatDuration(attrs.duration_ms)} icon={Clock} />}
+        {attrs.tool_result_size_bytes && <Stat label="size" value={`${formatTokens(attrs.tool_result_size_bytes)}B`} />}
+        {success === false && <Badge variant="warning">failed</Badge>}
       </div>
     );
   }

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -27,6 +27,7 @@ import {
   Minimize2,
   GitBranch,
   LogIn,
+  Users,
 } from "lucide-react";
 import { PageHeader } from "@/components/layouts/page-header";
 import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
@@ -79,13 +80,17 @@ function isHookEvent(eventName: string): boolean {
   return eventName.startsWith("hook_");
 }
 
+function getEventName(evt: RawOtelEvent): string {
+  return evt.attributes?.["event.name"] || evt.event_name;
+}
+
 function eventIcon(eventName: string) {
   if (eventName === "api_request") return Cpu;
   if (eventName === "tool_result") return Wrench;
   if (eventName === "tool_decision") return ShieldCheck;
   if (eventName === "user_prompt" || eventName === "hook_userpromptsubmit") return MessageSquare;
-  if (eventName === "hook_posttoolusetools" || eventName === "hook_posttooluse") return Wrench;
-  if (eventName === "hook_pretoolusetools" || eventName === "hook_pretooluse") return ShieldCheck;
+  if (eventName === "hook_posttooluse") return Wrench;
+  if (eventName === "hook_pretooluse") return ShieldCheck;
   if (eventName === "hook_posttoolusefailure") return AlertTriangle;
   if (eventName === "hook_subagentstart") return Play;
   if (eventName === "hook_subagentstop") return Square;
@@ -144,11 +149,198 @@ const FILTER_CATEGORIES: FilterCategory[] = [
   { key: "errors", label: "Errors", match: (e) => e === "hook_posttoolusefailure" || e === "hook_stopfailure", color: "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20" },
 ];
 
+/* ── Tree data structures ────────────────────────────────── */
+
+interface AgentScope {
+  agentId: string;
+  agentType: string;
+  startEvent?: RawOtelEvent;
+  stopEvent?: RawOtelEvent;
+  events: RawOtelEvent[];
+}
+
+interface Turn {
+  promptEvent?: RawOtelEvent;           // The user prompt that started this turn
+  responseEvent?: RawOtelEvent;         // The assistant response text
+  stopEvent?: RawOtelEvent;             // The stop/end event
+  topLevelEvents: RawOtelEvent[];       // Events not inside any subagent
+  agents: AgentScope[];                 // Subagent scopes with their events
+  allEvents: RawOtelEvent[];            // All events in this turn (for counting)
+}
+
+/* ── Dedup + Tree builder ────────────────────────────────── */
+
+function deduplicateEvents(events: RawOtelEvent[]): RawOtelEvent[] {
+  // Check if we have hook data at all
+  const hasHooks = events.some((e) => isHookEvent(getEventName(e)));
+  if (!hasHooks) return events;
+
+  // Build a set of tool_use_ids covered by hooks
+  const hookToolUseIds = new Set<string>();
+  for (const evt of events) {
+    const eName = getEventName(evt);
+    const tuid = evt.attributes?.tool_use_id;
+    if (tuid && isHookEvent(eName)) hookToolUseIds.add(tuid);
+  }
+
+  return events.filter((evt) => {
+    const eName = getEventName(evt);
+
+    // Remove OTEL user_prompt when we have hook_userpromptsubmit (hooks have full text)
+    if (eName === "user_prompt" && hasHooks) return false;
+
+    // Remove OTEL tool_decision/tool_result when hooks cover the same tool call
+    if (eName === "tool_decision" || eName === "tool_result") {
+      const tuid = evt.attributes?.tool_use_id;
+      if (tuid && hookToolUseIds.has(tuid)) return false;
+      // Even without matching tool_use_id, if hooks exist, they're richer
+      if (hasHooks) return false;
+    }
+
+    return true;
+  });
+}
+
+function buildEventTree(events: RawOtelEvent[]): { turns: Turn[]; preSessionEvents: RawOtelEvent[] } {
+  const deduped = deduplicateEvents(events);
+  const turns: Turn[] = [];
+  const preSessionEvents: RawOtelEvent[] = [];
+
+  let currentTurn: Turn | null = null;
+  // Track open agent scopes by agent_id
+  const openAgents = new Map<string, AgentScope>();
+
+  for (const evt of deduped) {
+    const eName = getEventName(evt);
+    const attrs = evt.attributes ?? {};
+
+    // Turn boundary: new prompt starts a turn
+    if (eName === "hook_userpromptsubmit" || eName === "user_prompt") {
+      // Close previous turn if open
+      if (currentTurn) {
+        turns.push(currentTurn);
+        openAgents.clear();
+      }
+      currentTurn = {
+        promptEvent: evt,
+        topLevelEvents: [],
+        agents: [],
+        allEvents: [evt],
+      };
+      continue;
+    }
+
+    // If no turn started yet, these are pre-session events (session start, etc.)
+    if (!currentTurn) {
+      preSessionEvents.push(evt);
+      continue;
+    }
+
+    currentTurn.allEvents.push(evt);
+
+    // SubagentStart: open an agent scope
+    if (eName === "hook_subagentstart") {
+      const agentId = attrs.agent_id || `agent-${currentTurn.agents.length}`;
+      const scope: AgentScope = {
+        agentId,
+        agentType: attrs.agent_type || "agent",
+        startEvent: evt,
+        events: [],
+      };
+      openAgents.set(agentId, scope);
+      currentTurn.agents.push(scope);
+      continue;
+    }
+
+    // SubagentStop: close the agent scope
+    if (eName === "hook_subagentstop") {
+      const agentId = attrs.agent_id || "";
+      const scope = openAgents.get(agentId);
+      if (scope) {
+        scope.stopEvent = evt;
+        openAgents.delete(agentId);
+      } else {
+        // Unmatched stop — add to top level
+        currentTurn.topLevelEvents.push(evt);
+      }
+      continue;
+    }
+
+    // Assistant response: mark on the turn
+    if (eName === "hook_assistant_response") {
+      currentTurn.responseEvent = evt;
+      continue;
+    }
+
+    // Stop events: mark turn end
+    if (eName === "hook_stop" || eName === "hook_stopfailure") {
+      currentTurn.stopEvent = evt;
+      continue;
+    }
+
+    // Regular events: check if they belong to an open agent scope
+    const evtAgentId = attrs.agent_id;
+    if (evtAgentId && openAgents.has(evtAgentId)) {
+      openAgents.get(evtAgentId)!.events.push(evt);
+    } else {
+      currentTurn.topLevelEvents.push(evt);
+    }
+  }
+
+  // Push final turn
+  if (currentTurn) turns.push(currentTurn);
+
+  return { turns, preSessionEvents };
+}
+
+/* ── Search helper ───────────────────────────────────────── */
+
+function eventMatchesSearch(evt: RawOtelEvent, q: string): boolean {
+  const attrs = evt.attributes ?? {};
+  const eName = getEventName(evt);
+  return (
+    eName.toLowerCase().includes(q) ||
+    (evt.body || "").toLowerCase().includes(q) ||
+    (attrs.tool_name || "").toLowerCase().includes(q) ||
+    (attrs.tool_input || "").toLowerCase().includes(q) ||
+    (attrs.tool_response || "").toLowerCase().includes(q) ||
+    (attrs.agent_type || "").toLowerCase().includes(q) ||
+    (attrs.agent_id || "").toLowerCase().includes(q) ||
+    (attrs.error || "").toLowerCase().includes(q) ||
+    (attrs.task_subject || "").toLowerCase().includes(q)
+  );
+}
+
+function eventMatchesFilter(evt: RawOtelEvent, activeFilters: Set<string>): boolean {
+  if (activeFilters.size === 0) return true;
+  const eName = getEventName(evt);
+  const activeCategories = FILTER_CATEGORIES.filter((c) => activeFilters.has(c.key));
+  return activeCategories.some((cat) => cat.match(eName));
+}
+
+function turnMatchesFilters(turn: Turn, activeFilters: Set<string>, searchQuery: string): boolean {
+  const q = searchQuery.toLowerCase();
+  return turn.allEvents.some((evt) => {
+    if (!eventMatchesFilter(evt, activeFilters)) return false;
+    if (q && !eventMatchesSearch(evt, q)) return false;
+    return true;
+  });
+}
+
+function filterTurnEvents(events: RawOtelEvent[], activeFilters: Set<string>, searchQuery: string): RawOtelEvent[] {
+  const q = searchQuery.toLowerCase();
+  return events.filter((evt) => {
+    if (!eventMatchesFilter(evt, activeFilters)) return false;
+    if (q && !eventMatchesSearch(evt, q)) return false;
+    return true;
+  });
+}
+
 /* ── Event inline summary (shown without expanding) ────── */
 
 function EventSummary({ event }: { event: RawOtelEvent }) {
   const attrs = event.attributes ?? {};
-  const eName = attrs["event.name"] || event.event_name;
+  const eName = getEventName(event);
 
   if (eName === "api_request") {
     return (
@@ -170,9 +362,6 @@ function EventSummary({ event }: { event: RawOtelEvent }) {
       <div className="flex items-center gap-3 flex-wrap">
         <Badge variant={success ? "success" : "warning"}>{attrs.tool_name || "?"}</Badge>
         {attrs.duration_ms && <Stat label="" value={formatDuration(attrs.duration_ms)} icon={Clock} />}
-        {attrs.tool_result_size_bytes && (
-          <Stat label="size" value={`${formatTokens(attrs.tool_result_size_bytes)}B`} />
-        )}
         {!success && <Badge variant="warning">failed</Badge>}
       </div>
     );
@@ -183,163 +372,87 @@ function EventSummary({ event }: { event: RawOtelEvent }) {
     return (
       <div className="flex items-center gap-3 flex-wrap">
         <Badge variant={accepted ? "muted" : "warning"}>{attrs.tool_name || "?"}</Badge>
-        <span className="text-xs text-muted-foreground">
-          {accepted ? "accepted" : "rejected"} via {attrs.source || "?"}
-        </span>
+        <span className="text-xs text-muted-foreground">{accepted ? "accepted" : "rejected"}</span>
       </div>
     );
   }
 
-  if (eName === "user_prompt") {
-    return (
-      <div className="flex items-center gap-3">
-        {attrs.prompt_length && <Stat label="length" value={`${attrs.prompt_length} chars`} />}
-      </div>
-    );
-  }
-
-  // Hook: user prompt
-  if (eName === "hook_userpromptsubmit") {
-    const preview = (attrs.tool_input || "").slice(0, 120);
-    return (
-      <div className="flex items-center gap-3 flex-wrap min-w-0">
-        <Badge variant="default">prompt</Badge>
-        {preview && <span className="text-xs text-muted-foreground truncate max-w-md">{preview}{(attrs.tool_input?.length ?? 0) > 120 ? "..." : ""}</span>}
-        {attrs.prompt_length && <Stat label="" value={`${attrs.prompt_length} chars`} />}
-      </div>
-    );
-  }
-
-  // Hook: tool use (PostToolUse / PreToolUse)
   if (eName === "hook_posttooluse" || eName === "hook_pretooluse") {
     return (
       <div className="flex items-center gap-3 flex-wrap">
         <Badge variant={eName === "hook_posttooluse" ? "success" : "muted"}>{attrs.tool_name || "?"}</Badge>
-        <span className="text-[11px] text-muted-foreground">{attrs.hook_event}</span>
       </div>
     );
   }
 
-  // Hook: subagent events
-  if (eName === "hook_subagentstart" || eName === "hook_subagentstop") {
-    return (
-      <div className="flex items-center gap-3 flex-wrap">
-        <Badge variant="default">{attrs.agent_type || "agent"}</Badge>
-        <span className="text-xs text-muted-foreground">{eName === "hook_subagentstart" ? "spawned" : "finished"}</span>
-      </div>
-    );
-  }
-
-  // Hook: MCP elicitation
-  if (eName === "hook_elicitation" || eName === "hook_elicitationresult") {
-    return (
-      <div className="flex items-center gap-3 flex-wrap">
-        <Badge variant="default">{attrs.mcp_server_name || "MCP"}</Badge>
-        <span className="text-xs text-muted-foreground">{eName === "hook_elicitation" ? "requesting input" : "got response"}</span>
-      </div>
-    );
-  }
-
-  // Hook: assistant response (Claude's text output)
-  if (eName === "hook_assistant_response") {
-    const preview = (attrs.tool_response || "").slice(0, 140);
-    return (
-      <div className="flex items-center gap-3 flex-wrap min-w-0">
-        <Badge variant="default">response</Badge>
-        {preview && <span className="text-xs text-muted-foreground truncate max-w-lg">{preview}{(attrs.tool_response?.length ?? 0) > 140 ? "..." : ""}</span>}
-      </div>
-    );
-  }
-
-  // Hook: stop
-  if (eName === "hook_stop") {
-    return (
-      <div className="flex items-center gap-3">
-        <Badge variant="muted">{attrs.stop_reason || "end_turn"}</Badge>
-      </div>
-    );
-  }
-
-  // Hook: tool failure
   if (eName === "hook_posttoolusefailure") {
     return (
       <div className="flex items-center gap-3 flex-wrap">
         <Badge variant="warning">{attrs.tool_name || "?"}</Badge>
         <span className="text-xs text-red-500">failed</span>
-        {attrs.error && <span className="text-xs text-muted-foreground truncate max-w-md">{attrs.error.slice(0, 100)}</span>}
+        {attrs.error && <span className="text-xs text-muted-foreground truncate max-w-md">{attrs.error.slice(0, 80)}</span>}
       </div>
     );
   }
 
-  // Hook: stop failure (API error)
   if (eName === "hook_stopfailure") {
     return (
       <div className="flex items-center gap-3 flex-wrap">
         <Badge variant="warning">API error</Badge>
-        {attrs.error && <span className="text-xs text-red-500 truncate max-w-md">{attrs.error.slice(0, 100)}</span>}
+        {attrs.error && <span className="text-xs text-red-500 truncate max-w-md">{attrs.error.slice(0, 80)}</span>}
       </div>
     );
   }
 
-  // Hook: session start
   if (eName === "hook_sessionstart") {
-    return (
-      <div className="flex items-center gap-3">
-        <Badge variant="success">{attrs.session_resumed === "True" ? "resumed" : "new session"}</Badge>
-      </div>
-    );
+    return <Badge variant="success">{attrs.session_resumed === "True" ? "resumed" : "new session"}</Badge>;
   }
 
-  // Hook: notification
   if (eName === "hook_notification") {
-    const title = attrs.notification_title || "";
-    const msg = (attrs.tool_response || "").slice(0, 100);
     return (
       <div className="flex items-center gap-3 flex-wrap">
-        {title && <Badge variant="default">{title}</Badge>}
-        {msg && <span className="text-xs text-muted-foreground truncate max-w-md">{msg}</span>}
+        {attrs.notification_title && <Badge>{attrs.notification_title}</Badge>}
+        {attrs.tool_response && <span className="text-xs text-muted-foreground truncate max-w-md">{attrs.tool_response.slice(0, 80)}</span>}
       </div>
     );
   }
 
-  // Hook: tasks
   if (eName === "hook_taskcreated" || eName === "hook_taskcompleted") {
     return (
       <div className="flex items-center gap-3 flex-wrap">
         <Badge variant={eName === "hook_taskcompleted" ? "success" : "default"}>
           {attrs.task_subject || attrs.task_id || "task"}
         </Badge>
-        <span className="text-xs text-muted-foreground">{eName === "hook_taskcreated" ? "created" : "completed"}</span>
       </div>
     );
   }
 
-  // Hook: compaction
   if (eName === "hook_precompact" || eName === "hook_postcompact") {
-    return (
-      <div className="flex items-center gap-3">
-        <Badge variant="muted">{eName === "hook_precompact" ? "compacting context" : "context compacted"}</Badge>
-      </div>
-    );
+    return <Badge variant="muted">{eName === "hook_precompact" ? "compacting" : "compacted"}</Badge>;
   }
 
-  // Hook: worktree
   if (eName === "hook_worktreecreate" || eName === "hook_worktreeremove") {
     return (
       <div className="flex items-center gap-3 flex-wrap">
-        <Badge variant="default">{attrs.branch || "worktree"}</Badge>
+        <Badge>{attrs.branch || "worktree"}</Badge>
         <span className="text-xs text-muted-foreground">{eName === "hook_worktreecreate" ? "created" : "removed"}</span>
       </div>
     );
   }
 
-  // Generic hook events
-  if (isHookEvent(eName)) {
-    const hookType = attrs.hook_event || eName.replace("hook_", "");
+  if (eName === "hook_elicitation" || eName === "hook_elicitationresult") {
     return (
       <div className="flex items-center gap-3 flex-wrap">
-        <Badge variant="default">{attrs.tool_name || attrs.agent_type || "?"}</Badge>
-        <span className="text-xs text-muted-foreground">{hookType}</span>
+        <Badge>{attrs.mcp_server_name || "MCP"}</Badge>
+        <span className="text-xs text-muted-foreground">{eName === "hook_elicitation" ? "ask" : "reply"}</span>
+      </div>
+    );
+  }
+
+  if (isHookEvent(eName)) {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge>{attrs.tool_name || attrs.agent_type || eName.replace("hook_", "")}</Badge>
       </div>
     );
   }
@@ -350,21 +463,17 @@ function EventSummary({ event }: { event: RawOtelEvent }) {
 /* ── Pretty JSON / content block ──────────────────────── */
 
 function ContentBlock({ label, content }: { label: string; content: string }) {
-  // Try to parse and pretty-print JSON
   let display = content;
   let isJson = false;
   try {
     const parsed = JSON.parse(content);
     display = JSON.stringify(parsed, null, 2);
     isJson = true;
-  } catch {
-    // Not JSON — show as-is
-  }
+  } catch { /* not JSON */ }
 
   const lines = display.split("\n").length;
   const isLong = lines > 20;
   const [showFull, setShowFull] = useState(false);
-
   const shown = isLong && !showFull ? display.split("\n").slice(0, 20).join("\n") + "\n..." : display;
 
   return (
@@ -374,11 +483,7 @@ function ContentBlock({ label, content }: { label: string; content: string }) {
         {shown}
       </pre>
       {isLong && (
-        <button
-          type="button"
-          onClick={() => setShowFull(!showFull)}
-          className="text-[11px] text-primary-accent hover:underline"
-        >
+        <button type="button" onClick={() => setShowFull(!showFull)} className="text-[11px] text-primary-accent hover:underline">
           {showFull ? "Show less" : `Show all ${lines} lines`}
         </button>
       )}
@@ -390,30 +495,20 @@ function ContentBlock({ label, content }: { label: string; content: string }) {
 
 function EventDetail({ event }: { event: RawOtelEvent }) {
   const attrs = event.attributes ?? {};
-  const eName = attrs["event.name"] || event.event_name;
+  const eName = getEventName(event);
 
-  // For hook events, show tool_input and tool_response as rich content blocks
   if (isHookEvent(eName) && (attrs.tool_input || attrs.tool_response)) {
     return (
       <div className="ml-6 mr-3 mb-2 mt-1 space-y-3">
-        {attrs.tool_input && (
-          <ContentBlock label="Input" content={attrs.tool_input} />
-        )}
-        {attrs.tool_response && (
-          <ContentBlock label="Response" content={attrs.tool_response} />
-        )}
-        {/* Show other attrs in a compact grid below */}
+        {attrs.tool_input && <ContentBlock label="Input" content={attrs.tool_input} />}
+        {attrs.tool_response && <ContentBlock label="Response" content={attrs.tool_response} />}
         <HookMetaGrid attrs={attrs} />
       </div>
     );
   }
 
-  // Default: attribute grid for OTEL events
   const skip = new Set(["event.name", "event.sequence", "event.timestamp", "session.id", "user.id", "terminal.type", "prompt.id"]);
-  const entries = Object.entries(attrs)
-    .filter(([k]) => !skip.has(k))
-    .sort(([a], [b]) => a.localeCompare(b));
-
+  const entries = Object.entries(attrs).filter(([k]) => !skip.has(k)).sort(([a], [b]) => a.localeCompare(b));
   if (entries.length === 0) return null;
 
   return (
@@ -432,9 +527,7 @@ function EventDetail({ event }: { event: RawOtelEvent }) {
 
 function HookMetaGrid({ attrs }: { attrs: Record<string, string> }) {
   const skip = new Set(["event.name", "session.id", "tool_input", "tool_response", "hook_event", "tool_name"]);
-  const entries = Object.entries(attrs)
-    .filter(([k]) => !skip.has(k))
-    .sort(([a], [b]) => a.localeCompare(b));
+  const entries = Object.entries(attrs).filter(([k]) => !skip.has(k)).sort(([a], [b]) => a.localeCompare(b));
   if (entries.length === 0) return null;
   return (
     <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-0.5 text-xs font-[family-name:var(--font-mono)] bg-surface-sunken rounded-md p-2">
@@ -448,19 +541,37 @@ function HookMetaGrid({ attrs }: { attrs: Record<string, string> }) {
   );
 }
 
-/* ── Event row ─────────────────────────────────────────── */
+/* ── Friendly event label ────────────────────────────────── */
 
-function EventRow({
-  event,
-  isExpanded,
-  onToggle,
-}: {
+function eventLabel(evt: RawOtelEvent): string {
+  const eName = getEventName(evt);
+  const attrs = evt.attributes ?? {};
+  if (eName === "hook_posttooluse" || eName === "hook_pretooluse") return attrs.tool_name || "tool";
+  if (eName === "hook_posttoolusefailure") return attrs.tool_name || "tool fail";
+  if (eName === "hook_taskcreated") return "task new";
+  if (eName === "hook_taskcompleted") return "task done";
+  if (eName === "hook_precompact") return "compact";
+  if (eName === "hook_postcompact") return "compacted";
+  if (eName === "hook_worktreecreate") return "worktree+";
+  if (eName === "hook_worktreeremove") return "worktree-";
+  if (eName === "hook_elicitation") return "MCP ask";
+  if (eName === "hook_elicitationresult") return "MCP reply";
+  if (eName === "hook_notification") return "notify";
+  if (eName === "hook_sessionstart") return "session";
+  if (isHookEvent(eName)) return attrs.tool_name || eName.replace("hook_", "");
+  return eName;
+}
+
+/* ── Leaf event row (used inside tree) ───────────────────── */
+
+function LeafEvent({ event, isExpanded, onToggle, depth = 0 }: {
   event: RawOtelEvent;
   isExpanded: boolean;
   onToggle: () => void;
+  depth?: number;
 }) {
+  const eName = getEventName(event);
   const attrs = event.attributes ?? {};
-  const eName = attrs["event.name"] || event.event_name;
   const Icon = eventIcon(eName);
   const color = eventColor(eName);
 
@@ -469,37 +580,14 @@ function EventRow({
       <button
         type="button"
         onClick={onToggle}
-        className="flex items-center gap-2 w-full text-left py-2 px-3 rounded-md hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/20"
+        className="flex items-center gap-2 w-full text-left py-1.5 px-3 rounded-md hover:bg-muted/50 transition-colors"
+        style={{ paddingLeft: `${12 + depth * 20}px` }}
       >
-        {isExpanded ? (
-          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-        ) : (
-          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-        )}
+        {isExpanded
+          ? <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
+          : <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />}
         <Icon className={`h-3.5 w-3.5 shrink-0 ${color}`} />
-        <span className="text-sm font-medium w-28 shrink-0">
-          {eName === "hook_assistant_response" ? "response" :
-           eName === "hook_userpromptsubmit" ? "prompt" :
-           eName === "hook_posttooluse" ? (attrs.tool_name || "tool") :
-           eName === "hook_pretooluse" ? (attrs.tool_name || "tool") :
-           eName === "hook_posttoolusefailure" ? (attrs.tool_name || "tool fail") :
-           eName === "hook_subagentstart" ? "agent start" :
-           eName === "hook_subagentstop" ? "agent stop" :
-           eName === "hook_stop" ? "turn end" :
-           eName === "hook_stopfailure" ? "API error" :
-           eName === "hook_sessionstart" ? "session" :
-           eName === "hook_notification" ? "notify" :
-           eName === "hook_taskcreated" ? "task new" :
-           eName === "hook_taskcompleted" ? "task done" :
-           eName === "hook_precompact" ? "compact" :
-           eName === "hook_postcompact" ? "compacted" :
-           eName === "hook_worktreecreate" ? "worktree+" :
-           eName === "hook_worktreeremove" ? "worktree-" :
-           eName === "hook_elicitation" ? "MCP ask" :
-           eName === "hook_elicitationresult" ? "MCP reply" :
-           isHookEvent(eName) ? (attrs.tool_name || eName) :
-           eName}
-        </span>
+        <span className="text-xs font-medium w-24 shrink-0 truncate">{eventLabel(event)}</span>
         {attrs.agent_id && (
           <span className="text-[10px] px-1 py-0.5 rounded bg-indigo-500/10 text-indigo-500 font-medium shrink-0">
             {attrs.agent_type || "agent"}
@@ -509,12 +597,227 @@ function EventRow({
           <EventSummary event={event} />
         </div>
         {event.timestamp && (
-          <span className="ml-auto text-[11px] text-muted-foreground tabular-nums shrink-0 pl-2">
+          <span className="ml-auto text-[10px] text-muted-foreground tabular-nums shrink-0 pl-2">
             {new Date(event.timestamp).toLocaleTimeString()}
           </span>
         )}
       </button>
-      {isExpanded && <EventDetail event={event} />}
+      {isExpanded && <div style={{ paddingLeft: `${depth * 20}px` }}><EventDetail event={event} /></div>}
+    </div>
+  );
+}
+
+/* ── Agent scope node (collapsible sub-tree) ─────────────── */
+
+function AgentNode({ agent, expandedSet, onToggleEvent, activeFilters, searchQuery, depth = 1 }: {
+  agent: AgentScope;
+  expandedSet: Set<string>;
+  onToggleEvent: (key: string) => void;
+  activeFilters: Set<string>;
+  searchQuery: string;
+  depth?: number;
+}) {
+  const nodeKey = `agent-${agent.agentId}`;
+  const isOpen = expandedSet.has(nodeKey);
+  const filtered = filterTurnEvents(agent.events, activeFilters, searchQuery);
+  const totalInAgent = agent.events.length;
+
+  if (filtered.length === 0 && activeFilters.size > 0) return null;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => onToggleEvent(nodeKey)}
+        className="flex items-center gap-2 w-full text-left py-1.5 px-3 rounded-md hover:bg-indigo-500/5 transition-colors"
+        style={{ paddingLeft: `${12 + depth * 20}px` }}
+      >
+        {isOpen
+          ? <ChevronDown className="h-3.5 w-3.5 text-indigo-500 shrink-0" />
+          : <ChevronRight className="h-3.5 w-3.5 text-indigo-500 shrink-0" />}
+        <Users className="h-3.5 w-3.5 text-indigo-500 shrink-0" />
+        <span className="text-xs font-semibold text-indigo-600 dark:text-indigo-400">{agent.agentType}</span>
+        <Badge variant="muted">{filtered.length} event{filtered.length !== 1 ? "s" : ""}</Badge>
+        {agent.startEvent?.timestamp && (
+          <span className="ml-auto text-[10px] text-muted-foreground tabular-nums shrink-0">
+            {new Date(agent.startEvent.timestamp).toLocaleTimeString()}
+            {agent.stopEvent?.timestamp && (
+              <> — {new Date(agent.stopEvent.timestamp).toLocaleTimeString()}</>
+            )}
+          </span>
+        )}
+      </button>
+      {isOpen && (
+        <div className="border-l-2 border-indigo-500/20" style={{ marginLeft: `${22 + depth * 20}px` }}>
+          {filtered.length === 0 ? (
+            <p className="text-xs text-muted-foreground py-2 pl-4">No matching events in this agent.</p>
+          ) : (
+            filtered.map((evt, i) => {
+              const key = `agent-${agent.agentId}-evt-${i}`;
+              return (
+                <LeafEvent
+                  key={key}
+                  event={evt}
+                  isExpanded={expandedSet.has(key)}
+                  onToggle={() => onToggleEvent(key)}
+                  depth={depth + 1}
+                />
+              );
+            })
+          )}
+          {totalInAgent > filtered.length && activeFilters.size > 0 && (
+            <p className="text-[10px] text-muted-foreground pl-4 py-1">
+              {totalInAgent - filtered.length} event{totalInAgent - filtered.length !== 1 ? "s" : ""} hidden by filters
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Turn node (collapsible root) ────────────────────────── */
+
+function TurnNode({ turn, index, expandedSet, onToggleEvent, activeFilters, searchQuery }: {
+  turn: Turn;
+  index: number;
+  expandedSet: Set<string>;
+  onToggleEvent: (key: string) => void;
+  activeFilters: Set<string>;
+  searchQuery: string;
+}) {
+  const nodeKey = `turn-${index}`;
+  const isOpen = expandedSet.has(nodeKey);
+  const attrs = turn.promptEvent?.attributes ?? {};
+  const promptPreview = (attrs.tool_input || attrs.prompt_text || "").slice(0, 120);
+
+  const filteredTop = filterTurnEvents(turn.topLevelEvents, activeFilters, searchQuery);
+  const hasMatchingAgents = turn.agents.some((a) => {
+    const agentFiltered = filterTurnEvents(a.events, activeFilters, searchQuery);
+    return agentFiltered.length > 0 || activeFilters.size === 0;
+  });
+
+  // Count totals for the turn
+  const toolCount = turn.allEvents.filter((e) => {
+    const en = getEventName(e);
+    return en === "hook_posttooluse" || en === "hook_pretooluse" || en === "tool_result";
+  }).length;
+  const apiCount = turn.allEvents.filter((e) => getEventName(e) === "api_request").length;
+  const agentCount = turn.agents.length;
+
+  // Timestamps
+  const startTime = turn.promptEvent?.timestamp;
+  const endTime = turn.stopEvent?.timestamp || turn.responseEvent?.timestamp;
+  const duration = startTime && endTime
+    ? new Date(endTime).getTime() - new Date(startTime).getTime()
+    : null;
+
+  return (
+    <div className="rounded-lg border border-border overflow-hidden">
+      {/* Turn header */}
+      <button
+        type="button"
+        onClick={() => onToggleEvent(nodeKey)}
+        className="flex items-start gap-2 w-full text-left py-2.5 px-3 hover:bg-purple-500/5 transition-colors"
+      >
+        {isOpen
+          ? <ChevronDown className="h-4 w-4 text-purple-500 mt-0.5 shrink-0" />
+          : <ChevronRight className="h-4 w-4 text-purple-500 mt-0.5 shrink-0" />}
+        <MessageSquare className="h-4 w-4 text-purple-500 mt-0.5 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-semibold">Turn {index + 1}</span>
+            <div className="flex items-center gap-1.5">
+              {toolCount > 0 && <Badge variant="muted"><Wrench className="h-2.5 w-2.5 mr-0.5 inline" />{toolCount}</Badge>}
+              {apiCount > 0 && <Badge variant="muted"><Cpu className="h-2.5 w-2.5 mr-0.5 inline" />{apiCount}</Badge>}
+              {agentCount > 0 && <Badge variant="default"><Users className="h-2.5 w-2.5 mr-0.5 inline" />{agentCount}</Badge>}
+              {duration !== null && <Stat label="" value={formatDuration(duration)} icon={Clock} />}
+            </div>
+          </div>
+          {promptPreview && (
+            <p className="text-xs text-muted-foreground mt-1 truncate max-w-2xl">
+              {promptPreview}{(attrs.tool_input?.length ?? 0) > 120 ? "..." : ""}
+            </p>
+          )}
+        </div>
+        {startTime && (
+          <span className="text-[10px] text-muted-foreground tabular-nums shrink-0 mt-1">
+            {new Date(startTime).toLocaleTimeString()}
+          </span>
+        )}
+      </button>
+
+      {/* Turn children */}
+      {isOpen && (
+        <div className="border-t border-border">
+          {/* Top-level events (not inside any agent) */}
+          {filteredTop.map((evt, i) => {
+            const key = `turn-${index}-evt-${i}`;
+            return (
+              <LeafEvent
+                key={key}
+                event={evt}
+                isExpanded={expandedSet.has(key)}
+                onToggle={() => onToggleEvent(key)}
+                depth={1}
+              />
+            );
+          })}
+
+          {/* Agent sub-trees */}
+          {turn.agents.map((agent, ai) => (
+            <AgentNode
+              key={`turn-${index}-agent-${ai}`}
+              agent={agent}
+              expandedSet={expandedSet}
+              onToggleEvent={onToggleEvent}
+              activeFilters={activeFilters}
+              searchQuery={searchQuery}
+              depth={1}
+            />
+          ))}
+
+          {/* Response at the bottom of the turn */}
+          {turn.responseEvent && (() => {
+            const key = `turn-${index}-response`;
+            const respAttrs = turn.responseEvent.attributes ?? {};
+            const preview = (respAttrs.tool_response || "").slice(0, 200);
+            return (
+              <div>
+                <button
+                  type="button"
+                  onClick={() => onToggleEvent(key)}
+                  className="flex items-center gap-2 w-full text-left py-1.5 px-3 hover:bg-violet-500/5 transition-colors"
+                  style={{ paddingLeft: "32px" }}
+                >
+                  {expandedSet.has(key)
+                    ? <ChevronDown className="h-3 w-3 text-violet-500 shrink-0" />
+                    : <ChevronRight className="h-3 w-3 text-violet-500 shrink-0" />}
+                  <Bot className="h-3.5 w-3.5 text-violet-500 shrink-0" />
+                  <span className="text-xs font-medium text-violet-600 dark:text-violet-400 w-20 shrink-0">response</span>
+                  <span className="text-xs text-muted-foreground truncate flex-1">{preview}{preview.length >= 200 ? "..." : ""}</span>
+                </button>
+                {expandedSet.has(key) && turn.responseEvent && (
+                  <div style={{ paddingLeft: "20px" }}>
+                    <EventDetail event={turn.responseEvent} />
+                  </div>
+                )}
+              </div>
+            );
+          })()}
+
+          {/* Turn end marker */}
+          {turn.stopEvent && (
+            <div className="flex items-center gap-2 py-1 px-3 text-[10px] text-muted-foreground" style={{ paddingLeft: "32px" }}>
+              <Square className="h-2.5 w-2.5 text-rose-400" />
+              <span>{turn.stopEvent.attributes?.stop_reason || "end_turn"}</span>
+              {turn.stopEvent.timestamp && (
+                <span className="ml-auto tabular-nums">{new Date(turn.stopEvent.timestamp).toLocaleTimeString()}</span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -534,7 +837,7 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
 
     for (const evt of events) {
       const attrs = evt.attributes ?? {};
-      const eName = attrs["event.name"] || evt.event_name;
+      const eName = getEventName(evt);
 
       if (eName === "api_request") {
         apiCalls++;
@@ -552,7 +855,7 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
 
       if (isHookEvent(eName)) {
         hookEvents++;
-        if (attrs.tool_name) {
+        if (attrs.tool_name && attrs.tool_name !== "user_prompt" && attrs.tool_name !== "assistant_response") {
           const tn = attrs.tool_name;
           tools[tn] = (tools[tn] || 0) + 1;
         }
@@ -593,22 +896,16 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
       <div className="space-y-1">
         <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Models</p>
         <div className="flex flex-wrap gap-1">
-          {[...stats.models].map((m) => (
-            <Badge key={m}>{m.replace("claude-", "")}</Badge>
-          ))}
+          {[...stats.models].map((m) => <Badge key={m}>{m.replace("claude-", "")}</Badge>)}
         </div>
       </div>
       {Object.keys(stats.tools).length > 0 && (
         <div className="col-span-full space-y-1">
           <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Tools Used</p>
           <div className="flex flex-wrap gap-1.5">
-            {Object.entries(stats.tools)
-              .sort(([, a], [, b]) => b - a)
-              .map(([tool, count]) => (
-                <Badge key={tool} variant="muted">
-                  {tool} ({count})
-                </Badge>
-              ))}
+            {Object.entries(stats.tools).sort(([, a], [, b]) => b - a).map(([tool, count]) => (
+              <Badge key={tool} variant="muted">{tool} ({count})</Badge>
+            ))}
           </div>
         </div>
       )}
@@ -625,7 +922,7 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
   const session = data as OtelSessionData;
   const events: RawOtelEvent[] = useMemo(() => session?.events ?? [], [session]);
 
-  const [expandedSet, setExpandedSet] = useState<Set<number>>(new Set());
+  const [expandedSet, setExpandedSet] = useState<Set<string>>(new Set());
   const [activeFilters, setActiveFilters] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -643,74 +940,44 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
     setSearchQuery("");
   }, []);
 
-  // Filter + search events
-  const filteredEvents = useMemo(() => {
-    let result = events;
-    // Apply category filters (OR within active filters)
-    if (activeFilters.size > 0) {
-      const activeCategories = FILTER_CATEGORIES.filter((c) => activeFilters.has(c.key));
-      result = result.filter((evt) => {
-        const eName = evt.attributes?.["event.name"] || evt.event_name;
-        return activeCategories.some((cat) => cat.match(eName));
-      });
-    }
-    // Apply search query
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      result = result.filter((evt) => {
-        const attrs = evt.attributes ?? {};
-        const eName = attrs["event.name"] || evt.event_name;
-        // Search across: event name, tool name, body, tool_input, tool_response, agent_type
-        return (
-          eName.toLowerCase().includes(q) ||
-          (evt.body || "").toLowerCase().includes(q) ||
-          (attrs.tool_name || "").toLowerCase().includes(q) ||
-          (attrs.tool_input || "").toLowerCase().includes(q) ||
-          (attrs.tool_response || "").toLowerCase().includes(q) ||
-          (attrs.agent_type || "").toLowerCase().includes(q) ||
-          (attrs.agent_id || "").toLowerCase().includes(q) ||
-          (attrs.error || "").toLowerCase().includes(q) ||
-          (attrs.task_subject || "").toLowerCase().includes(q)
-        );
-      });
-    }
-    return result;
-  }, [events, activeFilters, searchQuery]);
+  // Build the tree
+  const tree = useMemo(() => buildEventTree(events), [events]);
 
-  // Count events per filter category (on full event set, not filtered)
+  // Filter counts (on deduplicated events)
+  const allDeduped = useMemo(() => deduplicateEvents(events), [events]);
   const filterCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const cat of FILTER_CATEGORIES) {
-      counts[cat.key] = events.filter((evt) => {
-        const eName = evt.attributes?.["event.name"] || evt.event_name;
-        return cat.match(eName);
-      }).length;
+      counts[cat.key] = allDeduped.filter((evt) => cat.match(getEventName(evt))).length;
     }
     return counts;
-  }, [events]);
+  }, [allDeduped]);
 
-  const toggleEvent = useCallback((index: number) => {
+  // Visible turns after filtering
+  const visibleTurns = useMemo(() => {
+    if (activeFilters.size === 0 && !searchQuery.trim()) return tree.turns;
+    return tree.turns.filter((t) => turnMatchesFilters(t, activeFilters, searchQuery));
+  }, [tree.turns, activeFilters, searchQuery]);
+
+  const onToggleEvent = useCallback((key: string) => {
     setExpandedSet((prev) => {
       const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
-      } else {
-        next.add(index);
-      }
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return next;
     });
   }, []);
 
-  const toggleAll = useCallback(() => {
+  const expandAllTurns = useCallback(() => {
     setExpandedSet((prev) => {
-      if (prev.size === filteredEvents.length) {
-        return new Set();
-      }
-      return new Set(filteredEvents.map((_, i) => i));
+      const allTurnKeys = visibleTurns.map((_, i) => `turn-${tree.turns.indexOf(visibleTurns[i])}`);
+      const allOpen = allTurnKeys.every((k) => prev.has(k));
+      if (allOpen) return new Set(); // collapse all
+      const next = new Set(prev);
+      for (const k of allTurnKeys) next.add(k);
+      return next;
     });
-  }, [filteredEvents]);
-
-  const allExpanded = expandedSet.size === filteredEvents.length && filteredEvents.length > 0;
+  }, [visibleTurns, tree.turns]);
 
   return (
     <>
@@ -754,32 +1021,26 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
                   <span className="text-xs text-muted-foreground block mb-0.5">Duration</span>
                   <span className="text-sm tabular-nums">
                     {events.length > 1 && events[events.length - 1]?.timestamp && events[0]?.timestamp
-                      ? formatDuration(
-                          new Date(events[events.length - 1].timestamp).getTime() -
-                            new Date(events[0].timestamp).getTime()
-                        )
+                      ? formatDuration(new Date(events[events.length - 1].timestamp).getTime() - new Date(events[0].timestamp).getTime())
                       : "-"}
                   </span>
                 </div>
               )}
+              <div>
+                <span className="text-xs text-muted-foreground block mb-0.5">Turns</span>
+                <span className="text-sm font-semibold tabular-nums">{tree.turns.length}</span>
+              </div>
             </div>
 
             <Separator />
-
-            {/* Session summary */}
             <SessionStats events={events} />
-
             <Separator />
 
-            {/* Events */}
+            {/* Events tree */}
             {events.length === 0 ? (
-              <EmptyState
-                icon={FileText}
-                title="No events in this session"
-                description="Events will appear here once telemetry data is recorded."
-              />
+              <EmptyState icon={FileText} title="No events in this session" description="Events will appear here once telemetry data is recorded." />
             ) : (
-              <div className="animate-in stagger-1 space-y-0.5">
+              <div className="animate-in stagger-1 space-y-2">
                 {/* Search + Filter bar */}
                 <div className="space-y-2 mb-3">
                   <div className="flex items-center gap-2">
@@ -792,26 +1053,16 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
                         className="pl-8 h-8 text-sm"
                       />
                       {searchQuery && (
-                        <button
-                          type="button"
-                          onClick={() => setSearchQuery("")}
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                        >
+                        <button type="button" onClick={() => setSearchQuery("")} className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground">
                           <X className="h-3.5 w-3.5" />
                         </button>
                       )}
                     </div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={toggleAll}
-                      className="h-8 text-xs gap-1"
-                    >
+                    <Button variant="ghost" size="sm" onClick={expandAllTurns} className="h-8 text-xs gap-1">
                       <ChevronsUpDown className="h-3 w-3" />
-                      {allExpanded ? "Collapse" : "Expand"}
+                      Toggle turns
                     </Button>
                   </div>
-                  {/* Filter chips */}
                   <div className="flex items-center gap-1.5 flex-wrap">
                     <Filter className="h-3 w-3 text-muted-foreground shrink-0" />
                     {FILTER_CATEGORIES.filter((cat) => filterCounts[cat.key] > 0).map((cat) => (
@@ -820,9 +1071,7 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
                         key={cat.key}
                         onClick={() => toggleFilter(cat.key)}
                         className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border transition-all ${
-                          activeFilters.has(cat.key)
-                            ? cat.color + " border-current"
-                            : "bg-muted/50 text-muted-foreground border-transparent hover:bg-muted"
+                          activeFilters.has(cat.key) ? cat.color + " border-current" : "bg-muted/50 text-muted-foreground border-transparent hover:bg-muted"
                         }`}
                       >
                         {cat.label}
@@ -830,42 +1079,56 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
                       </button>
                     ))}
                     {(activeFilters.size > 0 || searchQuery) && (
-                      <button
-                        type="button"
-                        onClick={clearFilters}
-                        className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
-                      >
+                      <button type="button" onClick={clearFilters} className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground">
                         <X className="h-3 w-3" /> Clear
                       </button>
                     )}
                   </div>
                 </div>
 
-                {/* Event count */}
-                <div className="flex items-center justify-between mb-2">
+                {/* Turn count */}
+                <div className="flex items-center justify-between">
                   <span className="text-xs text-muted-foreground">
-                    {filteredEvents.length === events.length
-                      ? `${events.length} event${events.length !== 1 ? "s" : ""}`
-                      : `${filteredEvents.length} of ${events.length} events`}
+                    {visibleTurns.length === tree.turns.length
+                      ? `${tree.turns.length} turn${tree.turns.length !== 1 ? "s" : ""}`
+                      : `${visibleTurns.length} of ${tree.turns.length} turns`}
+                    {" · "}{allDeduped.length} events (deduped from {events.length})
                   </span>
                 </div>
 
-                {/* Event list */}
-                {filteredEvents.length === 0 ? (
-                  <div className="text-center py-8 text-sm text-muted-foreground">
-                    No events match your filters.
+                {/* Pre-session events */}
+                {tree.preSessionEvents.length > 0 && (
+                  <div className="rounded-lg border border-border/50 p-2 space-y-0.5">
+                    <span className="text-[10px] text-muted-foreground uppercase tracking-wide px-2">Pre-session</span>
+                    {tree.preSessionEvents.map((evt, i) => {
+                      const key = `pre-${i}`;
+                      return (
+                        <LeafEvent key={key} event={evt} isExpanded={expandedSet.has(key)} onToggle={() => onToggleEvent(key)} depth={0} />
+                      );
+                    })}
                   </div>
+                )}
+
+                {/* Turn nodes */}
+                {visibleTurns.length === 0 ? (
+                  <div className="text-center py-8 text-sm text-muted-foreground">No turns match your filters.</div>
                 ) : (
-                  filteredEvents.map((evt: RawOtelEvent, i: number) => (
-                    <div key={i}>
-                      <EventRow
-                        event={evt}
-                        isExpanded={expandedSet.has(i)}
-                        onToggle={() => toggleEvent(i)}
-                      />
-                      {i < filteredEvents.length - 1 && <Separator className="my-0" />}
-                    </div>
-                  ))
+                  <div className="space-y-2">
+                    {visibleTurns.map((turn) => {
+                      const originalIndex = tree.turns.indexOf(turn);
+                      return (
+                        <TurnNode
+                          key={`turn-${originalIndex}`}
+                          turn={turn}
+                          index={originalIndex}
+                          expandedSet={expandedSet}
+                          onToggleEvent={onToggleEvent}
+                          activeFilters={activeFilters}
+                          searchQuery={searchQuery}
+                        />
+                      );
+                    })}
+                  </div>
                 )}
               </div>
             )}

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -3,37 +3,452 @@
 import { use, useState, useCallback, useMemo } from "react";
 import { useOtelSession } from "@/hooks/use-api";
 import type { OtelSessionData, RawOtelEvent } from "@/lib/types";
-import { FileText, ChevronDown, ChevronRight, ChevronsUpDown } from "lucide-react";
+import {
+  FileText,
+  ChevronDown,
+  ChevronRight,
+  ChevronsUpDown,
+  Cpu,
+  Wrench,
+  ShieldCheck,
+  MessageSquare,
+  Clock,
+  Zap,
+  Play,
+  Square,
+  Globe,
+  Bot,
+  Search,
+  Filter,
+  X,
+  AlertTriangle,
+  Bell,
+  ListChecks,
+  Minimize2,
+  GitBranch,
+  LogIn,
+} from "lucide-react";
 import { PageHeader } from "@/components/layouts/page-header";
 import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
-function colorizeJson(raw: string): React.ReactNode {
-  const lines = raw.split("\n");
-  return lines.map((line, i) => {
-    const colonIdx = line.indexOf(":");
-    if (colonIdx === -1) {
-      return (
-        <span key={i}>
-          {line}
-          {i < lines.length - 1 ? "\n" : ""}
-        </span>
-      );
-    }
-    const key = line.slice(0, colonIdx);
-    const value = line.slice(colonIdx);
-    return (
-      <span key={i}>
-        <span className="text-muted-foreground">{key}</span>
-        <span className="text-foreground">{value}</span>
-        {i < lines.length - 1 ? "\n" : ""}
-      </span>
-    );
-  });
+/* ── Helpers ─────────────────────────────────────────────── */
+
+function Badge({ children, variant = "default" }: { children: React.ReactNode; variant?: "default" | "success" | "warning" | "muted" }) {
+  const cls = {
+    default: "bg-primary/10 text-primary",
+    success: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    muted: "bg-muted text-muted-foreground",
+  }[variant];
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium ${cls}`}>
+      {children}
+    </span>
+  );
 }
+
+function Stat({ label, value, icon: Icon }: { label: string; value: string | number; icon?: React.ElementType }) {
+  return (
+    <div className="flex items-center gap-1.5 text-xs">
+      {Icon && <Icon className="h-3 w-3 text-muted-foreground shrink-0" />}
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium font-[family-name:var(--font-mono)] tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+function formatDuration(ms: string | number): string {
+  const n = typeof ms === "string" ? parseFloat(ms) : ms;
+  if (n < 1000) return `${Math.round(n)}ms`;
+  return `${(n / 1000).toFixed(1)}s`;
+}
+
+function formatTokens(n: string | number): string {
+  const num = typeof n === "string" ? parseInt(n, 10) : n;
+  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
+  if (num >= 1_000) return `${(num / 1_000).toFixed(1)}k`;
+  return `${num}`;
+}
+
+function isHookEvent(eventName: string): boolean {
+  return eventName.startsWith("hook_");
+}
+
+function eventIcon(eventName: string) {
+  if (eventName === "api_request") return Cpu;
+  if (eventName === "tool_result") return Wrench;
+  if (eventName === "tool_decision") return ShieldCheck;
+  if (eventName === "user_prompt" || eventName === "hook_userpromptsubmit") return MessageSquare;
+  if (eventName === "hook_posttoolusetools" || eventName === "hook_posttooluse") return Wrench;
+  if (eventName === "hook_pretoolusetools" || eventName === "hook_pretooluse") return ShieldCheck;
+  if (eventName === "hook_posttoolusefailure") return AlertTriangle;
+  if (eventName === "hook_subagentstart") return Play;
+  if (eventName === "hook_subagentstop") return Square;
+  if (eventName === "hook_assistant_response") return Bot;
+  if (eventName === "hook_stop") return Square;
+  if (eventName === "hook_stopfailure") return AlertTriangle;
+  if (eventName === "hook_sessionstart") return LogIn;
+  if (eventName === "hook_notification") return Bell;
+  if (eventName === "hook_taskcreated" || eventName === "hook_taskcompleted") return ListChecks;
+  if (eventName === "hook_precompact" || eventName === "hook_postcompact") return Minimize2;
+  if (eventName === "hook_worktreecreate" || eventName === "hook_worktreeremove") return GitBranch;
+  if (eventName === "hook_elicitation" || eventName === "hook_elicitationresult") return Globe;
+  if (isHookEvent(eventName)) return Zap;
+  return FileText;
+}
+
+function eventColor(eventName: string): string {
+  if (eventName === "api_request") return "text-blue-500";
+  if (eventName === "tool_result") return "text-emerald-500";
+  if (eventName === "tool_decision") return "text-amber-500";
+  if (eventName === "user_prompt" || eventName === "hook_userpromptsubmit") return "text-purple-500";
+  if (eventName === "hook_posttooluse") return "text-cyan-500";
+  if (eventName === "hook_pretooluse") return "text-sky-400";
+  if (eventName === "hook_posttoolusefailure" || eventName === "hook_stopfailure") return "text-red-500";
+  if (eventName === "hook_subagentstart" || eventName === "hook_subagentstop") return "text-indigo-500";
+  if (eventName === "hook_assistant_response") return "text-violet-500";
+  if (eventName === "hook_stop") return "text-rose-500";
+  if (eventName === "hook_sessionstart") return "text-green-500";
+  if (eventName === "hook_notification") return "text-yellow-500";
+  if (eventName === "hook_taskcreated" || eventName === "hook_taskcompleted") return "text-lime-500";
+  if (eventName === "hook_precompact" || eventName === "hook_postcompact") return "text-slate-400";
+  if (eventName === "hook_worktreecreate" || eventName === "hook_worktreeremove") return "text-amber-400";
+  if (eventName === "hook_elicitation" || eventName === "hook_elicitationresult") return "text-teal-500";
+  if (isHookEvent(eventName)) return "text-orange-500";
+  return "text-muted-foreground";
+}
+
+/* ── Filter categories ───────────────────────────────────── */
+
+type FilterCategory = {
+  key: string;
+  label: string;
+  match: (eventName: string) => boolean;
+  color: string;
+};
+
+const FILTER_CATEGORIES: FilterCategory[] = [
+  { key: "prompts", label: "Prompts", match: (e) => e === "user_prompt" || e === "hook_userpromptsubmit", color: "bg-purple-500/10 text-purple-600 dark:text-purple-400 border-purple-500/20" },
+  { key: "responses", label: "Responses", match: (e) => e === "hook_assistant_response", color: "bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20" },
+  { key: "tools", label: "Tools", match: (e) => ["tool_result", "tool_decision", "hook_posttooluse", "hook_pretooluse", "hook_posttoolusefailure"].includes(e), color: "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 border-cyan-500/20" },
+  { key: "api", label: "API", match: (e) => e === "api_request", color: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20" },
+  { key: "agents", label: "Agents", match: (e) => e === "hook_subagentstart" || e === "hook_subagentstop", color: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/20" },
+  { key: "lifecycle", label: "Lifecycle", match: (e) => ["hook_sessionstart", "hook_stop", "hook_stopfailure", "hook_precompact", "hook_postcompact"].includes(e), color: "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20" },
+  { key: "tasks", label: "Tasks", match: (e) => e === "hook_taskcreated" || e === "hook_taskcompleted", color: "bg-lime-500/10 text-lime-600 dark:text-lime-400 border-lime-500/20" },
+  { key: "mcp", label: "MCP", match: (e) => e === "hook_elicitation" || e === "hook_elicitationresult", color: "bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20" },
+  { key: "errors", label: "Errors", match: (e) => e === "hook_posttoolusefailure" || e === "hook_stopfailure", color: "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20" },
+];
+
+/* ── Event inline summary (shown without expanding) ────── */
+
+function EventSummary({ event }: { event: RawOtelEvent }) {
+  const attrs = event.attributes ?? {};
+  const eName = attrs["event.name"] || event.event_name;
+
+  if (eName === "api_request") {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge>{attrs.model || "?"}</Badge>
+        {attrs.duration_ms && <Stat label="" value={formatDuration(attrs.duration_ms)} icon={Clock} />}
+        {attrs.input_tokens && parseInt(attrs.input_tokens) > 1 && <Stat label="in" value={formatTokens(attrs.input_tokens)} />}
+        {attrs.output_tokens && <Stat label="out" value={formatTokens(attrs.output_tokens)} />}
+        {attrs.cache_read_tokens && parseInt(attrs.cache_read_tokens) > 0 && (
+          <Stat label="cache" value={formatTokens(attrs.cache_read_tokens)} />
+        )}
+      </div>
+    );
+  }
+
+  if (eName === "tool_result") {
+    const success = attrs.success === "true";
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant={success ? "success" : "warning"}>{attrs.tool_name || "?"}</Badge>
+        {attrs.duration_ms && <Stat label="" value={formatDuration(attrs.duration_ms)} icon={Clock} />}
+        {attrs.tool_result_size_bytes && (
+          <Stat label="size" value={`${formatTokens(attrs.tool_result_size_bytes)}B`} />
+        )}
+        {!success && <Badge variant="warning">failed</Badge>}
+      </div>
+    );
+  }
+
+  if (eName === "tool_decision") {
+    const accepted = attrs.decision === "accept";
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant={accepted ? "muted" : "warning"}>{attrs.tool_name || "?"}</Badge>
+        <span className="text-xs text-muted-foreground">
+          {accepted ? "accepted" : "rejected"} via {attrs.source || "?"}
+        </span>
+      </div>
+    );
+  }
+
+  if (eName === "user_prompt") {
+    return (
+      <div className="flex items-center gap-3">
+        {attrs.prompt_length && <Stat label="length" value={`${attrs.prompt_length} chars`} />}
+      </div>
+    );
+  }
+
+  // Hook: user prompt
+  if (eName === "hook_userpromptsubmit") {
+    const preview = (attrs.tool_input || "").slice(0, 120);
+    return (
+      <div className="flex items-center gap-3 flex-wrap min-w-0">
+        <Badge variant="default">prompt</Badge>
+        {preview && <span className="text-xs text-muted-foreground truncate max-w-md">{preview}{(attrs.tool_input?.length ?? 0) > 120 ? "..." : ""}</span>}
+        {attrs.prompt_length && <Stat label="" value={`${attrs.prompt_length} chars`} />}
+      </div>
+    );
+  }
+
+  // Hook: tool use (PostToolUse / PreToolUse)
+  if (eName === "hook_posttooluse" || eName === "hook_pretooluse") {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant={eName === "hook_posttooluse" ? "success" : "muted"}>{attrs.tool_name || "?"}</Badge>
+        <span className="text-[11px] text-muted-foreground">{attrs.hook_event}</span>
+      </div>
+    );
+  }
+
+  // Hook: subagent events
+  if (eName === "hook_subagentstart" || eName === "hook_subagentstop") {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant="default">{attrs.agent_type || "agent"}</Badge>
+        <span className="text-xs text-muted-foreground">{eName === "hook_subagentstart" ? "spawned" : "finished"}</span>
+      </div>
+    );
+  }
+
+  // Hook: MCP elicitation
+  if (eName === "hook_elicitation" || eName === "hook_elicitationresult") {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant="default">{attrs.mcp_server_name || "MCP"}</Badge>
+        <span className="text-xs text-muted-foreground">{eName === "hook_elicitation" ? "requesting input" : "got response"}</span>
+      </div>
+    );
+  }
+
+  // Hook: assistant response (Claude's text output)
+  if (eName === "hook_assistant_response") {
+    const preview = (attrs.tool_response || "").slice(0, 140);
+    return (
+      <div className="flex items-center gap-3 flex-wrap min-w-0">
+        <Badge variant="default">response</Badge>
+        {preview && <span className="text-xs text-muted-foreground truncate max-w-lg">{preview}{(attrs.tool_response?.length ?? 0) > 140 ? "..." : ""}</span>}
+      </div>
+    );
+  }
+
+  // Hook: stop
+  if (eName === "hook_stop") {
+    return (
+      <div className="flex items-center gap-3">
+        <Badge variant="muted">{attrs.stop_reason || "end_turn"}</Badge>
+      </div>
+    );
+  }
+
+  // Hook: tool failure
+  if (eName === "hook_posttoolusefailure") {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant="warning">{attrs.tool_name || "?"}</Badge>
+        <span className="text-xs text-red-500">failed</span>
+        {attrs.error && <span className="text-xs text-muted-foreground truncate max-w-md">{attrs.error.slice(0, 100)}</span>}
+      </div>
+    );
+  }
+
+  // Hook: stop failure (API error)
+  if (eName === "hook_stopfailure") {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant="warning">API error</Badge>
+        {attrs.error && <span className="text-xs text-red-500 truncate max-w-md">{attrs.error.slice(0, 100)}</span>}
+      </div>
+    );
+  }
+
+  // Hook: session start
+  if (eName === "hook_sessionstart") {
+    return (
+      <div className="flex items-center gap-3">
+        <Badge variant="success">{attrs.session_resumed === "True" ? "resumed" : "new session"}</Badge>
+      </div>
+    );
+  }
+
+  // Hook: notification
+  if (eName === "hook_notification") {
+    const title = attrs.notification_title || "";
+    const msg = (attrs.tool_response || "").slice(0, 100);
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        {title && <Badge variant="default">{title}</Badge>}
+        {msg && <span className="text-xs text-muted-foreground truncate max-w-md">{msg}</span>}
+      </div>
+    );
+  }
+
+  // Hook: tasks
+  if (eName === "hook_taskcreated" || eName === "hook_taskcompleted") {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant={eName === "hook_taskcompleted" ? "success" : "default"}>
+          {attrs.task_subject || attrs.task_id || "task"}
+        </Badge>
+        <span className="text-xs text-muted-foreground">{eName === "hook_taskcreated" ? "created" : "completed"}</span>
+      </div>
+    );
+  }
+
+  // Hook: compaction
+  if (eName === "hook_precompact" || eName === "hook_postcompact") {
+    return (
+      <div className="flex items-center gap-3">
+        <Badge variant="muted">{eName === "hook_precompact" ? "compacting context" : "context compacted"}</Badge>
+      </div>
+    );
+  }
+
+  // Hook: worktree
+  if (eName === "hook_worktreecreate" || eName === "hook_worktreeremove") {
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant="default">{attrs.branch || "worktree"}</Badge>
+        <span className="text-xs text-muted-foreground">{eName === "hook_worktreecreate" ? "created" : "removed"}</span>
+      </div>
+    );
+  }
+
+  // Generic hook events
+  if (isHookEvent(eName)) {
+    const hookType = attrs.hook_event || eName.replace("hook_", "");
+    return (
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge variant="default">{attrs.tool_name || attrs.agent_type || "?"}</Badge>
+        <span className="text-xs text-muted-foreground">{hookType}</span>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+/* ── Pretty JSON / content block ──────────────────────── */
+
+function ContentBlock({ label, content }: { label: string; content: string }) {
+  // Try to parse and pretty-print JSON
+  let display = content;
+  let isJson = false;
+  try {
+    const parsed = JSON.parse(content);
+    display = JSON.stringify(parsed, null, 2);
+    isJson = true;
+  } catch {
+    // Not JSON — show as-is
+  }
+
+  const lines = display.split("\n").length;
+  const isLong = lines > 20;
+  const [showFull, setShowFull] = useState(false);
+
+  const shown = isLong && !showFull ? display.split("\n").slice(0, 20).join("\n") + "\n..." : display;
+
+  return (
+    <div className="space-y-1">
+      <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">{label}</span>
+      <pre className={`text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-all bg-background/50 border border-border rounded-md p-2.5 max-h-[400px] overflow-auto ${isJson ? "text-foreground" : "text-foreground/80"}`}>
+        {shown}
+      </pre>
+      {isLong && (
+        <button
+          type="button"
+          onClick={() => setShowFull(!showFull)}
+          className="text-[11px] text-primary-accent hover:underline"
+        >
+          {showFull ? "Show less" : `Show all ${lines} lines`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+/* ── Event detail (shown when expanded) ────────────────── */
+
+function EventDetail({ event }: { event: RawOtelEvent }) {
+  const attrs = event.attributes ?? {};
+  const eName = attrs["event.name"] || event.event_name;
+
+  // For hook events, show tool_input and tool_response as rich content blocks
+  if (isHookEvent(eName) && (attrs.tool_input || attrs.tool_response)) {
+    return (
+      <div className="ml-6 mr-3 mb-2 mt-1 space-y-3">
+        {attrs.tool_input && (
+          <ContentBlock label="Input" content={attrs.tool_input} />
+        )}
+        {attrs.tool_response && (
+          <ContentBlock label="Response" content={attrs.tool_response} />
+        )}
+        {/* Show other attrs in a compact grid below */}
+        <HookMetaGrid attrs={attrs} />
+      </div>
+    );
+  }
+
+  // Default: attribute grid for OTEL events
+  const skip = new Set(["event.name", "event.sequence", "event.timestamp", "session.id", "user.id", "terminal.type", "prompt.id"]);
+  const entries = Object.entries(attrs)
+    .filter(([k]) => !skip.has(k))
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="ml-6 mr-3 mb-2 mt-1">
+      <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-0.5 text-xs font-[family-name:var(--font-mono)] bg-surface-sunken rounded-md p-3">
+        {entries.map(([key, value]) => (
+          <div key={key} className="contents">
+            <span className="text-muted-foreground">{key}</span>
+            <span className="text-foreground truncate">{value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HookMetaGrid({ attrs }: { attrs: Record<string, string> }) {
+  const skip = new Set(["event.name", "session.id", "tool_input", "tool_response", "hook_event", "tool_name"]);
+  const entries = Object.entries(attrs)
+    .filter(([k]) => !skip.has(k))
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return null;
+  return (
+    <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-0.5 text-xs font-[family-name:var(--font-mono)] bg-surface-sunken rounded-md p-2">
+      {entries.map(([key, value]) => (
+        <div key={key} className="contents">
+          <span className="text-muted-foreground">{key}</span>
+          <span className="text-foreground truncate">{value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Event row ─────────────────────────────────────────── */
 
 function EventRow({
   event,
@@ -44,6 +459,11 @@ function EventRow({
   isExpanded: boolean;
   onToggle: () => void;
 }) {
+  const attrs = event.attributes ?? {};
+  const eName = attrs["event.name"] || event.event_name;
+  const Icon = eventIcon(eName);
+  const color = eventColor(eName);
+
   return (
     <div>
       <button
@@ -56,23 +476,147 @@ function EventRow({
         ) : (
           <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         )}
-        <span className="text-sm font-medium truncate">{event.event_name}</span>
+        <Icon className={`h-3.5 w-3.5 shrink-0 ${color}`} />
+        <span className="text-sm font-medium w-28 shrink-0">
+          {eName === "hook_assistant_response" ? "response" :
+           eName === "hook_userpromptsubmit" ? "prompt" :
+           eName === "hook_posttooluse" ? (attrs.tool_name || "tool") :
+           eName === "hook_pretooluse" ? (attrs.tool_name || "tool") :
+           eName === "hook_posttoolusefailure" ? (attrs.tool_name || "tool fail") :
+           eName === "hook_subagentstart" ? "agent start" :
+           eName === "hook_subagentstop" ? "agent stop" :
+           eName === "hook_stop" ? "turn end" :
+           eName === "hook_stopfailure" ? "API error" :
+           eName === "hook_sessionstart" ? "session" :
+           eName === "hook_notification" ? "notify" :
+           eName === "hook_taskcreated" ? "task new" :
+           eName === "hook_taskcompleted" ? "task done" :
+           eName === "hook_precompact" ? "compact" :
+           eName === "hook_postcompact" ? "compacted" :
+           eName === "hook_worktreecreate" ? "worktree+" :
+           eName === "hook_worktreeremove" ? "worktree-" :
+           eName === "hook_elicitation" ? "MCP ask" :
+           eName === "hook_elicitationresult" ? "MCP reply" :
+           isHookEvent(eName) ? (attrs.tool_name || eName) :
+           eName}
+        </span>
+        {attrs.agent_id && (
+          <span className="text-[10px] px-1 py-0.5 rounded bg-indigo-500/10 text-indigo-500 font-medium shrink-0">
+            {attrs.agent_type || "agent"}
+          </span>
+        )}
+        <div className="flex-1 min-w-0">
+          <EventSummary event={event} />
+        </div>
         {event.timestamp && (
-          <span className="ml-auto text-xs text-muted-foreground tabular-nums shrink-0">
+          <span className="ml-auto text-[11px] text-muted-foreground tabular-nums shrink-0 pl-2">
             {new Date(event.timestamp).toLocaleTimeString()}
           </span>
         )}
       </button>
-      {isExpanded && event.body && (
-        <div className="ml-6 mr-3 mb-2 mt-1">
-          <pre className="text-xs font-[family-name:var(--font-mono)] leading-relaxed whitespace-pre-wrap bg-surface-sunken rounded-md p-3 overflow-x-auto">
-            {colorizeJson(event.body)}
-          </pre>
+      {isExpanded && <EventDetail event={event} />}
+    </div>
+  );
+}
+
+/* ── Session summary stats ─────────────────────────────── */
+
+function SessionStats({ events }: { events: RawOtelEvent[] }) {
+  const stats = useMemo(() => {
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalCacheRead = 0;
+    let apiCalls = 0;
+    let toolCalls = 0;
+    let hookEvents = 0;
+    const models = new Set<string>();
+    const tools: Record<string, number> = {};
+
+    for (const evt of events) {
+      const attrs = evt.attributes ?? {};
+      const eName = attrs["event.name"] || evt.event_name;
+
+      if (eName === "api_request") {
+        apiCalls++;
+        if (attrs.input_tokens) totalInputTokens += parseInt(attrs.input_tokens, 10);
+        if (attrs.output_tokens) totalOutputTokens += parseInt(attrs.output_tokens, 10);
+        if (attrs.cache_read_tokens) totalCacheRead += parseInt(attrs.cache_read_tokens, 10);
+        if (attrs.model) models.add(attrs.model);
+      }
+
+      if (eName === "tool_result") {
+        toolCalls++;
+        const tn = attrs.tool_name || "unknown";
+        tools[tn] = (tools[tn] || 0) + 1;
+      }
+
+      if (isHookEvent(eName)) {
+        hookEvents++;
+        if (attrs.tool_name) {
+          const tn = attrs.tool_name;
+          tools[tn] = (tools[tn] || 0) + 1;
+        }
+      }
+    }
+
+    return { totalInputTokens, totalOutputTokens, totalCacheRead, apiCalls, toolCalls, hookEvents, models, tools };
+  }, [events]);
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+      <div className="space-y-1">
+        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Input Tokens</p>
+        <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalInputTokens)}</p>
+      </div>
+      <div className="space-y-1">
+        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Output Tokens</p>
+        <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalOutputTokens)}</p>
+      </div>
+      <div className="space-y-1">
+        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Read</p>
+        <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheRead)}</p>
+      </div>
+      <div className="space-y-1">
+        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">API Calls</p>
+        <p className="text-lg font-semibold tabular-nums">{stats.apiCalls}</p>
+      </div>
+      <div className="space-y-1">
+        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Tool Calls</p>
+        <p className="text-lg font-semibold tabular-nums">{stats.toolCalls}</p>
+      </div>
+      {stats.hookEvents > 0 && (
+        <div className="space-y-1">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Hook Captures</p>
+          <p className="text-lg font-semibold tabular-nums text-orange-500">{stats.hookEvents}</p>
+        </div>
+      )}
+      <div className="space-y-1">
+        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Models</p>
+        <div className="flex flex-wrap gap-1">
+          {[...stats.models].map((m) => (
+            <Badge key={m}>{m.replace("claude-", "")}</Badge>
+          ))}
+        </div>
+      </div>
+      {Object.keys(stats.tools).length > 0 && (
+        <div className="col-span-full space-y-1">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Tools Used</p>
+          <div className="flex flex-wrap gap-1.5">
+            {Object.entries(stats.tools)
+              .sort(([, a], [, b]) => b - a)
+              .map(([tool, count]) => (
+                <Badge key={tool} variant="muted">
+                  {tool} ({count})
+                </Badge>
+              ))}
+          </div>
         </div>
       )}
     </div>
   );
 }
+
+/* ── Page ───────────────────────────────────────────────── */
 
 export default function TraceDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -82,6 +626,68 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
   const events: RawOtelEvent[] = useMemo(() => session?.events ?? [], [session]);
 
   const [expandedSet, setExpandedSet] = useState<Set<number>>(new Set());
+  const [activeFilters, setActiveFilters] = useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const toggleFilter = useCallback((key: string) => {
+    setActiveFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setActiveFilters(new Set());
+    setSearchQuery("");
+  }, []);
+
+  // Filter + search events
+  const filteredEvents = useMemo(() => {
+    let result = events;
+    // Apply category filters (OR within active filters)
+    if (activeFilters.size > 0) {
+      const activeCategories = FILTER_CATEGORIES.filter((c) => activeFilters.has(c.key));
+      result = result.filter((evt) => {
+        const eName = evt.attributes?.["event.name"] || evt.event_name;
+        return activeCategories.some((cat) => cat.match(eName));
+      });
+    }
+    // Apply search query
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter((evt) => {
+        const attrs = evt.attributes ?? {};
+        const eName = attrs["event.name"] || evt.event_name;
+        // Search across: event name, tool name, body, tool_input, tool_response, agent_type
+        return (
+          eName.toLowerCase().includes(q) ||
+          (evt.body || "").toLowerCase().includes(q) ||
+          (attrs.tool_name || "").toLowerCase().includes(q) ||
+          (attrs.tool_input || "").toLowerCase().includes(q) ||
+          (attrs.tool_response || "").toLowerCase().includes(q) ||
+          (attrs.agent_type || "").toLowerCase().includes(q) ||
+          (attrs.agent_id || "").toLowerCase().includes(q) ||
+          (attrs.error || "").toLowerCase().includes(q) ||
+          (attrs.task_subject || "").toLowerCase().includes(q)
+        );
+      });
+    }
+    return result;
+  }, [events, activeFilters, searchQuery]);
+
+  // Count events per filter category (on full event set, not filtered)
+  const filterCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const cat of FILTER_CATEGORIES) {
+      counts[cat.key] = events.filter((evt) => {
+        const eName = evt.attributes?.["event.name"] || evt.event_name;
+        return cat.match(eName);
+      }).length;
+    }
+    return counts;
+  }, [events]);
 
   const toggleEvent = useCallback((index: number) => {
     setExpandedSet((prev) => {
@@ -97,19 +703,19 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
 
   const toggleAll = useCallback(() => {
     setExpandedSet((prev) => {
-      if (prev.size === events.length) {
+      if (prev.size === filteredEvents.length) {
         return new Set();
       }
-      return new Set(events.map((_, i) => i));
+      return new Set(filteredEvents.map((_, i) => i));
     });
-  }, [events]);
+  }, [filteredEvents]);
 
-  const allExpanded = expandedSet.size === events.length && events.length > 0;
+  const allExpanded = expandedSet.size === filteredEvents.length && filteredEvents.length > 0;
 
   return (
     <>
       <PageHeader
-        title={isLoading ? "Trace" : id.slice(0, 16) + "..."}
+        title={isLoading ? "Session" : id.slice(0, 16) + "..."}
         breadcrumbs={[
           { label: "Dashboard", href: "/dashboard" },
           { label: "Traces", href: "/traces" },
@@ -122,7 +728,7 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
         ) : isError ? (
           <ErrorState message={error?.message} onRetry={() => refetch()} />
         ) : !data ? (
-          <ErrorState message="Trace not found" />
+          <ErrorState message="Session not found" />
         ) : (
           <>
             {/* Header info */}
@@ -143,7 +749,25 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
                   <span className="text-sm tabular-nums">{new Date(events[0].timestamp).toLocaleString()}</span>
                 </div>
               )}
+              {events.length > 0 && (
+                <div>
+                  <span className="text-xs text-muted-foreground block mb-0.5">Duration</span>
+                  <span className="text-sm tabular-nums">
+                    {events.length > 1 && events[events.length - 1]?.timestamp && events[0]?.timestamp
+                      ? formatDuration(
+                          new Date(events[events.length - 1].timestamp).getTime() -
+                            new Date(events[0].timestamp).getTime()
+                        )
+                      : "-"}
+                  </span>
+                </div>
+              )}
             </div>
+
+            <Separator />
+
+            {/* Session summary */}
+            <SessionStats events={events} />
 
             <Separator />
 
@@ -151,35 +775,98 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
             {events.length === 0 ? (
               <EmptyState
                 icon={FileText}
-                title="No events in this trace"
-                description="Events will appear here once spans are recorded for this session."
+                title="No events in this session"
+                description="Events will appear here once telemetry data is recorded."
               />
             ) : (
-              <div className="animate-in stagger-1 space-y-1">
+              <div className="animate-in stagger-1 space-y-0.5">
+                {/* Search + Filter bar */}
+                <div className="space-y-2 mb-3">
+                  <div className="flex items-center gap-2">
+                    <div className="relative flex-1 max-w-sm">
+                      <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                      <Input
+                        placeholder="Search events, tools, content..."
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        className="pl-8 h-8 text-sm"
+                      />
+                      {searchQuery && (
+                        <button
+                          type="button"
+                          onClick={() => setSearchQuery("")}
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      )}
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={toggleAll}
+                      className="h-8 text-xs gap-1"
+                    >
+                      <ChevronsUpDown className="h-3 w-3" />
+                      {allExpanded ? "Collapse" : "Expand"}
+                    </Button>
+                  </div>
+                  {/* Filter chips */}
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <Filter className="h-3 w-3 text-muted-foreground shrink-0" />
+                    {FILTER_CATEGORIES.filter((cat) => filterCounts[cat.key] > 0).map((cat) => (
+                      <button
+                        type="button"
+                        key={cat.key}
+                        onClick={() => toggleFilter(cat.key)}
+                        className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border transition-all ${
+                          activeFilters.has(cat.key)
+                            ? cat.color + " border-current"
+                            : "bg-muted/50 text-muted-foreground border-transparent hover:bg-muted"
+                        }`}
+                      >
+                        {cat.label}
+                        <span className="opacity-60">{filterCounts[cat.key]}</span>
+                      </button>
+                    ))}
+                    {(activeFilters.size > 0 || searchQuery) && (
+                      <button
+                        type="button"
+                        onClick={clearFilters}
+                        className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
+                      >
+                        <X className="h-3 w-3" /> Clear
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {/* Event count */}
                 <div className="flex items-center justify-between mb-2">
                   <span className="text-xs text-muted-foreground">
-                    {events.length} event{events.length !== 1 ? "s" : ""}
+                    {filteredEvents.length === events.length
+                      ? `${events.length} event${events.length !== 1 ? "s" : ""}`
+                      : `${filteredEvents.length} of ${events.length} events`}
                   </span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={toggleAll}
-                    className="h-7 text-xs gap-1"
-                  >
-                    <ChevronsUpDown className="h-3 w-3" />
-                    {allExpanded ? "Collapse all" : "Expand all"}
-                  </Button>
                 </div>
-                {events.map((evt: RawOtelEvent, i: number) => (
-                  <div key={i}>
-                    <EventRow
-                      event={evt}
-                      isExpanded={expandedSet.has(i)}
-                      onToggle={() => toggleEvent(i)}
-                    />
-                    {i < events.length - 1 && <Separator className="my-0" />}
+
+                {/* Event list */}
+                {filteredEvents.length === 0 ? (
+                  <div className="text-center py-8 text-sm text-muted-foreground">
+                    No events match your filters.
                   </div>
-                ))}
+                ) : (
+                  filteredEvents.map((evt: RawOtelEvent, i: number) => (
+                    <div key={i}>
+                      <EventRow
+                        event={evt}
+                        isExpanded={expandedSet.has(i)}
+                        onToggle={() => toggleEvent(i)}
+                      />
+                      {i < filteredEvents.length - 1 && <Separator className="my-0" />}
+                    </div>
+                  ))
+                )}
               </div>
             )}
           </>

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -27,41 +27,88 @@ interface SessionRow {
   session_id: string;
   service_name: string;
   first_event_time?: string;
+  last_event_time?: string;
   prompt_count?: number;
+  api_request_count?: number;
+  tool_result_count?: number;
+  total_input_tokens?: number;
+  total_output_tokens?: number;
+  total_cache_read_tokens?: number;
+  model?: string;
+}
+
+function formatTokens(n: number | string | undefined): string {
+  if (n == null) return "-";
+  const num = typeof n === "string" ? parseInt(n, 10) : n;
+  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
+  if (num >= 1_000) return `${(num / 1_000).toFixed(1)}k`;
+  return `${num}`;
 }
 
 const columns: ColumnDef<SessionRow>[] = [
   {
     accessorKey: "session_id",
-    header: "Session ID",
+    header: "Session",
     cell: ({ row }) => (
       <Link
         href={`/traces/${row.original.session_id}`}
         className="font-[family-name:var(--font-mono)] text-xs hover:text-primary-accent transition-colors"
       >
-        {row.original.session_id.slice(0, 16)}...
+        {row.original.session_id.slice(0, 12)}...
       </Link>
     ),
   },
   {
-    accessorKey: "service_name",
-    header: "Service",
+    accessorKey: "model",
+    header: "Model",
+    cell: ({ row }) => {
+      const m = row.original.model;
+      return (
+        <span className="text-xs font-medium">
+          {m ? m.replace("claude-", "").replace("-20251001", "") : "-"}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "total_input_tokens",
+    header: "Tokens In",
     cell: ({ row }) => (
-      <span className="text-sm">{row.original.service_name || "-"}</span>
+      <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
+        {formatTokens(row.original.total_input_tokens)}
+      </span>
     ),
   },
   {
-    accessorKey: "prompt_count",
-    header: "Events",
+    accessorKey: "api_request_count",
+    header: "API Calls",
     cell: ({ row }) => (
-      <span className="text-xs text-muted-foreground font-[family-name:var(--font-mono)] tabular-nums">
-        {row.original.prompt_count ?? "-"}
+      <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
+        {row.original.api_request_count ?? "-"}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "tool_result_count",
+    header: "Tools",
+    cell: ({ row }) => (
+      <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
+        {row.original.tool_result_count ?? "-"}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "total_output_tokens",
+    header: "Tokens Out",
+    cell: ({ row }) => (
+      <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
+        {formatTokens(row.original.total_output_tokens)}
       </span>
     ),
   },
   {
     accessorKey: "first_event_time",
-    header: "Timestamp",
+    header: "Time",
     cell: ({ row }) => {
       const t = row.original.first_event_time;
       return (
@@ -122,14 +169,14 @@ export default function TracesPage() {
       />
       <div className="p-6 max-w-6xl mx-auto space-y-4">
         {isLoading ? (
-          <TableSkeleton rows={8} cols={4} />
+          <TableSkeleton rows={8} cols={7} />
         ) : isError ? (
           <ErrorState message={error?.message} onRetry={() => refetch()} />
         ) : (sessions ?? []).length === 0 ? (
           <EmptyState
             icon={Activity}
-            title="No traces yet"
-            description="Traces will appear here once telemetry data is collected from your agents."
+            title="No sessions yet"
+            description="Sessions will appear here once telemetry data is collected from Claude Code."
           />
         ) : (
           <div className="animate-in space-y-3">
@@ -137,7 +184,7 @@ export default function TracesPage() {
             <div className="relative max-w-sm">
               <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
               <Input
-                placeholder="Search sessions, services..."
+                placeholder="Search sessions, models..."
                 value={searchValue}
                 onChange={(e) => handleSearch(e.target.value)}
                 className="pl-8 h-8 text-sm"
@@ -169,7 +216,7 @@ export default function TracesPage() {
                   {table.getRowModel().rows.length === 0 ? (
                     <TableRow>
                       <TableCell colSpan={columns.length} className="h-24 text-center text-sm text-muted-foreground">
-                        No matching traces.
+                        No matching sessions.
                       </TableCell>
                     </TableRow>
                   ) : (
@@ -192,7 +239,7 @@ export default function TracesPage() {
             </div>
 
             <p className="text-xs text-muted-foreground">
-              {table.getFilteredRowModel().rows.length} trace{table.getFilteredRowModel().rows.length !== 1 ? "s" : ""}
+              {table.getFilteredRowModel().rows.length} session{table.getFilteredRowModel().rows.length !== 1 ? "s" : ""}
             </p>
           </div>
         )}

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -35,6 +35,8 @@ interface SessionRow {
   total_output_tokens?: number;
   total_cache_read_tokens?: number;
   model?: string;
+  user_id?: string;
+  terminal_type?: string;
 }
 
 function formatTokens(n: number | string | undefined): string {
@@ -68,6 +70,27 @@ const columns: ColumnDef<SessionRow>[] = [
           {m ? m.replace("claude-", "").replace("-20251001", "") : "-"}
         </span>
       );
+    },
+  },
+  {
+    accessorKey: "user_id",
+    header: "User",
+    cell: ({ row }) => {
+      const uid = row.original.user_id;
+      return (
+        <span className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground" title={uid}>
+          {uid ? uid.slice(0, 8) + "…" : "-"}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "terminal_type",
+    header: "IDE",
+    cell: ({ row }) => {
+      const t = row.original.terminal_type;
+      const label = t ? t.replace("wsl-", "WSL ") : "-";
+      return <span className="text-xs">{label}</span>;
     },
   },
   {

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -1,16 +1,28 @@
 "use client";
 
-import { Users } from "lucide-react";
-import { useAdminUsers } from "@/hooks/use-api";
+import { useState, useCallback } from "react";
+import { Users, Plus, Copy, Check, Loader2, Key } from "lucide-react";
+import { toast } from "sonner";
+import { useAdminUsers, useCreateUser, useUpdateUserRole } from "@/hooks/use-api";
 import type { AdminUser } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+
+const ROLES = ["admin", "developer", "viewer"] as const;
 
 function roleBadge(role: string) {
   switch (role) {
@@ -23,8 +35,71 @@ function roleBadge(role: string) {
   }
 }
 
+function RoleSelect({ userId, currentRole }: { userId: string; currentRole: string }) {
+  const mutation = useUpdateUserRole();
+
+  return (
+    <Select
+      value={currentRole}
+      onValueChange={(value) => mutation.mutate({ id: userId, role: value })}
+      disabled={mutation.isPending}
+    >
+      <SelectTrigger className="h-7 w-[120px] text-xs">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {ROLES.map((r) => (
+          <SelectItem key={r} value={r} className="text-xs">
+            {r}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
 export default function UsersPage() {
   const { data: users, isLoading, isError, error, refetch } = useAdminUsers();
+  const createUser = useCreateUser();
+  const [showCreate, setShowCreate] = useState(false);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<string>("developer");
+  const [createdApiKey, setCreatedApiKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCreate = useCallback(async () => {
+    if (!name.trim() || !email.trim()) return;
+    createUser.mutate(
+      { email: email.trim(), name: name.trim(), role },
+      {
+        onSuccess: (data) => {
+          setCreatedApiKey(data.api_key);
+          setName("");
+          setEmail("");
+          setRole("developer");
+        },
+      },
+    );
+  }, [name, email, role, createUser]);
+
+  const handleCopyKey = useCallback(() => {
+    if (!createdApiKey) return;
+    navigator.clipboard.writeText(createdApiKey);
+    setCopied(true);
+    toast.success("API key copied");
+    setTimeout(() => setCopied(false), 2000);
+  }, [createdApiKey]);
+
+  const closeDialog = useCallback(() => {
+    setShowCreate(false);
+    setCreatedApiKey(null);
+    setName("");
+    setEmail("");
+    setRole("developer");
+  }, []);
+
+  const userCount = (users ?? []).length;
 
   return (
     <>
@@ -34,51 +109,146 @@ export default function UsersPage() {
           { label: "Dashboard", href: "/dashboard" },
           { label: "Users" },
         ]}
+        actionButtonsRight={
+          <Button size="sm" variant="outline" onClick={() => setShowCreate(true)} className="h-8">
+            <Plus className="mr-1 h-3.5 w-3.5" /> Add User
+          </Button>
+        }
       />
       <div className="p-6 max-w-6xl mx-auto space-y-4">
         {isLoading ? (
           <TableSkeleton rows={5} cols={4} />
         ) : isError ? (
           <ErrorState message={error?.message} onRetry={() => refetch()} />
-        ) : (users ?? []).length === 0 ? (
+        ) : userCount === 0 ? (
           <EmptyState
             icon={Users}
             title="No users yet"
             description="Users will appear here once they sign up or are added by an admin."
           />
         ) : (
-          <div className="animate-in overflow-x-auto rounded-md border border-border">
-            <Table>
-              <TableHeader>
-                <TableRow className="hover:bg-transparent">
-                  <TableHead className="h-8 text-xs">Name</TableHead>
-                  <TableHead className="h-8 text-xs">Email</TableHead>
-                  <TableHead className="h-8 text-xs">Role</TableHead>
-                  <TableHead className="h-8 text-xs text-right">Joined</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {(users ?? []).map((u: AdminUser) => (
-                  <TableRow key={u.id}>
-                    <TableCell className="py-1.5">
-                      <span className="text-sm font-medium">{u.name ?? u.username ?? "-"}</span>
-                    </TableCell>
-                    <TableCell className="py-1.5 text-sm text-muted-foreground">
-                      {u.email ?? "-"}
-                    </TableCell>
-                    <TableCell className="py-1.5">
-                      {roleBadge(u.role)}
-                    </TableCell>
-                    <TableCell className="py-1.5 text-xs text-muted-foreground text-right tabular-nums">
-                      {u.created_at ? new Date(u.created_at).toLocaleDateString() : "-"}
-                    </TableCell>
+          <div className="animate-in space-y-3">
+            <p className="text-xs text-muted-foreground">{userCount} user{userCount !== 1 ? "s" : ""}</p>
+            <div className="overflow-x-auto rounded-md border border-border">
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead className="h-8 text-xs">Name</TableHead>
+                    <TableHead className="h-8 text-xs">Email</TableHead>
+                    <TableHead className="h-8 text-xs">Role</TableHead>
+                    <TableHead className="h-8 text-xs text-right">Joined</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {(users ?? []).map((u: AdminUser) => (
+                    <TableRow key={u.id}>
+                      <TableCell className="py-1.5">
+                        <span className="text-sm font-medium">{u.name ?? u.username ?? "-"}</span>
+                      </TableCell>
+                      <TableCell className="py-1.5 text-sm text-muted-foreground font-[family-name:var(--font-mono)]">
+                        {u.email ?? "-"}
+                      </TableCell>
+                      <TableCell className="py-1.5">
+                        <RoleSelect userId={u.id} currentRole={u.role} />
+                      </TableCell>
+                      <TableCell className="py-1.5 text-xs text-muted-foreground text-right tabular-nums">
+                        {u.created_at ? new Date(u.created_at).toLocaleDateString() : "-"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           </div>
         )}
       </div>
+
+      {/* Create User Dialog */}
+      <Dialog open={showCreate} onOpenChange={(open) => { if (!open) closeDialog(); }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{createdApiKey ? "User Created" : "Add User"}</DialogTitle>
+            <DialogDescription>
+              {createdApiKey
+                ? "Save this API key — it will not be shown again."
+                : "Create a new user account. They will receive an API key for authentication."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {createdApiKey ? (
+            <div className="space-y-4">
+              <div className="rounded-md border border-border bg-muted/30 p-3">
+                <div className="flex items-center gap-2 mb-2">
+                  <Key className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">API Key</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className="text-xs font-[family-name:var(--font-mono)] text-foreground break-all flex-1 select-all">
+                    {createdApiKey}
+                  </code>
+                  <Button variant="ghost" size="sm" className="h-7 w-7 p-0 shrink-0" onClick={handleCopyKey}>
+                    {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+                  </Button>
+                </div>
+              </div>
+              <DialogFooter>
+                <Button size="sm" onClick={closeDialog}>Done</Button>
+              </DialogFooter>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">Name</label>
+                <Input
+                  placeholder="Jane Smith"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="h-8 text-sm"
+                  autoFocus
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">Email</label>
+                <Input
+                  type="email"
+                  placeholder="jane@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="h-8 text-sm"
+                  onKeyDown={(e) => { if (e.key === "Enter") handleCreate(); }}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">Role</label>
+                <Select value={role} onValueChange={setRole}>
+                  <SelectTrigger className="h-8 text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ROLES.map((r) => (
+                      <SelectItem key={r} value={r}>{r}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <DialogFooter>
+                <Button variant="ghost" size="sm" onClick={closeDialog}>Cancel</Button>
+                <Button
+                  size="sm"
+                  onClick={handleCreate}
+                  disabled={createUser.isPending || !name.trim() || !email.trim()}
+                >
+                  {createUser.isPending ? (
+                    <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> Creating...</>
+                  ) : (
+                    "Create User"
+                  )}
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -5,7 +5,6 @@ import { Users, Plus, Copy, Check, Loader2, Key } from "lucide-react";
 import { toast } from "sonner";
 import { useAdminUsers, useCreateUser, useUpdateUserRole } from "@/hooks/use-api";
 import type { AdminUser } from "@/lib/types";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -23,17 +22,6 @@ import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 
 const ROLES = ["admin", "developer", "viewer"] as const;
-
-function roleBadge(role: string) {
-  switch (role) {
-    case "admin":
-      return <Badge variant="default" className="text-[10px] px-1.5 py-0">{role}</Badge>;
-    case "developer":
-      return <Badge variant="secondary" className="text-[10px] px-1.5 py-0">{role}</Badge>;
-    default:
-      return <Badge variant="outline" className="text-[10px] px-1.5 py-0 text-muted-foreground">{role}</Badge>;
-  }
-}
 
 function RoleSelect({ userId, currentRole }: { userId: string; currentRole: string }) {
   const mutation = useUpdateUserRole();

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -9,23 +9,67 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
+type Mode = "login" | "register" | "api-key";
+
 export default function LoginPage() {
   const router = useRouter();
+  const [mode, setMode] = useState<Mode>("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
   const [apiKey, setKey] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [showKey, setShowKey] = useState(false);
-  const [initMode, setInitMode] = useState(false);
-  const [email, setEmail] = useState("");
-  const [name, setName] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
 
-  async function handleLogin() {
+  function switchMode(next: Mode) {
+    setMode(next);
+    setError("");
+  }
+
+  async function handlePasswordLogin() {
     setError("");
     setLoading(true);
     try {
-      setApiKey(apiKey);
-      const user = await auth.login({ api_key: apiKey });
-      setUserRole(user.role);
+      const res = await auth.login({ email, password });
+      setApiKey(res.api_key);
+      setUserRole(res.user.role);
+      toast.success("Signed in successfully");
+      router.push("/");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Login failed";
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleRegister() {
+    setError("");
+    setLoading(true);
+    try {
+      const res = await auth.register({ email, name, password });
+      setApiKey(res.api_key);
+      setUserRole(res.user.role);
+      toast.success("Account created");
+      router.push("/");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Registration failed";
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleApiKeyLogin() {
+    setError("");
+    setLoading(true);
+    try {
+      const res = await auth.login({ api_key: apiKey });
+      setApiKey(res.api_key);
+      setUserRole(res.user.role);
       toast.success("Signed in successfully");
       router.push("/");
     } catch (e) {
@@ -37,23 +81,7 @@ export default function LoginPage() {
     }
   }
 
-  async function handleInit() {
-    setError("");
-    setLoading(true);
-    try {
-      const res = await auth.init({ email, name });
-      setApiKey(res.api_key);
-      setUserRole(res.user.role);
-      toast.success("Admin account created");
-      router.push("/");
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : "Initialization failed";
-      setError(msg);
-      toast.error(msg);
-    } finally {
-      setLoading(false);
-    }
-  }
+  const onSubmit = mode === "login" ? handlePasswordLogin : mode === "register" ? handleRegister : handleApiKeyLogin;
 
   return (
     <div className="flex min-h-dvh items-center justify-center bg-surface-sunken p-6">
@@ -65,90 +93,84 @@ export default function LoginPage() {
               Observal
             </h1>
             <p className="text-sm text-muted-foreground">
-              {initMode
-                ? "Create the first admin account"
-                : "The agent registry for your team"}
+              {mode === "register"
+                ? "Create your account"
+                : mode === "api-key"
+                  ? "Sign in with API key"
+                  : "Sign in to your account"}
             </p>
           </div>
 
           {/* Form */}
           <div className="px-8 py-6">
-            {initMode ? (
-              <form
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  handleInit();
-                }}
-                className="space-y-4"
-              >
-                <div className="space-y-2 animate-in">
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="admin@company.com"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                    autoFocus
-                  />
-                </div>
-                <div className="space-y-2 animate-in stagger-1">
-                  <Label htmlFor="name">Name</Label>
-                  <Input
-                    id="name"
-                    placeholder="Admin User"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    required
-                  />
-                </div>
-                {error && (
-                  <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2.5 text-sm text-destructive animate-in">
-                    <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                    <span>{error}</span>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                onSubmit();
+              }}
+              className="space-y-4"
+            >
+              {/* Email + Password mode (login & register) */}
+              {mode !== "api-key" && (
+                <>
+                  <div className="space-y-2 animate-in">
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      placeholder="you@company.com"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      required
+                      autoFocus
+                    />
                   </div>
-                )}
-                <div className="animate-in stagger-2">
-                  <Button type="submit" disabled={loading} className="w-full">
-                    {loading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <>
-                        Create Admin Account
-                        <ArrowRight className="ml-1 h-4 w-4" />
-                      </>
-                    )}
-                  </Button>
-                </div>
-                <div className="animate-in stagger-3">
-                  <button
-                    type="button"
-                    className="w-full text-center text-sm text-muted-foreground transition-colors hover:text-foreground"
-                    onClick={() => {
-                      setInitMode(false);
-                      setError("");
-                    }}
-                  >
-                    Already have a key? Sign in
-                  </button>
-                </div>
-              </form>
-            ) : (
-              <form
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  handleLogin();
-                }}
-                className="space-y-4"
-              >
+                  {mode === "register" && (
+                    <div className="space-y-2 animate-in stagger-1">
+                      <Label htmlFor="name">Name</Label>
+                      <Input
+                        id="name"
+                        placeholder="Your Name"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        required
+                      />
+                    </div>
+                  )}
+                  <div className="space-y-2 animate-in stagger-1">
+                    <Label htmlFor="password">Password</Label>
+                    <div className="relative">
+                      <Input
+                        id="password"
+                        type={showPassword ? "text" : "password"}
+                        placeholder={mode === "register" ? "Create a password" : "Enter password"}
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                        className="pr-10"
+                      />
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        className="absolute right-0 top-0 flex h-full w-10 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                        onClick={() => setShowPassword(!showPassword)}
+                      >
+                        {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {/* API Key mode */}
+              {mode === "api-key" && (
                 <div className="space-y-2 animate-in">
                   <Label htmlFor="api-key">API Key</Label>
                   <div className="relative">
                     <Input
                       id="api-key"
-                      type={showKey ? "text" : "password"}
-                      placeholder="obs_..."
+                      type={showPassword ? "text" : "password"}
+                      placeholder="Paste your API key"
                       value={apiKey}
                       onChange={(e) => setKey(e.target.value)}
                       required
@@ -159,48 +181,76 @@ export default function LoginPage() {
                       type="button"
                       tabIndex={-1}
                       className="absolute right-0 top-0 flex h-full w-10 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
-                      onClick={() => setShowKey(!showKey)}
+                      onClick={() => setShowPassword(!showPassword)}
                     >
-                      {showKey ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
+                      {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                     </button>
                   </div>
                 </div>
-                {error && (
-                  <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2.5 text-sm text-destructive animate-in">
-                    <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                    <span>{error}</span>
-                  </div>
-                )}
-                <div className="animate-in stagger-1">
-                  <Button type="submit" disabled={loading} className="w-full">
-                    {loading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <>
-                        Sign in
-                        <ArrowRight className="ml-1 h-4 w-4" />
-                      </>
-                    )}
-                  </Button>
+              )}
+
+              {/* Error */}
+              {error && (
+                <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2.5 text-sm text-destructive animate-in">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{error}</span>
                 </div>
-                <div className="animate-in stagger-2">
+              )}
+
+              {/* Submit */}
+              <div className="animate-in stagger-2">
+                <Button type="submit" disabled={loading} className="w-full">
+                  {loading ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <>
+                      {mode === "register" ? "Create Account" : "Sign in"}
+                      <ArrowRight className="ml-1 h-4 w-4" />
+                    </>
+                  )}
+                </Button>
+              </div>
+
+              {/* Mode switches */}
+              <div className="animate-in stagger-3 space-y-2 text-center">
+                {mode === "login" && (
+                  <>
+                    <button
+                      type="button"
+                      className="block w-full text-sm text-muted-foreground transition-colors hover:text-foreground"
+                      onClick={() => switchMode("register")}
+                    >
+                      Don&apos;t have an account? Register
+                    </button>
+                    <button
+                      type="button"
+                      className="block w-full text-sm text-muted-foreground/60 transition-colors hover:text-foreground"
+                      onClick={() => switchMode("api-key")}
+                    >
+                      Sign in with API key instead
+                    </button>
+                  </>
+                )}
+                {mode === "register" && (
                   <button
                     type="button"
-                    className="w-full text-center text-sm text-muted-foreground transition-colors hover:text-foreground"
-                    onClick={() => {
-                      setInitMode(true);
-                      setError("");
-                    }}
+                    className="block w-full text-sm text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={() => switchMode("login")}
                   >
-                    First time? Create admin account
+                    Already have an account? Sign in
                   </button>
-                </div>
-              </form>
-            )}
+                )}
+                {mode === "api-key" && (
+                  <button
+                    type="button"
+                    className="block w-full text-sm text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={() => switchMode("login")}
+                  >
+                    Sign in with email instead
+                  </button>
+                )}
+              </div>
+            </form>
           </div>
         </div>
       </div>

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -22,10 +22,8 @@ import {
   useFeedback,
   useFeedbackSummary,
   useEvalAggregate,
-  useWhoami,
 } from "@/hooks/use-api";
-import { registry } from "@/lib/api";
-import { getUserRole } from "@/lib/api";
+import { registry, getUserRole } from "@/lib/api";
 import type { FeedbackItem } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
 import { StatusBadge } from "@/components/registry/status-badge";

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -9,6 +9,10 @@ import {
   Check,
   Copy,
   Users,
+  Download,
+  BarChart3,
+  Loader2,
+  Activity,
 } from "lucide-react";
 import { useState, useCallback } from "react";
 import { toast } from "sonner";
@@ -17,7 +21,11 @@ import {
   useAgentDownloads,
   useFeedback,
   useFeedbackSummary,
+  useEvalAggregate,
+  useWhoami,
 } from "@/hooks/use-api";
+import { registry } from "@/lib/api";
+import { getUserRole } from "@/lib/api";
 import type { FeedbackItem } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
 import { StatusBadge } from "@/components/registry/status-badge";
@@ -38,6 +46,7 @@ interface AgentDetail {
   version?: string;
   owner?: string;
   description?: string;
+  prompt?: string;
   model_name?: string;
   download_count?: number;
   component_links?: ComponentLink[];
@@ -57,6 +66,151 @@ interface ComponentLink {
   component_id?: string;
   mcp_id?: string;
   status?: string;
+}
+
+function ExportButton({ agentId }: { agentId: string }) {
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    try {
+      const manifest = await registry.manifest(agentId);
+      const blob = new Blob([JSON.stringify(manifest, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `agent-${agentId.slice(0, 8)}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+      toast.success("Agent manifest exported");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to export agent");
+    } finally {
+      setExporting(false);
+    }
+  }, [agentId]);
+
+  return (
+    <Button variant="outline" size="sm" className="h-8" onClick={handleExport} disabled={exporting}>
+      {exporting ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Download className="mr-1 h-3.5 w-3.5" />}
+      Export
+    </Button>
+  );
+}
+
+function AnalyticsTab({ agentId }: { agentId: string }) {
+  const { data: aggregate, isLoading } = useEvalAggregate(agentId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!aggregate) {
+    return (
+      <EmptyState
+        icon={BarChart3}
+        title="No analytics yet"
+        description="Run evaluations on this agent to generate analytics data. Traces and spans will be collected as the agent is used."
+      />
+    );
+  }
+
+  const dims = aggregate.dimension_averages ?? {};
+  const trend = aggregate.trend ?? [];
+
+  return (
+    <div className="space-y-6">
+      {/* Score overview */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div className="rounded-md border border-border p-3 space-y-1">
+          <span className="text-xs text-muted-foreground">Composite Score</span>
+          <p className="text-xl font-mono font-bold">{aggregate.mean.toFixed(1)}</p>
+        </div>
+        <div className="rounded-md border border-border p-3 space-y-1">
+          <span className="text-xs text-muted-foreground">Std Dev</span>
+          <p className="text-xl font-mono font-bold">{aggregate.std.toFixed(2)}</p>
+        </div>
+        <div className="rounded-md border border-border p-3 space-y-1">
+          <span className="text-xs text-muted-foreground">95% CI</span>
+          <p className="text-sm font-mono font-medium">{aggregate.ci_low.toFixed(1)} - {aggregate.ci_high.toFixed(1)}</p>
+        </div>
+        <div className="rounded-md border border-border p-3 space-y-1">
+          <span className="text-xs text-muted-foreground">Drift Alert</span>
+          <p className="text-sm font-medium">
+            {aggregate.drift_alert ? (
+              <Badge variant="destructive" className="text-[10px]">Drift detected</Badge>
+            ) : (
+              <Badge variant="outline" className="text-[10px]">Stable</Badge>
+            )}
+          </p>
+        </div>
+      </div>
+
+      {/* Dimension scores */}
+      {Object.keys(dims).length > 0 && (
+        <div className="space-y-3">
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Dimension Averages</h4>
+          <div className="space-y-2">
+            {Object.entries(dims).map(([dim, score]) => (
+              <div key={dim} className="flex items-center gap-3">
+                <span className="text-xs text-muted-foreground w-32 shrink-0 truncate">{dim}</span>
+                <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-primary rounded-full transition-all"
+                    style={{ width: `${Math.min(Number(score) * 10, 100)}%` }}
+                  />
+                </div>
+                <span className="text-xs font-mono w-10 text-right">{Number(score).toFixed(1)}</span>
+              </div>
+            ))}
+          </div>
+          {aggregate.weakest_dimension && (
+            <p className="text-xs text-muted-foreground">
+              Weakest: <span className="text-foreground font-medium">{aggregate.weakest_dimension}</span>
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Score trend */}
+      {trend.length > 0 && (
+        <div className="space-y-3">
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Score Trend</h4>
+          <div className="rounded-md border border-border p-4 overflow-x-auto">
+            <div className="flex items-end gap-1 h-24 min-w-[200px]">
+              {trend.map((t, i) => {
+                const height = Math.max(t.composite * 10, 2);
+                return (
+                  <div key={i} className="flex-1 flex flex-col items-center gap-1" title={`${new Date(t.timestamp).toLocaleDateString()}: ${t.composite.toFixed(1)}`}>
+                    <div
+                      className="w-full bg-primary/70 rounded-t transition-all hover:bg-primary"
+                      style={{ height: `${height}%` }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Link to traces */}
+      <div className="rounded-md border border-border p-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-muted-foreground" />
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Traces & Spans</h4>
+        </div>
+        <p className="text-xs text-muted-foreground">View detailed trace and span data for this agent in the admin dashboard.</p>
+        <Link href="/traces" className="text-xs text-primary hover:underline inline-flex items-center gap-1">
+          View traces →
+        </Link>
+      </div>
+    </div>
+  );
 }
 
 export default function AgentDetailPage({
@@ -84,7 +238,10 @@ export default function AgentDetailPage({
     typeof window !== "undefined" &&
     !!localStorage.getItem("observal_api_key");
 
-  // `a` mirrors `agent` with extended fields; always guarded by `!agent` below
+  const isAdmin =
+    typeof window !== "undefined" &&
+    getUserRole() === "admin";
+
   const a = agent as unknown as AgentDetail | undefined;
   const components: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];
   const goalTemplate = a?.goal_template;
@@ -103,6 +260,9 @@ export default function AgentDetailPage({
           { label: "Agents", href: "/agents" },
           { label: isLoading ? "..." : agentName },
         ]}
+        actionButtonsRight={
+          !isLoading && a ? <ExportButton agentId={id} /> : undefined
+        }
       />
 
       <div className="p-6 lg:p-8 max-w-[1200px]">
@@ -187,6 +347,7 @@ export default function AgentDetailPage({
                     )}
                   </TabsTrigger>
                   <TabsTrigger value="install">Install</TabsTrigger>
+                  {isAdmin && <TabsTrigger value="analytics">Analytics</TabsTrigger>}
                 </TabsList>
 
                 <TabsContent value="overview" className="space-y-6 mt-6">
@@ -248,11 +409,25 @@ export default function AgentDetailPage({
 
                 <TabsContent value="components" className="mt-6">
                   {components.length === 0 ? (
-                    <EmptyState
-                      icon={Puzzle}
-                      title="No components linked"
-                      description="This agent does not have any linked MCP servers or components."
-                    />
+                    a.prompt ? (
+                      <div className="space-y-3">
+                        <p className="text-xs text-muted-foreground">
+                          This agent was registered via scan and uses an inline system prompt instead of linked components.
+                        </p>
+                        <div className="rounded-md border border-border bg-muted/20 p-4">
+                          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">System Prompt</h4>
+                          <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words text-foreground/80 leading-relaxed max-h-[400px] overflow-y-auto">
+                            {String(a.prompt)}
+                          </pre>
+                        </div>
+                      </div>
+                    ) : (
+                      <EmptyState
+                        icon={Puzzle}
+                        title="No components linked"
+                        description="This agent does not have any linked MCP servers or components."
+                      />
+                    )
                   ) : (
                     <div className="space-y-2">
                       {components.map((comp: ComponentLink, i: number) => {
@@ -343,7 +518,7 @@ export default function AgentDetailPage({
                                 <Star
                                   key={i}
                                   className={`h-3.5 w-3.5 ${
-                                    i < fb.stars
+                                    i < fb.rating
                                       ? "fill-current text-amber-500"
                                       : "text-muted-foreground/30"
                                   }`}
@@ -391,6 +566,12 @@ export default function AgentDetailPage({
                     <ConfigSnippet agentName={a.name} />
                   </div>
                 </TabsContent>
+
+                {isAdmin && (
+                  <TabsContent value="analytics" className="mt-6">
+                    <AnalyticsTab agentId={id} />
+                  </TabsContent>
+                )}
               </Tabs>
             </div>
 

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -22,11 +22,17 @@ import {
   TabsContent,
 } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/layouts/page-header";
-import { useRegistryList, useAgentValidation } from "@/hooks/use-api";
+import { useRegistryList, useAgentValidation, useWhoami } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import { registry, type RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
 import type { ValidationResult } from "@/lib/types";
+
+const MODEL_OPTIONS = [
+  { value: "claude-sonnet-4-20250514", label: "Claude Sonnet 4" },
+  { value: "claude-opus-4-20250514", label: "Claude Opus 4" },
+  { value: "claude-haiku-3-5-20241022", label: "Claude Haiku 3.5" },
+];
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
 import { ValidationPanel } from "@/components/builder/validation-panel";
 import { PreviewPanel } from "@/components/builder/preview-panel";
@@ -146,8 +152,11 @@ export default function AgentBuilderPage() {
   const { ready } = useAuthGuard();
 
   const router = useRouter();
+  const { data: whoami } = useWhoami();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [version, setVersion] = useState("1.0.0");
+  const [modelName, setModelName] = useState("claude-sonnet-4-20250514");
   const [publishing, setPublishing] = useState(false);
   const [activeTab, setActiveTab] = useState<RegistryType>("mcps");
 
@@ -280,28 +289,36 @@ export default function AgentBuilderPage() {
 
     setPublishing(true);
     try {
-      const componentLinks: string[] = [];
-      Object.values(selectedComponents).forEach((items) =>
-        items.forEach((item) => componentLinks.push(item.id)),
-      );
+      // Build components array with proper {component_type, component_id} format
+      const components: { component_type: string; component_id: string }[] = [];
+      for (const [type, items] of Object.entries(selectedComponents)) {
+        const singularType = TYPE_MAP[type] ?? type;
+        for (const item of items) {
+          components.push({ component_type: singularType, component_id: item.id });
+        }
+      }
 
-      const goal = goalSections
-        .filter((s) => s.title || s.content)
-        .reduce(
-          (acc, section) => {
-            if (section.title) {
-              acc[section.title] = section.content;
-            }
-            return acc;
-          },
-          {} as Record<string, string>,
-        );
+      // Build goal_template with sections
+      const sections = goalSections
+        .filter((s) => s.title.trim())
+        .map((s) => ({
+          name: s.title.trim(),
+          description: s.content.trim() || null,
+        }));
+
+      const goalDescription = description.trim() || name.trim();
 
       const body = {
         name: name.trim(),
-        description: description.trim() || undefined,
-        component_links: componentLinks.length > 0 ? componentLinks : undefined,
-        goal: Object.keys(goal).length > 0 ? goal : undefined,
+        version: version.trim() || "1.0.0",
+        description: description.trim(),
+        owner: whoami?.name || whoami?.email || "unknown",
+        model_name: modelName,
+        components: components.length > 0 ? components : [],
+        goal_template: {
+          description: goalDescription,
+          sections: sections.length > 0 ? sections : [{ name: "Default", description: goalDescription }],
+        },
       };
 
       const created = await registry.create("agents", body);
@@ -362,6 +379,36 @@ export default function AgentBuilderPage() {
                   rows={3}
                   className="max-w-lg resize-y"
                 />
+              </div>
+              <div className="flex gap-4">
+                <div className="space-y-2 flex-1 max-w-[200px]">
+                  <Label htmlFor="agent-version" className="text-sm font-medium">
+                    Version
+                  </Label>
+                  <Input
+                    id="agent-version"
+                    placeholder="1.0.0"
+                    value={version}
+                    onChange={(e) => setVersion(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2 flex-1 max-w-xs">
+                  <Label htmlFor="agent-model" className="text-sm font-medium">
+                    Model
+                  </Label>
+                  <select
+                    id="agent-model"
+                    value={modelName}
+                    onChange={(e) => setModelName(e.target.value)}
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  >
+                    {MODEL_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </div>
             </section>
 

--- a/web/src/app/(registry)/components/[id]/page.tsx
+++ b/web/src/app/(registry)/components/[id]/page.tsx
@@ -2,20 +2,48 @@
 
 import { use } from "react";
 import { useSearchParams } from "next/navigation";
-import { useRegistryItem } from "@/hooks/use-api";
+import { useState, useCallback } from "react";
+import { Star, Check, Copy } from "lucide-react";
+import { toast } from "sonner";
+import { useRegistryItem, useFeedback, useFeedbackSummary, useRegistryMetrics } from "@/hooks/use-api";
 import type { RegistryType } from "@/lib/api";
+import type { FeedbackItem, RegistryItem } from "@/lib/types";
+import { ReviewForm } from "@/components/registry/review-form";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/layouts/page-header";
 import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
+import { EmptyState } from "@/components/shared/empty-state";
+
+function statusVariant(status?: string) {
+  if (status === "approved") return "default" as const;
+  if (status === "rejected") return "destructive" as const;
+  return "secondary" as const;
+}
 
 export default function ComponentDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const searchParams = useSearchParams();
   const type = (searchParams.get("type") ?? "mcps") as RegistryType;
+  const singularType = type.replace(/s$/, "");
   const { data: item, isLoading, isError, error, refetch } = useRegistryItem(type, id);
+  const { data: feedbackItems, refetch: refetchFeedback } = useFeedback(singularType, id);
+  const { data: feedbackSummary, refetch: refetchSummary } = useFeedbackSummary(id);
+  const { data: rawMetrics } = useRegistryMetrics(type, id);
+
+  const isAuthenticated =
+    typeof window !== "undefined" &&
+    !!localStorage.getItem("observal_api_key");
 
   const componentName = item?.name ?? id.slice(0, 8);
+  const avgRating = feedbackSummary?.average_rating;
+  const totalReviews = feedbackSummary?.total_reviews ?? 0;
+  const metricsEntries: [string, string][] = rawMetrics && typeof rawMetrics === "object"
+    ? Object.entries(rawMetrics as Record<string, unknown>).map(([k, v]) => [k, typeof v === "number" ? v.toLocaleString() : String(v ?? "")])
+    : [];
 
   return (
     <>
@@ -35,25 +63,230 @@ export default function ComponentDetailPage({ params }: { params: Promise<{ id: 
         ) : !item ? (
           <ErrorState message="Component not found" />
         ) : (
-          <>
-            <div className="space-y-1">
+          <div className="animate-in space-y-6">
+            {/* Header */}
+            <div className="space-y-2">
               <div className="flex items-center gap-2 flex-wrap">
-                <Badge variant="outline">{type.replace(/s$/, "")}</Badge>
-                {item.status && <Badge variant={item.status === "approved" ? "default" : "secondary"}>{item.status}</Badge>}
+                <h1 className="text-2xl font-display font-bold tracking-tight">{item.name}</h1>
+                <Badge variant="outline" className="text-xs">{singularType}</Badge>
+                {item.status && <Badge variant={statusVariant(item.status)}>{item.status}</Badge>}
               </div>
+              {item.description && (
+                <p className="text-sm text-foreground/80 leading-relaxed max-w-2xl">{item.description}</p>
+              )}
+              {avgRating != null && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <div className="flex items-center gap-0.5">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <Star
+                        key={i}
+                        className={`h-3.5 w-3.5 ${i < Math.round(avgRating) ? "fill-current text-amber-500" : "text-muted-foreground/30"}`}
+                      />
+                    ))}
+                  </div>
+                  <span className="text-xs">{avgRating.toFixed(1)} ({totalReviews} review{totalReviews !== 1 ? "s" : ""})</span>
+                </div>
+              )}
             </div>
 
-            {item.description && <p className="text-sm">{item.description}</p>}
+            {/* Tabs */}
+            <Tabs defaultValue="overview">
+              <TabsList>
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="reviews">
+                  Reviews
+                  {totalReviews > 0 && (
+                    <span className="ml-1.5 text-[10px] bg-muted px-1.5 py-0.5 rounded-full">
+                      {totalReviews}
+                    </span>
+                  )}
+                </TabsTrigger>
+                <TabsTrigger value="install">Install</TabsTrigger>
+              </TabsList>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-              {"version" in item && item.version != null && <div><span className="text-muted-foreground">Version:</span> {String(item.version)}</div>}
-              {"git_url" in item && item.git_url != null && <div><span className="text-muted-foreground">Source:</span> <a href={String(item.git_url)} className="underline" target="_blank" rel="noopener noreferrer">{String(item.git_url)}</a></div>}
-              {"transport" in item && item.transport != null && <div><span className="text-muted-foreground">Transport:</span> {String(item.transport)}</div>}
-              {item.created_at && <div><span className="text-muted-foreground">Created:</span> {new Date(item.created_at).toLocaleDateString()}</div>}
-            </div>
-          </>
+              <TabsContent value="overview" className="mt-6 space-y-6">
+                <ComponentMetadata item={item} />
+                <MetricsSection entries={metricsEntries} />
+              </TabsContent>
+
+              <TabsContent value="reviews" className="mt-6 space-y-6">
+                {isAuthenticated && (
+                  <>
+                    <ReviewForm
+                      listingId={id}
+                      listingType={singularType}
+                      onSuccess={() => {
+                        refetchFeedback();
+                        refetchSummary();
+                      }}
+                    />
+                    <Separator />
+                  </>
+                )}
+
+                {!feedbackItems || feedbackItems.length === 0 ? (
+                  <EmptyState
+                    icon={Star}
+                    title="No reviews yet"
+                    description={
+                      isAuthenticated
+                        ? `Be the first to review this ${singularType}.`
+                        : "Log in to leave a review."
+                    }
+                  />
+                ) : (
+                  <div className="space-y-4">
+                    {feedbackItems.map((fb: FeedbackItem) => (
+                      <div key={fb.id} className="rounded-md border border-border p-4 space-y-2">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-1">
+                            {Array.from({ length: 5 }).map((_, i) => (
+                              <Star
+                                key={i}
+                                className={`h-3.5 w-3.5 ${
+                                  i < fb.rating
+                                    ? "fill-current text-amber-500"
+                                    : "text-muted-foreground/30"
+                                }`}
+                              />
+                            ))}
+                          </div>
+                          <span className="text-xs text-muted-foreground">
+                            {fb.username ?? fb.user ?? "Anonymous"}
+                            {fb.created_at && ` · ${new Date(fb.created_at).toLocaleDateString()}`}
+                          </span>
+                        </div>
+                        {fb.comment && (
+                          <p className="text-sm text-muted-foreground leading-relaxed">{fb.comment}</p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </TabsContent>
+
+              <TabsContent value="install" className="mt-6 space-y-6">
+                <div className="space-y-2">
+                  <h3 className="text-sm font-semibold font-display">Quick Install</h3>
+                  <p className="text-xs text-muted-foreground">
+                    Use the Observal CLI to add this {singularType} to your agent configuration.
+                  </p>
+                </div>
+                <InstallSnippet type={singularType} name={item.name} />
+
+                {"git_url" in item && item.git_url ? (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      <h3 className="text-sm font-semibold font-display">From Source</h3>
+                      <p className="text-xs text-muted-foreground">
+                        Clone directly from the source repository.
+                      </p>
+                      <code className="block rounded-md border border-border bg-muted/20 p-3 text-xs font-[family-name:var(--font-mono)]">
+                        git clone {String(item.git_url)}
+                      </code>
+                    </div>
+                  </>
+                ) : null}
+              </TabsContent>
+            </Tabs>
+          </div>
         )}
       </div>
     </>
+  );
+}
+
+function ComponentMetadata({ item }: { item: RegistryItem }) {
+  const fields: { label: string; value: string; mono?: boolean; href?: string }[] = [];
+  if ("version" in item && item.version != null) fields.push({ label: "Version", value: String(item.version), mono: true });
+  if ("git_url" in item && item.git_url != null) fields.push({ label: "Source", value: String(item.git_url), href: String(item.git_url) });
+  if ("transport" in item && item.transport != null) fields.push({ label: "Transport", value: String(item.transport) });
+  if (item.created_at) fields.push({ label: "Created", value: new Date(item.created_at).toLocaleDateString() });
+  if ("owner" in item && item.owner != null) fields.push({ label: "Owner", value: String(item.owner) });
+  if ("hook_type" in item && item.hook_type != null) fields.push({ label: "Hook Type", value: String(item.hook_type) });
+  if ("trigger_event" in item && item.trigger_event != null) fields.push({ label: "Trigger Event", value: String(item.trigger_event) });
+  if ("runtime" in item && item.runtime != null) fields.push({ label: "Runtime", value: String(item.runtime) });
+  if ("image" in item && item.image != null) fields.push({ label: "Image", value: String(item.image), mono: true });
+
+  const promptText = "prompt_text" in item && item.prompt_text ? String(item.prompt_text) : null;
+
+  return (
+    <>
+      {fields.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+          {fields.map((f) => (
+            <div key={f.label} className="rounded-md border border-border p-3 space-y-1">
+              <span className="text-xs text-muted-foreground">{f.label}</span>
+              {f.href ? (
+                <p><a href={f.href} className="text-sm text-primary hover:underline break-all" target="_blank" rel="noopener noreferrer">{f.value}</a></p>
+              ) : (
+                <p className={f.mono ? "font-mono text-sm" : "text-sm"}>{f.value}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {promptText && (
+        <div className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Prompt Content</h3>
+          <div className="rounded-md border border-border bg-muted/20 p-4">
+            <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words text-foreground/80 leading-relaxed max-h-[400px] overflow-y-auto">
+              {promptText}
+            </pre>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function MetricsSection({ entries }: { entries: [string, string][] }) {
+  if (entries.length === 0) return null;
+  return (
+    <div className="space-y-3">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Usage</h3>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {entries.map(([key, display]) => (
+          <div key={key} className="rounded-md border border-border p-3 space-y-1">
+            <span className="text-xs text-muted-foreground">{key.replace(/_/g, " ")}</span>
+            <p className="text-lg font-mono font-bold">{display}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function InstallSnippet({ type, name }: { type: string; name: string }) {
+  const [copied, setCopied] = useState(false);
+  const cmd = `observal add ${type} ${name}`;
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(cmd);
+    setCopied(true);
+    toast.success("Copied to clipboard");
+    setTimeout(() => setCopied(false), 2000);
+  }, [cmd]);
+
+  return (
+    <div className="relative rounded-md border border-border bg-surface-sunken">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute top-2 right-2 h-7 w-7"
+        onClick={handleCopy}
+        aria-label="Copy command"
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-green-500" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+      </Button>
+      <pre className="p-4 text-xs font-mono leading-relaxed overflow-x-auto text-foreground/80">
+        $ {cmd}
+      </pre>
+    </div>
   );
 }

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -29,6 +29,7 @@ import {
   ShieldCheck,
   Users,
   Settings,
+  AlertTriangle,
 } from "lucide-react";
 import { getUserRole } from "@/lib/api";
 
@@ -43,6 +44,7 @@ const registryNav: { title: string; href: string; icon: typeof Home; requiresAut
 const adminNav = [
   { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { title: "Traces", href: "/traces", icon: Activity },
+  { title: "Errors", href: "/errors", icon: AlertTriangle },
   { title: "Evals", href: "/eval", icon: FlaskConical },
   { title: "Review", href: "/review", icon: ShieldCheck },
   { title: "Users", href: "/users", icon: Users },

--- a/web/src/components/registry/feedback-list.tsx
+++ b/web/src/components/registry/feedback-list.tsx
@@ -8,7 +8,7 @@ export function FeedbackList({ data, isLoading }: { data: Record<string, unknown
       {data.map((fb, i) => (
         <div key={i} className="rounded-md border p-3">
           <div className="flex items-center gap-2 text-sm">
-            <span className="font-medium">{"★".repeat(Number(fb.stars ?? 0))}</span>
+            <span className="font-medium">{"★".repeat(Number(fb.rating ?? fb.stars ?? 0))}</span>
             <span className="text-muted-foreground">{String(fb.username ?? "Anonymous")}</span>
           </div>
           {fb.comment ? <p className="mt-1 text-sm">{String(fb.comment)}</p> : null}

--- a/web/src/components/registry/review-form.tsx
+++ b/web/src/components/registry/review-form.tsx
@@ -31,7 +31,7 @@ export function ReviewForm({
       {
         listing_type: listingType,
         listing_id: listingId,
-        stars: rating,
+        rating: rating,
         comment: comment.trim() || undefined,
       },
       {

--- a/web/src/components/traces/span-tree.tsx
+++ b/web/src/components/traces/span-tree.tsx
@@ -21,7 +21,6 @@ export interface Span {
   metadata?: Record<string, unknown>;
   token_input?: number;
   token_output?: number;
-  cost?: number;
   tool_schema_valid?: boolean;
 }
 

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -98,7 +98,7 @@ const SidebarProvider = React.forwardRef<
           ref={ref}
           data-sidebar-state={state}
           style={{ "--sidebar-width": SIDEBAR_WIDTH, "--sidebar-width-icon": SIDEBAR_WIDTH_ICON, ...style } as React.CSSProperties}
-          className={cn("flex h-dvh w-full overflow-hidden", className)}
+          className={cn("flex h-dvh w-full", className)}
           {...props}
         >
           {children}
@@ -220,7 +220,7 @@ const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<"main
   ({ className, ...props }, ref) => (
     <main
       ref={ref}
-      className={cn("relative flex min-w-0 flex-1 flex-col bg-background", className)}
+      className={cn("relative flex min-w-0 flex-1 flex-col overflow-y-auto bg-background", className)}
       {...props}
     />
   ),

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -245,6 +245,9 @@ export function useOtelTrace(id: string | undefined) {
 export function useOtelStats() {
   return useQuery({ queryKey: ['otel', 'stats'], queryFn: dashboard.otelStats });
 }
+export function useOtelErrors() {
+  return useQuery({ queryKey: ['otel', 'errors'], queryFn: dashboard.otelErrors });
+}
 
 // ── Agent-specific ──────────────────────────────────────────────────
 

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -207,6 +207,35 @@ export function useAdminUsers() {
   return useQuery({ queryKey: ["admin", "users"], queryFn: admin.users });
 }
 
+export function useCreateUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: admin.createUser,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "users"] });
+      toast.success("User created");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to create user");
+    },
+  });
+}
+
+export function useUpdateUserRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { id: string; role: string }) =>
+      admin.updateRole(vars.id, { role: vars.role }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "users"] });
+      toast.success("Role updated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to update role");
+    },
+  });
+}
+
 export function useAdminSettings() {
   return useQuery({ queryKey: ["admin", "settings"], queryFn: admin.settings });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   AdminUser,
   AdminSetting,
   OtelSession,
+  OtelErrorEvent,
   TelemetryStatus,
   ReviewItem,
   RegistryItem,
@@ -181,6 +182,7 @@ export const dashboard = {
   otelTraces: () => get<OtelTrace[]>('/otel/traces'),
   otelTrace: (id: string) => get<unknown>(`/otel/traces/${encodeURIComponent(id)}`),
   otelStats: () => get<OtelStats>('/otel/stats'),
+  otelErrors: () => get<OtelErrorEvent[]>('/otel/errors'),
 };
 
 // ── Feedback ────────────────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -106,11 +106,15 @@ export async function graphql<T = unknown>(
 }
 
 // ── Auth ────────────────────────────────────────────────────────────
+type AuthResponse = { user: { id: string; email: string; name: string; role: string; created_at: string }; api_key: string };
+
 export const auth = {
-  init: (body: { email: string; name: string }) =>
-    post<{ user: { id: string; email: string; name: string; role: string; created_at: string }; api_key: string }>("/auth/init", body),
-  login: (body: { api_key: string }) =>
-    post<{ id: string; email: string; name: string; role: string; created_at: string }>("/auth/login", body),
+  init: (body: { email: string; name: string; password?: string }) =>
+    post<AuthResponse>("/auth/init", body),
+  register: (body: { email: string; name: string; password: string }) =>
+    post<AuthResponse>("/auth/register", body),
+  login: (body: { api_key?: string; email?: string; password?: string }) =>
+    post<AuthResponse>("/auth/login", body),
   whoami: () => get<{ id: string; email: string; name: string; role: string }>("/auth/whoami"),
 };
 
@@ -136,6 +140,7 @@ export const registry = {
   metrics: (type: RegistryType, id: string) =>
     get<unknown>(`/${type}/${id}/metrics`),
   resolve: (id: string) => get<unknown>(`/agents/${id}/resolve`),
+  manifest: (id: string) => get<Record<string, unknown>>(`/agents/${id}/manifest`),
   downloads: (id: string) =>
     get<{ total: number; unique_users: number; recent_7d: number }>(`/agents/${id}/downloads`),
   validate: (body: { components: { component_type: string; component_id: string }[] }) =>
@@ -190,7 +195,7 @@ export const feedback = {
   submit: (body: {
     listing_type: string;
     listing_id: string;
-    stars: number;
+    rating: number;
     comment?: string;
   }) => post<FeedbackItem>("/feedback", body),
   get: (type: string, id: string) => get<FeedbackItem[]>(`/feedback/${type}/${id}`),
@@ -224,10 +229,12 @@ export const admin = {
   settings: () => get<AdminSetting[] | Record<string, string>>("/admin/settings"),
   updateSetting: (key: string, body: unknown) =>
     put<unknown>(`/admin/settings/${key}`, body),
+  deleteSetting: (key: string) => del(`/admin/settings/${key}`),
   users: () => get<AdminUser[]>("/admin/users"),
-  createUser: (body: unknown) => post<unknown>("/admin/users", body),
+  createUser: (body: { email: string; name: string; role?: string }) =>
+    post<{ id: string; email: string; name: string; role: string; api_key: string }>("/admin/users", body),
   updateRole: (id: string, body: { role: string }) =>
-    put<unknown>(`/admin/users/${id}/role`, body),
+    put<AdminUser>(`/admin/users/${id}/role`, body),
 };
 
 // ── Health ──────────────────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -252,6 +252,21 @@ export interface OtelSession {
   service_name: string;
 }
 
+export interface OtelErrorEvent {
+  timestamp: string;
+  event_name: string;
+  body: string;
+  session_id: string;
+  tool_name: string;
+  error: string;
+  agent_id: string;
+  agent_type: string;
+  tool_input: string;
+  tool_response: string;
+  stop_reason: string;
+  user_id: string;
+}
+
 // ── Telemetry ───────────────────────────────────────────────────────
 
 export interface TelemetryStatus {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -158,7 +158,7 @@ export interface FeedbackItem {
   listing_id?: string;
   listing_name?: string;
   listing_type?: string;
-  stars: number;
+  rating: number;
   comment?: string;
   user?: string;
   username?: string;


### PR DESCRIPTION
## Summary

Mega PR covering the full E2E local testing effort and all fixes/features discovered during it:

### Auth System Overhaul
- **Username/password authentication** as alternative to API keys — register, login with email+password, or use API key
- Password hashing via stdlib `hashlib.scrypt` (no new dependencies)
- `/auth/register` endpoint, updated `/auth/login` with dual-mode (key or password)
- `Authorization: Bearer` header support alongside `X-API-Key`
- Startup migration for `password_hash` column on existing databases
- Frontend login page rewritten: email+password default, register mode, API key fallback
- CLI `observal auth register` command, `--email`/`--password` flags on login
- **Fixes "invalid API key" bug** — CLI now uses proper POST /auth/login and stores server-returned keys

### Admin UI
- **Users page**: create user dialog with API key reveal, inline role editing via dropdown
- **Settings page**: add/edit/delete settings with dialogs, proper CRUD flow

### Registry UI
- **Agent detail**: export button (downloads manifest JSON), admin analytics tab (composite score, dimensions, trend chart)
- **Component detail**: rewritten with Overview/Reviews/Install tabs, type-specific metadata, CLI install snippet
- Fixed `stars` → `rating` field mismatch across all feedback components

### Traces & Observability
- Reddit-style collapsible span tree with OTEL/hooks dedup and agent attribution
- Inline diff rendering for Edit tool events
- Styled assistant response blocks, user prompt blocks
- Search bar, filter chips, expanded event type support
- Error dashboard with filtering and search
- Sessions list: User/IDE columns, token counts replacing cost

### Demo & Testing
- Replaced mock MCP framework with real `~/.claude` integration tests
- Fixed demo scripts and server bugs found during E2E testing
- Fixed agent builder publish payload alignment with server schema

### Bug Fixes
- `git_url` NOT NULL mismatch in skill, hook, prompt, sandbox models (Closes #132)
- Docker SDK missing from pyproject.toml dependencies (Closes #134)
- 18 hook types with agent attribution on all events
- Hook/OTEL event merging by timestamp proximity

## Test plan
- [x] Backend: register, password login, API key login, wrong password, duplicate email — all tested via curl
- [x] Backend: `X-API-Key` and `Authorization: Bearer` both validated via curl
- [x] Frontend: register flow tested via Playwright (redirects to dashboard)
- [x] Frontend: password login flow tested via Playwright (redirects to dashboard)
- [x] Frontend: wrong password shows error inline via Playwright
- [x] Frontend: API key mode toggle works via Playwright
- [x] Frontend: Next.js production build passes with zero TypeScript errors
- [x] Docker: containers rebuilt and healthy
- [x] All Python files pass syntax validation