### PR TITLE
feat(security): add asymmetric key management for JWT signing (ES256)

### DIFF
--- a/observal-server/api/routes/jwks.py
+++ b/observal-server/api/routes/jwks.py
@@ -1,0 +1,27 @@
+"""JWKS discovery endpoint for JWT public key distribution.
+
+Exposes the server's public signing key(s) in standard JWKS format so that
+clients and browsers can verify tokens without a shared secret.
+"""
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from services.crypto import get_key_manager
+
+router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
+
+
+@router.get("/.well-known/jwks.json")
+async def jwks() -> JSONResponse:
+    """Return the server's public signing keys in JWKS format (RFC 7517).
+
+    Clients use this endpoint to obtain the public key(s) needed to verify
+    JWTs issued by this server.  During key rotation, both the current and
+    recently retired keys are included so in-flight tokens remain valid.
+    """
+    km = get_key_manager()
+    return JSONResponse(
+        content=km.get_jwks(),
+        headers={"Cache-Control": "public, max-age=3600"},
+    )

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -23,6 +23,11 @@ class Settings(BaseSettings):
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     JWT_REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 
+    # JWT / Asymmetric key signing
+    JWT_SIGNING_ALGORITHM: str = "ES256"  # ES256 (ECDSA) or RS256 (RSA)
+    JWT_KEY_DIR: str = "~/.observal/keys"
+    JWT_KEY_PASSWORD: str | None = None  # Optional password for private key encryption at rest
+
     # Rate limiting
     RATE_LIMIT_AUTH: str = "10/minute"
     RATE_LIMIT_AUTH_STRICT: str = "5/minute"

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -27,6 +27,7 @@ from api.routes.dashboard import router as dashboard_router
 from api.routes.eval import router as eval_router
 from api.routes.feedback import router as feedback_router
 from api.routes.hook import router as hook_router
+from api.routes.jwks import router as jwks_router
 from api.routes.mcp import router as mcp_router
 from api.routes.otel_dashboard import router as otel_dashboard_router
 from api.routes.otlp import router as otlp_router
@@ -41,6 +42,7 @@ from database import engine
 from models import Base
 from models.user import User
 from services.clickhouse import init_clickhouse
+from services.crypto import init_key_manager
 from services.redis import close as close_redis
 
 
@@ -60,6 +62,11 @@ async def lifespan(app: FastAPI):
         await conn.run_sync(Base.metadata.create_all)
         await _ensure_columns(conn)
     await init_clickhouse()
+    # Initialize asymmetric key manager for JWT signing
+    init_key_manager(
+        key_dir=settings.JWT_KEY_DIR,
+        key_password=settings.JWT_KEY_PASSWORD,
+    )
     yield
     await close_redis()
 
@@ -151,6 +158,7 @@ app.include_router(otlp_router)
 
 # REST (CLI operations, auth, telemetry ingestion)
 app.include_router(auth_router)
+app.include_router(jwks_router)
 app.include_router(mcp_router)
 app.include_router(review_router)
 app.include_router(agent_router)

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "strawberry-graphql[fastapi]",
     "authlib",
     "itsdangerous",
-    "cryptography",
+    "cryptography>=43.0.0",
     "cffi",
     "slowapi",
     "PyJWT>=2.8.0",

