### PR TITLE
fix: ECONNREFUSED hook errors + empty span display (#236, #219)

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -543,12 +543,11 @@ def register_config(app: typer.Typer):
     app.add_typer(config_app, name="config")
 
 
-def _find_stop_hook_script() -> str | None:
-    """Locate the observal-stop-hook.sh script."""
-    # Check common locations
+def _find_hook_script(name: str) -> str | None:
+    """Locate a hook script by filename."""
     candidates = [
-        Path(__file__).parent / "hooks" / "observal-stop-hook.sh",
-        Path(shutil.which("observal-stop-hook.sh") or ""),
+        Path(__file__).parent / "hooks" / name,
+        Path(shutil.which(name) or ""),
     ]
     for p in candidates:
         if p.is_file():
@@ -602,37 +601,44 @@ def _configure_claude_code(server_url: str, api_key: str):
         settings["env"].update(otel_env)
 
         # ── Inject hooks for full content capture (prompts, tool I/O, MCP, agents) ──
+        # Use command hooks instead of HTTP hooks so that ECONNREFUSED errors
+        # don't flood the LLM when the Observal server is offline (#236).
         hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
-        hook_def: dict = {"type": "http", "url": hooks_url}
-        # Inject Observal user identity via header so the server can attribute sessions
-        cfg = config.load()
-        if cfg.get("user_id"):
-            hook_def["headers"] = {"X-Observal-User-Id": cfg["user_id"]}
-        http_hook = [{"hooks": [hook_def]}]
 
-        # Stop uses a command hook to read the transcript for Claude's response text
-        stop_script = _find_stop_hook_script()
-        stop_hook = [{"hooks": [{"type": "command", "command": stop_script}]}] if stop_script else http_hook
+        hook_script = _find_hook_script("observal-hook.sh")
+        stop_script = _find_hook_script("observal-stop-hook.sh")
+
+        if hook_script:
+            cmd_hook = [{"hooks": [{"type": "command", "command": hook_script}]}]
+        else:
+            # Fallback to HTTP if the script isn't found
+            hook_def: dict = {"type": "http", "url": hooks_url}
+            cfg = config.load()
+            if cfg.get("user_id"):
+                hook_def["headers"] = {"X-Observal-User-Id": cfg["user_id"]}
+            cmd_hook = [{"hooks": [hook_def]}]
+
+        stop_hook = [{"hooks": [{"type": "command", "command": stop_script}]}] if stop_script else cmd_hook
 
         settings["hooks"] = {
-            "SessionStart": http_hook,
-            "UserPromptSubmit": http_hook,
-            "PreToolUse": http_hook,
-            "PostToolUse": http_hook,
-            "PostToolUseFailure": http_hook,
-            "SubagentStart": http_hook,
-            "SubagentStop": http_hook,
+            "SessionStart": cmd_hook,
+            "UserPromptSubmit": cmd_hook,
+            "PreToolUse": cmd_hook,
+            "PostToolUse": cmd_hook,
+            "PostToolUseFailure": cmd_hook,
+            "SubagentStart": cmd_hook,
+            "SubagentStop": cmd_hook,
             "Stop": stop_hook,
-            "StopFailure": http_hook,
-            "Notification": http_hook,
-            "TaskCreated": http_hook,
-            "TaskCompleted": http_hook,
-            "PreCompact": http_hook,
-            "PostCompact": http_hook,
-            "WorktreeCreate": http_hook,
-            "WorktreeRemove": http_hook,
-            "Elicitation": http_hook,
-            "ElicitationResult": http_hook,
+            "StopFailure": cmd_hook,
+            "Notification": cmd_hook,
+            "TaskCreated": cmd_hook,
+            "TaskCompleted": cmd_hook,
+            "PreCompact": cmd_hook,
+            "PostCompact": cmd_hook,
+            "WorktreeCreate": cmd_hook,
+            "WorktreeRemove": cmd_hook,
+            "Elicitation": cmd_hook,
+            "ElicitationResult": cmd_hook,
         }
 
         # Set the hooks URL env var so the stop script knows where to POST

--- a/observal_cli/hooks/observal-hook.sh
+++ b/observal_cli/hooks/observal-hook.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# observal-hook.sh — Generic Claude Code hook that forwards the JSON
+# payload from stdin to the Observal hooks endpoint.
+#
+# Silently swallows failures (ECONNREFUSED, timeouts) so that Claude
+# Code sessions are never disrupted when the Observal server is offline.
+
+OBSERVAL_HOOKS_URL="${OBSERVAL_HOOKS_URL:-http://localhost:8000/api/v1/otel/hooks}"
+
+curl -sf --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
+  ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+  -H "Content-Type: application/json" \
+  -d @- >/dev/null 2>&1 || true

--- a/web/src/components/traces/span-tree.tsx
+++ b/web/src/components/traces/span-tree.tsx
@@ -61,7 +61,12 @@ const threadColor: Record<string, { line: string; hover: string; bg: string }> =
   sandbox_exec: { line: "bg-green-400",  hover: "bg-green-500",  bg: "bg-green-100 text-green-700" },
   hook:         { line: "bg-pink-400",   hover: "bg-pink-500",   bg: "bg-pink-100 text-pink-700" },
   prompt:       { line: "bg-teal-400",   hover: "bg-teal-500",   bg: "bg-teal-100 text-teal-700" },
+  lifecycle:    { line: "bg-gray-300",   hover: "bg-gray-400",   bg: "bg-gray-100 text-gray-500" },
 };
