### PR TITLE
feat(traces): add Active Sessions tab with live polling

### DIFF
--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 
 from services.clickhouse import _escape, _map_literal, _query
 from services.secrets_redactor import redact_secrets
@@ -22,7 +22,7 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
 
 
 @router.get("/sessions")
-async def list_sessions():
+async def list_sessions(status: str | None = Query(None)):
     rows = await _ch_json(
         "SELECT "
         # For Kiro sessions with a conversation_id, group by that instead of
@@ -32,6 +32,12 @@ async def list_sessions():
         "   LogAttributes['session.id']) AS session_id, "
         "min(Timestamp) AS first_event_time, "
         "max(Timestamp) AS last_event_time, "
+        "(max(Timestamp) > now('UTC') - INTERVAL 30 MINUTE "
+        " AND argMax("
+        "   if(LogAttributes['event.name'] != '', LogAttributes['event.name'], EventName),"
+        "   Timestamp"
+        " ) NOT IN ('hook_stop', 'hook_stopfailure')"
+        ") AS is_active, "
         "countIf(EventName = 'user_prompt' OR LogAttributes['event.name'] = 'user_prompt' OR LogAttributes['event.name'] = 'hook_userpromptsubmit') AS prompt_count, "
         "countIf(LogAttributes['event.name'] = 'api_request') AS api_request_count, "
         "countIf(LogAttributes['event.name'] = 'tool_result') AS tool_result_count, "
@@ -51,6 +57,10 @@ async def list_sessions():
         "ORDER BY last_event_time DESC "
         "LIMIT 100"
     )
