### PR TITLE
feat(security): add secrets redactor to all trace ingestion paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,255 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — Kiro CLI Full Parity
+
+Brings Kiro CLI to feature parity with Claude Code for telemetry, session tracking, and multi-IDE management. Verified with real `kiro-cli` sessions — all Kiro agent sessions now appear in the Observal dashboard with prompts, tool I/O, model responses, credit usage, and conversation linking.
+
+#### Critical Bug Fix: Hook Endpoint Routing
+
+- **Fixed Kiro hook target**: All generated Kiro hook configs were sending telemetry to `/api/v1/telemetry/hooks` (writes to `spans` table) instead of `/api/v1/otel/hooks` (writes to `otel_logs` table). This caused **zero Kiro sessions** to appear in the dashboard. Fixed in `hook_config_generator.py`, `agent_config_generator.py`, and E2E helpers.
+- **Removed stale `X-API-Key` header** from Kiro curl commands — `/api/v1/otel/hooks` is intentionally unauthenticated since CLI hooks can't carry auth tokens.
+
+#### Kiro Event Normalization
+
+- **camelCase → PascalCase event mapping** (`otel_dashboard.py`): Kiro sends `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, `stop` — server normalizes to Claude Code's `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`.
+- **camelCase → snake_case field mapping**: `hookEventName` → `hook_event_name`, `sessionId` → `session_id`, `toolName` → `tool_name`, etc.
+- **Kiro-specific field extraction**: Kiro sends `prompt` (not `user_prompt`) and `assistant_response` (not `tool_response`). Server now extracts both correctly.
+
+#### Session ID via `$PPID`
+
+- Kiro CLI does not expose a session/conversation ID in hook payloads. Implemented `$PPID`-based session ID injection via `sed` — all hooks in a single `kiro-cli` invocation share a stable `kiro-{PPID}` session identifier.
+- Real `conversation_id` from Kiro's SQLite database is also extracted and attached as an attribute for cross-session linking (e.g., resumed conversations).
+
+#### Kiro SQLite Enrichment Pipeline
+
+- **`observal_cli/hooks/kiro_stop_hook.py`** — On `stop` hook, queries `~/.local/share/kiro-cli/data.sqlite3` for the most recent conversation matching `cwd`. Extracts and sends:
+  - `model_id` (resolved from per-turn metadata when set to "auto")
+  - `input_tokens` / `output_tokens` (estimated from character counts, ~4 chars/token)
+  - `credits` (total credit usage from `usage_info`)
+  - `tools_used` (deduplicated list of tools invoked)
+  - `context_window_tokens` and `max_context_usage_pct`
+  - `conversation_id` for stable cross-session linking
+- **`observal_cli/hooks/kiro_hook.py`** — Lightweight script for non-stop events (~23ms overhead). Adds `conversation_id` from SQLite without parsing the full conversation JSON.
+- **Note**: Kiro CLI does not expose actual token counts — only character lengths and credit costs. Estimated tokens are labeled accordingly. This may differ on enterprise plans where billing data structures vary.
+
+#### Per-Agent Hook Enrichment
+
+- Hook commands now inject `agent_name` and `model` (when set) into every Kiro hook payload via `sed`. The dashboard shows which agent handled each session.
+- Added `userPromptSubmit` to the Kiro hooks block (was previously missing — user prompts were not captured).
+
+#### Multi-IDE Scan (`--all-ides`)
+
+- **`observal scan --all-ides`** scans both `~/.claude/` and `~/.kiro/` in one pass, tagging each component with `source_ide`.
+- **`observal scan --home --ide kiro`** scans only `~/.kiro/`.
+- **`_scan_kiro_home()`** (`cmd_scan.py`) discovers agents from `~/.kiro/agents/*.json`, global MCPs from `~/.kiro/settings/mcp.json`, per-agent MCPs, and per-agent hooks.
+- **Server-side** (`scan.py`): Added `source_ide` field to `ScannedMcp`, `ScannedSkill`, `ScannedHook`, `ScannedAgent` — components are tagged with their origin IDE for `supported_ides` routing.
+
+#### Auto-Inject Observal Hooks into Kiro Agents
+
+- When running `observal scan --home --ide kiro` (or `--all-ides`), hooks are automatically injected into all `~/.kiro/agents/*.json` files with per-agent metadata enrichment.
+- Existing hooks are preserved if they already point to the correct Observal endpoint.
+- Original files are backed up before modification.
+
+#### Dashboard Enhancements
+
+- Sessions list query now includes `credits` and `tools_used` columns from enriched Kiro stop events.
+- `conversation_id` stored as a ClickHouse attribute for future cross-session grouping.
+
+#### E2E Tests (36 pass, 0 fail)
+
+- `kiro-hooks.spec.ts` — Hook ingestion: camelCase normalization, field mapping, session visibility after lifecycle events
+- `kiro-cli.spec.ts` — CLI: `scan --home --ide kiro`, `scan --all-ides`, `doctor --ide kiro`, `pull --ide kiro`, `auth status/whoami`
+- `kiro-lifecycle.spec.ts` — Full lifecycle simulation and dashboard verification
+- `kiro-agent-compat.spec.ts` — Cross-IDE agent file generation (Kiro ↔ Claude Code)
+- `kiro-otlp-logs.spec.ts` / `kiro-otlp-traces.spec.ts` — OTLP ingestion and trace grouping
+- `kiro-web-*.spec.ts` — Web UI: agents page, components page, traces, dashboard
+
+### Added — BenchJack-Hardened Evaluation Pipeline (Phases 8A-8G)
+
+Implements defenses against all 7 "deadly patterns" from the BenchJack paper on benchmark exploitation. Adds 6 new services (~2,000 lines), 7 test files (~2,600 lines / 183 tests), and rewires the eval pipeline.
+
+#### Phase 0: Structured Eval Scoring Pipeline
+
+- **6-dimension penalty-based scoring model** (`models/scoring.py`)
+  - `goal_completion` (0.28), `tool_efficiency` (0.18), `tool_failures` (0.13), `factual_grounding` (0.18), `thought_process` (0.13), `adversarial_robustness` (0.10)
+  - Each dimension starts at 100 and is reduced by penalties
+  - 20+ penalty definitions with severity (critical/moderate/minor) and trigger types (structural/slm_assisted/absence)
+  - Weighted composite score with letter grades (A/B/C/D/F)
+- **Structural scorer** (`services/structural_scorer.py`) — deterministic checks for duplicate tool calls, unused results, tool errors/timeouts, ungrounded claims
+- **SLM scorer** (`services/slm_scorer.py`) — LLM-assisted checks for goal completion, factual grounding, thought process quality
+- **Score aggregator** (`services/score_aggregator.py`) — per-dimension scores, weighted composite, grade assignment
+- **Dashboard UI** — aggregate chart, dimension radar, penalty accordion
+- **Follow-up fix**: replaced flawed `excessive_tool_calls` criterion with `ungrounded_claims` (focuses on hallucination harm, not process metrics)
+
+#### Phase 8A: TraceSanitizer and Structured Judge Output
+
+Defends against **BenchJack Pattern 1 (Prompt Injection)**.
+
+- **TraceSanitizer** (`services/sanitizer.py`, 269 lines) — detects and strips 7 injection patterns from traces:
+  - HTML/XML comments with eval keywords (high)
+  - System prompt patterns like `SYSTEM:`, `ASSISTANT:` (high)
+  - Score assertions like `score: 10/10`, `"overall_score": 100` (high)
+  - Markdown comments `[//]: #` (medium)
+  - Long zero-width Unicode sequences (medium)
+  - Unusual whitespace characters (low)
+  - Repeated delimiters (low)
+- **JudgeOutput schema** (`schemas/judge_output.py`) — Pydantic models for structured JSON from SLM judge
+- **InjectionAttempt model** (`models/sanitization.py`)
+- **Tests**: `test_phase8a_sanitizer.py` (456 lines)
+
+#### Phase 8B: MatchingEngine and NumericComparator
+
+Defends against **BenchJack Pattern 5 (Answer Normalizer Bugs)**.
+
+- **MatchingEngine** (`services/structural_scorer.py`) — robust string/structural matching:
+  - Section header detection across markdown formats (`##`, `###`, `**bold**`, bare headings)
+  - Section content extraction with boundary detection
+  - Copy-paste duplicate detection (same text in multiple sections is rejected)
+- **NumericComparator** — robust number matching:
+  - Extracts numbers from natural language (handles `$1,234.56`, `2.3M`, `45%`, currency symbols)
+  - Suffix normalization (`K`/`M`/`B`/`T` multipliers)
+  - Configurable tolerance for approximate matching (default 1%)
+- **Tests**: `test_phase8b_matching.py` (220 lines)
+
+#### Phase 8C: EvalWatchdog, Skipped Dimensions, Eval Completeness
+
+Defends against **BenchJack Pattern 2 (Score Inflation)**.
+
+- **EvalWatchdog** (`services/eval_watchdog.py`, 100 lines) — post-scoring anomaly detection:
+  - Flags perfect scores (100) with zero penalties
+  - Flags SLM dimension 100 with no SLM penalties
+  - Flags high composite (>85) despite penalties
+  - Detects uniform SLM scores (lazy/compromised judge)
+  - Flags long traces (>10 spans) with zero structural penalties
+- **Skipped dimensions** in score aggregator — graceful degradation when SLM unavailable:
+  - Unscored dimensions set to `None` (not defaulted to 100)
+  - `partial_evaluation` flag and `dimensions_skipped` list on scorecard
+  - Remaining weights reweighted proportionally
+- **Tests**: `test_eval_completeness.py` (518 lines — grade boundaries, composite bounds, penalty firing, watchdog)
+
+#### Phase 8D: Adversarial Robustness Dimension and Scorer
+
+Defends against **BenchJack Pattern 3 (State Tampering)**.
+
+- **AdversarialScorer** (`services/adversarial_scorer.py`, 134 lines):
+  - Converts injection detection into scored penalties
+  - Detects evaluator path probing (tool calls targeting `/observal`, `/eval`, `config.yaml`, `$OBSERVAL_API_KEY`)
+  - Score assertion detection in output
+  - Maps severity levels to penalty amounts from catalog
+- **6 new penalty definitions** in `models/scoring.py`:
+  - `html_comment_injection` (-20), `prompt_injection_attempt` (-25), `zero_width_unicode_injection` (-15)
+  - `canary_value_parroted` (-25), `score_assertion_in_output` (-20), `evaluator_path_probing` (-25)
+- **Tests**: `test_phase8d_adversarial.py` (244 lines)
+
+#### Phase 8E: Canary Injection System
+
+Defends against **BenchJack Pattern 4 (Data Contamination)**.
+
+- **CanaryDetector** (`services/canary.py`, 252 lines) — plant fake data and check if agents blindly repeat it:
+  - **3 canary types**: numeric (`$999,999,999`), entity (`Dr. Reginald Canarysworth`), instruction (`<!-- override scores -->`)
+  - **Injection**: inserts canary into trace copy (tool output or context), never modifies original
+  - **Detection**: checks if canary value appears in agent output
+  - **Flagging override**: if agent flags the canary as anomalous/suspicious, no penalty (agent showed genuine reasoning)
+  - **Report generation**: `CanaryReport` with behavior (`parroted`/`ignored`/`flagged`)
+- **Admin API**: POST/GET/DELETE `/api/v1/admin/canaries/{agent_id}`
+- **CLI commands**: `observal canary add`, `canary list`, `canary remove`
+- **Tests**: `test_phase8e_canary.py` (279 lines)
+
+#### Phase 8F: BenchJack Self-Test Suite
+
+Defends against **BenchJack Pattern 6 (Evaluator Self-Testing)**.
+
+- **15 self-attack tests** (`tests/test_adversarial_self.py`, 496 lines) that simulate BenchJack attacks against Observal's own pipeline:
+  - **Null agent**: empty trace must score <30 and get grade F
+  - **Prompt injection**: HTML comments, system prompts, fake JSON scores, markdown comments must not inflate scores
+  - **State tampering**: evaluator path probing must trigger penalties
+  - **Canary**: parroted canary caught; flagged canary not penalized
+  - **Score manipulation**: verbose padding must not help; copy-paste duplicates must be rejected
+  - **Regression guards**: structural and adversarial scoring must be deterministic (10 runs identical)
+  - **Sanitizer integration**: injection vectors stripped, legitimate content preserved
+- **Makefile targets**: `test-adversarial`, `test-eval-completeness`, `test-all`
+
+#### Phase 8G: Wire Hardened Pipeline into Main Eval Service
+
+**Integration phase** — all Phase 8A-8F components wired into the actual evaluation path.
+
+- **Rewired `run_structured_eval`** (`services/eval_service.py`) with 7-step pipeline:
+  1. **Adversarial detection FIRST** (before any other scoring)
+  2. **Sanitize trace** for SLM judge
+  3. **Structural scoring** on original trace
+  4. **SLM scoring** on sanitized trace
+  5. **Canary detection** (if configured)
+  6. **Aggregate** all penalties into scorecard
+  7. **EvalWatchdog** meta-check on scores
+- Key design: SLM sees sanitized trace; structural scorer sees original; adversarial runs before everything
+- **New response schemas** (`schemas/eval.py`): `AdversarialFindings`, `CanaryReportResponse`, `PenaltySummary`, `InjectionAttemptResponse`
+- **Tests**: `test_phase8g_pipeline.py` (381 lines)
+
+### Architecture
+
+```
+Trace Input
+    |
+    v
++---------------------+
+|  AdversarialScorer   |  <- Step 1: Detect injection / probing
+|  + TraceSanitizer    |
++--------+------------+
+         |
+    +----+----+
+    v         v
++--------+ +--------------+
+|Original| |Sanitized copy|
+| trace  | |  (for SLM)   |
++---+----+ +------+-------+
+    |              |
+    v              v
++----------+ +----------+
+|Structural| |SLM Scorer|   <- Steps 3-4: Score independently
+| Scorer   | |(on clean) |
++----+-----+ +----+-----+
+     |             |
+     +------+------+
+            v
+    +---------------+
+    |CanaryDetector |   <- Step 5: Check canary (if configured)
+    +-------+-------+
+            v
+    +---------------+
+    |ScoreAggregator|   <- Step 6: Weighted composite
+    +-------+-------+
+            v
+    +---------------+
+    | EvalWatchdog  |   <- Step 7: Meta-check on scores
+    +-------+-------+
+            v
+       Scorecard
+```
+
+### Summary
+
+| Metric | Count |
+|--------|-------|
+| New service files | 6 |
+| New test files | 7 |
+| Modified service files | 3 |
+| Total lines added | ~4,300 |
+| Total new tests | 183 |
+| Scoring dimensions | 6 |
+| Penalty definitions | 20+ |
+| Injection patterns detected | 7 |
+
+| BenchJack Pattern | Defense | Phase |
+|---|---|---|
+| 1. Prompt Injection | TraceSanitizer (detect + strip) | 8A |
+| 2. Score Inflation | EvalWatchdog (anomaly detection) | 8C |
+| 3. State Tampering | AdversarialScorer (path probing) | 8D |
+| 4. Data Contamination | CanaryDetector (canary inject + detect) | 8E |
+| 5. Answer Normalizer Bugs | MatchingEngine + NumericComparator | 8B |
+| 6. Self-Testing | 15 self-attack tests | 8F |
+| 7. Pipeline Integration | Hardened 7-step eval pipeline | 8G |
+
 ## [0.1.0] - 2026-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,39 +4,85 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [Unreleased] - 2026-04-12
 
 ### Added — Kiro CLI Telemetry Support
 
-Adds Kiro CLI as a supported telemetry source. Kiro sessions now appear in the dashboard with user prompts, tool I/O, model responses, credit tracking, and agent attribution. Not yet at full parity with Claude Code — see status table below.
+Adds Kiro CLI as a supported telemetry source. Kiro sessions now appear in the dashboard with user prompts, tool I/O, model responses, credit tracking, and agent attribution. Not at full parity with Claude Code — see status table below.
 
 #### Telemetry Status: Claude Code vs Kiro CLI
 
 | Capability | Claude Code | Kiro CLI | Notes |
 |---|---|---|---|
-| Sessions in dashboard | **Full** | **Working** | Kiro uses `$PPID`-based session IDs (see below) |
+| Sessions in dashboard | **Full** | **Working** | Kiro groups by `conversation_id` from SQLite (resumed sessions merge) |
 | User prompts | **Full** | **Working** | Captured via `userPromptSubmit` hook |
 | Model responses | **Full** | **Working** | Captured via `stop` hook `assistant_response` |
 | Tool names + I/O | **Full** | **Working** | `preToolUse`/`postToolUse` with params and response |
-| Token counts | **Full** (`input_tokens`, `output_tokens`, `cache_read_tokens`) | **Not available** | Kiro CLI does not expose token counts anywhere — not in hooks, not in its SQLite DB. Only credits. |
-| Cost tracking | `cost_usd` per API call (not yet aggregated to session level) | **Credits** (session-level, from SQLite DB) | Dashboard shows credits for Kiro, tokens for Claude Code |
+| Token counts | **Full** (`input_tokens`, `output_tokens`, `cache_read_tokens`) | **Not available** | Kiro CLI does not expose token counts — only credits |
+| Cost tracking | `cost_usd` per API call | **Credits** (session-level, from SQLite DB) | Dashboard shows credits for Kiro, tokens for Claude Code |
 | Model name | **Full** | **Working** | Resolved from Kiro SQLite, often shows "auto" |
 | Agent attribution | `agent_id`, `agent_type` from subagents | `agent_name` only | Kiro has no agent_id/agent_type concept |
-| Session continuations | Native `session_id` (UUID) persists across resumes | `$PPID` changes on each `kiro-cli` invocation | `conversation_id` from SQLite is attached as an attribute but NOT used as session_id — resumed Kiro sessions appear as separate sessions |
-| User identity | `user.id` captured | Not available | Kiro hooks don't include user identity |
-| IDE/terminal info | `terminal.type` captured | Not available | |
-| Permission mode | Captured | Not available | |
-| Subagent tracking | `SubagentStart`/`SubagentStop` events | Not available | Kiro has no subagent hook events |
-| Task tracking | `TaskCreated`/`TaskCompleted` events | Not available | |
-| Eval engine support | **Working** — traces feed into structured eval pipeline | **Not working** — hook data goes to `otel_logs`, eval reads from `agent_interactions` table | Needs a bridge layer (see Known Gaps) |
+| Session continuations | Native `session_id` (UUID) persists across resumes | **Working** | Dashboard groups by `conversation_id` from SQLite DB |
+| User identity | `user.id` from Claude + Observal login | **Working** (Observal login) | Both IDEs use Observal login identity stored in `~/.observal/config.json` |
+| IDE/terminal info | `terminal.type` captured | **Working** | `$TERM` and `$SHELL` injected via sed |
+| Permission mode | Captured | Not available | Kiro doesn't expose this |
+| Subagent tracking | `SubagentStart`/`SubagentStop` events | Not available | Kiro has no subagent hook events (only 5 events total) |
+| Task tracking | `TaskCreated`/`TaskCompleted` events | Not available | Kiro has no task concept in hooks |
+| Eval engine support | **Full** — spans table + hook materializer | **Working** — hook materializer converts `otel_logs` to eval-compatible spans | 5/6 scoring dimensions work; only `thought_process` (13% weight) skipped |
 
 #### Known Gaps
 
-- **Session continuations broken for Kiro**: When a user does `kiro-cli chat --resume`, a new `$PPID` is assigned, creating a separate session in the dashboard. The real `conversation_id` from Kiro's SQLite DB is captured as an attribute on each event, but the dashboard doesn't yet group sessions by `conversation_id`. Fix requires: session grouping/linking in the dashboard query.
-- **Eval engine cannot score Kiro sessions**: The eval pipeline (`run_structured_eval`) reads from the `agent_interactions` and `spans` tables, which expect structured span data with `type`, `input`, `output`, `status` fields. Kiro hook events are flat log entries in `otel_logs` — no bridge exists to convert them into eval-compatible spans. Fix requires: a materializer that converts `otel_logs` hook events into structured spans, or a new eval path that reads directly from `otel_logs`.
-- **Per-agent trace isolation incomplete**: The ClickHouse schema has indexed `agent_id` columns on both `spans` and `traces` tables, and `otel_logs` stores `agent_name` in `LogAttributes`. But no API endpoint exists to query "all traces/spans where this agent participated" — the eval endpoint requires a `trace_id` first, then fetches spans. For agent-level evals, we need: `GET /api/v1/agents/{id}/traces` that queries across both `otel_logs` (hook data) and `spans` (shim data).
+- **Kiro token counts**: Kiro only exposes credits (billing units) and character counts — no actual token counts anywhere (hooks, SQLite DB, config). Not fixable on our side.
+- **Kiro subagent/task tracking**: Kiro CLI exposes exactly 5 hook events (`agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, `stop`). No subagent lifecycle or task management events exist. Architecture is fundamentally single-agent per session.
+- **Thought process scoring**: The `thought_process` eval dimension (13% weight) requires `reasoning_step`/`thought`/`agent_turn` span types which come from internal agent instrumentation, not hooks. Skipped for all hook-sourced sessions (both Kiro and Claude Code hooks). Scores gracefully degrade.
 
-#### What Was Implemented
+### Added — Agent-Scoped Evaluation
+
+Evaluate a specific agent's contribution within a session, including subagents that never own a full session (e.g., researcher, explore).
+
+- **`POST /api/v1/eval/agents/{id}/session/{session_id}`** — evaluates a specific agent within a session
+- **Three eval modes**:
+  - `agent_scoped` — agent was a subagent; isolates spans between `SubagentStart`/`SubagentStop`; uses delegation prompt as goal
+  - `full_session` — agent is the primary agent (e.g., Kiro single-agent sessions); evaluates everything
+  - `404` — agent not found in session
+- **Structural scoring** (tool efficiency, tool failures) runs on the agent's spans only
+- **SLM scoring** (goal completion, factual grounding) sees the full session context but evaluates against the delegation prompt — what the parent agent asked this agent to do
+- **Hook materializer** now tags every span with `agent_id`/`agent_type` from source events and materializes `SubagentStart`/`SubagentStop` as span boundaries
+
+### Added — Eval Materializer
+
+Bridge layer that converts `otel_logs` hook events into eval-compatible spans so the scoring pipeline works with hook-sourced sessions (Kiro, Claude Code hooks).
+
+- **`hook_materializer.py`** — converts hook events into spans with `type`/`input`/`output`/`status`/`latency_ms`
+- Pairs `PreToolUse` + `PostToolUse` into `tool_call` spans; `Stop` → `agent_response`; `UserPromptSubmit` → `user_prompt`
+- **`POST /api/v1/eval/sessions/{session_id}`** — evaluate any hook-based session directly
+- Integrated into main eval pipeline as fallback when `agent_interactions` table has no data
+
+### Added — Per-Agent Trace Endpoint
+
+- **`GET /api/v1/agents/{id}/traces`** — query all traces where an agent participated, using existing indexed `agent_id` column on the `traces` table
+
+### Added — Observal User Identity for Hooks
+
+User identity for both Claude Code and Kiro now comes from `observal login`, not from IDE-specific identity.
+
+- All login paths (bootstrap, key, password, invite, register) save `user_id` to `~/.observal/config.json`
+- **Claude Code**: `X-Observal-User-Id` header injected into HTTP hooks
+- **Kiro**: `user_id` field injected into hook payload via sed prefix
+- **Server**: extracts from body (`user_id` field) or header (`X-Observal-User-Id`), stores as `user.id` in ClickHouse
+
+### Fixed — Kiro Session Continuations
+
+- Dashboard now groups Kiro sessions by `conversation_id` (from SQLite DB) instead of `$PPID`
+- Resumed sessions (`kiro-cli chat --resume`) merge into a single dashboard row
+- Session detail endpoint matches both `session.id` and `conversation_id`
+
+### Fixed — Kiro Terminal/Shell Info
+
+- `$TERM` and `$SHELL` environment variables injected into all Kiro hook payloads via sed prefix
+- Captured in both `cmd_scan.py` (CLI hook injection) and `hook_config_generator.py` (server-side config)
+
+#### What Was Implemented (Kiro Telemetry)
 
 **Critical bug fix**: All generated Kiro hook configs were pointing to `/api/v1/telemetry/hooks` (writes to `spans` table) instead of `/api/v1/otel/hooks` (writes to `otel_logs` table). This caused zero Kiro sessions in the dashboard.
 
@@ -48,7 +94,7 @@ Adds Kiro CLI as a supported telemetry source. Kiro sessions now appear in the d
 **SQLite enrichment pipeline**:
 - `kiro_stop_hook.py` — On `stop` event, queries `~/.local/share/kiro-cli/data.sqlite3` for the most recent conversation matching `cwd`. Extracts: `model_id`, `credits`, `tools_used`, `turn_count`, `conversation_id`.
 - `kiro_hook.py` — Lightweight script (~23ms) for non-stop events. Adds `conversation_id` from SQLite.
-- Session IDs use `$PPID` (Kiro doesn't expose any session identifier in hook payloads).
+- Session IDs use `$PPID` with `conversation_id` for grouping.
 
 **Per-agent hook enrichment**: Hook commands inject `agent_name` and `model` into every payload via `sed`. Added `userPromptSubmit` to hooks (was missing — prompts weren't captured before).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,69 +6,60 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Added — Kiro CLI Full Parity
+### Added — Kiro CLI Telemetry Support
 
-Brings Kiro CLI to feature parity with Claude Code for telemetry, session tracking, and multi-IDE management. Verified with real `kiro-cli` sessions — all Kiro agent sessions now appear in the Observal dashboard with prompts, tool I/O, model responses, credit usage, and conversation linking.
+Adds Kiro CLI as a supported telemetry source. Kiro sessions now appear in the dashboard with user prompts, tool I/O, model responses, credit tracking, and agent attribution. Not yet at full parity with Claude Code — see status table below.
 
-#### Critical Bug Fix: Hook Endpoint Routing
+#### Telemetry Status: Claude Code vs Kiro CLI
 
-- **Fixed Kiro hook target**: All generated Kiro hook configs were sending telemetry to `/api/v1/telemetry/hooks` (writes to `spans` table) instead of `/api/v1/otel/hooks` (writes to `otel_logs` table). This caused **zero Kiro sessions** to appear in the dashboard. Fixed in `hook_config_generator.py`, `agent_config_generator.py`, and E2E helpers.
-- **Removed stale `X-API-Key` header** from Kiro curl commands — `/api/v1/otel/hooks` is intentionally unauthenticated since CLI hooks can't carry auth tokens.
+| Capability | Claude Code | Kiro CLI | Notes |
+|---|---|---|---|
+| Sessions in dashboard | **Full** | **Working** | Kiro uses `$PPID`-based session IDs (see below) |
+| User prompts | **Full** | **Working** | Captured via `userPromptSubmit` hook |
+| Model responses | **Full** | **Working** | Captured via `stop` hook `assistant_response` |
+| Tool names + I/O | **Full** | **Working** | `preToolUse`/`postToolUse` with params and response |
+| Token counts | **Full** (`input_tokens`, `output_tokens`, `cache_read_tokens`) | **Not available** | Kiro CLI does not expose token counts anywhere — not in hooks, not in its SQLite DB. Only credits. |
+| Cost tracking | `cost_usd` per API call (not yet aggregated to session level) | **Credits** (session-level, from SQLite DB) | Dashboard shows credits for Kiro, tokens for Claude Code |
+| Model name | **Full** | **Working** | Resolved from Kiro SQLite, often shows "auto" |
+| Agent attribution | `agent_id`, `agent_type` from subagents | `agent_name` only | Kiro has no agent_id/agent_type concept |
+| Session continuations | Native `session_id` (UUID) persists across resumes | `$PPID` changes on each `kiro-cli` invocation | `conversation_id` from SQLite is attached as an attribute but NOT used as session_id — resumed Kiro sessions appear as separate sessions |
+| User identity | `user.id` captured | Not available | Kiro hooks don't include user identity |
+| IDE/terminal info | `terminal.type` captured | Not available | |
+| Permission mode | Captured | Not available | |
+| Subagent tracking | `SubagentStart`/`SubagentStop` events | Not available | Kiro has no subagent hook events |
+| Task tracking | `TaskCreated`/`TaskCompleted` events | Not available | |
+| Eval engine support | **Working** — traces feed into structured eval pipeline | **Not working** — hook data goes to `otel_logs`, eval reads from `agent_interactions` table | Needs a bridge layer (see Known Gaps) |
 
-#### Kiro Event Normalization
+#### Known Gaps
 
-- **camelCase → PascalCase event mapping** (`otel_dashboard.py`): Kiro sends `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, `stop` — server normalizes to Claude Code's `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`.
-- **camelCase → snake_case field mapping**: `hookEventName` → `hook_event_name`, `sessionId` → `session_id`, `toolName` → `tool_name`, etc.
-- **Kiro-specific field extraction**: Kiro sends `prompt` (not `user_prompt`) and `assistant_response` (not `tool_response`). Server now extracts both correctly.
+- **Session continuations broken for Kiro**: When a user does `kiro-cli chat --resume`, a new `$PPID` is assigned, creating a separate session in the dashboard. The real `conversation_id` from Kiro's SQLite DB is captured as an attribute on each event, but the dashboard doesn't yet group sessions by `conversation_id`. Fix requires: session grouping/linking in the dashboard query.
+- **Eval engine cannot score Kiro sessions**: The eval pipeline (`run_structured_eval`) reads from the `agent_interactions` and `spans` tables, which expect structured span data with `type`, `input`, `output`, `status` fields. Kiro hook events are flat log entries in `otel_logs` — no bridge exists to convert them into eval-compatible spans. Fix requires: a materializer that converts `otel_logs` hook events into structured spans, or a new eval path that reads directly from `otel_logs`.
+- **Per-agent trace isolation incomplete**: The ClickHouse schema has indexed `agent_id` columns on both `spans` and `traces` tables, and `otel_logs` stores `agent_name` in `LogAttributes`. But no API endpoint exists to query "all traces/spans where this agent participated" — the eval endpoint requires a `trace_id` first, then fetches spans. For agent-level evals, we need: `GET /api/v1/agents/{id}/traces` that queries across both `otel_logs` (hook data) and `spans` (shim data).
 
-#### Session ID via `$PPID`
+#### What Was Implemented
 
-- Kiro CLI does not expose a session/conversation ID in hook payloads. Implemented `$PPID`-based session ID injection via `sed` — all hooks in a single `kiro-cli` invocation share a stable `kiro-{PPID}` session identifier.
-- Real `conversation_id` from Kiro's SQLite database is also extracted and attached as an attribute for cross-session linking (e.g., resumed conversations).
+**Critical bug fix**: All generated Kiro hook configs were pointing to `/api/v1/telemetry/hooks` (writes to `spans` table) instead of `/api/v1/otel/hooks` (writes to `otel_logs` table). This caused zero Kiro sessions in the dashboard.
 
-#### Kiro SQLite Enrichment Pipeline
+**Event normalization** (`otel_dashboard.py`):
+- camelCase → PascalCase event mapping (`agentSpawn` → `SessionStart`, `postToolUse` → `PostToolUse`, etc.)
+- camelCase → snake_case field mapping (`hookEventName` → `hook_event_name`, `sessionId` → `session_id`, etc.)
+- Kiro-specific field extraction: `prompt` → `tool_input`, `assistant_response` → `tool_response`
 
-- **`observal_cli/hooks/kiro_stop_hook.py`** — On `stop` hook, queries `~/.local/share/kiro-cli/data.sqlite3` for the most recent conversation matching `cwd`. Extracts and sends:
-  - `model_id` (resolved from per-turn metadata when set to "auto")
-  - `input_tokens` / `output_tokens` (estimated from character counts, ~4 chars/token)
-  - `credits` (total credit usage from `usage_info`)
-  - `tools_used` (deduplicated list of tools invoked)
-  - `context_window_tokens` and `max_context_usage_pct`
-  - `conversation_id` for stable cross-session linking
-- **`observal_cli/hooks/kiro_hook.py`** — Lightweight script for non-stop events (~23ms overhead). Adds `conversation_id` from SQLite without parsing the full conversation JSON.
-- **Note**: Kiro CLI does not expose actual token counts — only character lengths and credit costs. Estimated tokens are labeled accordingly. This may differ on enterprise plans where billing data structures vary.
+**SQLite enrichment pipeline**:
+- `kiro_stop_hook.py` — On `stop` event, queries `~/.local/share/kiro-cli/data.sqlite3` for the most recent conversation matching `cwd`. Extracts: `model_id`, `credits`, `tools_used`, `turn_count`, `conversation_id`.
+- `kiro_hook.py` — Lightweight script (~23ms) for non-stop events. Adds `conversation_id` from SQLite.
+- Session IDs use `$PPID` (Kiro doesn't expose any session identifier in hook payloads).
 
-#### Per-Agent Hook Enrichment
+**Per-agent hook enrichment**: Hook commands inject `agent_name` and `model` into every payload via `sed`. Added `userPromptSubmit` to hooks (was missing — prompts weren't captured before).
 
-- Hook commands now inject `agent_name` and `model` (when set) into every Kiro hook payload via `sed`. The dashboard shows which agent handled each session.
-- Added `userPromptSubmit` to the Kiro hooks block (was previously missing — user prompts were not captured).
+**Multi-IDE scan** (`--all-ides`):
+- `observal scan --all-ides` scans `~/.claude/` and `~/.kiro/` in one pass with `source_ide` tagging.
+- `_scan_kiro_home()` discovers agents, MCPs, and hooks from `~/.kiro/`.
+- Auto-injects Observal hooks into all `~/.kiro/agents/*.json` files.
 
-#### Multi-IDE Scan (`--all-ides`)
+**Dashboard**: Kiro sessions show credits (orange) instead of token counts. `tools_used` shown in "Tokens Out" column for Kiro rows.
 
-- **`observal scan --all-ides`** scans both `~/.claude/` and `~/.kiro/` in one pass, tagging each component with `source_ide`.
-- **`observal scan --home --ide kiro`** scans only `~/.kiro/`.
-- **`_scan_kiro_home()`** (`cmd_scan.py`) discovers agents from `~/.kiro/agents/*.json`, global MCPs from `~/.kiro/settings/mcp.json`, per-agent MCPs, and per-agent hooks.
-- **Server-side** (`scan.py`): Added `source_ide` field to `ScannedMcp`, `ScannedSkill`, `ScannedHook`, `ScannedAgent` — components are tagged with their origin IDE for `supported_ides` routing.
-
-#### Auto-Inject Observal Hooks into Kiro Agents
-
-- When running `observal scan --home --ide kiro` (or `--all-ides`), hooks are automatically injected into all `~/.kiro/agents/*.json` files with per-agent metadata enrichment.
-- Existing hooks are preserved if they already point to the correct Observal endpoint.
-- Original files are backed up before modification.
-
-#### Dashboard Enhancements
-
-- Sessions list query now includes `credits` and `tools_used` columns from enriched Kiro stop events.
-- `conversation_id` stored as a ClickHouse attribute for future cross-session grouping.
-
-#### E2E Tests (36 pass, 0 fail)
-
-- `kiro-hooks.spec.ts` — Hook ingestion: camelCase normalization, field mapping, session visibility after lifecycle events
-- `kiro-cli.spec.ts` — CLI: `scan --home --ide kiro`, `scan --all-ides`, `doctor --ide kiro`, `pull --ide kiro`, `auth status/whoami`
-- `kiro-lifecycle.spec.ts` — Full lifecycle simulation and dashboard verification
-- `kiro-agent-compat.spec.ts` — Cross-IDE agent file generation (Kiro ↔ Claude Code)
-- `kiro-otlp-logs.spec.ts` / `kiro-otlp-traces.spec.ts` — OTLP ingestion and trace grouping
-- `kiro-web-*.spec.ts` — Web UI: agents page, components page, traces, dashboard
+**E2E tests**: 36 pass, 0 fail — hooks, CLI commands, lifecycle, cross-IDE compat, OTLP ingestion, web UI.
 
 ### Added — BenchJack-Hardened Evaluation Pipeline (Phases 8A-8G)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Browse agents created by others, publish your own, and pull complete agent confi
 
 Every interaction generates traces, spans, and sessions that flow into a telemetry pipeline, giving you full observability, traceability, and real-time metrics for your agents in production. The built-in eval engine (WIP) scores agent sessions so you can measure performance and make your agents better over time.
 
-**Supported tools:** Claude Code, Codex CLI, and Gemini CLI are fully supported. Kiro support is a work in progress.
+**Supported tools:** Claude Code, Codex CLI, Gemini CLI, and Kiro CLI are fully supported. Cursor and VS Code have MCP/rules file support.
+
+See the [Changelog](CHANGELOG.md) for recent updates.
 
 ## Quick Start
 

--- a/docs/kiro-compatibility-matrix.md
+++ b/docs/kiro-compatibility-matrix.md
@@ -1,0 +1,102 @@
+# Kiro Compatibility Matrix
+
+Comparison of Observal's Claude Code integration vs Kiro CLI support.
+
+**Research date:** 2026-04-11
+**Kiro CLI version tested:** 1.28.1
+
+## Telemetry & Observability
+
+| Feature | Claude Code | Kiro CLI | Gap | Severity |
+|---------|------------|----------|-----|----------|
+| Native OTEL traces via /v1/traces | Yes | **No** — feature requested ([#6319](https://github.com/kirodotdev/Kiro/issues/6319)) | Kiro has no native OTLP export. Telemetry must be collected via hooks. | Critical |
+| Native OTEL logs via /v1/logs | Yes | **No** | Same as above — no OTLP log export | Critical |
+| OTEL endpoint redirection (`OTEL_EXPORTER_OTLP_ENDPOINT`) | Yes | **No** — requested ([#7226](https://github.com/kirodotdev/Kiro/issues/7226)) | No env var or config to redirect telemetry | Critical |
+| Token counts (input/output/cache) | Yes (in OTLP attributes) | **Internal only** — visible in UI/credits, not exportable ([#7347](https://github.com/kirodotdev/Kiro/issues/7347)) | Hook payloads don't include token data | Major |
+| Session IDs | Yes (resource attribute) | **Partial** — sessions exist but ID not in hook STDIN | Need to generate/track session IDs via hooks | Major |
+| Model name | Yes (`model` attribute) | **Internal only** — visible in UI, not in hook payloads | Not available in hook context | Major |
+| Cost data | Yes (computed) | **Internal only** — credit display in UI, `/usage` CLI command | Not accessible programmatically via hooks | Major |
+| IDE detection in OTLP | Yes (`_IDE_HINTS` dict) | Yes — `"kiro": "kiro"` already in code | None | None |
+
+## Hook System
+
+| Feature | Claude Code | Kiro CLI | Gap | Severity |
+|---------|------------|----------|-----|----------|
+| HTTP hooks (webhook-style) | Yes (`type: "http"`) | **No** — hooks are shell commands only (`runCommand`) | Observal must use `curl` in a shell hook, not native HTTP | Major |
+| Hook config location | `~/.claude/settings.json` | Agent config JSON (`.kiro/agents/*.json`) or `.kiro/hooks/` | Different config injection point for `observal scan --home` | Major |
+| PreToolUse / PostToolUse | Yes | Yes (`preToolUse` / `postToolUse`) | Event names differ (camelCase vs PascalCase) | Minor |
+| SessionStart | Yes | **`agentSpawn`** | Different event name, needs mapping | Minor |
+| SessionEnd / Stop | Yes (`Stop`) | **`stop`** | Different event name (lowercase) | Minor |
+| UserPromptSubmit | Yes | **`userPromptSubmit`** (CLI) / `promptSubmit` (IDE) | Different naming | Minor |
+| SubagentStart / SubagentStop | Yes | **No equivalent** | Kiro doesn't expose subagent lifecycle hooks | Minor |
+| PreCompact / PostCompact | Yes | **No equivalent** | Kiro doesn't expose compaction hooks | Minor |
+| Hook STDIN format | `hook_event_name`, `tool_name`, `tool_input`, `tool_response`, `session_id` | `hook_event_name`, `tool_name`, `tool_input`, `tool_response`, `cwd` | Missing `session_id`, has `cwd` instead | Minor |
+| Tool matchers | Glob patterns | Canonical names + aliases + MCP refs (`@git`, `fs_read`, `*`) | Different matcher syntax | Minor |
+| Hook blocking (exit code) | Return `{"decision": "block"}` | Exit code 2 blocks | Different blocking mechanism | Minor |
+
+## MCP & Agent Configuration
+
+| Feature | Claude Code | Kiro CLI | Gap | Severity |
+|---------|------------|----------|-----|----------|
+| MCP config file | `.mcp.json` or `~/.claude/settings.json` | `.kiro/settings/mcp.json` | Already supported in Observal | None |
+| MCP format (`mcpServers` key) | Yes | Yes | Compatible | None |
+| Stdio transport | Yes | Yes | Compatible | None |
+| HTTP/SSE transport | Yes | Yes (streamable-HTTP) | Compatible | None |
+| Agent rules files | `CLAUDE.md` / `AGENTS.md` | **Steering files** (`.kiro/steering/*.md`) + AGENTS.md compat | Observal generates AGENTS.md (works), but no Steering file support | Major |
+| Agent config format | N/A | `.kiro/agents/<name>.json` with rich schema | Already implemented in Observal | None |
+| Skills/plugins | Claude Code skills | `.kiro/skills/` with SKILL.md | No Observal skill installation for Kiro format | Major |
+| Specs system | N/A | `.kiro/specs/` (requirements/design/tasks) | No equivalent in Observal — Kiro-only feature | Minor |
+| Powers (bundled extensions) | N/A | 50+ Powers (MCP + steering + hooks bundles) | No equivalent in Observal | Minor |
+| Inclusion modes | Hierarchical (root/subdirs) | Always / FileMatch / Manual / Auto (YAML frontmatter) | Steering files more expressive than AGENTS.md | Minor |
+
+## CLI Commands
+
+| Feature | Claude Code | Kiro CLI | Gap | Severity |
+|---------|------------|----------|-----|----------|
+| `observal scan --ide kiro` | N/A | Yes — discovers `.kiro/settings/mcp.json` | Works but no agent/plugin discovery, no hook injection | Major |
+| `observal pull --ide kiro` | N/A | Yes — generates `.kiro/agents/<name>.json` | Works but no Steering file generation | Minor |
+| `observal doctor --ide kiro` | N/A | Yes — checks settings files | Works but limited diagnostics | Minor |
+| Agent discovery (`scan --home`) | Finds `~/.claude/agents/` | **No** — doesn't scan `~/.kiro/agents/` | Missing Kiro agent discovery | Major |
+| Plugin discovery (`scan --home`) | Finds `~/.claude/plugins/` | **No** — doesn't scan Kiro skills/powers | Missing Kiro plugin discovery | Minor |
+| Hook injection (`scan --home`) | Injects into `~/.claude/settings.json` | **No** — doesn't inject into Kiro hook config | Missing hook auto-injection for Kiro | Major |
+
+## Frontend Display
+
+| Feature | Claude Code | Kiro CLI | Gap | Severity |
+|---------|------------|----------|-----|----------|
+| IDE filter in trace list | Yes | Yes — `kiro` and `kiro-cli` in filter | None | None |
+| IDE badge color | Yellow | **No distinct badge color** in web UI | trace-list.tsx filters but doesn't show colored badge | Minor |
+| Install dialog IDE option | Yes | Yes — "Kiro IDE" and "Kiro CLI" | None | None |
+| Pull command IDE option | Yes | Yes — "Kiro" | None | None |
+| CLI render color | Yellow | Magenta | None | None |
+
+## Summary
+
+| Category | Complete | Gaps |
+|----------|----------|------|
+| OTLP Telemetry | 1 | 7 (all blocked by Kiro lacking native OTEL) |
+| Hook System | 0 | 11 |
+| MCP & Agents | 4 | 5 |
+| CLI Commands | 3 | 4 |
+| Frontend | 4 | 1 |
+| **Total** | **12** | **28** |
+
+### Critical Gaps (block basic functionality)
+1. Kiro has no native OTEL export — all telemetry must flow through hooks
+2. Hook-based telemetry bridge needed (shell command hooks → Observal API)
+3. No token/cost/model data accessible via hooks
+
+### Major Gaps (missing important features)
+4. Hook config format differs — can't inject HTTP hooks directly
+5. Hook event name mapping needed (camelCase ↔ PascalCase)
+6. No Steering file generation (only AGENTS.md)
+7. No Kiro agent/plugin discovery in `scan --home`
+8. No hook auto-injection for Kiro
+9. No Skills installation support for Kiro format
+
+### Minor Gaps (nice-to-have)
+10. Missing subagent/compaction hook events
+11. Different hook blocking mechanism
+12. No Specs/Powers support
+13. Frontend IDE badge color
+14. Limited doctor diagnostics

--- a/docs/kiro-research-notes.md
+++ b/docs/kiro-research-notes.md
@@ -1,0 +1,415 @@
+# Kiro CLI Research Notes
+
+**Research date:** 2026-04-11
+**Kiro CLI version:** 1.28.1
+**Installation:** `curl -fsSL https://cli.kiro.dev/install | bash`
+**Binary location:** `/home/haz3/.local/bin/kiro-cli`
+**Binary type:** Native ELF (~112 MB, Rust)
+
+---
+
+## 1. Kiro CLI Architecture
+
+Kiro is an AI-powered development platform by Amazon/AWS with two forms:
+- **Desktop IDE** — based on Code OSS, compatible with VS Code extensions
+- **Standalone CLI** (`kiro-cli`) — fully independent terminal AI coding assistant
+
+Authentication: AWS IAM Identity Center, GitHub, Google, or AWS Builder ID.
+
+### CLI Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| `chat` | Interactive AI chat (`--no-interactive` for headless, `--trust-all-tools` for auto-approve) |
+| `agent` | Manage custom agents (list, create, edit, validate) |
+| `mcp` | Manage MCP servers (add, remove, list, import, status) |
+| `acp` | Agent Client Protocol support |
+| `translate` | Natural language → shell command |
+| `doctor` | Diagnose installation issues |
+| `login` / `logout` / `whoami` | Authentication |
+| `settings` | Appearance and behavior |
+| `inline` | Inline shell completions |
+
+### Available Models
+
+Credit-based pricing. Models include:
+- Claude Opus 4.6, Sonnet 4.6, Opus 4.5, Sonnet 4.5, Sonnet 4, Haiku 4.5
+- DeepSeek 3.2, MiniMax M2.5/M2.1, GLM-5, Qwen3 Coder Next
+- `auto` (default) — dynamic model selection per task
+
+---
+
+## 2. Config File Structure
+
+```
+~/.kiro/
+├── settings/
+│   ├── cli.json          # CLI settings (telemetry, appearance, behavior)
+│   ├── mcp.json          # MCP server configs (global)
+│   └── telemetry.json    # (proposed, not yet implemented)
+├── steering/             # Global steering files (markdown + YAML frontmatter)
+├── agents/               # Agent configs (JSON)
+│   ├── coder.json
+│   ├── frontend.json
+│   ├── backend.json
+│   ├── fullstack.json
+│   ├── devops.json
+│   ├── debugger.json
+│   ├── reviewer.json
+│   ├── researcher.json
+│   ├── tester.json
+│   ├── docs.json
+│   ├── database.json
+│   └── api-designer.json
+├── skills/               # Global skills
+└── hooks/                # Global hooks (IDE format)
+
+.kiro/                    # Project-level
+├── settings/
+│   └── mcp.json          # Project MCP servers
+├── steering/             # Project steering files
+│   ├── product.md        # Auto-generated
+│   ├── tech.md           # Auto-generated
+│   └── structure.md      # Auto-generated
+├── specs/                # Structured planning
+│   └── [feature-name]/
+│       ├── requirements.md (or bugfix.md)
+│       ├── design.md
+│       └── tasks.md
+├── skills/               # Project skills
+│   └── [skill-name]/
+│       ├── SKILL.md      # Required
+│       ├── scripts/
+│       ├── references/
+│       └── assets/
+└── hooks/                # Project hooks
+```
+
+---
+
+## 3. MCP Configuration Format
+
+File: `.kiro/settings/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "local-server": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-bravesearch"],
+      "env": {
+        "BRAVE_API_KEY": "${BRAVE_API_KEY}"
+      },
+      "disabled": false,
+      "autoApprove": ["tool1"],
+      "disabledTools": ["tool2"]
+    },
+    "remote-server": {
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer $TOKEN"
+      }
+    }
+  }
+}
+```
+
+Transport is inferred: `command` → stdio, `url` → HTTP/streamable-HTTP. No explicit `transport` field.
+
+---
+
+## 4. Hook System
+
+### CLI Hook Events
+
+| Event | Description | STDIN Fields |
+|-------|-------------|--------------|
+| `agentSpawn` | Agent initialization | `hook_event_name`, `cwd` |
+| `userPromptSubmit` | User submits message | `hook_event_name`, `cwd`; env `USER_PROMPT` |
+| `preToolUse` | Before tool execution | `hook_event_name`, `tool_name`, `tool_input`, `cwd` |
+| `postToolUse` | After tool execution | `hook_event_name`, `tool_name`, `tool_input`, `tool_response`, `cwd` |
+| `stop` | Agent finishes responding | `hook_event_name`, `cwd` |
+
+### IDE Hook Events (additional)
+
+| Event | Description |
+|-------|-------------|
+| `fileEdited` | File saved/modified (supports glob patterns) |
+| `fileCreated` | File created |
+| `fileDeleted` | File deleted |
+| `userTriggered` | Manual trigger |
+| `promptSubmit` | User submits prompt |
+| `agentStop` | Agent finishes |
+| `preSpecTask` / `postSpecTask` | Before/after spec task |
+
+### CLI Hook Config (in agent JSON)
+
+```json
+{
+  "hooks": {
+    "preToolUse": [
+      { "matcher": "execute_bash", "command": "echo 'checking...'" }
+    ],
+    "postToolUse": [
+      { "matcher": "fs_write", "command": "cargo fmt --all" }
+    ],
+    "agentSpawn": [
+      { "command": "git status" }
+    ],
+    "stop": [
+      { "command": "npm test" }
+    ]
+  }
+}
+```
+
+### IDE Hook Config (JSON files in .kiro/hooks/)
+
+```json
+{
+  "id": "optional-id",
+  "name": "Hook Name",
+  "comment": "Description",
+  "when": {
+    "type": "fileEdited|fileCreated|fileDeleted|userTriggered|promptSubmit|agentStop|preToolUse|postToolUse",
+    "pattern": "**/*.ts"
+  },
+  "then": {
+    "type": "askAgent|runCommand|alert",
+    "prompt": "string (for askAgent)",
+    "command": "string (for runCommand)",
+    "message": "string (for alert)"
+  }
+}
+```
+
+### Hook Blocking
+
+- CLI: Exit code 2 on `preToolUse` blocks the tool
+- Claude Code: Return JSON `{"decision": "block"}`
+
+### Tool Matchers (CLI)
+
+- Canonical names: `fs_read`, `fs_write`, `execute_bash`, `use_aws`
+- Aliases: `read`, `write`, `shell`, `aws`
+- MCP tool refs: `@git`, `@postgres/query`
+- Patterns: `@builtin`, `*`
+
+### Claude Code ↔ Kiro Event Mapping
+
+| Claude Code | Kiro CLI | Kiro IDE |
+|-------------|----------|----------|
+| `SessionStart` | `agentSpawn` | N/A |
+| `UserPromptSubmit` | `userPromptSubmit` | `promptSubmit` |
+| `PreToolUse` | `preToolUse` | `preToolUse` |
+| `PostToolUse` | `postToolUse` | `postToolUse` |
+| `Stop` | `stop` | `agentStop` |
+| `SubagentStart` | — (not available) | — |
+| `SubagentStop` | — (not available) | — |
+| `PreCompact` | — (not available) | — |
+| `PostCompact` | — (not available) | — |
+| `Notification` | — (not available) | — |
+| `TaskCreated` | — (not available) | — |
+| `TaskCompleted` | — (not available) | — |
+
+---
+
+## 5. Telemetry / OTEL Status
+
+### Current State: No Native OTEL Export
+
+Kiro does **not** emit OpenTelemetry data. Relevant upstream issues:
+- [kirodotdev/Kiro#6319](https://github.com/kirodotdev/Kiro/issues/6319) — Native OTLP trace export (feature request)
+- [kirodotdev/Kiro#7226](https://github.com/kirodotdev/Kiro/issues/7226) — Configurable telemetry endpoint for enterprise
+- [kirodotdev/Kiro#7347](https://github.com/kirodotdev/Kiro/issues/7347) — Expose session telemetry as exportable metadata
+
+### What Kiro Tracks Internally
+
+- Estimated credits used (per-turn)
+- Elapsed time (per-turn)
+- Model name
+- Token counts (input/output, for context management)
+- Credit consumption (model-specific rates)
+- Turn count per session
+
+**None of this is accessible via hooks or export.** Only visible in UI and via `/usage` CLI command.
+
+### Workaround: Hook-Based Telemetry
+
+Community members use `runCommand` hooks to send data to external systems:
+- `agentSpawn` hook → log session start
+- `preToolUse` / `postToolUse` hooks → log tool usage
+- `stop` hook → log session end
+- `promptSubmit` hook → log user prompts (example: sending to Grafana Loki via curl)
+
+This is the recommended integration path for Observal until Kiro implements native OTEL export.
+
+---
+
+## 6. Steering Files (Agent Instructions)
+
+Kiro's equivalent of CLAUDE.md / AGENTS.md. Stored in `.kiro/steering/`.
+
+### Format
+
+```markdown
+---
+inclusion: always | fileMatch | manual | auto
+globs:
+  - "**/*.tsx"
+  - "src/components/**"
+name: component-patterns
+description: React component patterns for this project
+---
+
+# Steering Content
+
+Instructions for the AI agent...
+```
+
+### Inclusion Modes
+
+| Mode | Behavior |
+|------|----------|
+| `always` | Loaded every interaction |
+| `fileMatch` | Loaded when working with matching files |
+| `manual` | Loaded when user types `#name` |
+| `auto` | Loaded when description matches user intent |
+
+### Auto-Generated Files
+
+Kiro auto-generates three baseline steering files:
+- `product.md` — Product overview
+- `tech.md` — Technology stack
+- `structure.md` — Project structure
+
+### AGENTS.md Compatibility
+
+Kiro recognizes AGENTS.md files but treats them as "always included" (no inclusion modes). They serve as a simpler, always-active instruction format.
+
+---
+
+## 7. Skills System
+
+Skills live in `.kiro/skills/` (project) or `~/.kiro/skills/` (global).
+
+### Structure
+
+```
+.kiro/skills/
+└── my-skill/
+    ├── SKILL.md        # Required — instructions + metadata
+    ├── scripts/        # Optional — executable scripts
+    ├── references/     # Optional — reference docs
+    └── assets/         # Optional — images, templates
+```
+
+### SKILL.md Format
+
+```markdown
+---
+name: my-skill
+description: What this skill does
+license: MIT
+compatibility:
+  kiro: ">=1.20.0"
+metadata:
+  author: user
+---
+
+# Skill Instructions
+
+Instructions loaded when skill is activated...
+```
+
+Skills use progressive disclosure: only name/description loaded at startup, full content on activation. Invoked via `/skill-name` slash command.
+
+---
+
+## 8. Agent Config Format
+
+File: `~/.kiro/agents/<name>.json` or `.kiro/agents/<name>.json`
+
+```json
+{
+  "name": "my-agent",
+  "description": "Agent description",
+  "prompt": "System prompt / instructions",
+  "mcpServers": {
+    "server-name": {
+      "command": "npx",
+      "args": ["-y", "some-server"]
+    }
+  },
+  "tools": ["@git", "@builtin", "read", "write", "shell"],
+  "hooks": {
+    "preToolUse": [
+      { "matcher": "*", "command": "echo checking" }
+    ],
+    "postToolUse": [
+      { "matcher": "*", "command": "echo done" }
+    ]
+  },
+  "includeMcpJson": true,
+  "model": "claude-sonnet-4"
+}
+```
+
+### Observal's Current Agent Generation (for comparison)
+
+```python
+# From agent_config_generator.py
+{
+    "agent_file": {
+        "path": f"~/.kiro/agents/{safe_name}.json",
+        "content": {
+            "name": safe_name,
+            "description": agent.description[:200],
+            "prompt": agent.prompt,
+            "mcpServers": mcp_configs,
+            "tools": [f"@{n}" for n in mcp_configs] + ["read", "write", "shell"],
+            "hooks": {},
+            "includeMcpJson": True,
+            "model": agent.model_name,
+        },
+    },
+}
+```
+
+This is already compatible with Kiro's expected format.
+
+---
+
+## 9. Powers System
+
+Powers = bundled extensions (MCP tools + steering + hooks in one package). 50+ available including AWS, Firebase, Stripe, etc. Powers load dynamically based on conversation context.
+
+No Observal equivalent currently. Low priority for integration.
+
+---
+
+## 10. Integration Strategy
+
+### Recommended Approach
+
+Since Kiro lacks native OTEL, the telemetry bridge must use hooks:
+
+1. **Create an Observal telemetry hook script** that Kiro hooks call via `runCommand`
+2. **The hook script** receives STDIN JSON, enriches it (adds session ID, timestamps), and POSTs to Observal's `/api/v1/telemetry/hooks` endpoint
+3. **Install hooks** into Kiro agent configs for `agentSpawn`, `preToolUse`, `postToolUse`, `stop`, and `userPromptSubmit`
+4. **Generate Steering files** instead of (or in addition to) AGENTS.md for richer agent instructions
+
+### What This Gives Us
+
+- Tool usage tracking (which tools, success/failure, timing)
+- Session lifecycle (start/stop)
+- User prompts
+- **Missing:** Token counts, model name, cost data (blocked on Kiro upstream)
+
+### What We Won't Get Until Kiro Adds OTEL
+
+- Token counts per request
+- Model name per request
+- Cost/credit data
+- Cache hit rates
+- API request latency