+
+function isLifecycleSpan(span: Span): boolean {
+  return span.input == null && span.output == null;
+}
 
 function getColors(type: string) {
   return threadColor[type] ?? { line: "bg-gray-300", hover: "bg-gray-400", bg: "bg-gray-100 text-gray-700" };
@@ -95,7 +100,8 @@ function SpanRow({
   const hasChildren = node.children.length > 0;
   const isCollapsed = collapsed.has(node.span.span_id);
   const isSelected = selectedId === node.span.span_id;
-  const colors = getColors(node.span.type);
+  const isLifecycle = isLifecycleSpan(node.span);
+  const colors = isLifecycle ? threadColor.lifecycle : getColors(node.span.type);
   const descendantCount = isCollapsed ? countDescendants(node) : 0;
   const tokens = (node.span.token_input ?? 0) + (node.span.token_output ?? 0);
 
@@ -141,7 +147,8 @@ function SpanRow({
           onClick={() => onSelect(node.span)}
           className={cn(
             "flex w-full items-center gap-2 rounded px-2 py-1 text-sm hover:bg-muted/60 relative",
-            isSelected && "bg-muted"
+            isSelected && "bg-muted",
+            isLifecycle && "opacity-50"
           )}
           style={{ paddingLeft: `${depth * INDENT + 8}px` }}
         >
@@ -151,7 +158,7 @@ function SpanRow({
             <span className="text-[10px] text-muted-foreground whitespace-nowrap">[+{descendantCount}]</span>
           )}
           <Badge variant="outline" className={cn("ml-auto text-[10px] px-1.5 py-0 shrink-0", colors.bg)}>
-            {node.span.type}
+            {isLifecycle ? "lifecycle" : node.span.type}
           </Badge>
           {node.span.latency_ms != null && (
             <span className="text-xs text-muted-foreground tabular-nums shrink-0">{node.span.latency_ms}ms</span>

--- a/web/src/components/traces/trace-detail.tsx
+++ b/web/src/components/traces/trace-detail.tsx
@@ -9,6 +9,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SpanTree, type Span } from "./span-tree";
 
+function isLifecycleSpan(span: Span): boolean {
+  return span.input == null && span.output == null;
+}
+
 interface Trace {
   trace_id: string;
   parent_trace_id?: string;
@@ -90,6 +94,27 @@ export function TraceDetail({ trace, isLoading }: { trace?: Trace; isLoading: bo
                   <Badge variant={selectedSpan.status === "error" ? "destructive" : "secondary"}>{selectedSpan.status}</Badge>
                   {selectedSpan.latency_ms != null && <span className="text-sm text-muted-foreground">{selectedSpan.latency_ms}ms</span>}
                 </div>
+                {isLifecycleSpan(selectedSpan) && (
+                  <Card className="border-dashed">
+                    <CardContent className="pt-4">
+                      <p className="text-sm text-muted-foreground mb-3">Lifecycle span — no conversation content. Metrics captured:</p>
+                      <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                        {selectedSpan.latency_ms != null && (
+                          <div><span className="text-muted-foreground">Latency</span><p className="font-mono">{selectedSpan.latency_ms}ms</p></div>
+                        )}
+                        {(selectedSpan.token_input != null || selectedSpan.token_output != null) && (
+                          <div><span className="text-muted-foreground">Tokens</span><p className="font-mono">{selectedSpan.token_input ?? 0} in / {selectedSpan.token_output ?? 0} out</p></div>
+                        )}
+                        <div><span className="text-muted-foreground">Type</span><p>{selectedSpan.type}</p></div>
+                        <div><span className="text-muted-foreground">Status</span><p>{selectedSpan.status}</p></div>
+                        <div><span className="text-muted-foreground">Start</span><p className="font-mono text-xs">{new Date(selectedSpan.start_time).toLocaleString()}</p></div>
+                        {selectedSpan.end_time && (
+                          <div><span className="text-muted-foreground">End</span><p className="font-mono text-xs">{new Date(selectedSpan.end_time).toLocaleString()}</p></div>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
                 {selectedSpan.input != null && (
                   <Card><CardHeader className="py-2 px-4"><CardTitle className="text-sm">Input</CardTitle></CardHeader>
                     <CardContent className="px-4 pb-3"><JsonView src={typeof selectedSpan.input === "string" ? JSON.parse(selectedSpan.input as string) : selectedSpan.input} collapsed={2} /></CardContent>


### PR DESCRIPTION
## Summary
- **#236 ECONNREFUSED**: Switch Claude Code hooks from `type: "http"` to `type: "command"` using `observal-hook.sh` wrapper that silently handles server-offline failures via `curl -sf --max-time 5`. Same pattern as existing Kiro hooks. Falls back to HTTP if script not found.
- **#219 Empty spans**: Metrics-only spans (null input + output) now render with muted opacity and a "lifecycle" badge instead of appearing as blank Turn nodes. Selecting one shows available metrics (latency, tokens, status, timestamps) instead of empty cards.

Closes #236
Closes #219

## Test plan
- [x] `make test` — 881 passed
- [x] `make lint` — all checks passed
- [x] `npx tsc --noEmit` — TypeScript compiles clean
- [ ] Verify with Observal server stopped: Claude Code hooks should not produce ECONNREFUSED errors
- [ ] Verify trace UI: lifecycle spans appear muted with "lifecycle" badge, clicking shows metrics card