+    for row in rows:
+        row["is_active"] = bool(int(row.get("is_active", 0)))
+    if status == "active":
+        rows = [r for r in rows if r["is_active"]]
     return rows
 
 

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -18,6 +18,8 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -26,6 +28,7 @@ import { EmptyState } from "@/components/shared/empty-state";
 interface SessionRow {
   session_id: string;
   service_name: string;
+  is_active?: boolean;
   first_event_time?: string;
   last_event_time?: string;
   prompt_count?: number;
@@ -65,12 +68,20 @@ const columns: ColumnDef<SessionRow>[] = [
     accessorKey: "session_id",
     header: "Session",
     cell: ({ row }) => (
-      <Link
-        href={`/traces/${row.original.session_id}`}
-        className="font-[family-name:var(--font-mono)] text-xs hover:text-primary-accent transition-colors"
-      >
-        {row.original.session_id.slice(0, 12)}...
-      </Link>
+      <div className="flex items-center gap-2">
+        {row.original.is_active && (
+          <span className="relative flex h-2 w-2 shrink-0">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+          </span>
+        )}
+        <Link
+          href={`/traces/${row.original.session_id}`}
+          className="font-[family-name:var(--font-mono)] text-xs hover:text-primary-accent transition-colors"
+        >
+          {row.original.session_id.slice(0, 12)}...
+        </Link>
+      </div>
     ),
   },
   {
@@ -182,13 +193,21 @@ function SortIcon({ sorted }: { sorted: false | "asc" | "desc" }) {
 }
 
 export default function TracesPage() {
-  const { data: sessions, isLoading, isError, error, refetch } = useOtelSessions();
+  const [tab, setTab] = useState<"all" | "active">("all");
+  const { data: sessions, isLoading, isError, error, refetch } = useOtelSessions({
+    refetchInterval: tab === "active" ? 10_000 : false,
+  });
   const router = useRouter();
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
 
-  const data = useMemo(() => (sessions ?? []) as SessionRow[], [sessions]);
+  const allSessions = useMemo(() => (sessions ?? []) as SessionRow[], [sessions]);
+  const activeCount = useMemo(() => allSessions.filter((s) => s.is_active).length, [allSessions]);
+  const data = useMemo(
+    () => (tab === "active" ? allSessions.filter((s) => s.is_active) : allSessions),
+    [allSessions, tab],
+  );
 
   const table = useReactTable({
     data,
@@ -227,7 +246,7 @@ export default function TracesPage() {
           <TableSkeleton rows={8} cols={7} />
         ) : isError ? (
           <ErrorState message={error?.message} onRetry={() => refetch()} />
-        ) : (sessions ?? []).length === 0 ? (
+        ) : allSessions.length === 0 ? (
           <EmptyState
             icon={Activity}
             title="No sessions yet"
@@ -235,15 +254,37 @@ export default function TracesPage() {
           />
         ) : (
           <div className="animate-in space-y-3">
-            {/* Search */}
-            <div className="relative max-w-sm">
-              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-              <Input
-                placeholder="Search sessions, models..."
-                value={searchValue}
-                onChange={(e) => handleSearch(e.target.value)}
-                className="pl-8 h-8 text-sm"
-              />
+            {/* Tabs + Search */}
+            <div className="flex items-center gap-4">
+              <Tabs value={tab} onValueChange={(v) => setTab(v as "all" | "active")}>
+                <TabsList>
+                  <TabsTrigger value="all">
+                    All
+                    <span className="ml-1.5 text-[10px] text-muted-foreground tabular-nums">{allSessions.length}</span>
+                  </TabsTrigger>
+                  <TabsTrigger value="active" className="gap-1.5">
+                    <span className="relative flex h-2 w-2">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+                    </span>
+                    Active
+                    {activeCount > 0 && (
+                      <Badge variant="secondary" className="ml-1 h-4 px-1 text-[10px] font-medium">
+                        {activeCount}
+                      </Badge>
+                    )}
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <div className="relative max-w-sm flex-1">
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                <Input
+                  placeholder="Search sessions, models..."
+                  value={searchValue}
+                  onChange={(e) => handleSearch(e.target.value)}
+                  className="pl-8 h-8 text-sm"
+                />
+              </div>
             </div>
 
             {/* Table */}
@@ -295,6 +336,7 @@ export default function TracesPage() {
 
             <p className="text-xs text-muted-foreground">
               {table.getFilteredRowModel().rows.length} session{table.getFilteredRowModel().rows.length !== 1 ? "s" : ""}
+              {tab === "active" && " \u00b7 auto-refreshing every 10s"}
             </p>
           </div>
         )}

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { Suspense, useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Eye, EyeOff, ArrowRight, Loader2, AlertCircle, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
@@ -11,7 +11,7 @@ import { Label } from "@/components/ui/label";
 
 type Mode = "login" | "register" | "api-key" | "reset-request" | "reset-confirm";
 
-export default function LoginPage() {
+function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [mode, setMode] = useState<Mode>("login");
@@ -162,8 +162,7 @@ export default function LoginPage() {
       <div className="w-full max-w-md">
         <div className="rounded-lg border bg-card shadow-sm">
           {/* Brand header */}
-          <div className="flex flex-col items-center gap-2 border-b px-8 pb-6 pt-8 animate-in
-">
+          <div className="flex flex-col items-center gap-2 border-b px-8 pb-6 pt-8 animate-in">
             <h1 className="text-2xl font-semibold tracking-tight font-[family-name:var(--font
 -display)]">
               Observal
@@ -444,5 +443,13 @@ export default function LoginPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -259,8 +259,12 @@ export function useIdeUsage() {
 }
 // ── OTel ────────────────────────────────────────────────────────────
 
-export function useOtelSessions() {
-  return useQuery({ queryKey: ['otel', 'sessions'], queryFn: dashboard.otelSessions });
+export function useOtelSessions(options?: { refetchInterval?: number | false }) {
+  return useQuery({
+    queryKey: ['otel', 'sessions'],
+    queryFn: dashboard.otelSessions,
+    refetchInterval: options?.refetchInterval,
+  });
 }
 export function useOtelSession(id: string | undefined) {
   return useQuery({ queryKey: ['otel', 'session', id], queryFn: () => dashboard.otelSession(id!), enabled: !!id });

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -246,6 +246,7 @@ export interface OtelSession {
   session_id: string;
   first_event_time: string;
   last_event_time: string;
+  is_active?: boolean;
   prompt_count: number;
   api_request_count: number;
   tool_result_count: number;


### PR DESCRIPTION
## Summary
- Adds "All" / "Active" tab bar to the Traces page for quick identification of live sessions
- Active detection uses composite ClickHouse check: `last_event_time` within 30 min AND last event is not `hook_stop`/`hook_stopfailure` — handles resumed sessions correctly
- Pulsing green dot indicator on active sessions in the table and on the Active tab trigger
- 10-second auto-refresh polling when Active tab is selected; no polling on All tab
- Supports multiple concurrent sessions per user (each shown independently)

## Changes
- **`observal-server/api/routes/otel_dashboard.py`** — `argMax`-based `is_active` computed field, optional `?status=active` query param
- **`web/src/app/(admin)/traces/page.tsx`** — Tab bar (All/Active), client-side filtering, conditional `refetchInterval`, green dot indicators
- **`web/src/hooks/use-api.ts`** — `useOtelSessions` accepts optional `refetchInterval`
- **`web/src/lib/types.ts`** — `is_active` field on `OtelSession`

## Test plan
- [x] TypeScript type check passes
- [x] 881 backend tests pass
- [x] Ruff lint clean
- [ ] Verify Active tab shows pulsing green dot for sessions with recent activity
- [ ] Verify switching to Active tab triggers auto-refresh (network tab shows 10s polling)
- [ ] Verify sessions with `hook_stop` as last event are NOT marked active
- [ ] Verify multiple concurrent sessions from same user each show independently