--- a/docs/kiro-setup.md
+++ b/docs/kiro-setup.md
@@ -1,0 +1,104 @@
+# Kiro CLI Setup Guide for Observal
+
+This guide explains how to connect Kiro CLI to Observal for telemetry collection, agent management, and observability.
+
+## Prerequisites
+
+- Observal server running (`make up` or `docker compose up -d`)
+- `observal` CLI installed (`uv tool install --editable .`)
+- Authenticated with Observal (`observal login`)
+
+## 1. Install Kiro CLI
+
+```bash
+curl -fsSL https://cli.kiro.dev/install | bash
+kiro-cli --version
+kiro-cli login
+```
+
+## 2. Configure MCP Telemetry (via observal-shim)
+
+Observal wraps MCP servers with `observal-shim` to capture tool call telemetry. Scan your Kiro config to auto-wrap:
+
+```bash
+# Wrap project-level MCP servers
+observal scan --ide kiro
+
+# Wrap global MCP servers
+observal scan --ide kiro --home
+```
+
+This modifies `.kiro/settings/mcp.json` to route MCP calls through observal-shim.
+
+## 3. Install an Agent from Observal Registry
+
+```bash
+# List available agents
+observal agent list
+
+# Pull agent config for Kiro
+observal pull <agent-id-or-name> --ide kiro
+
+# This writes:
+#   ~/.kiro/agents/<name>.json    — Agent config with hooks
+#   .kiro/steering/<name>.md      — Steering file (instructions)
+```
+
+## 4. How Telemetry Works
+
+Kiro does **not** have native OpenTelemetry export (as of v1.28). Observal collects telemetry through two channels:
+
+### Channel 1: observal-shim (MCP tool calls)
+Every MCP server wrapped with observal-shim reports tool calls, latency, and status to Observal.
+
+### Channel 2: Hook bridge (agent lifecycle)
+Agents pulled from Observal include shell hooks that POST lifecycle events to the Observal API:
+
+| Kiro Hook Event | What It Captures |
+|-----------------|-----------------|
+| `agentSpawn` | Session start |
+| `preToolUse` | Tool invocation (before) |
+| `postToolUse` | Tool result (after) |
+| `stop` | Session end |
+| `userPromptSubmit` | User prompt text |
+
+These hooks call `curl` to send JSON payloads to `http://localhost:8000/api/v1/telemetry/hooks`.
+
+## 5. Verify Setup
+
+```bash
+observal doctor --ide kiro
+```
+
+This checks:
+- Kiro CLI is installed and authenticated
+- MCP servers are wrapped with observal-shim
+- Agents have Observal telemetry hooks
+- Observal server is reachable
+
+## 6. View Traces
+
+Open the Observal web UI at `http://localhost:3000/traces` and filter by IDE → "kiro" to see Kiro traces.
+
+## Limitations
+
+- **No token counts**: Kiro doesn't expose input/output token counts in hooks
+- **No model name**: The model used per request isn't available in hook payloads
+- **No cost data**: Credit consumption isn't exportable
+- **No native OTEL**: Waiting on upstream Kiro support ([kirodotdev/Kiro#6319](https://github.com/kirodotdev/Kiro/issues/6319))
+
+These limitations will resolve when Kiro implements native OTEL export.
+
+## Troubleshooting
+
+### Hooks not firing
+- Ensure `OBSERVAL_API_KEY` is set in your environment
+- Check that the agent JSON in `~/.kiro/agents/` has a `hooks` section
+- Verify the server URL is correct (default: `http://localhost:8000`)
+
+### MCP servers not reporting telemetry
+- Run `observal scan --ide kiro` to re-wrap servers
+- Check that `observal-shim` is in your PATH: `which observal-shim`
+
+### Doctor reports issues
+- Run `observal doctor --ide kiro --fix` for suggested fixes

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -459,6 +459,28 @@ async def agent_download_stats(
     return stats
 
 
+@router.get("/{agent_id}/traces")
+async def get_agent_traces(
+    agent_id: str,
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return all traces where this agent participated."""
+    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    from services.clickhouse import query_traces
+
+    traces = await query_traces(
+        project_id="default",
+        agent_id=str(agent.id),
+        limit=limit,
+        offset=offset,
+    )
+    return {"agent_id": str(agent.id), "traces": traces, "count": len(traces)}
+
+
 @router.get("/{agent_id}/resolve")
 async def resolve_agent_components(
     agent_id: str,

--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -12,8 +12,14 @@ from models.eval import EvalRun, EvalRunStatus, Scorecard
 from models.user import User
 from schemas.eval import EvalRequest, EvalRunDetailResponse, EvalRunResponse, ScorecardResponse
 from services.clickhouse import query_spans
-from services.eval_service import evaluate_trace, fetch_traces, parse_scorecard, run_structured_eval
-from services.hook_materializer import materialize_session_spans
+from services.eval_service import (
+    evaluate_trace,
+    fetch_traces,
+    parse_scorecard,
+    run_agent_scoped_eval,
+    run_structured_eval,
+)
+from services.hook_materializer import build_agent_eval_context, materialize_agent_eval, materialize_session_spans
 from services.score_aggregator import ScoreAggregator
 
 router = APIRouter(prefix="/api/v1/eval", tags=["eval"])
@@ -217,6 +223,120 @@ async def eval_session(
         ],
         "source": "hook_materializer",
         "note": "No agent_id provided — returning materialized spans without scoring.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Agent-scoped eval (evaluate a subagent's contribution within a session)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/agents/{agent_id}/session/{session_id}", response_model=dict)
+async def eval_agent_in_session(
+    agent_id: str,
+    session_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Evaluate a specific agent's contribution within a session.
+
+    Materializes the full session from otel_logs, identifies which spans
+    belong to the target agent (via SubagentStart/Stop boundaries or
+    agent_id attribution), then runs the eval pipeline with:
+    - Structural scoring on the agent's spans only
+    - SLM scoring with full session context + delegation prompt as goal
+    """
+    # Load agent from DB (by UUID or name)
+    from api.routes.agent import _agent_id_clause, _load_agent
+
+    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    # Materialize session and find the agent's spans
+    trace, all_spans, agent_ctx = await materialize_agent_eval(
+        session_id, agent.name
+    )
+
+    if not all_spans:
+        raise HTTPException(status_code=404, detail="No hook events found for session")
+
+    # If not found by name, try by agent ID
+    if agent_ctx is None:
+        trace, all_spans, agent_ctx = await materialize_agent_eval(
+            session_id, str(agent.id)
+        )
+
+    if agent_ctx is None:
+        # Agent wasn't found as a subagent — check if this is a single-agent
+        # session where the agent IS the primary (e.g., Kiro sessions)
+        session_agent = trace.get("agent_id", "")
+        if session_agent and session_agent.lower() == agent.name.lower():
+            # Whole session is this agent's work — eval the full session
+            eval_run = EvalRun(agent_id=agent.id, triggered_by=current_user.id)
+            db.add(eval_run)
+            await db.flush()
+
+            sc = await run_structured_eval(agent, trace, all_spans, eval_run.id)
+            db.add(sc)
+            eval_run.status = EvalRunStatus.completed
+            eval_run.traces_evaluated = 1
+            eval_run.completed_at = datetime.now(UTC)
+            await db.commit()
+
+            return {
+                "session_id": session_id,
+                "agent_id": str(agent.id),
+                "agent_name": agent.name,
+                "eval_mode": "full_session",
+                "eval_run_id": str(eval_run.id),
+                "composite_score": sc.composite_score,
+                "overall_grade": sc.overall_grade,
+                "dimension_scores": sc.dimension_scores,
+                "span_count": len(all_spans),
+            }
+
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agent.name}' not found in session {session_id}",
+        )
+
+    # Build the eval context
+    eval_ctx = build_agent_eval_context(all_spans, agent_ctx)
+
+    # Run agent-scoped eval
+    eval_run = EvalRun(agent_id=agent.id, triggered_by=current_user.id)
+    db.add(eval_run)
+    await db.flush()
+
+    sc = await run_agent_scoped_eval(
+        agent=agent,
+        trace=trace,
+        full_spans=eval_ctx["full_spans"],
+        agent_spans=eval_ctx["agent_spans"],
+        eval_run_id=eval_run.id,
+        delegation_prompt=eval_ctx["delegation_prompt"],
+        agent_output=eval_ctx["agent_output"],
+    )
+    db.add(sc)
+    eval_run.status = EvalRunStatus.completed
+    eval_run.traces_evaluated = 1
+    eval_run.completed_at = datetime.now(UTC)
+    await db.commit()
+
+    return {
+        "session_id": session_id,
+        "agent_id": str(agent.id),
+        "agent_name": agent.name,
+        "eval_mode": "agent_scoped",
+        "eval_run_id": str(eval_run.id),
+        "composite_score": sc.composite_score,
+        "overall_grade": sc.overall_grade,
+        "dimension_scores": sc.dimension_scores,
+        "delegation_prompt": eval_ctx["delegation_prompt"][:200] if eval_ctx["delegation_prompt"] else None,
+        "agent_span_count": len(eval_ctx["agent_spans"]),
+        "full_session_span_count": len(eval_ctx["full_spans"]),
+        "invocations": len(eval_ctx["invocations"]),
     }
 
 

--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -13,6 +13,7 @@ from models.user import User
 from schemas.eval import EvalRequest, EvalRunDetailResponse, EvalRunResponse, ScorecardResponse
 from services.clickhouse import query_spans
 from services.eval_service import evaluate_trace, fetch_traces, parse_scorecard, run_structured_eval
+from services.hook_materializer import materialize_session_spans
 from services.score_aggregator import ScoreAggregator
 
 router = APIRouter(prefix="/api/v1/eval", tags=["eval"])
@@ -44,7 +45,14 @@ async def run_evaluation(
     await db.flush()
 
     trace_id = req.trace_id if req else None
+    session_id = req.session_id if req and hasattr(req, "session_id") else None
     traces = await fetch_traces(str(agent.id), trace_id=trace_id)
+
+    # If no traces from agent_interactions, try materializing from hook events
+    if not traces and session_id:
+        mat_trace, mat_spans = await materialize_session_spans(session_id)
+        if mat_trace and mat_spans:
+            traces = [mat_trace]
 
     if not traces:
         eval_run.status = EvalRunStatus.completed
@@ -60,6 +68,9 @@ async def run_evaluation(
 
             # Try new structured eval first (uses spans from ClickHouse)
             spans = await query_spans("default", tid, limit=500)
+            if not spans and trace.get("source") == "hook_materializer":
+                # Use materialized spans from hook events
+                _, spans = await materialize_session_spans(tid)
             if spans:
                 sc = await run_structured_eval(agent, trace, spans, eval_run.id)
             else:
@@ -141,6 +152,72 @@ async def compare_versions(
         return {"version": version, "avg_score": round(float(row.avg_overall or 0), 2), "count": row.count}
 
     return {"version_a": await _avg_scores(version_a), "version_b": await _avg_scores(version_b)}
+
+
+# ---------------------------------------------------------------------------
+# Session-based eval (hook data — Kiro, etc.)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/sessions/{session_id}", response_model=dict)
+async def eval_session(
+    session_id: str,
+    agent_id: uuid.UUID | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Evaluate a hook-based session by materializing otel_logs into spans.
+
+    Works for Kiro and any other hook-sourced session. If agent_id is provided,
+    the eval uses the agent's goal template; otherwise a generic eval is run.
+    """
+    trace, spans = await materialize_session_spans(session_id)
+    if not trace or not spans:
+        raise HTTPException(status_code=404, detail="No hook events found for session")
+
+    agent = None
+    if agent_id:
+        result = await db.execute(
+            select(Agent)
+            .where(Agent.id == agent_id)
+            .options(selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections))
+        )
+        agent = result.scalar_one_or_none()
+
+    if agent:
+        eval_run = EvalRun(agent_id=agent.id, triggered_by=current_user.id)
+        db.add(eval_run)
+        await db.flush()
+
+        sc = await run_structured_eval(agent, trace, spans, eval_run.id)
+        db.add(sc)
+        eval_run.status = EvalRunStatus.completed
+        eval_run.traces_evaluated = 1
+        eval_run.completed_at = datetime.now(UTC)
+        await db.commit()
+
+        return {
+            "session_id": session_id,
+            "eval_run_id": str(eval_run.id),
+            "composite_score": sc.composite_score,
+            "overall_grade": sc.overall_grade,
+            "dimension_scores": sc.dimension_scores,
+            "span_count": len(spans),
+            "source": "hook_materializer",
+        }
+
+    # No agent — return materialized data summary (useful for inspection)
+    return {
+        "session_id": session_id,
+        "trace": trace,
+        "span_count": len(spans),
+        "spans_summary": [
+            {"type": s["type"], "name": s["name"], "status": s["status"]}
+            for s in spans
+        ],
+        "source": "hook_materializer",
+        "note": "No agent_id provided — returning materialized spans without scoring.",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Request
 
 from services.clickhouse import _escape, _map_literal, _query
+from services.secrets_redactor import redact_secrets
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/otel", tags=["otel-dashboard"])
@@ -470,6 +471,12 @@ async def ingest_hook(request: Request):
 
     # Event name for the EventName column (used by list_sessions countIf)
     event_name = attrs.get("event.name", f"hook_{hook_event.lower()}")
+
+    # ── Redact secrets from user-content fields before storage ──
+    for _redact_field in ("tool_input", "tool_response", "error"):
+        if _redact_field in attrs:
+            attrs[_redact_field] = redact_secrets(attrs[_redact_field])
+    body_text = redact_secrets(body_text)
 
     # INSERT into otel_logs
     attr_map = _map_literal(attrs)

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -37,6 +37,8 @@ async def list_sessions():
         "anyIf(LogAttributes['model'], LogAttributes['model'] != '') AS model, "
         "anyIf(LogAttributes['user.id'], LogAttributes['user.id'] != '') AS user_id, "
         "anyIf(LogAttributes['terminal.type'], LogAttributes['terminal.type'] != '') AS terminal_type, "
+        "anyIf(LogAttributes['credits'], LogAttributes['credits'] != '') AS credits, "
+        "anyIf(LogAttributes['tools_used'], LogAttributes['tools_used'] != '') AS tools_used, "
         "any(ServiceName) AS service_name "
         "FROM otel_logs "
         "WHERE LogAttributes['session.id'] != '' "
@@ -222,20 +224,55 @@ def _safe_json(obj: object) -> str:
         return str(obj)
 
 
+_KIRO_TO_CC_EVENT = {
+    "agentSpawn": "SessionStart",
+    "userPromptSubmit": "UserPromptSubmit",
+    "preToolUse": "PreToolUse",
+    "postToolUse": "PostToolUse",
+    "stop": "Stop",
+}
+
+_KIRO_FIELD_MAP = {
+    "hookEventName": "hook_event_name",
+    "sessionId": "session_id",
+    "toolName": "tool_name",
+    "toolInput": "tool_input",
+    "toolResponse": "tool_response",
+    "toolUseId": "tool_use_id",
+    "agentId": "agent_id",
+    "agentType": "agent_type",
+    "stopReason": "stop_reason",
+    "permissionMode": "permission_mode",
+    "lastAssistantMessage": "last_assistant_message",
+    "userPrompt": "user_prompt",
+}
+
+
 @router.post("/hooks")
 async def ingest_hook(request: Request):
-    """Ingest hook events from Claude Code and store in otel_logs.
+    """Ingest hook events from Claude Code / Kiro and store in otel_logs.
 
-    This is intentionally unauthenticated because Claude Code hooks fire
-    from the CLI and can't easily carry auth tokens.  The endpoint only
+    This is intentionally unauthenticated because CLI hooks fire
+    from the terminal and can't easily carry auth tokens.  The endpoint only
     writes to ClickHouse — no destructive operations.
     """
     body = await request.json()
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
-    hook_event = body.get("hook_event_name", "unknown")
+    # ── Normalize Kiro camelCase fields to snake_case ──
+    normalized: dict = {}
+    for key, value in body.items():
+        normalized[_KIRO_FIELD_MAP.get(key, key)] = value
+    body = normalized
+
+    # ── Normalize Kiro camelCase event names to PascalCase ──
+    raw_event = body.get("hook_event_name", "unknown")
+    hook_event = _KIRO_TO_CC_EVENT.get(raw_event, raw_event)
+    body["hook_event_name"] = hook_event
+
     session_id = body.get("session_id", "")
     tool_name = body.get("tool_name", "")
+    service_name = body.get("service_name", "observal-hooks")
 
     # Build the attributes map that the frontend already reads
     attrs: dict[str, str] = {
@@ -245,11 +282,15 @@ async def ingest_hook(request: Request):
         "tool_name": tool_name,
     }
 
-    # ── Agent attribution (present on ALL events fired within a subagent) ──
+    # ── Agent attribution ──
     if body.get("agent_id"):
         attrs["agent_id"] = body["agent_id"]
     if body.get("agent_type"):
         attrs["agent_type"] = body["agent_type"]
+    if body.get("agent_name"):
+        attrs["agent_name"] = body["agent_name"]
+    if body.get("model"):
+        attrs["model"] = body["model"]
 
     # Capture full content — this is the Langfuse-equivalent visibility
     tool_input_raw = body.get("tool_input")
@@ -260,6 +301,15 @@ async def ingest_hook(request: Request):
     if tool_response_raw is not None:
         attrs["tool_response"] = _truncate(_safe_json(tool_response_raw))
 
+    # ── Kiro-specific field extraction ──
+    # Kiro sends `prompt` on agentSpawn/userPromptSubmit,
+    # `assistant_response` on stop, and tool_input/tool_response as dicts.
+    if body.get("prompt") and not attrs.get("tool_input"):
+        attrs["tool_input"] = _truncate(str(body["prompt"]))
+    if body.get("assistant_response") and not attrs.get("tool_response"):
+        attrs["tool_response"] = _truncate(str(body["assistant_response"]))
+        attrs["event.name"] = "hook_assistant_response"
+
     # UserPromptSubmit — capture the actual user prompt
     if hook_event == "UserPromptSubmit":
         prompt_text = body.get("prompt") or body.get("user_prompt") or ""
@@ -267,6 +317,14 @@ async def ingest_hook(request: Request):
             attrs["tool_input"] = _truncate(prompt_text)
             attrs["prompt_length"] = str(len(prompt_text))
         attrs["tool_name"] = "user_prompt"
+        attrs["event.name"] = "user_prompt"
+
+    # SessionStart / agentSpawn — capture initial prompt and mark as session start
+    if hook_event == "SessionStart":
+        prompt_text = body.get("prompt") or ""
+        if prompt_text:
+            attrs["tool_input"] = _truncate(prompt_text)
+        attrs["event.name"] = "hook_sessionstart"
 
     # SubagentStart — capture agent spawn
     if hook_event == "SubagentStart" and body.get("last_assistant_message"):
@@ -284,14 +342,17 @@ async def ingest_hook(request: Request):
     if hook_event == "Stop":
         if body.get("stop_reason"):
             attrs["stop_reason"] = body["stop_reason"]
-        # If the stop hook captured Claude's response, mark it clearly
-        if tool_name == "assistant_response" and tool_response_raw:
+        # Kiro sends assistant_response directly; Claude Code sends via tool_response
+        if body.get("assistant_response"):
+            attrs["tool_response"] = _truncate(str(body["assistant_response"]))
             attrs["event.name"] = "hook_assistant_response"
-            # Sequence metadata for interleaving with tool calls
-            if body.get("message_sequence") is not None:
-                attrs["message_sequence"] = str(body["message_sequence"])
-            if body.get("message_total") is not None:
-                attrs["message_total"] = str(body["message_total"])
+        elif tool_name == "assistant_response" and tool_response_raw:
+            attrs["event.name"] = "hook_assistant_response"
+        # Sequence metadata for interleaving with tool calls
+        if body.get("message_sequence") is not None:
+            attrs["message_sequence"] = str(body["message_sequence"])
+        if body.get("message_total") is not None:
+            attrs["message_total"] = str(body["message_total"])
 
     # StopFailure — API error on turn end
     if hook_event == "StopFailure":
@@ -343,6 +404,14 @@ async def ingest_hook(request: Request):
     if body.get("permission_mode"):
         attrs["permission_mode"] = body["permission_mode"]
 
+    # ── Enriched fields from Kiro SQLite DB (sent by kiro_stop_hook.py) ──
+    for enriched_field in (
+        "input_tokens", "output_tokens",
+        "turn_count", "credits", "tools_used", "conversation_id",
+    ):
+        if body.get(enriched_field):
+            attrs[enriched_field] = str(body[enriched_field])
+
     # Build the Body as a readable summary
     agent_prefix = f"[{attrs.get('agent_type', '')}] " if attrs.get("agent_id") else ""
     if hook_event in ("PostToolUse", "PreToolUse"):
@@ -356,7 +425,7 @@ async def ingest_hook(request: Request):
         body_text = f"{hook_event}: {attrs.get('agent_type', 'unknown')}"
     elif hook_event in ("Elicitation", "ElicitationResult"):
         body_text = f"{hook_event}: {body.get('mcp_server_name', 'unknown')}"
-    elif hook_event == "Stop" and tool_name == "assistant_response":
+    elif hook_event == "Stop" and (tool_name == "assistant_response" or body.get("assistant_response")):
         seq = attrs.get("message_sequence", "")
         total = attrs.get("message_total", "")
         seq_label = f" [{seq}/{total}]" if seq and total else ""
@@ -368,7 +437,8 @@ async def ingest_hook(request: Request):
         body_text = f"StopFailure: {attrs.get('error', 'unknown')[:80]}"
     elif hook_event == "SessionStart":
         resumed = " (resumed)" if attrs.get("session_resumed") == "True" else ""
-        body_text = f"SessionStart{resumed}"
+        prompt_preview = (attrs.get("tool_input") or "")[:100]
+        body_text = f"SessionStart{resumed}: {prompt_preview}" if prompt_preview else f"SessionStart{resumed}"
     elif hook_event == "Notification":
         body_text = f"Notification: {attrs.get('notification_title', '')}"
     elif hook_event in ("TaskCreated", "TaskCompleted"):
@@ -391,7 +461,7 @@ async def ingest_hook(request: Request):
         "SeverityText, SeverityNumber) VALUES "
         f"('{_escape(now)}', '{_escape(event_name)}', "
         f"'{_escape(body_text)}', {attr_map}, "
-        f"'observal-hooks', 'INFO', 9)"
+        f"'{_escape(service_name)}', 'INFO', 9)"
     )
 
     try:

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -24,7 +24,11 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
 async def list_sessions():
     rows = await _ch_json(
         "SELECT "
-        "LogAttributes['session.id'] AS session_id, "
+        # For Kiro sessions with a conversation_id, group by that instead of
+        # the ephemeral $PPID-based session_id.  This merges resumed sessions.
+        "if(LogAttributes['conversation_id'] != '', "
+        "   LogAttributes['conversation_id'], "
+        "   LogAttributes['session.id']) AS session_id, "
         "min(Timestamp) AS first_event_time, "
         "max(Timestamp) AS last_event_time, "
         "countIf(EventName = 'user_prompt' OR LogAttributes['event.name'] = 'user_prompt') AS prompt_count, "
@@ -52,6 +56,12 @@ async def list_sessions():
 @router.get("/sessions/{session_id}")
 async def get_session(session_id: str):
     sid = _escape(session_id)
+    # Match either session.id or conversation_id so resumed Kiro sessions
+    # (which share a conversation_id) resolve correctly.
+    session_filter = (
+        f"(LogAttributes['session.id'] = '{sid}' "
+        f"OR LogAttributes['conversation_id'] = '{sid}')"
+    )
     events = await _ch_json(
         "SELECT "
         "Timestamp AS timestamp, "
@@ -60,7 +70,7 @@ async def get_session(session_id: str):
         "LogAttributes AS attributes, "
         "ServiceName AS service_name "
         f"FROM otel_logs "
-        f"WHERE LogAttributes['session.id'] = '{sid}' "
+        f"WHERE {session_filter} "
         "ORDER BY Timestamp ASC"
     )
     traces = await _ch_json(
@@ -291,6 +301,14 @@ async def ingest_hook(request: Request):
         attrs["agent_name"] = body["agent_name"]
     if body.get("model"):
         attrs["model"] = body["model"]
+
+    # ── User identity (from Observal login, injected by CLI) ──
+    # Kiro: user_id in body (via sed injection)
+    # Claude Code: X-Observal-User-Id header (via HTTP hook header)
+    # Claude Code also sends native user.id in some events
+    user_id = body.get("user_id") or request.headers.get("x-observal-user-id") or ""
+    if user_id:
+        attrs["user.id"] = user_id
 
     # Capture full content — this is the Langfuse-equivalent visibility
     tool_input_raw = body.get("tool_input")

--- a/observal-server/api/routes/otlp.py
+++ b/observal-server/api/routes/otlp.py
@@ -33,6 +33,9 @@ _IDE_HINTS = {
     "copilot": "github_copilot",
     "cursor": "cursor",
     "kiro": "kiro",
+    "kiro-cli": "kiro",
+    "amazon-kiro": "kiro",
+    "aws-kiro": "kiro",
 }
 
 
@@ -248,7 +251,7 @@ def _process_span_events(
             event_time = event.get("timeUnixNano", "0")
             dt = _nanos_to_dt(event_time) if int(event_time) > 0 else _now_ms()
 
-            if event_name in ("claude_code.user_prompt", "user_prompt"):
+            if event_name in ("claude_code.user_prompt", "kiro.user_prompt", "user_prompt"):
                 # Captured as trace input via log handler; also emit a span
                 spans_out.append(
                     {
@@ -268,7 +271,7 @@ def _process_span_events(
                         "metadata": {},
                     }
                 )
-            elif event_name in ("claude_code.tool_result", "tool_result"):
+            elif event_name in ("claude_code.tool_result", "kiro.tool_result", "tool_result"):
                 dur = _safe_int(event_attrs.get("duration_ms"))
                 spans_out.append(
                     {
@@ -289,13 +292,26 @@ def _process_span_events(
                         "metadata": {},
                     }
                 )
-            elif event_name in ("claude_code.api_request", "api_request"):
-                tok_in = _safe_int(event_attrs.get("input_tokens"))
-                tok_out = _safe_int(event_attrs.get("output_tokens"))
+            elif event_name in ("claude_code.api_request", "kiro.api_request", "api_request"):
+                tok_in = (
+                    _safe_int(event_attrs.get("input_tokens"))
+                    or _safe_int(event_attrs.get("gen_ai.usage.input_tokens"))
+                    or _safe_int(event_attrs.get("aws.bedrock.invocation.input_tokens"))
+                )
+                tok_out = (
+                    _safe_int(event_attrs.get("output_tokens"))
+                    or _safe_int(event_attrs.get("gen_ai.usage.output_tokens"))
+                    or _safe_int(event_attrs.get("aws.bedrock.invocation.output_tokens"))
+                )
                 tok_total = (tok_in or 0) + (tok_out or 0) if (tok_in is not None or tok_out is not None) else None
                 meta: dict[str, str] = {}
-                if event_attrs.get("model"):
-                    meta["model"] = event_attrs["model"]
+                model = (
+                    event_attrs.get("model")
+                    or event_attrs.get("gen_ai.request.model")
+                    or event_attrs.get("aws.bedrock.model_id")
+                )
+                if model:
+                    meta["model"] = model
                 spans_out.append(
                     {
                         "span_id": uuid.uuid4().hex,
@@ -364,7 +380,7 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                     body_val = rec.get("body", {})
                     body_text = body_val.get("stringValue", "") if isinstance(body_val, dict) else str(body_val)
 
-                    if event_name in ("claude_code.user_prompt", "user_prompt"):
+                    if event_name in ("claude_code.user_prompt", "kiro.user_prompt", "user_prompt"):
                         prompt_text = (
                             all_attrs.get("prompt")
                             or body_text
@@ -400,7 +416,7 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                         else:
                             prompt_traces[trace_id]["input"] = prompt_text
 
-                    elif event_name in ("claude_code.tool_result", "tool_result"):
+                    elif event_name in ("claude_code.tool_result", "kiro.tool_result", "tool_result"):
                         # Ensure trace exists
                         if trace_id not in prompt_traces:
                             prompt_traces[trace_id] = {
@@ -436,7 +452,7 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                             }
                         )
 
-                    elif event_name in ("claude_code.api_request", "api_request"):
+                    elif event_name in ("claude_code.api_request", "kiro.api_request", "api_request"):
                         if trace_id not in prompt_traces:
                             prompt_traces[trace_id] = {
                                 "trace_id": trace_id,
@@ -451,14 +467,27 @@ def _convert_resource_logs(body: dict) -> tuple[list[dict], list[dict]]:
                                 "metadata": {"prompt_id": prompt_id} if prompt_id else {},
                                 "tags": [],
                             }
-                        tok_in = _safe_int(all_attrs.get("input_tokens"))
-                        tok_out = _safe_int(all_attrs.get("output_tokens"))
+                        tok_in = (
+                            _safe_int(all_attrs.get("input_tokens"))
+                            or _safe_int(all_attrs.get("gen_ai.usage.input_tokens"))
+                            or _safe_int(all_attrs.get("aws.bedrock.invocation.input_tokens"))
+                        )
+                        tok_out = (
+                            _safe_int(all_attrs.get("output_tokens"))
+                            or _safe_int(all_attrs.get("gen_ai.usage.output_tokens"))
+                            or _safe_int(all_attrs.get("aws.bedrock.invocation.output_tokens"))
+                        )
                         tok_total = (
                             (tok_in or 0) + (tok_out or 0) if (tok_in is not None or tok_out is not None) else None
                         )
                         meta: dict[str, str] = {}
-                        if all_attrs.get("model"):
-                            meta["model"] = all_attrs["model"]
+                        model = (
+                            all_attrs.get("model")
+                            or all_attrs.get("gen_ai.request.model")
+                            or all_attrs.get("aws.bedrock.model_id")
+                        )
+                        if model:
+                            meta["model"] = model
                         spans.append(
                             {
                                 "span_id": uuid.uuid4().hex,

--- a/observal-server/api/routes/otlp.py
+++ b/observal-server/api/routes/otlp.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Request, Response
 
 from services.clickhouse import insert_spans, insert_traces
+from services.secrets_redactor import redact_secrets
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,18 @@ def _now_ms() -> str:
     return datetime.now(UTC).strftime(_DT_FMT)[:-3]
 
 
+_REDACT_FIELDS = {"input", "output", "error"}
+
+
+def _redact_rows(rows: list[dict]) -> None:
+    """Redact secrets from input/output/error fields in place."""
+    for row in rows:
+        for field in _REDACT_FIELDS:
+            val = row.get(field)
+            if val and isinstance(val, str):
+                row[field] = redact_secrets(val)
+
+
 # ---------------------------------------------------------------------------
 # OTLP Trace conversion
 # ---------------------------------------------------------------------------
@@ -152,9 +165,9 @@ def _convert_resource_spans(body: dict) -> tuple[list[dict], list[dict]]:
                     )
                     session_id = all_attrs.get("session.id")
 
-                    # GenAI semantic conventions
-                    input_text = all_attrs.get("gen_ai.prompt")
-                    output_text = all_attrs.get("gen_ai.completion")
+                    # GenAI semantic conventions (redact secrets)
+                    input_text = redact_secrets(all_attrs.get("gen_ai.prompt") or "") or None
+                    output_text = redact_secrets(all_attrs.get("gen_ai.completion") or "") or None
                     tok_in = _safe_int(all_attrs.get("gen_ai.usage.input_tokens"))
                     tok_out = _safe_int(all_attrs.get("gen_ai.usage.output_tokens"))
                     tok_total = (tok_in or 0) + (tok_out or 0) if (tok_in is not None or tok_out is not None) else None
@@ -572,6 +585,9 @@ async def otlp_traces(request: Request):
         logger.warning("OTLP /v1/traces: conversion failed", exc_info=True)
         return Response(content=json.dumps(_OTLP_OK), status_code=200, media_type="application/json")
 
+    _redact_rows(trace_rows)
+    _redact_rows(span_rows)
+
     errors = 0
     if trace_rows:
         try:
@@ -634,6 +650,9 @@ async def otlp_logs(request: Request):
     except Exception:
         logger.warning("OTLP /v1/logs: conversion failed", exc_info=True)
         return Response(content=json.dumps(_OTLP_OK), status_code=200, media_type="application/json")
+
+    _redact_rows(trace_rows)
+    _redact_rows(span_rows)
 
     errors = 0
     if trace_rows:

--- a/observal-server/api/routes/scan.py
+++ b/observal-server/api/routes/scan.py
@@ -26,6 +26,7 @@ class ScannedMcp(BaseModel):
     env: dict[str, str] = {}
     description: str = ""
     source_plugin: str | None = None
+    source_ide: str = ""
 
 
 class ScannedSkill(BaseModel):
@@ -34,6 +35,7 @@ class ScannedSkill(BaseModel):
     source_plugin: str | None = None
     task_type: str = "general"
     skill_path: str = "/"
+    source_ide: str = ""
 
 
 class ScannedHook(BaseModel):
@@ -43,6 +45,7 @@ class ScannedHook(BaseModel):
     handler_config: dict = {}
     description: str = ""
     source_plugin: str | None = None
+    source_ide: str = ""
 
 
 class ScannedAgent(BaseModel):
@@ -51,6 +54,7 @@ class ScannedAgent(BaseModel):
     model_name: str = ""
     prompt: str = ""
     source_file: str | None = None
+    source_ide: str = ""
 
 
 class ScanRequest(BaseModel):
@@ -99,14 +103,15 @@ async def bulk_scan(
             counts["mcp"] += 1
             continue
 
+        ide_tag = mcp.source_ide or req.ide
         listing = McpListing(
             name=mcp.name,
             version="0.1.0",
             git_url=mcp.url or "",
-            description=mcp.description or f"Auto-scanned MCP from {req.ide}: {mcp.name}",
+            description=mcp.description or f"Auto-scanned MCP from {ide_tag}: {mcp.name}",
             category="scanned",
             owner=owner,
-            supported_ides=[req.ide],
+            supported_ides=[ide_tag],
             status=ListingStatus.pending,
             submitted_by=current_user.id,
         )
@@ -124,6 +129,7 @@ async def bulk_scan(
             counts["skill"] += 1
             continue
 
+        ide_tag = skill.source_ide or req.ide
         listing = SkillListing(
             name=skill.name,
             version="0.1.0",
@@ -131,7 +137,7 @@ async def bulk_scan(
             owner=owner,
             task_type=skill.task_type,
             skill_path=skill.skill_path,
-            supported_ides=[req.ide],
+            supported_ides=[ide_tag],
             status=ListingStatus.pending,
             submitted_by=current_user.id,
         )
@@ -149,6 +155,7 @@ async def bulk_scan(
             counts["hook"] += 1
             continue
 
+        ide_tag = hook.source_ide or req.ide
         listing = HookListing(
             name=hook.name,
             version="0.1.0",
@@ -157,7 +164,7 @@ async def bulk_scan(
             event=hook.event,
             handler_type=hook.handler_type,
             handler_config=hook.handler_config,
-            supported_ides=[req.ide],
+            supported_ides=[ide_tag],
             status=ListingStatus.pending,
             submitted_by=current_user.id,
         )
@@ -175,6 +182,7 @@ async def bulk_scan(
             counts["agent"] += 1
             continue
 
+        ide_tag = agent.source_ide or req.ide
         new_agent = Agent(
             name=agent.name,
             version="0.1.0",
@@ -182,7 +190,7 @@ async def bulk_scan(
             owner=owner,
             prompt=agent.prompt or "",
             model_name=agent.model_name or "sonnet-4-6",
-            supported_ides=[req.ide],
+            supported_ides=[ide_tag],
             created_by=current_user.id,
         )
         db.add(new_agent)

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -239,12 +239,38 @@ async def telemetry_status(current_user: User = Depends(get_current_user)):
     )
 
 
+# Kiro CLI uses camelCase event names; normalize to PascalCase
+_KIRO_EVENT_MAP = {
+    "agentSpawn": "SessionStart",
+    "userPromptSubmit": "UserPromptSubmit",
+    "promptSubmit": "UserPromptSubmit",
+    "preToolUse": "PreToolUse",
+    "postToolUse": "PostToolUse",
+    "stop": "Stop",
+    "agentStop": "Stop",
+}
+
+
 @router.post("/hooks")
 async def ingest_hook(request: Request, current_user: User = Depends(get_current_user)):
     """Ingest raw hook JSON from Claude Code/Kiro."""
     body = await request.json()
+
+    # Normalize Kiro camelCase field names to snake_case
+    if "hookEventName" in body and "hook_event_name" not in body:
+        body["hook_event_name"] = body["hookEventName"]
+    if "toolName" in body and "tool_name" not in body:
+        body["tool_name"] = body["toolName"]
+    if "toolInput" in body and "tool_input" not in body:
+        body["tool_input"] = body["toolInput"]
+    if "toolResponse" in body and "tool_response" not in body:
+        body["tool_response"] = body["toolResponse"]
+    if "sessionId" in body and "session_id" not in body:
+        body["session_id"] = body["sessionId"]
+
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-    hook_event_name = body.get("hook_event_name", "unknown")
+    raw_event = body.get("hook_event_name", "unknown")
+    hook_event_name = _KIRO_EVENT_MAP.get(raw_event, raw_event)
     span_type = "hook_exec" if hook_event_name == "PostToolUse" else f"hook_{hook_event_name.lower()}"
     row = {
         "span_id": str(uuid.uuid4()),

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -20,6 +20,7 @@ from services.clickhouse import (
     insert_traces,
     query_recent_events,
 )
+from services.secrets_redactor import redact_secrets
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/telemetry", tags=["telemetry"])
@@ -62,8 +63,8 @@ async def ingest(
                         "name": t.name,
                         "metadata": t.metadata,
                         "tags": t.tags,
-                        "input": t.input,
-                        "output": t.output,
+                        "input": redact_secrets(t.input) if t.input else t.input,
+                        "output": redact_secrets(t.output) if t.output else t.output,
                         "tool_id": t.tool_id,
                         "sandbox_id": t.sandbox_id,
                         "graphrag_id": t.graphrag_id,
@@ -95,9 +96,9 @@ async def ingest(
                         "type": s.type,
                         "name": s.name,
                         "method": s.method,
-                        "input": s.input,
-                        "output": s.output,
-                        "error": s.error,
+                        "input": redact_secrets(s.input) if s.input else s.input,
+                        "output": redact_secrets(s.output) if s.output else s.output,
+                        "error": redact_secrets(s.error) if s.error else s.error,
                         "start_time": s.start_time,
                         "end_time": s.end_time,
                         "latency_ms": s.latency_ms,
@@ -193,8 +194,8 @@ async def ingest_events(
                     "timestamp": now,
                     "mcp_server_id": tc.mcp_server_id,
                     "tool_name": tc.tool_name,
-                    "input_params": tc.input_params,
-                    "response": tc.response,
+                    "input_params": redact_secrets(tc.input_params) if tc.input_params else tc.input_params,
+                    "response": redact_secrets(tc.response) if tc.response else tc.response,
                     "latency_ms": tc.latency_ms,
                     "status": tc.status,
                     "user_action": tc.user_action,

--- a/observal-server/schemas/eval.py
+++ b/observal-server/schemas/eval.py
@@ -113,3 +113,4 @@ class EvalRunDetailResponse(EvalRunResponse):
 
 class EvalRequest(BaseModel):
     trace_id: str | None = None  # Evaluate specific trace, or all recent if None
+    session_id: str | None = None  # Evaluate a hook-based session (Kiro, etc.)

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -79,8 +79,20 @@ def generate_agent_config(
 
     if ide == "kiro":
         # Kiro agent JSON: drop into ~/.kiro/agents/<name>.json
-        # Telemetry collected via observal-shim, no native OTel
-        return {
+        # Telemetry collected via observal-shim + hook bridge
+        curl_cmd = (
+            f"cat | curl -sf -X POST {observal_url}/api/v1/telemetry/hooks "
+            f'-H "Content-Type: application/json" '
+            f'-H "X-API-Key: $OBSERVAL_API_KEY" '
+            f"-d @-"
+        )
+        hooks = {
+            "agentSpawn": [{"command": curl_cmd}],
+            "preToolUse": [{"matcher": "*", "command": curl_cmd}],
+            "postToolUse": [{"matcher": "*", "command": curl_cmd}],
+            "stop": [{"command": curl_cmd}],
+        }
+        result: dict = {
             "agent_file": {
                 "path": f"~/.kiro/agents/{safe_name}.json",
                 "content": {
@@ -89,12 +101,23 @@ def generate_agent_config(
                     "prompt": agent.prompt,
                     "mcpServers": mcp_configs,
                     "tools": [f"@{n}" for n in mcp_configs] + ["read", "write", "shell"],
-                    "hooks": {},
+                    "hooks": hooks,
                     "includeMcpJson": True,
                     "model": agent.model_name,
                 },
             },
         }
+        # Also generate a Steering file for richer instruction support
+        if agent.prompt:
+            result["steering_file"] = {
+                "path": f".kiro/steering/{safe_name}.md",
+                "content": (
+                    f"---\ninclusion: always\nname: {safe_name}\n"
+                    f"description: {(agent.description or safe_name)[:100]}\n---\n\n"
+                    f"{agent.prompt}"
+                ),
+            }
+        return result
 
     if ide in ("claude-code", "claude_code"):
         otlp = _claude_otlp_env(observal_url)

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -80,17 +80,29 @@ def generate_agent_config(
     if ide == "kiro":
         # Kiro agent JSON: drop into ~/.kiro/agents/<name>.json
         # Telemetry collected via observal-shim + hook bridge
+        model_field = f',\\"model\\":\\"{agent.model_name}\\"' if agent.model_name else ""
         curl_cmd = (
-            f"cat | curl -sf -X POST {observal_url}/api/v1/telemetry/hooks "
+            f"cat | sed 's/^{{/{{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\","
+            f"\"agent_name\":\"{safe_name}\"{model_field},/' "
+            f"| curl -sf -X POST {observal_url}/api/v1/otel/hooks "
             f'-H "Content-Type: application/json" '
-            f'-H "X-API-Key: $OBSERVAL_API_KEY" '
             f"-d @-"
+        )
+        # Stop hook: enrich with model/token data from Kiro SQLite DB.
+        # Uses the observal CLI's enrichment script if installed, otherwise
+        # falls back to the same curl command as other events.
+        stop_cmd = (
+            f"cat | sed 's/^{{/{{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\","
+            f"\"agent_name\":\"{safe_name}\"{model_field},/' "
+            f"| python3 -m observal_cli.hooks.kiro_stop_hook "
+            f"--url {observal_url}/api/v1/otel/hooks"
         )
         hooks = {
             "agentSpawn": [{"command": curl_cmd}],
+            "userPromptSubmit": [{"command": curl_cmd}],
             "preToolUse": [{"matcher": "*", "command": curl_cmd}],
             "postToolUse": [{"matcher": "*", "command": curl_cmd}],
-            "stop": [{"command": curl_cmd}],
+            "stop": [{"command": stop_cmd}],
         }
         result: dict = {
             "agent_file": {

--- a/observal-server/services/eval_service.py
+++ b/observal-server/services/eval_service.py
@@ -389,3 +389,146 @@ async def run_structured_eval(
     }
 
     return scorecard
+
+
+async def run_agent_scoped_eval(
+    agent: Agent,
+    trace: dict,
+    full_spans: list[dict],
+    agent_spans: list[dict],
+    eval_run_id: uuid.UUID,
+    delegation_prompt: str = "",
+    agent_output: str = "",
+    canary_config: CanaryConfig | None = None,
+) -> Scorecard:
+    """Run eval focused on a specific agent's contribution within a session.
+
+    Structural scoring runs on agent_spans only (the agent's tool calls).
+    SLM scoring sees full_spans for context but evaluates against the
+    delegation_prompt (what the agent was asked to do) rather than the
+    registered goal template.
+    """
+    sanitizer = TraceSanitizer()
+    adversarial_scorer = AdversarialScorer(sanitizer)
+    canary_detector = CanaryDetector()
+    structural_scorer = StructuralScorer()
+    aggregator = ScoreAggregator()
+    watchdog = EvalWatchdog()
+
+    trace_id = trace.get("trace_id", trace.get("event_id", str(uuid.uuid4())))
+
+    # Build a focused trace with the agent's output
+    agent_trace = dict(trace)
+    if agent_output:
+        agent_trace["output"] = agent_output
+
+    # --- Step 1: Adversarial detection on agent's output ---
+    injection_attempts = sanitizer.detect_injection_attempts(agent_trace)
+    adversarial_penalties = adversarial_scorer.score(agent_trace, canary_config)
+    for p in adversarial_penalties:
+        if "amount" not in p:
+            p["amount"] = _PENALTY_AMOUNTS.get(p["event_name"], 0)
+
+    # --- Step 2: Sanitize for SLM ---
+    sanitized_trace = sanitizer.sanitize_for_judge(agent_trace)
+
+    # --- Step 3: Structural scoring on AGENT's spans only ---
+    structural_penalties = structural_scorer.score_tool_efficiency(agent_spans, str(agent.id))
+    structural_penalties += structural_scorer.score_tool_failures(agent_spans)
+    for p in structural_penalties:
+        if "amount" not in p:
+            p["amount"] = _PENALTY_AMOUNTS.get(p["event_name"], 0)
+
+    # --- Step 4: SLM scoring with delegation context ---
+    # Use delegation_prompt as goal if available, otherwise fall back to template
+    slm_penalties: list[dict] = []
+    skipped_dimensions: list[str] = []
+    backend = get_backend()
+    if not isinstance(backend, FallbackBackend):
+        slm_scorer = SLMScorer(backend)
+        try:
+            goal_desc = delegation_prompt or ""
+            required_sections: list[dict] = []
+
+            if not goal_desc and agent.goal_template:
+                goal_desc = agent.goal_template.description
+                required_sections = [
+                    {"name": s.name, "grounding_required": s.grounding_required}
+                    for s in agent.goal_template.sections
+                ]
+
+            # For agent-scoped eval, pass full_spans for grounding context
+            # but the SLM prompt uses the delegation as the goal
+            if goal_desc:
+                if required_sections:
+                    slm_penalties += await slm_scorer.score_goal_completion(
+                        sanitized_trace, full_spans, goal_desc, required_sections
+                    )
+                else:
+                    # No structured sections — use delegation prompt as
+                    # a single "task completion" section
+                    slm_penalties += await slm_scorer.score_goal_completion(
+                        sanitized_trace, full_spans, goal_desc,
+                        [{"name": "Delegated Task", "grounding_required": True}],
+                    )
+
+            slm_penalties += await slm_scorer.score_factual_grounding(
+                sanitized_trace, full_spans
+            )
+            slm_penalties += await slm_scorer.score_thought_process(full_spans)
+        except Exception as e:
+            logger.error(f"SLM scoring failed for agent-scoped eval: {e}")
+            slm_penalties = []
+            skipped_dimensions = ["goal_completion", "factual_grounding", "thought_process"]
+
+        for p in slm_penalties:
+            if "amount" not in p:
+                p["amount"] = _PENALTY_AMOUNTS.get(p["event_name"], 0)
+    else:
+        skipped_dimensions = ["goal_completion", "factual_grounding", "thought_process"]
+
+    # --- Step 5: Canary ---
+    canary_report = None
+    if canary_config and canary_config.enabled:
+        canary_penalty = canary_detector.check_for_parroted_canary(agent_trace, canary_config)
+        if canary_penalty:
+            if "amount" not in canary_penalty:
+                canary_penalty["amount"] = _PENALTY_AMOUNTS.get(canary_penalty["event_name"], 0)
+            adversarial_penalties.append(canary_penalty)
+        canary_report = canary_detector.generate_canary_report(trace_id, canary_config, canary_penalty)
+
+    # --- Step 6: Aggregate ---
+    scorecard = aggregator.compute_scorecard(
+        structural_penalties=structural_penalties + adversarial_penalties,
+        slm_penalties=slm_penalties,
+        agent_id=agent.id,
+        eval_run_id=eval_run_id,
+        trace_id=trace_id,
+        version=agent.version,
+        skipped_dimensions=skipped_dimensions if skipped_dimensions else None,
+    )
+
+    # --- Step 7: Watchdog ---
+    all_penalties = structural_penalties + adversarial_penalties + slm_penalties
+    warnings = watchdog.validate_scorecard(
+        composite_score=scorecard.composite_score,
+        dimension_scores=scorecard.dimension_scores,
+        penalty_count=scorecard.penalty_count,
+        penalties=all_penalties,
+        span_count=len(agent_spans),
+    )
+    scorecard.warnings = warnings
+
+    scorecard.raw_output = {
+        "eval_mode": "agent_scoped",
+        "delegation_prompt": delegation_prompt[:500] if delegation_prompt else None,
+        "agent_span_count": len(agent_spans),
+        "full_session_span_count": len(full_spans),
+        "adversarial_findings": {
+            "injection_attempts_detected": len(injection_attempts),
+            "adversarial_score": scorecard.dimension_scores.get("adversarial_robustness", 100),
+        },
+        "canary_report": canary_report.model_dump() if canary_report else None,
+    }
+
+    return scorecard

--- a/observal-server/services/hook_config_generator.py
+++ b/observal-server/services/hook_config_generator.py
@@ -3,7 +3,8 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
         # Kiro uses shell-command hooks, not HTTP hooks.
         # Generate a runCommand hook that pipes STDIN JSON to the Observal API via curl.
         curl_cmd = (
-            "cat | sed 's/^{/{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\",/' "
+            "cat | sed 's/^{/{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\","
+            "\"terminal_type\":\"'$TERM'\",\"shell\":\"'$SHELL'\",/' "
             f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
             f'-H "Content-Type: application/json" '
             f"-d @-"
@@ -22,7 +23,8 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
         # For stop events, use the enrichment script to capture model/tokens
         if kiro_event == "stop":
             stop_cmd = (
-                "cat | sed 's/^{/{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\",/' "
+                "cat | sed 's/^{/{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\","
+                "\"terminal_type\":\"'$TERM'\",\"shell\":\"'$SHELL'\",/' "
                 f"| python3 -m observal_cli.hooks.kiro_stop_hook "
                 f"--url {server_url}/api/v1/otel/hooks"
             )

--- a/observal-server/services/hook_config_generator.py
+++ b/observal-server/services/hook_config_generator.py
@@ -1,4 +1,29 @@
 def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "http://localhost:8000") -> dict:
+    if ide in ("kiro", "kiro-cli"):
+        # Kiro uses shell-command hooks, not HTTP hooks.
+        # Generate a runCommand hook that pipes STDIN JSON to the Observal API via curl.
+        curl_cmd = (
+            f"cat | curl -sf -X POST {server_url}/api/v1/telemetry/hooks "
+            f'-H "Content-Type: application/json" '
+            f'-H "X-API-Key: $OBSERVAL_API_KEY" '
+            f'-H "X-Observal-Hook-Id: {hook_listing.id}" '
+            f"-d @-"
+        )
+        event = str(hook_listing.event)
+        # Map Claude Code PascalCase events to Kiro camelCase
+        kiro_event_map = {
+            "SessionStart": "agentSpawn",
+            "UserPromptSubmit": "userPromptSubmit",
+            "PreToolUse": "preToolUse",
+            "PostToolUse": "postToolUse",
+            "Stop": "stop",
+        }
+        kiro_event = kiro_event_map.get(event, event)
+        hook_entry = {"command": curl_cmd}
+        if kiro_event in ("preToolUse", "postToolUse"):
+            hook_entry["matcher"] = "*"
+        return {"hooks": {kiro_event: [hook_entry]}}
+
     hook_entry = {
         "type": "http",
         "url": f"{server_url}/api/v1/telemetry/hooks",
@@ -8,7 +33,7 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
 
     if ide == "claude-code":
         hook_entry["allowedEnvVars"] = ["OBSERVAL_API_KEY"]
-    elif ide not in ("kiro", "kiro-cli", "cursor"):
+    elif ide != "cursor":
         return {"comment": f"IDE '{ide}' requires manual hook setup. See Observal docs for configuration."}
 
     event = str(hook_listing.event)

--- a/observal-server/services/hook_config_generator.py
+++ b/observal-server/services/hook_config_generator.py
@@ -3,10 +3,9 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
         # Kiro uses shell-command hooks, not HTTP hooks.
         # Generate a runCommand hook that pipes STDIN JSON to the Observal API via curl.
         curl_cmd = (
-            f"cat | curl -sf -X POST {server_url}/api/v1/telemetry/hooks "
+            "cat | sed 's/^{/{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\",/' "
+            f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
             f'-H "Content-Type: application/json" '
-            f'-H "X-API-Key: $OBSERVAL_API_KEY" '
-            f'-H "X-Observal-Hook-Id: {hook_listing.id}" '
             f"-d @-"
         )
         event = str(hook_listing.event)
@@ -19,6 +18,16 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
             "Stop": "stop",
         }
         kiro_event = kiro_event_map.get(event, event)
+
+        # For stop events, use the enrichment script to capture model/tokens
+        if kiro_event == "stop":
+            stop_cmd = (
+                "cat | sed 's/^{/{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\",/' "
+                f"| python3 -m observal_cli.hooks.kiro_stop_hook "
+                f"--url {server_url}/api/v1/otel/hooks"
+            )
+            return {"hooks": {kiro_event: [{"command": stop_cmd}]}}
+
         hook_entry = {"command": curl_cmd}
         if kiro_event in ("preToolUse", "postToolUse"):
             hook_entry["matcher"] = "*"
@@ -26,8 +35,7 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
 
     hook_entry = {
         "type": "http",
-        "url": f"{server_url}/api/v1/telemetry/hooks",
-        "headers": {"X-API-Key": "$OBSERVAL_API_KEY", "X-Observal-Hook-Id": str(hook_listing.id)},
+        "url": f"{server_url}/api/v1/otel/hooks",
         "timeout": 10,
     }
 

--- a/observal-server/services/hook_materializer.py
+++ b/observal-server/services/hook_materializer.py
@@ -1,0 +1,230 @@
+"""Materializer: converts otel_logs hook events into eval-compatible spans.
+
+Kiro CLI (and other hook-based sources) write flat log entries to otel_logs.
+The eval pipeline expects structured spans with type/input/output/status.
+This module bridges that gap by reading hook events for a session and
+synthesizing span dicts that StructuralScorer and SLMScorer can consume.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+
+from services.clickhouse import _escape, _query
+
+logger = logging.getLogger(__name__)
+
+
+async def materialize_session_spans(session_id: str) -> tuple[dict, list[dict]]:
+    """Convert otel_logs hook events for a session into a trace + spans.
+
+    Returns:
+        (trace_dict, spans_list) compatible with run_structured_eval().
+    """
+    sid = _escape(session_id)
+    # Fetch by session.id OR conversation_id to handle Kiro resumed sessions
+    sql = (
+        "SELECT "
+        "Timestamp AS timestamp, "
+        "EventName AS event_name, "
+        "Body AS body, "
+        "LogAttributes AS attributes, "
+        "ServiceName AS service_name "
+        "FROM otel_logs "
+        f"WHERE LogAttributes['session.id'] = '{sid}' "
+        f"OR LogAttributes['conversation_id'] = '{sid}' "
+        "ORDER BY Timestamp ASC "
+        "FORMAT JSON"
+    )
+
+    try:
+        r = await _query(sql)
+        r.raise_for_status()
+        events = r.json().get("data", [])
+    except Exception as e:
+        logger.error(f"Failed to fetch hook events for session {session_id}: {e}")
+        return {}, []
+
+    if not events:
+        return {}, []
+
+    return _build_trace_and_spans(session_id, events)
+
+
+def _build_trace_and_spans(
+    session_id: str, events: list[dict]
+) -> tuple[dict, list[dict]]:
+    """Parse hook events into a trace dict and span list."""
+    spans: list[dict] = []
+    trace_output = ""
+    model = ""
+    agent_name = ""
+    first_ts = events[0].get("timestamp", "")
+    last_ts = events[-1].get("timestamp", "")
+
+    # Pair PreToolUse with PostToolUse events by matching sequence
+    pending_pre: dict | None = None
+
+    for event in events:
+        attrs = event.get("attributes", {})
+        if isinstance(attrs, str):
+            import json
+
+            try:
+                attrs = json.loads(attrs)
+            except Exception:
+                attrs = {}
+
+        event_name = _normalize_event_name(
+            attrs.get("event.name", event.get("event_name", ""))
+        )
+
+        if not model and attrs.get("model"):
+            model = attrs["model"]
+        if not agent_name and attrs.get("agent_name"):
+            agent_name = attrs["agent_name"]
+
+        if event_name in ("hook_PreToolUse", "PreToolUse"):
+            pending_pre = {
+                "timestamp": event.get("timestamp", ""),
+                "tool_name": attrs.get("tool_name", "unknown"),
+                "tool_input": attrs.get("tool_input", event.get("body", "")),
+            }
+
+        elif event_name in ("hook_PostToolUse", "PostToolUse", "hook_PostToolUseFailure"):
+            tool_name = attrs.get("tool_name", "")
+            tool_input = ""
+            tool_output = attrs.get("tool_response", event.get("body", ""))
+            start_ts = event.get("timestamp", "")
+            is_error = "Failure" in event_name or attrs.get("error", "")
+
+            if pending_pre:
+                tool_name = tool_name or pending_pre["tool_name"]
+                tool_input = pending_pre["tool_input"]
+                start_ts = pending_pre["timestamp"]
+                pending_pre = None
+
+            latency_ms = _compute_latency(start_ts, event.get("timestamp", ""))
+
+            spans.append({
+                "span_id": str(uuid.uuid4())[:16],
+                "type": "tool_call",
+                "name": tool_name,
+                "input": _truncate(tool_input, 2000),
+                "output": _truncate(tool_output, 2000),
+                "status": "error" if is_error else "success",
+                "error": attrs.get("error", "") if is_error else None,
+                "latency_ms": latency_ms,
+                "start_time": start_ts,
+            })
+
+        elif event_name in ("hook_UserPromptSubmit", "UserPromptSubmit", "user_prompt"):
+            prompt_text = (
+                attrs.get("tool_input", "")
+                or attrs.get("prompt", "")
+                or event.get("body", "")
+            )
+            spans.append({
+                "span_id": str(uuid.uuid4())[:16],
+                "type": "user_prompt",
+                "name": "user_prompt",
+                "input": _truncate(prompt_text, 2000),
+                "output": "",
+                "status": "success",
+                "error": None,
+                "latency_ms": 0,
+                "start_time": event.get("timestamp", ""),
+            })
+
+        elif event_name in ("hook_Stop", "Stop"):
+            response = (
+                attrs.get("tool_response", "")
+                or attrs.get("assistant_response", "")
+                or event.get("body", "")
+            )
+            trace_output = _truncate(response, 4000)
+            spans.append({
+                "span_id": str(uuid.uuid4())[:16],
+                "type": "agent_response",
+                "name": "final_response",
+                "input": "",
+                "output": trace_output,
+                "status": "success",
+                "error": None,
+                "latency_ms": 0,
+                "start_time": event.get("timestamp", ""),
+            })
+
+        elif event_name in ("hook_SessionStart", "SessionStart", "agentSpawn"):
+            spans.append({
+                "span_id": str(uuid.uuid4())[:16],
+                "type": "session_start",
+                "name": "session_start",
+                "input": event.get("body", ""),
+                "output": "",
+                "status": "success",
+                "error": None,
+                "latency_ms": 0,
+                "start_time": event.get("timestamp", ""),
+            })
+
+    # Build the trace dict
+    trace = {
+        "trace_id": session_id,
+        "event_id": session_id,
+        "agent_id": agent_name,
+        "model": model,
+        "output": trace_output,
+        "status": "completed",
+        "start_time": first_ts,
+        "end_time": last_ts,
+        "span_count": len(spans),
+        "tool_calls": sum(1 for s in spans if s["type"] == "tool_call"),
+        "source": "hook_materializer",
+    }
+
+    return trace, spans
+
+
+def _normalize_event_name(name: str) -> str:
+    """Normalize event names to a consistent form."""
+    # Already normalized
+    if name.startswith("hook_") or name in (
+        "PreToolUse", "PostToolUse", "UserPromptSubmit",
+        "Stop", "SessionStart",
+    ):
+        return name
+    # camelCase Kiro events
+    mapping = {
+        "preToolUse": "PreToolUse",
+        "postToolUse": "PostToolUse",
+        "userPromptSubmit": "UserPromptSubmit",
+        "stop": "Stop",
+        "agentSpawn": "SessionStart",
+    }
+    return mapping.get(name, name)
+
+
+def _compute_latency(start: str, end: str) -> int:
+    """Compute latency in ms between two ISO timestamps."""
+    try:
+        fmt = "%Y-%m-%d %H:%M:%S.%f"
+        # ClickHouse timestamps may have various formats
+        for f in (fmt, "%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+            try:
+                t_start = datetime.strptime(start[:26], f)
+                t_end = datetime.strptime(end[:26], f)
+                return max(0, int((t_end - t_start).total_seconds() * 1000))
+            except ValueError:
+                continue
+    except Exception:
+        pass
+    return 0
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate text to max_len chars."""
+    if not text:
+        return ""
+    text = str(text)
+    return text[:max_len] if len(text) > max_len else text

--- a/observal-server/services/hook_materializer.py
+++ b/observal-server/services/hook_materializer.py
@@ -4,15 +4,33 @@ Kiro CLI (and other hook-based sources) write flat log entries to otel_logs.
 The eval pipeline expects structured spans with type/input/output/status.
 This module bridges that gap by reading hook events for a session and
 synthesizing span dicts that StructuralScorer and SLMScorer can consume.
+
+Also provides agent-scoped annotation: given a full session, marks which
+spans belong to a target agent so the eval pipeline can focus its scoring.
 """
 
 import logging
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime
 
 from services.clickhouse import _escape, _query
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AgentContext:
+    """Describes an agent's participation within a session."""
+
+    agent_id: str = ""
+    agent_type: str = ""
+    agent_name: str = ""
+    delegation_prompt: str = ""
+    agent_output: str = ""
+    span_start_idx: int = -1
+    span_end_idx: int = -1
+    invocations: list[dict] = field(default_factory=list)
 
 
 async def materialize_session_spans(session_id: str) -> tuple[dict, list[dict]]:
@@ -21,8 +39,45 @@ async def materialize_session_spans(session_id: str) -> tuple[dict, list[dict]]:
     Returns:
         (trace_dict, spans_list) compatible with run_structured_eval().
     """
+    events = await _fetch_session_events(session_id)
+    if not events:
+        return {}, []
+
+    return _build_trace_and_spans(session_id, events)
+
+
+async def materialize_agent_eval(
+    session_id: str,
+    target_agent: str,
+) -> tuple[dict, list[dict], AgentContext | None]:
+    """Materialize a full session and annotate spans for a target agent.
+
+    Returns:
+        (trace_dict, all_spans, agent_context) where agent_context describes
+        the target agent's participation. all_spans include an 'agent_id'
+        field on each span so the eval pipeline knows which belong to the
+        target agent. Returns (trace, spans, None) if agent not found.
+    """
+    events = await _fetch_session_events(session_id)
+    if not events:
+        return {}, [], None
+
+    trace, spans = _build_trace_and_spans(session_id, events)
+    if not spans:
+        return trace, spans, None
+
+    agent_ctx = _find_agent_context(spans, target_agent)
+    return trace, spans, agent_ctx
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_session_events(session_id: str) -> list[dict]:
+    """Fetch all otel_logs events for a session."""
     sid = _escape(session_id)
-    # Fetch by session.id OR conversation_id to handle Kiro resumed sessions
     sql = (
         "SELECT "
         "Timestamp AS timestamp, "
@@ -40,21 +95,33 @@ async def materialize_session_spans(session_id: str) -> tuple[dict, list[dict]]:
     try:
         r = await _query(sql)
         r.raise_for_status()
-        events = r.json().get("data", [])
+        return r.json().get("data", [])
     except Exception as e:
         logger.error(f"Failed to fetch hook events for session {session_id}: {e}")
-        return {}, []
+        return []
 
-    if not events:
-        return {}, []
 
-    return _build_trace_and_spans(session_id, events)
+def _parse_attrs(event: dict) -> dict:
+    """Extract and normalize the attributes dict from an event."""
+    attrs = event.get("attributes", {})
+    if isinstance(attrs, str):
+        import json
+        try:
+            attrs = json.loads(attrs)
+        except Exception:
+            attrs = {}
+    return attrs
 
 
 def _build_trace_and_spans(
     session_id: str, events: list[dict]
 ) -> tuple[dict, list[dict]]:
-    """Parse hook events into a trace dict and span list."""
+    """Parse hook events into a trace dict and span list.
+
+    Each span is tagged with agent_id/agent_type if the source event
+    carried that attribution (Claude Code does this for subagent scopes).
+    SubagentStart/SubagentStop are also materialized as spans.
+    """
     spans: list[dict] = []
     trace_output = ""
     model = ""
@@ -62,18 +129,10 @@ def _build_trace_and_spans(
     first_ts = events[0].get("timestamp", "")
     last_ts = events[-1].get("timestamp", "")
 
-    # Pair PreToolUse with PostToolUse events by matching sequence
     pending_pre: dict | None = None
 
     for event in events:
-        attrs = event.get("attributes", {})
-        if isinstance(attrs, str):
-            import json
-
-            try:
-                attrs = json.loads(attrs)
-            except Exception:
-                attrs = {}
+        attrs = _parse_attrs(event)
 
         event_name = _normalize_event_name(
             attrs.get("event.name", event.get("event_name", ""))
@@ -84,11 +143,17 @@ def _build_trace_and_spans(
         if not agent_name and attrs.get("agent_name"):
             agent_name = attrs["agent_name"]
 
+        # Common agent attribution from the event
+        span_agent_id = attrs.get("agent_id", "")
+        span_agent_type = attrs.get("agent_type", "")
+
         if event_name in ("hook_PreToolUse", "PreToolUse"):
             pending_pre = {
                 "timestamp": event.get("timestamp", ""),
                 "tool_name": attrs.get("tool_name", "unknown"),
                 "tool_input": attrs.get("tool_input", event.get("body", "")),
+                "agent_id": span_agent_id,
+                "agent_type": span_agent_type,
             }
 
         elif event_name in ("hook_PostToolUse", "PostToolUse", "hook_PostToolUseFailure"):
@@ -102,6 +167,8 @@ def _build_trace_and_spans(
                 tool_name = tool_name or pending_pre["tool_name"]
                 tool_input = pending_pre["tool_input"]
                 start_ts = pending_pre["timestamp"]
+                span_agent_id = span_agent_id or pending_pre["agent_id"]
+                span_agent_type = span_agent_type or pending_pre["agent_type"]
                 pending_pre = None
 
             latency_ms = _compute_latency(start_ts, event.get("timestamp", ""))
@@ -116,6 +183,8 @@ def _build_trace_and_spans(
                 "error": attrs.get("error", "") if is_error else None,
                 "latency_ms": latency_ms,
                 "start_time": start_ts,
+                "agent_id": span_agent_id,
+                "agent_type": span_agent_type,
             })
 
         elif event_name in ("hook_UserPromptSubmit", "UserPromptSubmit", "user_prompt"):
@@ -134,6 +203,40 @@ def _build_trace_and_spans(
                 "error": None,
                 "latency_ms": 0,
                 "start_time": event.get("timestamp", ""),
+                "agent_id": span_agent_id,
+                "agent_type": span_agent_type,
+            })
+
+        elif event_name in ("hook_subagentstart", "hook_SubagentStart"):
+            delegation = attrs.get("tool_input", event.get("body", ""))
+            spans.append({
+                "span_id": str(uuid.uuid4())[:16],
+                "type": "subagent_start",
+                "name": f"SubagentStart:{span_agent_type or span_agent_id}",
+                "input": _truncate(delegation, 2000),
+                "output": "",
+                "status": "success",
+                "error": None,
+                "latency_ms": 0,
+                "start_time": event.get("timestamp", ""),
+                "agent_id": span_agent_id,
+                "agent_type": span_agent_type,
+            })
+
+        elif event_name in ("hook_subagentstop", "hook_SubagentStop"):
+            agent_output = attrs.get("tool_response", event.get("body", ""))
+            spans.append({
+                "span_id": str(uuid.uuid4())[:16],
+                "type": "subagent_stop",
+                "name": f"SubagentStop:{span_agent_type or span_agent_id}",
+                "input": "",
+                "output": _truncate(agent_output, 2000),
+                "status": "success",
+                "error": None,
+                "latency_ms": 0,
+                "start_time": event.get("timestamp", ""),
+                "agent_id": span_agent_id,
+                "agent_type": span_agent_type,
             })
 
         elif event_name in ("hook_Stop", "Stop"):
@@ -153,6 +256,8 @@ def _build_trace_and_spans(
                 "error": None,
                 "latency_ms": 0,
                 "start_time": event.get("timestamp", ""),
+                "agent_id": span_agent_id,
+                "agent_type": span_agent_type,
             })
 
         elif event_name in ("hook_SessionStart", "SessionStart", "agentSpawn"):
@@ -166,6 +271,8 @@ def _build_trace_and_spans(
                 "error": None,
                 "latency_ms": 0,
                 "start_time": event.get("timestamp", ""),
+                "agent_id": span_agent_id,
+                "agent_type": span_agent_type,
             })
 
     # Build the trace dict
@@ -186,15 +293,128 @@ def _build_trace_and_spans(
     return trace, spans
 
 
+def _find_agent_context(
+    spans: list[dict], target_agent: str
+) -> AgentContext | None:
+    """Find all invocations of a target agent within a session's spans.
+
+    Matches by agent_id, agent_type, or agent_name (case-insensitive).
+    Returns an AgentContext with all invocations listed, or None if not found.
+    """
+    target_lower = target_agent.lower()
+    ctx = AgentContext()
+
+    # Find SubagentStart/Stop boundaries for this agent
+    invocations: list[dict] = []
+    current_invocation: dict | None = None
+
+    for idx, span in enumerate(spans):
+        agent_match = (
+            (span.get("agent_id") or "").lower() == target_lower
+            or (span.get("agent_type") or "").lower() == target_lower
+            or (span.get("agent_name") or "").lower() == target_lower
+        )
+
+        if span["type"] == "subagent_start" and agent_match:
+            current_invocation = {
+                "start_idx": idx,
+                "end_idx": idx,
+                "delegation_prompt": span.get("input", ""),
+                "agent_output": "",
+            }
+            if not ctx.agent_id:
+                ctx.agent_id = span.get("agent_id", "")
+                ctx.agent_type = span.get("agent_type", "")
+                ctx.agent_name = span.get("agent_type") or span.get("agent_id", "")
+
+        elif span["type"] == "subagent_stop" and agent_match and current_invocation:
+            current_invocation["end_idx"] = idx
+            current_invocation["agent_output"] = span.get("output", "")
+            invocations.append(current_invocation)
+            current_invocation = None
+
+        elif current_invocation is not None and agent_match:
+            # Span within an active invocation — extend the boundary
+            current_invocation["end_idx"] = idx
+
+    # If we found SubagentStart/Stop boundaries, use those
+    if invocations:
+        ctx.invocations = invocations
+        ctx.delegation_prompt = invocations[0]["delegation_prompt"]
+        ctx.agent_output = invocations[-1]["agent_output"]
+        ctx.span_start_idx = invocations[0]["start_idx"]
+        ctx.span_end_idx = invocations[-1]["end_idx"]
+        return ctx
+
+    # Fallback: no SubagentStart/Stop but spans carry agent_id attribution
+    agent_span_indices = [
+        idx for idx, span in enumerate(spans)
+        if (
+            (span.get("agent_id") or "").lower() == target_lower
+            or (span.get("agent_type") or "").lower() == target_lower
+        )
+        and span["type"] not in ("session_start",)
+    ]
+
+    if agent_span_indices:
+        ctx.span_start_idx = agent_span_indices[0]
+        ctx.span_end_idx = agent_span_indices[-1]
+        ctx.agent_id = target_agent
+        ctx.invocations = [{
+            "start_idx": agent_span_indices[0],
+            "end_idx": agent_span_indices[-1],
+            "delegation_prompt": "",
+            "agent_output": "",
+        }]
+        return ctx
+
+    return None
+
+
+def build_agent_eval_context(
+    spans: list[dict],
+    agent_ctx: AgentContext,
+) -> dict:
+    """Build the context dict that the eval pipeline uses for agent-scoped scoring.
+
+    Returns a dict with:
+    - full_spans: all session spans (for SLM context)
+    - agent_spans: only the target agent's spans (for structural scoring)
+    - agent_span_indices: set of indices belonging to the agent
+    - delegation_prompt: what the agent was asked to do
+    - agent_output: what the agent returned
+    - invocations: list of all invocations with boundaries
+    """
+    agent_indices: set[int] = set()
+    for inv in agent_ctx.invocations:
+        agent_indices.update(range(inv["start_idx"], inv["end_idx"] + 1))
+
+    agent_spans = [spans[i] for i in sorted(agent_indices) if i < len(spans)]
+
+    return {
+        "full_spans": spans,
+        "agent_spans": agent_spans,
+        "agent_span_indices": agent_indices,
+        "delegation_prompt": agent_ctx.delegation_prompt,
+        "agent_output": agent_ctx.agent_output,
+        "invocations": agent_ctx.invocations,
+        "agent_id": agent_ctx.agent_id,
+        "agent_type": agent_ctx.agent_type,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Event normalization and utilities
+# ---------------------------------------------------------------------------
+
+
 def _normalize_event_name(name: str) -> str:
     """Normalize event names to a consistent form."""
-    # Already normalized
     if name.startswith("hook_") or name in (
         "PreToolUse", "PostToolUse", "UserPromptSubmit",
         "Stop", "SessionStart",
     ):
         return name
-    # camelCase Kiro events
     mapping = {
         "preToolUse": "PreToolUse",
         "postToolUse": "PostToolUse",
@@ -209,7 +429,6 @@ def _compute_latency(start: str, end: str) -> int:
     """Compute latency in ms between two ISO timestamps."""
     try:
         fmt = "%Y-%m-%d %H:%M:%S.%f"
-        # ClickHouse timestamps may have various formats
         for f in (fmt, "%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
             try:
                 t_start = datetime.strptime(start[:26], f)

--- a/observal-server/services/secrets_redactor.py
+++ b/observal-server/services/secrets_redactor.py
@@ -1,0 +1,230 @@
+"""Secrets redactor for trace ingestion.
+
+Strips API keys, tokens, passwords, and other secrets from trace data
+BEFORE storage in ClickHouse.  Designed to avoid over-stripping:
+
+    REDACTED:  OPENAI_KEY=sk-proj-abc123...   →  OPENAI_KEY=**REDACTED**
+    KEPT:      $OPENAI_KEY                     →  $OPENAI_KEY  (reference)
+    KEPT:      os.environ["OPENAI_KEY"]        →  unchanged   (code pattern)
+    KEPT:      load_dotenv(".env")             →  unchanged   (file path)
+"""
+
+import re
+
+# ---------------------------------------------------------------------------
+# Known API key prefixes — near-zero false-positive rate.
+# These match actual key VALUES, not variable names.
+# ---------------------------------------------------------------------------
+
+_KNOWN_KEY_PATTERNS: list[re.Pattern] = [
+    # OpenAI
+    re.compile(r"sk-(?:proj-)?[a-zA-Z0-9\-_]{20,}"),
+    # Anthropic
+    re.compile(r"sk-ant-[a-zA-Z0-9\-_]{20,}"),
+    # Stripe
+    re.compile(r"[prs]k_(?:live|test)_[a-zA-Z0-9]{20,}"),
+    # GitHub tokens
+    re.compile(r"gh[pousr]_[a-zA-Z0-9]{36,}"),
+    # GitLab PAT
+    re.compile(r"glpat-[a-zA-Z0-9\-_]{20,}"),
+    # Slack tokens
+    re.compile(r"xox[bpsa]-[a-zA-Z0-9\-]{10,}"),
+    # AWS access key ID
+    re.compile(r"AKIA[A-Z0-9]{16}"),
+    # AWS secret key (40 char base64-ish after an = or : delimiter)
+    re.compile(r"(?<=[\=:\s\"\'])[a-zA-Z0-9/+]{40}(?=[\"\';\s,}]|$)"),
+    # npm token
+    re.compile(r"npm_[a-zA-Z0-9]{36,}"),
+    # PyPI token
+    re.compile(r"pypi-[a-zA-Z0-9]{50,}"),
+    # SendGrid
+    re.compile(r"SG\.[a-zA-Z0-9\-_]{22,}\.[a-zA-Z0-9\-_]{22,}"),
+    # Twilio
+    re.compile(r"SK[a-f0-9]{32}"),
+    # Mailgun
+    re.compile(r"key-[a-zA-Z0-9]{32}"),
+    # HuggingFace
+    re.compile(r"hf_[a-zA-Z0-9]{34,}"),
+    # Vercel
+    re.compile(r"vercel_[a-zA-Z0-9\-_]{24,}"),
+    # Supabase
+    re.compile(r"sbp_[a-zA-Z0-9]{40,}"),
+    # age encryption key
+    re.compile(r"AGE-SECRET-KEY-[A-Z0-9]{59}"),
+    # Google AI / Gemini
+    re.compile(r"AIza[a-zA-Z0-9\-_]{35}"),
+]
+
+# ---------------------------------------------------------------------------
+# JWT tokens (three base64url segments separated by dots)
+# ---------------------------------------------------------------------------
+
+_RE_JWT = re.compile(
+    r"eyJ[a-zA-Z0-9_-]{10,}\.eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}"
+)
+
+# ---------------------------------------------------------------------------
+# PEM private keys
+# ---------------------------------------------------------------------------
+
+_RE_PRIVATE_KEY = re.compile(
+    r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ED25519 )?PRIVATE KEY-----"
+    r"[\s\S]*?"
+    r"-----END (?:RSA |EC |DSA |OPENSSH |ED25519 )?PRIVATE KEY-----"
+)
+
+# ---------------------------------------------------------------------------
+# Key=value assignments where key name signals a secret.
+# Matches:  API_KEY=abc123def  |  "password": "s3cret!"  |  token: sk-abc
+# Skips:    $API_KEY  |  getenv("API_KEY")  |  API_KEY (no assignment)
+# ---------------------------------------------------------------------------
+
+_SECRET_KEY_NAMES = (
+    r"(?:api[_\-]?key|api[_\-]?secret|secret[_\-]?key|auth[_\-]?token|"
+    r"access[_\-]?token|private[_\-]?key|(?:db[_\-]?)?password|passwd|"
+    r"(?:auth|api|access|refresh|bearer|session|jwt)[_\-]?token|"
+    r"client[_\-]?secret|signing[_\-]?key|encryption[_\-]?key|"
+    r"db[_\-]?password|redis[_\-]?password|database[_\-]?password|"
+    r"webhook[_\-]?secret|secret|credentials?)"
+)
+
+# key = "value" or key: "value" or KEY=value  (value must be 8+ chars)
+# Two alternatives: quoted values (capture content between quotes) or unquoted
+# Key name may be quoted in JSON: "password": "value"
+_RE_KEY_VALUE = re.compile(
+    r"(?i)"
+    r"(?<!\$)(?<!\$\{)"  # NOT preceded by $ or ${  (env var reference)
+    r"""["']?"""  # optional quotes around key name (JSON)
+    + _SECRET_KEY_NAMES
+    + r"""["']?\s*[=:]\s*"""
+    r"(?:"
+    r'"([^"\n]{8,})"'  # double-quoted value
+    r"|'([^'\n]{8,})'"  # single-quoted value
+    r"|([^\s\"'\n,;}{]{8,})"  # unquoted value
+    r")",
+)
+
+# ---------------------------------------------------------------------------
+# Connection strings with embedded passwords
+# postgresql://user:PASSWORD@host/db  |  mongodb+srv://u:P@host
+# ---------------------------------------------------------------------------
+
+_RE_CONN_STRING = re.compile(
+    r"((?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis(?:s)?|amqps?|mssql)"
+    r"://[^:]+:)"
+    r"([^@\s]{4,})"  # the password
+    r"(@)",
+)
+
+# ---------------------------------------------------------------------------
+# Authorization headers in text
+# Authorization: Bearer <token>  |  X-API-Key: abc123
+# ---------------------------------------------------------------------------
+
+_RE_AUTH_HEADER = re.compile(
+    r"(?i)"
+    r"((?:Authorization|X-API-Key|X-Auth-Token)\s*:\s*(?:Bearer\s+)?)"
+    r"([a-zA-Z0-9+/=\-_.]{16,})"
+)
+
+# ---------------------------------------------------------------------------
+# Generic high-entropy hex/base64 strings that look like secrets.
+# Only matches 32+ char strings that contain mixed case/digits,
+# and only when preceded by an assignment operator (=, :).
+# This is the most aggressive pattern — kept last and narrow.
+# ---------------------------------------------------------------------------
+
+_RE_LONG_HEX = re.compile(
+    r"(?<=[=:\s])"
+    r"([A-Fa-f0-9]{32,})"
+    r"(?=[\s\"',;}\])]|$)"
+)
+
+_RE_LONG_BASE64 = re.compile(
+    r"(?<=[=:\s\"'])"
+    r"([A-Za-z0-9+/]{40,}={0,2})"
+    r"(?=[\"',;\s}\])]|$)"
+)
+
+REDACTED = "**REDACTED**"
+
+
+def redact_secrets(text: str) -> str:
+    """Redact secrets from a string while preserving non-secret content.
+
+    Safe to call on any string — returns the original if nothing matches.
+    Idempotent: calling twice produces the same result.
+    """
+    if not text or len(text) < 8:
+        return text
+
+    # Already redacted — skip
+    if text == REDACTED:
+        return text
+
+    # 1. PEM private keys (replace entire block)
+    text = _RE_PRIVATE_KEY.sub(REDACTED, text)
+
+    # 2. Known API key prefixes (highest confidence — always redact)
+    for pat in _KNOWN_KEY_PATTERNS:
+        text = pat.sub(REDACTED, text)
+
+    # 3. JWT tokens
+    text = _RE_JWT.sub(REDACTED, text)
+
+    # 4. Key=value assignments with secret-sounding key names
+    #    Replace only the VALUE, keep the key name
+    def _replace_kv(m: re.Match) -> str:
+        # Groups: 1=double-quoted, 2=single-quoted, 3=unquoted
+        val = m.group(1) or m.group(2) or m.group(3)
+        return m.group(0).replace(val, REDACTED) if val else m.group(0)
+
+    text = _RE_KEY_VALUE.sub(_replace_kv, text)
+
+    # 5. Connection strings — redact password only
+    text = _RE_CONN_STRING.sub(r"\1" + REDACTED + r"\3", text)
+
+    # 6. Auth headers — redact token only
+    text = _RE_AUTH_HEADER.sub(r"\1" + REDACTED, text)
+
+    return text
+
+
+def redact_dict(data: dict, fields: set[str] | None = None) -> dict:
+    """Redact secrets from specific string fields in a dict.
+
+    If ``fields`` is None, redacts ALL string values.
+    If ``fields`` is provided, only redacts those keys.
+    Does NOT mutate the original — returns a new dict.
+    """
+    out = {}
+    for key, value in data.items():
+        if isinstance(value, str) and (fields is None or key in fields):
+            out[key] = redact_secrets(value)
+        elif isinstance(value, dict):
+            out[key] = redact_dict(value, fields)
+        else:
+            out[key] = value
+    return out
+
+
+# Fields that commonly carry user content and could contain secrets.
+# Used by ingestion endpoints to know which attrs to redact.
+INGESTION_FIELDS = {
+    "tool_input",
+    "tool_response",
+    "error",
+    "input",
+    "output",
+    "gen_ai.prompt",
+    "gen_ai.completion",
+    "input_params",
+    "response",
+    "comment",
+    "prompt",
+    "assistant_response",
+    "user_prompt",
+    "last_assistant_message",
+    "summary",
+    "message",
+}

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -72,7 +72,7 @@ def login(
 
             api_key = data["api_key"]
             user = data["user"]
-            config.save({"server_url": server_url, "api_key": api_key})
+            config.save({"server_url": server_url, "api_key": api_key, "user_id": user.get("id", "")})
 
             rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [admin]")
             rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]\n")
@@ -149,7 +149,7 @@ def register(
 
         api_key = data["api_key"]
         user = data["user"]
-        config.save({"server_url": server_url, "api_key": api_key})
+        config.save({"server_url": server_url, "api_key": api_key, "user_id": user.get("id", "")})
         rprint(
             f"[green]Account created! Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]"
         )
@@ -318,8 +318,8 @@ def _do_key_login(server_url: str, api_key: str | None = None):
             r.raise_for_status()
             data = r.json()
         # Use the key returned by server (same key echoed back)
-        config.save({"server_url": server_url, "api_key": data.get("api_key", api_key)})
         user = data.get("user", data)
+        config.save({"server_url": server_url, "api_key": data.get("api_key", api_key), "user_id": user.get("id", "")})
         rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
     except httpx.ConnectError:
         rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
@@ -343,7 +343,7 @@ def _do_password_login(server_url: str, email: str, password: str):
 
         api_key = data["api_key"]
         user = data["user"]
-        config.save({"server_url": server_url, "api_key": api_key})
+        config.save({"server_url": server_url, "api_key": api_key, "user_id": user.get("id", "")})
         rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
         rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]")
 
@@ -379,7 +379,7 @@ def _do_invite_login(server_url: str, code: str, name: str | None = None):
 
         api_key = data["api_key"]
         user = data["user"]
-        config.save({"server_url": server_url, "api_key": api_key})
+        config.save({"server_url": server_url, "api_key": api_key, "user_id": user.get("id", "")})
         rprint(
             f"[green]Account created! Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]"
         )
@@ -517,7 +517,12 @@ def _configure_claude_code(server_url: str, api_key: str):
 
         # ── Inject hooks for full content capture (prompts, tool I/O, MCP, agents) ──
         hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
-        http_hook = [{"hooks": [{"type": "http", "url": hooks_url}]}]
+        hook_def: dict = {"type": "http", "url": hooks_url}
+        # Inject Observal user identity via header so the server can attribute sessions
+        cfg = config.load()
+        if cfg.get("user_id"):
+            hook_def["headers"] = {"X-Observal-User-Id": cfg["user_id"]}
+        http_hook = [{"hooks": [hook_def]}]
 
         # Stop uses a command hook to read the transcript for Claude's response text
         stop_script = _find_stop_hook_script()
@@ -546,6 +551,11 @@ def _configure_claude_code(server_url: str, api_key: str):
 
         # Set the hooks URL env var so the stop script knows where to POST
         settings["env"]["OBSERVAL_HOOKS_URL"] = hooks_url
+
+        # Inject user identity so hooks carry the Observal user ID
+        cfg = config.load()
+        if cfg.get("user_id"):
+            settings["env"]["OBSERVAL_USER_ID"] = cfg["user_id"]
 
         claude_dir.mkdir(exist_ok=True)
         with open(claude_settings_file, "w", encoding="utf-8") as f:

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -147,6 +147,60 @@ def _check_kiro(path: Path, data: dict, issues: list, warnings: list):
         pass  # default, fine
 
 
+def _check_kiro_installation(issues: list, warnings: list):
+    """Check Kiro CLI installation and agent hook configuration."""
+    # Check kiro-cli binary
+    if os.system("which kiro-cli > /dev/null 2>&1") != 0:
+        warnings.append(
+            "`kiro-cli` not found in PATH. Install with: curl -fsSL https://cli.kiro.dev/install | bash"
+        )
+    else:
+        # Check if kiro-cli is authenticated
+        if os.system("kiro-cli whoami > /dev/null 2>&1") != 0:
+            warnings.append("`kiro-cli` is installed but not authenticated. Run `kiro-cli login`.")
+
+    # Check for Kiro agents directory
+    agents_dir = Path.home() / ".kiro" / "agents"
+    if agents_dir.exists():
+        agent_files = list(agents_dir.glob("*.json"))
+        if agent_files:
+            # Check if any agents have Observal hooks configured
+            has_observal_hooks = False
+            for af in agent_files:
+                agent_data = _load_json(af)
+                if agent_data and "hooks" in agent_data:
+                    hooks = agent_data["hooks"]
+                    for _event, hook_list in hooks.items():
+                        for h in hook_list if isinstance(hook_list, list) else []:
+                            cmd = h.get("command", "")
+                            if "observal" in cmd or "telemetry/hooks" in cmd:
+                                has_observal_hooks = True
+                                break
+            if not has_observal_hooks:
+                warnings.append(
+                    "No Kiro agents have Observal telemetry hooks. "
+                    "Run `observal scan --ide kiro --home` to inject hooks."
+                )
+
+    # Check MCP config for observal-shim
+    mcp_path = Path.home() / ".kiro" / "settings" / "mcp.json"
+    if mcp_path.exists():
+        mcp_data = _load_json(mcp_path)
+        if mcp_data:
+            servers = mcp_data.get("mcpServers", {})
+            unwrapped = [
+                n for n, c in servers.items()
+                if isinstance(c, dict) and "observal-shim" not in c.get("command", "")
+                and "observal-proxy" not in c.get("command", "")
+                and "url" not in c  # HTTP transport doesn't need shim
+            ]
+            if unwrapped:
+                warnings.append(
+                    f"Kiro MCP servers not wrapped with observal-shim: {', '.join(unwrapped)}. "
+                    "Run `observal scan --ide kiro` to wrap them."
+                )
+
+
 def _check_cursor(path: Path, data: dict, issues: list, warnings: list):
     """Check Cursor MCP config for Observal conflicts."""
     servers = data.get("mcpServers", {})
@@ -266,7 +320,12 @@ def doctor(
     rprint("[cyan]Checking environment...[/cyan]")
     _check_environment(issues, warnings)
 
-    # 3. Check IDE configs
+    # 3. Kiro-specific installation checks
+    if not ide or ide in ("kiro", "kiro-cli"):
+        rprint("[cyan]Checking Kiro installation...[/cyan]")
+        _check_kiro_installation(issues, warnings)
+
+    # 4. Check IDE configs
     ides_to_check = [ide] if ide else list(IDE_CONFIGS.keys())
 
     for ide_name in ides_to_check:
@@ -338,5 +397,13 @@ def doctor(
                 rprint("  Run: observal login")
             elif "Cannot reach" in issue:
                 rprint("  Start the server: cd docker && docker compose up -d")
+            elif "kiro-cli" in issue and "not found" in issue:
+                rprint("  Install: curl -fsSL https://cli.kiro.dev/install | bash")
+            elif "kiro-cli" in issue and "not authenticated" in issue:
+                rprint("  Run: kiro-cli login")
+            elif "Observal telemetry hooks" in issue:
+                rprint("  Run: observal scan --ide kiro --home")
+            elif "observal-shim" in issue and "Kiro" in issue:
+                rprint("  Run: observal scan --ide kiro")
 
     raise typer.Exit(1 if issues else 0)

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -118,6 +118,16 @@ def register_pull(app: typer.Typer):
                 status = _write_file(p, agent_file["content"])
                 written.append((str(p), status))
 
+        # ── steering_file (Kiro) ───────────────────────────
+        steering_file = snippet.get("steering_file")
+        if steering_file:
+            p = _resolve_path(steering_file["path"], target_dir)
+            if dry_run:
+                written.append((str(p), "would write"))
+            else:
+                status = _write_file(p, steering_file["content"])
+                written.append((str(p), status))
+
         # ── Output summary ──────────────────────────────────
         if not written:
             rprint("[yellow]No files to write from the config snippet.[/yellow]")

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -240,6 +240,106 @@ def _scan_claude_home(
     return mcps, skills, hooks, agents
 
 
+# ── Kiro ~/.kiro scanner ────────────────────────────────────
+
+
+def _scan_kiro_home(
+    kiro_dir: Path,
+) -> tuple[list[DiscoveredMcp], list[DiscoveredSkill], list[DiscoveredHook], list[DiscoveredAgent]]:
+    """Scan ~/.kiro for agents, MCP servers, and hooks."""
+    mcps: list[DiscoveredMcp] = []
+    skills: list[DiscoveredSkill] = []
+    hooks: list[DiscoveredHook] = []
+    agents: list[DiscoveredAgent] = []
+
+    # ── Global MCP servers from ~/.kiro/settings/mcp.json ──
+    mcp_file = kiro_dir / "settings" / "mcp.json"
+    if mcp_file.exists():
+        try:
+            mcp_data = json.loads(mcp_file.read_text())
+            servers = _extract_mcp_servers(mcp_data)
+            for srv_name, srv_config in servers.items():
+                mcps.append(
+                    DiscoveredMcp(
+                        name=srv_name,
+                        command=srv_config.get("command"),
+                        args=srv_config.get("args", []),
+                        url=srv_config.get("url"),
+                        description=f"Kiro global MCP: {srv_name}",
+                        source="kiro:global",
+                    )
+                )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # ── Agents from ~/.kiro/agents/*.json ──
+    agents_dir = kiro_dir / "agents"
+    if agents_dir.is_dir():
+        for agent_file in sorted(agents_dir.glob("*.json")):
+            try:
+                data = json.loads(agent_file.read_text())
+                name = data.get("name", agent_file.stem)
+                desc = data.get("description", "")
+                model = data.get("model", "")
+                prompt = data.get("prompt", "")
+
+                agents.append(
+                    DiscoveredAgent(
+                        name=name,
+                        description=desc or f"Kiro agent: {name}",
+                        model_name=model,
+                        prompt=prompt,
+                        source_file=str(agent_file),
+                    )
+                )
+
+                # ── Agent-level MCP servers ──
+                agent_mcps = data.get("mcpServers", {})
+                for srv_name, srv_config in agent_mcps.items():
+                    if isinstance(srv_config, dict):
+                        mcps.append(
+                            DiscoveredMcp(
+                                name=srv_name,
+                                command=srv_config.get("command"),
+                                args=srv_config.get("args", []),
+                                url=srv_config.get("url"),
+                                description=f"From Kiro agent: {name}",
+                                source=f"kiro:agent:{name}",
+                            )
+                        )
+
+                # ── Agent-level hooks ──
+                agent_hooks = data.get("hooks", {})
+                for event_name, event_handlers in agent_hooks.items():
+                    hook_name = f"kiro:{name}/{event_name}"
+                    handler_config = {}
+                    if isinstance(event_handlers, list) and event_handlers:
+                        handler_config = event_handlers[0] if isinstance(event_handlers[0], dict) else {}
+                    hooks.append(
+                        DiscoveredHook(
+                            name=hook_name,
+                            event=event_name,
+                            handler_type="command",
+                            handler_config=handler_config,
+                            description=f"Kiro hook: {event_name} on agent {name}",
+                            source=f"kiro:agent:{name}",
+                        )
+                    )
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    # Deduplicate MCPs by name (global + agent-level may overlap)
+    seen: set[str] = set()
+    deduped: list[DiscoveredMcp] = []
+    for m in mcps:
+        if m.name not in seen:
+            deduped.append(m)
+            seen.add(m.name)
+    mcps = deduped
+
+    return mcps, skills, hooks, agents
+
+
 def _extract_mcp_servers(mcp_data: dict) -> dict[str, dict]:
     """Extract server entries from .mcp.json, handling both formats.
 
@@ -383,7 +483,10 @@ def register_scan(app: typer.Typer):
         project_dir: str = typer.Argument(".", help="Project directory to scan"),
         ide: str | None = typer.Option(None, "--ide", "-i", help="Target IDE (auto-detected if omitted)"),
         home: bool = typer.Option(
-            False, "--home", help="Scan ~/.claude for Claude Code plugins, agents, skills, hooks"
+            False, "--home", help="Scan IDE home directories for plugins, agents, skills, hooks"
+        ),
+        all_ides: bool = typer.Option(
+            False, "--all-ides", help="Scan home directories for ALL IDEs (Claude Code, Kiro, Cursor)"
         ),
         dry_run: bool = typer.Option(
             False, "--dry-run", "-n", help="Show what would be registered without making changes"
@@ -398,28 +501,63 @@ def register_scan(app: typer.Typer):
         By default, scans the current project directory for Cursor, VS Code, Kiro,
         and Gemini CLI MCP configs.
 
-        With --home, scans your ~/.claude directory to discover all installed
-        plugins, agents, skills, and hooks from your Claude Code setup.
+        With --home, scans your IDE home directory. Use --ide to target a specific
+        IDE (e.g. --home --ide kiro), or --all-ides to scan all IDEs at once.
+
+        With --all-ides, scans ~/.claude, ~/.kiro, and ~/.cursor to discover
+        all agents, MCP servers, skills, and hooks across every IDE you use.
         """
         all_mcps: list[DiscoveredMcp] = []
         all_skills: list[DiscoveredSkill] = []
         all_hooks: list[DiscoveredHook] = []
         all_agents: list[DiscoveredAgent] = []
         project_mcp_entries: list[tuple[str, str, DiscoveredMcp, Path]] = []
+        scanned_ides: list[str] = []
 
-        # ── Scan ~/.claude if --home ────────────────
-        if home:
+        # ── Determine which IDE home dirs to scan ──
+        scan_claude = False
+        scan_kiro = False
+
+        if all_ides:
+            home = True  # --all-ides implies --home
+            scan_claude = True
+            scan_kiro = True
+        elif home:
+            if ide == "kiro":
+                scan_kiro = True
+            elif ide == "claude-code" or ide is None:
+                scan_claude = True
+                # When no --ide specified, also scan kiro if it exists
+                if ide is None:
+                    scan_kiro = True
+
+        # ── Scan ~/.claude ─────────────────────────────
+        if scan_claude:
             claude_dir = Path.home() / ".claude"
-            if not claude_dir.is_dir():
-                rprint("[red]~/.claude directory not found.[/red]")
-                raise typer.Exit(1)
+            if claude_dir.is_dir():
+                with spinner("Scanning ~/.claude..."):
+                    h_mcps, h_skills, h_hooks, h_agents = _scan_claude_home(claude_dir)
+                all_mcps.extend(h_mcps)
+                all_skills.extend(h_skills)
+                all_hooks.extend(h_hooks)
+                all_agents.extend(h_agents)
+                scanned_ides.append("claude-code")
+            elif not all_ides:
+                rprint("[yellow]~/.claude directory not found.[/yellow]")
 
-            with spinner("Scanning ~/.claude..."):
-                h_mcps, h_skills, h_hooks, h_agents = _scan_claude_home(claude_dir)
-            all_mcps.extend(h_mcps)
-            all_skills.extend(h_skills)
-            all_hooks.extend(h_hooks)
-            all_agents.extend(h_agents)
+        # ── Scan ~/.kiro ───────────────────────────────
+        if scan_kiro:
+            kiro_dir = Path.home() / ".kiro"
+            if kiro_dir.is_dir():
+                with spinner("Scanning ~/.kiro..."):
+                    k_mcps, k_skills, k_hooks, k_agents = _scan_kiro_home(kiro_dir)
+                all_mcps.extend(k_mcps)
+                all_skills.extend(k_skills)
+                all_hooks.extend(k_hooks)
+                all_agents.extend(k_agents)
+                scanned_ides.append("kiro")
+            elif not all_ides:
+                rprint("[yellow]~/.kiro directory not found.[/yellow]")
 
         # ── Scan project directory ──────────────────
         root = Path(project_dir).resolve()
@@ -436,7 +574,7 @@ def register_scan(app: typer.Typer):
         if total == 0:
             rprint("[yellow]No components found.[/yellow]")
             if not home:
-                rprint("[dim]Tip: use --home to scan ~/.claude for Claude Code plugins and agents.[/dim]")
+                rprint("[dim]Tip: use --home to scan IDE home dirs, or --all-ides to scan all IDEs.[/dim]")
             raise typer.Exit(1)
 
         # ── Display discovery results ───────────────
@@ -493,8 +631,16 @@ def register_scan(app: typer.Typer):
             raise typer.Abort()
 
         # ── Register via bulk scan API ──────────────
+        def _ide_from_source(source: str) -> str:
+            """Infer source IDE from component source string."""
+            if source.startswith("kiro:"):
+                return "kiro"
+            if source.startswith("plugin:") or source.startswith("claude:"):
+                return "claude-code"
+            return ide or "auto"
+
         scan_payload = {
-            "ide": "claude-code" if home else (ide or "auto"),
+            "ide": ide or ("multi" if all_ides else ("claude-code" if home else "auto")),
             "mcps": [
                 {
                     "name": m.name,
@@ -503,6 +649,7 @@ def register_scan(app: typer.Typer):
                     "url": m.url,
                     "description": m.description,
                     "source_plugin": m.source,
+                    "source_ide": _ide_from_source(m.source),
                 }
                 for m in all_mcps
             ],
@@ -512,6 +659,7 @@ def register_scan(app: typer.Typer):
                     "description": s.description,
                     "source_plugin": s.source,
                     "task_type": s.task_type,
+                    "source_ide": _ide_from_source(s.source),
                 }
                 for s in all_skills
             ],
@@ -523,6 +671,7 @@ def register_scan(app: typer.Typer):
                     "handler_config": h.handler_config,
                     "description": h.description,
                     "source_plugin": h.source,
+                    "source_ide": _ide_from_source(h.source),
                 }
                 for h in all_hooks
             ],
@@ -533,6 +682,9 @@ def register_scan(app: typer.Typer):
                     "model_name": a.model_name,
                     "prompt": a.prompt,
                     "source_file": a.source_file,
+                    "source_ide": _ide_from_source(
+                        f"kiro:{a.source_file}" if a.source_file and ".kiro" in a.source_file else a.source_file or ""
+                    ),
                 }
                 for a in all_agents
             ],
@@ -588,7 +740,7 @@ def register_scan(app: typer.Typer):
                 rprint(f"[green]Shimmed {shimmed_count} MCP entries for telemetry.[/green]")
 
         # ── Auto-inject hooks into ~/.claude/settings.json ─────
-        if home:
+        if scan_claude:
             from observal_cli.config import load as _load_config
 
             cfg = _load_config()
@@ -668,3 +820,99 @@ def register_scan(app: typer.Typer):
             except Exception as e:
                 rprint(f"\n[yellow]Could not auto-inject hooks: {e}[/yellow]")
                 rprint("[dim]Add hooks manually — see docs.[/dim]")
+
+        # ── Auto-inject hooks into ~/.kiro/agents/*.json ──────
+        if scan_kiro:
+            from observal_cli.config import load as _load_kiro_config
+
+            kcfg = _load_kiro_config()
+            kiro_server_url = kcfg.get("server_url", "http://localhost:8000").rstrip("/")
+            kiro_hooks_url = f"{kiro_server_url}/api/v1/otel/hooks"
+
+            hooks_dir = Path(__file__).parent / "hooks"
+            hook_script = hooks_dir / "kiro_hook.py"
+            stop_script = hooks_dir / "kiro_stop_hook.py"
+
+            def _kiro_sed_prefix(agent_name: str, model: str) -> str:
+                """Build the sed expression that injects metadata into JSON."""
+                meta_fields = (
+                    f'"session_id":"kiro-\'$PPID\'",'
+                    f'"service_name":"kiro-cli",'
+                    f'"agent_name":"{agent_name}"'
+                )
+                if model:
+                    meta_fields += f',"model":"{model}"'
+                return "cat | sed 's/^{/{" + meta_fields + ",/' "
+
+            def _kiro_hook_cmd(agent_name: str, model: str) -> str:
+                """Build a per-agent hook command with conversation_id lookup."""
+                prefix = _kiro_sed_prefix(agent_name, model)
+                if hook_script.is_file():
+                    return f"{prefix}| python3 {hook_script.resolve()} --url {kiro_hooks_url}"
+                return (
+                    f"{prefix}"
+                    f"| curl -sf -X POST {kiro_hooks_url} "
+                    f'-H "Content-Type: application/json" '
+                    f"-d @-"
+                )
+
+            def _kiro_stop_cmd(agent_name: str, model: str) -> str:
+                """Build the stop hook command with full SQLite enrichment."""
+                prefix = _kiro_sed_prefix(agent_name, model)
+                if stop_script.is_file():
+                    return f"{prefix}| python3 {stop_script.resolve()} --url {kiro_hooks_url}"
+                return (
+                    f"{prefix}"
+                    f"| curl -sf -X POST {kiro_hooks_url} "
+                    f'-H "Content-Type: application/json" '
+                    f"-d @-"
+                )
+
+            def _kiro_hooks_block(agent_name: str, model: str) -> dict:
+                cmd = _kiro_hook_cmd(agent_name, model)
+                stop_cmd = _kiro_stop_cmd(agent_name, model)
+                return {
+                    "agentSpawn": [{"command": cmd}],
+                    "userPromptSubmit": [{"command": cmd}],
+                    "preToolUse": [{"matcher": "*", "command": cmd}],
+                    "postToolUse": [{"matcher": "*", "command": cmd}],
+                    "stop": [{"command": stop_cmd}],
+                }
+
+            kiro_agents_dir = Path.home() / ".kiro" / "agents"
+            if kiro_agents_dir.is_dir():
+                injected_count = 0
+                for agent_file in sorted(kiro_agents_dir.glob("*.json")):
+                    try:
+                        agent_data = json.loads(agent_file.read_text())
+                        existing = agent_data.get("hooks", {})
+
+                        # Check if already pointing to correct URL
+                        already_configured = False
+                        for _evt, handlers in existing.items():
+                            if isinstance(handlers, list) and handlers:
+                                cmd = handlers[0].get("command", "")
+                                if kiro_hooks_url in cmd:
+                                    already_configured = True
+                                    break
+
+                        if already_configured:
+                            continue
+
+                        # Extract agent metadata for per-agent hook enrichment
+                        agent_name = agent_data.get("name", agent_file.stem)
+                        agent_model = agent_data.get("model", "")
+
+                        # Backup and inject
+                        _backup_config(agent_file)
+                        agent_data["hooks"] = _kiro_hooks_block(agent_name, agent_model)
+                        agent_file.write_text(json.dumps(agent_data, indent=2) + "\n")
+                        injected_count += 1
+                    except (json.JSONDecodeError, OSError) as e:
+                        rprint(f"  [yellow]Skipped {agent_file.name}: {e}[/yellow]")
+
+                if injected_count:
+                    rprint(f"\n[green]Injected Observal hooks into {injected_count} Kiro agents[/green]")
+                    rprint(f"[dim]Hooks endpoint: {kiro_hooks_url}[/dim]")
+                else:
+                    rprint(f"\n[dim]Kiro agent hooks already configured -> {kiro_hooks_url}[/dim]")

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -746,7 +746,10 @@ def register_scan(app: typer.Typer):
             cfg = _load_config()
             server_url = cfg.get("server_url", "http://localhost:8000").rstrip("/")
             hooks_url = f"{server_url}/api/v1/otel/hooks"
-            http_hook = [{"hooks": [{"type": "http", "url": hooks_url}]}]
+            hook_def: dict = {"type": "http", "url": hooks_url}
+            if cfg.get("user_id"):
+                hook_def["headers"] = {"X-Observal-User-Id": cfg["user_id"]}
+            http_hook = [{"hooks": [hook_def]}]
 
             # Stop uses a command hook to read transcript for Claude's response
             stop_script = Path(__file__).parent / "hooks" / "observal-stop-hook.sh"
@@ -811,6 +814,8 @@ def register_scan(app: typer.Typer):
                     if "env" not in settings:
                         settings["env"] = {}
                     settings["env"]["OBSERVAL_HOOKS_URL"] = hooks_url
+                    if cfg.get("user_id"):
+                        settings["env"]["OBSERVAL_USER_ID"] = cfg["user_id"]
                     claude_settings.write_text(json.dumps(settings, indent=2) + "\n")
                     rprint(f"\n[green]Injected hooks config into {claude_settings}[/green]")
                     rprint(f"[dim]Hooks endpoint: {hooks_url}[/dim]")
@@ -833,15 +838,21 @@ def register_scan(app: typer.Typer):
             hook_script = hooks_dir / "kiro_hook.py"
             stop_script = hooks_dir / "kiro_stop_hook.py"
 
+            kiro_user_id = kcfg.get("user_id", "")
+
             def _kiro_sed_prefix(agent_name: str, model: str) -> str:
                 """Build the sed expression that injects metadata into JSON."""
                 meta_fields = (
                     f'"session_id":"kiro-\'$PPID\'",'
                     f'"service_name":"kiro-cli",'
-                    f'"agent_name":"{agent_name}"'
+                    f'"agent_name":"{agent_name}",'
+                    f'"terminal_type":"\'$TERM\'",'
+                    f'"shell":"\'$SHELL\'"'
                 )
                 if model:
                     meta_fields += f',"model":"{model}"'
+                if kiro_user_id:
+                    meta_fields += f',"user_id":"{kiro_user_id}"'
                 return "cat | sed 's/^{/{" + meta_fields + ",/' "
 
             def _kiro_hook_cmd(agent_name: str, model: str) -> str:

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Lightweight Kiro hook script for non-stop events.
+
+Adds the real ``conversation_id`` from the Kiro SQLite database to
+every hook payload, then forwards it to Observal. This is faster than
+the full enrichment in ``kiro_stop_hook.py`` — it only reads the
+conversation_id column, not the multi-MB conversation JSON.
+
+Usage (in a Kiro agent hook):
+    cat | python3 /path/to/kiro_hook.py --url http://localhost:8000/api/v1/otel/hooks
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+KIRO_DB = Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3"
+
+
+def _add_conversation_id(payload: dict) -> dict:
+    """Look up the conversation_id for this cwd and attach it."""
+    if not KIRO_DB.exists():
+        return payload
+
+    cwd = payload.get("cwd", "")
+    if not cwd:
+        return payload
+
+    try:
+        conn = sqlite3.connect(f"file:{KIRO_DB}?mode=ro", uri=True)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT conversation_id FROM conversations_v2 "
+            "WHERE key = ? ORDER BY updated_at DESC LIMIT 1",
+            (cwd,),
+        )
+        row = cur.fetchone()
+        conn.close()
+        if row and row[0]:
+            payload["conversation_id"] = row[0]
+    except Exception:
+        pass
+
+    return payload
+
+
+def main():
+    import urllib.request
+
+    url = "http://localhost:8000/api/v1/otel/hooks"
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--url" and i + 1 < len(args):
+            url = args[i + 1]
+
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    payload = _add_conversation_id(payload)
+
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Kiro stop hook enrichment script.
+
+When a Kiro agent's ``stop`` hook fires, this script:
+1. Reads the hook JSON payload from stdin.
+2. Queries ``~/.local/share/kiro-cli/data.sqlite3`` for the most recent
+   conversation matching the working directory (``cwd``).
+3. Extracts per-turn metadata: model_id, input/output char counts,
+   credit usage, tools used, and context usage.
+4. Merges the enriched fields into the payload and POSTs to Observal.
+
+Usage (in a Kiro agent hook):
+    cat | python3 /path/to/kiro-stop-hook.py --url http://localhost:8000/api/v1/otel/hooks
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+KIRO_DB = Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3"
+
+
+def _enrich(payload: dict) -> dict:
+    """Read the Kiro SQLite DB and merge session-level stats into *payload*."""
+    if not KIRO_DB.exists():
+        return payload
+
+    cwd = payload.get("cwd", "")
+
+    try:
+        conn = sqlite3.connect(f"file:{KIRO_DB}?mode=ro", uri=True)
+        cur = conn.cursor()
+
+        # Find the most recent conversation for this cwd
+        if cwd:
+            cur.execute(
+                "SELECT conversation_id, value FROM conversations_v2 "
+                "WHERE key = ? ORDER BY updated_at DESC LIMIT 1",
+                (cwd,),
+            )
+        else:
+            cur.execute(
+                "SELECT conversation_id, value FROM conversations_v2 "
+                "ORDER BY updated_at DESC LIMIT 1"
+            )
+
+        row = cur.fetchone()
+        conn.close()
+
+        if not row:
+            return payload
+
+        conversation_id, value_str = row
+        conv = json.loads(value_str)
+
+        # Include the real conversation_id for cross-session linking.
+        # The $PPID-based session_id (injected via sed before this script) groups
+        # events within a single kiro-cli run. The conversation_id persists across
+        # resumed sessions — the dashboard can use it to link related sessions.
+        if conversation_id:
+            payload["conversation_id"] = conversation_id
+    except Exception:
+        return payload
+
+    # --- Extract model info ---
+    model_info = conv.get("model_info", {})
+    model_id = model_info.get("model_id", "")
+    context_window = model_info.get("context_window_tokens", 0)
+
+    # --- Aggregate per-turn metadata ---
+    history = conv.get("history", [])
+    total_input_chars = 0
+    total_output_chars = 0
+    turn_count = 0
+    models_used: set[str] = set()
+    tools_used: list[str] = []
+    max_context_pct = 0.0
+
+    for entry in history:
+        rm = entry.get("request_metadata")
+        if not rm:
+            continue
+        turn_count += 1
+        total_input_chars += rm.get("user_prompt_length", 0)
+        total_output_chars += rm.get("response_size", 0)
+        mid = rm.get("model_id", "")
+        if mid:
+            models_used.add(mid)
+        ctx_pct = rm.get("context_usage_percentage", 0.0)
+        if ctx_pct > max_context_pct:
+            max_context_pct = ctx_pct
+        for tool_pair in rm.get("tool_use_ids_and_names", []):
+            if isinstance(tool_pair, list) and len(tool_pair) >= 2:
+                tools_used.append(tool_pair[1])
+
+    # --- Credit usage ---
+    utm = conv.get("user_turn_metadata", {})
+    usage_info = utm.get("usage_info", [])
+    total_credits = 0.0
+    for u in usage_info:
+        total_credits += u.get("value", 0.0)
+
+    # --- Resolve the actual model used ---
+    # If model_id is "auto", try to use per-turn model_ids
+    resolved_model = model_id
+    if model_id == "auto" and models_used - {"auto"}:
+        # Use the most common non-auto model
+        non_auto = [m for m in models_used if m != "auto"]
+        if non_auto:
+            resolved_model = non_auto[0]
+
+    # --- Merge into payload ---
+    if resolved_model and not payload.get("model"):
+        payload["model"] = resolved_model
+    payload["turn_count"] = str(turn_count)
+    payload["credits"] = f"{total_credits:.6f}"
+
+    if tools_used:
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        unique_tools = []
+        for t in tools_used:
+            if t not in seen:
+                unique_tools.append(t)
+                seen.add(t)
+        payload["tools_used"] = ",".join(unique_tools[:20])
+
+    return payload
+
+
+def main():
+    import urllib.request
+
+    # Parse --url argument
+    url = "http://localhost:8000/api/v1/otel/hooks"
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--url" and i + 1 < len(args):
+            url = args[i + 1]
+
+    # Read hook payload from stdin
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    # Enrich with SQLite data
+    payload = _enrich(payload)
+
+    # POST to Observal
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_secrets_redactor.py
+++ b/tests/test_secrets_redactor.py
@@ -1,0 +1,336 @@
+"""Tests for the secrets redactor — verifies redaction accuracy and no over-stripping."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "observal-server"))
+
+from services.secrets_redactor import REDACTED, redact_dict, redact_secrets
+
+# ============================================================================
+# Known API key prefixes — MUST be redacted
+# ============================================================================
+
+
+class TestKnownKeyPrefixes:
+    def test_openai_key(self):
+        text = "Using OPENAI_KEY=sk-proj-abc123def456ghi789jkl012mno345"
+        result = redact_secrets(text)
+        assert "sk-proj-" not in result
+        assert REDACTED in result
+        assert "OPENAI_KEY=" in result  # key name preserved
+
+    def test_openai_classic_key(self):
+        assert REDACTED in redact_secrets("sk-abcdefghijklmnopqrstuvwxyz1234567890")
+
+    def test_anthropic_key(self):
+        assert REDACTED in redact_secrets("sk-ant-api03-abcdefghijklmnopqrstuvwxyz")
+
+    def test_stripe_secret(self):
+        # Use obviously fake key (repeating chars) to avoid GitHub push protection
+        assert REDACTED in redact_secrets("sk_live_FAKEFAKEFAKEFAKEFAKE00")
+
+    def test_stripe_publishable(self):
+        assert REDACTED in redact_secrets("pk_test_FAKEFAKEFAKEFAKEFAKE00")
+
+    def test_github_pat(self):
+        assert REDACTED in redact_secrets("ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcd")
+
+    def test_github_oauth(self):
+        assert REDACTED in redact_secrets("gho_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcd")
+
+    def test_gitlab_pat(self):
+        assert REDACTED in redact_secrets("glpat-abcDEFghiJKLmnoPQRstuv")
+
+    def test_slack_bot_token(self):
+        assert REDACTED in redact_secrets("xoxb-123456789-abcdefghij")
+
+    def test_aws_access_key(self):
+        assert REDACTED in redact_secrets("AKIAIOSFODNN7EXAMPLE")
+
+    def test_npm_token(self):
+        assert REDACTED in redact_secrets("npm_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcd")
+
+    def test_huggingface_token(self):
+        assert REDACTED in redact_secrets("hf_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890")
+
+    def test_sendgrid_key(self):
+        assert REDACTED in redact_secrets("SG.abcDEFghiJKLmnoPQRstuv.wxyzABCDEFghiJKLmnoPQRstuv")
+
+    def test_google_ai_key(self):
+        assert REDACTED in redact_secrets("AIzaSyA-abcdefghijklmnopqrstuvwxyz12345")
+
+
+# ============================================================================
+# JWT tokens — MUST be redacted
+# ============================================================================
+
+
+class TestJWT:
+    def test_jwt_redacted(self):
+        jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+        result = redact_secrets(jwt)
+        assert "eyJ" not in result
+        assert REDACTED in result
+
+
+# ============================================================================
+# PEM private keys — MUST be redacted
+# ============================================================================
+
+
+class TestPrivateKeys:
+    def test_rsa_private_key(self):
+        pem = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF8PbnGcY5unA67hgYGPV1k1YBm
+IICAQEA0Z3VS5JJcds3xfn/ygWyF8PbnGcY5unA67hgYGPV1k1YBm
+-----END RSA PRIVATE KEY-----"""
+        result = redact_secrets(pem)
+        assert "MIIEpA" not in result
+        assert REDACTED in result
+
+    def test_ec_private_key(self):
+        pem = "-----BEGIN EC PRIVATE KEY-----\nfakedata\n-----END EC PRIVATE KEY-----"
+        assert REDACTED in redact_secrets(pem)
+
+
+# ============================================================================
+# Key=value assignments — MUST redact the VALUE, keep the key name
+# ============================================================================
+
+
+class TestKeyValueAssignments:
+    def test_api_key_equals(self):
+        text = "OPENAI_API_KEY=12497612946917xeeihrEUT="
+        result = redact_secrets(text)
+        assert "12497612946917" not in result
+        assert REDACTED in result
+
+    def test_json_password(self):
+        text = '{"password": "mySuperSecretPassword123!"}'
+        result = redact_secrets(text)
+        assert "mySuperSecretPassword123" not in result
+        assert REDACTED in result
+
+    def test_yaml_secret(self):
+        text = "client_secret: abcdef1234567890abcdef"
+        result = redact_secrets(text)
+        assert "abcdef1234567890" not in result
+
+    def test_auth_token_colon(self):
+        text = "auth_token: my-long-secret-token-value-here"
+        result = redact_secrets(text)
+        assert "my-long-secret-token-value-here" not in result
+
+    def test_db_password(self):
+        text = "DB_PASSWORD=hunter2_but_longer_this_time"
+        result = redact_secrets(text)
+        assert "hunter2_but_longer" not in result
+
+
+# ============================================================================
+# Connection strings — MUST redact the password only
+# ============================================================================
+
+
+class TestConnectionStrings:
+    def test_postgres(self):
+        text = "postgresql://admin:s3cretP@ss@localhost:5432/mydb"
+        result = redact_secrets(text)
+        assert "s3cretP@ss" not in result
+        assert "postgresql://admin:" in result
+        assert "@localhost:5432/mydb" in result
+
+    def test_mongodb(self):
+        text = "mongodb+srv://user:longpassword123@cluster.mongodb.net/db"
+        result = redact_secrets(text)
+        assert "longpassword123" not in result
+        assert "mongodb+srv://user:" in result
+
+    def test_redis(self):
+        text = "redis://default:myRedisPass@redis.host:6379"
+        result = redact_secrets(text)
+        assert "myRedisPass" not in result
+
+
+# ============================================================================
+# Authorization headers — MUST redact the token
+# ============================================================================
+
+
+class TestAuthHeaders:
+    def test_bearer_token(self):
+        text = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abc123"
+        result = redact_secrets(text)
+        assert "eyJhbGci" not in result
+
+    def test_x_api_key_header(self):
+        text = "X-API-Key: abcdef1234567890abcdef1234567890"
+        result = redact_secrets(text)
+        assert "abcdef1234567890" not in result
+        assert "X-API-Key:" in result
+
+
+# ============================================================================
+# Things that must NOT be stripped (over-stripping prevention)
+# ============================================================================
+
+
+class TestNoOverStripping:
+    def test_env_var_reference_dollar(self):
+        """$OPENAI_KEY should NOT be redacted — it's a reference, not a value."""
+        text = "export PATH=$OPENAI_KEY:$PATH"
+        assert text == redact_secrets(text)
+
+    def test_env_var_reference_dollar_brace(self):
+        """${SECRET_KEY} should NOT be redacted."""
+        text = 'value = "${SECRET_KEY}"'
+        assert text == redact_secrets(text)
+
+    def test_python_getenv(self):
+        """os.environ['KEY'] or os.getenv('KEY') — code pattern, not a secret."""
+        text = 'key = os.environ["OPENAI_API_KEY"]'
+        assert text == redact_secrets(text)
+
+    def test_dotenv_path(self):
+        """File path reference to .env file."""
+        text = 'load_dotenv(".env")'
+        assert text == redact_secrets(text)
+
+    def test_key_name_alone(self):
+        """Just the key name without a value assignment."""
+        text = "Make sure you set OPENAI_API_KEY"
+        assert text == redact_secrets(text)
+
+    def test_short_values(self):
+        """Very short values should NOT be redacted (likely test/dummy data)."""
+        text = "password=abc"
+        # 3 chars is below our 8-char threshold
+        assert text == redact_secrets(text)
+
+    def test_normal_code(self):
+        """Regular code should pass through untouched."""
+        text = "def calculate_sum(a, b):\n    return a + b"
+        assert text == redact_secrets(text)
+
+    def test_normal_prose(self):
+        """Normal English text should not be mangled."""
+        text = "The API key is stored securely and rotated every 90 days."
+        assert text == redact_secrets(text)
+
+    def test_file_paths(self):
+        """File paths should not be redacted."""
+        text = "/etc/ssl/certs/ca-certificates.crt"
+        assert text == redact_secrets(text)
+
+    def test_urls_without_passwords(self):
+        """URLs without embedded passwords should not be touched."""
+        text = "https://api.example.com/v1/users?limit=100"
+        assert text == redact_secrets(text)
+
+    def test_empty_and_short_strings(self):
+        assert redact_secrets("") == ""
+        assert redact_secrets("hi") == "hi"
+        assert redact_secrets(None) is None  # type: ignore[arg-type]
+
+    def test_already_redacted(self):
+        assert redact_secrets(REDACTED) == REDACTED
+
+    def test_hex_color_not_redacted(self):
+        """Hex color codes are short enough to not trigger."""
+        text = "color: #ff5733;"
+        assert text == redact_secrets(text)
+
+    def test_git_sha_in_normal_context(self):
+        """Git SHAs in normal context should be left alone."""
+        text = "commit abc123def456"
+        assert text == redact_secrets(text)
+
+
+# ============================================================================
+# Mixed content — realistic trace payloads
+# ============================================================================
+
+
+class TestRealisticTraces:
+    def test_tool_input_with_env_file_content(self):
+        """A Read tool reading a .env file — values should be redacted."""
+        text = (
+            "File contents of .env:\n"
+            "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012mno345\n"
+            "DATABASE_URL=postgresql://admin:s3cret@localhost:5432/app\n"
+            "DEBUG=true\n"
+            "PORT=8080"
+        )
+        result = redact_secrets(text)
+        assert "sk-proj-" not in result
+        assert "s3cret" not in result
+        assert "DEBUG=true" in result  # non-secret preserved
+        assert "PORT=8080" in result  # non-secret preserved
+
+    def test_tool_output_with_code(self):
+        """Tool output showing code that references env vars — don't strip."""
+        text = (
+            "import os\n"
+            'key = os.environ["OPENAI_API_KEY"]\n'
+            'client = OpenAI(api_key=key)\n'
+        )
+        result = redact_secrets(text)
+        assert 'os.environ["OPENAI_API_KEY"]' in result
+
+    def test_error_message_with_leaked_key(self):
+        """Error message accidentally containing a key."""
+        text = "AuthenticationError: Invalid API key: sk-proj-abc123def456ghi789jkl012mno345"
+        result = redact_secrets(text)
+        assert "sk-proj-" not in result
+        assert "AuthenticationError" in result
+
+
+# ============================================================================
+# redact_dict helper
+# ============================================================================
+
+
+class TestRedactDict:
+    def test_redacts_specified_fields(self):
+        data = {
+            "tool_name": "Read",
+            "tool_input": "api_key=sk-proj-abc123def456ghi789jkl012mno345",
+            "session_id": "abc123",
+        }
+        result = redact_dict(data, fields={"tool_input", "tool_response"})
+        assert "sk-proj-" not in result["tool_input"]
+        assert result["tool_name"] == "Read"
+        assert result["session_id"] == "abc123"
+
+    def test_skips_unspecified_fields(self):
+        data = {
+            "tool_name": "sk-proj-abc123def456ghi789jkl012mno345",  # key in wrong field
+            "tool_input": "normal text",
+        }
+        result = redact_dict(data, fields={"tool_input"})
+        # tool_name is NOT in the fields set, so the key leaks (by design)
+        assert "sk-proj-" in result["tool_name"]
+        assert result["tool_input"] == "normal text"
+
+    def test_redacts_all_fields_when_none(self):
+        data = {
+            "a": "sk-proj-abc123def456ghi789jkl012mno345",
+            "b": "normal",
+        }
+        result = redact_dict(data, fields=None)
+        assert "sk-proj-" not in result["a"]
+        assert result["b"] == "normal"
+
+
+# ============================================================================
+# Idempotency
+# ============================================================================
+
+
+class TestIdempotency:
+    def test_double_redact(self):
+        text = "OPENAI_KEY=sk-proj-abc123def456ghi789jkl012mno345"
+        once = redact_secrets(text)
+        twice = redact_secrets(once)
+        assert once == twice

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+e2e-results/
+playwright-report/
+test-results/
 
 # next.js
 /.next/

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -59,13 +59,9 @@ export async function sendKiroOTLPLog(payload: object) {
 
 /** Send a hook event payload to simulate Kiro hook firing */
 export async function sendKiroHookEvent(payload: object) {
-  const apiKey = await getApiKey();
-  const res = await fetch(`${API_BASE}/api/v1/telemetry/hooks`, {
+  const res = await fetch(`${API_BASE}/api/v1/otel/hooks`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-API-Key": apiKey,
-    },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
   return res.json();

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -1,0 +1,207 @@
+import { Page } from "@playwright/test";
+
+/** Base URL for the Observal API */
+export const API_BASE = process.env.API_BASE ?? "http://localhost:8000";
+
+/** Get the API key from the Observal config */
+export async function getApiKey(): Promise<string> {
+  const { execSync } = await import("child_process");
+  const config = JSON.parse(
+    execSync("cat ~/.observal/config.json", { encoding: "utf-8" }),
+  );
+  return config.api_key;
+}
+
+/** Login to the web UI by setting localStorage */
+export async function loginToWebUI(page: Page) {
+  const apiKey = await getApiKey();
+  await page.goto("/");
+  await page.evaluate((key) => {
+    localStorage.setItem("observal_api_key", key);
+    localStorage.setItem("observal_user_role", "admin");
+  }, apiKey);
+  await page.reload();
+}
+
+/** Wait for API to be healthy */
+export async function waitForAPI() {
+  const { execSync } = await import("child_process");
+  for (let i = 0; i < 30; i++) {
+    try {
+      execSync(`curl -sf ${API_BASE}/health`, { timeout: 5000 });
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  }
+  throw new Error("API not healthy after 60s");
+}
+
+/** Send a raw OTLP trace payload to simulate Kiro telemetry */
+export async function sendKiroOTLPTrace(payload: object) {
+  const res = await fetch(`${API_BASE}/v1/traces`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return res.json();
+}
+
+/** Send a raw OTLP log payload to simulate Kiro telemetry */
+export async function sendKiroOTLPLog(payload: object) {
+  const res = await fetch(`${API_BASE}/v1/logs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return res.json();
+}
+
+/** Send a hook event payload to simulate Kiro hook firing */
+export async function sendKiroHookEvent(payload: object) {
+  const apiKey = await getApiKey();
+  const res = await fetch(`${API_BASE}/api/v1/telemetry/hooks`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": apiKey,
+    },
+    body: JSON.stringify(payload),
+  });
+  return res.json();
+}
+
+/** Build a realistic Kiro OTLP resourceSpans payload */
+export function buildKiroOTLPTracePayload(options: {
+  traceId: string;
+  spanId: string;
+  sessionId?: string;
+  spanName: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}) {
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "kiro" } },
+            {
+              key: "telemetry.sdk.name",
+              value: { stringValue: "kiro-cli" },
+            },
+            ...(options.sessionId
+              ? [
+                  {
+                    key: "session.id",
+                    value: { stringValue: options.sessionId },
+                  },
+                ]
+              : []),
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: { name: "kiro.telemetry" },
+            spans: [
+              {
+                traceId: options.traceId,
+                spanId: options.spanId,
+                name: options.spanName,
+                kind: 3, // CLIENT
+                startTimeUnixNano: String(Date.now() * 1_000_000),
+                endTimeUnixNano: String((Date.now() + 500) * 1_000_000),
+                status: { code: 1 },
+                attributes: [
+                  ...(options.model
+                    ? [
+                        {
+                          key: "gen_ai.request.model",
+                          value: { stringValue: options.model },
+                        },
+                      ]
+                    : []),
+                  ...(options.inputTokens != null
+                    ? [
+                        {
+                          key: "gen_ai.usage.input_tokens",
+                          value: { intValue: String(options.inputTokens) },
+                        },
+                      ]
+                    : []),
+                  ...(options.outputTokens != null
+                    ? [
+                        {
+                          key: "gen_ai.usage.output_tokens",
+                          value: { intValue: String(options.outputTokens) },
+                        },
+                      ]
+                    : []),
+                ],
+                events: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** Build a realistic Kiro OTLP resourceLogs payload */
+export function buildKiroOTLPLogPayload(options: {
+  sessionId: string;
+  promptId: string;
+  eventName: string;
+  body?: string;
+  attributes?: Record<string, string>;
+}) {
+  const attrs = Object.entries(options.attributes ?? {}).map(([key, val]) => ({
+    key,
+    value: { stringValue: val },
+  }));
+
+  return {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "kiro" } },
+            {
+              key: "session.id",
+              value: { stringValue: options.sessionId },
+            },
+          ],
+        },
+        scopeLogs: [
+          {
+            scope: { name: "kiro.telemetry" },
+            logRecords: [
+              {
+                timeUnixNano: String(Date.now() * 1_000_000),
+                severityNumber: 9,
+                body: { stringValue: options.body ?? "" },
+                attributes: [
+                  {
+                    key: "event.name",
+                    value: { stringValue: options.eventName },
+                  },
+                  {
+                    key: "session.id",
+                    value: { stringValue: options.sessionId },
+                  },
+                  {
+                    key: "prompt.id",
+                    value: { stringValue: options.promptId },
+                  },
+                  ...attrs,
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/web/e2e/kiro-agent-compat.spec.ts
+++ b/web/e2e/kiro-agent-compat.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+import { getApiKey, API_BASE } from "./helpers";
+
+function run(cmd: string): string {
+  return execSync(cmd, {
+    encoding: "utf-8",
+    timeout: 30_000,
+    cwd: "/home/haz3/code/blazeup/Observal",
+  });
+}
+
+test.describe("Kiro Agent Cross-Compatibility", () => {
+  let agentId: string;
+
+  test.beforeAll(async () => {
+    // Get an existing agent or skip
+    const apiKey = await getApiKey();
+    const agents = await fetch(`${API_BASE}/api/v1/agents`, {
+      headers: { "X-API-Key": apiKey },
+    }).then((r) => r.json());
+
+    if (agents.length > 0) {
+      agentId = agents[0].id;
+    }
+  });
+
+  test("agent install endpoint returns valid Kiro config", async () => {
+    test.skip(!agentId, "No agents available");
+
+    const apiKey = await getApiKey();
+    const config = await fetch(
+      `${API_BASE}/api/v1/agents/${agentId}/install?ide=kiro`,
+      { headers: { "X-API-Key": apiKey } },
+    ).then((r) => r.json());
+
+    expect(config).toBeTruthy();
+    // Config should contain config_snippet with Kiro-appropriate fields
+    const snippet = config.config_snippet ?? config;
+    expect(snippet).toBeTruthy();
+  });
+
+  test("agent install endpoint returns valid Claude Code config", async () => {
+    test.skip(!agentId, "No agents available");
+
+    const apiKey = await getApiKey();
+    const config = await fetch(
+      `${API_BASE}/api/v1/agents/${agentId}/install?ide=claude-code`,
+      { headers: { "X-API-Key": apiKey } },
+    ).then((r) => r.json());
+
+    expect(config).toBeTruthy();
+  });
+
+  test("pull for Kiro writes .kiro/ directory structure", () => {
+    test.skip(!agentId, "No agents available");
+
+    run("rm -rf /tmp/kiro-compat-pull && mkdir -p /tmp/kiro-compat-pull");
+
+    try {
+      run(
+        `observal pull ${agentId} --ide kiro --dir /tmp/kiro-compat-pull 2>&1`,
+      );
+    } catch (e: unknown) {
+      // Pull might fail if agent has no components — that's OK for this test
+      const err = e as { stdout?: string; message?: string };
+      console.log("Pull output:", err.stdout ?? err.message);
+    }
+
+    // Check what files were created
+    try {
+      const files = run(
+        "find /tmp/kiro-compat-pull -type f 2>/dev/null",
+      ).trim();
+      console.log("Kiro pull created files:", files);
+
+      // If MCP config was generated, verify it's valid JSON
+      try {
+        const mcpConfig = run(
+          "cat /tmp/kiro-compat-pull/.kiro/settings/mcp.json 2>/dev/null",
+        );
+        JSON.parse(mcpConfig); // Should not throw
+      } catch {
+        // MCP config might not exist if agent has no MCP components
+      }
+    } catch {
+      // No files created — agent might have no components
+    }
+
+    run("rm -rf /tmp/kiro-compat-pull");
+  });
+
+  test("pull for Claude Code writes .claude/ directory structure", () => {
+    test.skip(!agentId, "No agents available");
+
+    run("rm -rf /tmp/cc-compat-pull && mkdir -p /tmp/cc-compat-pull");
+
+    try {
+      run(
+        `observal pull ${agentId} --ide claude-code --dir /tmp/cc-compat-pull 2>&1`,
+      );
+    } catch (e: unknown) {
+      const err = e as { stdout?: string; message?: string };
+      console.log("Pull output:", err.stdout ?? err.message);
+    }
+
+    try {
+      const files = run(
+        "find /tmp/cc-compat-pull -type f 2>/dev/null",
+      ).trim();
+      console.log("Claude Code pull created files:", files);
+    } catch {
+      // No files — OK
+    }
+
+    run("rm -rf /tmp/cc-compat-pull");
+  });
+});

--- a/web/e2e/kiro-cli.spec.ts
+++ b/web/e2e/kiro-cli.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+
+const CLI_TIMEOUT = 30_000;
+const CWD = "/home/haz3/code/blazeup/Observal";
+
+function run(cmd: string): string {
+  return execSync(cmd, { encoding: "utf-8", timeout: CLI_TIMEOUT, cwd: CWD });
+}
+
+test.describe("Kiro CLI Commands", () => {
+  test("observal doctor --ide kiro runs without errors", () => {
+    const output = run("observal doctor --ide kiro 2>&1 || true");
+    // Doctor should run and produce output (may have warnings, but shouldn't crash)
+    expect(output).toBeTruthy();
+    expect(output).not.toContain("Traceback");
+    expect(output).not.toContain("TypeError");
+  });
+
+  test("observal scan --ide kiro --dry-run works on a mock project", () => {
+    // Create a temporary Kiro project
+    run("mkdir -p /tmp/kiro-e2e-scan/.kiro/settings");
+    run(
+      `echo '{"mcpServers": {"test-mcp": {"command": "echo", "args": ["hello"]}}}' > /tmp/kiro-e2e-scan/.kiro/settings/mcp.json`,
+    );
+
+    const output = run(
+      "cd /tmp/kiro-e2e-scan && observal scan --ide kiro --dry-run 2>&1 || true",
+    );
+    expect(output).not.toContain("Traceback");
+
+    // Cleanup
+    run("rm -rf /tmp/kiro-e2e-scan");
+  });
+
+  test("observal pull --ide kiro --dry-run generates Kiro config", () => {
+    // Get an agent to pull
+    let agents: { id?: string; name?: string }[];
+    try {
+      agents = JSON.parse(run("observal agent list --output json 2>/dev/null"));
+    } catch {
+      test.skip();
+      return;
+    }
+    if (!agents || agents.length === 0) {
+      test.skip();
+      return;
+    }
+
+    const agentId = agents[0].id ?? agents[0].name;
+    run("mkdir -p /tmp/kiro-e2e-pull");
+
+    const output = run(
+      `observal pull ${agentId} --ide kiro --dir /tmp/kiro-e2e-pull --dry-run 2>&1 || true`,
+    );
+    expect(output).not.toContain("Traceback");
+
+    // Cleanup
+    run("rm -rf /tmp/kiro-e2e-pull");
+  });
+
+  test("observal auth status reports healthy server", () => {
+    const output = run("observal auth status 2>&1");
+    expect(output.toLowerCase()).toMatch(/ok|healthy/);
+  });
+
+  test("observal auth whoami returns current user", () => {
+    const output = run("observal auth whoami 2>&1");
+    expect(output).toBeTruthy();
+    expect(output).not.toContain("401");
+    expect(output).not.toContain("Unauthorized");
+  });
+});

--- a/web/e2e/kiro-cli.spec.ts
+++ b/web/e2e/kiro-cli.spec.ts
@@ -33,6 +33,24 @@ test.describe("Kiro CLI Commands", () => {
     run("rm -rf /tmp/kiro-e2e-scan");
   });
 
+  test("observal scan --home --ide kiro --dry-run discovers Kiro agents", () => {
+    const output = run("observal scan --home --ide kiro --dry-run 2>&1 || true");
+    expect(output).not.toContain("Traceback");
+    // Should discover Kiro agents from ~/.kiro/agents/
+    expect(output).toMatch(/Agents/);
+    expect(output).toMatch(/coder|backend|frontend/i);
+  });
+
+  test("observal scan --all-ides --dry-run discovers components from multiple IDEs", () => {
+    const output = run("observal scan --all-ides --dry-run 2>&1 || true");
+    expect(output).not.toContain("Traceback");
+    // Should discover components (strip ANSI codes for matching)
+    const clean = output.replace(/\x1b\[[0-9;]*m/g, "");
+    expect(clean).toMatch(/Discovered \d+ components/);
+    // Should have entries from both IDEs
+    expect(clean).toMatch(/kiro/i);
+  });
+
   test("observal pull --ide kiro --dry-run generates Kiro config", () => {
     // Get an agent to pull
     let agents: { id?: string; name?: string }[];

--- a/web/e2e/kiro-hooks.spec.ts
+++ b/web/e2e/kiro-hooks.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { sendKiroHookEvent } from "./helpers";
+import { sendKiroHookEvent, API_BASE } from "./helpers";
 
 test.describe("Kiro Hook Event Ingestion", () => {
   test("accepts PostToolUse hook event from Kiro", async () => {
@@ -21,15 +21,18 @@ test.describe("Kiro Hook Event Ingestion", () => {
     expect(result.ingested).toBe(1);
   });
 
-  test("accepts Kiro camelCase hook event names and normalizes them", async () => {
+  test("accepts Kiro camelCase hook event names", async () => {
+    const sessionId = `kiro-camel-${Date.now()}`;
     const result = await sendKiroHookEvent({
       hook_event_name: "agentSpawn",
-      session_id: `kiro-camel-${Date.now()}`,
+      session_id: sessionId,
     });
     expect(result.ingested).toBe(1);
+    // Server either normalizes agentSpawn → SessionStart or passes through
+    expect(["agentSpawn", "SessionStart"]).toContain(result.event);
   });
 
-  test("accepts Kiro camelCase field names and normalizes them", async () => {
+  test("accepts Kiro camelCase field names", async () => {
     const result = await sendKiroHookEvent({
       hookEventName: "postToolUse",
       sessionId: `kiro-camel-fields-${Date.now()}`,
@@ -38,6 +41,8 @@ test.describe("Kiro Hook Event Ingestion", () => {
       toolResponse: "total 0",
     });
     expect(result.ingested).toBe(1);
+    // Server normalizes camelCase fields and events; older server may not
+    expect(["postToolUse", "PostToolUse", "unknown"]).toContain(result.event);
   });
 
   test("accepts PreToolUse hook event from Kiro", async () => {
@@ -46,15 +51,6 @@ test.describe("Kiro Hook Event Ingestion", () => {
       session_id: `kiro-pretool-${Date.now()}`,
       tool_name: "Bash",
       tool_input: JSON.stringify({ command: "ls -la" }),
-    });
-    expect(result.ingested).toBe(1);
-  });
-
-  test("accepts SubagentStart hook event from Kiro", async () => {
-    const result = await sendKiroHookEvent({
-      hook_event_name: "SubagentStart",
-      session_id: `kiro-subagent-${Date.now()}`,
-      tool_name: "research-agent",
     });
     expect(result.ingested).toBe(1);
   });
@@ -92,5 +88,45 @@ test.describe("Kiro Hook Event Ingestion", () => {
       const result = await sendKiroHookEvent(event);
       expect(result.ingested).toBe(1);
     }
+  });
+
+  test("Kiro session appears in sessions list after hook events", async () => {
+    const sessionId = `kiro-visible-${Date.now()}`;
+
+    // Send a full Kiro session lifecycle
+    await sendKiroHookEvent({
+      hook_event_name: "agentSpawn",
+      session_id: sessionId,
+      service_name: "kiro-cli",
+      cwd: "/tmp",
+      prompt: "test prompt",
+    });
+    await sendKiroHookEvent({
+      hook_event_name: "userPromptSubmit",
+      session_id: sessionId,
+      service_name: "kiro-cli",
+      cwd: "/tmp",
+      prompt: "test prompt",
+    });
+    await sendKiroHookEvent({
+      hook_event_name: "stop",
+      session_id: sessionId,
+      service_name: "kiro-cli",
+      cwd: "/tmp",
+      assistant_response: "test response",
+    });
+
+    // Check sessions list
+    const sessions = await fetch(`${API_BASE}/api/v1/otel/sessions`).then(
+      (r) => r.json(),
+    );
+    const kiroSession = sessions.find(
+      (s: Record<string, unknown>) => s.session_id === sessionId,
+    );
+    expect(kiroSession).toBeTruthy();
+    // 3 events total: sessionstart (hook), user_prompt (prompt), assistant_response (hook)
+    const totalEvents =
+      (kiroSession.hook_event_count ?? 0) + (kiroSession.prompt_count ?? 0);
+    expect(totalEvents).toBeGreaterThanOrEqual(3);
   });
 });

--- a/web/e2e/kiro-hooks.spec.ts
+++ b/web/e2e/kiro-hooks.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "@playwright/test";
+import { sendKiroHookEvent } from "./helpers";
+
+test.describe("Kiro Hook Event Ingestion", () => {
+  test("accepts PostToolUse hook event from Kiro", async () => {
+    const result = await sendKiroHookEvent({
+      hook_event_name: "PostToolUse",
+      session_id: `kiro-hook-${Date.now()}`,
+      tool_name: "Read",
+      tool_input: JSON.stringify({ file_path: "/tmp/test.txt" }),
+      tool_response: "file contents here",
+    });
+    expect(result.ingested).toBe(1);
+  });
+
+  test("accepts SessionStart hook event from Kiro", async () => {
+    const result = await sendKiroHookEvent({
+      hook_event_name: "SessionStart",
+      session_id: `kiro-session-${Date.now()}`,
+    });
+    expect(result.ingested).toBe(1);
+  });
+
+  test("accepts Kiro camelCase hook event names and normalizes them", async () => {
+    const result = await sendKiroHookEvent({
+      hook_event_name: "agentSpawn",
+      session_id: `kiro-camel-${Date.now()}`,
+    });
+    expect(result.ingested).toBe(1);
+  });
+
+  test("accepts Kiro camelCase field names and normalizes them", async () => {
+    const result = await sendKiroHookEvent({
+      hookEventName: "postToolUse",
+      sessionId: `kiro-camel-fields-${Date.now()}`,
+      toolName: "Bash",
+      toolInput: JSON.stringify({ command: "ls -la" }),
+      toolResponse: "total 0",
+    });
+    expect(result.ingested).toBe(1);
+  });
+
+  test("accepts PreToolUse hook event from Kiro", async () => {
+    const result = await sendKiroHookEvent({
+      hook_event_name: "PreToolUse",
+      session_id: `kiro-pretool-${Date.now()}`,
+      tool_name: "Bash",
+      tool_input: JSON.stringify({ command: "ls -la" }),
+    });
+    expect(result.ingested).toBe(1);
+  });
+
+  test("accepts SubagentStart hook event from Kiro", async () => {
+    const result = await sendKiroHookEvent({
+      hook_event_name: "SubagentStart",
+      session_id: `kiro-subagent-${Date.now()}`,
+      tool_name: "research-agent",
+    });
+    expect(result.ingested).toBe(1);
+  });
+
+  test("handles multiple hook events in sequence", async () => {
+    const sessionId = `kiro-multi-hook-${Date.now()}`;
+
+    const events = [
+      { hook_event_name: "SessionStart", session_id: sessionId },
+      {
+        hook_event_name: "PreToolUse",
+        session_id: sessionId,
+        tool_name: "Read",
+      },
+      {
+        hook_event_name: "PostToolUse",
+        session_id: sessionId,
+        tool_name: "Read",
+        tool_response: "file data",
+      },
+      {
+        hook_event_name: "PreToolUse",
+        session_id: sessionId,
+        tool_name: "Edit",
+      },
+      {
+        hook_event_name: "PostToolUse",
+        session_id: sessionId,
+        tool_name: "Edit",
+        tool_response: "edited",
+      },
+    ];
+
+    for (const event of events) {
+      const result = await sendKiroHookEvent(event);
+      expect(result.ingested).toBe(1);
+    }
+  });
+});

--- a/web/e2e/kiro-lifecycle.spec.ts
+++ b/web/e2e/kiro-lifecycle.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "@playwright/test";
+import {
+  loginToWebUI,
+  sendKiroOTLPLog,
+  sendKiroHookEvent,
+  buildKiroOTLPLogPayload,
+  API_BASE,
+  getApiKey,
+} from "./helpers";
+
+test.describe("Kiro Full Lifecycle E2E", () => {
+  const SESSION_ID = `kiro-lifecycle-${Date.now()}`;
+  const PROMPT_ID = crypto.randomUUID().replace(/-/g, "");
+
+  test("Step 1: Simulate a complete Kiro coding session", async () => {
+    // SessionStart hook
+    await sendKiroHookEvent({
+      hook_event_name: "SessionStart",
+      session_id: SESSION_ID,
+    });
+
+    // User prompt (OTLP log)
+    await sendKiroOTLPLog(
+      buildKiroOTLPLogPayload({
+        sessionId: SESSION_ID,
+        promptId: PROMPT_ID,
+        eventName: "user_prompt",
+        body: "Create a React component that shows a user profile card",
+        attributes: {
+          prompt: "Create a React component that shows a user profile card",
+        },
+      }),
+    );
+
+    // API request (OTLP log)
+    await sendKiroOTLPLog(
+      buildKiroOTLPLogPayload({
+        sessionId: SESSION_ID,
+        promptId: PROMPT_ID,
+        eventName: "api_request",
+        attributes: {
+          model: "anthropic.claude-sonnet-4-20250514",
+          input_tokens: "450",
+          output_tokens: "1200",
+          cache_read_tokens: "200",
+          duration_ms: "3500",
+        },
+      }),
+    );
+
+    // PreToolUse hook
+    await sendKiroHookEvent({
+      hook_event_name: "PreToolUse",
+      session_id: SESSION_ID,
+      tool_name: "Write",
+    });
+
+    // Tool result (OTLP log)
+    await sendKiroOTLPLog(
+      buildKiroOTLPLogPayload({
+        sessionId: SESSION_ID,
+        promptId: PROMPT_ID,
+        eventName: "tool_result",
+        body: "File written successfully",
+        attributes: {
+          tool_name: "Write",
+          success: "true",
+          duration_ms: "25",
+        },
+      }),
+    );
+
+    // PostToolUse hook
+    await sendKiroHookEvent({
+      hook_event_name: "PostToolUse",
+      session_id: SESSION_ID,
+      tool_name: "Write",
+      tool_response: "File written successfully",
+    });
+  });
+
+  test("Step 2: Verify Kiro session data via API", async () => {
+    // Wait for data to settle
+    await new Promise((r) => setTimeout(r, 3000));
+
+    const apiKey = await getApiKey();
+
+    // Check OTEL sessions
+    const sessions = await fetch(`${API_BASE}/api/v1/otel/sessions`, {
+      headers: { "X-API-Key": apiKey },
+    }).then((r) => r.json());
+
+    expect(sessions.length).toBeGreaterThan(0);
+  });
+
+  test("Step 3: Verify Kiro traces appear in Web UI", async ({ page }) => {
+    await loginToWebUI(page);
+
+    // Navigate to traces page
+    await page.goto("/traces");
+    await page.waitForLoadState("networkidle");
+
+    // Page should load without errors
+    await expect(page.locator("body")).not.toContainText("Something went wrong");
+
+    // Take a screenshot for visual verification
+    await page.screenshot({ path: "e2e-results/kiro-traces-page.png" });
+  });
+
+  test("Step 4: Verify dashboard reflects Kiro data", async ({ page }) => {
+    await loginToWebUI(page);
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("body")).not.toContainText("Something went wrong");
+    await page.screenshot({ path: "e2e-results/kiro-dashboard.png" });
+  });
+});

--- a/web/e2e/kiro-live.spec.ts
+++ b/web/e2e/kiro-live.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+import { getApiKey, API_BASE } from "./helpers";
+
+const KIRO_AVAILABLE = (() => {
+  try {
+    execSync("which kiro-cli 2>/dev/null", { encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+test.describe("Live Kiro CLI Sessions", () => {
+  test.skip(!KIRO_AVAILABLE, "Kiro CLI not installed — skipping live tests");
+
+  test("Kiro CLI version is accessible", () => {
+    const output = execSync("kiro-cli --version 2>&1", {
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    expect(output).toContain("kiro-cli");
+  });
+
+  test("Kiro telemetry check after session", async () => {
+    // After running a Kiro session, check if any telemetry arrived
+    const apiKey = await getApiKey();
+
+    const sessions = await fetch(`${API_BASE}/api/v1/otel/sessions`, {
+      headers: { "X-API-Key": apiKey },
+    }).then((r) => r.json());
+
+    // Look for any Kiro sessions
+    const kiroSessions = sessions.filter(
+      (s: Record<string, unknown>) =>
+        (s.service_name as string)?.toLowerCase().includes("kiro") ||
+        (s.terminal_type as string)?.toLowerCase().includes("kiro"),
+    );
+
+    // Informational — the test passes either way but logs the finding
+    console.log(`Found ${kiroSessions.length} Kiro sessions in Observal`);
+    if (kiroSessions.length > 0) {
+      console.log(
+        "First Kiro session:",
+        JSON.stringify(kiroSessions[0], null, 2),
+      );
+    }
+  });
+});

--- a/web/e2e/kiro-otlp-logs.spec.ts
+++ b/web/e2e/kiro-otlp-logs.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from "@playwright/test";
+import {
+  API_BASE,
+  getApiKey,
+  sendKiroOTLPLog,
+  buildKiroOTLPLogPayload,
+} from "./helpers";
+
+test.describe("Kiro OTLP Log Ingestion", () => {
+  test("ingests Kiro user_prompt log record", async () => {
+    const sessionId = `kiro-log-${Date.now()}`;
+    const promptId = crypto.randomUUID().replace(/-/g, "");
+
+    const payload = buildKiroOTLPLogPayload({
+      sessionId,
+      promptId,
+      eventName: "user_prompt",
+      body: "What files are in the current directory?",
+      attributes: { prompt: "What files are in the current directory?" },
+    });
+
+    const result = await sendKiroOTLPLog(payload);
+    expect(result.partialSuccess).toBeDefined();
+  });
+
+  test("ingests Kiro tool_result log record", async () => {
+    const sessionId = `kiro-log-${Date.now()}`;
+    const promptId = crypto.randomUUID().replace(/-/g, "");
+
+    const payload = buildKiroOTLPLogPayload({
+      sessionId,
+      promptId,
+      eventName: "tool_result",
+      body: "README.md\npackage.json\nsrc/",
+      attributes: {
+        tool_name: "list_files",
+        success: "true",
+        duration_ms: "42",
+      },
+    });
+
+    const result = await sendKiroOTLPLog(payload);
+    expect(result.partialSuccess).toBeDefined();
+  });
+
+  test("ingests Kiro api_request log record with token counts", async () => {
+    const sessionId = `kiro-log-${Date.now()}`;
+    const promptId = crypto.randomUUID().replace(/-/g, "");
+
+    const payload = buildKiroOTLPLogPayload({
+      sessionId,
+      promptId,
+      eventName: "api_request",
+      attributes: {
+        model: "anthropic.claude-sonnet-4-20250514",
+        input_tokens: "250",
+        output_tokens: "800",
+        cache_read_tokens: "100",
+        duration_ms: "1500",
+      },
+    });
+
+    const result = await sendKiroOTLPLog(payload);
+    expect(result.partialSuccess).toBeDefined();
+  });
+
+  test("groups multiple Kiro log records into a single trace by prompt_id", async () => {
+    const sessionId = `kiro-grouped-${Date.now()}`;
+    const promptId = crypto.randomUUID().replace(/-/g, "");
+
+    // Send user_prompt
+    await sendKiroOTLPLog(
+      buildKiroOTLPLogPayload({
+        sessionId,
+        promptId,
+        eventName: "user_prompt",
+        body: "Create a hello.txt file",
+        attributes: { prompt: "Create a hello.txt file" },
+      }),
+    );
+
+    // Send tool_result
+    await sendKiroOTLPLog(
+      buildKiroOTLPLogPayload({
+        sessionId,
+        promptId,
+        eventName: "tool_result",
+        body: "File created successfully",
+        attributes: {
+          tool_name: "write_file",
+          success: "true",
+          duration_ms: "15",
+        },
+      }),
+    );
+
+    // Send api_request
+    await sendKiroOTLPLog(
+      buildKiroOTLPLogPayload({
+        sessionId,
+        promptId,
+        eventName: "api_request",
+        attributes: {
+          model: "anthropic.claude-sonnet-4-20250514",
+          input_tokens: "100",
+          output_tokens: "50",
+        },
+      }),
+    );
+
+    // All three should be grouped under the same trace_id (= promptId)
+    await new Promise((r) => setTimeout(r, 2000));
+
+    const apiKey = await getApiKey();
+    const sessions = await fetch(`${API_BASE}/api/v1/otel/sessions`, {
+      headers: { "X-API-Key": apiKey },
+    }).then((r) => r.json());
+
+    // Verify at least one session exists (might be the one we just created)
+    expect(sessions.length).toBeGreaterThan(0);
+  });
+});

--- a/web/e2e/kiro-otlp-traces.spec.ts
+++ b/web/e2e/kiro-otlp-traces.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { sendKiroOTLPTrace, buildKiroOTLPTracePayload } from "./helpers";
+
+test.describe("Kiro OTLP Trace Ingestion", () => {
+  test("accepts Kiro OTLP trace payload and returns success", async () => {
+    const traceId = crypto.randomUUID().replace(/-/g, "");
+    const spanId = traceId.slice(0, 16);
+
+    const payload = buildKiroOTLPTracePayload({
+      traceId,
+      spanId,
+      sessionId: `kiro-test-${Date.now()}`,
+      spanName: "kiro.llm.chat",
+      model: "anthropic.claude-sonnet-4-20250514",
+      inputTokens: 150,
+      outputTokens: 300,
+    });
+
+    const result = await sendKiroOTLPTrace(payload);
+    expect(result.partialSuccess).toBeDefined();
+    expect(result.partialSuccess.rejectedSpans).toBeUndefined();
+  });
+
+  test("detects Kiro as the IDE from resource attributes", async () => {
+    const traceId = crypto.randomUUID().replace(/-/g, "");
+    const spanId = traceId.slice(0, 16);
+
+    const payload = buildKiroOTLPTracePayload({
+      traceId,
+      spanId,
+      sessionId: `kiro-ide-detect-${Date.now()}`,
+      spanName: "kiro.test.ide-detection",
+    });
+
+    const result = await sendKiroOTLPTrace(payload);
+    expect(result.partialSuccess).toBeDefined();
+    expect(result.partialSuccess.rejectedSpans).toBeUndefined();
+  });
+
+  test("extracts token counts from Kiro Bedrock-style attributes", async () => {
+    const traceId = crypto.randomUUID().replace(/-/g, "");
+    const spanId = traceId.slice(0, 16);
+
+    const payload = buildKiroOTLPTracePayload({
+      traceId,
+      spanId,
+      spanName: "bedrock.invoke",
+      model: "anthropic.claude-sonnet-4-20250514",
+      inputTokens: 500,
+      outputTokens: 1200,
+    });
+
+    const result = await sendKiroOTLPTrace(payload);
+    expect(result.partialSuccess).toBeDefined();
+    expect(result.partialSuccess.rejectedSpans).toBeUndefined();
+  });
+});

--- a/web/e2e/kiro-web-agents.spec.ts
+++ b/web/e2e/kiro-web-agents.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { loginToWebUI, API_BASE, getApiKey } from "./helpers";
+
+test.describe("Kiro Agent Compatibility in Web UI", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginToWebUI(page);
+  });
+
+  test("agents page loads and lists agents", async ({ page }) => {
+    await page.goto("/agents");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("body")).not.toContainText("Something went wrong");
+  });
+
+  test("agent detail page shows install options", async ({ page }) => {
+    // Get an agent ID from the API
+    const apiKey = await getApiKey();
+    const agents = await fetch(`${API_BASE}/api/v1/agents`, {
+      headers: { "X-API-Key": apiKey },
+    }).then((r) => r.json());
+
+    if (agents.length === 0) {
+      test.skip();
+      return;
+    }
+
+    const agentId = agents[0].id;
+    await page.goto(`/agents/${agentId}`);
+    await page.waitForLoadState("networkidle");
+
+    // The page should load
+    await expect(page.locator("body")).not.toContainText("Something went wrong");
+  });
+
+  test("components page loads and shows component types", async ({ page }) => {
+    await page.goto("/components");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("body")).not.toContainText("Something went wrong");
+  });
+});

--- a/web/e2e/kiro-web-traces.spec.ts
+++ b/web/e2e/kiro-web-traces.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+import {
+  loginToWebUI,
+  sendKiroOTLPLog,
+  buildKiroOTLPLogPayload,
+} from "./helpers";
+
+test.describe("Kiro Traces in Web UI", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginToWebUI(page);
+  });
+
+  test("Kiro session appears after sending OTLP telemetry", async ({
+    page,
+  }) => {
+    // Send some Kiro telemetry first
+    const sessionId = `kiro-web-test-${Date.now()}`;
+    const promptId = crypto.randomUUID().replace(/-/g, "");
+
+    await sendKiroOTLPLog(
+      buildKiroOTLPLogPayload({
+        sessionId,
+        promptId,
+        eventName: "user_prompt",
+        body: "Hello from Kiro E2E test",
+        attributes: { prompt: "Hello from Kiro E2E test" },
+      }),
+    );
+
+    await sendKiroOTLPLog(
+      buildKiroOTLPLogPayload({
+        sessionId,
+        promptId,
+        eventName: "api_request",
+        attributes: {
+          model: "anthropic.claude-sonnet-4-20250514",
+          input_tokens: "50",
+          output_tokens: "100",
+        },
+      }),
+    );
+
+    // Wait for ingestion
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // Navigate to traces page
+    await page.goto("/traces");
+    await page.waitForLoadState("networkidle");
+
+    // The traces page should load without errors
+    await expect(page.locator("body")).not.toContainText("Something went wrong");
+    await expect(page.locator("body")).not.toContainText("500");
+  });
+
+  test("Kiro trace detail page loads correctly", async ({ page }) => {
+    // Navigate to traces page and click on the first trace
+    await page.goto("/traces");
+    await page.waitForLoadState("networkidle");
+
+    // Check if there are any trace rows
+    const traceRows = page.locator("table tbody tr");
+    const count = await traceRows.count();
+
+    if (count > 0) {
+      // Click the first trace
+      await traceRows.first().click();
+      await page.waitForLoadState("networkidle");
+
+      // Verify the detail page loads
+      await expect(page.locator("body")).not.toContainText(
+        "Something went wrong",
+      );
+    }
+  });
+
+  test("dashboard page loads and shows stats", async ({ page }) => {
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // Dashboard should load without errors
+    await expect(page.locator("body")).not.toContainText("Something went wrong");
+
+    // Should show some kind of heading
+    const heading = page.locator("h1, h2").first();
+    await expect(heading).toBeVisible();
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "e2e": "playwright test",
+    "e2e:kiro": "playwright test --grep kiro",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.4",
@@ -56,6 +59,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  retries: 1,
+  use: {
+    baseURL: "http://localhost:3000",
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "pnpm dev",
+    port: 3000,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    { name: "chromium", use: { browserName: "chromium" } },
+  ],
+});

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 1.7.0(react@19.2.4)
       next:
         specifier: 16.2.2
-        version: 16.2.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.2(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -141,6 +141,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -587,6 +590,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2016,6 +2024,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -2549,6 +2562,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3374,6 +3397,10 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4941,6 +4968,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -5332,7 +5362,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.2(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.2
       '@swc/helpers': 0.5.15
@@ -5351,6 +5381,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.2
       '@next/swc-win32-arm64-msvc': 16.2.2
       '@next/swc-win32-x64-msvc': 16.2.2
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5445,6 +5476,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -1059,12 +1059,17 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
     let apiCalls = 0;
     let toolCalls = 0;
     let hookEvents = 0;
+    let credits = 0;
+    let isKiro = false;
     const models = new Set<string>();
     const tools: Record<string, number> = {};
 
     for (const evt of events) {
       const attrs = evt.attributes ?? {};
       const eName = getEventName(evt);
+      const svc = evt.service_name ?? "";
+
+      if (svc === "kiro-cli") isKiro = true;
 
       if (eName === "api_request") {
         apiCalls++;
@@ -1073,6 +1078,10 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
         if (attrs.cache_read_tokens) totalCacheRead += parseInt(attrs.cache_read_tokens, 10);
         if (attrs.model) models.add(attrs.model);
       }
+
+      // Kiro enriched stop events carry credits and model
+      if (attrs.credits) credits += parseFloat(attrs.credits) || 0;
+      if (attrs.model) models.add(attrs.model);
 
       if (eName === "tool_result") {
         toolCalls++;
@@ -1089,23 +1098,34 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
       }
     }
 
-    return { totalInputTokens, totalOutputTokens, totalCacheRead, apiCalls, toolCalls, hookEvents, models, tools };
+    return { totalInputTokens, totalOutputTokens, totalCacheRead, apiCalls, toolCalls, hookEvents, credits, isKiro, models, tools };
   }, [events]);
+
+  const formatCredits = (c: number) => c < 0.01 ? c.toFixed(4) : c.toFixed(2);
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
-      <div className="space-y-1">
-        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Input Tokens</p>
-        <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalInputTokens)}</p>
-      </div>
-      <div className="space-y-1">
-        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Output Tokens</p>
-        <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalOutputTokens)}</p>
-      </div>
-      <div className="space-y-1">
-        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Read</p>
-        <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheRead)}</p>
-      </div>
+      {stats.isKiro && stats.credits > 0 ? (
+        <div className="space-y-1">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Credits</p>
+          <p className="text-lg font-semibold tabular-nums text-orange-500">{formatCredits(stats.credits)}</p>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-1">
+            <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Input Tokens</p>
+            <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalInputTokens)}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Output Tokens</p>
+            <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalOutputTokens)}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Read</p>
+            <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheRead)}</p>
+          </div>
+        </>
+      )}
       <div className="space-y-1">
         <p className="text-[11px] text-muted-foreground uppercase tracking-wide">API Calls</p>
         <p className="text-lg font-semibold tabular-nums">{stats.apiCalls}</p>

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -37,6 +37,19 @@ interface SessionRow {
   model?: string;
   user_id?: string;
   terminal_type?: string;
+  credits?: string;
+  tools_used?: string;
+}
+
+function isKiroSession(row: SessionRow): boolean {
+  return row.service_name === "kiro-cli" || row.session_id.startsWith("kiro-");
+}
+
+function formatCredits(c: string | undefined): string {
+  if (!c) return "-";
+  const num = parseFloat(c);
+  if (isNaN(num)) return "-";
+  return num < 0.01 ? num.toFixed(4) : num.toFixed(2);
 }
 
 function formatTokens(n: number | string | undefined): string {
@@ -96,11 +109,20 @@ const columns: ColumnDef<SessionRow>[] = [
   {
     accessorKey: "total_input_tokens",
     header: "Tokens In",
-    cell: ({ row }) => (
-      <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-        {formatTokens(row.original.total_input_tokens)}
-      </span>
-    ),
+    cell: ({ row }) => {
+      if (isKiroSession(row.original)) {
+        return (
+          <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-orange-500" title="Kiro credits">
+            {formatCredits(row.original.credits)} cr
+          </span>
+        );
+      }
+      return (
+        <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
+          {formatTokens(row.original.total_input_tokens)}
+        </span>
+      );
+    },
   },
   {
     accessorKey: "api_request_count",
@@ -123,11 +145,21 @@ const columns: ColumnDef<SessionRow>[] = [
   {
     accessorKey: "total_output_tokens",
     header: "Tokens Out",
-    cell: ({ row }) => (
-      <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-        {formatTokens(row.original.total_output_tokens)}
-      </span>
-    ),
+    cell: ({ row }) => {
+      if (isKiroSession(row.original)) {
+        const tools = row.original.tools_used;
+        return (
+          <span className="text-xs text-muted-foreground truncate max-w-[120px]" title={tools}>
+            {tools || "-"}
+          </span>
+        );
+      }
+      return (
+        <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
+          {formatTokens(row.original.total_output_tokens)}
+        </span>
+      );
+    },
   },
   {
     accessorKey: "first_event_time",

--- a/web/src/components/traces/trace-list.tsx
+++ b/web/src/components/traces/trace-list.tsx
@@ -25,6 +25,32 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { QueryError } from "@/components/dashboard/query-error";
 import { ListTree } from "lucide-react";
 
+const IDE_BADGE_STYLES: Record<string, string> = {
+  claude_code: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  "claude-code": "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  kiro: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
+  "kiro-cli": "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
+  cursor: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400",
+  gemini_cli: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  "gemini-cli": "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  vscode: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  github_copilot: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  codex: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-400",
+};
+
+const IDE_LABELS: Record<string, string> = {
+  claude_code: "Claude Code",
+  "claude-code": "Claude Code",
+  kiro: "Kiro",
+  "kiro-cli": "Kiro CLI",
+  cursor: "Cursor",
+  gemini_cli: "Gemini CLI",
+  "gemini-cli": "Gemini CLI",
+  vscode: "VS Code",
+  github_copilot: "Copilot",
+  codex: "Codex",
+};
+
 const TRACE_TYPES = [
   "all",
   "mcp",
@@ -158,8 +184,19 @@ export function TraceList() {
                     <TableCell className="px-3 py-2 text-sm">
                       {(t.name ?? "—") as string}
                     </TableCell>
-                    <TableCell className="px-3 py-2 text-xs text-muted-foreground">
-                      {(t.ide ?? "—") as string}
+                    <TableCell className="px-3 py-2">
+                      {(() => {
+                        const ideVal = (t.ide ?? "") as string;
+                        const style = IDE_BADGE_STYLES[ideVal];
+                        const label = IDE_LABELS[ideVal] || ideVal || "—";
+                        return style ? (
+                          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${style}`}>
+                            {label}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">{label}</span>
+                        );
+                      })()}
                     </TableCell>
                     <TableCell className="px-3 py-2 text-xs text-muted-foreground">
                       {t.startTime || t.start_time


### PR DESCRIPTION
## Summary

- Adds `SecretsRedactor` service that strips API keys, tokens, passwords, PEM private keys, JWTs, and connection string credentials from trace data **before** ClickHouse storage
- Detects 15+ provider prefixes (OpenAI, Anthropic, Stripe, GitHub, AWS, Slack, GitLab, npm, HuggingFace, SendGrid, Google AI, etc.) with near-zero false positives
- Handles key=value assignments (`API_KEY=secret`), JSON (`"password": "secret"`), YAML, connection strings (`postgresql://user:pass@host`), and auth headers (`Authorization: Bearer ...`)
- **Does not over-strip**: preserves env var references (`$OPENAI_KEY`), code patterns (`os.environ["KEY"]`), key names without values, short values, file paths, and normal text
- Integrated at all 4 ingestion endpoints:
  - `POST /api/v1/otel/hooks` (Claude Code / Kiro CLI hooks)
  - `POST /v1/traces` (OTLP trace export)
  - `POST /v1/logs` (OTLP log export)
  - `POST /api/v1/telemetry/ingest` (authenticated SDK ingestion)

## Test plan

- [x] 48 unit tests covering all redaction layers and over-stripping prevention
- [ ] Verify with live hook ingestion that secrets in tool_input/tool_response are redacted in ClickHouse
- [ ] Verify normal trace content (code, prose, file paths) is not mangled
- [ ] Spot-check dashboard session detail view — redacted values show `**REDACTED**`