### PR TITLE
patch fix for observal auth login

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -38,7 +38,7 @@ def login(
 ):
     """Connect to Observal.
 
-    On a fresh server: auto-creates admin, no prompts needed.
+    On a fresh server: prompts for email, name, and password to create admin.
     With email+password: logs in with credentials.
     With an invite code: redeems it and creates your account.
     With --key: logs in with an API key.
@@ -61,12 +61,28 @@ def login(
 
     initialized = health_data.get("initialized", True)
 
-    # 2. Fresh server → auto-bootstrap admin
+    # 2. Fresh server → prompt for admin credentials and initialize
     if not initialized:
-        rprint("[green]Connected.[/green] No users yet — creating admin account.\n")
+        rprint("[green]Connected.[/green] No users yet — let's set up your admin account.\n")
+
+        admin_email = email or typer.prompt("Admin email")
+        admin_name = name or typer.prompt("Admin name", default="admin")
+        if password:
+            admin_password = password
+        else:
+            admin_password = typer.prompt("Admin password", hide_input=True)
+            confirm = typer.prompt("Confirm password", hide_input=True)
+            if admin_password != confirm:
+                rprint("[red]Passwords do not match.[/red]")
+                raise typer.Exit(1)
+
         try:
-            with spinner("Bootstrapping..."):
-                r = httpx.post(f"{server_url}/api/v1/auth/bootstrap", timeout=30)
+            with spinner("Creating admin account..."):
+                r = httpx.post(
+                    f"{server_url}/api/v1/auth/init",
+                    json={"email": admin_email, "name": admin_name, "password": admin_password},
+                    timeout=30,
+                )
                 r.raise_for_status()
                 data = r.json()
 
@@ -87,7 +103,7 @@ def login(
                 rprint("[yellow]Server was just initialized by someone else.[/yellow]")
                 _do_key_login(server_url, key)
             else:
-                rprint(f"[red]Bootstrap failed ({e.response.status_code}):[/red] {e.response.text}")
+                rprint(f"[red]Setup failed ({e.response.status_code}):[/red] {e.response.text}")
                 raise typer.Exit(1)
         return
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Forces 'observal auth login' to prompt user for admin credentials, allowing simpler login as admin for testing purposes

## Approach
The first run of 'observal auth login' called /api/v1/auth/bootstrap, which hardcoded admin@localhost without a password.
This replaces it with a pre-existing endpoint /api/v1/auth/init, which accepts user provided inputs for the email, name, and password fields. The CLI now prompts for these credentials and calls /init.

## How Has This Been Tested?
Run docker compose down -v and then docker compose up -d to get the containers emptied and started again, then run 'observal auth login'. It should prompt for the required fields, and the frontend http://localhost:3000 should allow login to admin account using the given credentials. Then attempted the same test after cloning into a new folder and following SETUP.md to test it from scratch. Same results are expected.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->