### PR TITLE
fix: add overflow-y-auto to SidebarInset to restore page scrolling

### DIFF
--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -98,7 +98,7 @@ const SidebarProvider = React.forwardRef<
           ref={ref}
           data-sidebar-state={state}
           style={{ "--sidebar-width": SIDEBAR_WIDTH, "--sidebar-width-icon": SIDEBAR_WIDTH_ICON, ...style } as React.CSSProperties}
-          className={cn("flex h-dvh w-full overflow-hidden", className)}
+          className={cn("flex h-dvh w-full", className)}
           {...props}
         >
           {children}
@@ -220,7 +220,7 @@ const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<"main
   ({ className, ...props }, ref) => (
     <main
       ref={ref}
-      className={cn("relative flex min-w-0 flex-1 flex-col bg-background", className)}
+      className={cn("relative flex min-w-0 flex-1 flex-col overflow-y-auto bg-background", className)}
       {...props}
     />
   ),


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The scroll wasn't working on pages which needed it 

## Fixes
* Fixes #155 

## Approach
The scrollbar provider had [overflow-hidden](https://www.w3schools.com/css/css_overflow.asp) which basically locks the screen and clips any content that doesn't fit. Removed this and also added auto overflow to the sidebar inset to allow for scroll.

## How Has This Been Tested?
Tested it physically by running the app

## Learning (optional, can help others)
https://www.w3schools.com/css/css_overflow.asp

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->