### PR TITLE
Added 'observal uninstall' command in CLI

### DIFF
--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -161,3 +161,5 @@ def register_uninstall(app: typer.Typer):
             _uninstall_cli()
 
         rprint("\n[green]Observal has been uninstalled. Goodbye![/green]")
+        if repo_root:
+            rprint(f"\n[dim]Run [bold]cd {repo_root.parent}[/bold] to leave the deleted directory.[/dim]")

--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -1,0 +1,163 @@
+"""Observal uninstall command — tears down Docker stack, removes repo and config."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import typer
+from rich import print as rprint
+
+from observal_cli.config import CONFIG_DIR
+from observal_cli.render import spinner
+
+CONFIRMATION_PHRASE = "uninstall observal"
+
+
+def _find_repo_root(explicit_dir: str | None) -> Path | None:
+    """Locate the Observal repo root by looking for docker/docker-compose.yml."""
+    if explicit_dir:
+        candidate = Path(explicit_dir).resolve()
+        if (candidate / "docker" / "docker-compose.yml").exists():
+            return candidate
+        rprint(f"[red]No docker/docker-compose.yml found in {candidate}[/red]")
+        return None
+
+    # Check CWD and walk up parent directories
+    current = Path.cwd().resolve()
+    for directory in [current, *current.parents]:
+        if (directory / "docker" / "docker-compose.yml").exists():
+            return directory
+
+    rprint("[yellow]Could not detect Observal repo directory.[/yellow]")
+    rprint("[dim]Run from inside the repo or pass --repo-dir.[/dim]")
+    return None
+
+
+def _docker_teardown(repo_root: Path) -> bool:
+    """Run docker compose down -v to stop containers and remove volumes."""
+    docker_dir = repo_root / "docker"
+    try:
+        with spinner("Stopping containers and removing volumes..."):
+            result = subprocess.run(
+                ["docker", "compose", "down", "-v"],
+                cwd=docker_dir,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        if result.returncode == 0:
+            rprint("[green]\u2713 Docker containers and volumes removed.[/green]")
+            return True
+        else:
+            rprint(f"[red]Docker teardown failed:[/red] {result.stderr.strip()}")
+            return False
+    except FileNotFoundError:
+        rprint("[yellow]docker not found. Skipping container teardown.[/yellow]")
+        return False
+    except subprocess.TimeoutExpired:
+        rprint("[red]Docker teardown timed out.[/red]")
+        return False
+
+
+def _delete_directory(path: Path, label: str) -> bool:
+    """Remove a directory tree, handling errors gracefully."""
+    if not path.exists():
+        rprint(f"[dim]{label} not found at {path}, skipping.[/dim]")
+        return True
+    try:
+        shutil.rmtree(path)
+        rprint(f"[green]\u2713 Deleted {label}: {path}[/green]")
+        return True
+    except PermissionError:
+        rprint(f"[red]Permission denied deleting {label}: {path}[/red]")
+        return False
+    except OSError as exc:
+        rprint(f"[red]Failed to delete {label}: {exc}[/red]")
+        return False
+
+
+def _uninstall_cli() -> bool:
+    """Uninstall the CLI tool via uv."""
+    try:
+        with spinner("Uninstalling CLI tool..."):
+            result = subprocess.run(
+                ["uv", "tool", "uninstall", "observal-cli"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        if result.returncode == 0:
+            rprint("[green]\u2713 CLI tool uninstalled.[/green]")
+            return True
+        else:
+            rprint(f"[red]CLI uninstall failed:[/red] {result.stderr.strip()}")
+            return False
+    except FileNotFoundError:
+        rprint("[yellow]uv not found. Remove the CLI manually.[/yellow]")
+        return False
+
+
+def register_uninstall(app: typer.Typer):
+    """Register the root-level `observal uninstall` command."""
+
+    @app.command("uninstall")
+    def uninstall(
+        repo_dir: str | None = typer.Option(
+            None, "--repo-dir", "-d", help="Path to cloned Observal repo."
+        ),
+        keep_config: bool = typer.Option(
+            False, "--keep-config", help="Keep ~/.observal/ config directory."
+        ),
+        keep_cli: bool = typer.Option(
+            False, "--keep-cli", help="Keep the CLI tool installed."
+        ),
+    ):
+        """Completely uninstall Observal: stop containers, remove volumes, delete repo and config."""
+        repo_root = _find_repo_root(repo_dir)
+
+        # ── Show what will be removed ──────────────────────
+        rprint("\n[bold red]Observal Uninstall[/bold red]\n")
+        rprint("[bold]The following will be removed:[/bold]")
+        if repo_root:
+            rprint("  - Docker containers and volumes (via docker compose down -v)")
+            rprint(f"  - Repo directory: [bold]{repo_root}[/bold]")
+        else:
+            rprint("  - [dim]Repo directory: not detected (skipping Docker and repo cleanup)[/dim]")
+        if not keep_config:
+            rprint(f"  - Config directory: [bold]{CONFIG_DIR}[/bold]")
+        if not keep_cli:
+            rprint("  - CLI tool: observal-cli (via uv)")
+        rprint()
+
+        # ── Confirmation ───────────────────────────────────
+        rprint("[bold red]WARNING: This action is irreversible.[/bold red]")
+        rprint(f'Type [bold]"{CONFIRMATION_PHRASE}"[/bold] to confirm:\n')
+        user_input = typer.prompt("Confirm")
+        if user_input.strip().lower() != CONFIRMATION_PHRASE:
+            rprint("[yellow]Confirmation did not match. Aborting.[/yellow]")
+            raise typer.Exit(1)
+
+        rprint()
+
+        # ── Phase 1: Docker teardown ──────────────────────
+        if repo_root:
+            _docker_teardown(repo_root)
+
+        # ── Phase 2: Delete repo directory ────────────────
+        if repo_root:
+            # Move out of the repo dir before deleting it
+            os.chdir(Path.home())
+            _delete_directory(repo_root, "Observal repo")
+
+        # ── Phase 3: Delete config directory ──────────────
+        if not keep_config:
+            _delete_directory(CONFIG_DIR, "config directory (~/.observal)")
+
+        # ── Phase 4: Uninstall CLI ────────────────────────
+        if not keep_cli:
+            _uninstall_cli()
+
+        rprint("\n[green]Observal has been uninstalled. Goodbye![/green]")

--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -13,7 +13,7 @@ from rich import print as rprint
 from observal_cli.config import CONFIG_DIR
 from observal_cli.render import spinner
 
-CONFIRMATION_PHRASE = "uninstall observal"
+CONFIRMATION_PHRASE = "confirm"
 
 
 def _find_repo_root(explicit_dir: str | None) -> Path | None:
@@ -37,19 +37,19 @@ def _find_repo_root(explicit_dir: str | None) -> Path | None:
 
 
 def _docker_teardown(repo_root: Path) -> bool:
-    """Run docker compose down -v to stop containers and remove volumes."""
+    """Run docker compose down -v --rmi all to stop containers, remove volumes and images."""
     docker_dir = repo_root / "docker"
     try:
-        with spinner("Stopping containers and removing volumes..."):
+        with spinner("Stopping containers, removing volumes and images..."):
             result = subprocess.run(
-                ["docker", "compose", "down", "-v"],
+                ["docker", "compose", "down", "-v", "--rmi", "all"],
                 cwd=docker_dir,
                 capture_output=True,
                 text=True,
                 timeout=120,
             )
         if result.returncode == 0:
-            rprint("[green]\u2713 Docker containers and volumes removed.[/green]")
+            rprint("[green]\u2713 Docker containers, volumes, and images removed.[/green]")
             return True
         else:
             rprint(f"[red]Docker teardown failed:[/red] {result.stderr.strip()}")
@@ -148,8 +148,8 @@ def register_uninstall(app: typer.Typer):
 
         # ── Phase 2: Delete repo directory ────────────────
         if repo_root:
-            # Move out of the repo dir before deleting it
-            os.chdir(Path.home())
+            # Move to parent of repo dir before deleting it
+            os.chdir(repo_root.parent)
             _delete_directory(repo_root, "Observal repo")
 
         # ── Phase 3: Delete config directory ──────────────

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -56,6 +56,7 @@ from observal_cli.cmd_prompt import prompt_app
 from observal_cli.cmd_pull import register_pull
 from observal_cli.cmd_sandbox import sandbox_app
 from observal_cli.cmd_scan import register_scan
+from observal_cli.cmd_uninstall import register_uninstall
 from observal_cli.cmd_skill import skill_app
 
 # ═══════════════════════════════════════════════════════════
@@ -84,6 +85,7 @@ register_deprecated_auth(app)
 register_config(app)
 register_pull(app)
 register_scan(app)
+register_uninstall(app)
 register_use(app)
 
 # ── Subgroups ─────────────────────────────────────────────

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -84,7 +84,7 @@ def test_docker_down_called(mock_rmtree: MagicMock, mock_run: MagicMock, tmp_pat
     # Find the docker compose call
     docker_calls = [
         c for c in mock_run.call_args_list
-        if c.args and c.args[0] == ["docker", "compose", "down", "-v"]
+        if c.args and c.args[0] == ["docker", "compose", "down", "-v", "--rmi", "all"]
     ]
     assert len(docker_calls) == 1
     assert docker_calls[0].kwargs["cwd"] == repo / "docker"
@@ -258,7 +258,7 @@ def test_explicit_repo_dir_option(mock_rmtree: MagicMock, mock_run: MagicMock, t
     assert result.exit_code == 0
     docker_calls = [
         c for c in mock_run.call_args_list
-        if c.args and c.args[0] == ["docker", "compose", "down", "-v"]
+        if c.args and c.args[0] == ["docker", "compose", "down", "-v", "--rmi", "all"]
     ]
     assert len(docker_calls) == 1
     assert docker_calls[0].kwargs["cwd"] == repo / "docker"

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,299 @@
+"""Tests for the `observal uninstall` command."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from typer.testing import CliRunner
+
+from observal_cli.cmd_uninstall import CONFIRMATION_PHRASE
+from observal_cli.main import app as cli_app
+
+runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+# ── Confirmation tests ─────────────────────────────────────
+
+
+def test_aborts_on_wrong_confirmation(tmp_path: Path):
+    """Wrong confirmation phrase should abort."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    result = runner.invoke(
+        cli_app,
+        ["uninstall", "--repo-dir", str(repo)],
+        input="wrong phrase\n",
+    )
+    assert result.exit_code == 1
+    assert "did not match" in _plain(result.output).lower()
+
+
+def test_aborts_on_empty_confirmation(tmp_path: Path):
+    """Empty confirmation should abort."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    result = runner.invoke(
+        cli_app,
+        ["uninstall", "--repo-dir", str(repo)],
+        input="\n",
+    )
+    assert result.exit_code == 1
+    output = _plain(result.output).lower()
+    # Typer aborts on empty prompt input
+    assert "aborted" in output or "did not match" in output
+
+
+# ── Docker teardown tests ──────────────────────────────────
+
+
+@patch("observal_cli.cmd_uninstall.subprocess.run")
+@patch("observal_cli.cmd_uninstall.shutil.rmtree")
+def test_docker_down_called(mock_rmtree: MagicMock, mock_run: MagicMock, tmp_path: Path):
+    """docker compose down -v should be called with the correct cwd."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    result = runner.invoke(
+        cli_app,
+        ["uninstall", "--repo-dir", str(repo), "--keep-config", "--keep-cli"],
+        input=f"{CONFIRMATION_PHRASE}\n",
+    )
+    assert result.exit_code == 0
+
+    # Find the docker compose call
+    docker_calls = [
+        c for c in mock_run.call_args_list
+        if c.args and c.args[0] == ["docker", "compose", "down", "-v"]
+    ]
+    assert len(docker_calls) == 1
+    assert docker_calls[0].kwargs["cwd"] == repo / "docker"
+
+
+@patch("observal_cli.cmd_uninstall.subprocess.run", side_effect=FileNotFoundError)
+@patch("observal_cli.cmd_uninstall.shutil.rmtree")
+def test_docker_failure_continues(mock_rmtree: MagicMock, mock_run: MagicMock, tmp_path: Path):
+    """Docker failure should not abort the rest of the uninstall."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    result = runner.invoke(
+        cli_app,
+        ["uninstall", "--repo-dir", str(repo), "--keep-config", "--keep-cli"],
+        input=f"{CONFIRMATION_PHRASE}\n",
+    )
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "docker not found" in output.lower()
+    assert "uninstalled" in output.lower()
+
+
+# ── Directory deletion tests ───────────────────────────────
+
+
+@patch("observal_cli.cmd_uninstall.subprocess.run")
+@patch("observal_cli.cmd_uninstall.shutil.rmtree")
+def test_repo_directory_deleted(mock_rmtree: MagicMock, mock_run: MagicMock, tmp_path: Path):
+    """Repo directory should be deleted after docker teardown."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    result = runner.invoke(
+        cli_app,
+        ["uninstall", "--repo-dir", str(repo), "--keep-config", "--keep-cli"],
+        input=f"{CONFIRMATION_PHRASE}\n",
+    )
+    assert result.exit_code == 0
+    # rmtree should have been called with the repo path
+    rmtree_paths = [str(c.args[0]) for c in mock_rmtree.call_args_list]
+    assert str(repo) in rmtree_paths
+
+
+@patch("observal_cli.cmd_uninstall.subprocess.run")
+@patch("observal_cli.cmd_uninstall.shutil.rmtree")
+@patch("observal_cli.cmd_uninstall.CONFIG_DIR", new_callable=lambda: property(lambda self: None))
+def test_config_directory_deleted(mock_config_dir, mock_rmtree: MagicMock, mock_run: MagicMock, tmp_path: Path):
+    """~/.observal/ config should be deleted by default."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    fake_config = tmp_path / ".observal"
+    fake_config.mkdir()
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("observal_cli.cmd_uninstall.CONFIG_DIR", fake_config):
+        result = runner.invoke(
+            cli_app,
+            ["uninstall", "--repo-dir", str(repo), "--keep-cli"],
+            input=f"{CONFIRMATION_PHRASE}\n",
+        )
+    assert result.exit_code == 0
+    rmtree_paths = [str(c.args[0]) for c in mock_rmtree.call_args_list]
+    assert str(fake_config) in rmtree_paths
+
+
+@patch("observal_cli.cmd_uninstall.subprocess.run")
+@patch("observal_cli.cmd_uninstall.shutil.rmtree")
+def test_keep_config_flag(mock_rmtree: MagicMock, mock_run: MagicMock, tmp_path: Path):
+    """--keep-config should skip config directory deletion."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("observal_cli.cmd_uninstall.CONFIG_DIR", tmp_path / ".observal"):
+        result = runner.invoke(
+            cli_app,
+            ["uninstall", "--repo-dir", str(repo), "--keep-config", "--keep-cli"],
+            input=f"{CONFIRMATION_PHRASE}\n",
+        )
+    assert result.exit_code == 0
+    # rmtree should only be called for the repo, not config
+    rmtree_paths = [str(c.args[0]) for c in mock_rmtree.call_args_list]
+    assert str(tmp_path / ".observal") not in rmtree_paths
+
+
+# ── CLI uninstall tests ────────────────────────────────────
+
+
+@patch("observal_cli.cmd_uninstall.subprocess.run")
+@patch("observal_cli.cmd_uninstall.shutil.rmtree")
+def test_cli_uninstall_called(mock_rmtree: MagicMock, mock_run: MagicMock, tmp_path: Path):
+    """uv tool uninstall should be called when --keep-cli is not set."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("observal_cli.cmd_uninstall.CONFIG_DIR", tmp_path / ".observal"):
+        result = runner.invoke(
+            cli_app,
+            ["uninstall", "--repo-dir", str(repo), "--keep-config"],
+            input=f"{CONFIRMATION_PHRASE}\n",
+        )
+    assert result.exit_code == 0
+    uv_calls = [
+        c for c in mock_run.call_args_list
+        if c.args and c.args[0] == ["uv", "tool", "uninstall", "observal-cli"]
+    ]
+    assert len(uv_calls) == 1
+
+
+@patch("observal_cli.cmd_uninstall.subprocess.run")
+@patch("observal_cli.cmd_uninstall.shutil.rmtree")
+def test_keep_cli_flag(mock_rmtree: MagicMock, mock_run: MagicMock, tmp_path: Path):
+    """--keep-cli should skip CLI uninstall."""
+    repo = tmp_path / "Observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    result = runner.invoke(
+        cli_app,
+        ["uninstall", "--repo-dir", str(repo), "--keep-config", "--keep-cli"],
+        input=f"{CONFIRMATION_PHRASE}\n",
+    )
+    assert result.exit_code == 0
+    uv_calls = [
+        c for c in mock_run.call_args_list
+        if c.args and c.args[0] == ["uv", "tool", "uninstall", "observal-cli"]
+    ]
+    assert len(uv_calls) == 0
+
+
+# ── Repo detection tests ──────────────────────────────────
+
+
+@patch("observal_cli.cmd_uninstall.subprocess.run")
+@patch("observal_cli.cmd_uninstall.shutil.rmtree")
+def test_explicit_repo_dir_option(mock_rmtree: MagicMock, mock_run: MagicMock, tmp_path: Path):
+    """--repo-dir should be used directly when provided."""
+    repo = tmp_path / "my-observal"
+    repo.mkdir()
+    (repo / "docker").mkdir()
+    (repo / "docker" / "docker-compose.yml").write_text("services:")
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    result = runner.invoke(
+        cli_app,
+        ["uninstall", "--repo-dir", str(repo), "--keep-config", "--keep-cli"],
+        input=f"{CONFIRMATION_PHRASE}\n",
+    )
+    assert result.exit_code == 0
+    docker_calls = [
+        c for c in mock_run.call_args_list
+        if c.args and c.args[0] == ["docker", "compose", "down", "-v"]
+    ]
+    assert len(docker_calls) == 1
+    assert docker_calls[0].kwargs["cwd"] == repo / "docker"
+
+
+def test_repo_not_found_continues(tmp_path: Path):
+    """When repo dir cannot be detected, command still proceeds with config/cli cleanup."""
+    with (
+        patch("observal_cli.cmd_uninstall.subprocess.run") as mock_run,
+        patch("observal_cli.cmd_uninstall.shutil.rmtree"),
+        patch("observal_cli.cmd_uninstall.Path.cwd", return_value=tmp_path),
+        patch("observal_cli.cmd_uninstall.CONFIG_DIR", tmp_path / ".observal"),
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = runner.invoke(
+            cli_app,
+            ["uninstall", "--keep-config"],
+            input=f"{CONFIRMATION_PHRASE}\n",
+        )
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "not detected" in output.lower()
+    assert "uninstalled" in output.lower()
+
+
+# ── Help text test ─────────────────────────────────────────
+
+
+def test_help_shows_uninstall():
+    """observal uninstall --help should show the command description."""
+    result = runner.invoke(cli_app, ["uninstall", "--help"])
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "uninstall" in output.lower()
+    assert "--repo-dir" in output
+    assert "--keep-config" in output
+    assert "--keep-cli" in output


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Required a feature to add CLI command 'observal uninstall' to remove docker volumes and images, delete the directory, clear the config, and uninstall the CLI

## Fixes
* Fixes #170

## Approach
Added /observal_cli.cmd_uninstall.py with 'observal uninstall' command, with --keep-config and --keep-cli flags to keep config file and/or CLI.
This runs docker compose down -v --rmi all to remove volumes and images.
Uses shutil.rmtree to delete the directory.
Runs uv tool uninstall and removes config file depending on command flags.
Requests confirmation of uninstalling with message "confirm".

 
## How Has This Been Tested?

Tested flags one by one, expects the flagged unit to be absent from the tentative deletion list that shows up.
Create fake/temp clone and expect full deletion

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->