### PR TITLE
fix: provide standard local dev defaults for .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # Required
-DATABASE_URL=postgresql+asyncpg://postgres:<your-password>@observal-db:5432/observal
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@observal-db:5432/observal
 CLICKHOUSE_URL=clickhouse://default:clickhouse@observal-clickhouse:8123/observal
 REDIS_URL=redis://observal-redis:6379
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=<your-password>
-SECRET_KEY=<generate-a-random-key>
+POSTGRES_PASSWORD=postgres
+# Generate with: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+SECRET_KEY=change-me-to-a-random-string
 
 # Optional: ClickHouse credentials
 CLICKHOUSE_USER=default

--- a/README.md
+++ b/README.md
@@ -374,8 +374,8 @@ All `{id}` parameters accept either a UUID or a name.
 | `DATABASE_URL` | Yes | | PostgreSQL connection string (asyncpg) |
 | `CLICKHOUSE_URL` | Yes | | ClickHouse connection string |
 | `POSTGRES_USER` | Yes | `postgres` | PostgreSQL user |
-| `POSTGRES_PASSWORD` | Yes | | PostgreSQL password |
-| `SECRET_KEY` | Yes | | Secret key for API key hashing |
+| `POSTGRES_PASSWORD` | Yes | `postgres` | PostgreSQL password |
+| `SECRET_KEY` | Yes | | Secret key for API key hashing. Generate with: `python3 -c "import secrets; print(secrets.token_urlsafe(32))"` |
 | `CLICKHOUSE_USER` | No | `default` | ClickHouse user |
 | `CLICKHOUSE_PASSWORD` | No | `clickhouse` | ClickHouse password |
 | `EVAL_MODEL_URL` | No | | OpenAI-compatible endpoint for the eval engine |

--- a/SETUP.md
+++ b/SETUP.md
@@ -76,8 +76,8 @@ You're ready to go. See the [README](README.md) for usage.
 | `DATABASE_URL` | Yes | | PostgreSQL connection string (e.g. `postgresql+asyncpg://postgres:secret@observal-db:5432/observal`) |
 | `CLICKHOUSE_URL` | Yes | | ClickHouse connection string (e.g. `clickhouse://default:clickhouse@observal-clickhouse:8123/observal`) |
 | `POSTGRES_USER` | Yes | `postgres` | PostgreSQL user |
-| `POSTGRES_PASSWORD` | Yes | | PostgreSQL password |
-| `SECRET_KEY` | Yes | | Secret key for API key hashing. Generate one with `openssl rand -hex 32` |
+| `POSTGRES_PASSWORD` | Yes | `postgres` | PostgreSQL password |
+| `SECRET_KEY` | Yes | | Secret key for API key hashing. Generate one with `python3 -c "import secrets; print(secrets.token_urlsafe(32))"` |
 | `CLICKHOUSE_USER` | No | `default` | ClickHouse user |
 | `CLICKHOUSE_PASSWORD` | No | `clickhouse` | ClickHouse password |
 | `EVAL_MODEL_URL` | No | | OpenAI-compatible endpoint for the eval engine |

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -5,7 +5,7 @@ class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/observal"
     CLICKHOUSE_URL: str = "clickhouse://localhost:8123/observal"
     REDIS_URL: str = "redis://localhost:6379"
-    SECRET_KEY: str = "change-me-in-production"
+    SECRET_KEY: str = "change-me-to-a-random-string"
     API_KEY_LENGTH: int = 32
     EVAL_MODEL_URL: str = ""  # OpenAI-compatible endpoint (e.g., https://bedrock-runtime.us-east-1.amazonaws.com)
     EVAL_MODEL_API_KEY: str = ""  # API key or empty for AWS credential chain


### PR DESCRIPTION
### Purpose
New users were hitting database auth errors on first run because `.env.example` had blank passwords.

### Fixes
Fixes #165

### Approach
Set `postgres` as the default password and synced the `DATABASE_URL`. Added a placeholder for `SECRET_KEY` with a quick generation command. Also updated `config.py` and the docs (`README.md` & `SETUP.md`) to keep everything consistent.

### How Has This Been Tested?
Copied the new `.env.example` to `.env` and ran `docker compose up -d` locally to verify the Postgres container starts perfectly without auth errors.

### Checklist
Please, go through these checks before submitting the PR.

- [x] All commits are signed off (`git commit -s`) per the DCO
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code