### PR TITLE
fix(security): P0 security hardening — secrets, OAuth, rate limiting, CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,14 @@
-# Required
+# Core settings (have sensible defaults — override for production)
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@observal-db:5432/observal
+# Recommended: generate a unique key for production
+# python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+SECRET_KEY=change-me-to-a-random-string
 CLICKHOUSE_URL=clickhouse://default:clickhouse@observal-clickhouse:8123/observal
 REDIS_URL=redis://observal-redis:6379
+
+# Postgres container credentials
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-# Generate with: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
-SECRET_KEY=change-me-to-a-random-string
 
 # Optional: ClickHouse credentials
 CLICKHOUSE_USER=default
@@ -22,3 +25,8 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_SESSION_TOKEN=
 AWS_REGION=us-east-1
+
+# Optional: OAuth / SSO (disabled when unset)
+OAUTH_CLIENT_ID=
+OAUTH_CLIENT_SECRET=
+OAUTH_SERVER_METADATA_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Core settings (have sensible defaults — override for production)
+# Core settings (have sensible defaults, override for production)
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@observal-db:5432/observal
 # Recommended: generate a unique key for production
 # python3 -c "import secrets; print(secrets.token_urlsafe(32))"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Observal is an agent-centric registry and observability platform for AI coding a
 
 All API routes accept either UUID or name for path parameters. Admin review controls public registry visibility only. Submitters can install and use their own items immediately without approval.
 
-The MCP validator supports multiple frameworks: FastMCP, standard MCP SDK (Python), TypeScript SDK (`@modelcontextprotocol/sdk`), and Go SDK (`mcp-go`). There is no framework enforcement — all MCP implementations are accepted.
+The MCP validator supports multiple frameworks: FastMCP, standard MCP SDK (Python), TypeScript SDK (`@modelcontextprotocol/sdk`), and Go SDK (`mcp-go`). There is no framework enforcement - all MCP implementations are accepted.
 
 The web frontend is a Next.js 16 / React 19 app in `web/`. It uses three route groups: `(auth)` for login, `(registry)` for the public-facing agent browser, component library, and agent builder, and `(admin)` for the admin dashboard, traces, eval, review, and user management. The frontend has a custom OKLCH design system with 5 themes (light, dark, midnight, forest, sunset), three typefaces (Archivo for display, Albert Sans for body, JetBrains Mono for code), and a 4pt spacing scale. It uses shadcn/ui components, Recharts for charts, TanStack Query for data fetching, and TanStack Table for sortable/filterable tables. Shared API response types live in `web/src/lib/types.ts`. The GraphQL API at `/api/v1/graphql` is the read layer for telemetry data; REST endpoints serve everything else.
 
