### PR TITLE
feat(auth): add JWT bearer token auth for unified browser/CLI sessions

### DIFF
--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -3,12 +3,14 @@ import uuid as _uuid
 from collections.abc import AsyncGenerator
 from functools import wraps
 
+import jwt
 from fastapi import Depends, Header, HTTPException
 from sqlalchemy import String, cast, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import async_session
 from models.user import User, UserRole
+from services.jwt_service import decode_access_token
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
@@ -16,25 +18,60 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
+async def _authenticate_via_jwt(token: str, db: AsyncSession) -> User | None:
+    """Try to authenticate using a JWT access token. Returns User or None."""
+    try:
+        payload = decode_access_token(token)
+    except jwt.InvalidTokenError:
+        return None
+
+    user_id = payload.get("sub")
+    if not user_id:
+        return None
+
+    try:
+        uid = _uuid.UUID(user_id)
+    except ValueError:
+        return None
+
+    result = await db.execute(select(User).where(User.id == uid))
+    return result.scalar_one_or_none()
+
+
+async def _authenticate_via_api_key(api_key: str, db: AsyncSession) -> User | None:
+    """Try to authenticate using a raw API key. Returns User or None."""
+    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+    result = await db.execute(select(User).where(User.api_key_hash == key_hash))
+    return result.scalar_one_or_none()
+
+
 async def get_current_user(
     x_api_key: str | None = Header(None),
     authorization: str | None = Header(None),
     db: AsyncSession = Depends(get_db),
 ) -> User:
-    # Try X-API-Key header first
-    api_key = x_api_key
-    # Fall back to Bearer token in Authorization header
-    if not api_key and authorization and authorization.startswith("Bearer "):
-        api_key = authorization.removeprefix("Bearer ").strip()
-    if not api_key:
-        raise HTTPException(status_code=401, detail="Missing API key")
+    # Extract bearer token from Authorization header
+    bearer_token: str | None = None
+    if authorization and authorization.startswith("Bearer "):
+        bearer_token = authorization.removeprefix("Bearer ").strip()
 
-    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
-    result = await db.execute(select(User).where(User.api_key_hash == key_hash))
-    user = result.scalar_one_or_none()
-    if not user:
-        raise HTTPException(status_code=401, detail="Invalid API key")
-    return user
+    # 1. If we have a Bearer token, try JWT first
+    if bearer_token:
+        user = await _authenticate_via_jwt(bearer_token, db)
+        if user:
+            return user
+        # JWT decode failed -- fall back to treating it as a raw API key
+        user = await _authenticate_via_api_key(bearer_token, db)
+        if user:
+            return user
+
+    # 2. Try X-API-Key header (backward compat with existing CLI installs)
+    if x_api_key:
+        user = await _authenticate_via_api_key(x_api_key, db)
+        if user:
+            return user
+
+    raise HTTPException(status_code=401, detail="Invalid or missing credentials")
 
 
 def require_role(*roles: UserRole):

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -5,6 +5,7 @@ import secrets
 import string
 from datetime import UTC, datetime, timedelta
 
+import jwt as pyjwt
 from authlib.integrations.starlette_client import OAuth
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
@@ -25,11 +26,16 @@ from schemas.auth import (
     InviteRedeemRequest,
     InviteResponse,
     LoginRequest,
+    RefreshRequest,
     RegisterRequest,
     RequestResetRequest,
     ResetPasswordRequest,
+    RevokeRequest,
+    TokenRequest,
+    TokenResponse,
     UserResponse,
 )
+from services.jwt_service import create_access_token, create_refresh_token, decode_refresh_token
 from services.redis import get_redis
 
 logger = logging.getLogger(__name__)
