### PR TITLE
feat(cli): add local SQLite buffer for offline telemetry collection

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -323,6 +323,23 @@ def status():
     else:
         rprint("  Health:  [red]unreachable[/red]")
 
+    # Show local telemetry buffer summary
+    try:
+        from observal_cli.telemetry_buffer import stats as buffer_stats
+
+        buf = buffer_stats()
+        if buf["total"] > 0:
+            rprint()
+            pending = buf["pending"]
+            label = f"[yellow]{pending} pending[/yellow]" if pending else "[green]0 pending[/green]"
+            rprint(f"  Buffer:  {label}, {buf['failed']} failed, {buf['sent']} sent")
+            if buf["oldest_pending"]:
+                rprint(f"  Oldest:  {buf['oldest_pending']} UTC")
+            if pending and not ok:
+                rprint("  [dim]Run `observal ops sync` when the server is back online.[/dim]")
+    except Exception:
+        pass
+
 
 def version_callback():
     """Show CLI version."""

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -124,6 +124,27 @@ def telemetry_status():
     rprint(f"  Tool calls:   {data.get('tool_call_events', 0)} (last hour)")
     rprint(f"  Interactions: {data.get('agent_interaction_events', 0)} (last hour)")
 
+    # Show local buffer stats
+    try:
+        from observal_cli.telemetry_buffer import stats as buffer_stats
+
+        buf = buffer_stats()
+        rprint()
+        rprint("  [bold]Local Buffer[/bold]")
+        rprint(f"  Pending:      {buf['pending']} events")
+        if buf["failed"]:
+            rprint(f"  Failed:       [red]{buf['failed']} events[/red]")
+        if buf["sent"]:
+            rprint(f"  Sent (cached):{buf['sent']} events")
+        if buf["oldest_pending"]:
+            rprint(f"  Oldest:       {buf['oldest_pending']} UTC")
+        if buf["last_sync"]:
+            rprint(f"  Last sync:    {buf['last_sync']} UTC")
+        if buf["total"] == 0:
+            rprint("  [dim]Buffer is empty (all events sent directly)[/dim]")
+    except Exception:
+        pass
+
 
 @telemetry_app.command(name="test")
 def telemetry_test():
@@ -144,6 +165,94 @@ def telemetry_test():
             },
         )
     rprint(f"[green]✓ Test event sent![/green] Ingested: {result.get('ingested', 0)}")
+
+
+# ── Sync (on ops_app) ──────────────────────────────────
+
+
+@ops_app.command(name="sync")
+def ops_sync():
+    """Flush locally buffered telemetry events to the server.
+
+    When the Observal server is unreachable, hook events are stored in a
+    local SQLite buffer (~/.observal/telemetry_buffer.db). This command
+    sends pending events in batches and reports the result.
+    """
+    import httpx
+
+    from observal_cli.telemetry_buffer import (
+        BATCH_SIZE,
+        cleanup,
+        get_pending,
+        mark_failed,
+        mark_sent,
+    )
+    from observal_cli.telemetry_buffer import (
+        stats as buffer_stats,
+    )
+
+    buf = buffer_stats()
+    if buf["pending"] == 0:
+        rprint("[dim]No pending events to sync.[/dim]")
+        cleaned = cleanup()
+        if cleaned:
+            rprint(f"[dim]Cleaned up {cleaned} old sent events.[/dim]")
+        return
+
+    cfg = config.load()
+    hooks_url = cfg.get("server_url", "http://localhost:8000").rstrip("/") + "/api/v1/otel/hooks"
+    user_id = cfg.get("user_id", "")
+
+    total_sent = 0
+    total_failed = 0
+
+    with spinner("Syncing buffered events..."):
+        while True:
+            batch = get_pending(limit=BATCH_SIZE)
+            if not batch:
+                break
+
+            sent_ids = []
+            failed_ids = []
+
+            for event in batch:
+                try:
+                    headers = {"Content-Type": "application/json"}
+                    if user_id:
+                        headers["X-Observal-User-Id"] = user_id
+
+                    r = httpx.post(
+                        hooks_url,
+                        content=event["payload"],
+                        headers=headers,
+                        timeout=5,
+                    )
+                    if r.status_code < 300:
+                        sent_ids.append(event["id"])
+                    else:
+                        failed_ids.append(event["id"])
+                except Exception:
+                    failed_ids.append(event["id"])
+
+            mark_sent(sent_ids)
+            mark_failed(failed_ids)
+            total_sent += len(sent_ids)
+            total_failed += len(failed_ids)
+
+            # If entire batch failed, server is probably down -- stop
+            if not sent_ids:
+                break
+
+    remaining = buffer_stats()["pending"]
+    cleaned = cleanup()
+
+    rprint(
+        f"[green]Synced {total_sent} events[/green], "
+        f"[{'red' if total_failed else 'dim'}]{total_failed} failed[/], "
+        f"[dim]{remaining} remaining[/dim]"
+    )
+    if cleaned:
+        rprint(f"[dim]Cleaned up {cleaned} old sent events.[/dim]")
 
 
 # ── Dashboard (on ops_app) ──────────────────────────────