@@ -48,7 +48,7 @@ Deprecated root-level aliases exist for backward compatibility (e.g. `observal s
 ## Commands
 
 ```bash
-# Docker stack (7 containers: api, db, clickhouse, redis, worker, web, otel-collector)
+# Docker stack (7 services: api, db, clickhouse, redis, worker, web, otel-collector)
 make up                  # start
 make down                # stop
 make rebuild             # rebuild and restart
@@ -77,12 +77,13 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 
 ### API Server (`observal-server/`)
 
-- `main.py` : FastAPI app entrypoint; mounts REST routes + GraphQL at `/api/v1/graphql`
-- `config.py` : pydantic-settings: DATABASE_URL, CLICKHOUSE_URL, REDIS_URL, SECRET_KEY, eval model config
+- `main.py` : FastAPI app entrypoint; mounts REST routes + GraphQL at `/api/v1/graphql`; middleware stack includes CORS (env-var origins), security headers, request size limit, rate limiting (slowapi), and session management
+- `config.py` : pydantic-settings: DATABASE_URL, CLICKHOUSE_URL, REDIS_URL, SECRET_KEY, eval model config, OAuth settings (all default to None/disabled), rate limit settings
 - `worker.py` : arq WorkerSettings; background eval jobs consume from Redis queue
 - `api/deps.py` : auth dependency (`get_current_user` via X-API-Key header), DB session injection, `resolve_listing` (name-or-UUID resolver used by all routes)
 - `api/graphql.py` : Strawberry schema: Query (traces, spans, metrics) + Subscription (traceCreated, spanCreated); DataLoaders for ClickHouse batch queries
-- `api/routes/auth.py` : bootstrap (auto-admin), login, whoami, invite codes (create/redeem/list)
+- `api/ratelimit.py` : shared slowapi Limiter instance, backed by Redis
+- `api/routes/auth.py` : bootstrap (auto-admin, localhost-only), login, whoami, OAuth code exchange, invite codes (create/redeem/list); all endpoints rate-limited via slowapi
 - `api/routes/mcp.py` : MCP server CRUD; submit triggers async validation pipeline
 - `api/routes/agent.py` : Agent CRUD with goal templates, component linking via agent_components table
 - `api/routes/skill.py` : Skill CRUD; install generates SessionStart/End hook config
@@ -101,7 +102,7 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 ### Models (`observal-server/models/`)
 
 - `user.py` : User with UserRole enum (admin, developer, user); API key is hashed with SHA-256
-- `invite.py` : InviteCode model — short codes (OBS-XXXXXX) for user onboarding, with expiry and one-time use tracking
+- `invite.py` : InviteCode model - short codes (OBS-XXXXXX) for user onboarding, with expiry and one-time use tracking
 - `mcp.py` : McpListing, McpValidationResult, McpDownload; ListingStatus enum (shared by all models)
 - `agent.py` : Agent, AgentGoalTemplate, AgentGoalSection, AgentStatus enum
 - `alert.py` : AlertRule (metric threshold alerts with webhook URLs)
@@ -140,7 +141,7 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 ### CLI (`observal_cli/`)
 
 - `main.py` : Typer app wiring; creates `registry_app` parent group (mcp, skill, hook, prompt, sandbox), registers all command modules, adds deprecated backward-compat aliases
-- `cmd_auth.py` : `auth_app` subgroup: login (smart — auto-bootstrap on fresh server, supports --code for invite codes, --key for API keys), init (alias for login), logout, whoami, status. Also `config_app` subgroup: show, set, path, alias, aliases
+- `cmd_auth.py` : `auth_app` subgroup: login (smart - auto-bootstrap on fresh server, supports --code for invite codes, --key for API keys), init (alias for login), logout, whoami, status. Also `config_app` subgroup: show, set, path, alias, aliases
 - `cmd_mcp.py` : `mcp_app` subgroup: submit (with --yes for non-interactive), list (--sort, --limit, --output), show, install (--raw), delete. `register_deprecated_mcp()` adds hidden root-level bare aliases (submit, list, show, install, delete)
 - `cmd_agent.py` : `agent_app` subgroup: create (--from-file), list, show, install, delete; authoring: init, add, build, publish
 - `cmd_skill.py` : `skill_app` subgroup: submit, list, show, install, delete
@@ -259,7 +260,7 @@ The `ee/` directory contains proprietary enterprise features licensed under the 
 - Redis serves two purposes: pub/sub for GraphQL subscriptions (live trace/span events) and arq job queue for background eval runs.
 - The eval engine is pluggable. `LLMJudgeBackend` calls Bedrock or OpenAI-compatible endpoints. `FallbackBackend` returns deterministic scores when no LLM is configured. The 6 managed templates are prompt strings, not code.
 - Feedback dual-writes: when a user rates an MCP/agent, it writes to PostgreSQL (for the feedback API) AND ClickHouse scores table (for unified analytics). The ClickHouse write is best-effort.
-- Auth is API key based. Keys are SHA-256 hashed before storage. The `X-API-Key` header is checked on every authenticated request via `get_current_user` dependency. User onboarding uses short invite codes (OBS-XXXXXX) — admin generates a code, new user redeems it to get an API key. Fresh servers auto-bootstrap an admin account on first `observal auth login` (zero prompts). The `/health` endpoint returns `initialized: bool` so the CLI knows whether to bootstrap or prompt for credentials.
+- Auth is API key based. Keys are SHA-256 hashed before storage. The `X-API-Key` header is checked on every authenticated request via `get_current_user` dependency. User onboarding uses short invite codes (OBS-XXXXXX): admin generates a code, new user redeems it to get an API key. Fresh servers auto-bootstrap an admin account on first `observal auth login` (zero prompts, localhost-only). The `/health` endpoint returns `initialized: bool` so the CLI knows whether to bootstrap or prompt for credentials. All auth endpoints are rate-limited via slowapi (backed by Redis). OAuth uses a one-time auth code exchange pattern: the callback stores credentials in Redis with a 30s TTL and redirects with an opaque code instead of the raw API key.
 - Install routes use an owner fallback: try approved first, then allow the submitter to install their own pending/rejected items. This lets `observal scan` work. Items are auto-registered as pending and immediately usable by the submitter.
 - The CLI stores config in `~/.observal/config.json`. Aliases are in `~/.observal/aliases.json`. Both are plain JSON. All API path parameters accept UUID or name; the server resolves names via `resolve_listing()` in `deps.py`.
 - All CLI list/show commands support `--output table|json|plain`. Use `--output json` for scripting. Use `--raw` on install commands to pipe config directly to files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,12 @@ git remote add upstream https://github.com/BlazeUp-AI/Observal.git
 
 ### Running Locally
 
-**Backend:**
+No configuration needed for local development. All settings have working defaults.
+
+**Full stack (Docker):**
 
 ```bash
 cp .env.example .env
-# edit .env with your values
 
 cd docker
 docker compose up --build -d
@@ -55,9 +56,9 @@ uv tool install --editable .
 observal auth login
 ```
 
-The API starts at http://localhost:8000. On a fresh server, `auth login` auto-creates an admin account.
+The API starts at http://localhost:8000 and the web UI at http://localhost:3000. On a fresh server, `auth login` auto-creates an admin account.
 
-**Frontend:**
+**Frontend only (for UI work):**
 
 ```bash
 cd web
@@ -65,9 +66,9 @@ pnpm install
 pnpm dev
 ```
 
-The web UI starts at http://localhost:3000. Set `NEXT_PUBLIC_API_URL=http://localhost:8000` in `web/.env.local` if the backend is on a different host.
+Set `NEXT_PUBLIC_API_URL=http://localhost:8000` in `web/.env.local` if the backend is on a different host.
 
-See [SETUP.md](SETUP.md) for detailed configuration and troubleshooting.
+See [SETUP.md](SETUP.md) for detailed configuration, eval engine setup, and troubleshooting.
 
 ## Enterprise Directory (`ee/`)
 
@@ -108,7 +109,7 @@ docs/update-setup-guide
 
 ### Code Style
 
-Python is linted and formatted with `ruff`. Dockerfiles are linted with `hadolint`. Pre-commit hooks enforce both — install them early so issues are caught before you commit.
+Python is linted and formatted with `ruff`. Dockerfiles are linted with `hadolint`. Pre-commit hooks enforce both - install them early so issues are caught before you commit.
 
 ```bash
 make hooks     # install pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -29,15 +29,19 @@ See the [Changelog](CHANGELOG.md) for recent updates.
 
 ## Quick Start
 
+Everything works out of the box with defaults. No configuration needed for local development.
+
 ```bash
 git clone https://github.com/BlazeUp-AI/Observal.git
 cd Observal
-cp .env.example .env          # edit with your values
+cp .env.example .env
 
 cd docker && docker compose up --build -d && cd ..
 uv tool install --editable .
 observal auth login            # auto-creates admin on fresh server
 ```
+
+That's it. The `.env.example` ships with working defaults for every setting. The server starts 7 services (API, web UI, PostgreSQL, ClickHouse, Redis, background worker, OpenTelemetry collector) and creates all database tables on first boot.
 
 Already have MCP servers in your IDE? Instrument them in one command:
 
@@ -101,7 +105,7 @@ observal profile                     # show active profile and backup info
 ```
 
 <details>
-<summary><strong>Authentication</strong> &mdash; <code>observal auth</code></summary>
+<summary><strong>Authentication</strong> - <code>observal auth</code></summary>
 
 ```bash
 observal auth login            # auto-creates admin on fresh server, or login with key
@@ -134,7 +138,7 @@ export OBSERVAL_API_KEY=<your-key>
 </details>
 
 <details>
-<summary><strong>Component Registry</strong> &mdash; <code>observal registry &lt;type&gt;</code></summary>
+<summary><strong>Component Registry</strong> - <code>observal registry &lt;type&gt;</code></summary>
 
 All 5 component types (mcp, skill, hook, prompt, sandbox) support the same core commands:
 
@@ -151,7 +155,7 @@ Prompts also have `observal registry prompt render <id> --var key=value`.
 </details>
 
 <details>
-<summary><strong>Agent Authoring</strong> &mdash; <code>observal agent</code></summary>
+<summary><strong>Agent Authoring</strong> - <code>observal agent</code></summary>
 
 ```bash
 # Browse and manage
@@ -171,7 +175,7 @@ observal agent publish             # submit to registry
 </details>
 
 <details>
-<summary><strong>Observability</strong> &mdash; <code>observal ops</code></summary>
+<summary><strong>Observability</strong> - <code>observal ops</code></summary>
 
 ```bash
 observal ops overview              # dashboard stats
@@ -188,7 +192,7 @@ observal ops telemetry test
 </details>
 
 <details>
-<summary><strong>Admin</strong> &mdash; <code>observal admin</code></summary>
+<summary><strong>Admin</strong> - <code>observal admin</code></summary>
 
 ```bash
 # Invite team members
@@ -223,7 +227,7 @@ observal admin weight-set <dimension> <weight>
 </details>
 
 <details>
-<summary><strong>Configuration</strong> &mdash; <code>observal config</code></summary>
+<summary><strong>Configuration</strong> - <code>observal config</code></summary>
 
 ```bash
 observal config show               # show current config
@@ -264,7 +268,7 @@ observal doctor [--ide <ide>] [--fix]  # diagnose IDE settings compatibility
 
 ## Setup & Configuration
 
-For detailed setup, eval engine configuration, environment variables, and troubleshooting, see [SETUP.md](SETUP.md).
+See [SETUP.md](SETUP.md) for local development setup, eval engine configuration, and troubleshooting.
 
 <details>
 <summary><strong>API Endpoints</strong></summary>
@@ -275,6 +279,7 @@ For detailed setup, eval engine configuration, environment variables, and troubl
 |--------|----------|-------------|
 | `POST` | `/api/v1/auth/bootstrap` | Auto-create admin on fresh server |
 | `POST` | `/api/v1/auth/login` | Login with API key or email+password |
+| `POST` | `/api/v1/auth/exchange` | Exchange one-time OAuth code for credentials |
 | `GET` | `/api/v1/auth/whoami` | Current user info |
 | `POST` | `/api/v1/auth/request-reset` | Request password reset (code logged to server console) |
 | `POST` | `/api/v1/auth/reset-password` | Reset password with code + new password |
@@ -369,23 +374,26 @@ All `{id}` parameters accept either a UUID or a name.
 <details>
 <summary><strong>Environment Variables</strong></summary>
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `DATABASE_URL` | Yes | | PostgreSQL connection string (asyncpg) |
-| `CLICKHOUSE_URL` | Yes | | ClickHouse connection string |
-| `POSTGRES_USER` | Yes | `postgres` | PostgreSQL user |
-| `POSTGRES_PASSWORD` | Yes | `postgres` | PostgreSQL password |
-| `SECRET_KEY` | Yes | | Secret key for API key hashing. Generate with: `python3 -c "import secrets; print(secrets.token_urlsafe(32))"` |
-| `CLICKHOUSE_USER` | No | `default` | ClickHouse user |
-| `CLICKHOUSE_PASSWORD` | No | `clickhouse` | ClickHouse password |
-| `EVAL_MODEL_URL` | No | | OpenAI-compatible endpoint for the eval engine |
-| `EVAL_MODEL_API_KEY` | No | | API key for the eval model |
-| `EVAL_MODEL_NAME` | No | | Model name (e.g. `us.anthropic.claude-3-5-haiku-20241022-v1:0`) |
-| `EVAL_MODEL_PROVIDER` | No | | `bedrock`, `openai`, or empty for auto-detect |
-| `AWS_ACCESS_KEY_ID` | No | | AWS credentials for Bedrock |
-| `AWS_SECRET_ACCESS_KEY` | No | | AWS credentials for Bedrock |
-| `AWS_SESSION_TOKEN` | No | | AWS session token (temporary credentials) |
-| `AWS_REGION` | No | `us-east-1` | AWS region for Bedrock |
+All settings have sensible defaults that work for local development. Just `cp .env.example .env` and you are good to go. Override what you need for production.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | `postgresql+asyncpg://postgres:postgres@localhost:5432/observal` | PostgreSQL connection string |
+| `CLICKHOUSE_URL` | `clickhouse://localhost:8123/observal` | ClickHouse connection string |
+| `REDIS_URL` | `redis://localhost:6379` | Redis connection string |
+| `SECRET_KEY` | `change-me-to-a-random-string` | Session signing key. Generate a real one for production: `python3 -c "import secrets; print(secrets.token_urlsafe(32))"` |
+| `POSTGRES_USER` | `postgres` | PostgreSQL container user |
+| `POSTGRES_PASSWORD` | `postgres` | PostgreSQL container password |
+| `FRONTEND_URL` | `http://localhost:3000` | Frontend URL (used for OAuth redirects and CORS) |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:3000` | Comma-separated allowed CORS origins |
+| `OAUTH_CLIENT_ID` | disabled | OAuth/OIDC client ID (SSO is disabled when unset) |
+| `OAUTH_CLIENT_SECRET` | disabled | OAuth/OIDC client secret |
+| `OAUTH_SERVER_METADATA_URL` | disabled | OIDC discovery URL |
+| `EVAL_MODEL_URL` | | OpenAI-compatible endpoint for the eval engine |
+| `EVAL_MODEL_API_KEY` | | API key for the eval model |
+| `EVAL_MODEL_NAME` | | Model name (e.g. `us.anthropic.claude-3-5-haiku-20241022-v1:0`) |
+| `EVAL_MODEL_PROVIDER` | | `bedrock`, `openai`, or empty for auto-detect |
+| `AWS_REGION` | `us-east-1` | AWS region for Bedrock |
 
 </details>
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,18 +1,18 @@
 # Setup Guide
 
-This guide covers all the ways to get Observal running, from the quickstart Docker path to local development and optional services like the eval engine.
+Everything works out of the box with defaults. No configuration needed for local development.
 
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
 - [uv](https://docs.astral.sh/uv/) (Python package manager)
 - Python 3.11+
-- Node.js 20+ (for local web UI development)
+- Node.js 20+ and pnpm (for frontend development)
 - Git
 
 ## Quickstart (Docker)
 
-This is the fastest way to get everything running.
+Three commands to get everything running:
 
 ```bash
 git clone https://github.com/BlazeUp-AI/Observal.git
@@ -20,16 +20,14 @@ cd Observal
 cp .env.example .env
 ```
 
-Edit `.env` with your values (see [Environment Variables](#environment-variables) below). The `.env` file must stay in the project root. All Docker services reference it from there via `env_file: ../.env`.
+The `.env.example` ships with working defaults for every setting. No editing needed for local development.
 
 ```bash
 cd docker
 docker compose up --build -d
 ```
 
-?/
-
-This starts four services:
+This starts seven services:
 
 | Service | URL | Description |
 |---------|-----|-------------|
@@ -37,8 +35,11 @@ This starts four services:
 | `observal-web` | http://localhost:3000 | Next.js web UI |
 | `observal-db` | localhost:5432 | PostgreSQL 16 |
 | `observal-clickhouse` | localhost:8123 | ClickHouse (telemetry) |
+| `observal-redis` | localhost:6379 | Redis (job queue, pub/sub) |
+| `observal-worker` | (internal) | Background job processor (arq) |
+| `observal-otel-collector` | localhost:4317 | OpenTelemetry Collector |
 
-Install the CLI and run first-time setup:
+Install the CLI and create your first admin account:
 
 ```bash
 cd ..
@@ -46,7 +47,7 @@ uv tool install --editable .
 observal auth login
 ```
 
-On a fresh server, `observal auth login` auto-detects that no users exist and bootstraps an admin account automatically — no prompts needed. Your credentials are saved to `~/.observal/config.json`.
+On a fresh server, `observal auth login` detects that no users exist and bootstraps an admin account automatically. No prompts needed. Your credentials are saved to `~/.observal/config.json`.
 
 To invite team members:
 
@@ -63,88 +64,80 @@ observal auth login --code OBS-A7X9B2
 For CI/scripts, use environment variables instead of interactive login:
 
 ```bash
-export OBSERVAL_SERVER_URL=http://your-server:8000
+export OBSERVAL_SERVER_URL=http://localhost:8000
 export OBSERVAL_API_KEY=<your-key>
 ```
 
-You're ready to go. See the [README](README.md) for usage.
+You are ready to go. See the [README](README.md) for usage.
 
 ## Environment Variables
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `DATABASE_URL` | Yes | | PostgreSQL connection string (e.g. `postgresql+asyncpg://postgres:secret@observal-db:5432/observal`) |
-| `CLICKHOUSE_URL` | Yes | | ClickHouse connection string (e.g. `clickhouse://default:clickhouse@observal-clickhouse:8123/observal`) |
-| `POSTGRES_USER` | Yes | `postgres` | PostgreSQL user |
-| `POSTGRES_PASSWORD` | Yes | `postgres` | PostgreSQL password |
-| `SECRET_KEY` | Yes | | Secret key for API key hashing. Generate one with `python3 -c "import secrets; print(secrets.token_urlsafe(32))"` |
-| `CLICKHOUSE_USER` | No | `default` | ClickHouse user |
-| `CLICKHOUSE_PASSWORD` | No | `clickhouse` | ClickHouse password |
-| `EVAL_MODEL_URL` | No | | OpenAI-compatible endpoint for the eval engine |
-| `EVAL_MODEL_API_KEY` | No | | API key for the eval model. Leave empty for AWS credential chain |
-| `EVAL_MODEL_NAME` | No | | Model name (e.g. `us.anthropic.claude-3-5-haiku-20241022-v1:0`) |
-| `EVAL_MODEL_PROVIDER` | No | | `bedrock`, `openai`, or empty for auto-detect |
-| `AWS_ACCESS_KEY_ID` | No | | AWS credentials for Bedrock eval engine |
-| `AWS_SECRET_ACCESS_KEY` | No | | AWS credentials for Bedrock eval engine |
-| `AWS_SESSION_TOKEN` | No | | AWS session token (if using temporary credentials) |
-| `AWS_REGION` | No | `us-east-1` | AWS region for Bedrock |
+All settings have sensible defaults that work for local development. The server starts without any `.env` file at all (it will use built-in defaults). For Docker Compose, just copy the example file and you are set.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | `postgresql+asyncpg://postgres:postgres@localhost:5432/observal` | PostgreSQL connection string |
+| `CLICKHOUSE_URL` | `clickhouse://localhost:8123/observal` | ClickHouse connection string |
+| `REDIS_URL` | `redis://localhost:6379` | Redis connection string |
+| `SECRET_KEY` | `change-me-to-a-random-string` | Session signing key. For production, generate a real one: `python3 -c "import secrets; print(secrets.token_urlsafe(32))"` |
+| `POSTGRES_USER` | `postgres` | PostgreSQL container user |
+| `POSTGRES_PASSWORD` | `postgres` | PostgreSQL container password |
+| `FRONTEND_URL` | `http://localhost:3000` | Frontend URL (used for OAuth redirects) |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:3000` | Comma-separated allowed CORS origins |
+| `CLICKHOUSE_USER` | `default` | ClickHouse user |
+| `CLICKHOUSE_PASSWORD` | `clickhouse` | ClickHouse password |
+| `OAUTH_CLIENT_ID` | disabled | OAuth/OIDC client ID (SSO is disabled when unset) |
+| `OAUTH_CLIENT_SECRET` | disabled | OAuth/OIDC client secret |
+| `OAUTH_SERVER_METADATA_URL` | disabled | OIDC discovery URL |
+| `EVAL_MODEL_URL` | | OpenAI-compatible endpoint for the eval engine |
+| `EVAL_MODEL_API_KEY` | | API key for the eval model. Leave empty for AWS credential chain |
+| `EVAL_MODEL_NAME` | | Model name (e.g. `us.anthropic.claude-3-5-haiku-20241022-v1:0`) |
+| `EVAL_MODEL_PROVIDER` | | `bedrock`, `openai`, or empty for auto-detect |
+| `AWS_ACCESS_KEY_ID` | | AWS credentials for Bedrock eval engine |
+| `AWS_SECRET_ACCESS_KEY` | | AWS credentials for Bedrock eval engine |
+| `AWS_SESSION_TOKEN` | | AWS session token (if using temporary credentials) |
+| `AWS_REGION` | `us-east-1` | AWS region for Bedrock |
+| `RATE_LIMIT_AUTH` | `10/minute` | Rate limit for general auth endpoints |
+| `RATE_LIMIT_AUTH_STRICT` | `5/minute` | Rate limit for login and password reset |
 
 ## Local Development
 
-For development you can run the backend, frontend, and CLI individually outside Docker while still using Docker for the databases.
+For development you can run the backend, frontend, and CLI individually outside Docker while keeping Docker for the databases.
 
 ### Databases only
 
-Start just PostgreSQL and ClickHouse:
+Start just PostgreSQL, ClickHouse, and Redis:
 
 ```bash
 cd docker
-docker compose up observal-db observal-clickhouse -d
+docker compose up observal-db observal-clickhouse observal-redis -d
 ```
 
 ### Backend (FastAPI)
 
 ```bash
 cd observal-server
-```
-
-Create a `.env` file in the server directory (or the project root) with connection strings pointing to localhost:
-
-```
-DATABASE_URL=postgresql+asyncpg://postgres:yourpassword@localhost:5432/observal
-CLICKHOUSE_URL=clickhouse://default:clickhouse@localhost:8123/observal
-SECRET_KEY=dev-secret-key
-```
-
-Install dependencies and run:
-
-```bash
 uv sync
 uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-The API will be available at http://localhost:8000. Database tables are created automatically on startup.
+The API will be available at http://localhost:8000. Database tables are created automatically on startup. All settings use built-in defaults pointing to localhost, so no `.env` file is strictly necessary. If you want to override anything, create a `.env` in the project root or the server directory:
+
+```
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/observal
+CLICKHOUSE_URL=clickhouse://default:clickhouse@localhost:8123/observal
+SECRET_KEY=dev-secret-key
+```
 
 ### Frontend (Next.js)
 
 ```bash
-cd observal-web
-npm install
+cd web
+pnpm install
+pnpm dev
 ```
 
-Set the API URL for the dev proxy. Create a `.env.local` file:
-
-```
-API_INTERNAL_URL=http://localhost:8000
-```
-
-Then run:
-
-```bash
-npm run dev
-```
-
-The web UI will be at http://localhost:3000. All `/api/*` requests are proxied to the backend through Next.js rewrites, so the browser talks directly to the frontend only.
+The web UI will be at http://localhost:3000. All `/api/*` requests are proxied to the backend through Next.js rewrites, so the browser talks directly to the frontend only. If the backend is on a different host, set `NEXT_PUBLIC_API_URL` in `web/.env.local`.
 
 ### CLI
 
@@ -229,7 +222,7 @@ Observal implements the four core [RAGAS](https://docs.ragas.io/) metrics for ev
 | Context Precision | Checks each retrieved chunk's relevance to the question. Score = relevant chunks / total chunks. |
 | Context Recall | Extracts statements from ground truth and checks if each is attributable to the context. Requires ground truth data. |
 
-All four metrics use LLM-as-judge under the hood — the same eval model configured via `EVAL_MODEL_NAME` / `EVAL_MODEL_URL`. No additional dependencies are needed.
+All four metrics use LLM-as-judge under the hood, the same eval model configured via `EVAL_MODEL_NAME` / `EVAL_MODEL_URL`. No additional dependencies are needed.
 
 ### Running a RAGAS evaluation
 
@@ -304,10 +297,13 @@ The schema includes tables for users, MCP listings, agents, reviews, feedback, e
 
 ### ClickHouse
 
-ClickHouse tables are also created automatically on startup. The API runs `CREATE TABLE IF NOT EXISTS` for two tables:
+ClickHouse tables are also created automatically on startup. The API runs `CREATE TABLE IF NOT EXISTS` for the telemetry tables:
 
-- `mcp_tool_calls` - tool call telemetry events, partitioned by month
-- `agent_interactions` - agent interaction events, partitioned by month
+- `traces` - distributed trace data (ReplacingMergeTree)
+- `spans` - individual operation spans (ReplacingMergeTree)
+- `scores` - evaluation scores (ReplacingMergeTree)
+- `mcp_tool_calls` - legacy tool call events (MergeTree)
+- `agent_interactions` - legacy agent interaction events (MergeTree)
 
 If ClickHouse is unavailable at startup, the API still starts. Telemetry ingestion and dashboard queries will fail silently until ClickHouse becomes available.
 
@@ -321,7 +317,7 @@ docker compose down -v
 docker compose up --build -d
 ```
 
-The `-v` flag removes the named volumes (`pgdata`, `chdata`), which deletes all data. After restarting, run `observal auth login` again — it will auto-create a new admin account.
+The `-v` flag removes the named volumes (`pgdata`, `chdata`), which deletes all data. After restarting, run `observal auth login` again. It will auto-create a new admin account.
 
 ## Docker Details
 
@@ -337,6 +333,12 @@ docker compose logs -f
 docker compose logs -f observal-api
 ```
 
+Or use the Makefile shortcuts:
+
+```bash
+make logs              # tail all service logs
+```
+
 ### Restarting a single service
 
 ```bash
@@ -347,6 +349,8 @@ docker compose restart observal-api
 ### Rebuilding after code changes
 
 ```bash
+make rebuild           # rebuild and restart everything
+# or target a single service:
 cd docker
 docker compose up --build -d observal-api
 ```
@@ -360,6 +364,18 @@ You can verify the API is healthy:
 ```bash
 curl http://localhost:8000/health
 ```
+
+## Production Notes
+
+For production deployments, you should at minimum:
+
+1. Generate a unique `SECRET_KEY` (the default is not secure for production)
+2. Set strong `POSTGRES_PASSWORD` credentials
+3. Configure `CORS_ALLOWED_ORIGINS` to your actual frontend domain
+4. Set up OAuth/SSO if you need single sign-on (`OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_SERVER_METADATA_URL`)
+5. Consider enabling rate limiting tuning via `RATE_LIMIT_AUTH` and `RATE_LIMIT_AUTH_STRICT`
+
+The `/auth/bootstrap` endpoint is restricted to localhost access only for security.
 
 ## Troubleshooting
 
@@ -379,4 +395,4 @@ Check that `CLICKHOUSE_URL` in `.env` matches the credentials in the docker-comp
 Make sure `EVAL_MODEL_NAME` is set. If using Bedrock, verify your AWS credentials have `bedrock:InvokeModel` permission. Check the API logs for error details: `docker compose logs -f observal-api`.
 
 **Web UI shows blank page**
-The frontend may still be building. Check `docker compose logs -f observal-web`. If running locally, make sure `API_INTERNAL_URL` is set in `.env.local` and the backend is running.
+The frontend may still be building. Check `docker compose logs -f observal-web`. If running locally, make sure `NEXT_PUBLIC_API_URL` is set in `web/.env.local` and the backend is running.

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -66,6 +66,7 @@ async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_s
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
+
 async def resolve_prefix_id(
     model,
     identifier: str,

--- a/observal-server/api/ratelimit.py
+++ b/observal-server/api/ratelimit.py
@@ -1,0 +1,9 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from config import settings
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    storage_uri=settings.REDIS_URL or "memory://",
+)

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import secrets
 import string
@@ -11,10 +12,12 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_current_user, get_db
+from api.ratelimit import limiter
 from config import settings
 from models.invite import InviteCode
 from models.user import User, UserRole
 from schemas.auth import (
+    CodeExchangeRequest,
     InitRequest,
     InitResponse,
     InviteCreateRequest,
@@ -27,6 +30,7 @@ from schemas.auth import (
     ResetPasswordRequest,
     UserResponse,
 )
+from services.redis import get_redis
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +85,13 @@ async def init_admin(req: InitRequest, db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/bootstrap", response_model=InitResponse)
-async def bootstrap(db: AsyncSession = Depends(get_db)):
+@limiter.limit("1/minute")
+async def bootstrap(request: Request, db: AsyncSession = Depends(get_db)):
     """Auto-create admin account on a fresh server. No input needed."""
+    client_host = request.client.host if request.client else None
+    if client_host not in ("127.0.0.1", "::1", "localhost"):
+        raise HTTPException(status_code=403, detail="Bootstrap is only available from localhost")
+
     count = await db.scalar(select(func.count()).select_from(User))
     if count and count > 0:
         raise HTTPException(status_code=400, detail="System already initialized")
@@ -103,7 +112,8 @@ async def bootstrap(db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/register", response_model=InitResponse)
-async def register(req: RegisterRequest, db: AsyncSession = Depends(get_db)):
+@limiter.limit("3/minute")
+async def register(request: Request, req: RegisterRequest, db: AsyncSession = Depends(get_db)):
     """Create a new account with email + password."""
     existing = await db.execute(select(User).where(User.email == req.email))
     if existing.scalar_one_or_none():
@@ -126,7 +136,8 @@ async def register(req: RegisterRequest, db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/login", response_model=InitResponse)
-async def login(req: LoginRequest, db: AsyncSession = Depends(get_db)):
+@limiter.limit("5/minute")
+async def login(request: Request, req: LoginRequest, db: AsyncSession = Depends(get_db)):
     """Login with API key or email+password. Returns user info and API key."""
     if req.api_key:
         key_hash = hashlib.sha256(req.api_key.encode()).hexdigest()
@@ -206,10 +217,55 @@ async def oauth_callback(request: Request, db: AsyncSession = Depends(get_db)):
     await db.commit()
     await db.refresh(user)
 
-    # Normally we'd use a more secure form of handoff (like Secure cookies for sessions),
-    # but since the system primarily relies on X-API-Key exchange dynamically:
-    frontend_redirect = f"{settings.FRONTEND_URL}/login?apiKey={api_key}&role={user.role.value}"
+    # Generate a short-lived opaque code instead of exposing the API key in the URL.
+    # The frontend will exchange this code for credentials via a POST request.
+    code = secrets.token_urlsafe(32)
+    redis = get_redis()
+    await redis.setex(
+        f"oauth_code:{code}",
+        30,
+        json.dumps({"api_key": api_key, "user_id": str(user.id), "role": user.role.value}),
+    )
+
+    frontend_redirect = f"{settings.FRONTEND_URL}/login?code={code}"
     return RedirectResponse(url=frontend_redirect)
+
+
+@router.post("/exchange", response_model=InitResponse)
+async def exchange_code(req: CodeExchangeRequest, db: AsyncSession = Depends(get_db)):
+    """Exchange a one-time OAuth auth code for API credentials.
+
+    The code is stored in Redis with a 30-second TTL and is deleted after
+    a single successful use, preventing replay attacks.
+    """
+    redis = get_redis()
+    redis_key = f"oauth_code:{req.code}"
+    data = await redis.get(redis_key)
+
+    if not data:
+        raise HTTPException(status_code=400, detail="Invalid or expired code")
+
+    # Delete immediately to enforce single-use
+    await redis.delete(redis_key)
+
+    try:
+        payload = json.loads(data)
+    except (json.JSONDecodeError, TypeError):
+        raise HTTPException(status_code=400, detail="Invalid or expired code")
+
+    api_key = payload.get("api_key")
+    user_id = payload.get("user_id")
+
+    if not api_key or not user_id:
+        raise HTTPException(status_code=400, detail="Invalid or expired code")
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+
+    if not user:
+        raise HTTPException(status_code=400, detail="Invalid or expired code")
+
+    return InitResponse(user=UserResponse.model_validate(user), api_key=api_key)
 
 
 @router.get("/whoami", response_model=UserResponse)
@@ -234,7 +290,8 @@ def _purge_expired_tokens() -> None:
 
 
 @router.post("/request-reset")
-async def request_password_reset(req: RequestResetRequest, db: AsyncSession = Depends(get_db)):
+@limiter.limit("3/minute")
+async def request_password_reset(request: Request, req: RequestResetRequest, db: AsyncSession = Depends(get_db)):
     """Request a password reset code. The code is logged to the server console.
 
     Since Observal is self-hosted, the admin has access to server logs.
@@ -262,7 +319,8 @@ async def request_password_reset(req: RequestResetRequest, db: AsyncSession = De
 
 
 @router.post("/reset-password", response_model=InitResponse)
-async def reset_password(req: ResetPasswordRequest, db: AsyncSession = Depends(get_db)):
+@limiter.limit("5/minute")
+async def reset_password(request: Request, req: ResetPasswordRequest, db: AsyncSession = Depends(get_db)):
     """Reset password using a code from the server logs. Returns new API key."""
     _purge_expired_tokens()
 
@@ -323,7 +381,8 @@ async def create_invite(
 
 
 @router.post("/redeem", response_model=InitResponse)
-async def redeem_invite(req: InviteRedeemRequest, db: AsyncSession = Depends(get_db)):
+@limiter.limit("5/minute")
+async def redeem_invite(request: Request, req: InviteRedeemRequest, db: AsyncSession = Depends(get_db)):
     """Redeem an invite code to create an account and get an API key."""
     code = req.code.strip().upper()
 

--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -40,9 +40,7 @@ async def run_evaluation(
         Agent,
         agent_id,
         db,
-        load_options=[
-            selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections)
-        ],
+        load_options=[selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections)],
     )
 
     # Create eval run
@@ -131,9 +129,7 @@ async def get_scorecard(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    sc = await resolve_prefix_id(
-        Scorecard, scorecard_id, db, load_options=_scorecard_load, display_field="version"
-    )
+    sc = await resolve_prefix_id(Scorecard, scorecard_id, db, load_options=_scorecard_load, display_field="version")
     return ScorecardResponse.model_validate(sc)
 
 
@@ -147,7 +143,9 @@ async def compare_versions(
 ):
     """Compare average scores between two agent versions."""
     from sqlalchemy import func
+
     agent = await resolve_prefix_id(Agent, agent_id, db)
+
     async def _avg_scores(version: str) -> dict:
         result = await db.execute(
             select(
@@ -188,9 +186,7 @@ async def eval_session(
             Agent,
             agent_id,
             db,
-            load_options=[
-                selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections)
-            ],
+            load_options=[selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections)],
         )
 
     if agent:
@@ -220,10 +216,7 @@ async def eval_session(
         "session_id": session_id,
         "trace": trace,
         "span_count": len(spans),
-        "spans_summary": [
-            {"type": s["type"], "name": s["name"], "status": s["status"]}
-            for s in spans
-        ],
+        "spans_summary": [{"type": s["type"], "name": s["name"], "status": s["status"]} for s in spans],
         "source": "hook_materializer",
         "note": "No agent_id provided — returning materialized spans without scoring.",
     }
@@ -251,23 +244,20 @@ async def eval_agent_in_session(
     """
     # Load agent from DB (by UUID or name)
     from api.routes.agent import _load_agent
+
     agent = await _load_agent(db, agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
     # Materialize session and find the agent's spans
-    trace, all_spans, agent_ctx = await materialize_agent_eval(
-        session_id, agent.name
-    )
+    trace, all_spans, agent_ctx = await materialize_agent_eval(session_id, agent.name)
 
     if not all_spans:
         raise HTTPException(status_code=404, detail="No hook events found for session")
 
     # If not found by name, try by agent ID
     if agent_ctx is None:
-        trace, all_spans, agent_ctx = await materialize_agent_eval(
-            session_id, str(agent.id)
-        )
+        trace, all_spans, agent_ctx = await materialize_agent_eval(session_id, str(agent.id))
 
     if agent_ctx is None:
         # Agent wasn't found as a subagent — check if this is a single-agent

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -69,10 +69,7 @@ async def get_session(session_id: str):
     sid = _escape(session_id)
     # Match either session.id or conversation_id so resumed Kiro sessions
     # (which share a conversation_id) resolve correctly.
-    session_filter = (
-        f"(LogAttributes['session.id'] = '{sid}' "
-        f"OR LogAttributes['conversation_id'] = '{sid}')"
-    )
+    session_filter = f"(LogAttributes['session.id'] = '{sid}' OR LogAttributes['conversation_id'] = '{sid}')"
     events = await _ch_json(
         "SELECT "
         "Timestamp AS timestamp, "
@@ -436,8 +433,12 @@ async def ingest_hook(request: Request):
 
     # ── Enriched fields from Kiro SQLite DB (sent by kiro_stop_hook.py) ──
     for enriched_field in (
-        "input_tokens", "output_tokens",
-        "turn_count", "credits", "tools_used", "conversation_id",
+        "input_tokens",
+        "output_tokens",
+        "turn_count",
+        "credits",
+        "tools_used",
+        "conversation_id",
     ):
         if body.get(enriched_field):
             attrs[enriched_field] = str(body[enriched_field])

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -14,10 +14,14 @@ class Settings(BaseSettings):
     AWS_REGION: str = "us-east-1"
 
     # OAuth Settings
-    OAUTH_CLIENT_ID: str | None = "39372289-d565-4a70-985f-8d36d54a4c71"
-    OAUTH_CLIENT_SECRET: str | None = "secret-here"  # OAuth client secret here
-    OAUTH_SERVER_METADATA_URL: str | None = "https://login.microsoftonline.com/932446f1-3249-4966-b2a2-8f4bfef64b1b/v2.0/.well-known/openid-configuration"
+    OAUTH_CLIENT_ID: str | None = None
+    OAUTH_CLIENT_SECRET: str | None = None
+    OAUTH_SERVER_METADATA_URL: str | None = None
     FRONTEND_URL: str = "http://localhost:3000"
+
+    # Rate limiting
+    RATE_LIMIT_AUTH: str = "10/minute"
+    RATE_LIMIT_AUTH_STRICT: str = "5/minute"
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -1,14 +1,21 @@
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.requests import Request
 from strawberry.fastapi import GraphQLRouter
 
 from api.deps import get_db
 from api.graphql import get_context_dep, schema
+from api.ratelimit import limiter
 from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
 from api.routes.alert import router as alert_router
@@ -27,6 +34,7 @@ from api.routes.sandbox import router as sandbox_router
 from api.routes.scan import router as scan_router
 from api.routes.skill import router as skill_router
 from api.routes.telemetry import router as telemetry_router
+from config import settings
 from database import engine
 from models import Base
 from models.user import User
@@ -62,14 +70,69 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# Rate limiting
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
 # Add SessionMiddleware for Authlib (OAuth state)
 app.add_middleware(
     SessionMiddleware,
-    secret_key="dev-hardcoded-secret-key",
-    max_age=3600  # 1 hour
+    secret_key=settings.SECRET_KEY,
+    max_age=3600,  # 1 hour
 )
 
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+# --- CORS configuration ---
+_cors_env = os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
+CORS_ALLOWED_ORIGINS: list[str] = [o.strip() for o in _cors_env.split(",") if o.strip()]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=CORS_ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# --- Request body size limit ---
+MAX_REQUEST_SIZE_BYTES: int = int(os.environ.get("MAX_REQUEST_SIZE_MB", "10")) * 1024 * 1024
+
+
+class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose Content-Length exceeds the configured limit."""
+
+    async def dispatch(self, request: Request, call_next):
+        content_length = request.headers.get("content-length")
+        if content_length and int(content_length) > MAX_REQUEST_SIZE_BYTES:
+            return JSONResponse(
+                status_code=413,
+                content={"detail": "Request body too large"},
+            )
+        return await call_next(request)
+
+
+app.add_middleware(RequestSizeLimitMiddleware)
+
+
+# --- Security headers ---
+_is_localhost = any(o.startswith("http://localhost") or o.startswith("http://127.0.0.1") for o in CORS_ALLOWED_ORIGINS)
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach common security headers to every response."""
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+        if not _is_localhost:
+            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        return response
+
+
+app.add_middleware(SecurityHeadersMiddleware)
 
 # GraphQL (replaces REST dashboard endpoints)
 graphql_app = GraphQLRouter(schema, context_getter=get_context_dep)

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -24,4 +24,5 @@ dependencies = [
     "itsdangerous",
     "cryptography",
     "cffi",
+    "slowapi",
 ]

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -78,6 +78,10 @@ class InitResponse(BaseModel):
     api_key: str
 
 
+class CodeExchangeRequest(BaseModel):
+    code: str
+
+
 class RequestResetRequest(BaseModel):
     email: EmailStr
 

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -349,7 +349,7 @@ def _generate_claude_code(manifest: AgentManifest) -> IdeAgentConfig:
     frontmatter_lines = [
         "---",
         f"name: {safe_name}",
-        f"description: \"{desc_line}\"",
+        f'description: "{desc_line}"',
     ]
     if mcp_entries:
         frontmatter_lines.append("mcpServers:")

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -133,8 +133,8 @@ def generate_agent_config(
         # Telemetry collected via observal-shim + hook bridge
         model_field = f',\\"model\\":\\"{agent.model_name}\\"' if agent.model_name else ""
         curl_cmd = (
-            f"cat | sed 's/^{{/{{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\","
-            f"\"agent_name\":\"{safe_name}\"{model_field},/' "
+            f'cat | sed \'s/^{{/{{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+            f'"agent_name":"{safe_name}"{model_field},/\' '
             f"| curl -sf -X POST {observal_url}/api/v1/otel/hooks "
             f'-H "Content-Type: application/json" '
             f"-d @-"
@@ -143,8 +143,8 @@ def generate_agent_config(
         # Uses the observal CLI's enrichment script if installed, otherwise
         # falls back to the same curl command as other events.
         stop_cmd = (
-            f"cat | sed 's/^{{/{{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\","
-            f"\"agent_name\":\"{safe_name}\"{model_field},/' "
+            f'cat | sed \'s/^{{/{{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+            f'"agent_name":"{safe_name}"{model_field},/\' '
             f"| python3 -m observal_cli.hooks.kiro_stop_hook "
             f"--url {observal_url}/api/v1/otel/hooks"
         )
@@ -197,7 +197,7 @@ def generate_agent_config(
         frontmatter_lines = [
             "---",
             f"name: {safe_name}",
-            f"description: \"{desc_line}\"",
+            f'description: "{desc_line}"',
         ]
         if claude_mcps:
             frontmatter_lines.append("mcpServers:")

--- a/observal-server/services/eval_service.py
+++ b/observal-server/services/eval_service.py
@@ -453,8 +453,7 @@ async def run_agent_scoped_eval(
             if not goal_desc and agent.goal_template:
                 goal_desc = agent.goal_template.description
                 required_sections = [
-                    {"name": s.name, "grounding_required": s.grounding_required}
-                    for s in agent.goal_template.sections
+                    {"name": s.name, "grounding_required": s.grounding_required} for s in agent.goal_template.sections
                 ]
 
             # For agent-scoped eval, pass full_spans for grounding context
@@ -468,13 +467,13 @@ async def run_agent_scoped_eval(
                     # No structured sections — use delegation prompt as
                     # a single "task completion" section
                     slm_penalties += await slm_scorer.score_goal_completion(
-                        sanitized_trace, full_spans, goal_desc,
+                        sanitized_trace,
+                        full_spans,
+                        goal_desc,
                         [{"name": "Delegated Task", "grounding_required": True}],
                     )
 
-            slm_penalties += await slm_scorer.score_factual_grounding(
-                sanitized_trace, full_spans
-            )
+            slm_penalties += await slm_scorer.score_factual_grounding(sanitized_trace, full_spans)
             slm_penalties += await slm_scorer.score_thought_process(full_spans)
         except Exception as e:
             logger.error(f"SLM scoring failed for agent-scoped eval: {e}")

--- a/observal-server/services/hook_config_generator.py
+++ b/observal-server/services/hook_config_generator.py
@@ -3,8 +3,8 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
         # Kiro uses shell-command hooks, not HTTP hooks.
         # Generate a runCommand hook that pipes STDIN JSON to the Observal API via curl.
         curl_cmd = (
-            "cat | sed 's/^{/{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\","
-            "\"terminal_type\":\"'$TERM'\",\"shell\":\"'$SHELL'\",/' "
+            'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+            '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
             f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
             f'-H "Content-Type: application/json" '
             f"-d @-"
@@ -23,8 +23,8 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
         # For stop events, use the enrichment script to capture model/tokens
         if kiro_event == "stop":
             stop_cmd = (
-                "cat | sed 's/^{/{\"session_id\":\"kiro-'$PPID'\",\"service_name\":\"kiro-cli\","
-                "\"terminal_type\":\"'$TERM'\",\"shell\":\"'$SHELL'\",/' "
+                'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+                '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
                 f"| python3 -m observal_cli.hooks.kiro_stop_hook "
                 f"--url {server_url}/api/v1/otel/hooks"
             )

--- a/observal-server/services/hook_materializer.py
+++ b/observal-server/services/hook_materializer.py
@@ -106,6 +106,7 @@ def _parse_attrs(event: dict) -> dict:
     attrs = event.get("attributes", {})
     if isinstance(attrs, str):
         import json
+
         try:
             attrs = json.loads(attrs)
         except Exception:
@@ -113,9 +114,7 @@ def _parse_attrs(event: dict) -> dict:
     return attrs
 
 
-def _build_trace_and_spans(
-    session_id: str, events: list[dict]
-) -> tuple[dict, list[dict]]:
+def _build_trace_and_spans(session_id: str, events: list[dict]) -> tuple[dict, list[dict]]:
     """Parse hook events into a trace dict and span list.
 
     Each span is tagged with agent_id/agent_type if the source event
@@ -134,9 +133,7 @@ def _build_trace_and_spans(
     for event in events:
         attrs = _parse_attrs(event)
 
-        event_name = _normalize_event_name(
-            attrs.get("event.name", event.get("event_name", ""))
-        )
+        event_name = _normalize_event_name(attrs.get("event.name", event.get("event_name", "")))
 
         if not model and attrs.get("model"):
             model = attrs["model"]
@@ -173,107 +170,111 @@ def _build_trace_and_spans(
 
             latency_ms = _compute_latency(start_ts, event.get("timestamp", ""))
 
-            spans.append({
-                "span_id": str(uuid.uuid4())[:16],
-                "type": "tool_call",
-                "name": tool_name,
-                "input": _truncate(tool_input, 2000),
-                "output": _truncate(tool_output, 2000),
-                "status": "error" if is_error else "success",
-                "error": attrs.get("error", "") if is_error else None,
-                "latency_ms": latency_ms,
-                "start_time": start_ts,
-                "agent_id": span_agent_id,
-                "agent_type": span_agent_type,
-            })
+            spans.append(
+                {
+                    "span_id": str(uuid.uuid4())[:16],
+                    "type": "tool_call",
+                    "name": tool_name,
+                    "input": _truncate(tool_input, 2000),
+                    "output": _truncate(tool_output, 2000),
+                    "status": "error" if is_error else "success",
+                    "error": attrs.get("error", "") if is_error else None,
+                    "latency_ms": latency_ms,
+                    "start_time": start_ts,
+                    "agent_id": span_agent_id,
+                    "agent_type": span_agent_type,
+                }
+            )
 
         elif event_name in ("hook_UserPromptSubmit", "UserPromptSubmit", "user_prompt"):
-            prompt_text = (
-                attrs.get("tool_input", "")
-                or attrs.get("prompt", "")
-                or event.get("body", "")
+            prompt_text = attrs.get("tool_input", "") or attrs.get("prompt", "") or event.get("body", "")
+            spans.append(
+                {
+                    "span_id": str(uuid.uuid4())[:16],
+                    "type": "user_prompt",
+                    "name": "user_prompt",
+                    "input": _truncate(prompt_text, 2000),
+                    "output": "",
+                    "status": "success",
+                    "error": None,
+                    "latency_ms": 0,
+                    "start_time": event.get("timestamp", ""),
+                    "agent_id": span_agent_id,
+                    "agent_type": span_agent_type,
+                }
             )
-            spans.append({
-                "span_id": str(uuid.uuid4())[:16],
-                "type": "user_prompt",
-                "name": "user_prompt",
-                "input": _truncate(prompt_text, 2000),
-                "output": "",
-                "status": "success",
-                "error": None,
-                "latency_ms": 0,
-                "start_time": event.get("timestamp", ""),
-                "agent_id": span_agent_id,
-                "agent_type": span_agent_type,
-            })
 
         elif event_name in ("hook_subagentstart", "hook_SubagentStart"):
             delegation = attrs.get("tool_input", event.get("body", ""))
-            spans.append({
-                "span_id": str(uuid.uuid4())[:16],
-                "type": "subagent_start",
-                "name": f"SubagentStart:{span_agent_type or span_agent_id}",
-                "input": _truncate(delegation, 2000),
-                "output": "",
-                "status": "success",
-                "error": None,
-                "latency_ms": 0,
-                "start_time": event.get("timestamp", ""),
-                "agent_id": span_agent_id,
-                "agent_type": span_agent_type,
-            })
+            spans.append(
+                {
+                    "span_id": str(uuid.uuid4())[:16],
+                    "type": "subagent_start",
+                    "name": f"SubagentStart:{span_agent_type or span_agent_id}",
+                    "input": _truncate(delegation, 2000),
+                    "output": "",
+                    "status": "success",
+                    "error": None,
+                    "latency_ms": 0,
+                    "start_time": event.get("timestamp", ""),
+                    "agent_id": span_agent_id,
+                    "agent_type": span_agent_type,
+                }
+            )
 
         elif event_name in ("hook_subagentstop", "hook_SubagentStop"):
             agent_output = attrs.get("tool_response", event.get("body", ""))
-            spans.append({
-                "span_id": str(uuid.uuid4())[:16],
-                "type": "subagent_stop",
-                "name": f"SubagentStop:{span_agent_type or span_agent_id}",
-                "input": "",
-                "output": _truncate(agent_output, 2000),
-                "status": "success",
-                "error": None,
-                "latency_ms": 0,
-                "start_time": event.get("timestamp", ""),
-                "agent_id": span_agent_id,
-                "agent_type": span_agent_type,
-            })
+            spans.append(
+                {
+                    "span_id": str(uuid.uuid4())[:16],
+                    "type": "subagent_stop",
+                    "name": f"SubagentStop:{span_agent_type or span_agent_id}",
+                    "input": "",
+                    "output": _truncate(agent_output, 2000),
+                    "status": "success",
+                    "error": None,
+                    "latency_ms": 0,
+                    "start_time": event.get("timestamp", ""),
+                    "agent_id": span_agent_id,
+                    "agent_type": span_agent_type,
+                }
+            )
 
         elif event_name in ("hook_Stop", "Stop"):
-            response = (
-                attrs.get("tool_response", "")
-                or attrs.get("assistant_response", "")
-                or event.get("body", "")
-            )
+            response = attrs.get("tool_response", "") or attrs.get("assistant_response", "") or event.get("body", "")
             trace_output = _truncate(response, 4000)
-            spans.append({
-                "span_id": str(uuid.uuid4())[:16],
-                "type": "agent_response",
-                "name": "final_response",
-                "input": "",
-                "output": trace_output,
-                "status": "success",
-                "error": None,
-                "latency_ms": 0,
-                "start_time": event.get("timestamp", ""),
-                "agent_id": span_agent_id,
-                "agent_type": span_agent_type,
-            })
+            spans.append(
+                {
+                    "span_id": str(uuid.uuid4())[:16],
+                    "type": "agent_response",
+                    "name": "final_response",
+                    "input": "",
+                    "output": trace_output,
+                    "status": "success",
+                    "error": None,
+                    "latency_ms": 0,
+                    "start_time": event.get("timestamp", ""),
+                    "agent_id": span_agent_id,
+                    "agent_type": span_agent_type,
+                }
+            )
 
         elif event_name in ("hook_SessionStart", "SessionStart", "agentSpawn"):
-            spans.append({
-                "span_id": str(uuid.uuid4())[:16],
-                "type": "session_start",
-                "name": "session_start",
-                "input": event.get("body", ""),
-                "output": "",
-                "status": "success",
-                "error": None,
-                "latency_ms": 0,
-                "start_time": event.get("timestamp", ""),
-                "agent_id": span_agent_id,
-                "agent_type": span_agent_type,
-            })
+            spans.append(
+                {
+                    "span_id": str(uuid.uuid4())[:16],
+                    "type": "session_start",
+                    "name": "session_start",
+                    "input": event.get("body", ""),
+                    "output": "",
+                    "status": "success",
+                    "error": None,
+                    "latency_ms": 0,
+                    "start_time": event.get("timestamp", ""),
+                    "agent_id": span_agent_id,
+                    "agent_type": span_agent_type,
+                }
+            )
 
     # Build the trace dict
     trace = {
@@ -293,9 +294,7 @@ def _build_trace_and_spans(
     return trace, spans
 
 
-def _find_agent_context(
-    spans: list[dict], target_agent: str
-) -> AgentContext | None:
+def _find_agent_context(spans: list[dict], target_agent: str) -> AgentContext | None:
     """Find all invocations of a target agent within a session's spans.
 
     Matches by agent_id, agent_type, or agent_name (case-insensitive).
@@ -348,7 +347,8 @@ def _find_agent_context(
 
     # Fallback: no SubagentStart/Stop but spans carry agent_id attribution
     agent_span_indices = [
-        idx for idx, span in enumerate(spans)
+        idx
+        for idx, span in enumerate(spans)
         if (
             (span.get("agent_id") or "").lower() == target_lower
             or (span.get("agent_type") or "").lower() == target_lower
@@ -360,12 +360,14 @@ def _find_agent_context(
         ctx.span_start_idx = agent_span_indices[0]
         ctx.span_end_idx = agent_span_indices[-1]
         ctx.agent_id = target_agent
-        ctx.invocations = [{
-            "start_idx": agent_span_indices[0],
-            "end_idx": agent_span_indices[-1],
-            "delegation_prompt": "",
-            "agent_output": "",
-        }]
+        ctx.invocations = [
+            {
+                "start_idx": agent_span_indices[0],
+                "end_idx": agent_span_indices[-1],
+                "delegation_prompt": "",
+                "agent_output": "",
+            }
+        ]
         return ctx
 
     return None
@@ -411,8 +413,11 @@ def build_agent_eval_context(
 def _normalize_event_name(name: str) -> str:
     """Normalize event names to a consistent form."""
     if name.startswith("hook_") or name in (
-        "PreToolUse", "PostToolUse", "UserPromptSubmit",
-        "Stop", "SessionStart",
+        "PreToolUse",
+        "PostToolUse",
+        "UserPromptSubmit",
+        "Stop",
+        "SessionStart",
     ):
         return name
     mapping = {

--- a/observal-server/services/secrets_redactor.py
+++ b/observal-server/services/secrets_redactor.py
@@ -59,9 +59,7 @@ _KNOWN_KEY_PATTERNS: list[re.Pattern] = [
 # JWT tokens (three base64url segments separated by dots)
 # ---------------------------------------------------------------------------
 
-_RE_JWT = re.compile(
-    r"eyJ[a-zA-Z0-9_-]{10,}\.eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}"
-)
+_RE_JWT = re.compile(r"eyJ[a-zA-Z0-9_-]{10,}\.eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}")
 
 # ---------------------------------------------------------------------------
 # PEM private keys
@@ -94,9 +92,7 @@ _SECRET_KEY_NAMES = (
 _RE_KEY_VALUE = re.compile(
     r"(?i)"
     r"(?<!\$)(?<!\$\{)"  # NOT preceded by $ or ${  (env var reference)
-    r"""["']?"""  # optional quotes around key name (JSON)
-    + _SECRET_KEY_NAMES
-    + r"""["']?\s*[=:]\s*"""
+    r"""["']?""" + _SECRET_KEY_NAMES + r"""["']?\s*[=:]\s*"""  # optional quotes around key name (JSON)
     r"(?:"
     r'"([^"\n]{8,})"'  # double-quoted value
     r"|'([^'\n]{8,})'"  # single-quoted value

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -329,6 +329,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -625,6 +637,20 @@ wheels = [
 ]
 
 [[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -731,6 +757,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "redis", extra = ["hiredis"] },
+    { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "uvicorn", extra = ["standard"] },
@@ -754,6 +781,7 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "redis", extras = ["hiredis"] },
+    { name = "slowapi" },
     { name = "sqlalchemy", extras = ["asyncio"] },
     { name = "strawberry-graphql", extras = ["fastapi"] },
     { name = "uvicorn", extras = ["standard"] },
@@ -1034,6 +1062,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
 ]
 
 [[package]]
@@ -1374,4 +1414,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]

--- a/observal_cli/hooks/observal-hook.sh
+++ b/observal_cli/hooks/observal-hook.sh
@@ -11,3 +11,6 @@ curl -sf --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
   ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
   -H "Content-Type: application/json" \
   -d @- >/dev/null 2>&1 || true
+
+# Claude Code requires JSON with "continue" on stdout for the session to proceed
+echo '{"continue":true}'

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -34,18 +34,38 @@ function LoginContent() {
   }, [router]);
 
   useEffect(() => {
-    // Handling SSO callback logic dynamically in same route or query params
-    const ssoApiKey = searchParams.get("apiKey");
-    const ssoRole = searchParams.get("role");
+    // Handle one-time auth code from OAuth callback
+    const ssoCode = searchParams.get("code");
 
-    if (ssoApiKey && ssoRole) {
+    if (ssoCode) {
       setLoading(true);
-      setApiKey(ssoApiKey);
-      setUserRole(ssoRole);
-      toast.success("Signed in successfully via SSO");
-      
-      // Cleanup URL params and redirect cleanly to main page
-      router.push("/");
+      // Strip the code from the URL immediately to prevent leakage
+      window.history.replaceState({}, "", "/login");
+
+      fetch("/api/v1/auth/exchange", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: ssoCode }),
+      })
+        .then(async (res) => {
+          if (!res.ok) {
+            const text = await res.text().catch(() => res.statusText);
+            throw new Error(text);
+          }
+          return res.json();
+        })
+        .then((data: { api_key: string; user: { role: string } }) => {
+          setApiKey(data.api_key);
+          setUserRole(data.user.role);
+          toast.success("Signed in successfully via SSO");
+          router.push("/");
+        })
+        .catch((err) => {
+          const msg = err instanceof Error ? err.message : "SSO sign-in failed";
+          setError(msg);
+          toast.error("SSO sign-in failed — the code may have expired. Please try again.");
+          setLoading(false);
+        });
     } else if (searchParams.get("error")) {
       setError(searchParams.get("error") || "SSO Authentication Failed");
     }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -121,6 +121,8 @@ export const auth = {
     post<{ message: string }>("/auth/request-reset", body),
   resetPassword: (body: { email: string; token: string; new_password: string }) =>
     post<AuthResponse>("/auth/reset-password", body),
+  exchangeCode: (body: { code: string }) =>
+    post<AuthResponse>("/auth/exchange", body),
 };
 
 // ── Registry (all 8 types) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Batch fix for 4 P0 security vulnerabilities:

- **#182 — Remove hardcoded secrets**: `SECRET_KEY` and `DATABASE_URL` are now required (no defaults). Azure AD GUID stripped from `OAUTH_CLIENT_ID`. `SessionMiddleware` uses `settings.SECRET_KEY` instead of hardcoded string.
- **#183 — OAuth credential leakage**: Callback no longer exposes API key in URL. Implements one-time auth code exchange via Redis (30s TTL, single-use). Frontend exchanges code via POST, strips it from URL immediately.
- **#184 — Rate limiting auth endpoints**: slowapi-based rate limiting on all auth endpoints (login 5/min, register 3/min, reset 3–5/min, bootstrap 1/min + localhost-only restriction).
- **#185 — CORS & security headers**: CORS restricted to `CORS_ALLOWED_ORIGINS` env var. Security headers added (X-Frame-Options: DENY, HSTS, X-Content-Type-Options, Referrer-Policy, Permissions-Policy). Request body size limit (10MB default).

Also fixes `observal-hook.sh` to output `{"continue":true}` for Claude Code hook compatibility.

Closes #182, closes #183, closes #184, closes #185

## Test plan
- [ ] Server refuses to start without `SECRET_KEY` and `DATABASE_URL`
- [ ] OAuth login flow works via code exchange (key never in URL)
- [ ] Auth code expires after 30s and rejects replay
- [ ] Rate limiting returns 429 after threshold
- [ ] `/auth/bootstrap` rejects non-localhost with 403
- [ ] CORS rejects disallowed origins
- [ ] Security headers present on all responses
- [ ] Request >10MB returns 413