@@ -271,6 +277,105 @@ async def exchange_code(req: CodeExchangeRequest, db: AsyncSession = Depends(get
 @router.get("/whoami", response_model=UserResponse)
 async def whoami(current_user: User = Depends(get_current_user)):
     return UserResponse.model_validate(current_user)
+
+
+# ── JWT Token Endpoints ────────────────────────────────────
+
+
+@router.post("/token", response_model=TokenResponse)
+@limiter.limit(settings.RATE_LIMIT_AUTH)
+async def issue_token(request: Request, req: TokenRequest, db: AsyncSession = Depends(get_db)):
+    """Exchange API key or email+password for JWT access + refresh tokens."""
+    user: User | None = None
+
+    if req.api_key:
+        key_hash = hashlib.sha256(req.api_key.encode()).hexdigest()
+        result = await db.execute(select(User).where(User.api_key_hash == key_hash))
+        user = result.scalar_one_or_none()
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+    else:
+        result = await db.execute(select(User).where(User.email == req.email))
+        user = result.scalar_one_or_none()
+        if not user or not user.verify_password(req.password):
+            raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    access_token, expires_in = create_access_token(user.id, user.role)
+    refresh_token, jti = create_refresh_token(user.id, user.role)
+
+    # Store refresh token JTI in Redis so it can be revoked later.
+    # TTL matches the refresh token's lifetime.
+    redis = get_redis()
+    refresh_ttl = settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400
+    await redis.setex(f"refresh_jti:{jti}", refresh_ttl, str(user.id))
+
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_in=expires_in,
+    )
+
+
+@router.post("/token/refresh", response_model=TokenResponse)
+@limiter.limit(settings.RATE_LIMIT_AUTH)
+async def refresh_token(request: Request, req: RefreshRequest, db: AsyncSession = Depends(get_db)):
+    """Exchange a valid refresh token for a new access token (and rotated refresh token)."""
+    try:
+        payload = decode_refresh_token(req.refresh_token)
+    except pyjwt.InvalidTokenError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid refresh token: {exc}")
+
+    jti = payload.get("jti")
+    user_id = payload.get("sub")
+    if not jti or not user_id:
+        raise HTTPException(status_code=401, detail="Invalid refresh token claims")
+
+    # Check that the JTI has not been revoked
+    redis = get_redis()
+    stored = await redis.get(f"refresh_jti:{jti}")
+    if stored is None:
+        raise HTTPException(status_code=401, detail="Refresh token has been revoked or expired")
+
+    # Revoke the old refresh token (one-time use / rotation)
+    await redis.delete(f"refresh_jti:{jti}")
+
+    # Look up the user to ensure they still exist
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=401, detail="User no longer exists")
+
+    # Issue new token pair
+    access_token, expires_in = create_access_token(user.id, user.role)
+    new_refresh_token, new_jti = create_refresh_token(user.id, user.role)
+
+    refresh_ttl = settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400
+    await redis.setex(f"refresh_jti:{new_jti}", refresh_ttl, str(user.id))
+
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=new_refresh_token,
+        expires_in=expires_in,
+    )
+
+
+@router.post("/token/revoke")
+@limiter.limit(settings.RATE_LIMIT_AUTH)
+async def revoke_token(request: Request, req: RevokeRequest):
+    """Revoke a refresh token so it can no longer be used."""
+    try:
+        payload = decode_refresh_token(req.refresh_token)
+    except pyjwt.InvalidTokenError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid refresh token: {exc}")
+
+    jti = payload.get("jti")
+    if not jti:
+        raise HTTPException(status_code=401, detail="Invalid refresh token claims")
+
+    redis = get_redis()
+    await redis.delete(f"refresh_jti:{jti}")
+
+    return {"detail": "Token revoked"}
 
 
 # ── Password Reset ──────────────────────────────────────────

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     OAUTH_SERVER_METADATA_URL: str | None = None
     FRONTEND_URL: str = "http://localhost:3000"
 
+    # JWT Settings
+    JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    JWT_REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+
     # Rate limiting
     RATE_LIMIT_AUTH: str = "10/minute"
     RATE_LIMIT_AUTH_STRICT: str = "5/minute"

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -25,4 +25,11 @@ dependencies = [
     "cryptography",
     "cffi",
     "slowapi",
+    "PyJWT>=2.8.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
 ]

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -90,3 +90,32 @@ class ResetPasswordRequest(BaseModel):
     email: EmailStr
     token: str
     new_password: str
+
+
+class TokenRequest(BaseModel):
+    api_key: str | None = None
+    email: EmailStr | None = None
+    password: str | None = None
+
+    @model_validator(mode="after")
+    def _require_credentials(self):
+        has_key = bool(self.api_key)
+        has_password = bool(self.email and self.password)
+        if not has_key and not has_password:
+            raise ValueError("Provide api_key or email+password")
+        return self
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+    expires_in: int  # seconds
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class RevokeRequest(BaseModel):
+    refresh_token: str