--- a/observal_cli/hooks/buffer_event.py
+++ b/observal_cli/hooks/buffer_event.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Buffer a telemetry event from stdin into the local SQLite store.
+
+Called by the shell hook when the server is unreachable.
+No dependencies beyond Python stdlib (sqlite3, json, sys, os).
+"""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+DB_PATH = Path.home() / ".observal" / "telemetry_buffer.db"
+MAX_EVENTS = 10_000
+
+
+def main() -> None:
+    payload = sys.stdin.read().strip()
+    if not payload:
+        return
+
+    # Validate JSON
+    try:
+        json.loads(payload)
+    except json.JSONDecodeError:
+        return
+
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(DB_PATH), timeout=5)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=3000")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pending_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                event_type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                last_attempt TEXT,
+                status TEXT NOT NULL DEFAULT 'pending'
+            )
+            """
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_status ON pending_events(status)")
+        conn.execute(
+            "INSERT INTO pending_events (event_type, payload) VALUES (?, ?)",
+            ("hook", payload),
+        )
+        conn.commit()
+
+        # Enforce cap: drop oldest when over limit
+        count = conn.execute("SELECT COUNT(*) FROM pending_events").fetchone()[0]
+        if count > MAX_EVENTS:
+            excess = count - MAX_EVENTS
+            conn.execute(
+                "DELETE FROM pending_events WHERE id IN (  SELECT id FROM pending_events ORDER BY id ASC LIMIT ?)",
+                (excess,),
+            )
+            conn.commit()
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/observal_cli/hooks/flush_buffer.py
+++ b/observal_cli/hooks/flush_buffer.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Flush up to 20 buffered telemetry events to the Observal server.
+
+Called in the background by the shell hook after a successful curl.
+No dependencies beyond Python stdlib (sqlite3, json, os, urllib).
+"""
+
+import os
+import sqlite3
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DB_PATH = Path.home() / ".observal" / "telemetry_buffer.db"
+FLUSH_LIMIT = 20
+MAX_RETRIES = 3
+
+
+def main() -> None:
+    hooks_url = os.environ.get("OBSERVAL_HOOKS_URL", "http://localhost:8000/api/v1/otel/hooks")
+    user_id = os.environ.get("OBSERVAL_USER_ID", "")
+
+    if not DB_PATH.exists():
+        return
+
+    conn = sqlite3.connect(str(DB_PATH), timeout=5)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=3000")
+
+        rows = conn.execute(
+            "SELECT id, payload FROM pending_events WHERE status = 'pending' AND attempts < ? ORDER BY id ASC LIMIT ?",
+            (MAX_RETRIES, FLUSH_LIMIT),
+        ).fetchall()
+
+        if not rows:
+            # Also clean up old sent events while we're here
+            conn.execute(
+                "DELETE FROM pending_events WHERE status = 'sent' AND created_at < datetime('now', '-24 hours')"
+            )
+            conn.commit()
+            return
+
+        sent_ids = []
+        failed_ids = []
+
+        for row_id, payload in rows:
+            try:
+                req = urllib.request.Request(
+                    hooks_url,
+                    data=payload.encode("utf-8"),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                if user_id:
+                    req.add_header("X-Observal-User-Id", user_id)
+
+                with urllib.request.urlopen(req, timeout=5) as resp:
+                    if resp.status < 300:
+                        sent_ids.append(row_id)
+                    else:
+                        failed_ids.append(row_id)
+            except Exception:
+                failed_ids.append(row_id)
+
+        if sent_ids:
+            placeholders = ",".join("?" for _ in sent_ids)
+            conn.execute(
+                f"UPDATE pending_events SET status = 'sent', "
+                f"last_attempt = datetime('now') WHERE id IN ({placeholders})",
+                sent_ids,
+            )
+
+        if failed_ids:
+            placeholders = ",".join("?" for _ in failed_ids)
+            conn.execute(
+                f"UPDATE pending_events SET attempts = attempts + 1, "
+                f"last_attempt = datetime('now'), "
+                f"status = CASE WHEN attempts + 1 >= {MAX_RETRIES} THEN 'failed' ELSE 'pending' END "
+                f"WHERE id IN ({placeholders})",
+                failed_ids,
+            )
+
+        conn.commit()
+
+        # Clean up old sent events
+        conn.execute("DELETE FROM pending_events WHERE status = 'sent' AND created_at < datetime('now', '-24 hours')")
+        conn.commit()
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/observal_cli/hooks/observal-hook.sh
+++ b/observal_cli/hooks/observal-hook.sh
@@ -2,15 +2,29 @@
 # observal-hook.sh — Generic Claude Code hook that forwards the JSON
 # payload from stdin to the Observal hooks endpoint.
 #
-# Silently swallows failures (ECONNREFUSED, timeouts) so that Claude
-# Code sessions are never disrupted when the Observal server is offline.
+# If the server is unreachable, the payload is buffered locally in a
+# SQLite database (~/.observal/telemetry_buffer.db) so it can be
+# retried later via `observal ops sync` or on the next successful hook.
+#
+# Claude Code sessions are never disrupted regardless of server state.
 
 OBSERVAL_HOOKS_URL="${OBSERVAL_HOOKS_URL:-http://localhost:8000/api/v1/otel/hooks}"
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-curl -sf --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
+# Read payload from stdin into a variable so we can reuse it
+payload=$(cat)
+
+# Try to send to server first
+if echo "$payload" | curl -sf --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
   ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
   -H "Content-Type: application/json" \
-  -d @- >/dev/null 2>&1 || true
+  -d @- >/dev/null 2>&1; then
+    # Success — flush any buffered events in the background
+    python3 "$HOOK_DIR/flush_buffer.py" &>/dev/null &
+else
+    # Server unreachable — buffer the event locally
+    echo "$payload" | python3 "$HOOK_DIR/buffer_event.py" 2>/dev/null || true
+fi
 
 # Claude Code requires JSON with "continue" on stdout for the session to proceed
 echo '{"continue":true}'

--- a/observal_cli/telemetry_buffer.py
+++ b/observal_cli/telemetry_buffer.py
@@ -1,0 +1,163 @@
+"""Lightweight SQLite buffer for offline telemetry events.
+
+Stores telemetry events locally when the Observal server is unreachable,
+and provides methods to flush them when connectivity is restored.
+
+Database location: ~/.observal/telemetry_buffer.db
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+DB_PATH = Path.home() / ".observal" / "telemetry_buffer.db"
+MAX_EVENTS = 10_000
+SENT_TTL_HOURS = 24
+MAX_RETRIES = 3
+BATCH_SIZE = 50
+
+
+def _connect() -> sqlite3.Connection:
+    """Open (or create) the telemetry buffer database with WAL mode."""
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(DB_PATH), timeout=5)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=3000")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS pending_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            event_type TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            last_attempt TEXT,
+            status TEXT NOT NULL DEFAULT 'pending'
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_status ON pending_events(status)")
+    conn.commit()
+    return conn
+
+
+def buffer_event(payload: str, event_type: str = "hook") -> None:
+    """Write a single event to the local buffer.
+
+    Enforces the FIFO cap: if the buffer exceeds MAX_EVENTS, the oldest
+    pending rows are deleted to make room.
+    """
+    conn = _connect()
+    try:
+        conn.execute(
+            "INSERT INTO pending_events (event_type, payload) VALUES (?, ?)",
+            (event_type, payload),
+        )
+        conn.commit()
+        _enforce_cap(conn)
+    finally:
+        conn.close()
+
+
+def get_pending(limit: int = BATCH_SIZE) -> list[dict]:
+    """Return up to *limit* pending events ordered oldest-first."""
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT id, event_type, payload FROM pending_events "
+            "WHERE status = 'pending' AND attempts < ? "
+            "ORDER BY id ASC LIMIT ?",
+            (MAX_RETRIES, limit),
+        ).fetchall()
+        return [{"id": r[0], "event_type": r[1], "payload": r[2]} for r in rows]
+    finally:
+        conn.close()
+
+
+def mark_sent(event_ids: list[int]) -> None:
+    """Mark events as successfully sent."""
+    if not event_ids:
+        return
+    conn = _connect()
+    try:
+        placeholders = ",".join("?" for _ in event_ids)
+        conn.execute(
+            f"UPDATE pending_events SET status = 'sent', last_attempt = datetime('now') WHERE id IN ({placeholders})",
+            event_ids,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def mark_failed(event_ids: list[int]) -> None:
+    """Increment attempt counter for events that failed to send."""
+    if not event_ids:
+        return
+    conn = _connect()
+    try:
+        placeholders = ",".join("?" for _ in event_ids)
+        conn.execute(
+            f"UPDATE pending_events SET attempts = attempts + 1, "
+            f"last_attempt = datetime('now'), "
+            f"status = CASE WHEN attempts + 1 >= {MAX_RETRIES} THEN 'failed' ELSE 'pending' END "
+            f"WHERE id IN ({placeholders})",
+            event_ids,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def cleanup() -> int:
+    """Delete sent events older than SENT_TTL_HOURS. Returns rows deleted."""
+    conn = _connect()
+    try:
+        cutoff = (datetime.now(UTC) - timedelta(hours=SENT_TTL_HOURS)).strftime("%Y-%m-%d %H:%M:%S")
+        cur = conn.execute(
+            "DELETE FROM pending_events WHERE status = 'sent' AND created_at < ?",
+            (cutoff,),
+        )
+        conn.commit()
+        return cur.rowcount
+    finally:
+        conn.close()
+
+
+def stats() -> dict:
+    """Return buffer statistics for the status command."""
+    conn = _connect()
+    try:
+        pending = conn.execute("SELECT COUNT(*) FROM pending_events WHERE status = 'pending'").fetchone()[0]
+        failed = conn.execute("SELECT COUNT(*) FROM pending_events WHERE status = 'failed'").fetchone()[0]
+        sent = conn.execute("SELECT COUNT(*) FROM pending_events WHERE status = 'sent'").fetchone()[0]
+        oldest_row = conn.execute(
+            "SELECT created_at FROM pending_events WHERE status = 'pending' ORDER BY id ASC LIMIT 1"
+        ).fetchone()
+        last_sync_row = conn.execute(
+            "SELECT last_attempt FROM pending_events WHERE status = 'sent' ORDER BY last_attempt DESC LIMIT 1"
+        ).fetchone()
+        return {
+            "pending": pending,
+            "failed": failed,
+            "sent": sent,
+            "total": pending + failed + sent,
+            "oldest_pending": oldest_row[0] if oldest_row else None,
+            "last_sync": last_sync_row[0] if last_sync_row else None,
+        }
+    finally:
+        conn.close()
+
+
+def _enforce_cap(conn: sqlite3.Connection) -> None:
+    """Delete oldest pending events when buffer exceeds MAX_EVENTS."""
+    count = conn.execute("SELECT COUNT(*) FROM pending_events").fetchone()[0]
+    if count > MAX_EVENTS:
+        excess = count - MAX_EVENTS
+        conn.execute(
+            "DELETE FROM pending_events WHERE id IN (  SELECT id FROM pending_events ORDER BY id ASC LIMIT ?)",
+            (excess,),
+        )
+        conn.commit()


### PR DESCRIPTION
## Summary

- Add telemetry_buffer.py — SQLite buffer at ~/.observal/telemetry_buffer.db with WAL mode, 10K event cap, FIFO eviction
- Add buffer_event.py and flush_buffer.py hook helpers (stdlib only, no dependencies)
- Modify observal-hook.sh to buffer events on curl failure and trigger background flush on success
- Add observal ops sync command to manually flush buffered events
- Enhance observal ops telemetry status to show buffer stats

Relates to #252

## Test plan

- [x] All 881 tests pass
- [ ] Verify events buffer to SQLite when server is unreachable
- [ ] Verify observal ops sync flushes buffered events
- [ ] Verify FIFO eviction when buffer exceeds 10K events