### PR TITLE
Fixed observal admin review list not showing submitted by name and tr…

### DIFF
--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -64,21 +64,35 @@ async def list_pending(
 
     models_to_query = {type: LISTING_MODELS[type]} if type and type in LISTING_MODELS else LISTING_MODELS
     items = []
+    user_ids = set()
     for listing_type, model in models_to_query.items():
         result = await db.execute(
             select(model).where(model.status == ListingStatus.pending).order_by(model.created_at.desc())
         )
         for r in result.scalars().all():
+            user_ids.add(r.submitted_by)
             items.append(
                 {
                     "type": listing_type,
                     "id": str(r.id),
                     "name": r.name,
                     "status": r.status.value,
-                    "submitted_by": str(r.submitted_by),
+                    "submitted_by": r.submitted_by,
                     "created_at": r.created_at.isoformat(),
                 }
             )
+
+    # Resolve user UUIDs to display names
+    user_map = {}
+    if user_ids:
+        result = await db.execute(select(User).where(User.id.in_(user_ids)))
+        for u in result.scalars().all():
+            user_map[u.id] = u.name or u.email
+
+    for item in items:
+        uid = item["submitted_by"]
+        item["submitted_by"] = user_map.get(uid, str(uid))
+
     return items
 
 

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -57,14 +57,14 @@ def review_list(output: str = typer.Option("table", "--output", "-o")):
     table.add_column("Name", style="bold")
     table.add_column("Submitted By")
     table.add_column("Status")
-    table.add_column("ID", style="dim", max_width=12)
+    table.add_column("ID", style="dim", no_wrap=True)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
             item.get("name", ""),
             item.get("submitted_by", ""),
             status_badge(item.get("status", "")),
-            str(item["id"])[:8] + "…",
+            str(item["id"]),
         )
     console.print(table)
 


### PR DESCRIPTION
## Purpose / Description
`observal admin review list` shows a raw UUID for the "Created by" column and truncates the Entry ID to 8 characters, making it unusable for copy-pasting into other commands.

## Fixes
* Fixes #166

## Approach
- **Backend (review.py):** After collecting pending review items, batch-query the Users table to resolve `submitted_by` UUIDs to human-readable names (falls back to email).
- **CLI (cmd_ops.py):** Remove `max_width=12` and `[:8]` truncation on the ID column so the full UUID is displayed.

## How Has This Been Tested?

1. Submitted a test MCP server to create a pending review
2. Ran `observal admin review list` before and after the fix
3. **Before:** Submitted By = `ad152368-5119-491f-9345-5f…`, ID = `4014ba87…`
4. **After:** Submitted By = `lokesh`, ID = `4014ba87-47b6-4b39-925f-c2f1bda70534`

## Learning (optional, can help others)
N/A

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