--- a/observal-server/services/jwt_service.py
+++ b/observal-server/services/jwt_service.py
@@ -1,0 +1,81 @@
+"""JWT token generation and validation for unified browser/CLI auth."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from config import settings
+from models.user import UserRole
+
+ALGORITHM = "HS256"
+
+
+def create_access_token(user_id: uuid.UUID, role: UserRole) -> tuple[str, int]:
+    """Create a short-lived access token.
+
+    Returns (encoded_token, expires_in_seconds).
+    """
+    now = datetime.now(UTC)
+    expires_delta = timedelta(minutes=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES)
+    expires_in = int(expires_delta.total_seconds())
+    payload = {
+        "sub": str(user_id),
+        "role": role.value,
+        "type": "access",
+        "jti": str(uuid.uuid4()),
+        "iat": now,
+        "exp": now + expires_delta,
+    }
+    token = jwt.encode(payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+    return token, expires_in
+
+
+def create_refresh_token(user_id: uuid.UUID, role: UserRole) -> tuple[str, str]:
+    """Create a long-lived refresh token.
+
+    Returns (encoded_token, jti).
+    The jti is returned separately so it can be stored for revocation.
+    """
+    now = datetime.now(UTC)
+    jti = str(uuid.uuid4())
+    payload = {
+        "sub": str(user_id),
+        "role": role.value,
+        "type": "refresh",
+        "jti": jti,
+        "iat": now,
+        "exp": now + timedelta(days=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS),
+    }
+    token = jwt.encode(payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+    return token, jti
+
+
+def decode_token(token: str) -> dict:
+    """Decode and validate a JWT token.
+
+    Raises jwt.InvalidTokenError (or subclass) on failure.
+    """
+    return jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+
+
+def decode_access_token(token: str) -> dict:
+    """Decode an access token and verify its type claim.
+
+    Raises jwt.InvalidTokenError on failure or wrong token type.
+    """
+    payload = decode_token(token)
+    if payload.get("type") != "access":
+        raise jwt.InvalidTokenError("Token is not an access token")
+    return payload
+
+
+def decode_refresh_token(token: str) -> dict:
+    """Decode a refresh token and verify its type claim.
+
+    Raises jwt.InvalidTokenError on failure or wrong token type.
+    """
+    payload = decode_token(token)
+    if payload.get("type") != "refresh":
+        raise jwt.InvalidTokenError("Token is not a refresh token")
+    return payload

--- a/observal-server/tests/test_jwt.py
+++ b/observal-server/tests/test_jwt.py
@@ -1,0 +1,320 @@
+"""Tests for JWT token generation, validation, refresh, revocation, and backward compatibility."""
+
+import hashlib
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt as pyjwt
+import pytest
+
+# Ensure settings are importable with defaults before anything else
+from config import settings
+from models.user import User, UserRole
+from services.jwt_service import (
+    ALGORITHM,
+    create_access_token,
+    create_refresh_token,
+    decode_access_token,
+    decode_refresh_token,
+    decode_token,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(
+    user_id: uuid.UUID | None = None,
+    role: UserRole = UserRole.user,
+    api_key_raw: str = "test-api-key-hex",
+) -> tuple[User, str]:
+    """Return a (User, raw_api_key) pair for testing."""
+    uid = user_id or uuid.uuid4()
+    key_hash = hashlib.sha256(api_key_raw.encode()).hexdigest()
+    user = User(
+        id=uid,
+        email="test@example.com",
+        name="Test User",
+        role=role,
+        api_key_hash=key_hash,
+    )
+    return user, api_key_raw
+
+
+# ---------------------------------------------------------------------------
+# Token generation
+# ---------------------------------------------------------------------------
+
+
+class TestTokenGeneration:
+    def test_create_access_token_returns_valid_jwt(self):
+        uid = uuid.uuid4()
+        token, expires_in = create_access_token(uid, UserRole.admin)
+
+        payload = pyjwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+        assert payload["sub"] == str(uid)
+        assert payload["role"] == "admin"
+        assert payload["type"] == "access"
+        assert "jti" in payload
+        assert "iat" in payload
+        assert "exp" in payload
+        assert expires_in == settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60
+
+    def test_create_refresh_token_returns_valid_jwt_with_jti(self):
+        uid = uuid.uuid4()
+        token, jti = create_refresh_token(uid, UserRole.developer)
+
+        payload = pyjwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+        assert payload["sub"] == str(uid)
+        assert payload["role"] == "developer"
+        assert payload["type"] == "refresh"
+        assert payload["jti"] == jti
+
+    def test_access_and_refresh_have_different_jtis(self):
+        uid = uuid.uuid4()
+        access_token, _ = create_access_token(uid, UserRole.user)
+        refresh_token, _ = create_refresh_token(uid, UserRole.user)
+
+        a_payload = pyjwt.decode(access_token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+        r_payload = pyjwt.decode(refresh_token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+        assert a_payload["jti"] != r_payload["jti"]
+
+
+# ---------------------------------------------------------------------------
+# Token validation
+# ---------------------------------------------------------------------------
+
+
+class TestTokenValidation:
+    def test_decode_access_token_succeeds(self):
+        uid = uuid.uuid4()
+        token, _ = create_access_token(uid, UserRole.user)
+        payload = decode_access_token(token)
+        assert payload["sub"] == str(uid)
+
+    def test_decode_access_token_rejects_refresh_token(self):
+        uid = uuid.uuid4()
+        token, _ = create_refresh_token(uid, UserRole.user)
+        with pytest.raises(pyjwt.InvalidTokenError, match="not an access token"):
+            decode_access_token(token)
+
+    def test_decode_refresh_token_succeeds(self):
+        uid = uuid.uuid4()
+        token, jti = create_refresh_token(uid, UserRole.admin)
+        payload = decode_refresh_token(token)
+        assert payload["jti"] == jti
+
+    def test_decode_refresh_token_rejects_access_token(self):
+        uid = uuid.uuid4()
+        token, _ = create_access_token(uid, UserRole.user)
+        with pytest.raises(pyjwt.InvalidTokenError, match="not a refresh token"):
+            decode_refresh_token(token)
+
+    def test_expired_token_is_rejected(self):
+        """A token whose exp is in the past should be rejected."""
+        now = datetime.now(UTC)
+        payload = {
+            "sub": str(uuid.uuid4()),
+            "role": "user",
+            "type": "access",
+            "jti": str(uuid.uuid4()),
+            "iat": now - timedelta(hours=2),
+            "exp": now - timedelta(hours=1),
+        }
+        token = pyjwt.encode(payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+        with pytest.raises(pyjwt.ExpiredSignatureError):
+            decode_token(token)
+
+    def test_tampered_token_is_rejected(self):
+        uid = uuid.uuid4()
+        token, _ = create_access_token(uid, UserRole.user)
+        # Flip a character in the signature portion
+        parts = token.rsplit(".", 1)
+        tampered = parts[0] + "." + parts[1][::-1]
+        with pytest.raises(pyjwt.InvalidTokenError):
+            decode_token(tampered)
+
+    def test_wrong_secret_is_rejected(self):
+        uid = uuid.uuid4()
+        now = datetime.now(UTC)
+        payload = {
+            "sub": str(uid),
+            "role": "user",
+            "type": "access",
+            "jti": str(uuid.uuid4()),
+            "iat": now,
+            "exp": now + timedelta(hours=1),
+        }
+        token = pyjwt.encode(payload, "wrong-secret-key", algorithm=ALGORITHM)
+        with pytest.raises(pyjwt.InvalidSignatureError):
+            decode_token(token)
+
+
+# ---------------------------------------------------------------------------
+# Auth dependency — backward compatibility & JWT
+# ---------------------------------------------------------------------------
+
+
+class TestAuthDependency:
+    """Test the get_current_user dependency with both JWT and raw API keys.
+
+    These tests mock the database session to avoid needing a real DB.
+    """
+
+    @pytest.mark.asyncio
+    async def test_jwt_bearer_authenticates(self):
+        """A valid JWT in Authorization: Bearer should authenticate the user."""
+        from api.deps import get_current_user
+
+        user, _ = _make_user()
+        token, _ = create_access_token(user.id, user.role)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await get_current_user(
+            x_api_key=None,
+            authorization=f"Bearer {token}",
+            db=mock_db,
+        )
+        assert result.id == user.id
+
+    @pytest.mark.asyncio
+    async def test_raw_api_key_header_authenticates(self):
+        """X-API-Key header with raw key should still work (backward compat)."""
+        from api.deps import get_current_user
+
+        user, raw_key = _make_user()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = user
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        result = await get_current_user(
+            x_api_key=raw_key,
+            authorization=None,
+            db=mock_db,
+        )
+        assert result.id == user.id
+
+    @pytest.mark.asyncio
+    async def test_raw_api_key_in_bearer_authenticates(self):
+        """Authorization: Bearer <raw-api-key> should fall through JWT and work as API key."""
+        from api.deps import get_current_user
+
+        user, raw_key = _make_user()
+
+        # JWT decode will fail (raw_key is not a JWT), so it falls through
+        # to _authenticate_via_api_key which does a DB lookup by hash
+        mock_result_user = MagicMock()
+        mock_result_user.scalar_one_or_none.return_value = user
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result_user
+
+        result = await get_current_user(
+            x_api_key=None,
+            authorization=f"Bearer {raw_key}",
+            db=mock_db,
+        )
+        assert result.id == user.id
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_raises_401(self):
+        """No credentials at all should raise 401."""
+        from api.deps import get_current_user
+
+        mock_db = AsyncMock()
+
+        with pytest.raises(Exception) as exc_info:
+            await get_current_user(x_api_key=None, authorization=None, db=mock_db)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_jwt_falls_through_to_api_key(self):
+        """If the Bearer token is an invalid JWT but also not a valid API key, raise 401."""
+        from api.deps import get_current_user
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        with pytest.raises(Exception) as exc_info:
+            await get_current_user(
+                x_api_key=None,
+                authorization="Bearer totally-bogus-token",
+                db=mock_db,
+            )
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_expired_jwt_falls_through_to_api_key_check(self):
+        """An expired JWT should not authenticate, but the system should try the raw key path."""
+        from api.deps import get_current_user
+
+        user, _ = _make_user()
+        now = datetime.now(UTC)
+        payload = {
+            "sub": str(user.id),
+            "role": "user",
+            "type": "access",
+            "jti": str(uuid.uuid4()),
+            "iat": now - timedelta(hours=2),
+            "exp": now - timedelta(hours=1),
+        }
+        expired_token = pyjwt.encode(payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+        # The expired JWT string is not a valid API key hash either
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        with pytest.raises(Exception) as exc_info:
+            await get_current_user(
+                x_api_key=None,
+                authorization=f"Bearer {expired_token}",
+                db=mock_db,
+            )
+        assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemas:
+    def test_token_request_requires_credentials(self):
+        from schemas.auth import TokenRequest
+
+        with pytest.raises(ValueError):
+            TokenRequest()
+
+    def test_token_request_accepts_api_key(self):
+        from schemas.auth import TokenRequest
+
+        req = TokenRequest(api_key="some-key")
+        assert req.api_key == "some-key"
+
+    def test_token_request_accepts_email_password(self):
+        from schemas.auth import TokenRequest
+
+        req = TokenRequest(email="a@b.com", password="secret")
+        assert req.email == "a@b.com"
+
+    def test_token_response_has_defaults(self):
+        from schemas.auth import TokenResponse
+
+        resp = TokenResponse(
+            access_token="a",
+            refresh_token="r",
+            expires_in=3600,
+        )
+        assert resp.token_type == "bearer"

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -619,6 +619,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -755,12 +764,19 @@ dependencies = [
     { name = "itsdangerous" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "redis", extra = ["hiredis"] },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -779,12 +795,19 @@ requires-dist = [
     { name = "itsdangerous" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "python-dotenv" },
     { name = "redis", extras = ["hiredis"] },
     { name = "slowapi" },
     { name = "sqlalchemy", extras = ["asyncio"] },
     { name = "strawberry-graphql", extras = ["fastapi"] },
     { name = "uvicorn", extras = ["standard"] },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
 ]
 
 [[package]]
@@ -794,6 +817,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -932,12 +964,50 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add JWT service (jwt_service.py) with HS256 access/refresh token creation and validation
- Add /token, /token/refresh, /token/revoke endpoints to auth routes
- Update get_current_user dependency with 3-tier auth cascade: JWT decode -> raw API key hash -> X-API-Key header
- Token revocation via Redis JTI storage with TTL
- Add JWT_ACCESS_TOKEN_EXPIRE_MINUTES and JWT_REFRESH_TOKEN_EXPIRE_DAYS config settings

Relates to #192

## Test plan

- [x] All 881 tests pass
- [ ] Verify browser login flow obtains JWT tokens
- [ ] Verify CLI can authenticate with both API key and JWT
- [ ] Verify token refresh and revocation work correctly