### PR TITLE
feat: support short prefix ID matching for review and eval commands (#167)

### DIFF
--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator
 from functools import wraps
 
 from fastapi import Depends, Header, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, cast, String
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import async_session
@@ -65,3 +65,61 @@ async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_s
         stmt = stmt.where(model.status == require_status)
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
+
+async def resolve_prefix_id(
+    model,
+    identifier: str,
+    db: AsyncSession,
+    *,
+    extra_conditions=None,
+    load_options=None,
+    display_field: str = "name",
+):
+    """Find a record by UUID or unique prefix."""
+    norm_id = identifier.strip().lower()
+
+    try:
+        uid = _uuid.UUID(norm_id)
+        stmt = select(model).where(model.id == uid)
+        if load_options:
+            stmt = stmt.options(*load_options)
+        if extra_conditions:
+            stmt = stmt.where(*extra_conditions)
+        result = await db.execute(stmt)
+        record = result.scalar_one_or_none()
+        if not record:
+            raise HTTPException(status_code=404, detail=f"{model.__name__} not found")
+        return record
+    except ValueError:
+        pass
+
+    if len(norm_id) < 4:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Prefix '{norm_id}' is too short (minimum 4 characters required)",
+        )
+
+    stmt = select(model).where(cast(model.id, String).like(f"{norm_id}%"))
+    if load_options:
+        stmt = stmt.options(*load_options)
+    if extra_conditions:
+        stmt = stmt.where(*extra_conditions)
+    result = await db.execute(stmt)
+    records = result.scalars().all()
+
+    if not records:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No {model.__name__} found matching prefix '{norm_id}'",
+        )
+    if len(records) == 1:
+        return records[0]
+
+    matches = []
+    for r in records[:5]:
+        label = getattr(r, display_field, None) or "unnamed"
+        matches.append(f"{label} ({str(r.id)[:13]}...)")
+    detail = f"Ambiguous prefix '{norm_id}' matches {len(records)} records: {', '.join(matches)}"
+    if len(records) > 5:
+        detail += " and more..."
+    raise HTTPException(status_code=400, detail=detail)

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -1,6 +1,8 @@
 import hashlib
+import uuid as _uuid
 from collections.abc import AsyncGenerator
 from functools import wraps
+
 
 from fastapi import Depends, Header, HTTPException
 from sqlalchemy import select, cast, String
@@ -51,7 +53,6 @@ def require_role(*roles: UserRole):
 
 async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_status=None):
     """Resolve a listing by UUID or name."""
-    import uuid as _uuid
 
     if isinstance(identifier, _uuid.UUID):
         stmt = select(model).where(model.id == identifier)

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -6,7 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, resolve_prefix_id
 from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus
 from models.agent_component import AgentComponent
 from models.download import AgentDownloadRecord
@@ -38,20 +38,20 @@ _agent_load_options = [
 ]
 
 
-def _agent_id_clause(agent_id: str):
-    if isinstance(agent_id, _uuid.UUID):
-        return Agent.id == agent_id
+async def _load_agent(db: AsyncSession, agent_id: str, extra_conditions=None) -> Agent | None:
+    """Load an agent by UUID, prefix, or name with eager loading."""
     try:
-        uid = _uuid.UUID(agent_id)
-        return Agent.id == uid
-    except ValueError:
-        return Agent.name == agent_id
-
-
-async def _load_agent(db: AsyncSession, *where_clauses) -> Agent | None:
-    stmt = select(Agent).where(*where_clauses).options(*_agent_load_options)
-    result = await db.execute(stmt)
-    return result.scalar_one_or_none()
+        return await resolve_prefix_id(
+            Agent, agent_id, db, load_options=_agent_load_options, extra_conditions=extra_conditions
+        )
+    except HTTPException as e:
+        if e.status_code == 400:
+            raise e
+        stmt = select(Agent).where(Agent.name == agent_id).options(*_agent_load_options)
+        if extra_conditions:
+            stmt = stmt.where(*extra_conditions)
+        result = await db.execute(stmt)
+        return result.scalar_one_or_none()
 
 
 def _agent_to_response(agent: Agent, name_map: dict[str, str] | None = None) -> AgentResponse:
