### PR TITLE
fix(frontend): preserve hook-sourced user_prompt events in dedup

### DIFF
--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -197,8 +197,14 @@ function deduplicateEvents(events: RawOtelEvent[]): RawOtelEvent[] {
   for (const evt of events) {
     const eName = getEventName(evt);
 
-    // Drop OTEL user_prompt when hooks have the richer version
-    if (eName === "user_prompt" && hasHooks) continue;
+    // Drop OTEL user_prompt when hooks have the richer version.
+    // But keep hook-sourced user_prompt events (they have hook_event attr
+    // or prompt_length — these were stored before the event name fix).
+    if (eName === "user_prompt" && hasHooks) {
+      const a = evt.attributes ?? {};
+      const isFromHook = a.hook_event || a.prompt_length || a.tool_name === "user_prompt";
+      if (!isFromHook) continue;
+    }
 
     // Drop OTEL tool_decision / tool_result — their metadata gets merged into hooks below
     if ((eName === "tool_decision" || eName === "tool_result") && hasHooks) continue;


### PR DESCRIPTION
## Summary

- The frontend event deduplicator was dropping **all** `user_prompt` events when hooks were present, including backward-compat events that originated from hooks (stored before the event name fix in #159)
- This caused session turns to be invisible in the detail view — metadata updated but no turn boundaries rendered
- Now checks for hook-origin markers (`hook_event`, `prompt_length`) before dropping, so both old and new event formats render correctly

Companion to #159 (backend fix, already merged).

## Test plan

- [ ] Open a session that has events stored with the old `user_prompt` name (pre-#159) — turns should still be visible
- [ ] Open a session with new `hook_userpromptsubmit` events — turns render correctly
- [ ] Verify no duplicate turns appear for sessions with both event name variants