### PR TITLE
feat: enterprise deployment mode PR1 — RBAC, Alembic, require_role, frontend guards

### DIFF
--- a/docs/superpowers/plans/2026-04-13-enterprise-mode-pr1.md
+++ b/docs/superpowers/plans/2026-04-13-enterprise-mode-pr1.md
@@ -1,0 +1,1098 @@
+# Enterprise Mode PR1: Alembic + RBAC Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Initialize Alembic migrations, upgrade from 3-tier to 4-tier RBAC (super_admin > admin > reviewer > user), add is_demo flag, add deployment config, and replace all inline role checks with a hierarchy-aware `require_role` dependency.
+
+**Architecture:** The UserRole enum gains `super_admin` and renames `developer` → `reviewer`. A new `require_role(min_role)` FastAPI dependency replaces the existing unused decorator and all inline `_require_admin()` calls. Alembic is initialized from scratch with an async PostgreSQL driver. `create_all()` is kept for development; Alembic handles production migrations.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLAlchemy (async), Alembic, PostgreSQL, pytest, pytest-asyncio
+
+**Spec:** `docs/superpowers/specs/2026-04-13-enterprise-mode-design.md`
+
+**Branch:** `feat/enterprise-deployment-mode` (create from current `fix/db-consistency-audit`)
+
+**DCO:** All commits MUST use `-s` flag for sign-off.
+
+---
+
+### Task 1: Initialize Alembic with async PostgreSQL support
+
+**Context:** The project has no migration infrastructure. Schema is managed via `Base.metadata.create_all()` at startup. We need Alembic for the role enum migration and all future schema changes. Alembic is already a dependency in `observal-server/pyproject.toml`.
+
+**Files:**
+**Design note:** The spec calls for a "baseline migration capturing full current schema." We intentionally skip this because `Base.metadata.create_all()` remains in the lifespan for development. Alembic starts with the role enum migration (Task 3) as its first revision. On existing databases, `alembic upgrade head` applies only schema changes. On new databases, `create_all()` builds tables and Alembic handles incremental changes. All migrations use idempotent SQL (`IF NOT EXISTS` / `IF EXISTS`) so either order is safe.
+
+**Files:**
+- Create: `observal-server/alembic.ini`
+- Create: `observal-server/alembic/env.py`
+- Create: `observal-server/alembic/script.py.mako`
+- Create: `observal-server/alembic/versions/` (empty directory)
+
+- [ ] **Step 1: Initialize Alembic with async template**
+
+Run from `observal-server/`:
+```bash
+cd observal-server && uv run alembic init -t async alembic
+```
+
+This creates `alembic.ini`, `alembic/env.py`, `alembic/script.py.mako`, and `alembic/versions/`.
+
+- [ ] **Step 2: Configure alembic.ini**
+
+Edit `observal-server/alembic.ini`. The key change is setting a placeholder URL (env.py will override it from config.py):
+
+```ini
+# Alembic Configuration
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@localhost:5432/observal
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S
+```
+
+- [ ] **Step 3: Configure env.py for async + model imports**
+
+Replace `observal-server/alembic/env.py` with:
+
+```python
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from config import settings
+
+# Alembic Config object
+config = context.config
+
+# Override URL from application settings
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+
+# Set up logging
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Import all models so metadata is populated
+from models import Base  # noqa: E402
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode — emit SQL to stdout."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """Run migrations in 'online' mode with async engine."""
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+```
+
+- [ ] **Step 4: Verify Alembic can see models**
+
+Run from `observal-server/`:
+```bash
+uv run alembic heads
+```
+
+Expected: No errors, shows "(head)" or empty (no migrations yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add observal-server/alembic.ini observal-server/alembic/
+git commit -s -m "$(cat <<'EOF'
+feat(db): initialize Alembic with async PostgreSQL support
+
+Set up Alembic migration infrastructure using the async template.
+Configured env.py to read DATABASE_URL from application settings
+and import all ORM models for autogeneration support.
+EOF
+)"
+```
+
+---
+
+### Task 2: Update UserRole enum and User model
+
+**Context:** Current roles are `admin`, `developer`, `user`. We need to add `super_admin`, rename `developer` → `reviewer`, and add `is_demo` boolean column. The Python model changes first; the Alembic migration (Task 3) handles existing databases.
+
+**Files:**
+- Test: `observal-server/tests/test_rbac.py` (create)
+- Modify: `observal-server/models/user.py`
+
+- [ ] **Step 1: Write failing test for new enum values**
+
+Create `observal-server/tests/test_rbac.py`:
+
+```python
+"""Tests for the 4-tier RBAC system."""
+
+from models.user import User, UserRole
+
+
+def test_userrole_enum_has_four_tiers():
+    """UserRole must have exactly super_admin, admin, reviewer, user."""
+    expected = {"super_admin", "admin", "reviewer", "user"}
+    actual = {r.value for r in UserRole}
+    assert actual == expected, f"Expected {expected}, got {actual}"
+
+
+def test_userrole_enum_values():
+    """Each role's .value matches its name."""
+    assert UserRole.super_admin.value == "super_admin"
+    assert UserRole.admin.value == "admin"
+    assert UserRole.reviewer.value == "reviewer"
+    assert UserRole.user.value == "user"
+
+
+def test_developer_role_does_not_exist():
+    """The old 'developer' role must not exist."""
+    assert not hasattr(UserRole, "developer"), "developer role should be removed"
+
+
+def test_user_model_has_is_demo_field():
+    """User model must have is_demo boolean field."""
+    user = User(
+        email="test@example.com",
+        name="Test",
+        api_key_hash="a" * 64,
+    )
+    assert user.is_demo is False, "is_demo should default to False"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd observal-server && uv run pytest tests/test_rbac.py -v
+```
+
+Expected: FAIL — `UserRole` has no `super_admin` or `reviewer`, has `developer`, and `User` has no `is_demo`.
+
+- [ ] **Step 3: Update UserRole enum and User model**
+
+Edit `observal-server/models/user.py`:
+
+Replace the `UserRole` enum:
+```python
+class UserRole(str, enum.Enum):
+    super_admin = "super_admin"
+    admin = "admin"
+    reviewer = "reviewer"
+    user = "user"
+```
+
+Add `is_demo` column to the `User` class, after `created_at`:
+```python
+    is_demo: Mapped[bool] = mapped_column(default=False, server_default="false")
+```
+
+Add the `Boolean` import from sqlalchemy:
+```python
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd observal-server && uv run pytest tests/test_rbac.py -v
+```
+
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add observal-server/models/user.py observal-server/tests/test_rbac.py
+git commit -s -m "$(cat <<'EOF'
+feat(rbac): upgrade UserRole to 4-tier hierarchy with is_demo flag
+
+Replace 3-tier (admin/developer/user) with 4-tier
+(super_admin/admin/reviewer/user). Rename developer → reviewer.
+Add is_demo boolean column to User model for demo account tracking.
+EOF
+)"
+```
+
+---
+
+### Task 3: Create Alembic migration for role enum changes + is_demo
+
+**Context:** Existing databases have the old 3-value enum and no `is_demo` column. This migration handles the transition. Uses `IF NOT EXISTS` / `IF EXISTS` guards for idempotency — safe whether database was created by `create_all()` (new schema) or is an existing database (old schema).
+
+**Files:**
+- Create: `observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py`
+
+- [ ] **Step 1: Create the migration file**
+
+Create `observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py`:
+
+```python
+"""Add super_admin and reviewer roles, rename developer to reviewer, add is_demo column.
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-04-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add new enum values (idempotent — safe on fresh databases)
+    op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'super_admin'")
+    op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'reviewer'")
+
+    # Rename developer -> reviewer in existing rows
+    # (PostgreSQL doesn't support renaming enum values, but we can update rows)
+    op.execute("UPDATE users SET role = 'reviewer' WHERE role = 'developer'")
+
+    # Add is_demo column (idempotent via IF NOT EXISTS pattern)
+    # Use raw SQL for IF NOT EXISTS since op.add_column doesn't support it
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'users' AND column_name = 'is_demo'
+            ) THEN
+                ALTER TABLE users ADD COLUMN is_demo BOOLEAN NOT NULL DEFAULT false;
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    # Drop is_demo column
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'users' AND column_name = 'is_demo'
+            ) THEN
+                ALTER TABLE users DROP COLUMN is_demo;
+            END IF;
+        END
+        $$;
+    """)
+
+    # Rename reviewer back to developer in rows
+    op.execute("UPDATE users SET role = 'developer' WHERE role = 'reviewer'")
+
+    # Note: PostgreSQL doesn't support removing enum values.
+    # 'super_admin' and 'reviewer' will remain in the enum type but won't be used.
+```
+
+- [ ] **Step 2: Verify migration file is detected**
+
+```bash
+cd observal-server && uv run alembic heads
+```
+
+Expected: Shows `0001 (head)`.
+
+- [ ] **Step 3: Also update _ensure_columns for the transition period**
+
+Edit `observal-server/main.py` — add `is_demo` to the `_ensure_columns` function so existing databases that haven't run Alembic yet still get the column:
+
+```python
+async def _ensure_columns(conn):
+    """Add columns that may be missing on existing databases."""
+    from sqlalchemy import text
+
+    try:
+        await conn.execute(text("ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255)"))
+    except Exception:
+        pass
+    try:
+        await conn.execute(text("ALTER TABLE users ADD COLUMN IF NOT EXISTS is_demo BOOLEAN DEFAULT false"))
+    except Exception:
+        pass
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py observal-server/main.py
+git commit -s -m "$(cat <<'EOF'
+feat(db): add Alembic migration for 4-tier RBAC enum and is_demo column
+
+Migration adds super_admin and reviewer to userrole enum, renames
+existing developer rows to reviewer, and adds is_demo boolean column.
+All operations are idempotent for safety on fresh and existing databases.
+EOF
+)"
+```
+
+---
+
+### Task 4: Add deployment mode and demo account config
+
+**Context:** `config.py` needs `DEPLOYMENT_MODE` and 8 `DEMO_*` env vars. These are read by later PRs (demo seeding, route guards) but the config should be in place now.
+
+**Files:**
+- Test: `observal-server/tests/test_config.py` (create)
+- Modify: `observal-server/config.py`
+
+- [ ] **Step 1: Write failing test for new config vars**
+
+Create `observal-server/tests/test_config.py`:
+
+```python
+"""Tests for configuration settings."""
+
+import os
+
+
+def test_deployment_mode_defaults_to_local():
+    """DEPLOYMENT_MODE should default to 'local'."""
+    # Import fresh to pick up defaults
+    from config import Settings
+
+    s = Settings(
+        DATABASE_URL="sqlite+aiosqlite:///",
+        SECRET_KEY="test",
+    )
+    assert s.DEPLOYMENT_MODE == "local"
+
+
+def test_deployment_mode_reads_env(monkeypatch):
+    """DEPLOYMENT_MODE should read from environment."""
+    monkeypatch.setenv("DEPLOYMENT_MODE", "enterprise")
+    from config import Settings
+
+    s = Settings(
+        DATABASE_URL="sqlite+aiosqlite:///",
+        SECRET_KEY="test",
+        DEPLOYMENT_MODE="enterprise",
+    )
+    assert s.DEPLOYMENT_MODE == "enterprise"
+
+
+def test_demo_env_vars_default_to_none():
+    """All DEMO_* vars should default to None."""
+    from config import Settings
+
+    s = Settings(
+        DATABASE_URL="sqlite+aiosqlite:///",
+        SECRET_KEY="test",
+    )
+    assert s.DEMO_SUPER_ADMIN_EMAIL is None
+    assert s.DEMO_SUPER_ADMIN_PASSWORD is None
+    assert s.DEMO_ADMIN_EMAIL is None
+    assert s.DEMO_ADMIN_PASSWORD is None
+    assert s.DEMO_REVIEWER_EMAIL is None
+    assert s.DEMO_REVIEWER_PASSWORD is None
+    assert s.DEMO_USER_EMAIL is None
+    assert s.DEMO_USER_PASSWORD is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd observal-server && uv run pytest tests/test_config.py -v
+```
+
+Expected: FAIL — `Settings` has no `DEPLOYMENT_MODE` or `DEMO_*` attributes.
+
+- [ ] **Step 3: Add new settings**
+
+Edit `observal-server/config.py`. Add after the rate limiting settings (before `model_config`):
+
+```python
+    # Deployment mode
+    DEPLOYMENT_MODE: str = "local"  # "local" | "enterprise"
+
+    # Demo accounts (seeded on first startup if set and no real users exist)
+    DEMO_SUPER_ADMIN_EMAIL: str | None = None
+    DEMO_SUPER_ADMIN_PASSWORD: str | None = None
+    DEMO_ADMIN_EMAIL: str | None = None
+    DEMO_ADMIN_PASSWORD: str | None = None
+    DEMO_REVIEWER_EMAIL: str | None = None
+    DEMO_REVIEWER_PASSWORD: str | None = None
+    DEMO_USER_EMAIL: str | None = None
+    DEMO_USER_PASSWORD: str | None = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd observal-server && uv run pytest tests/test_config.py -v
+```
+
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add observal-server/config.py observal-server/tests/test_config.py
+git commit -s -m "$(cat <<'EOF'
+feat(config): add DEPLOYMENT_MODE and demo account env vars
+
+Add DEPLOYMENT_MODE (local|enterprise, defaults to local) and 8
+DEMO_* env vars for seeding demo accounts on first startup.
+EOF
+)"
+```
+
+---
+
+### Task 5: Refactor require_role to hierarchy-aware FastAPI dependency
+
+**Context:** The current `require_role` in `deps.py` is an unused decorator (lines 73-82) with a bug (unreachable `return`). Replace it with a hierarchy-aware FastAPI dependency that returns the authenticated user. Routes use it via `Depends(require_role(UserRole.admin))`.
+
+**Files:**
+- Test: `observal-server/tests/test_rbac.py` (append)
+- Modify: `observal-server/api/deps.py`
+
+- [ ] **Step 1: Write failing tests for hierarchy-aware require_role**
+
+Append to `observal-server/tests/test_rbac.py`:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import HTTPException
+
+from api.deps import require_role, ROLE_HIERARCHY
+
+
+def test_role_hierarchy_ordering():
+    """super_admin has lowest number (highest privilege)."""
+    assert ROLE_HIERARCHY[UserRole.super_admin] < ROLE_HIERARCHY[UserRole.admin]
+    assert ROLE_HIERARCHY[UserRole.admin] < ROLE_HIERARCHY[UserRole.reviewer]
+    assert ROLE_HIERARCHY[UserRole.reviewer] < ROLE_HIERARCHY[UserRole.user]
+
+
+def test_role_hierarchy_has_all_roles():
+    """Every UserRole must be in the hierarchy."""
+    for role in UserRole:
+        assert role in ROLE_HIERARCHY, f"{role} missing from ROLE_HIERARCHY"
+
+
+@pytest.mark.asyncio
+async def test_require_role_allows_exact_match():
+    """User with exact required role should pass."""
+    dep = require_role(UserRole.admin)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.admin
+    result = await dep(current_user=mock_user)
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_require_role_allows_higher_role():
+    """super_admin should pass an admin check."""
+    dep = require_role(UserRole.admin)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.super_admin
+    result = await dep(current_user=mock_user)
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_require_role_blocks_lower_role():
+    """user should not pass an admin check."""
+    dep = require_role(UserRole.admin)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.user
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(current_user=mock_user)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_require_role_reviewer_allows_admin():
+    """admin should pass a reviewer check."""
+    dep = require_role(UserRole.reviewer)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.admin
+    result = await dep(current_user=mock_user)
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_require_role_reviewer_blocks_user():
+    """user should not pass a reviewer check."""
+    dep = require_role(UserRole.reviewer)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.user
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(current_user=mock_user)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_require_role_user_allows_everyone():
+    """Every role should pass a user-level check."""
+    dep = require_role(UserRole.user)
+    for role in UserRole:
+        mock_user = MagicMock()
+        mock_user.role = role
+        result = await dep(current_user=mock_user)
+        assert result is mock_user
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd observal-server && uv run pytest tests/test_rbac.py -v
+```
+
+Expected: FAIL — `ROLE_HIERARCHY` not importable, `require_role` doesn't work as a dependency.
+
+- [ ] **Step 3: Implement hierarchy-aware require_role**
+
+Edit `observal-server/api/deps.py`. Replace the existing `require_role` function (lines 73-82) with:
+
+```python
+# Role hierarchy: lower number = higher privilege
+ROLE_HIERARCHY: dict[UserRole, int] = {
+    UserRole.super_admin: 0,
+    UserRole.admin: 1,
+    UserRole.reviewer: 2,
+    UserRole.user: 3,
+}
+
+
+def require_role(min_role: UserRole):
+    """FastAPI dependency that requires the user to have at least the given role level.
+
+    Usage: current_user: User = Depends(require_role(UserRole.admin))
+    """
+
+    async def _check(current_user: User = Depends(get_current_user)) -> User:
+        user_level = ROLE_HIERARCHY.get(current_user.role, 999)
+        required_level = ROLE_HIERARCHY[min_role]
+        if user_level > required_level:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return current_user
+
+    return _check
+
+
+# Convenience shorthand for super_admin-only endpoints
+require_super_admin = require_role(UserRole.super_admin)
+```
+
+Also remove the `functools.wraps` import from the top of the file (line 4) since the old decorator pattern is gone.
+
+**Note:** `require_super_admin` is a pre-built dependency for future destructive endpoints (data wipe, org deletion). No routes use it in PR1, but it's defined here so it's importable when needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd observal-server && uv run pytest tests/test_rbac.py -v
+```
+
+Expected: All 12 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add observal-server/api/deps.py observal-server/tests/test_rbac.py
+git commit -s -m "$(cat <<'EOF'
+feat(rbac): implement hierarchy-aware require_role FastAPI dependency
+
+Replace the unused role decorator with a dependency-based approach.
+require_role(min_role) returns a FastAPI Depends that checks the
+user's role against a hierarchy: super_admin > admin > reviewer > user.
+EOF
+)"
+```
+
+---
+
+### Task 6: Refactor admin.py — replace inline _require_admin with require_role
+
+**Context:** `api/routes/admin.py` has 17 endpoints that all call `_require_admin(current_user)` in the function body. Replace every instance with `Depends(require_role(UserRole.admin))` in the function signature. Remove the `_require_admin` helper.
+
+**Files:**
+- Modify: `observal-server/api/routes/admin.py`
+
+- [ ] **Step 1: Read the current file**
+
+Read `observal-server/api/routes/admin.py` to identify all `_require_admin(current_user)` calls and the current import of `get_current_user`.
+
+- [ ] **Step 2: Update imports**
+
+In `observal-server/api/routes/admin.py`, change the import:
+
+```python
+# Old:
+from api.deps import get_current_user, get_db
+# New:
+from api.deps import get_db, require_role
+```
+
+Also ensure `UserRole` is imported:
+```python
+from models.user import User, UserRole
+```
+
+- [ ] **Step 3: Remove the _require_admin function**
+
+Delete the `_require_admin` function (around lines 27-29):
+```python
+# DELETE THIS:
+def _require_admin(user: User):
+    if user.role != UserRole.admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+```
+
+- [ ] **Step 4: Replace all endpoint signatures**
+
+For every endpoint in admin.py, change the `current_user` parameter and remove the `_require_admin()` call. The pattern for each endpoint is:
+
+```python
+# Old pattern:
+async def endpoint_name(
+    ...,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    _require_admin(current_user)
+    ...
+
+# New pattern:
+async def endpoint_name(
+    ...,
+    current_user: User = Depends(require_role(UserRole.admin)),
+    db: AsyncSession = Depends(get_db),
+):
+    ...
+```
+
+Apply this to ALL endpoints in admin.py:
+1. `list_settings` 
+2. `get_setting`
+3. `upsert_setting`
+4. `delete_setting`
+5. `list_users`
+6. `create_user`
+7. `update_user_role`
+8. `reset_user_password`
+9. `list_penalties`
+10. `update_penalty`
+11. `list_weights`
+12. `set_global_weights`
+13. `set_agent_weights`
+14. `create_canary`
+15. `list_canaries`
+16. `list_canary_reports`
+17. `delete_canary`
+
+- [ ] **Step 5: Verify no references to _require_admin remain**
+
+```bash
+cd observal-server && grep -rn "_require_admin" api/routes/admin.py
+```
+
+Expected: No output (zero matches).
+
+- [ ] **Step 6: Verify no references to get_current_user remain**
+
+```bash
+cd observal-server && grep -rn "get_current_user" api/routes/admin.py
+```
+
+Expected: No output (zero matches).
+
+- [ ] **Step 7: Run linter**
+
+```bash
+cd observal-server && uv run ruff check api/routes/admin.py --fix
+```
+
+Expected: No errors (or auto-fixed import ordering).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add observal-server/api/routes/admin.py
+git commit -s -m "$(cat <<'EOF'
+refactor(admin): replace inline _require_admin with require_role dependency
+
+All 17 admin endpoints now use Depends(require_role(UserRole.admin))
+instead of calling _require_admin() in the function body. This means
+super_admin also passes admin checks via the role hierarchy.
+EOF
+)"
+```
+
+---
+
+### Task 7: Refactor review.py — replace inline _require_admin with require_role(reviewer)
+
+**Context:** `api/routes/review.py` has its own `_require_admin` function and 4 endpoints using it. Per the spec, review endpoints should require `reviewer` role (not admin), since the new `reviewer` role is purpose-built for this. Admin and super_admin still pass due to hierarchy.
+
+**Files:**
+- Modify: `observal-server/api/routes/review.py`
+
+- [ ] **Step 1: Read the current file**
+
+Read `observal-server/api/routes/review.py` to identify all `_require_admin(current_user)` calls and current imports.
+
+- [ ] **Step 2: Update imports**
+
+```python
+# Old:
+from api.deps import get_current_user, get_db
+# New:
+from api.deps import get_db, require_role
+```
+
+Ensure `UserRole` is imported:
+```python
+from models.user import User, UserRole
+```
+
+- [ ] **Step 3: Remove the _require_admin function**
+
+Delete the `_require_admin` function (around lines 25-27).
+
+- [ ] **Step 4: Replace all endpoint signatures**
+
+Change all 4 endpoints from `Depends(get_current_user)` + `_require_admin()` to `Depends(require_role(UserRole.reviewer))`:
+
+```python
+# New pattern for all review endpoints:
+async def endpoint_name(
+    ...,
+    current_user: User = Depends(require_role(UserRole.reviewer)),
+    db: AsyncSession = Depends(get_db),
+):
+    # No _require_admin call needed
+    ...
+```
+
+Apply to: `list_pending`, `get_review`, `approve`, `reject`.
+
+- [ ] **Step 5: Verify no references to _require_admin or get_current_user remain**
+
+```bash
+cd observal-server && grep -rn "_require_admin\|get_current_user" api/routes/review.py
+```
+
+Expected: No output.
+
+- [ ] **Step 6: Run linter**
+
+```bash
+cd observal-server && uv run ruff check api/routes/review.py --fix
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add observal-server/api/routes/review.py
+git commit -s -m "$(cat <<'EOF'
+refactor(review): use require_role(reviewer) for review endpoints
+
+Review endpoints now require reviewer role (previously required admin).
+The new reviewer role is purpose-built for component review workflows.
+Admin and super_admin pass via role hierarchy.
+EOF
+)"
+```
+
+---
+
+### Task 8: Add require_role(admin) to admin-level route files
+
+**Context:** These route files currently have NO role checks — any authenticated user can access them. Per the spec, they require admin-level access: `telemetry.py` (viewing all traces), `eval.py`, `otel_dashboard.py`, `dashboard.py`.
+
+**Files:**
+- Modify: `observal-server/api/routes/telemetry.py`
+- Modify: `observal-server/api/routes/eval.py`
+- Modify: `observal-server/api/routes/otel_dashboard.py`
+- Modify: `observal-server/api/routes/dashboard.py`
+
+- [ ] **Step 1: Read all four files**
+
+Read each file to identify the current import pattern and all endpoints that use `get_current_user`.
+
+- [ ] **Step 2: Apply the same pattern to all four files**
+
+For each file:
+
+1. **Update imports** — replace `get_current_user` with `require_role` in the import from `api.deps`. Add `UserRole` import from `models.user` if not already present.
+
+2. **Update all endpoint signatures** — change every `current_user: User = Depends(get_current_user)` to `current_user: User = Depends(require_role(UserRole.admin))`.
+
+The mechanical change for each endpoint:
+```python
+# Old:
+async def endpoint(current_user: User = Depends(get_current_user), ...):
+
+# New:
+async def endpoint(current_user: User = Depends(require_role(UserRole.admin)), ...):
+```
+
+- [ ] **Step 3: Verify no get_current_user references remain in these files**
+
+```bash
+cd observal-server && grep -rn "get_current_user" api/routes/telemetry.py api/routes/eval.py api/routes/otel_dashboard.py api/routes/dashboard.py
+```
+
+Expected: No output.
+
+- [ ] **Step 4: Run linter on all four files**
+
+```bash
+cd observal-server && uv run ruff check api/routes/telemetry.py api/routes/eval.py api/routes/otel_dashboard.py api/routes/dashboard.py --fix
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add observal-server/api/routes/telemetry.py observal-server/api/routes/eval.py observal-server/api/routes/otel_dashboard.py observal-server/api/routes/dashboard.py
+git commit -s -m "$(cat <<'EOF'
+feat(rbac): add admin role requirement to telemetry, eval, otel, dashboard routes
+
+These routes previously had no role checks — any authenticated user
+could access them. Now require admin role for viewing all traces,
+running evals, accessing OTEL dashboard, and dashboard queries.
+EOF
+)"
+```
+
+---
+
+### Task 9: Add require_role(user) to resource-level route files
+
+**Context:** These route files currently have NO role checks. Per the spec, they require at least `user` role (which all authenticated users have). This replaces bare `get_current_user` with `require_role(UserRole.user)` — functionally equivalent now but enforces the role hierarchy framework for when roles become more granular.
+
+**Files:**
+- Modify: `observal-server/api/routes/agent.py`
+- Modify: `observal-server/api/routes/skill.py`
+- Modify: `observal-server/api/routes/hook.py`
+- Modify: `observal-server/api/routes/prompt.py`
+- Modify: `observal-server/api/routes/sandbox.py`
+- Modify: `observal-server/api/routes/scan.py`
+- Modify: `observal-server/api/routes/mcp.py`
+- Modify: `observal-server/api/routes/component_source.py`
+- Modify: `observal-server/api/routes/feedback.py`
+- Modify: `observal-server/api/routes/alert.py`
+
+- [ ] **Step 1: Read all ten files**
+
+Read each file to identify import patterns and all endpoints using `get_current_user`.
+
+- [ ] **Step 2: Apply the same pattern to all ten files**
+
+For each file:
+
+1. **Update imports** — replace `get_current_user` with `require_role`. Add `UserRole` import if missing.
+
+2. **Update all endpoint signatures** — change every `current_user: User = Depends(get_current_user)` to `current_user: User = Depends(require_role(UserRole.user))`.
+
+```python
+# Old:
+async def endpoint(current_user: User = Depends(get_current_user), ...):
+
+# New:
+async def endpoint(current_user: User = Depends(require_role(UserRole.user)), ...):
+```
+
+**Important:** Some endpoints may not have a `current_user` parameter at all (public endpoints). Leave those unchanged. Only modify endpoints that currently depend on `get_current_user`.
+
+- [ ] **Step 3: Check if get_current_user is still used anywhere in route files**
+
+```bash
+cd observal-server && grep -rn "get_current_user" api/routes/
+```
+
+Expected: Only `api/routes/auth.py` should still use `get_current_user` (auth endpoints handle their own authentication logic and should not go through role checks).
+
+- [ ] **Step 4: Run linter on all modified files**
+
+```bash
+cd observal-server && uv run ruff check api/routes/ --fix
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add observal-server/api/routes/agent.py observal-server/api/routes/skill.py observal-server/api/routes/hook.py observal-server/api/routes/prompt.py observal-server/api/routes/sandbox.py observal-server/api/routes/scan.py observal-server/api/routes/mcp.py observal-server/api/routes/component_source.py observal-server/api/routes/feedback.py observal-server/api/routes/alert.py
+git commit -s -m "$(cat <<'EOF'
+feat(rbac): add user role requirement to all resource route files
+
+All resource endpoints (agents, skills, hooks, prompts, sandboxes,
+scans, MCPs, components, feedback, alerts) now use
+require_role(UserRole.user) instead of bare get_current_user.
+Functionally equivalent for now but enforces the role hierarchy.
+EOF
+)"
+```
+
+---
+
+### Task 10: Verify get_current_user is only used in auth.py and deps.py
+
+**Context:** After Tasks 6-9, the only files that should still reference `get_current_user` directly are `api/deps.py` (where it's defined) and `api/routes/auth.py` (where auth endpoints handle their own logic). This task verifies the refactor is complete.
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Search for remaining get_current_user usage**
+
+```bash
+cd observal-server && grep -rn "get_current_user" --include="*.py"
+```
+
+Expected output should only show:
+- `api/deps.py` — definition and use inside `require_role`
+- `api/routes/auth.py` — auth endpoints that handle their own auth logic
+
+If any other file appears, go back and fix it.
+
+- [ ] **Step 2: Search for any remaining _require_admin**
+
+```bash
+cd observal-server && grep -rn "_require_admin" --include="*.py"
+```
+
+Expected: No output (zero matches anywhere).
+
+- [ ] **Step 3: Run all existing tests**
+
+```bash
+cd observal-server && uv run pytest tests/ -v
+```
+
+Expected: All tests pass. The RBAC tests from Task 2 and Task 5 should all pass.
+
+- [ ] **Step 4: Run ruff on entire codebase**
+
+```bash
+cd /home/haz3/code/blazeup/Observal && uv run ruff check observal-server/ --fix
+```
+
+Expected: Clean or only pre-existing issues.
+
+- [ ] **Step 5: Run the root test suite**
+
+```bash
+cd /home/haz3/code/blazeup/Observal && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich pytest tests/ -q
+```
+
+Expected: All existing tests still pass (no regressions from role rename or import changes).
+
+- [ ] **Step 6: Final commit if any lint fixes were needed**
+
+Only if ruff made changes:
+```bash
+git add -u
+git commit -s -m "$(cat <<'EOF'
+style: fix lint issues from RBAC refactor
+EOF
+)"
+```
+
+---
+
+## Summary of Changes
+
+| File | Change |
+|------|--------|
+| `observal-server/alembic.ini` | New — Alembic configuration |
+| `observal-server/alembic/env.py` | New — async migration runner with model imports |
+| `observal-server/alembic/script.py.mako` | New — migration template |
+| `observal-server/alembic/versions/0001_*.py` | New — role enum + is_demo migration |
+| `observal-server/models/user.py` | Modified — 4-tier UserRole, is_demo column |
+| `observal-server/config.py` | Modified — DEPLOYMENT_MODE, DEMO_* vars |
+| `observal-server/api/deps.py` | Modified — hierarchy-aware require_role dependency |
+| `observal-server/main.py` | Modified — is_demo in _ensure_columns |
+| `observal-server/api/routes/admin.py` | Modified — require_role(admin), remove _require_admin |
+| `observal-server/api/routes/review.py` | Modified — require_role(reviewer), remove _require_admin |
+| `observal-server/api/routes/telemetry.py` | Modified — require_role(admin) |
+| `observal-server/api/routes/eval.py` | Modified — require_role(admin) |
+| `observal-server/api/routes/otel_dashboard.py` | Modified — require_role(admin) |
+| `observal-server/api/routes/dashboard.py` | Modified — require_role(admin) |
+| `observal-server/api/routes/agent.py` | Modified — require_role(user) |
+| `observal-server/api/routes/skill.py` | Modified — require_role(user) |
+| `observal-server/api/routes/hook.py` | Modified — require_role(user) |
+| `observal-server/api/routes/prompt.py` | Modified — require_role(user) |
+| `observal-server/api/routes/sandbox.py` | Modified — require_role(user) |
+| `observal-server/api/routes/scan.py` | Modified — require_role(user) |
+| `observal-server/api/routes/mcp.py` | Modified — require_role(user) |
+| `observal-server/api/routes/component_source.py` | Modified — require_role(user) |
+| `observal-server/api/routes/feedback.py` | Modified — require_role(user) |
+| `observal-server/api/routes/alert.py` | Modified — require_role(user) |
+| `observal-server/tests/test_rbac.py` | New — RBAC hierarchy + require_role tests |
+| `observal-server/tests/test_config.py` | New — deployment mode config tests |

--- a/docs/superpowers/specs/2026-04-13-enterprise-mode-design.md
+++ b/docs/superpowers/specs/2026-04-13-enterprise-mode-design.md
@@ -1,0 +1,490 @@
+# Enterprise vs Local Deployment Mode Split — Design Spec
+
+**Issue:** #189
+**Branch:** `feat/enterprise-deployment-mode`
+**Date:** 2026-04-13
+**Status:** Approved
+
+---
+
+## Overview
+
+Observal splits into two deployment modes gated by `DEPLOYMENT_MODE` env var:
+- **Local** (default): self-hosted, email+password auth, self-registration, basic RBAC
+- **Enterprise**: SSO-only auth, SCIM provisioning, IdP role mapping, audit logging, plugin integrations
+
+Core remains Apache-2.0. Enterprise features live in `ee/` under custom commercial license.
+
+---
+
+## Design Decisions
+
+### Gating
+- `DEPLOYMENT_MODE` env var: `"local"` (default) | `"enterprise"`
+- No license key validation for now (future issue)
+
+### Import Boundary
+- `ee/` imports from `observal-server/`, NEVER the reverse
+- Single exception: guarded block in `main.py` calls `ee.register_enterprise(app)`
+- Enforced by: ruff `TID251` banned-api rule + CI grep check (dual enforcement)
+
+### PR Series (4 PRs)
+1. **PR1**: Alembic init + baseline migration + RBAC foundation + config changes + require_role refactor
+2. **PR2**: Deployment mode guards + demo accounts + health endpoints + ee/ structure + hook system + main.py integration
+3. **PR3**: Frontend — role guard, login page modes, public config endpoint
+4. **PR4**: Docker/env + tests + CI import boundary check
+
+---
+
+## Section 1: RBAC Foundation + Alembic
+
+### 4-Tier Role Hierarchy
+
+```
+super_admin > admin > reviewer > user
+```
+
+| Role | Permissions | Scope |
+|------|-------------|-------|
+| `super_admin` | Destructive actions (delete orgs, wipe data, reset images), everything below | Platform-wide |
+| `admin` | View all traces, manage users, configure settings, everything below | Org-scoped (enterprise), global (local) |
+| `reviewer` | Review/approve submitted components, everything below | Org-scoped (enterprise), global (local) |
+| `user` | Upload agents/components, pull configs, view own traces | Own resources |
+
+### UserRole Enum Update (`models/user.py`)
+
+```python
+class UserRole(str, enum.Enum):
+    super_admin = "super_admin"
+    admin = "admin"
+    reviewer = "reviewer"  # renamed from "developer"
+    user = "user"
+```
+
+Add `is_demo: bool` column (default `False`) to User model.
+
+### Alembic Initialization
+
+Full Alembic setup from scratch:
+1. `alembic init` with async PostgreSQL driver (`asyncpg`)
+2. Baseline migration capturing the full current schema (all existing ORM models)
+3. Second migration on top:
+   - Add `super_admin` to `userrole` enum (`ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'super_admin'`)
+   - Add `reviewer` to `userrole` enum (`ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'reviewer'`)
+   - Update existing rows: `developer` -> `reviewer`
+   - Add `is_demo` boolean column (server_default `false`, not nullable)
+   - Idempotent, safe on databases with existing data
+
+**Note:** PostgreSQL doesn't support removing enum values. Downgrade for enum changes is best-effort — `developer` value remains in the enum type but won't be used.
+
+### require_role Refactor (`api/deps.py`)
+
+`require_role()` becomes hierarchy-aware:
+- Accepts a minimum role level
+- If route requires `admin`, both `admin` and `super_admin` pass
+- Hierarchy order: `super_admin(0) > admin(1) > reviewer(2) > user(3)`
+- Add `require_super_admin` shorthand
+
+Replace ALL inline `_require_admin()` calls across every route file:
+
+| Route File | New Guard |
+|-----------|-----------|
+| `admin.py` | `require_role(UserRole.admin)` |
+| `review.py` | `require_role(UserRole.reviewer)` |
+| `agent.py` | `require_role(UserRole.user)` for CRUD |
+| `telemetry.py` | `require_role(UserRole.admin)` for viewing all traces |
+| `eval.py` | `require_role(UserRole.admin)` |
+| `otel_dashboard.py` | `require_role(UserRole.admin)` |
+| `skill.py` | `require_role(UserRole.user)` |
+| `sandbox.py` | `require_role(UserRole.user)` |
+| `prompt.py` | `require_role(UserRole.user)` |
+| `hook.py` | `require_role(UserRole.user)` |
+| `mcp.py` | `require_role(UserRole.user)` |
+| `component_source.py` | `require_role(UserRole.user)` |
+| `feedback.py` | `require_role(UserRole.user)` |
+| `alert.py` | `require_role(UserRole.user)` |
+| `dashboard.py` | `require_role(UserRole.admin)` |
+| `scan.py` | `require_role(UserRole.user)` |
+| Future destructive endpoints | `require_role(UserRole.super_admin)` |
+
+---
+
+## Section 2: Config + Deployment Mode Guards
+
+### Config Additions (`config.py`)
+
+```python
+# Deployment mode
+DEPLOYMENT_MODE: str = "local"  # "local" | "enterprise"
+
+# Demo accounts (seeded on first startup if set and no real users exist)
+DEMO_SUPER_ADMIN_EMAIL: str | None = None
+DEMO_SUPER_ADMIN_PASSWORD: str | None = None
+DEMO_ADMIN_EMAIL: str | None = None
+DEMO_ADMIN_PASSWORD: str | None = None
+DEMO_REVIEWER_EMAIL: str | None = None
+DEMO_REVIEWER_PASSWORD: str | None = None
+DEMO_USER_EMAIL: str | None = None
+DEMO_USER_PASSWORD: str | None = None
+```
+
+### Route Guards
+
+`require_local_mode` dependency:
+- Returns 403 `"Disabled in enterprise mode"` for:
+  - `POST /auth/bootstrap`
+  - `POST /auth/register`
+  - `POST /auth/invite` (enterprise uses SCIM for provisioning)
+  - `POST /auth/redeem` (no invite codes in enterprise)
+- Enterprise users come in via SSO/SCIM only
+
+### Health Endpoints (Two-Tier)
+
+**`GET /health`** (unauthenticated):
+```json
+{"status": "ok", "initialized": true}
+```
+- `status`: `"ok"` | `"degraded"` (degraded if enterprise mode has config issues)
+- No details exposed publicly
+- K8s readiness probes use this
+
+**`GET /admin/diagnostics`** (admin-only):
+```json
+{
+  "deployment_mode": "enterprise",
+  "status": "misconfigured",
+  "issues": [
+    "SECRET_KEY is using default value",
+    "OAUTH_CLIENT_ID is not set",
+    "FRONTEND_URL is localhost"
+  ]
+}
+```
+- Enterprise config validation: SECRET_KEY not default, OAUTH_CLIENT_ID set, FRONTEND_URL not localhost
+- Always available (returns `{"deployment_mode": "local", "status": "ok", "issues": []}` in local mode)
+
+### Public Config Endpoint
+
+**`GET /api/v1/config/public`** (unauthenticated):
+```json
+{"deployment_mode": "local", "sso_enabled": true, "saml_enabled": false}
+```
+- Frontend reads this to decide which login UI to show
+
+---
+
+## Section 3: Hook System + ee/ Module Structure
+
+### Hook System (`services/hooks.py`)
+
+Core defines named extension points. EE registers handlers during startup. Core fires them at natural points without knowing who's listening.
+
+```python
+class HookRegistry:
+    def register(self, event: str, handler: Callable): ...
+    async def fire(self, event: str, **kwargs): ...
+```
+
+**Named hooks:**
+
+| Hook | Fired When | Kwargs |
+|------|-----------|--------|
+| `user_created` | After any user creation (register, SSO, SCIM, admin create) | `user`, `db` |
+| `user_deleted` | After user deletion | `user`, `db` |
+| `login_success` | After successful authentication | `user`, `method` |
+| `login_failure` | After failed authentication attempt | `email`, `method`, `reason` |
+| `role_changed` | After a user's role is updated | `user`, `old_role`, `new_role` |
+| `settings_changed` | After enterprise config key is updated | `key`, `value` |
+
+**Properties:**
+- Handlers are async
+- Fire is non-blocking: errors are logged, never crash core
+- Registry is a singleton on `app.state.hooks`
+- EE registers handlers during `register_enterprise()` call
+
+### ee/ Directory Structure
+
+```
+ee/
+  LICENSE                              (exists, keep as-is)
+  __init__.py                          (register_enterprise, register_plugin)
+  observal_server/
+    __init__.py
+    routes/
+      __init__.py
+      sso_saml.py                      (placeholder -> 501 "Not yet implemented")
+      scim.py                          (placeholder -> 501 "Not yet implemented")
+    services/
+      __init__.py
+      sso_provider.py                  (placeholder)
+      enterprise_config_validator.py   (config validation logic)
+    middleware/
+      __init__.py
+      enterprise_guard.py              (503 for misconfigured EE routes)
+  plugins/
+    __init__.py                        (plugin registry)
+    grafana/                           (placeholder)
+    prometheus/                        (placeholder)
+    datadog/                           (placeholder)
+    siem/                              (placeholder)
+```
+
+### Enterprise Registration Flow
+
+1. `main.py` calls `register_enterprise(app, settings)` if `DEPLOYMENT_MODE == "enterprise"`
+2. EE validates config, returns issues list
+3. EE mounts routes (SAML, SCIM — all return 501 for now)
+4. EE adds `EnterpriseGuardMiddleware` (returns 503 on EE routes when misconfigured)
+5. EE registers hook handlers (audit logging placeholders)
+6. Issues stored on `app.state.enterprise_issues` for diagnostics endpoint
+
+### Import Boundary Enforcement (Dual)
+
+**Ruff `TID251`** (`pyproject.toml`):
+```toml
+[tool.ruff.lint]
+select = [..., "TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"ee" = { msg = "Core must not import from ee/. Only allowed in main.py." }
+
+[tool.ruff.lint.per-file-ignores]
+"observal-server/main.py" = ["TID251"]
+```
+
+**CI grep** (`.github/workflows/ci.yml`):
+```bash
+! grep -rn "from ee\|import ee" observal-server/ --include="*.py" | grep -v "main.py"
+```
+Required status check — fails the build on any violation.
+
+---
+
+## Section 4: Demo Account Seeding + Cleanup
+
+### Seeding (in `main.py` lifespan)
+
+After DB table creation:
+1. Query for any non-demo users (`is_demo = False`)
+2. If none exist AND `DEMO_*_EMAIL` env vars are set, create up to 4 demo accounts with `is_demo=True`
+3. Log warning: `"Demo accounts active -- create a real super_admin to remove them"`
+4. Fire `user_created` hook for each demo account
+
+### Cleanup (`services/demo.py`)
+
+Service function `check_demo_cleanup(db, new_user)` called explicitly from every user-creation codepath:
+- `POST /auth/register`
+- `POST /auth/bootstrap`
+- SSO auto-create (OAuth callback)
+- Admin user creation
+- Future: SCIM provisioning
+
+**Logic:**
+- New non-demo `super_admin` created -> delete ALL demo accounts
+- New non-demo `admin` created -> delete demo admin
+- New non-demo `reviewer` created -> delete demo reviewer
+- New non-demo `user` created -> delete demo user
+
+**Properties:**
+- Runs in the same DB transaction as user creation (rollback-safe)
+- Fires `user_deleted` hook for each removed demo account
+- Logs each deletion: `"Demo <role> account removed -- real <role> created"`
+
+---
+
+## Section 5: Frontend Updates
+
+### Role Guard Refactor
+
+`use-admin-guard.ts` -> `use-role-guard.ts`:
+
+```typescript
+type Role = "super_admin" | "admin" | "reviewer" | "user";
+const ROLE_HIERARCHY: Role[] = ["super_admin", "admin", "reviewer", "user"];
+
+function useRoleGuard(minRole: Role): { ready: boolean }
+```
+
+Hierarchy check: if `minRole` is `reviewer`, then `reviewer`, `admin`, and `super_admin` all pass.
+
+**Display label mapping:**
+```typescript
+const ROLE_LABELS: Record<Role, string> = {
+  super_admin: "Super Admin",
+  admin: "Admin",
+  reviewer: "Reviewer",
+  user: "Viewer",
+};
+```
+
+Backend enum values are canonical. Frontend uses display labels in all user-facing UI.
+
+### Generic RoleGuard Component
+
+Replaces `AdminGuard`:
+```tsx
+<RoleGuard minRole="admin">{children}</RoleGuard>
+```
+
+### Route Protection
+
+| Route Group | Guard |
+|------------|-------|
+| `(admin)/layout.tsx` | `RoleGuard minRole="admin"` |
+| Review pages | `RoleGuard minRole="reviewer"` |
+| Registry pages | `AuthGuard` (any authenticated user) |
+
+### Sidebar
+
+Filter nav items by role hierarchy instead of binary `isAdmin` check:
+- Admin section: visible to `admin` + `super_admin`
+- Review section: visible to `reviewer` and above
+- Registry items: based on `requiresAuth` flag (unchanged)
+
+### Login Page (Deployment Mode Aware)
+
+On mount, fetches `GET /api/v1/config/public`:
+
+**Local mode:**
+- Email + password login form
+- Registration link
+- OIDC button (if `sso_enabled`)
+- API key mode
+- Password reset
+
+**Enterprise mode:**
+- SSO login button only (OIDC + SAML)
+- No registration link
+- No password form
+- Clean, single-action login
+
+### Users Page
+
+- `ROLES` constant updated to 4-tier
+- Role dropdown uses display labels
+- Role assignment capped at own level:
+  - `super_admin` can assign any role
+  - `admin` can assign `reviewer` and `user` only
+  - `reviewer` and `user` cannot assign roles
+
+---
+
+## Section 6: Docker, Env, Tests, CI
+
+### Docker (`docker-compose.yml`)
+
+Add to API service:
+```yaml
+DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-local}
+DEMO_SUPER_ADMIN_EMAIL: ${DEMO_SUPER_ADMIN_EMAIL:-super@demo.local}
+DEMO_SUPER_ADMIN_PASSWORD: ${DEMO_SUPER_ADMIN_PASSWORD:-super-changeme}
+DEMO_ADMIN_EMAIL: ${DEMO_ADMIN_EMAIL:-admin@demo.local}
+DEMO_ADMIN_PASSWORD: ${DEMO_ADMIN_PASSWORD:-admin-changeme}
+DEMO_REVIEWER_EMAIL: ${DEMO_REVIEWER_EMAIL:-reviewer@demo.local}
+DEMO_REVIEWER_PASSWORD: ${DEMO_REVIEWER_PASSWORD:-reviewer-changeme}
+DEMO_USER_EMAIL: ${DEMO_USER_EMAIL:-user@demo.local}
+DEMO_USER_PASSWORD: ${DEMO_USER_PASSWORD:-user-changeme}
+```
+
+### `.env.example`
+
+Add all new vars under clear section headers with comments.
+
+### CI Import Boundary (`.github/workflows/ci.yml`)
+
+New `import-boundary` job:
+```bash
+! grep -rn "from ee\|import ee" observal-server/ --include="*.py" | grep -v "main.py"
+```
+Required status check.
+
+### Ruff Config (`pyproject.toml`)
+
+Add `TID251` to selected rules. Configure `banned-api` for `ee` module. Per-file-ignore exempting `main.py`.
+
+### Tests
+
+| Test | Validates |
+|------|----------|
+| 4-tier RBAC | Each role can only access its permitted endpoints |
+| Role hierarchy | `super_admin` passes `admin` checks, `admin` passes `reviewer` checks |
+| `require_local_mode` | Bootstrap/register return 403 in enterprise mode |
+| Demo seeding | Accounts created when env vars set + no real users |
+| Demo cleanup | Cascading deletion when real `super_admin` created; per-tier for lower roles |
+| Health endpoint | `/health` returns `degraded` (no details) in misconfigured enterprise |
+| Admin diagnostics | `/admin/diagnostics` returns full issues behind auth |
+| EE route 501 | SAML/SCIM placeholders return 501 |
+| EE route 503 | Misconfigured enterprise returns 503 on EE routes |
+| Hook system | Handlers registered, fired on events, errors don't crash core |
+| Alembic migration | `developer` -> `reviewer` rename on existing data, `super_admin` added, `is_demo` column |
+| Public config | Returns correct `deployment_mode` and SSO flags |
+| Role assignment cap | Admin can't assign `admin` or `super_admin` roles |
+
+---
+
+## Future: Agent Registry Access Control
+
+**Not in scope for this work.** Documented here for architectural alignment.
+
+The Agent Registry will use a **Backstage/Artifactory catalog model** for visibility and access control:
+
+### Visibility Tiers (per agent/component)
+- `public` — visible to anyone, including unauthenticated users
+- `internal` — visible to any authenticated user on the platform
+- `org` — visible only to members of the owning organization
+- `private` — visible only to the owner and explicitly granted users/teams
+
+### Access Grants
+On top of visibility tiers, explicit grants enable cross-org sharing:
+- Org X grants Org Y read access to agent Z
+- Team "platform-eng" gets access to all agents tagged "infrastructure"
+- Individual user gets access to a specific private agent
+
+### Catalog Layer
+Separation between **Registry** (where agents are stored, visibility-controlled) and **Catalog** (curated view filtered by user's org membership, role, and grants). Query layer filters results based on requesting user's context.
+
+### RBAC Integration
+The 4-tier role hierarchy handles coarse authorization (who can publish, approve, manage). A future fine-grained permission layer (Grafana hybrid model) adds action-scope permissions:
+- `agents:publish` — submit an agent to the registry
+- `agents:approve` — approve/reject submitted agents
+- `agents:fork` — fork an agent into your org
+- `agents:delete` — remove from registry
+- `agents:read` — view agent details
+- `catalog:read` — browse shared catalog
+- `catalog:manage` — curate catalog visibility
+
+Roles provide permission defaults; individual overrides per-user or per-org in enterprise mode.
+
+---
+
+## Feature Split Summary
+
+| Core (local mode) | ee/ (enterprise mode) |
+|--------------------|-----------------------|
+| Email + password auth | SAML 2.0 SSO |
+| Basic OIDC (authlib) | SCIM 2.0 provisioning |
+| Bootstrap endpoint | Multi-IdP config (per-org) |
+| Self-registration | Azure AD / Okta adapters |
+| Account creation page | IdP group -> role mapping |
+| 4-tier basic RBAC | Audit logging |
+| Invite codes | SIEM integration (plugin) |
+| JWT tokens (HS256/ES256) | GDPR tools |
+| Password reset | Encryption at rest |
+| API key auth | Secrets manager integration (plugin) |
+| Hook system (core) | Hook handlers (ee/) |
+| Public config endpoint | Enterprise config validation |
+| | Team access control |
+| | Multi-tenancy enforcement |
+| | Grafana/Prometheus/Datadog exporters (plugins) |
+
+---
+
+## Constraints
+
+- All Alembic migrations in `observal-server/alembic/versions/` (NEVER in ee/)
+- Import boundary: ee/ imports core, never reverse. Only exception: main.py
+- All git commits use `-s` flag (DCO sign-off)
+- Rebase on upstream/main before pushing
+- SAML/SCIM/audit internals are placeholders only (501 responses)
+- Don't touch multi-tenancy (#196) — org-scoping is a separate issue
+- Rename `developer` role to `reviewer` in this PR series

--- a/observal-server/alembic.ini
+++ b/observal-server/alembic.ini
@@ -1,0 +1,149 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@localhost:5432/observal
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/observal-server/alembic/README
+++ b/observal-server/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration with an async dbapi.

--- a/observal-server/alembic/env.py
+++ b/observal-server/alembic/env.py
@@ -1,0 +1,86 @@
+import asyncio
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+from config import settings
+from models import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Override sqlalchemy.url from application settings so the single source of
+# truth for the database URL remains config.py / environment variables.
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# SQLAlchemy MetaData for 'autogenerate' support
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """In this scenario we need to create an Engine
+    and associate a connection with the context.
+    """
+
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/observal-server/alembic/env.py
+++ b/observal-server/alembic/env.py
@@ -6,7 +6,6 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
-
 from config import settings
 from models import Base
 

--- a/observal-server/alembic/script.py.mako
+++ b/observal-server/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py
+++ b/observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py
@@ -1,0 +1,56 @@
+"""Add super_admin and reviewer roles, rename developer to reviewer, add is_demo column.
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-04-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add new enum values (idempotent — safe on fresh databases)
+    op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'super_admin'")
+    op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'reviewer'")
+
+    # Rename developer -> reviewer in existing rows
+    op.execute("UPDATE users SET role = 'reviewer' WHERE role = 'developer'")
+
+    # Add is_demo column (idempotent via IF NOT EXISTS pattern)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'users' AND column_name = 'is_demo'
+            ) THEN
+                ALTER TABLE users ADD COLUMN is_demo BOOLEAN NOT NULL DEFAULT false;
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    # Drop is_demo column
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'users' AND column_name = 'is_demo'
+            ) THEN
+                ALTER TABLE users DROP COLUMN is_demo;
+            END IF;
+        END
+        $$;
+    """)
+
+    # Rename reviewer back to developer in rows
+    op.execute("UPDATE users SET role = 'developer' WHERE role = 'reviewer'")

--- a/observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py
+++ b/observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py
@@ -5,8 +5,8 @@ Revises:
 Create Date: 2026-04-13
 """
 
+
 from alembic import op
-import sqlalchemy as sa
 
 revision = "0001"
 down_revision = None

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -1,7 +1,6 @@
 import hashlib
 import uuid as _uuid
 from collections.abc import AsyncGenerator
-from functools import wraps
 
 import jwt
 from fastapi import Depends, Header, HTTPException
@@ -74,17 +73,33 @@ async def get_current_user(
     raise HTTPException(status_code=401, detail="Invalid or missing credentials")
 
 
-def require_role(*roles: UserRole):
-    def decorator(func):
-        @wraps(func)
-        async def wrapper(*args, current_user: User = Depends(get_current_user), **kwargs):
-            if current_user.role not in roles:
-                raise HTTPException(status_code=403, detail="Insufficient permissions")
-            return await func(*args, current_user=current_user, **kwargs)
+# Role hierarchy: lower number = higher privilege
+ROLE_HIERARCHY: dict[UserRole, int] = {
+    UserRole.super_admin: 0,
+    UserRole.admin: 1,
+    UserRole.reviewer: 2,
+    UserRole.user: 3,
+}
 
-        return wrapper
 
-    return decorator
+def require_role(min_role: UserRole):
+    """FastAPI dependency that requires the user to have at least the given role level.
+
+    Usage: current_user: User = Depends(require_role(UserRole.admin))
+    """
+
+    async def _check(current_user: User = Depends(get_current_user)) -> User:
+        user_level = ROLE_HIERARCHY.get(current_user.role, 999)
+        required_level = ROLE_HIERARCHY[min_role]
+        if user_level > required_level:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return current_user
+
+    return _check
+
+
+# Convenience shorthand for super_admin-only endpoints
+require_super_admin = require_role(UserRole.super_admin)
 
 
 async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_status=None):

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db
+from api.deps import get_db, require_role
 from config import settings
 from models.enterprise_config import EnterpriseConfig
 from models.user import User, UserRole
@@ -24,20 +24,14 @@ from schemas.admin import (
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 
 
-def _require_admin(user: User):
-    if user.role != UserRole.admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
-
-
 # ── Enterprise Settings ──────────────────────────────────
 
 
 @router.get("/settings", response_model=list[EnterpriseConfigResponse])
 async def list_settings(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    _require_admin(current_user)
     result = await db.execute(select(EnterpriseConfig).order_by(EnterpriseConfig.key))
     return [EnterpriseConfigResponse.model_validate(c) for c in result.scalars().all()]
 
@@ -46,9 +40,8 @@ async def list_settings(
 async def get_setting(
     key: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    _require_admin(current_user)
     result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key == key))
     cfg = result.scalar_one_or_none()
     if not cfg:
@@ -61,9 +54,8 @@ async def upsert_setting(
     key: str,
     req: EnterpriseConfigUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    _require_admin(current_user)
     result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key == key))
     cfg = result.scalar_one_or_none()
     if cfg:
@@ -80,9 +72,8 @@ async def upsert_setting(
 async def delete_setting(
     key: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    _require_admin(current_user)
     result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key == key))
     cfg = result.scalar_one_or_none()
     if not cfg:
@@ -98,9 +89,8 @@ async def delete_setting(
 @router.get("/users", response_model=list[UserAdminResponse])
 async def list_users(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    _require_admin(current_user)
     result = await db.execute(select(User).order_by(User.created_at.desc()))
     return [UserAdminResponse.model_validate(u) for u in result.scalars().all()]
 
@@ -109,11 +99,9 @@ async def list_users(
 async def create_user(
     req: UserCreateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Admin creates a new user and gets back their API key."""
-    _require_admin(current_user)
-
     existing = await db.execute(select(User).where(User.email == req.email))
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail="Email already registered")
@@ -149,9 +137,8 @@ async def update_user_role(
     user_id: uuid.UUID,
     req: UserRoleUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    _require_admin(current_user)
     try:
         new_role = UserRole(req.role)
     except ValueError:
@@ -175,11 +162,9 @@ async def reset_user_password(
     user_id: uuid.UUID,
     req: AdminResetPasswordRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Admin resets a user's password."""
-    _require_admin(current_user)
-
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
     if not user:
@@ -196,10 +181,9 @@ async def reset_user_password(
 @router.get("/penalties", response_model=list[dict])
 async def list_penalties(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """List all penalty definitions."""
-    _require_admin(current_user)
     from models.scoring import PenaltyDefinition
 
     result = await db.execute(
@@ -225,10 +209,9 @@ async def update_penalty(
     penalty_id: uuid.UUID,
     req: dict,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Enable/disable or modify a penalty definition."""
-    _require_admin(current_user)
     from models.scoring import PenaltyDefinition
 
     result = await db.execute(select(PenaltyDefinition).where(PenaltyDefinition.id == penalty_id))
@@ -256,10 +239,9 @@ async def update_penalty(
 @router.get("/weights", response_model=list[dict])
 async def list_weights(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """List global dimension weights."""
-    _require_admin(current_user)
     from models.scoring import DEFAULT_DIMENSION_WEIGHTS, DimensionWeight
 
     result = await db.execute(select(DimensionWeight).where(DimensionWeight.agent_id.is_(None)))
@@ -282,10 +264,9 @@ async def list_weights(
 async def set_global_weights(
     req: dict,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Set global dimension weights. Body: {dimension: weight, ...}"""
-    _require_admin(current_user)
     from models.scoring import DimensionWeight, ScoringDimension
 
     updated = {}
@@ -317,10 +298,9 @@ async def set_agent_weights(
     agent_id: uuid.UUID,
     req: dict,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Set per-agent dimension weights. Body: {dimension: weight, ...}"""
-    _require_admin(current_user)
     from models.scoring import DimensionWeight, ScoringDimension
 
     updated = {}
@@ -357,10 +337,9 @@ _canary_reports: dict[str, list[dict]] = {}  # agent_id -> list of reports
 @router.post("/canaries", response_model=dict)
 async def create_canary(
     req: dict,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Create a canary configuration for an agent."""
-    _require_admin(current_user)
     from services.canary import CanaryConfig
 
     agent_id = req.get("agent_id")
@@ -386,30 +365,27 @@ async def create_canary(
 @router.get("/canaries/{agent_id}", response_model=list[dict])
 async def list_canaries(
     agent_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """List canary configs for an agent."""
-    _require_admin(current_user)
     return _canary_configs.get(agent_id, [])
 
 
 @router.get("/canaries/{agent_id}/reports", response_model=list[dict])
 async def list_canary_reports(
     agent_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """List canary reports with pass/fail stats."""
-    _require_admin(current_user)
     return _canary_reports.get(agent_id, [])
 
 
 @router.delete("/canaries/{canary_id}")
 async def delete_canary(
     canary_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Remove a canary config."""
-    _require_admin(current_user)
     for _agent_id, configs in _canary_configs.items():
         for i, config in enumerate(configs):
             if config.get("id") == canary_id:

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -5,12 +5,12 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from api.deps import get_current_user, get_db, resolve_prefix_id
+from api.deps import get_db, require_role, resolve_prefix_id
 from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus
 from models.agent_component import AgentComponent
 from models.download import AgentDownloadRecord
 from models.mcp import ListingStatus, McpListing
-from models.user import User
+from models.user import User, UserRole
 from schemas.agent import (
     AgentCreateRequest,
     AgentInstallRequest,
@@ -134,7 +134,7 @@ async def _validate_mcp_ids(mcp_ids: list[uuid.UUID], db: AsyncSession) -> list[
 async def create_agent(
     req: AgentCreateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     # If `components` is provided, it supersedes legacy `mcp_server_ids`
     if req.components:
@@ -282,7 +282,7 @@ async def update_agent(
     agent_id: str,
     req: AgentUpdateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     agent = await _load_agent(db, agent_id)
     if not agent:
@@ -409,7 +409,7 @@ async def install_agent(
     req: AgentInstallRequest,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     agent = await _load_agent(db, agent_id, extra_conditions=[Agent.status == AgentStatus.active])
     if not agent:
@@ -488,7 +488,7 @@ async def get_agent_traces(
 async def resolve_agent_components(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Resolve all components for an agent — validates they exist and are approved."""
     agent = await _load_agent(db, agent_id)
@@ -506,7 +506,7 @@ async def resolve_agent_components(
 async def get_agent_manifest(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Generate a portable agent manifest with all resolved components."""
     agent = await _load_agent(db, agent_id)
@@ -535,7 +535,7 @@ async def get_agent_manifest(
 async def validate_agent_composition(
     req: AgentValidateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Validate a set of components for compatibility before publishing an agent."""
     if not req.components:
@@ -563,7 +563,7 @@ async def validate_agent_composition(
 async def delete_agent(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     from models.eval import EvalRun, Scorecard
     from models.feedback import Feedback

--- a/observal-server/api/routes/alert.py
+++ b/observal-server/api/routes/alert.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db
+from api.deps import get_db, require_role
 from models.alert import AlertRule
 from models.user import User, UserRole
 from schemas.alert import AlertRuleCreate, AlertRuleResponse, AlertRuleUpdate
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/api/v1/alerts", tags=["alerts"])
 @router.get("", response_model=list[AlertRuleResponse])
 async def list_alerts(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     # Admins see all alerts; regular users only see their own
     stmt = select(AlertRule).order_by(AlertRule.created_at.desc())
@@ -29,7 +29,7 @@ async def list_alerts(
 async def create_alert(
     body: AlertRuleCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     rule = AlertRule(
         name=body.name,
@@ -52,7 +52,7 @@ async def update_alert(
     alert_id: uuid.UUID,
     body: AlertRuleUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     rule = await db.get(AlertRule, alert_id)
     if not rule:
@@ -69,7 +69,7 @@ async def update_alert(
 async def delete_alert(
     alert_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     rule = await db.get(AlertRule, alert_id)
     if not rule:

--- a/observal-server/api/routes/alert.py
+++ b/observal-server/api/routes/alert.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role
+from api.deps import ROLE_HIERARCHY, get_db, require_role
 from models.alert import AlertRule
 from models.user import User, UserRole
 from schemas.alert import AlertRuleCreate, AlertRuleResponse, AlertRuleUpdate
@@ -17,9 +17,9 @@ async def list_alerts(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    # Admins see all alerts; regular users only see their own
+    # Admins and above see all alerts; lower roles only see their own
     stmt = select(AlertRule).order_by(AlertRule.created_at.desc())
-    if current_user.role != UserRole.admin:
+    if ROLE_HIERARCHY.get(current_user.role, 999) > ROLE_HIERARCHY[UserRole.admin]:
         stmt = stmt.where(AlertRule.created_by == current_user.id)
     result = await db.execute(stmt)
     return result.scalars().all()
@@ -57,7 +57,8 @@ async def update_alert(
     rule = await db.get(AlertRule, alert_id)
     if not rule:
         raise HTTPException(404, "Alert rule not found")
-    if rule.created_by != current_user.id and current_user.role != UserRole.admin:
+    is_admin_or_above = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
+    if rule.created_by != current_user.id and not is_admin_or_above:
         raise HTTPException(403, "Not authorized to modify this alert rule")
     rule.status = body.status
     await db.commit()
@@ -74,7 +75,8 @@ async def delete_alert(
     rule = await db.get(AlertRule, alert_id)
     if not rule:
         raise HTTPException(404, "Alert rule not found")
-    if rule.created_by != current_user.id and current_user.role != UserRole.admin:
+    is_admin_or_above = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
+    if rule.created_by != current_user.id and not is_admin_or_above:
         raise HTTPException(403, "Not authorized to delete this alert rule")
     await db.delete(rule)
     await db.commit()

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -533,7 +533,7 @@ async def redeem_invite(request: Request, req: InviteRedeemRequest, db: AsyncSes
     try:
         role = UserRole(invite.role)
     except ValueError:
-        role = UserRole.developer
+        role = UserRole.reviewer
 
     user = User(
         email=email,

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -187,8 +187,10 @@ async def oauth_login(request: Request):
     if not oauth.oidc:
         raise HTTPException(status_code=500, detail="OAuth is not configured on the server")
 
-    # Needs absolute URL so reverse handles schemes correctly for proxy deployments
-    redirect_uri = str(request.base_url).rstrip("/") + "/api/v1/auth/oauth/callback"
+    # Use FRONTEND_URL as the base so the redirect works through the Next.js proxy.
+    # This avoids Docker-internal hostnames (e.g. observal-api:8000) leaking into
+    # the redirect URI, which would fail Azure AD's redirect URI validation.
+    redirect_uri = settings.FRONTEND_URL.rstrip("/") + "/api/v1/auth/oauth/callback"
     return await oauth.oidc.authorize_redirect(request, redirect_uri)
 
 

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -13,7 +13,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, require_role
 from api.ratelimit import limiter
 from config import settings
 from models.invite import InviteCode
@@ -488,12 +488,9 @@ async def reset_password(request: Request, req: ResetPasswordRequest, db: AsyncS
 async def create_invite(
     req: InviteCreateRequest = InviteCreateRequest(),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Admin creates an invite code for a new user."""
-    if current_user.role != UserRole.admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
-
     from datetime import timedelta
 
     invite = InviteCode(
@@ -560,11 +557,9 @@ async def redeem_invite(request: Request, req: InviteRedeemRequest, db: AsyncSes
 @router.get("/invites", response_model=list[InviteListResponse])
 async def list_invites(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Admin lists all invite codes."""
-    if current_user.role != UserRole.admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
 
     result = await db.execute(select(InviteCode).order_by(InviteCode.created_at.desc()))
     return [InviteListResponse.model_validate(i) for i in result.scalars().all()]

--- a/observal-server/api/routes/component_source.py
+++ b/observal-server/api/routes/component_source.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db
+from api.deps import get_db, require_role
 from models.component_source import ComponentSource
 from models.user import User, UserRole
 from schemas.component_source import (
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/api/v1/component-sources", tags=["component-sources"
 async def add_source(
     req: ComponentSourceCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     # Detect provider from URL
     provider = "github"
@@ -57,7 +57,7 @@ async def add_source(
 async def list_sources(
     component_type: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     stmt = select(ComponentSource)
     if component_type:
@@ -70,7 +70,7 @@ async def list_sources(
 async def get_source(
     source_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     source = await db.get(ComponentSource, source_id)
     if not source:
@@ -82,7 +82,7 @@ async def get_source(
 async def trigger_sync(
     source_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     if current_user.role != UserRole.admin:
         raise HTTPException(status_code=403, detail="Admin access required")
@@ -119,7 +119,7 @@ async def trigger_sync(
 async def delete_source(
     source_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     if current_user.role != UserRole.admin:
         raise HTTPException(status_code=403, detail="Admin access required")

--- a/observal-server/api/routes/component_source.py
+++ b/observal-server/api/routes/component_source.py
@@ -82,10 +82,8 @@ async def get_source(
 async def trigger_sync(
     source_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    if current_user.role != UserRole.admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
     source = await db.get(ComponentSource, source_id)
     if not source:
         raise HTTPException(status_code=404, detail="Source not found")
@@ -119,10 +117,8 @@ async def trigger_sync(
 async def delete_source(
     source_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    if current_user.role != UserRole.admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
     source = await db.get(ComponentSource, source_id)
     if not source:
         raise HTTPException(status_code=404, detail="Source not found")

--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+from config import settings
+
+router = APIRouter(prefix="/api/v1/config", tags=["config"])
+
+
+@router.get("/public")
+async def get_public_config():
+    """Public configuration for frontend. No auth required."""
+    return {
+        "deployment_mode": settings.DEPLOYMENT_MODE,
+        "sso_enabled": bool(settings.OAUTH_CLIENT_ID),
+        "saml_enabled": False,  # placeholder for future ee/ SAML
+    }

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -7,11 +7,11 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db
+from api.deps import get_db, require_role
 from models.agent import Agent, AgentStatus
 from models.download import AgentDownloadRecord
 from models.mcp import ListingStatus, McpDownload, McpListing
-from models.user import User
+from models.user import User, UserRole
 from schemas.dashboard import (
     AgentMetrics,
     DateAvg,
@@ -66,7 +66,7 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
 async def mcp_metrics(
     listing_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     dl_count = await db.scalar(select(func.count(McpDownload.id)).where(McpDownload.listing_id == listing_id)) or 0
 
@@ -102,7 +102,7 @@ async def mcp_metrics(
 async def agent_metrics(
     agent_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     from models.eval import Scorecard
     from services.score_aggregator import ScoreAggregator
@@ -336,7 +336,7 @@ async def agent_leaderboard(
 async def trends(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     days = _range_days(range_)
     now = dt.now(UTC)
@@ -374,7 +374,7 @@ async def trends(
 async def token_stats(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     days = _range_days(range_)
     days_param = {"param_days": str(days)}
@@ -506,7 +506,7 @@ async def token_stats(
 @router.get("/dashboard/ide-usage", response_model=IdeUsage)
 async def ide_usage(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     rows = await _ch_json(
         "SELECT t.ide AS ide, "
@@ -540,7 +540,7 @@ async def ide_usage(
 @router.get("/dashboard/sandbox-metrics", response_model=SandboxStats)
 async def sandbox_metrics(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     agg = await _ch_json(
         "SELECT count() AS total_runs, "
@@ -609,7 +609,7 @@ async def sandbox_metrics(
 @router.get("/dashboard/graphrag-metrics", response_model=GraphRagStats)
 async def graphrag_metrics(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     agg = await _ch_json(
         "SELECT count() AS total_queries, "
@@ -676,7 +676,7 @@ async def graphrag_metrics(
 async def run_graphrag_ragas_eval(
     req: RagasEvalRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Run RAGAS evaluation on recent retrieval spans for a GraphRAG."""
     from services.ragas_eval import run_ragas_on_graphrag
@@ -703,7 +703,7 @@ async def run_graphrag_ragas_eval(
 async def graphrag_ragas_scores(
     graphrag_id: str | None = None,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Get previously computed RAGAS scores. If graphrag_id is provided, scoped to that GraphRAG; otherwise aggregate."""
     if graphrag_id:
@@ -731,7 +731,7 @@ async def graphrag_ragas_scores(
 @router.get("/dashboard/latency-heatmap", response_model=list[LatencyCell])
 async def latency_heatmap(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     rows = await _ch_json(
         "SELECT name, toStartOfHour(start_time) AS hour, "
@@ -765,7 +765,7 @@ async def latency_heatmap(
 @router.get("/dashboard/unannotated-traces", response_model=list[UnannotatedTrace])
 async def unannotated_traces(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     rows = await _ch_json(
         "SELECT trace_id, name, session_id, ide, trace_type, start_time "

--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -6,10 +6,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from api.deps import get_current_user, get_db, resolve_prefix_id
+from api.deps import get_db, require_role, resolve_prefix_id
 from models.agent import Agent, AgentGoalTemplate
 from models.eval import EvalRun, EvalRunStatus, Scorecard
-from models.user import User
+from models.user import User, UserRole
 from schemas.eval import EvalRequest, EvalRunDetailResponse, EvalRunResponse, ScorecardResponse
 from services.clickhouse import query_spans
 from services.eval_service import (
@@ -33,7 +33,7 @@ async def run_evaluation(
     agent_id: str,
     req: EvalRequest | None = None,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     # Load agent with goal template
     agent = await resolve_prefix_id(
@@ -101,7 +101,7 @@ async def run_evaluation(
 async def list_eval_runs(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     agent = await resolve_prefix_id(Agent, agent_id, db)
     result = await db.execute(select(EvalRun).where(EvalRun.agent_id == agent.id).order_by(EvalRun.started_at.desc()))
@@ -113,7 +113,7 @@ async def list_scorecards(
     agent_id: str,
     version: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     agent = await resolve_prefix_id(Agent, agent_id, db)
     stmt = select(Scorecard).where(Scorecard.agent_id == agent.id).options(*_scorecard_load)
@@ -127,7 +127,7 @@ async def list_scorecards(
 async def get_scorecard(
     scorecard_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     sc = await resolve_prefix_id(Scorecard, scorecard_id, db, load_options=_scorecard_load, display_field="version")
     return ScorecardResponse.model_validate(sc)
@@ -139,7 +139,7 @@ async def compare_versions(
     version_a: str = Query(...),
     version_b: str = Query(...),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Compare average scores between two agent versions."""
     from sqlalchemy import func
@@ -169,7 +169,7 @@ async def eval_session(
     session_id: str,
     agent_id: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Evaluate a hook-based session by materializing otel_logs into spans.
 
@@ -232,7 +232,7 @@ async def eval_agent_in_session(
     agent_id: str,
     session_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Evaluate a specific agent's contribution within a session.
 
@@ -342,7 +342,7 @@ async def agent_aggregate(
     agent_id: str,
     window_size: int = Query(50, ge=1, le=500),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Get aggregate scoring stats for an agent (CI, drift, dimension breakdown)."""
     agent = await resolve_prefix_id(Agent, agent_id, db)
@@ -369,7 +369,7 @@ async def agent_aggregate(
 async def scorecard_penalties(
     scorecard_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Get the list of penalties applied to a scorecard with evidence."""
     sc = await resolve_prefix_id(Scorecard, scorecard_id, db, display_field="version")

--- a/observal-server/api/routes/feedback.py
+++ b/observal-server/api/routes/feedback.py
@@ -5,11 +5,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db
+from api.deps import get_db, require_role
 from models.agent import Agent
 from models.feedback import Feedback
 from models.mcp import McpListing
-from models.user import User
+from models.user import User, UserRole
 from schemas.feedback import FeedbackCreateRequest, FeedbackResponse, FeedbackSummary
 from services.clickhouse import insert_scores
 
@@ -20,7 +20,7 @@ router = APIRouter(prefix="/api/v1/feedback", tags=["feedback"])
 async def create_feedback(
     req: FeedbackCreateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     # Validate listing exists
     if req.listing_type == "mcp":
@@ -93,7 +93,7 @@ async def get_agent_feedback(listing_id: uuid.UUID, db: AsyncSession = Depends(g
 @router.get("/me", response_model=list[FeedbackResponse])
 async def my_feedback_received(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Feedback received on listings submitted/created by the current user."""
     mcp_ids = list(

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -2,10 +2,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db, resolve_listing
+from api.deps import get_db, require_role, resolve_listing
 from models.hook import HookDownload, HookListing
 from models.mcp import ListingStatus
-from models.user import User
+from models.user import User, UserRole
 from schemas.hook import (
     HookInstallRequest,
     HookInstallResponse,
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/api/v1/hooks", tags=["hooks"])
 async def submit_hook(
     req: HookSubmitRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     existing = await db.execute(
         select(HookListing).where(HookListing.name == req.name, HookListing.submitted_by == current_user.id)
@@ -85,7 +85,7 @@ async def install_hook(
     listing_id: str,
     req: HookInstallRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(HookListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
@@ -106,7 +106,7 @@ async def install_hook(
 async def delete_hook(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(HookListing, listing_id, db)
     if not listing:

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -4,10 +4,10 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db, resolve_listing
+from api.deps import get_db, require_role, resolve_listing
 from database import async_session
 from models.mcp import ListingStatus, McpDownload, McpListing
-from models.user import User
+from models.user import User, UserRole
 from schemas.mcp import (
     McpAnalyzeRequest,
     McpAnalyzeResponse,
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 @router.post("/analyze", response_model=McpAnalyzeResponse)
 async def analyze_mcp(
     req: McpAnalyzeRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     result = await analyze_repo(req.git_url)
     return McpAnalyzeResponse(**result)
@@ -51,7 +51,7 @@ async def submit_mcp(
     req: McpSubmitRequest,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     # Prevent duplicate names for the same user
     existing = await db.execute(
@@ -113,7 +113,7 @@ async def install_mcp(
     listing_id: str,
     req: McpInstallRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(McpListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
@@ -132,7 +132,7 @@ async def install_mcp(
 async def delete_mcp(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     from models.feedback import Feedback
 

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -4,8 +4,8 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query, Request
 
-from api.deps import get_current_user
-from models.user import User
+from api.deps import require_role
+from models.user import User, UserRole
 from services.clickhouse import _query
 from services.secrets_redactor import redact_secrets
 
@@ -26,7 +26,7 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
 @router.get("/sessions")
 async def list_sessions(
     status: str | None = Query(None),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     rows = await _ch_json(
         "SELECT "
@@ -70,7 +70,7 @@ async def list_sessions(
 
 
 @router.get("/sessions/{session_id}")
-async def get_session(session_id: str, current_user: User = Depends(get_current_user)):
+async def get_session(session_id: str, current_user: User = Depends(require_role(UserRole.admin))):
     events = await _ch_json(
         "SELECT "
         "Timestamp AS timestamp, "
@@ -103,7 +103,7 @@ async def get_session(session_id: str, current_user: User = Depends(get_current_
 
 
 @router.get("/traces")
-async def list_traces(current_user: User = Depends(get_current_user)):
+async def list_traces(current_user: User = Depends(require_role(UserRole.admin))):
     rows = await _ch_json(
         "SELECT "
         "TraceId AS trace_id, "
@@ -122,7 +122,7 @@ async def list_traces(current_user: User = Depends(get_current_user)):
 
 
 @router.get("/traces/{trace_id}")
-async def get_trace(trace_id: str, current_user: User = Depends(get_current_user)):
+async def get_trace(trace_id: str, current_user: User = Depends(require_role(UserRole.admin))):
     rows = await _ch_json(
         "SELECT "
         "SpanId AS span_id, "
@@ -168,7 +168,7 @@ async def get_trace(trace_id: str, current_user: User = Depends(get_current_user
 
 
 @router.get("/errors")
-async def list_errors(current_user: User = Depends(get_current_user)):
+async def list_errors(current_user: User = Depends(require_role(UserRole.admin))):
     """List recent error events (tool failures, stop failures, API errors)."""
     rows = await _ch_json(
         "SELECT "
@@ -195,7 +195,7 @@ async def list_errors(current_user: User = Depends(get_current_user)):
 
 
 @router.get("/stats")
-async def otel_stats(current_user: User = Depends(get_current_user)):
+async def otel_stats(current_user: User = Depends(require_role(UserRole.admin))):
     log_rows = await _ch_json(
         "SELECT "
         "count(DISTINCT LogAttributes['session.id']) AS total_sessions, "

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -5,10 +5,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db, resolve_listing
+from api.deps import get_db, require_role, resolve_listing
 from models.mcp import ListingStatus
 from models.prompt import PromptDownload, PromptListing
-from models.user import User
+from models.user import User, UserRole
 from schemas.prompt import (
     PromptListingResponse,
     PromptListingSummary,
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/api/v1/prompts", tags=["prompts"])
 async def submit_prompt(
     req: PromptSubmitRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     existing = await db.execute(
         select(PromptListing).where(PromptListing.name == req.name, PromptListing.submitted_by == current_user.id)
@@ -79,7 +79,7 @@ async def get_prompt(listing_id: str, db: AsyncSession = Depends(get_db)):
 async def install_prompt(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(PromptListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
@@ -108,7 +108,7 @@ async def render_prompt(
     listing_id: str,
     req: PromptRenderRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(PromptListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
@@ -156,7 +156,7 @@ async def render_prompt(
 async def delete_prompt(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(PromptListing, listing_id, db)
     if not listing:

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db, resolve_prefix_id
+from api.deps import get_db, require_role, resolve_prefix_id
 from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
 from models.prompt import PromptListing
@@ -20,11 +20,6 @@ LISTING_MODELS = {
     "prompt": PromptListing,
     "sandbox": SandboxListing,
 }
-
-
-def _require_admin(user: User):
-    if user.role != UserRole.admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
 
 
 async def _find_listing(listing_id: str, db: AsyncSession):
@@ -62,9 +57,8 @@ async def _find_listing(listing_id: str, db: AsyncSession):
 async def list_pending(
     type: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
-    _require_admin(current_user)
 
     models_to_query = {type: LISTING_MODELS[type]} if type and type in LISTING_MODELS else LISTING_MODELS
     items = []
@@ -117,9 +111,8 @@ async def list_pending(
 async def get_review(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
-    _require_admin(current_user)
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
@@ -146,9 +139,8 @@ async def get_review(
 async def approve(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
-    _require_admin(current_user)
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
@@ -163,9 +155,8 @@ async def reject(
     listing_id: str,
     req: ReviewActionRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
-    _require_admin(current_user)
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -2,10 +2,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db, resolve_listing
+from api.deps import get_db, require_role, resolve_listing
 from models.mcp import ListingStatus
 from models.sandbox import SandboxDownload, SandboxListing
-from models.user import User
+from models.user import User, UserRole
 from schemas.sandbox import (
     SandboxInstallRequest,
     SandboxInstallResponse,
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/api/v1/sandboxes", tags=["sandboxes"])
 async def submit_sandbox(
     req: SandboxSubmitRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     existing = await db.execute(
         select(SandboxListing).where(SandboxListing.name == req.name, SandboxListing.submitted_by == current_user.id)
@@ -80,7 +80,7 @@ async def install_sandbox(
     listing_id: str,
     req: SandboxInstallRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(SandboxListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
@@ -101,7 +101,7 @@ async def install_sandbox(
 async def delete_sandbox(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(SandboxListing, listing_id, db)
     if not listing:

--- a/observal-server/api/routes/scan.py
+++ b/observal-server/api/routes/scan.py
@@ -5,12 +5,12 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db
+from api.deps import get_db, require_role
 from models.agent import Agent, AgentGoalSection, AgentGoalTemplate
 from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
 from models.skill import SkillListing
-from models.user import User
+from models.user import User, UserRole
 
 router = APIRouter(prefix="/api/v1/scan", tags=["scan"])
 
@@ -87,7 +87,7 @@ class ScanResponse(BaseModel):
 async def bulk_scan(
     req: ScanRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     registered = []
     counts: dict[str, int] = {"mcp": 0, "skill": 0, "hook": 0, "agent": 0}

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -2,10 +2,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db, resolve_listing
+from api.deps import get_db, require_role, resolve_listing
 from models.mcp import ListingStatus
 from models.skill import SkillDownload, SkillListing
-from models.user import User
+from models.user import User, UserRole
 from schemas.skill import (
     SkillInstallRequest,
     SkillInstallResponse,
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
 async def submit_skill(
     req: SkillSubmitRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     existing = await db.execute(
         select(SkillListing).where(SkillListing.name == req.name, SkillListing.submitted_by == current_user.id)
@@ -87,7 +87,7 @@ async def install_skill(
     listing_id: str,
     req: SkillInstallRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(SkillListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
@@ -108,7 +108,7 @@ async def install_skill(
 async def delete_skill(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     listing = await resolve_listing(SkillListing, listing_id, db)
     if not listing:

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -4,8 +4,8 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Header, Request
 
-from api.deps import get_current_user
-from models.user import User
+from api.deps import require_role
+from models.user import User, UserRole
 from schemas.telemetry import (
     IngestBatch,
     IngestResponse,
@@ -31,7 +31,7 @@ DEFAULT_PROJECT = "default"
 @router.post("/ingest", response_model=IngestResponse)
 async def ingest(
     batch: IngestBatch,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
     x_observal_environment: str = Header("default"),
 ):
     """New ingestion endpoint for shim/proxy telemetry."""
@@ -180,7 +180,7 @@ async def ingest(
 @router.post("/events")
 async def ingest_events(
     batch: TelemetryBatch,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     ingested = 0
@@ -231,7 +231,7 @@ async def ingest_events(
 
 
 @router.get("/status", response_model=TelemetryStatusResponse)
-async def telemetry_status(current_user: User = Depends(get_current_user)):
+async def telemetry_status(current_user: User = Depends(require_role(UserRole.admin))):
     counts = await query_recent_events(60)
     return TelemetryStatusResponse(
         tool_call_events=counts["tool_call_events"],
@@ -253,7 +253,7 @@ _KIRO_EVENT_MAP = {
 
 
 @router.post("/hooks")
-async def ingest_hook(request: Request, current_user: User = Depends(get_current_user)):
+async def ingest_hook(request: Request, current_user: User = Depends(require_role(UserRole.admin))):
     """Ingest raw hook JSON from Claude Code/Kiro."""
     body = await request.json()
 

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -31,7 +31,7 @@ DEFAULT_PROJECT = "default"
 @router.post("/ingest", response_model=IngestResponse)
 async def ingest(
     batch: IngestBatch,
-    current_user: User = Depends(require_role(UserRole.admin)),
+    current_user: User = Depends(require_role(UserRole.user)),
     x_observal_environment: str = Header("default"),
 ):
     """New ingestion endpoint for shim/proxy telemetry."""
@@ -180,7 +180,7 @@ async def ingest(
 @router.post("/events")
 async def ingest_events(
     batch: TelemetryBatch,
-    current_user: User = Depends(require_role(UserRole.admin)),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     ingested = 0
@@ -253,7 +253,7 @@ _KIRO_EVENT_MAP = {
 
 
 @router.post("/hooks")
-async def ingest_hook(request: Request, current_user: User = Depends(require_role(UserRole.admin))):
+async def ingest_hook(request: Request, current_user: User = Depends(require_role(UserRole.user))):
     """Ingest raw hook JSON from Claude Code/Kiro."""
     body = await request.json()
 

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic_settings import BaseSettings
 
 
@@ -33,7 +35,7 @@ class Settings(BaseSettings):
     RATE_LIMIT_AUTH_STRICT: str = "5/minute"
 
     # Deployment mode
-    DEPLOYMENT_MODE: str = "local"  # "local" | "enterprise"
+    DEPLOYMENT_MODE: Literal["local", "enterprise"] = "local"
 
     # Demo accounts (seeded on first startup if set and no real users exist)
     DEMO_SUPER_ADMIN_EMAIL: str | None = None

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -32,6 +32,19 @@ class Settings(BaseSettings):
     RATE_LIMIT_AUTH: str = "10/minute"
     RATE_LIMIT_AUTH_STRICT: str = "5/minute"
 
+    # Deployment mode
+    DEPLOYMENT_MODE: str = "local"  # "local" | "enterprise"
+
+    # Demo accounts (seeded on first startup if set and no real users exist)
+    DEMO_SUPER_ADMIN_EMAIL: str | None = None
+    DEMO_SUPER_ADMIN_PASSWORD: str | None = None
+    DEMO_ADMIN_EMAIL: str | None = None
+    DEMO_ADMIN_PASSWORD: str | None = None
+    DEMO_REVIEWER_EMAIL: str | None = None
+    DEMO_REVIEWER_PASSWORD: str | None = None
+    DEMO_USER_EMAIL: str | None = None
+    DEMO_USER_PASSWORD: str | None = None
+
     model_config = {"env_file": ".env", "extra": "ignore"}
 
 

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -60,6 +60,11 @@ async def _ensure_columns(conn):
         except Exception:
             pass  # column already exists or DB doesn't support IF NOT EXISTS
 
+    try:
+        await conn.execute(text("ALTER TABLE users ADD COLUMN IF NOT EXISTS is_demo BOOLEAN DEFAULT false"))
+    except Exception:
+        pass
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -23,6 +23,7 @@ from api.routes.agent import router as agent_router
 from api.routes.alert import router as alert_router
 from api.routes.auth import router as auth_router
 from api.routes.component_source import router as component_source_router
+from api.routes.config import router as config_router
 from api.routes.dashboard import router as dashboard_router
 from api.routes.eval import router as eval_router
 from api.routes.feedback import router as feedback_router
@@ -185,6 +186,7 @@ app.include_router(admin_router)
 app.include_router(alert_router)
 app.include_router(otel_dashboard_router)
 app.include_router(component_source_router)
+app.include_router(config_router)
 
 
 @app.get("/health")

--- a/observal-server/models/invite.py
+++ b/observal-server/models/invite.py
@@ -25,7 +25,7 @@ class InviteCode(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     code: Mapped[str] = mapped_column(String(20), unique=True, nullable=False, default=_generate_code)
-    role: Mapped[str] = mapped_column(String(20), nullable=False, default="developer")
+    role: Mapped[str] = mapped_column(String(20), nullable=False, default="reviewer")
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     expires_at: Mapped[datetime] = mapped_column(

--- a/observal-server/models/user.py
+++ b/observal-server/models/user.py
@@ -4,7 +4,7 @@ import os
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, Enum, ForeignKey, String
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -12,8 +12,9 @@ from models.base import Base
 
 
 class UserRole(str, enum.Enum):
+    super_admin = "super_admin"
     admin = "admin"
-    developer = "developer"
+    reviewer = "reviewer"
     user = "user"
 
 
@@ -27,7 +28,12 @@ class User(Base):
     api_key_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True)
+    is_demo: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+    def __init__(self, **kwargs: object) -> None:
+        kwargs.setdefault("is_demo", False)
+        super().__init__(**kwargs)
 
     def set_password(self, password: str) -> None:
         salt = os.urandom(16)

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "cffi",
     "slowapi",
     "PyJWT>=2.8.0",
+    "aiosqlite>=0.22.1",
 ]
 
 [dependency-groups]

--- a/observal-server/schemas/admin.py
+++ b/observal-server/schemas/admin.py
@@ -30,7 +30,7 @@ class UserRoleUpdate(BaseModel):
 class UserCreateRequest(BaseModel):
     email: str
     name: str
-    role: str = "developer"
+    role: str = "reviewer"
 
 
 class UserCreateResponse(BaseModel):

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -39,7 +39,7 @@ class InviteRedeemRequest(BaseModel):
 
 
 class InviteCreateRequest(BaseModel):
-    role: str = "developer"
+    role: str = "reviewer"
     expires_days: int = 7
 
 

--- a/observal-server/tests/test_config.py
+++ b/observal-server/tests/test_config.py
@@ -1,0 +1,42 @@
+"""Tests for configuration settings."""
+
+
+def test_deployment_mode_defaults_to_local():
+    """DEPLOYMENT_MODE should default to 'local'."""
+    from config import Settings
+
+    s = Settings(
+        DATABASE_URL="sqlite+aiosqlite:///",
+        SECRET_KEY="test",
+    )
+    assert s.DEPLOYMENT_MODE == "local"
+
+
+def test_deployment_mode_accepts_enterprise():
+    """DEPLOYMENT_MODE should accept 'enterprise'."""
+    from config import Settings
+
+    s = Settings(
+        DATABASE_URL="sqlite+aiosqlite:///",
+        SECRET_KEY="test",
+        DEPLOYMENT_MODE="enterprise",
+    )
+    assert s.DEPLOYMENT_MODE == "enterprise"
+
+
+def test_demo_env_vars_default_to_none():
+    """All DEMO_* vars should default to None."""
+    from config import Settings
+
+    s = Settings(
+        DATABASE_URL="sqlite+aiosqlite:///",
+        SECRET_KEY="test",
+    )
+    assert s.DEMO_SUPER_ADMIN_EMAIL is None
+    assert s.DEMO_SUPER_ADMIN_PASSWORD is None
+    assert s.DEMO_ADMIN_EMAIL is None
+    assert s.DEMO_ADMIN_PASSWORD is None
+    assert s.DEMO_REVIEWER_EMAIL is None
+    assert s.DEMO_REVIEWER_PASSWORD is None
+    assert s.DEMO_USER_EMAIL is None
+    assert s.DEMO_USER_PASSWORD is None

--- a/observal-server/tests/test_config.py
+++ b/observal-server/tests/test_config.py
@@ -24,6 +24,21 @@ def test_deployment_mode_accepts_enterprise():
     assert s.DEPLOYMENT_MODE == "enterprise"
 
 
+def test_deployment_mode_rejects_invalid():
+    """DEPLOYMENT_MODE should reject values other than 'local' or 'enterprise'."""
+    import pytest
+    from pydantic import ValidationError
+
+    from config import Settings
+
+    with pytest.raises(ValidationError):
+        Settings(
+            DATABASE_URL="sqlite+aiosqlite:///",
+            SECRET_KEY="test",
+            DEPLOYMENT_MODE="staging",
+        )
+
+
 def test_demo_env_vars_default_to_none():
     """All DEMO_* vars should default to None."""
     from config import Settings

--- a/observal-server/tests/test_crypto.py
+++ b/observal-server/tests/test_crypto.py
@@ -231,11 +231,11 @@ class TestTokenRoundTrip:
     """Test the public sign_token / verify_token API (uses PyJWT if available)."""
 
     def test_sign_and_verify(self, km):
-        payload = {"sub": "user-456", "role": "developer"}
+        payload = {"sub": "user-456", "role": "reviewer"}
         token = km.sign_token(payload)
         decoded = km.verify_token(token)
         assert decoded["sub"] == "user-456"
-        assert decoded["role"] == "developer"
+        assert decoded["role"] == "reviewer"
 
     def test_roundtrip_with_nested_payload(self, km):
         payload = {"data": {"items": [1, 2, 3]}, "count": 3}

--- a/observal-server/tests/test_jwt.py
+++ b/observal-server/tests/test_jwt.py
@@ -64,11 +64,11 @@ class TestTokenGeneration:
 
     def test_create_refresh_token_returns_valid_jwt_with_jti(self):
         uid = uuid.uuid4()
-        token, jti = create_refresh_token(uid, UserRole.developer)
+        token, jti = create_refresh_token(uid, UserRole.reviewer)
 
         payload = pyjwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
         assert payload["sub"] == str(uid)
-        assert payload["role"] == "developer"
+        assert payload["role"] == "reviewer"
         assert payload["type"] == "refresh"
         assert payload["jti"] == jti
 

--- a/observal-server/tests/test_rbac.py
+++ b/observal-server/tests/test_rbac.py
@@ -31,3 +31,86 @@ def test_user_model_has_is_demo_field():
         api_key_hash="a" * 64,
     )
     assert user.is_demo is False, "is_demo should default to False"
+
+
+import pytest
+from unittest.mock import MagicMock
+from fastapi import HTTPException
+
+from api.deps import require_role, ROLE_HIERARCHY
+
+
+def test_role_hierarchy_ordering():
+    """super_admin has lowest number (highest privilege)."""
+    assert ROLE_HIERARCHY[UserRole.super_admin] < ROLE_HIERARCHY[UserRole.admin]
+    assert ROLE_HIERARCHY[UserRole.admin] < ROLE_HIERARCHY[UserRole.reviewer]
+    assert ROLE_HIERARCHY[UserRole.reviewer] < ROLE_HIERARCHY[UserRole.user]
+
+
+def test_role_hierarchy_has_all_roles():
+    """Every UserRole must be in the hierarchy."""
+    for role in UserRole:
+        assert role in ROLE_HIERARCHY, f"{role} missing from ROLE_HIERARCHY"
+
+
+@pytest.mark.asyncio
+async def test_require_role_allows_exact_match():
+    """User with exact required role should pass."""
+    dep = require_role(UserRole.admin)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.admin
+    result = await dep(current_user=mock_user)
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_require_role_allows_higher_role():
+    """super_admin should pass an admin check."""
+    dep = require_role(UserRole.admin)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.super_admin
+    result = await dep(current_user=mock_user)
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_require_role_blocks_lower_role():
+    """user should not pass an admin check."""
+    dep = require_role(UserRole.admin)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.user
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(current_user=mock_user)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_require_role_reviewer_allows_admin():
+    """admin should pass a reviewer check."""
+    dep = require_role(UserRole.reviewer)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.admin
+    result = await dep(current_user=mock_user)
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_require_role_reviewer_blocks_user():
+    """user should not pass a reviewer check."""
+    dep = require_role(UserRole.reviewer)
+    mock_user = MagicMock()
+    mock_user.role = UserRole.user
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(current_user=mock_user)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_require_role_user_allows_everyone():
+    """Every role should pass a user-level check."""
+    dep = require_role(UserRole.user)
+    for role in UserRole:
+        mock_user = MagicMock()
+        mock_user.role = role
+        result = await dep(current_user=mock_user)
+        assert result is mock_user

--- a/observal-server/tests/test_rbac.py
+++ b/observal-server/tests/test_rbac.py
@@ -1,0 +1,33 @@
+"""Tests for the 4-tier RBAC system."""
+
+from models.user import User, UserRole
+
+
+def test_userrole_enum_has_four_tiers():
+    """UserRole must have exactly super_admin, admin, reviewer, user."""
+    expected = {"super_admin", "admin", "reviewer", "user"}
+    actual = {r.value for r in UserRole}
+    assert actual == expected, f"Expected {expected}, got {actual}"
+
+
+def test_userrole_enum_values():
+    """Each role's .value matches its name."""
+    assert UserRole.super_admin.value == "super_admin"
+    assert UserRole.admin.value == "admin"
+    assert UserRole.reviewer.value == "reviewer"
+    assert UserRole.user.value == "user"
+
+
+def test_developer_role_does_not_exist():
+    """The old 'developer' role must not exist."""
+    assert not hasattr(UserRole, "developer"), "developer role should be removed"
+
+
+def test_user_model_has_is_demo_field():
+    """User model must have is_demo boolean field."""
+    user = User(
+        email="test@example.com",
+        name="Test",
+        api_key_hash="a" * 64,
+    )
+    assert user.is_demo is False, "is_demo should default to False"

--- a/observal-server/tests/test_rbac.py
+++ b/observal-server/tests/test_rbac.py
@@ -1,5 +1,11 @@
 """Tests for the 4-tier RBAC system."""
 
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from api.deps import ROLE_HIERARCHY, require_role
 from models.user import User, UserRole
 
 
@@ -31,13 +37,6 @@ def test_user_model_has_is_demo_field():
         api_key_hash="a" * 64,
     )
     assert user.is_demo is False, "is_demo should default to False"
-
-
-import pytest
-from unittest.mock import MagicMock
-from fastapi import HTTPException
-
-from api.deps import require_role, ROLE_HIERARCHY
 
 
 def test_role_hierarchy_ordering():

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -750,6 +759,7 @@ name = "observal-server"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "alembic" },
     { name = "arq" },
     { name = "asyncpg" },
@@ -781,13 +791,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic" },
     { name = "arq" },
     { name = "asyncpg" },
     { name = "authlib" },
     { name = "boto3" },
     { name = "cffi" },
-    { name = "cryptography" },
+    { name = "cryptography", specifier = ">=43.0.0" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "gitpython" },

--- a/tests/test_registry_types.py
+++ b/tests/test_registry_types.py
@@ -549,7 +549,7 @@ class TestUnifiedReview:
     async def test_list_pending_requires_admin(self):
         from api.routes.review import router
 
-        user = _user(role=UserRole.developer)
+        user = _user(role=UserRole.user)
         app, db, _ = _app_with(router, user=user)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.get("/api/v1/review")

--- a/tests/test_review_queue.py
+++ b/tests/test_review_queue.py
@@ -231,7 +231,7 @@ class TestListPending:
 
     @pytest.mark.asyncio
     async def test_requires_admin(self):
-        user = _user(role=UserRole.developer)
+        user = _user(role=UserRole.user)
         app, _, _ = _app_with(user=user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -284,7 +284,7 @@ class TestGetReview:
 
     @pytest.mark.asyncio
     async def test_requires_admin(self):
-        user = _user(role=UserRole.developer)
+        user = _user(role=UserRole.user)
         app, _, _ = _app_with(user=user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -341,7 +341,7 @@ class TestApprove:
 
     @pytest.mark.asyncio
     async def test_requires_admin(self):
-        user = _user(role=UserRole.developer)
+        user = _user(role=UserRole.user)
         app, _, _ = _app_with(user=user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -406,7 +406,7 @@ class TestReject:
 
     @pytest.mark.asyncio
     async def test_requires_admin(self):
-        user = _user(role=UserRole.developer)
+        user = _user(role=UserRole.user)
         app, _, _ = _app_with(user=user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:

--- a/web/e2e/sso-login.spec.ts
+++ b/web/e2e/sso-login.spec.ts
@@ -1,0 +1,306 @@
+import { test, expect, Page } from "@playwright/test";
+import { API_BASE } from "./helpers";
+
+/**
+ * Real SSO integration tests using Microsoft Entra ID.
+ *
+ * Prerequisites:
+ *   - API running on localhost:8000 with OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET,
+ *     OAUTH_SERVER_METADATA_URL configured for a Microsoft Entra ID tenant
+ *   - Frontend running on localhost:3000
+ *   - FRONTEND_URL=http://localhost:3000 in the API environment
+ *   - Redis running (for OAuth code exchange)
+ *
+ * These tests are skipped automatically if SSO is not configured.
+ */
+
+const SSO_EMAIL =
+  process.env.SSO_TEST_EMAIL ?? "hari-srinivasan@tx131.onmicrosoft.com";
+const SSO_PASSWORD = process.env.SSO_TEST_PASSWORD ?? "TestObserval@2026!";
+
+/** Check if SSO is enabled on the running API.
+ *  Tries the public config endpoint first, falls back to probing
+ *  the OAuth login endpoint (302 redirect means OAuth is configured). */
+async function isSsoEnabled(): Promise<boolean> {
+  try {
+    // Preferred: check the public config endpoint
+    const configRes = await fetch(`${API_BASE}/api/v1/config/public`);
+    if (configRes.ok) {
+      const config = await configRes.json();
+      return config.sso_enabled === true;
+    }
+  } catch {
+    // Config endpoint not available
+  }
+
+  try {
+    // Fallback: probe the OAuth login endpoint (redirect = configured)
+    const oauthRes = await fetch(`${API_BASE}/api/v1/auth/oauth/login`, {
+      redirect: "manual",
+    });
+    return oauthRes.status === 302;
+  } catch {
+    return false;
+  }
+}
+
+/** New password to use if Microsoft forces a password update during login. */
+const SSO_NEW_PASSWORD = process.env.SSO_TEST_NEW_PASSWORD ?? SSO_PASSWORD;
+
+/** Fill out the Microsoft Entra ID login form.
+ *  Handles: email → password → optional password update → optional consent
+ *  → optional "Stay signed in?" prompt. */
+async function completeMicrosoftLogin(page: Page) {
+  // Microsoft login page — wait for the email input
+  await page.waitForURL(/login\.microsoftonline\.com/, { timeout: 15_000 });
+
+  // Enter email
+  const emailInput = page.locator('input[type="email"]');
+  await emailInput.waitFor({ state: "visible", timeout: 10_000 });
+  await emailInput.fill(SSO_EMAIL);
+  await page.locator('input[type="submit"][value="Next"]').click();
+
+  // Enter password
+  const passwordInput = page.locator('input[type="password"]');
+  await passwordInput.waitFor({ state: "visible", timeout: 10_000 });
+  await passwordInput.fill(SSO_PASSWORD);
+  await page.locator('input[type="submit"][value="Sign in"]').click();
+
+  // Handle "Update your password" prompt if it appears (first sign-in or expired)
+  try {
+    const updateHeading = page.locator('text="Update your password"');
+    await updateHeading.waitFor({ state: "visible", timeout: 5_000 });
+    // Fill current + new + confirm
+    await page
+      .locator('input[placeholder="Current password"]')
+      .fill(SSO_PASSWORD);
+    await page
+      .locator('input[placeholder="New password"]')
+      .fill(SSO_NEW_PASSWORD);
+    await page
+      .locator('input[placeholder="Confirm password"]')
+      .fill(SSO_NEW_PASSWORD);
+    await page.locator('input[type="submit"][value="Sign in"]').click();
+  } catch {
+    // No password update needed — continue
+  }
+
+  // Handle consent prompt if it appears (first-time app authorization)
+  try {
+    const acceptButton = page.locator(
+      'input[type="submit"][value="Accept"], button:has-text("Accept")',
+    );
+    await acceptButton.first().waitFor({ state: "visible", timeout: 5_000 });
+    await acceptButton.first().click();
+  } catch {
+    // No consent prompt — continue
+  }
+
+  // Handle "Stay signed in?" prompt if it appears
+  try {
+    const staySignedIn = page.locator(
+      'input[type="submit"][value="Yes"], input[type="button"][value="No"]',
+    );
+    await staySignedIn.first().waitFor({ state: "visible", timeout: 5_000 });
+    // Click "No" to avoid persistent cookies that affect other tests
+    const noButton = page.locator('input[type="button"][value="No"]');
+    if (await noButton.isVisible()) {
+      await noButton.click();
+    } else {
+      await staySignedIn.first().click();
+    }
+  } catch {
+    // No "Stay signed in?" prompt — continue
+  }
+}
+
+test.describe("SSO Login Flow", () => {
+  test.beforeEach(async () => {
+    const enabled = await isSsoEnabled();
+    test.skip(!enabled, "SSO is not configured — skipping SSO tests");
+  });
+
+  test("SSO button is visible on login page when SSO is enabled", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    const ssoButton = page.locator('button:has-text("Sign in with SSO")');
+    await expect(ssoButton).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("full SSO login flow authenticates user and redirects to home", async ({
+    page,
+  }) => {
+    // Extend timeout for the full OAuth round-trip
+    test.setTimeout(90_000);
+
+    // Navigate to login page
+    await page.goto("/login");
+
+    // Click SSO button
+    const ssoButton = page.locator('button:has-text("Sign in with SSO")');
+    await expect(ssoButton).toBeVisible({ timeout: 10_000 });
+    await ssoButton.click();
+
+    // Complete Microsoft login flow
+    await completeMicrosoftLogin(page);
+
+    // After SSO callback, we should land back on our app
+    await page.waitForURL(
+      (url) => url.origin === "http://localhost:3000" && url.pathname !== "/login",
+      { timeout: 30_000 },
+    );
+
+    // Verify authentication state
+    const role = await page.evaluate(() =>
+      localStorage.getItem("observal_user_role"),
+    );
+    expect(role).toBeTruthy();
+
+    const apiKey = await page.evaluate(() =>
+      localStorage.getItem("observal_api_key"),
+    );
+    expect(apiKey).toBeTruthy();
+  });
+
+  test("SSO user can access authenticated endpoints after login", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    await page.goto("/login");
+    const ssoButton = page.locator('button:has-text("Sign in with SSO")');
+    await ssoButton.click();
+
+    await completeMicrosoftLogin(page);
+
+    // Wait for redirect back to the app
+    await page.waitForURL(
+      (url) => url.origin === "http://localhost:3000" && url.pathname !== "/login",
+      { timeout: 30_000 },
+    );
+
+    // Verify the whoami endpoint works with the stored credentials
+    const apiKey = await page.evaluate(() =>
+      localStorage.getItem("observal_api_key"),
+    );
+    expect(apiKey).toBeTruthy();
+
+    const whoami = await page.evaluate(async (key) => {
+      const res = await fetch("/api/v1/auth/whoami", {
+        headers: { "X-API-Key": key! },
+      });
+      return res.json();
+    }, apiKey);
+
+    expect(whoami.email).toBe(SSO_EMAIL);
+    expect(whoami.role).toBeTruthy();
+  });
+});
+
+test.describe("Enterprise Mode Login Page", () => {
+  test("enterprise mode hides password form and shows only SSO button", async ({
+    page,
+  }) => {
+    // Mock the config endpoint BEFORE navigation and wait for it to resolve
+    let configFetched = false;
+    await page.route("**/api/v1/config/public", (route) => {
+      configFetched = true;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          deployment_mode: "enterprise",
+          sso_enabled: true,
+          saml_enabled: false,
+        }),
+      });
+    });
+
+    await page.goto("/login");
+
+    // Wait for the config response to be processed by React by waiting for the
+    // SSO button to appear — this confirms the deployment config has loaded
+    const ssoButton = page.locator('button:has-text("Sign in with SSO")');
+    await expect(ssoButton).toBeVisible({ timeout: 10_000 });
+
+    // In enterprise mode, the email/password form is conditionally not rendered.
+    // Wait for the email input to be detached from the DOM (not just hidden).
+    await expect(page.locator('input[id="email"]')).toHaveCount(0, {
+      timeout: 5_000,
+    });
+    await expect(page.locator('input[id="password"]')).toHaveCount(0);
+
+    // Registration, forgot password, API key links should not be rendered
+    await expect(
+      page.locator('button:has-text("Don\'t have an account")'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('button:has-text("Forgot password")'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('button:has-text("Sign in with API key")'),
+    ).toHaveCount(0);
+  });
+
+  test("local mode shows full login UI with SSO button when enabled", async ({
+    page,
+  }) => {
+    await page.route("**/api/v1/config/public", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          deployment_mode: "local",
+          sso_enabled: true,
+          saml_enabled: false,
+        }),
+      }),
+    );
+
+    await page.goto("/login");
+
+    // Wait for config to load — SSO button confirms it
+    const ssoButton = page.locator('button:has-text("Sign in with SSO")');
+    await expect(ssoButton).toBeVisible({ timeout: 10_000 });
+
+    // Email and password should be visible in local mode
+    await expect(page.locator('input[id="email"]')).toBeVisible();
+    await expect(page.locator('input[id="password"]')).toBeVisible();
+
+    // Registration link should be visible
+    await expect(
+      page.locator('button:has-text("Don\'t have an account")'),
+    ).toBeVisible();
+  });
+
+  test("local mode without SSO shows only password login", async ({
+    page,
+  }) => {
+    await page.route("**/api/v1/config/public", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          deployment_mode: "local",
+          sso_enabled: false,
+          saml_enabled: false,
+        }),
+      }),
+    );
+
+    await page.goto("/login");
+
+    // Email and password should be visible
+    await expect(page.locator('input[id="email"]')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator('input[id="password"]')).toBeVisible();
+
+    // SSO button should NOT be in the DOM when sso_enabled is false
+    // and deployment_mode is "local"
+    await expect(
+      page.locator('button:has-text("Sign in with SSO")'),
+    ).toHaveCount(0, { timeout: 5_000 });
+  });
+});

--- a/web/src/app/(admin)/layout.tsx
+++ b/web/src/app/(admin)/layout.tsx
@@ -3,7 +3,7 @@ import { RegistrySidebar } from "@/components/nav/registry-sidebar";
 import { CommandMenu } from "@/components/nav/command-menu";
 import { Toaster } from "@/components/ui/sonner";
 import { AuthGuard } from "@/components/layouts/auth-guard";
-import { AdminGuard } from "@/components/layouts/admin-guard";
+import { RoleGuard } from "@/components/layouts/role-guard";
 
 export default function AdminLayout({
   children,
@@ -12,14 +12,14 @@ export default function AdminLayout({
 }) {
   return (
     <AuthGuard>
-      <AdminGuard>
+      <RoleGuard minRole="admin">
         <SidebarProvider>
           <RegistrySidebar />
           <SidebarInset>{children}</SidebarInset>
           <CommandMenu />
           <Toaster visibleToasts={1} />
         </SidebarProvider>
-      </AdminGuard>
+      </RoleGuard>
     </AuthGuard>
   );
 }

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -20,8 +20,9 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+import { ROLE_LABELS, type Role } from "@/hooks/use-role-guard";
 
-const ROLES = ["admin", "developer", "viewer"] as const;
+const ROLES: Role[] = ["super_admin", "admin", "reviewer", "user"];
 
 function RoleSelect({ userId, currentRole }: { userId: string; currentRole: string }) {
   const mutation = useUpdateUserRole();
@@ -32,13 +33,15 @@ function RoleSelect({ userId, currentRole }: { userId: string; currentRole: stri
       onValueChange={(value) => mutation.mutate({ id: userId, role: value })}
       disabled={mutation.isPending}
     >
-      <SelectTrigger className="h-7 w-[120px] text-xs">
-        <SelectValue />
+      <SelectTrigger className="h-7 w-[140px] text-xs">
+        <SelectValue>
+          {ROLE_LABELS[currentRole as Role] ?? currentRole}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent>
         {ROLES.map((r) => (
           <SelectItem key={r} value={r} className="text-xs">
-            {r}
+            {ROLE_LABELS[r]}
           </SelectItem>
         ))}
       </SelectContent>
@@ -52,7 +55,7 @@ export default function UsersPage() {
   const [showCreate, setShowCreate] = useState(false);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState<string>("developer");
+  const [role, setRole] = useState<string>("user");
   const [createdApiKey, setCreatedApiKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -65,7 +68,7 @@ export default function UsersPage() {
           setCreatedApiKey(data.api_key);
           setName("");
           setEmail("");
-          setRole("developer");
+          setRole("user");
         },
       },
     );
@@ -84,7 +87,7 @@ export default function UsersPage() {
     setCreatedApiKey(null);
     setName("");
     setEmail("");
-    setRole("developer");
+    setRole("user");
   }, []);
 
   const userCount = (users ?? []).length;
@@ -210,11 +213,13 @@ export default function UsersPage() {
                 <label className="text-xs font-medium text-muted-foreground">Role</label>
                 <Select value={role} onValueChange={setRole}>
                   <SelectTrigger className="h-8 text-sm">
-                    <SelectValue />
+                    <SelectValue>
+                      {ROLE_LABELS[role as Role] ?? role}
+                    </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     {ROLES.map((r) => (
-                      <SelectItem key={r} value={r}>{r}</SelectItem>
+                      <SelectItem key={r} value={r}>{ROLE_LABELS[r]}</SelectItem>
                     ))}
                   </SelectContent>
                 </Select>

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Eye, EyeOff, ArrowRight, Loader2, AlertCircle, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { auth, setApiKey, setUserRole, getUserRole } from "@/lib/api";
+import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -14,6 +15,8 @@ type Mode = "login" | "register" | "api-key" | "reset-request" | "reset-confirm"
 function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { deploymentMode, ssoEnabled } = useDeploymentConfig();
+  const isEnterprise = deploymentMode === "enterprise";
   const [mode, setMode] = useState<Mode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -209,8 +212,8 @@ function LoginContent() {
               }}
               className="space-y-4"
             >
-              {/* Email + Password mode (login & register) */}
-              {(mode === "login" || mode === "register") && (
+              {/* Email + Password mode (login & register) — hidden in enterprise login mode */}
+              {(mode === "login" || mode === "register") && !(isEnterprise && mode === "login") && (
                 <>
                   <div className="space-y-2 animate-in">
                     <Label htmlFor="email">Email</Label>
@@ -360,21 +363,24 @@ function LoginContent() {
 
               {/* Submit */}
               <div className="animate-in stagger-2 space-y-3">
-                <Button type="submit" disabled={loading || ssoLoading} className="w-full">
-                  {loading && !ssoLoading ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <>
-                      {mode === "register" ? "Create Account"
-                        : mode === "reset-request" ? "Send Reset Code"
-                        : mode === "reset-confirm" ? "Reset Password"
-                        : "Sign in"}
-                      <ArrowRight className="ml-1 h-4 w-4" />
-                    </>
-                  )}
-                </Button>
+                {/* In enterprise login mode, hide the password submit button */}
+                {!(isEnterprise && mode === "login") && (
+                  <Button type="submit" disabled={loading || ssoLoading} className="w-full">
+                    {loading && !ssoLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <>
+                        {mode === "register" ? "Create Account"
+                          : mode === "reset-request" ? "Send Reset Code"
+                          : mode === "reset-confirm" ? "Reset Password"
+                          : "Sign in"}
+                        <ArrowRight className="ml-1 h-4 w-4" />
+                      </>
+                    )}
+                  </Button>
+                )}
 
-                {mode === "login" && (
+                {mode === "login" && !isEnterprise && (
                   <div className="relative py-2">
                     <div className="absolute inset-0 flex items-center">
                       <span className="w-full border-t" />
@@ -384,12 +390,12 @@ function LoginContent() {
                     </div>
                   </div>
                 )}
-                
-                {mode === "login" && (
-                  <Button 
-                    type="button" 
-                    variant="outline" 
-                    className="w-full" 
+
+                {mode === "login" && (isEnterprise || ssoEnabled) && (
+                  <Button
+                    type="button"
+                    variant={isEnterprise ? "default" : "outline"}
+                    className="w-full"
                     onClick={handleSsoLogin}
                     disabled={loading || ssoLoading}
                   >
@@ -405,7 +411,7 @@ function LoginContent() {
 
               {/* Mode switches */}
               <div className="animate-in stagger-3 space-y-2 text-center">
-                {mode === "login" && (
+                {mode === "login" && !isEnterprise && (
                   <>
                     <button
                       type="button"

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
   useEvalAggregate,
 } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
+import { hasMinRole } from "@/hooks/use-role-guard";
 import type { FeedbackItem } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
 import { StatusBadge } from "@/components/registry/status-badge";
@@ -238,7 +239,7 @@ export default function AgentDetailPage({
 
   const isAdmin =
     typeof window !== "undefined" &&
-    getUserRole() === "admin";
+    hasMinRole(getUserRole(), "admin");
 
   const a = agent as unknown as AgentDetail | undefined;
   const components: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];

--- a/web/src/components/layouts/admin-guard.tsx
+++ b/web/src/components/layouts/admin-guard.tsx
@@ -1,8 +1,11 @@
 "use client";
-import { useAdminGuard } from "@/hooks/use-admin-guard";
 
+import { RoleGuard } from "@/components/layouts/role-guard";
+
+/**
+ * @deprecated Use `<RoleGuard minRole="admin">` instead.
+ * Kept for backward compatibility.
+ */
 export function AdminGuard({ children }: { children: React.ReactNode }) {
-  const ready = useAdminGuard();
-  if (!ready) return null;
-  return <>{children}</>;
+  return <RoleGuard minRole="admin">{children}</RoleGuard>;
 }

--- a/web/src/components/layouts/role-guard.tsx
+++ b/web/src/components/layouts/role-guard.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useRoleGuard, type Role } from "@/hooks/use-role-guard";
+
+export function RoleGuard({ minRole, children }: { minRole: Role; children: React.ReactNode }) {
+  const { ready } = useRoleGuard(minRole);
+  if (!ready) return null;
+  return <>{children}</>;
+}

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -32,8 +32,11 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { getUserRole } from "@/lib/api";
+import { hasMinRole, type Role } from "@/hooks/use-role-guard";
 
-const registryNav: { title: string; href: string; icon: typeof Home; requiresAuth?: boolean }[] = [
+type NavItem = { title: string; href: string; icon: typeof Home; requiresAuth?: boolean; minRole?: Role };
+
+const registryNav: NavItem[] = [
   { title: "Home", href: "/", icon: Home },
   { title: "Agents", href: "/agents", icon: Bot },
   { title: "Leaderboard", href: "/agents/leaderboard", icon: Trophy },
@@ -41,25 +44,28 @@ const registryNav: { title: string; href: string; icon: typeof Home; requiresAut
   { title: "Builder", href: "/agents/builder", icon: Hammer, requiresAuth: true },
 ];
 
-const adminNav = [
-  { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-  { title: "Traces", href: "/traces", icon: Activity },
-  { title: "Errors", href: "/errors", icon: AlertTriangle },
-  { title: "Evals", href: "/eval", icon: FlaskConical },
-  { title: "Review", href: "/review", icon: ShieldCheck },
-  { title: "Users", href: "/users", icon: Users },
-  { title: "Settings", href: "/settings", icon: Settings },
+const reviewNav: NavItem[] = [
+  { title: "Review", href: "/review", icon: ShieldCheck, minRole: "reviewer" },
+];
+
+const adminNav: NavItem[] = [
+  { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard, minRole: "admin" },
+  { title: "Traces", href: "/traces", icon: Activity, minRole: "admin" },
+  { title: "Errors", href: "/errors", icon: AlertTriangle, minRole: "admin" },
+  { title: "Evals", href: "/eval", icon: FlaskConical, minRole: "admin" },
+  { title: "Users", href: "/users", icon: Users, minRole: "admin" },
+  { title: "Settings", href: "/settings", icon: Settings, minRole: "admin" },
 ];
 
 export const allNavItems = [
   { group: "Registry", items: registryNav },
+  { group: "Review", items: reviewNav },
   { group: "Admin", items: adminNav },
 ];
 
 export function RegistrySidebar() {
   const pathname = usePathname();
   const role = getUserRole();
-  const isAdmin = role === "admin";
   const isAuthenticated = typeof window !== "undefined" && !!localStorage.getItem("observal_api_key");
 
   function isActive(href: string) {
@@ -70,6 +76,14 @@ export function RegistrySidebar() {
   const visibleRegistryNav = registryNav.filter(
     (item) => !item.requiresAuth || isAuthenticated,
   );
+
+  const visibleReviewNav = isAuthenticated
+    ? reviewNav.filter((item) => !item.minRole || hasMinRole(role, item.minRole))
+    : [];
+
+  const visibleAdminNav = isAuthenticated
+    ? adminNav.filter((item) => !item.minRole || hasMinRole(role, item.minRole))
+    : [];
 
   return (
     <Sidebar collapsible="icon">
@@ -101,14 +115,36 @@ export function RegistrySidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {isAuthenticated && isAdmin && (
+        {visibleReviewNav.length > 0 && (
+          <SidebarGroup>
+            <SidebarGroupLabel className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+              Review
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {visibleReviewNav.map((item) => (
+                  <SidebarMenuItem key={item.href}>
+                    <SidebarMenuButton asChild isActive={isActive(item.href)}>
+                      <Link href={item.href}>
+                        <item.icon className="h-4 w-4" />
+                        <span>{item.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
+
+        {visibleAdminNav.length > 0 && (
           <SidebarGroup>
             <SidebarGroupLabel className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
               Admin
             </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {adminNav.map((item) => (
+                {visibleAdminNav.map((item) => (
                   <SidebarMenuItem key={item.href}>
                     <SidebarMenuButton asChild isActive={isActive(item.href)}>
                       <Link href={item.href}>

--- a/web/src/hooks/use-admin-guard.ts
+++ b/web/src/hooks/use-admin-guard.ts
@@ -1,20 +1,12 @@
 "use client";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { getUserRole } from "@/lib/api";
 
+import { useRoleGuard } from "@/hooks/use-role-guard";
+
+/**
+ * @deprecated Use `useRoleGuard("admin")` instead.
+ * Kept for backward compatibility.
+ */
 export function useAdminGuard() {
-  const router = useRouter();
-  const [ready] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return getUserRole() === "admin";
-  });
-
-  useEffect(() => {
-    if (!ready) {
-      router.replace("/");
-    }
-  }, [ready, router]);
-
+  const { ready } = useRoleGuard("admin");
   return ready;
 }

--- a/web/src/hooks/use-deployment-config.ts
+++ b/web/src/hooks/use-deployment-config.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { config, type PublicConfig } from "@/lib/api";
+
+export function useDeploymentConfig() {
+  const { data, isLoading } = useQuery<PublicConfig>({
+    queryKey: ["config", "public"],
+    queryFn: config.public,
+    staleTime: 5 * 60 * 1000, // cache for 5 minutes
+    retry: 1,
+  });
+
+  return {
+    deploymentMode: data?.deployment_mode ?? "local",
+    ssoEnabled: data?.sso_enabled ?? false,
+    samlEnabled: data?.saml_enabled ?? false,
+    loading: isLoading,
+  };
+}

--- a/web/src/hooks/use-role-guard.ts
+++ b/web/src/hooks/use-role-guard.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getUserRole } from "@/lib/api";
+
+/** Canonical role type matching the backend 4-tier RBAC. */
+export type Role = "super_admin" | "admin" | "reviewer" | "user";
+
+/** Ordered from most to least privileged. */
+const ROLE_HIERARCHY: Role[] = ["super_admin", "admin", "reviewer", "user"];
+
+/** Display labels for UI rendering. */
+export const ROLE_LABELS: Record<Role, string> = {
+  super_admin: "Super Admin",
+  admin: "Admin",
+  reviewer: "Reviewer",
+  user: "Viewer",
+};
+
+/** Returns true if `userRole` is at or above `minRole` in the hierarchy. */
+export function hasMinRole(userRole: string | null, minRole: Role): boolean {
+  if (!userRole) return false;
+  const userIdx = ROLE_HIERARCHY.indexOf(userRole as Role);
+  const minIdx = ROLE_HIERARCHY.indexOf(minRole);
+  // Lower index = higher privilege. Unknown roles fail closed.
+  if (userIdx === -1) return false;
+  return userIdx <= minIdx;
+}
+
+/**
+ * Guard hook that checks if the current user meets a minimum role.
+ * Redirects to "/" if the role is insufficient.
+ */
+export function useRoleGuard(minRole: Role) {
+  const router = useRouter();
+  const [ready] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return hasMinRole(getUserRole(), minRole);
+  });
+
+  useEffect(() => {
+    if (!ready) {
+      router.replace("/");
+    }
+  }, [ready, router]);
+
+  return { ready };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -246,6 +246,17 @@ export const admin = {
     put<{ message: string }>(`/admin/users/${id}/password`, body),
 };
 
+// ── Config ─────────────────────────────────────────────────────────
+export type PublicConfig = {
+  deployment_mode: "local" | "enterprise";
+  sso_enabled: boolean;
+  saml_enabled: boolean;
+};
+
+export const config = {
+  public: () => get<PublicConfig>("/config/public"),
+};
+
 // ── Health ──────────────────────────────────────────────────────────
 export const health = () =>
   fetch("/health").then((r) => r.json());


### PR DESCRIPTION
## Summary

First PR in the 4-PR enterprise deployment mode series (#189). Establishes the RBAC foundation, Alembic migrations, and frontend enterprise-mode support.

### Backend
- **4-tier RBAC**: `super_admin > admin > reviewer > user` (replaces 3-tier `admin/developer/user`)
- **Alembic**: Initialized async PostgreSQL migrations; idempotent migration adds `super_admin`/`reviewer` enum values, renames `developer→reviewer`, adds `is_demo` column
- **`require_role(min_role)`**: Hierarchy-aware FastAPI dependency replaces broken decorator; applied to all 14 route files
- **Config**: `DEPLOYMENT_MODE` as `Literal["local", "enterprise"]` with validation; 8 `DEMO_*` env vars
- **Public config endpoint**: `GET /api/v1/config/public` returns `{deployment_mode, sso_enabled, saml_enabled}`
- **OAuth fix**: Redirect URI uses `FRONTEND_URL` instead of Docker-internal hostname

### Frontend
- **`useRoleGuard(minRole)`** hook with 4-tier hierarchy and display labels (`user→"Viewer"`)
- **`useDeploymentConfig()`** hook fetching `/api/v1/config/public` (5-min cache)
- **`<RoleGuard>`** component replacing `AdminGuard`
- **Enterprise login**: Hides password form, shows SSO-only in enterprise mode
- **Sidebar**: Role-based nav sections (admin, reviewer, registry)
- **Users page**: 4-tier role dropdown with display labels

### Tests
- 16 backend unit tests (RBAC enum, hierarchy, require_role, config validation)
- Playwright SSO e2e tests: real Microsoft Entra ID login flow + enterprise mode UI tests
- 91 server tests passing, ruff clean, TypeScript clean

### Hierarchy bypass fixes
- `component_source.py`, `alert.py`, `auth.py` inline `!= admin` checks replaced with hierarchy-aware comparisons so `super_admin` is not excluded
- Telemetry ingest endpoints changed from admin-only to user-level (CLI users push telemetry)

## Test plan

- [ ] `uv run pytest tests/ -v` — 91 tests pass
- [ ] `uv run ruff check .` — clean
- [ ] `npx tsc --noEmit` — frontend type check clean
- [ ] `npx playwright test e2e/sso-login.spec.ts` — SSO tests (requires OAuth config + Azure redirect URI)
- [ ] Verify login page shows SSO-only in enterprise mode
- [ ] Verify `super_admin` can access admin endpoints
- [ ] Verify `reviewer` can access review but not admin endpoints

Refs: #189