### PR TITLE
Uninstaller2

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -261,9 +261,13 @@ def reset_password(
 @auth_app.command()
 def init(
     server: str = typer.Option(None, "--server", "-s", help="Server URL"),
+    config_only: bool = typer.Option(False, "--config-only", help="Initialize config without server validation"),
 ):
     """First-run setup (alias for login)."""
-    login(server=server, key=None, email=None, password=None, code=None, name=None)
+    if config_only:
+        _do_config_only_init(server)
+    else:
+        login(server=server, key=None, email=None, password=None, code=None, name=None)
 
 
 @auth_app.command()
@@ -365,10 +369,16 @@ def register_deprecated_auth(app: typer.Typer):
     """Register deprecated root-level aliases."""
 
     @app.command(name="init", hidden=True)
-    def deprecated_init(server: str = typer.Option(None, "--server", "-s", help="Server URL")):
+    def deprecated_init(
+        server: str = typer.Option(None, "--server", "-s", help="Server URL"),
+        config_only: bool = typer.Option(False, "--config-only", help="Initialize config without server validation"),
+    ):
         """[Deprecated] Use 'observal auth login' instead."""
         _deprecation_notice("login")
-        login(server=server, key=None, email=None, password=None, code=None, name=None)
+        if config_only:
+            _do_config_only_init(server)
+        else:
+            login(server=server, key=None, email=None, password=None, code=None, name=None)
 
     @app.command(name="login", hidden=True)
     def deprecated_login(
@@ -408,6 +418,24 @@ def register_deprecated_auth(app: typer.Typer):
 
 
 # ── Helper functions ────────────────────────────────────────
+
+
+def _do_config_only_init(server_url: str | None = None):
+    """Initialize config without validating server connection."""
+    server_url = server_url or typer.prompt("Server URL", default="http://localhost:8000")
+    server_url = server_url.rstrip("/")
+
+    api_key = typer.prompt("API Key (optional, press Enter to skip)", default="", show_default=False)
+
+    cfg_data = {"server_url": server_url}
+    if api_key:
+        cfg_data["api_key"] = api_key
+
+    config.save(cfg_data)
+    rprint(f"[green]Config initialized.[/green]")
+    rprint(f"[dim]Saved to {config.CONFIG_FILE}[/dim]")
+    rprint("\n[yellow]Note:[/yellow] Server connection not validated.")
+    rprint("[dim]Run 'observal auth login' to authenticate when the server is running.[/dim]")
 
 
 def _do_key_login(server_url: str, api_key: str | None = None):

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -432,7 +432,7 @@ def _do_config_only_init(server_url: str | None = None):
         cfg_data["api_key"] = api_key
 
     config.save(cfg_data)
-    rprint(f"[green]Config initialized.[/green]")
+    rprint("[green]Config initialized.[/green]")
     rprint(f"[dim]Saved to {config.CONFIG_FILE}[/dim]")
     rprint("\n[yellow]Note:[/yellow] Server connection not validated.")
     rprint("[dim]Run 'observal auth login' to authenticate when the server is running.[/dim]")

--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -159,4 +159,6 @@ def register_uninstall(app: typer.Typer):
 
         rprint("\n[green]Observal has been uninstalled. Goodbye.[/green]")
         if not keep_repo:
-            rprint(f"\n[cyan]Run [bold]cd {repo_root.parent}[/bold] or [bold]cd ..[/bold] to leave the deleted directory.[/cyan]")
+            rprint(
+                f"\n[cyan]Run [bold]cd {repo_root.parent}[/bold] or [bold]cd ..[/bold] to leave the deleted directory.[/cyan]"
+            )

--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -157,6 +157,6 @@ def register_uninstall(app: typer.Typer):
         if not keep_cli:
             _uninstall_cli()
 
-        rprint("\n[green]Observal has been uninstalled. Goodbye![/green]")
+        rprint("\n[green]Observal has been uninstalled. Goodbye.[/green]")
         if not keep_repo:
-            rprint(f"\n[cyan]Run [bold]cd {repo_root.parent}[/bold] to leave the deleted directory.[/cyan]")
+            rprint(f"\n[cyan]Run [bold]cd {repo_root.parent}[/bold] or [bold]cd ..[/bold] to leave the deleted directory.[/cyan]")

--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -32,7 +32,7 @@ def _find_repo_root(explicit_dir: str | None) -> Path | None:
             return directory
 
     rprint("[yellow]Could not detect Observal repo directory.[/yellow]")
-    rprint("[dim]Run from inside the repo or pass --repo-dir.[/dim]")
+    rprint("[bold bright_magenta]Run from inside the repo or pass --repo-dir.[/bold bright_magenta]")
     return None
 
 
@@ -108,18 +108,22 @@ def register_uninstall(app: typer.Typer):
         repo_dir: str | None = typer.Option(None, "--repo-dir", "-d", help="Path to cloned Observal repo."),
         keep_config: bool = typer.Option(False, "--keep-config", help="Keep ~/.observal/ config directory."),
         keep_cli: bool = typer.Option(False, "--keep-cli", help="Keep the CLI tool installed."),
+        keep_repo: bool = typer.Option(False, "--keep-repo", help="Keep the repo directory (still tears down Docker)."),
     ):
         """Completely uninstall Observal: stop containers, remove volumes, delete repo and config."""
         repo_root = _find_repo_root(repo_dir)
 
+        # Require repo detection - Docker teardown is mandatory
+        if repo_root is None:
+            rprint("[red]ERROR: Repo not found. Could not initiate Docker teardown: required for uninstall.[/red]")
+            raise typer.Exit(1)
+
         # ── Show what will be removed ──────────────────────
         rprint("\n[bold red]Observal Uninstall[/bold red]\n")
         rprint("[bold]The following will be removed:[/bold]")
-        if repo_root:
-            rprint("  - Docker containers and volumes (via docker compose down -v)")
+        rprint("  - Docker containers and volumes (via docker compose down -v)")
+        if not keep_repo:
             rprint(f"  - Repo directory: [bold]{repo_root}[/bold]")
-        else:
-            rprint("  - [dim]Repo directory: not detected (skipping Docker and repo cleanup)[/dim]")
         if not keep_config:
             rprint(f"  - Config directory: [bold]{CONFIG_DIR}[/bold]")
         if not keep_cli:
@@ -137,11 +141,10 @@ def register_uninstall(app: typer.Typer):
         rprint()
 
         # ── Phase 1: Docker teardown ──────────────────────
-        if repo_root:
-            _docker_teardown(repo_root)
+        _docker_teardown(repo_root)
 
         # ── Phase 2: Delete repo directory ────────────────
-        if repo_root:
+        if not keep_repo:
             # Move to parent of repo dir before deleting it
             os.chdir(repo_root.parent)
             _delete_directory(repo_root, "Observal repo")
@@ -155,5 +158,5 @@ def register_uninstall(app: typer.Typer):
             _uninstall_cli()
 
         rprint("\n[green]Observal has been uninstalled. Goodbye![/green]")
-        if repo_root:
+        if not keep_repo:
             rprint(f"\n[dim]Run [bold]cd {repo_root.parent}[/bold] to leave the deleted directory.[/dim]")

--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -159,4 +159,4 @@ def register_uninstall(app: typer.Typer):
 
         rprint("\n[green]Observal has been uninstalled. Goodbye![/green]")
         if not keep_repo:
-            rprint(f"\n[bright cyan]Run [bold]cd {repo_root.parent}[/bold] to leave the deleted directory.[/bright cyan]")
+            rprint(f"\n[cyan]Run [bold]cd {repo_root.parent}[/bold] to leave the deleted directory.[/cyan]")

--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -159,4 +159,4 @@ def register_uninstall(app: typer.Typer):
 
         rprint("\n[green]Observal has been uninstalled. Goodbye![/green]")
         if not keep_repo:
-            rprint(f"\n[dim]Run [bold]cd {repo_root.parent}[/bold] to leave the deleted directory.[/dim]")
+            rprint(f"\n[bright cyan]Run [bold]cd {repo_root.parent}[/bold] to leave the deleted directory.[/bright cyan]")

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -265,7 +265,7 @@ def test_explicit_repo_dir_option(mock_rmtree: MagicMock, mock_run: MagicMock, t
 
 
 def test_repo_not_found_continues(tmp_path: Path):
-    """When repo dir cannot be detected, command still proceeds with config/cli cleanup."""
+    """When repo dir cannot be detected, command exits with error (Docker teardown is required)."""
     with (
         patch("observal_cli.cmd_uninstall.subprocess.run") as mock_run,
         patch("observal_cli.cmd_uninstall.shutil.rmtree"),
@@ -279,10 +279,10 @@ def test_repo_not_found_continues(tmp_path: Path):
             ["uninstall", "--keep-config"],
             input=f"{CONFIRMATION_PHRASE}\n",
         )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     output = _plain(result.output)
-    assert "not detected" in output.lower()
-    assert "uninstalled" in output.lower()
+    assert "repo not found" in output.lower()
+    assert "docker teardown" in output.lower()
 
 
 # ── Help text test ─────────────────────────────────────────


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
observal uninstall had some unintuitive behaviors, and unclear instructions.
## Fixes
* Fixes #267

## Approach
Checks _find_repo_root(), if none then exit code 1.
Added flag '--config-only' to observal init to create config directory bypassing server running requirement.

## How Has This Been Tested?

Tested each flag individually, and the validity of the instructions given.



## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->