--- a/observal-server/services/crypto.py
+++ b/observal-server/services/crypto.py
@@ -1,0 +1,352 @@
+"""Asymmetric key management for JWT signing and verification (ES256 / ECDSA P-256).
+
+This module provides:
+- Automatic key-pair generation on first server boot
+- PEM-based key persistence with optional password protection
+- JWKS endpoint data for standard token verification
+- Key rotation with old-key retention for graceful transition
+- ``sign_token`` / ``verify_token`` helpers for JWT auth
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64url(data: bytes) -> str:
+    """Base64url-encode *without* padding (per RFC 7515)."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    """Base64url-decode, re-adding padding as needed."""
+    s += "=" * (4 - len(s) % 4)
+    return base64.urlsafe_b64decode(s)
+
+
+def _kid_from_public_key(pub: ec.EllipticCurvePublicKey) -> str:
+    """Derive a deterministic key-id (kid) from the public key bytes."""
+    raw = pub.public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _public_key_to_jwk(pub: ec.EllipticCurvePublicKey, kid: str) -> dict:
+    """Convert an EC public key to a JWK dict (RFC 7517 / 7518)."""
+    numbers = pub.public_numbers()
+    # P-256 coordinates are 32 bytes each
+    x_bytes = numbers.x.to_bytes(32, byteorder="big")
+    y_bytes = numbers.y.to_bytes(32, byteorder="big")
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": _b64url(x_bytes),
+        "y": _b64url(y_bytes),
+        "kid": kid,
+        "use": "sig",
+        "alg": "ES256",
+    }
+
+
+# ---------------------------------------------------------------------------
+# KeyManager
+# ---------------------------------------------------------------------------
+
+
+class KeyManager:
+    """Manages ES256 (ECDSA P-256) key pairs for JWT signing.
+
+    On first run the manager generates a new key pair and persists it to
+    *key_dir*.  On subsequent runs the existing key is loaded.  Key rotation
+    is supported: the current signing key is stored as ``signing.pem`` while
+    retired public keys are kept as ``retired_<kid>.pem`` so tokens signed
+    with a previous key can still be verified during a transition window.
+    """
+
+    def __init__(
+        self,
+        key_dir: str = "~/.observal/keys",
+        key_password: str | None = None,
+    ) -> None:
+        self._key_dir = Path(key_dir).expanduser()
+        self._key_password = key_password.encode() if key_password else None
+
+        self._private_key: ec.EllipticCurvePrivateKey | None = None
+        self._public_key: ec.EllipticCurvePublicKey | None = None
+        self._kid: str | None = None
+
+        # Retired public keys: kid -> EllipticCurvePublicKey
+        self._retired_keys: dict[str, ec.EllipticCurvePublicKey] = {}
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def initialize(self) -> None:
+        """Load or generate the signing key pair.  Call once at startup."""
+        self._key_dir.mkdir(parents=True, exist_ok=True)
+        # Restrict directory to owner-only
+        os.chmod(self._key_dir, 0o700)
+
+        signing_path = self._key_dir / "signing.pem"
+        if signing_path.exists():
+            self._load_private_key(signing_path)
+            logger.info("Loaded existing signing key (kid=%s)", self._kid)
+        else:
+            self._generate_key_pair(signing_path)
+            logger.info("Generated new signing key (kid=%s)", self._kid)
+
+        self._load_retired_keys()
+
+    # -- public API ----------------------------------------------------------
+
+    def get_private_key(self) -> ec.EllipticCurvePrivateKey:
+        """Return the current signing private key."""
+        if self._private_key is None:
+            raise RuntimeError("KeyManager has not been initialized")
+        return self._private_key
+
+    def get_public_key(self) -> ec.EllipticCurvePublicKey:
+        """Return the current signing public key."""
+        if self._public_key is None:
+            raise RuntimeError("KeyManager has not been initialized")
+        return self._public_key
+
+    def get_kid(self) -> str:
+        """Return the key-id of the current signing key."""
+        if self._kid is None:
+            raise RuntimeError("KeyManager has not been initialized")
+        return self._kid
+
+    def get_public_key_pem(self) -> str:
+        """Return the PEM-encoded public key for distribution."""
+        return (
+            self.get_public_key()
+            .public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode()
+        )
+
+    def get_jwks(self) -> dict:
+        """Return all public keys (current + retired) in JWKS format."""
+        keys: list[dict] = []
+        # Current key
+        keys.append(_public_key_to_jwk(self.get_public_key(), self.get_kid()))
+        # Retired keys
+        for kid, pub in self._retired_keys.items():
+            keys.append(_public_key_to_jwk(pub, kid))
+        return {"keys": keys}
+
+    def rotate_key(self) -> str:
+        """Generate a new signing key, retiring the current one.
+
+        Returns the *kid* of the newly generated key.
+        """
+        if self._public_key is not None and self._kid is not None:
+            # Persist current public key as retired
+            retired_path = self._key_dir / f"retired_{self._kid}.pem"
+            retired_path.write_bytes(
+                self._public_key.public_bytes(
+                    serialization.Encoding.PEM,
+                    serialization.PublicFormat.SubjectPublicKeyInfo,
+                )
+            )
+            self._retired_keys[self._kid] = self._public_key
+            logger.info("Retired signing key kid=%s", self._kid)
+
+        signing_path = self._key_dir / "signing.pem"
+        self._generate_key_pair(signing_path)
+        logger.info("Rotated to new signing key kid=%s", self._kid)
+        return self.get_kid()
+
+    def find_public_key(self, kid: str) -> ec.EllipticCurvePublicKey | None:
+        """Look up a public key by its *kid* (current or retired)."""
+        if kid == self._kid:
+            return self._public_key
+        return self._retired_keys.get(kid)
+
+    # -- token helpers -------------------------------------------------------
+
+    def sign_token(self, payload: dict) -> str:
+        """Sign a JWT-like payload with the current private key.
+
+        Produces a compact JWS (header.payload.signature) using ES256.
+        If ``PyJWT`` is installed this delegates to it; otherwise a
+        minimal implementation using the ``cryptography`` library is used.
+        """
+        try:
+            import jwt as pyjwt
+
+            return pyjwt.encode(
+                payload,
+                self.get_private_key(),
+                algorithm="ES256",
+                headers={"kid": self.get_kid()},
+            )
+        except ImportError:
+            pass
+
+        return self._sign_token_raw(payload)
+
+    def verify_token(self, token: str) -> dict:
+        """Verify and decode a JWT signed by this server.
+
+        Supports tokens signed with both the current and retired keys.
+        """
+        try:
+            import jwt as pyjwt
+
+            # Extract kid from unverified header
+            header = pyjwt.get_unverified_header(token)
+            kid = header.get("kid", self.get_kid())
+            pub = self.find_public_key(kid)
+            if pub is None:
+                raise ValueError(f"Unknown key id: {kid}")
+            return pyjwt.decode(token, pub, algorithms=["ES256"])
+        except ImportError:
+            pass
+
+        return self._verify_token_raw(token)
+
+    # -- internal ------------------------------------------------------------
+
+    def _encryption_args(self) -> serialization.KeySerializationEncryption:
+        if self._key_password:
+            return serialization.BestAvailableEncryption(self._key_password)
+        return serialization.NoEncryption()
+
+    def _generate_key_pair(self, path: Path) -> None:
+        key = ec.generate_private_key(ec.SECP256R1())
+        pem = key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            self._encryption_args(),
+        )
+        path.write_bytes(pem)
+        os.chmod(path, 0o600)
+        self._private_key = key
+        self._public_key = key.public_key()
+        self._kid = _kid_from_public_key(self._public_key)
+
+    def _load_private_key(self, path: Path) -> None:
+        pem_data = path.read_bytes()
+        key = serialization.load_pem_private_key(pem_data, password=self._key_password)
+        if not isinstance(key, ec.EllipticCurvePrivateKey):
+            raise TypeError(f"Expected an EC private key, got {type(key).__name__}")
+        self._private_key = key
+        self._public_key = key.public_key()
+        self._kid = _kid_from_public_key(self._public_key)
+
+    def _load_retired_keys(self) -> None:
+        for p in self._key_dir.glob("retired_*.pem"):
+            try:
+                pub = serialization.load_pem_public_key(p.read_bytes())
+                if isinstance(pub, ec.EllipticCurvePublicKey):
+                    kid = _kid_from_public_key(pub)
+                    self._retired_keys[kid] = pub
+                    logger.debug("Loaded retired key kid=%s from %s", kid, p.name)
+            except Exception:
+                logger.warning("Failed to load retired key %s", p, exc_info=True)
+
+    # -- raw JWS (no PyJWT dependency) ---------------------------------------
+
+    def _sign_token_raw(self, payload: dict) -> str:
+        """Minimal JWS compact serialization using ``cryptography``."""
+        header = {"alg": "ES256", "typ": "JWT", "kid": self.get_kid()}
+        segments = [
+            _b64url(json.dumps(header, separators=(",", ":")).encode()),
+            _b64url(json.dumps(payload, separators=(",", ":")).encode()),
+        ]
+        signing_input = f"{segments[0]}.{segments[1]}".encode()
+
+        # ECDSA signature in DER, convert to fixed-size (r || s) per RFC 7518
+        der_sig = self.get_private_key().sign(
+            signing_input,
+            ec.ECDSA(hashes.SHA256()),
+        )
+        r, s = utils.decode_dss_signature(der_sig)
+        sig_bytes = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+        segments.append(_b64url(sig_bytes))
+        return ".".join(segments)
+
+    def _verify_token_raw(self, token: str) -> dict:
+        """Minimal JWS verification using ``cryptography``."""
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise ValueError("Invalid JWT format")
+
+        header = json.loads(_b64url_decode(parts[0]))
+        kid = header.get("kid", self.get_kid())
+        pub = self.find_public_key(kid)
+        if pub is None:
+            raise ValueError(f"Unknown key id: {kid}")
+
+        signing_input = f"{parts[0]}.{parts[1]}".encode()
+        sig_bytes = _b64url_decode(parts[2])
+
+        if len(sig_bytes) != 64:
+            raise ValueError("Invalid signature length")
+
+        r = int.from_bytes(sig_bytes[:32], "big")
+        s = int.from_bytes(sig_bytes[32:], "big")
+        der_sig = utils.encode_dss_signature(r, s)
+
+        pub.verify(der_sig, signing_input, ec.ECDSA(hashes.SHA256()))
+
+        payload = json.loads(_b64url_decode(parts[1]))
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_key_manager: KeyManager | None = None
+
+
+def get_key_manager() -> KeyManager:
+    """Return the global KeyManager instance (must be initialized first)."""
+    if _key_manager is None:
+        raise RuntimeError("KeyManager not initialized. Call init_key_manager() during app startup.")
+    return _key_manager
+
+
+def init_key_manager(
+    key_dir: str = "~/.observal/keys",
+    key_password: str | None = None,
+) -> KeyManager:
+    """Create, initialize, and register the global KeyManager singleton."""
+    global _key_manager
+    km = KeyManager(key_dir=key_dir, key_password=key_password)
+    km.initialize()
+    _key_manager = km
+    return km
+
+
+# Convenience wrappers ------------------------------------------------------
+
+
+def sign_token(payload: dict) -> str:
+    """Sign a JWT payload with the server's private key."""
+    return get_key_manager().sign_token(payload)
+
+
+def verify_token(token: str) -> dict:
+    """Verify and decode a JWT using the server's public key."""
+    return get_key_manager().verify_token(token)