@@ -270,7 +270,7 @@ async def list_agents(
 
 @router.get("/{agent_id}", response_model=AgentResponse)
 async def get_agent(agent_id: str, db: AsyncSession = Depends(get_db)):
-    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     name_map = await _resolve_component_names(agent.components, db)
@@ -284,7 +284,7 @@ async def update_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.created_by != current_user.id:
@@ -411,9 +411,9 @@ async def install_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    agent = await _load_agent(db, _agent_id_clause(agent_id), Agent.status == AgentStatus.active)
+    agent = await _load_agent(db, agent_id, extra_conditions=[Agent.status == AgentStatus.active])
     if not agent:
-        agent = await _load_agent(db, _agent_id_clause(agent_id))
+        agent = await _load_agent(db, agent_id)
         if not agent or agent.created_by != current_user.id:
             raise HTTPException(status_code=404, detail="Agent not found or not active")
 
@@ -450,7 +450,7 @@ async def agent_download_stats(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
 ):
-    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     from services.download_tracker import get_download_stats
@@ -467,7 +467,7 @@ async def get_agent_traces(
     db: AsyncSession = Depends(get_db),
 ):
     """Return all traces where this agent participated."""
-    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     from services.clickhouse import query_traces
@@ -488,7 +488,7 @@ async def resolve_agent_components(
     current_user: User = Depends(get_current_user),
 ):
     """Resolve all components for an agent — validates they exist and are approved."""
-    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     from services.agent_resolver import resolve_agent
@@ -506,7 +506,7 @@ async def get_agent_manifest(
     current_user: User = Depends(get_current_user),
 ):
     """Generate a portable agent manifest with all resolved components."""
-    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     from services.agent_resolver import resolve_agent
@@ -565,7 +565,7 @@ async def delete_agent(
     from models.eval import EvalRun, Scorecard
     from models.feedback import Feedback
 
-    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.created_by != current_user.id and current_user.role.value != "admin":

--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, resolve_prefix_id
 from models.agent import Agent, AgentGoalTemplate
 from models.eval import EvalRun, EvalRunStatus, Scorecard
 from models.user import User
@@ -30,20 +30,20 @@ _eval_run_load = [selectinload(EvalRun.scorecards).selectinload(Scorecard.dimens
 
 @router.post("/agents/{agent_id}", response_model=EvalRunDetailResponse)
 async def run_evaluation(
-    agent_id: uuid.UUID,
+    agent_id: str,
     req: EvalRequest | None = None,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     # Load agent with goal template
-    result = await db.execute(
-        select(Agent)
-        .where(Agent.id == agent_id)
-        .options(selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections))
+    agent = await resolve_prefix_id(
+        Agent,
+        agent_id,
+        db,
+        load_options=[
+            selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections)
+        ],
     )
-    agent = result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
 
     # Create eval run
     eval_run = EvalRun(agent_id=agent.id, triggered_by=current_user.id)
@@ -101,22 +101,24 @@ async def run_evaluation(
 
 @router.get("/agents/{agent_id}/runs", response_model=list[EvalRunResponse])
 async def list_eval_runs(
-    agent_id: uuid.UUID,
+    agent_id: str,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    result = await db.execute(select(EvalRun).where(EvalRun.agent_id == agent_id).order_by(EvalRun.started_at.desc()))
+    agent = await resolve_prefix_id(Agent, agent_id, db)
+    result = await db.execute(select(EvalRun).where(EvalRun.agent_id == agent.id).order_by(EvalRun.started_at.desc()))
     return [EvalRunResponse.model_validate(r) for r in result.scalars().all()]
 
 
 @router.get("/agents/{agent_id}/scorecards", response_model=list[ScorecardResponse])
 async def list_scorecards(
-    agent_id: uuid.UUID,
+    agent_id: str,
     version: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    stmt = select(Scorecard).where(Scorecard.agent_id == agent_id).options(*_scorecard_load)
+    agent = await resolve_prefix_id(Agent, agent_id, db)
+    stmt = select(Scorecard).where(Scorecard.agent_id == agent.id).options(*_scorecard_load)
     if version:
         stmt = stmt.where(Scorecard.version == version)
     result = await db.execute(stmt.order_by(Scorecard.evaluated_at.desc()).limit(50))
@@ -125,20 +127,19 @@ async def list_scorecards(
 
 @router.get("/scorecards/{scorecard_id}", response_model=ScorecardResponse)
 async def get_scorecard(
-    scorecard_id: uuid.UUID,
+    scorecard_id: str,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    result = await db.execute(select(Scorecard).where(Scorecard.id == scorecard_id).options(*_scorecard_load))
-    sc = result.scalar_one_or_none()
-    if not sc:
-        raise HTTPException(status_code=404, detail="Scorecard not found")
+    sc = await resolve_prefix_id(
+        Scorecard, scorecard_id, db, load_options=_scorecard_load, display_field="version"
+    )
     return ScorecardResponse.model_validate(sc)
 
 
 @router.get("/agents/{agent_id}/compare", response_model=dict)
 async def compare_versions(
-    agent_id: uuid.UUID,
+    agent_id: str,
     version_a: str = Query(...),
     version_b: str = Query(...),
     db: AsyncSession = Depends(get_db),
@@ -146,13 +147,13 @@ async def compare_versions(
 ):
     """Compare average scores between two agent versions."""
     from sqlalchemy import func
-
+    agent = await resolve_prefix_id(Agent, agent_id, db)
     async def _avg_scores(version: str) -> dict:
         result = await db.execute(
             select(
                 func.avg(Scorecard.overall_score).label("avg_overall"),
                 func.count(Scorecard.id).label("count"),
-            ).where(Scorecard.agent_id == agent_id, Scorecard.version == version)
+            ).where(Scorecard.agent_id == agent.id, Scorecard.version == version)
         )
         row = result.one()
         return {"version": version, "avg_score": round(float(row.avg_overall or 0), 2), "count": row.count}
@@ -168,7 +169,7 @@ async def compare_versions(
 @router.post("/sessions/{session_id}", response_model=dict)
 async def eval_session(
     session_id: str,
-    agent_id: uuid.UUID | None = Query(None),
+    agent_id: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -183,12 +184,14 @@ async def eval_session(
 
     agent = None
     if agent_id:
-        result = await db.execute(
-            select(Agent)
-            .where(Agent.id == agent_id)
-            .options(selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections))
+        agent = await resolve_prefix_id(
+            Agent,
+            agent_id,
+            db,
+            load_options=[
+                selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections)
+            ],
         )
-        agent = result.scalar_one_or_none()
 
     if agent:
         eval_run = EvalRun(agent_id=agent.id, triggered_by=current_user.id)
@@ -247,9 +250,8 @@ async def eval_agent_in_session(
     - SLM scoring with full session context + delegation prompt as goal
     """
     # Load agent from DB (by UUID or name)
-    from api.routes.agent import _agent_id_clause, _load_agent
-
-    agent = await _load_agent(db, _agent_id_clause(agent_id))
+    from api.routes.agent import _load_agent
+    agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -347,15 +349,16 @@ async def eval_agent_in_session(
 
 @router.get("/agents/{agent_id}/aggregate", response_model=dict)
 async def agent_aggregate(
-    agent_id: uuid.UUID,
+    agent_id: str,
     window_size: int = Query(50, ge=1, le=500),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """Get aggregate scoring stats for an agent (CI, drift, dimension breakdown)."""
+    agent = await resolve_prefix_id(Agent, agent_id, db)
     result = await db.execute(
         select(Scorecard)
-        .where(Scorecard.agent_id == agent_id)
+        .where(Scorecard.agent_id == agent.id)
         .order_by(Scorecard.evaluated_at.desc())
         .limit(window_size + 50)  # extra for baseline
     )
@@ -374,15 +377,12 @@ async def agent_aggregate(
 
 @router.get("/scorecards/{scorecard_id}/penalties", response_model=list[dict])
 async def scorecard_penalties(
-    scorecard_id: uuid.UUID,
+    scorecard_id: str,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """Get the list of penalties applied to a scorecard with evidence."""
-    result = await db.execute(select(Scorecard).where(Scorecard.id == scorecard_id))
-    sc = result.scalar_one_or_none()
-    if not sc:
-        raise HTTPException(status_code=404, detail="Scorecard not found")
+    sc = await resolve_prefix_id(Scorecard, scorecard_id, db, display_field="version")
 
     # Penalties are stored in raw_output
     raw = sc.raw_output or {}

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, resolve_prefix_id
 from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
 from models.prompt import PromptListing
@@ -28,29 +28,33 @@ def _require_admin(user: User):
 
 
 async def _find_listing(listing_id: str, db: AsyncSession):
-    """Try each listing model to find the listing by id or name."""
-    import uuid as _uuid
-
-    if isinstance(listing_id, _uuid.UUID):
-
-        def clause_fn(model):
-            return model.id == listing_id
-    else:
-        try:
-            uid = _uuid.UUID(listing_id)
-
-            def clause_fn(model):
-                return model.id == uid
-        except ValueError:
-
-            def clause_fn(model):
-                return model.name == listing_id
-
+    """Find a listing by ID, prefix, or name across all component types."""
+    hits = []
     for listing_type, model in LISTING_MODELS.items():
-        result = await db.execute(select(model).where(clause_fn(model)))
+        try:
+            listing = await resolve_prefix_id(model, listing_id, db)
+            hits.append((listing_type, listing))
+        except HTTPException as e:
+            if e.status_code == 400:
+                raise e
+            continue
+
+    if len(hits) == 1:
+        return hits[0]
+    if len(hits) > 1:
+        types = [h[0] for h in hits]
+        raise HTTPException(
+            status_code=400,
+            detail=f"Prefix '{listing_id}' matches records across multiple types: {', '.join(types)}",
+        )
+
+    # Fallback: name-based lookup
+    for listing_type, model in LISTING_MODELS.items():
+        result = await db.execute(select(model).where(model.name == listing_id))
         listing = result.scalar_one_or_none()
         if listing:
             return listing_type, listing
+
     return None, None
 
 


### PR DESCRIPTION
## Summary
Allows users to use short ID prefixes instead of full UUIDs, similar to `git` short SHAs.

```bash
# Before
observal admin review show 8a3f29b1-4c7e-4d2a-9f1b-abc123def456

# After
observal admin review show 8a3f
```

## Changes

**`api/deps.py`** — Added `resolve_prefix_id` helper:
- Normalizes input, tries exact UUID first, then prefix match via `cast(model.id, String).like(...)`
- Rejects prefixes shorter than 4 chars
- Returns 400 with match list if prefix is ambiguous
- Supports `extra_conditions` and `load_options` for route-specific needs

**`api/routes/review.py`** — Updated `_find_listing` to use the helper across all 5 component models with cross-model ambiguity detection.

**`api/routes/eval.py`** — Changed path params from `uuid.UUID` to `str`, all lookups use the helper.

**`api/routes/agent.py`** — Replaced `_agent_id_clause` with `_load_agent` which resolves by UUID, prefix, or name with eager loading.

**CLI** — No changes required. All ID arguments were already typed as `str` and pass through correctly.

## Behavior
- Unique prefix → resolves to matching record
- Ambiguous prefix → 400 error listing up to 5 matches
- Prefix < 4 chars → 400 error
- Full UUIDs → continue to work unchanged
- Name-based lookups → continue to work unchanged