--- a/observal-server/tests/conftest.py
+++ b/observal-server/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for JWT / auth tests."""
+
+import hashlib
+import os
+import uuid
+
+import pytest
+
+# Override settings before any app code imports them
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-do-not-use-in-prod")
+
+
+@pytest.fixture()
+def user_id():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture()
+def user_role():
+    return "admin"
+
+
+@pytest.fixture()
+def api_key():
+    """A deterministic raw API key for testing."""
+    return "deadbeef" * 8
+
+
+@pytest.fixture()
+def api_key_hash(api_key):
+    return hashlib.sha256(api_key.encode()).hexdigest()

--- a/observal-server/tests/test_crypto.py
+++ b/observal-server/tests/test_crypto.py
@@ -1,0 +1,412 @@
+"""Tests for the asymmetric key management service (services/crypto.py).
+
+Covers:
+- Key generation (creates valid EC P-256 key pair)
+- Key persistence (loads existing key on restart)
+- JWKS format output
+- Token signing and verification round-trip (raw + PyJWT)
+- Key rotation (old tokens still verify with old public key)
+- Password-protected keys
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from services.crypto import (
+    KeyManager,
+    _b64url,
+    _b64url_decode,
+    _kid_from_public_key,
+    get_key_manager,
+    init_key_manager,
+)
+
+
+@pytest.fixture()
+def tmp_key_dir(tmp_path):
+    """Provide a temporary directory for key storage."""
+    d = tmp_path / "keys"
+    d.mkdir()
+    return str(d)
+
+
+@pytest.fixture()
+def km(tmp_key_dir):
+    """Return an initialized KeyManager with a fresh key pair."""
+    manager = KeyManager(key_dir=tmp_key_dir)
+    manager.initialize()
+    return manager
+
+
+# ===================================================================
+# Key generation
+# ===================================================================
+
+
+class TestKeyGeneration:
+    def test_generates_ec_key_pair(self, km):
+        priv = km.get_private_key()
+        pub = km.get_public_key()
+        assert isinstance(priv, ec.EllipticCurvePrivateKey)
+        assert isinstance(pub, ec.EllipticCurvePublicKey)
+        # Must be P-256
+        assert priv.curve.name == "secp256r1"
+
+    def test_kid_is_deterministic(self, km):
+        kid1 = km.get_kid()
+        kid2 = _kid_from_public_key(km.get_public_key())
+        assert kid1 == kid2
+
+    def test_kid_is_hex_string(self, km):
+        kid = km.get_kid()
+        assert len(kid) == 16
+        int(kid, 16)  # should not raise
+
+    def test_public_key_pem_format(self, km):
+        pem = km.get_public_key_pem()
+        assert pem.startswith("-----BEGIN PUBLIC KEY-----")
+        assert pem.strip().endswith("-----END PUBLIC KEY-----")
+
+    def test_signing_pem_created_on_disk(self, tmp_key_dir):
+        manager = KeyManager(key_dir=tmp_key_dir)
+        manager.initialize()
+        assert os.path.exists(os.path.join(tmp_key_dir, "signing.pem"))
+
+    def test_key_file_permissions(self, tmp_key_dir):
+        manager = KeyManager(key_dir=tmp_key_dir)
+        manager.initialize()
+        pem_path = os.path.join(tmp_key_dir, "signing.pem")
+        mode = oct(os.stat(pem_path).st_mode & 0o777)
+        assert mode == "0o600"
+
+
+# ===================================================================
+# Key persistence
+# ===================================================================
+
+
+class TestKeyPersistence:
+    def test_loads_existing_key_on_restart(self, tmp_key_dir):
+        # First boot: generate
+        km1 = KeyManager(key_dir=tmp_key_dir)
+        km1.initialize()
+        kid1 = km1.get_kid()
+        pem1 = km1.get_public_key_pem()
+
+        # Second boot: load
+        km2 = KeyManager(key_dir=tmp_key_dir)
+        km2.initialize()
+        kid2 = km2.get_kid()
+        pem2 = km2.get_public_key_pem()
+
+        assert kid1 == kid2
+        assert pem1 == pem2
+
+    def test_password_protected_key(self, tmp_key_dir):
+        password = "test-password-1234"
+        km1 = KeyManager(key_dir=tmp_key_dir, key_password=password)
+        km1.initialize()
+        kid1 = km1.get_kid()
+
+        # Reload with correct password
+        km2 = KeyManager(key_dir=tmp_key_dir, key_password=password)
+        km2.initialize()
+        assert km2.get_kid() == kid1
+
+    def test_wrong_password_fails(self, tmp_key_dir):
+        km1 = KeyManager(key_dir=tmp_key_dir, key_password="correct")
+        km1.initialize()
+
+        km2 = KeyManager(key_dir=tmp_key_dir, key_password="wrong")
+        with pytest.raises((ValueError, TypeError)):
+            km2.initialize()
+
+
+# ===================================================================
+# JWKS format
+# ===================================================================
+
+
+class TestJWKS:
+    def test_jwks_structure(self, km):
+        jwks = km.get_jwks()
+        assert "keys" in jwks
+        assert len(jwks["keys"]) == 1
+
+    def test_jwk_fields(self, km):
+        jwk = km.get_jwks()["keys"][0]
+        assert jwk["kty"] == "EC"
+        assert jwk["crv"] == "P-256"
+        assert jwk["use"] == "sig"
+        assert jwk["alg"] == "ES256"
+        assert jwk["kid"] == km.get_kid()
+        assert "x" in jwk
+        assert "y" in jwk
+
+    def test_jwk_coordinates_decode(self, km):
+        jwk = km.get_jwks()["keys"][0]
+        x_bytes = _b64url_decode(jwk["x"])
+        y_bytes = _b64url_decode(jwk["y"])
+        # P-256 coordinates are 32 bytes each
+        assert len(x_bytes) == 32
+        assert len(y_bytes) == 32
+
+    def test_jwks_includes_retired_keys_after_rotation(self, km):
+        old_kid = km.get_kid()
+        km.rotate_key()
+        jwks = km.get_jwks()
+        assert len(jwks["keys"]) == 2
+        kids = {k["kid"] for k in jwks["keys"]}
+        assert old_kid in kids
+        assert km.get_kid() in kids
+
+
+# ===================================================================
+# Token signing and verification — raw (no PyJWT)
+# ===================================================================
+
+
+class TestTokenRoundTripRaw:
+    """Test the raw JWS implementation (no PyJWT dependency)."""
+
+    def test_sign_and_verify_raw(self, km):
+        payload = {"sub": "user-123", "role": "admin"}
+        token = km._sign_token_raw(payload)
+        decoded = km._verify_token_raw(token)
+        assert decoded["sub"] == "user-123"
+        assert decoded["role"] == "admin"
+
+    def test_raw_token_is_three_part_jws(self, km):
+        token = km._sign_token_raw({"test": True})
+        parts = token.split(".")
+        assert len(parts) == 3
+
+    def test_raw_token_header_contains_kid(self, km):
+        token = km._sign_token_raw({"test": True})
+        header_b64 = token.split(".")[0]
+        header = json.loads(_b64url_decode(header_b64))
+        assert header["alg"] == "ES256"
+        assert header["typ"] == "JWT"
+        assert header["kid"] == km.get_kid()
+
+    def test_tampered_payload_fails_verification(self, km):
+        token = km._sign_token_raw({"sub": "user-123"})
+        parts = token.split(".")
+        # Tamper with the payload
+        fake_payload = _b64url(json.dumps({"sub": "admin"}).encode())
+        tampered = f"{parts[0]}.{fake_payload}.{parts[2]}"
+        with pytest.raises((ValueError, InvalidSignature)):
+            km._verify_token_raw(tampered)
+
+    def test_invalid_token_format(self, km):
+        with pytest.raises(ValueError, match="Invalid JWT format"):
+            km._verify_token_raw("not.a.valid.token.at.all")
+
+    def test_unknown_kid_fails(self, km):
+        token = km._sign_token_raw({"sub": "user-123"})
+        parts = token.split(".")
+        # Forge header with unknown kid
+        header = json.loads(_b64url_decode(parts[0]))
+        header["kid"] = "unknown-kid-1234"
+        fake_header = _b64url(json.dumps(header, separators=(",", ":")).encode())
+        forged = f"{fake_header}.{parts[1]}.{parts[2]}"
+        with pytest.raises(ValueError, match="Unknown key id"):
+            km._verify_token_raw(forged)
+
+
+# ===================================================================
+# Token signing and verification — via sign_token / verify_token
+# ===================================================================
+
+
+class TestTokenRoundTrip:
+    """Test the public sign_token / verify_token API (uses PyJWT if available)."""
+
+    def test_sign_and_verify(self, km):
+        payload = {"sub": "user-456", "role": "developer"}
+        token = km.sign_token(payload)
+        decoded = km.verify_token(token)
+        assert decoded["sub"] == "user-456"
+        assert decoded["role"] == "developer"
+
+    def test_roundtrip_with_nested_payload(self, km):
+        payload = {"data": {"items": [1, 2, 3]}, "count": 3}
+        token = km.sign_token(payload)
+        decoded = km.verify_token(token)
+        assert decoded["data"]["items"] == [1, 2, 3]
+
+
+# ===================================================================
+# Key rotation
+# ===================================================================
+
+
+class TestKeyRotation:
+    def test_rotation_generates_new_kid(self, km):
+        old_kid = km.get_kid()
+        km.rotate_key()
+        new_kid = km.get_kid()
+        assert old_kid != new_kid
+
+    def test_old_token_still_verifies_after_rotation(self, km):
+        payload = {"sub": "user-rotate", "test": True}
+        token_before = km._sign_token_raw(payload)
+
+        km.rotate_key()
+
+        # Old token should still verify (raw implementation checks retired keys)
+        decoded = km._verify_token_raw(token_before)
+        assert decoded["sub"] == "user-rotate"
+
+    def test_new_token_verifies_after_rotation(self, km):
+        km.rotate_key()
+        payload = {"sub": "user-new"}
+        token = km._sign_token_raw(payload)
+        decoded = km._verify_token_raw(token)
+        assert decoded["sub"] == "user-new"
+
+    def test_retired_key_persisted_on_disk(self, tmp_key_dir):
+        km = KeyManager(key_dir=tmp_key_dir)
+        km.initialize()
+        old_kid = km.get_kid()
+
+        km.rotate_key()
+
+        retired_path = os.path.join(tmp_key_dir, f"retired_{old_kid}.pem")
+        assert os.path.exists(retired_path)
+
+    def test_retired_keys_loaded_on_restart(self, tmp_key_dir):
+        km1 = KeyManager(key_dir=tmp_key_dir)
+        km1.initialize()
+        token = km1._sign_token_raw({"sub": "persist-test"})
+
+        km1.rotate_key()
+        new_kid = km1.get_kid()
+
+        # Restart
+        km2 = KeyManager(key_dir=tmp_key_dir)
+        km2.initialize()
+        assert km2.get_kid() == new_kid
+
+        # Old token should verify via retired keys
+        decoded = km2._verify_token_raw(token)
+        assert decoded["sub"] == "persist-test"
+
+    def test_multiple_rotations(self, km):
+        kids = [km.get_kid()]
+        for _ in range(3):
+            km.rotate_key()
+            kids.append(km.get_kid())
+
+        # All kids should be unique
+        assert len(set(kids)) == 4
+
+        # JWKS should contain all 4 keys (1 current + 3 retired)
+        jwks = km.get_jwks()
+        assert len(jwks["keys"]) == 4
+
+    def test_find_public_key(self, km):
+        old_kid = km.get_kid()
+        km.rotate_key()
+        new_kid = km.get_kid()
+
+        # Both should be findable
+        assert km.find_public_key(old_kid) is not None
+        assert km.find_public_key(new_kid) is not None
+        # Unknown should return None
+        assert km.find_public_key("nonexistent") is None
+
+
+# ===================================================================
+# Module-level singleton
+# ===================================================================
+
+
+class TestSingleton:
+    def test_init_and_get(self, tmp_key_dir):
+        km = init_key_manager(key_dir=tmp_key_dir)
+        assert get_key_manager() is km
+
+    def test_get_before_init_raises(self, monkeypatch):
+        import services.crypto as mod
+
+        monkeypatch.setattr(mod, "_key_manager", None)
+        with pytest.raises(RuntimeError, match="not initialized"):
+            get_key_manager()
+
+
+# ===================================================================
+# Base64url helpers
+# ===================================================================
+
+
+class TestBase64Url:
+    def test_roundtrip(self):
+        data = b"hello world"
+        encoded = _b64url(data)
+        decoded = _b64url_decode(encoded)
+        assert decoded == data
+
+    def test_no_padding(self):
+        encoded = _b64url(b"a")
+        assert "=" not in encoded
+
+
+# ===================================================================
+# JWKS HTTP endpoint
+# ===================================================================
+
+
+class TestJWKSEndpoint:
+    """Test the GET /api/v1/auth/.well-known/jwks.json route."""
+
+    @pytest.fixture()
+    def jwks_app(self, tmp_key_dir):
+        """Build a minimal FastAPI app with just the JWKS route."""
+        import services.crypto as crypto_mod
+
+        init_key_manager(key_dir=tmp_key_dir)
+
+        from api.routes.jwks import router
+
+        app = FastAPI()
+        app.include_router(router)
+        yield app
+        # Cleanup singleton so other tests are not affected
+        crypto_mod._key_manager = None
+
+    @pytest.fixture()
+    async def jwks_client(self, jwks_app):
+        transport = ASGITransport(app=jwks_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield c
+
+    @pytest.mark.asyncio
+    async def test_jwks_endpoint_returns_200(self, jwks_client):
+        resp = await jwks_client.get("/api/v1/auth/.well-known/jwks.json")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_jwks_endpoint_returns_valid_jwks(self, jwks_client):
+        resp = await jwks_client.get("/api/v1/auth/.well-known/jwks.json")
+        data = resp.json()
+        assert "keys" in data
+        assert len(data["keys"]) >= 1
+        key = data["keys"][0]
+        assert key["kty"] == "EC"
+        assert key["crv"] == "P-256"
+        assert key["alg"] == "ES256"
+        assert "kid" in key
+
+    @pytest.mark.asyncio
+    async def test_jwks_endpoint_cache_header(self, jwks_client):
+        resp = await jwks_client.get("/api/v1/auth/.well-known/jwks.json")
+        assert "max-age" in resp.headers.get("cache-control", "")


### PR DESCRIPTION
## Summary

- Add KeyManager class (crypto.py) with ES256 key management: auto-generation, PEM persistence, key rotation, JWKS output
- Add sign_token()/verify_token() helpers for asymmetric JWT operations
- Add GET /api/v1/auth/.well-known/jwks.json endpoint for public key distribution
- Add JWT_SIGNING_ALGORITHM, JWT_KEY_DIR, JWT_KEY_PASSWORD config settings
- Initialize key manager in FastAPI lifespan

Relates to #192

## Test plan

- [x] All 881 tests pass
- [ ] Verify JWKS endpoint returns valid JWK set
- [ ] Verify key auto-generation on first startup
- [ ] Verify ES256 signed tokens can be verified via JWKS