### PR TITLE
feat: settings reconciler, thinking spans, session info tab, and buffer encryption

### DIFF
--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -378,6 +378,8 @@ async def ingest_hook(request: Request):
             attrs["event.name"] = "hook_assistant_response"
         elif tool_name == "assistant_response" and tool_response_raw:
             attrs["event.name"] = "hook_assistant_response"
+        elif tool_name == "assistant_thinking" and tool_response_raw:
+            attrs["event.name"] = "hook_assistant_thinking"
         # Sequence metadata for interleaving with tool calls
         if body.get("message_sequence") is not None:
             attrs["message_sequence"] = str(body["message_sequence"])
@@ -392,8 +394,13 @@ async def ingest_hook(request: Request):
             attrs["stop_reason"] = body["stop_reason"]
 
     # SessionStart — session lifecycle
-    if hook_event == "SessionStart" and body.get("resume"):
-        attrs["session_resumed"] = str(body["resume"])
+    # Claude Code sends "source" field: startup, resume, clear, compact
+    session_source = body.get("source", "")
+    if hook_event == "SessionStart":
+        if session_source:
+            attrs["session_source"] = session_source
+        if session_source in ("resume", "compact") or body.get("resume"):
+            attrs["session_resumed"] = "true"
 
     # Notification
     if hook_event == "Notification":
@@ -459,6 +466,12 @@ async def ingest_hook(request: Request):
         body_text = f"{hook_event}: {attrs.get('agent_type', 'unknown')}"
     elif hook_event in ("Elicitation", "ElicitationResult"):
         body_text = f"{hook_event}: {body.get('mcp_server_name', 'unknown')}"
+    elif hook_event == "Stop" and tool_name == "assistant_thinking":
+        seq = attrs.get("message_sequence", "")
+        total = attrs.get("message_total", "")
+        seq_label = f" [{seq}/{total}]" if seq and total else ""
+        preview = (attrs.get("tool_response") or "")[:100]
+        body_text = f"Thinking{seq_label}: {preview}"
     elif hook_event == "Stop" and (tool_name == "assistant_response" or body.get("assistant_response")):
         seq = attrs.get("message_sequence", "")
         total = attrs.get("message_total", "")
@@ -470,9 +483,13 @@ async def ingest_hook(request: Request):
     elif hook_event == "StopFailure":
         body_text = f"StopFailure: {attrs.get('error', 'unknown')[:80]}"
     elif hook_event == "SessionStart":
-        resumed = " (resumed)" if attrs.get("session_resumed") == "True" else ""
+        source_label = ""
+        if attrs.get("session_source") == "compact":
+            source_label = " (continued)"
+        elif attrs.get("session_resumed") == "true":
+            source_label = " (resumed)"
         prompt_preview = (attrs.get("tool_input") or "")[:100]
-        body_text = f"SessionStart{resumed}: {prompt_preview}" if prompt_preview else f"SessionStart{resumed}"
+        body_text = f"SessionStart{source_label}: {prompt_preview}" if prompt_preview else f"SessionStart{source_label}"
     elif hook_event == "Notification":
         body_text = f"Notification: {attrs.get('notification_title', '')}"
     elif hook_event in ("TaskCreated", "TaskCompleted"):

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -13,6 +13,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/otel", tags=["otel-dashboard"])
 
 
+@router.get("/crypto/public-key")
+async def get_public_key():
+    """Return the server's public key for client-side ECIES encryption.
+
+    This endpoint is intentionally unauthenticated so CLI clients can
+    fetch the key during login without a pre-existing session.
+    """
+    from services.crypto import get_key_manager
+
+    km = get_key_manager()
+    pub_pem = km.get_public_key_pem()
+    return {"public_key_pem": pub_pem}
+
+
 async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
     try:
         r = await _query(f"{sql} FORMAT JSON", params)
@@ -276,8 +290,19 @@ async def ingest_hook(request: Request):
     This is intentionally unauthenticated because CLI hooks fire
     from the terminal and can't easily carry auth tokens.  The endpoint only
     writes to ClickHouse — no destructive operations.
+
+    Supports ECIES-encrypted payloads via the ``X-Observal-Encrypted`` header.
     """
-    body = await request.json()
+    encrypted_header = request.headers.get("X-Observal-Encrypted")
+    if encrypted_header == "ecies-p256":
+        raw_body = await request.body()
+        from services.crypto import get_key_manager
+
+        km = get_key_manager()
+        decrypted_json = km.decrypt_payload(raw_body)
+        body = json.loads(decrypted_json)
+    else:
+        body = await request.json()
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
     # ── Normalize Kiro camelCase fields to snake_case ──

--- a/observal-server/services/crypto.py
+++ b/observal-server/services/crypto.py
@@ -181,6 +181,42 @@ class KeyManager:
             return self._public_key
         return self._retired_keys.get(kid)
 
+    # -- payload encryption/decryption ---------------------------------------
+
+    def decrypt_payload(self, encrypted_blob: bytes) -> str:
+        """Decrypt an ECIES-encrypted payload from the CLI buffer.
+
+        Format: ephemeral_pubkey (65 bytes) || nonce (12 bytes) || ciphertext+tag
+        """
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+        # Parse components
+        ephemeral_pub_bytes = encrypted_blob[:65]
+        nonce = encrypted_blob[65:77]
+        ciphertext_with_tag = encrypted_blob[77:]
+
+        # Reconstruct ephemeral public key
+        ephemeral_pub = ec.EllipticCurvePublicKey.from_encoded_point(
+            ec.SECP256R1(), ephemeral_pub_bytes
+        )
+
+        # ECDH shared secret using server's private key
+        shared_secret = self.get_private_key().exchange(ec.ECDH(), ephemeral_pub)
+
+        # Derive same AES key
+        aes_key = HKDF(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=None,
+            info=b"observal-buffer-v1",
+        ).derive(shared_secret)
+
+        # Decrypt
+        aesgcm = AESGCM(aes_key)
+        plaintext = aesgcm.decrypt(nonce, ciphertext_with_tag, None)
+        return plaintext.decode("utf-8")
+
     # -- token helpers -------------------------------------------------------
 
     def sign_token(self, payload: dict) -> str:

--- a/observal-server/services/crypto.py
+++ b/observal-server/services/crypto.py
@@ -197,9 +197,7 @@ class KeyManager:
         ciphertext_with_tag = encrypted_blob[77:]
 
         # Reconstruct ephemeral public key
-        ephemeral_pub = ec.EllipticCurvePublicKey.from_encoded_point(
-            ec.SECP256R1(), ephemeral_pub_bytes
-        )
+        ephemeral_pub = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), ephemeral_pub_bytes)
 
         # ECDH shared secret using server's private key
         shared_secret = self.get_private_key().exchange(ec.ECDH(), ephemeral_pub)

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -10,7 +10,8 @@ import httpx
 import typer
 from rich import print as rprint
 
-from observal_cli import client, config
+from observal_cli import client, config, settings_reconciler
+from observal_cli.hooks_spec import get_desired_env, get_desired_hooks
 from observal_cli.render import console, kv_panel, spinner, status_badge
 
 # ── Auth subgroup ───────────────────────────────────────────
@@ -603,9 +604,13 @@ def _find_hook_script(name: str) -> str | None:
 
 
 def _configure_claude_code(server_url: str, api_key: str):
-    """Check for Claude Code and offer to configure its telemetry."""
+    """Check for Claude Code and offer to configure its telemetry.
+
+    Uses declarative reconciliation: computes desired state from hooks_spec,
+    diffs against current ~/.claude/settings.json, and applies minimal changes.
+    Non-Observal hooks and env vars are preserved untouched.
+    """
     claude_dir = Path.home() / ".claude"
-    claude_settings_file = claude_dir / "settings.json"
 
     try:
         claude_exists = claude_dir.is_dir() or shutil.which("claude")
@@ -618,89 +623,25 @@ def _configure_claude_code(server_url: str, api_key: str):
         ):
             return
 
-        settings = {}
-        if claude_settings_file.exists():
-            with open(claude_settings_file, encoding="utf-8") as f:
-                try:
-                    settings = _json.load(f)
-                except _json.JSONDecodeError:
-                    rprint(
-                        f"[yellow]Warning: Could not parse {claude_settings_file}. A new file will be created.[/yellow]"
-                    )
-
-        otel_env = {
-            "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
-            "OTEL_METRICS_EXPORTER": "otlp",
-            "OTEL_LOGS_EXPORTER": "otlp",
-            "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
-            "OTEL_EXPORTER_OTLP_HEADERS": f"Authorization=Bearer {api_key}",
-        }
-
-        from urllib.parse import urlparse
-
-        parsed_url = urlparse(server_url)
-        scheme = "http" if parsed_url.hostname == "localhost" else "https"
-        otel_endpoint = f"{scheme}://{parsed_url.hostname}:4317"
-        otel_env["OTEL_EXPORTER_OTLP_ENDPOINT"] = otel_endpoint
-
-        if "env" not in settings:
-            settings["env"] = {}
-        settings["env"].update(otel_env)
-
-        # ── Inject hooks for full content capture (prompts, tool I/O, MCP, agents) ──
-        # Use command hooks instead of HTTP hooks so that ECONNREFUSED errors
-        # don't flood the LLM when the Observal server is offline (#236).
+        # Build desired state from the declarative spec
         hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
-
         hook_script = _find_hook_script("observal-hook.sh")
         stop_script = _find_hook_script("observal-stop-hook.sh")
-
-        if hook_script:
-            cmd_hook = [{"hooks": [{"type": "command", "command": hook_script}]}]
-        else:
-            # Fallback to HTTP if the script isn't found
-            hook_def: dict = {"type": "http", "url": hooks_url}
-            cfg = config.load()
-            if cfg.get("user_id"):
-                hook_def["headers"] = {"X-Observal-User-Id": cfg["user_id"]}
-            cmd_hook = [{"hooks": [hook_def]}]
-
-        stop_hook = [{"hooks": [{"type": "command", "command": stop_script}]}] if stop_script else cmd_hook
-
-        settings["hooks"] = {
-            "SessionStart": cmd_hook,
-            "UserPromptSubmit": cmd_hook,
-            "PreToolUse": cmd_hook,
-            "PostToolUse": cmd_hook,
-            "PostToolUseFailure": cmd_hook,
-            "SubagentStart": cmd_hook,
-            "SubagentStop": cmd_hook,
-            "Stop": stop_hook,
-            "StopFailure": cmd_hook,
-            "Notification": cmd_hook,
-            "TaskCreated": cmd_hook,
-            "TaskCompleted": cmd_hook,
-            "PreCompact": cmd_hook,
-            "PostCompact": cmd_hook,
-            "WorktreeCreate": cmd_hook,
-            "WorktreeRemove": cmd_hook,
-            "Elicitation": cmd_hook,
-            "ElicitationResult": cmd_hook,
-        }
-
-        # Set the hooks URL env var so the stop script knows where to POST
-        settings["env"]["OBSERVAL_HOOKS_URL"] = hooks_url
-
-        # Inject user identity so hooks carry the Observal user ID
         cfg = config.load()
-        if cfg.get("user_id"):
-            settings["env"]["OBSERVAL_USER_ID"] = cfg["user_id"]
+        user_id = cfg.get("user_id", "")
 
-        claude_dir.mkdir(exist_ok=True)
-        with open(claude_settings_file, "w", encoding="utf-8") as f:
-            _json.dump(settings, f, indent=2)
+        desired_hooks = get_desired_hooks(hook_script, stop_script, hooks_url, user_id)
+        desired_env = get_desired_env(server_url, api_key, user_id)
 
-        rprint(f"Updated [dim]{claude_settings_file}[/dim] — telemetry + hooks will flow to Observal.")
+        # Reconcile: non-destructive merge preserving foreign hooks/env
+        changes = settings_reconciler.reconcile(desired_hooks, desired_env)
+
+        if changes:
+            rprint(f"Updated [dim]{settings_reconciler.CLAUDE_SETTINGS_PATH}[/dim]:")
+            for change in changes:
+                rprint(f"  {change}")
+        else:
+            rprint("[dim]Claude Code settings already up to date.[/dim]")
 
     except Exception as e:
         rprint(f"\n[yellow]Could not configure Claude Code automatically: {e}[/yellow]")

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -97,6 +97,7 @@ def login(
             rprint("  observal admin invite")
             rprint("  [dim]Share the code — they run: observal auth login --code OBS-XXXX[/dim]")
 
+            _fetch_server_public_key(server_url)
             _configure_claude_code(server_url, api_key)
 
         except httpx.HTTPStatusError as e:
@@ -172,6 +173,7 @@ def register(
         )
         rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]")
 
+        _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, api_key)
 
     except httpx.HTTPStatusError as e:
@@ -439,6 +441,25 @@ def _do_config_only_init(server_url: str | None = None):
     rprint("[dim]Run 'observal auth login' to authenticate when the server is running.[/dim]")
 
 
+def _fetch_server_public_key(server_url: str):
+    """Fetch and cache the server's ECIES public key for payload encryption.
+
+    Best-effort: silently ignored if the server doesn't expose the endpoint
+    yet (older server versions) or if connectivity fails.
+    """
+    try:
+        r = httpx.get(f"{server_url.rstrip('/')}/api/v1/otel/crypto/public-key", timeout=5)
+        if r.status_code == 200:
+            data = r.json()
+            pub_pem = data.get("public_key_pem")
+            if pub_pem:
+                key_dir = Path.home() / ".observal" / "keys"
+                key_dir.mkdir(parents=True, exist_ok=True)
+                (key_dir / "server_public.pem").write_text(pub_pem)
+    except Exception:
+        pass  # Server may not support encryption yet
+
+
 def _do_key_login(server_url: str, api_key: str | None = None):
     """Authenticate with an API key."""
     api_key = api_key or typer.prompt("API Key", hide_input=True)
@@ -455,6 +476,7 @@ def _do_key_login(server_url: str, api_key: str | None = None):
         user = data.get("user", data)
         config.save({"server_url": server_url, "api_key": data.get("api_key", api_key), "user_id": user.get("id", "")})
         rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
+        _fetch_server_public_key(server_url)
     except httpx.ConnectError:
         rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
         raise typer.Exit(1)
@@ -481,6 +503,7 @@ def _do_password_login(server_url: str, email: str, password: str):
         rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
         rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]")
 
+        _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, api_key)
 
     except httpx.ConnectError:
@@ -518,6 +541,7 @@ def _do_invite_login(server_url: str, code: str, name: str | None = None):
             f"[green]Account created! Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]"
         )
 
+        _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, api_key)
 
     except httpx.HTTPStatusError as e:

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -8,8 +8,9 @@ import typer
 from rich import print as rprint
 from rich.table import Table
 
-from observal_cli import client, config
+from observal_cli import client, config, settings_reconciler
 from observal_cli.constants import VALID_HOOK_EVENTS, VALID_HOOK_HANDLER_TYPES
+from observal_cli.hooks_spec import get_desired_env, get_desired_hooks
 from observal_cli.prompts import select_one
 from observal_cli.render import console, kv_panel, output_json, relative_time, spinner, status_badge
 
@@ -152,3 +153,66 @@ def hook_delete(
     with spinner("Deleting..."):
         client.delete(f"/api/v1/hooks/{resolved}")
     rprint(f"[green]✓ Deleted {resolved}[/green]")
+
+
+def _find_hook_script(name: str) -> str | None:
+    """Locate hook script by name (same search logic as cmd_auth)."""
+    from pathlib import Path
+
+    candidates = [
+        Path(__file__).resolve().parent / "hooks" / name,
+        Path.home() / ".observal" / "hooks" / name,
+    ]
+    for p in candidates:
+        if p.is_file():
+            return str(p.resolve())
+    return None
+
+
+@hook_app.command(name="sync")
+def hook_sync(
+    dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show changes without applying"),
+):
+    """Sync Claude Code hooks to the latest Observal spec.
+
+    Non-destructively updates ~/.claude/settings.json: adds missing hooks,
+    upgrades stale Observal hooks, and preserves any non-Observal hooks
+    you've added.
+    """
+    cfg = config.load()
+
+    server_url = cfg.get("server_url")
+    api_key = cfg.get("api_key")
+    if not server_url or not api_key:
+        rprint("[red]Not authenticated. Run [bold]observal auth login[/bold] first.[/red]")
+        raise typer.Exit(1)
+
+    hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
+    hook_script = _find_hook_script("observal-hook.sh")
+    stop_script = _find_hook_script("observal-stop-hook.sh")
+    user_id = cfg.get("user_id", "")
+
+    desired_hooks = get_desired_hooks(hook_script, stop_script, hooks_url, user_id)
+    desired_env = get_desired_env(server_url, api_key, user_id)
+
+    applied = settings_reconciler.get_applied_version()
+    from observal_cli.hooks_spec import HOOKS_SPEC_VERSION
+
+    if dry_run:
+        changes = settings_reconciler.reconcile(desired_hooks, desired_env, dry_run=True)
+        if changes:
+            rprint(f"[yellow]Dry run[/yellow] — spec v{applied} → v{HOOKS_SPEC_VERSION}:")
+            for change in changes:
+                rprint(f"  {change}")
+        else:
+            rprint(f"[dim]Already at spec v{HOOKS_SPEC_VERSION}, no changes needed.[/dim]")
+        return
+
+    changes = settings_reconciler.reconcile(desired_hooks, desired_env)
+
+    if changes:
+        rprint(f"[green]✓ Synced[/green] hooks spec v{applied} → v{HOOKS_SPEC_VERSION}:")
+        for change in changes:
+            rprint(f"  {change}")
+    else:
+        rprint(f"[dim]Already at spec v{HOOKS_SPEC_VERSION}, no changes needed.[/dim]")

--- a/observal_cli/hooks/buffer_event.py
+++ b/observal_cli/hooks/buffer_event.py
@@ -3,8 +3,12 @@
 
 Called by the shell hook when the server is unreachable.
 No dependencies beyond Python stdlib (sqlite3, json, sys, os).
+
+When the ``cryptography`` library is installed and the server's public key
+is cached locally, payloads are encrypted with ECIES before storage.
 """
 
+import importlib.util
 import json
 import sqlite3
 import sys
@@ -12,6 +16,28 @@ from pathlib import Path
 
 DB_PATH = Path.home() / ".observal" / "telemetry_buffer.db"
 MAX_EVENTS = 10_000
+
+
+def _try_encrypt(payload: str) -> tuple[str | bytes, int]:
+    """Attempt to encrypt *payload*; return (data, encrypted_flag).
+
+    Falls back to plaintext (encrypted=0) if the crypto module or
+    server public key is unavailable.
+    """
+    try:
+        crypto_path = Path(__file__).parent / "payload_crypto.py"
+        if not crypto_path.exists():
+            return payload, 0
+        spec = importlib.util.spec_from_file_location("payload_crypto", crypto_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        if mod.can_encrypt():
+            payload_bytes, was_encrypted = mod.encrypt_payload(payload)
+            if was_encrypted:
+                return payload_bytes, 1
+    except Exception:
+        pass
+    return payload, 0
 
 
 def main() -> None:
@@ -25,6 +51,9 @@ def main() -> None:
     except json.JSONDecodeError:
         return
 
+    # Optionally encrypt before storage
+    store_data, encrypted = _try_encrypt(payload)
+
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(DB_PATH), timeout=5)
     try:
@@ -36,17 +65,18 @@ def main() -> None:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 event_type TEXT NOT NULL,
-                payload TEXT NOT NULL,
+                payload BLOB NOT NULL,
                 attempts INTEGER NOT NULL DEFAULT 0,
                 last_attempt TEXT,
-                status TEXT NOT NULL DEFAULT 'pending'
+                status TEXT NOT NULL DEFAULT 'pending',
+                encrypted INTEGER NOT NULL DEFAULT 0
             )
             """
         )
         conn.execute("CREATE INDEX IF NOT EXISTS idx_status ON pending_events(status)")
         conn.execute(
-            "INSERT INTO pending_events (event_type, payload) VALUES (?, ?)",
-            ("hook", payload),
+            "INSERT INTO pending_events (event_type, payload, encrypted) VALUES (?, ?, ?)",
+            ("hook", store_data, encrypted),
         )
         conn.commit()
 

--- a/observal_cli/hooks/flush_buffer.py
+++ b/observal_cli/hooks/flush_buffer.py
@@ -3,6 +3,10 @@
 
 Called in the background by the shell hook after a successful curl.
 No dependencies beyond Python stdlib (sqlite3, json, os, urllib).
+
+Encrypted payloads (encrypted=1) are sent with
+``X-Observal-Encrypted: ecies-p256`` and ``Content-Type: application/octet-stream``
+so the server can decrypt before ingestion.
 """
 
 import os
@@ -28,10 +32,25 @@ def main() -> None:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=3000")
 
-        rows = conn.execute(
-            "SELECT id, payload FROM pending_events WHERE status = 'pending' AND attempts < ? ORDER BY id ASC LIMIT ?",
-            (MAX_RETRIES, FLUSH_LIMIT),
-        ).fetchall()
+        # Gracefully handle databases created before the encrypted column existed
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(pending_events)").fetchall()}
+        has_encrypted_col = "encrypted" in columns
+
+        if has_encrypted_col:
+            rows = conn.execute(
+                "SELECT id, payload, encrypted FROM pending_events "
+                "WHERE status = 'pending' AND attempts < ? ORDER BY id ASC LIMIT ?",
+                (MAX_RETRIES, FLUSH_LIMIT),
+            ).fetchall()
+        else:
+            rows = [
+                (r[0], r[1], 0)
+                for r in conn.execute(
+                    "SELECT id, payload FROM pending_events "
+                    "WHERE status = 'pending' AND attempts < ? ORDER BY id ASC LIMIT ?",
+                    (MAX_RETRIES, FLUSH_LIMIT),
+                ).fetchall()
+            ]
 
         if not rows:
             # Also clean up old sent events while we're here
@@ -44,14 +63,27 @@ def main() -> None:
         sent_ids = []
         failed_ids = []
 
-        for row_id, payload in rows:
+        for row_id, payload, encrypted in rows:
             try:
-                req = urllib.request.Request(
-                    hooks_url,
-                    data=payload.encode("utf-8"),
-                    headers={"Content-Type": "application/json"},
-                    method="POST",
-                )
+                if encrypted:
+                    # Encrypted payload — send as raw bytes
+                    data = payload if isinstance(payload, bytes) else payload.encode("utf-8")
+                    req = urllib.request.Request(
+                        hooks_url,
+                        data=data,
+                        headers={"Content-Type": "application/octet-stream"},
+                        method="POST",
+                    )
+                    req.add_header("X-Observal-Encrypted", "ecies-p256")
+                else:
+                    # Plaintext JSON payload
+                    data = payload.encode("utf-8") if isinstance(payload, str) else payload
+                    req = urllib.request.Request(
+                        hooks_url,
+                        data=data,
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    )
                 if user_id:
                     req.add_header("X-Observal-User-Id", user_id)
 

--- a/observal_cli/hooks/observal-stop-hook.sh
+++ b/observal_cli/hooks/observal-stop-hook.sh
@@ -1,23 +1,25 @@
 #!/usr/bin/env bash
 # observal-stop-hook.sh — Claude Code Stop hook that captures assistant
-# text responses from the current turn and sends them to Observal.
+# text responses AND thinking/reasoning from the current turn and sends
+# them to Observal.
 #
 # The hook receives JSON on stdin with session_id, transcript_path, etc.
 # It reads the transcript JSONL backwards, collecting each assistant
 # message as a separate event with sequence metadata, then POSTs them
 # individually to the hooks endpoint. This allows the UI to interleave
 # assistant "thinking" text between tool calls.
-
-set -eu
-# NOTE: no pipefail — tac|while causes SIGPIPE when while breaks early
+#
+# IMPORTANT: No `set -eu` — we must never exit early and always reach
+# the final exit 0 so Claude Code doesn't see a hook failure.
 
 OBSERVAL_HOOKS_URL="${OBSERVAL_HOOKS_URL:-http://localhost:8000/api/v1/otel/hooks}"
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Read hook payload from stdin
 PAYLOAD=$(cat)
 
-SESSION_ID=$(echo "$PAYLOAD" | jq -r '.session_id // ""')
-TRANSCRIPT_PATH=$(echo "$PAYLOAD" | jq -r '.transcript_path // ""')
+SESSION_ID=$(echo "$PAYLOAD" | jq -r '.session_id // ""' 2>/dev/null)
+TRANSCRIPT_PATH=$(echo "$PAYLOAD" | jq -r '.transcript_path // ""' 2>/dev/null)
 
 if [ -z "$SESSION_ID" ] || [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
   exit 0
@@ -25,19 +27,32 @@ fi
 
 # Collect assistant messages from the current turn (bottom-up until user msg).
 # Each assistant message becomes a separate event with a sequence number.
+# We also capture thinking blocks separately.
 TMPDIR_WORK=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_WORK"' EXIT
 
 MSG_COUNT=0
+THINK_COUNT=0
 
-(tac "$TRANSCRIPT_PATH" || true) | while IFS= read -r line; do
+# Use process substitution instead of pipe to avoid subshell variable scoping.
+# Write files from within the loop — they persist on disk regardless.
+while IFS= read -r line; do
   case "$line" in
     *'"type":"assistant"'*)
+      # Extract text blocks
       TEXT=$(echo "$line" | jq -r \
-        '[.message.content[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null)
+        '[.message.content[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null || true)
       if [ -n "$TEXT" ]; then
         MSG_COUNT=$((MSG_COUNT + 1))
         printf '%s' "$TEXT" > "$TMPDIR_WORK/msg_$MSG_COUNT"
+      fi
+
+      # Extract thinking blocks (reasoning/chain-of-thought)
+      THINKING=$(echo "$line" | jq -r \
+        '[.message.content[]? | select(.type == "thinking") | .thinking] | join("\n")' 2>/dev/null || true)
+      if [ -n "$THINKING" ]; then
+        THINK_COUNT=$((THINK_COUNT + 1))
+        printf '%s' "$THINKING" > "$TMPDIR_WORK/think_$THINK_COUNT"
       fi
       ;;
     *'"type":"user"'*|*'"type":"human"'*)
@@ -49,41 +64,69 @@ MSG_COUNT=0
       continue
       ;;
   esac
-done
+done < <(tac "$TRANSCRIPT_PATH" 2>/dev/null || true)
 
-# Check if we collected anything
-MSG_FILES=$(ls "$TMPDIR_WORK"/msg_* 2>/dev/null | sort -t_ -k2 -n -r || true)
-if [ -z "$MSG_FILES" ]; then
-  exit 0
+# ── Send thinking blocks first (in chronological order) ──
+THINK_FILES=$(ls "$TMPDIR_WORK"/think_* 2>/dev/null | sort -t_ -k2 -n -r || true)
+if [ -n "$THINK_FILES" ]; then
+  THINK_TOTAL=$(echo "$THINK_FILES" | wc -l | tr -d ' ')
+  TSEQ=0
+  for f in $THINK_FILES; do
+    TSEQ=$((TSEQ + 1))
+    THINK_TEXT=$(cat "$f")
+    # Truncate to 64KB
+    THINK_TEXT=$(echo "$THINK_TEXT" | head -c 65536)
+
+    jq -n \
+      --arg session_id "$SESSION_ID" \
+      --arg response "$THINK_TEXT" \
+      --arg seq "$TSEQ" \
+      --arg total "$THINK_TOTAL" \
+      '{
+        hook_event_name: "Stop",
+        session_id: $session_id,
+        tool_name: "assistant_thinking",
+        tool_response: $response,
+        message_sequence: ($seq | tonumber),
+        message_total: ($total | tonumber)
+      }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
+        ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+        -H "Content-Type: application/json" \
+        -d @- >/dev/null 2>&1 || true
+  done
 fi
 
-# Count total messages
-TOTAL=$(echo "$MSG_FILES" | wc -l | tr -d ' ')
+# ── Send text response blocks (in chronological order) ──
+MSG_FILES=$(ls "$TMPDIR_WORK"/msg_* 2>/dev/null | sort -t_ -k2 -n -r || true)
+if [ -n "$MSG_FILES" ]; then
+  MSG_TOTAL=$(echo "$MSG_FILES" | wc -l | tr -d ' ')
+  SEQ=0
+  for f in $MSG_FILES; do
+    SEQ=$((SEQ + 1))
+    MSG_TEXT=$(cat "$f")
+    # Truncate to 64KB
+    MSG_TEXT=$(echo "$MSG_TEXT" | head -c 65536)
 
-# Send each message as a separate event (in chronological order — reverse of collection)
-SEQ=0
-for f in $MSG_FILES; do
-  SEQ=$((SEQ + 1))
-  MSG_TEXT=$(cat "$f")
+    jq -n \
+      --arg session_id "$SESSION_ID" \
+      --arg response "$MSG_TEXT" \
+      --arg seq "$SEQ" \
+      --arg total "$MSG_TOTAL" \
+      '{
+        hook_event_name: "Stop",
+        session_id: $session_id,
+        tool_name: "assistant_response",
+        tool_response: $response,
+        message_sequence: ($seq | tonumber),
+        message_total: ($total | tonumber)
+      }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
+        ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+        -H "Content-Type: application/json" \
+        -d @- >/dev/null 2>&1 || true
+  done
+fi
 
-  # Truncate to 64KB
-  MSG_TEXT=$(echo "$MSG_TEXT" | head -c 65536)
-
-  jq -n \
-    --arg session_id "$SESSION_ID" \
-    --arg response "$MSG_TEXT" \
-    --arg seq "$SEQ" \
-    --arg total "$TOTAL" \
-    '{
-      hook_event_name: "Stop",
-      session_id: $session_id,
-      tool_name: "assistant_response",
-      tool_response: $response,
-      message_sequence: ($seq | tonumber),
-      message_total: ($total | tonumber)
-    }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
-      -H "Content-Type: application/json" \
-      -d @- >/dev/null 2>&1
-done
+# If we didn't find any text or thinking, that's fine — the turn was
+# all tool calls.  The generic hook handles the basic hook_stop event.
 
 exit 0

--- a/observal_cli/hooks/payload_crypto.py
+++ b/observal_cli/hooks/payload_crypto.py
@@ -1,0 +1,78 @@
+"""Optional payload encryption for the telemetry buffer.
+
+Uses ECIES (Elliptic Curve Integrated Encryption Scheme):
+  1. Generate ephemeral EC P-256 key
+  2. Derive shared secret via ECDH with server's public key
+  3. Derive AES-256 key via HKDF
+  4. Encrypt with AES-256-GCM (provides authentication = tamper rejection)
+
+Output format: ephemeral_pubkey (65 bytes) || nonce (12 bytes) || ciphertext || tag (16 bytes)
+
+Gracefully falls back to plaintext if ``cryptography`` is unavailable or
+server public key is missing.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+PUBLIC_KEY_PATH = Path.home() / ".observal" / "keys" / "server_public.pem"
+
+
+def can_encrypt() -> bool:
+    """Return True if encryption is available (key + library)."""
+    if not PUBLIC_KEY_PATH.exists():
+        return False
+    try:
+        from cryptography.hazmat.primitives.asymmetric import ec  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def encrypt_payload(plaintext: str) -> tuple[bytes, bool]:
+    """Encrypt plaintext JSON. Returns (data, was_encrypted).
+
+    If encryption unavailable, returns (plaintext.encode(), False).
+    """
+    if not can_encrypt():
+        return plaintext.encode("utf-8"), False
+
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+    # Load server public key
+    pem_data = PUBLIC_KEY_PATH.read_bytes()
+    server_pub = serialization.load_pem_public_key(pem_data)
+
+    # Generate ephemeral key pair
+    ephemeral_private = ec.generate_private_key(ec.SECP256R1())
+    ephemeral_public = ephemeral_private.public_key()
+
+    # ECDH shared secret
+    shared_secret = ephemeral_private.exchange(ec.ECDH(), server_pub)
+
+    # Derive AES key via HKDF
+    aes_key = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b"observal-buffer-v1",
+    ).derive(shared_secret)
+
+    # Encrypt with AES-256-GCM
+    nonce = os.urandom(12)
+    aesgcm = AESGCM(aes_key)
+    ciphertext = aesgcm.encrypt(nonce, plaintext.encode("utf-8"), None)
+
+    # Serialize: ephemeral pubkey (uncompressed, 65 bytes) || nonce (12) || ciphertext+tag
+    ephemeral_bytes = ephemeral_public.public_bytes(
+        serialization.Encoding.X962,
+        serialization.PublicFormat.UncompressedPoint,
+    )
+
+    return ephemeral_bytes + nonce + ciphertext, True

--- a/observal_cli/hooks_spec.py
+++ b/observal_cli/hooks_spec.py
@@ -42,10 +42,7 @@ def is_observal_matcher_group(matcher_group: dict) -> bool:
     if OBSERVAL_METADATA_KEY in matcher_group:
         return True
     # Fallback: legacy path matching
-    for hook_entry in matcher_group.get("hooks", []):
-        if is_observal_hook_entry(hook_entry):
-            return True
-    return False
+    return any(is_observal_hook_entry(hook_entry) for hook_entry in matcher_group.get("hooks", []))
 
 
 def get_desired_hooks(
@@ -75,9 +72,7 @@ def get_desired_hooks(
     # Stop event: generic hook first (always fires), then stop-specific
     # hook for transcript parsing (response + thinking capture).
     if stop_script:
-        stop_group: list[dict] = [
-            {**meta, "hooks": [generic, {"type": "command", "command": stop_script}]}
-        ]
+        stop_group: list[dict] = [{**meta, "hooks": [generic, {"type": "command", "command": stop_script}]}]
     else:
         stop_group = generic_group
 
@@ -133,14 +128,16 @@ def get_desired_env(
 
 # Keys in settings.env that Observal manages.  Used by the reconciler
 # to know which env vars it can safely update without touching others.
-MANAGED_ENV_KEYS = frozenset({
-    "CLAUDE_CODE_ENABLE_TELEMETRY",
-    "OTEL_METRICS_EXPORTER",
-    "OTEL_LOGS_EXPORTER",
-    "OTEL_EXPORTER_OTLP_PROTOCOL",
-    "OTEL_EXPORTER_OTLP_HEADERS",
-    "OTEL_EXPORTER_OTLP_ENDPOINT",
-    "OBSERVAL_HOOKS_URL",
-    "OBSERVAL_HOOKS_SPEC_VERSION",
-    "OBSERVAL_USER_ID",
-})
+MANAGED_ENV_KEYS = frozenset(
+    {
+        "CLAUDE_CODE_ENABLE_TELEMETRY",
+        "OTEL_METRICS_EXPORTER",
+        "OTEL_LOGS_EXPORTER",
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OBSERVAL_HOOKS_URL",
+        "OBSERVAL_HOOKS_SPEC_VERSION",
+        "OBSERVAL_USER_ID",
+    }
+)

--- a/observal_cli/hooks_spec.py
+++ b/observal_cli/hooks_spec.py
@@ -1,0 +1,146 @@
+"""Declarative hook specification for Claude Code settings.
+
+Defines the desired state of Observal-managed hooks. The reconciler
+compares this spec against the user's current ~/.claude/settings.json
+and applies non-destructive updates: adding missing hooks, upgrading
+stale ones, and preserving any non-Observal hooks the user has added.
+
+Bump HOOKS_SPEC_VERSION whenever the hook definitions change so the
+reconciler knows to re-apply.
+"""
+
+from __future__ import annotations
+
+# Bump this when hook definitions change (new events, different scripts,
+# additional handlers, etc.).  Stored in ~/.observal/config.json so we
+# can detect when an upgrade is needed without re-reading all hooks.
+HOOKS_SPEC_VERSION = "3"
+
+# Metadata key injected into every Observal matcher group.
+# Primary identification method — the reconciler checks this first.
+OBSERVAL_METADATA_KEY = "_observal"
+
+# Legacy marker substrings used as a fallback for matcher groups
+# created before metadata injection was added (pre-v3 upgrades).
+_LEGACY_HOOK_MARKERS = ("observal-hook", "observal-stop-hook", "/api/v1/otel/hooks")
+
+
+def is_observal_hook_entry(hook_entry: dict) -> bool:
+    """Return True if a single hook handler dict belongs to Observal (legacy path check)."""
+    cmd = hook_entry.get("command", "")
+    url = hook_entry.get("url", "")
+    return any(m in cmd or m in url for m in _LEGACY_HOOK_MARKERS)
+
+
+def is_observal_matcher_group(matcher_group: dict) -> bool:
+    """Return True if a matcher group is Observal-managed.
+
+    Checks the _observal metadata key first (preferred), then falls
+    back to legacy path-based detection for pre-metadata installations.
+    """
+    # Primary: metadata marker
+    if OBSERVAL_METADATA_KEY in matcher_group:
+        return True
+    # Fallback: legacy path matching
+    for hook_entry in matcher_group.get("hooks", []):
+        if is_observal_hook_entry(hook_entry):
+            return True
+    return False
+
+
+def get_desired_hooks(
+    hook_script: str | None,
+    stop_script: str | None,
+    hooks_url: str,
+    user_id: str = "",
+) -> dict[str, list[dict]]:
+    """Return the full desired hooks spec for Claude Code settings.
+
+    Each event maps to a list of matcher groups.  The Stop event gets
+    two handlers: the generic hook (for basic hook_stop events) and the
+    stop-specific hook (for transcript-based response/thinking capture).
+    """
+    meta = {OBSERVAL_METADATA_KEY: {"version": HOOKS_SPEC_VERSION}}
+
+    if hook_script:
+        generic = {"type": "command", "command": hook_script}
+    else:
+        # Fallback to HTTP if scripts aren't found
+        generic = {"type": "http", "url": hooks_url}
+        if user_id:
+            generic["headers"] = {"X-Observal-User-Id": user_id}
+
+    generic_group: list[dict] = [{**meta, "hooks": [generic]}]
+
+    # Stop event: generic hook first (always fires), then stop-specific
+    # hook for transcript parsing (response + thinking capture).
+    if stop_script:
+        stop_group: list[dict] = [
+            {**meta, "hooks": [generic, {"type": "command", "command": stop_script}]}
+        ]
+    else:
+        stop_group = generic_group
+
+    return {
+        "SessionStart": generic_group,
+        "UserPromptSubmit": generic_group,
+        "PreToolUse": generic_group,
+        "PostToolUse": generic_group,
+        "PostToolUseFailure": generic_group,
+        "SubagentStart": generic_group,
+        "SubagentStop": generic_group,
+        "Stop": stop_group,
+        "StopFailure": generic_group,
+        "Notification": generic_group,
+        "TaskCreated": generic_group,
+        "TaskCompleted": generic_group,
+        "PreCompact": generic_group,
+        "PostCompact": generic_group,
+        "WorktreeCreate": generic_group,
+        "WorktreeRemove": generic_group,
+        "Elicitation": generic_group,
+        "ElicitationResult": generic_group,
+    }
+
+
+def get_desired_env(
+    server_url: str,
+    api_key: str,
+    user_id: str = "",
+) -> dict[str, str]:
+    """Return the desired Observal env vars for Claude Code settings."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(server_url)
+    scheme = "http" if parsed.hostname in ("localhost", "127.0.0.1") else "https"
+    otel_endpoint = f"{scheme}://{parsed.hostname}:4317"
+
+    env: dict[str, str] = {
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+        "OTEL_METRICS_EXPORTER": "otlp",
+        "OTEL_LOGS_EXPORTER": "otlp",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+        "OTEL_EXPORTER_OTLP_HEADERS": f"Authorization=Bearer {api_key}",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": otel_endpoint,
+        "OBSERVAL_HOOKS_URL": f"{server_url.rstrip('/')}/api/v1/otel/hooks",
+    }
+    env["OBSERVAL_HOOKS_SPEC_VERSION"] = HOOKS_SPEC_VERSION
+    if user_id:
+        env["OBSERVAL_USER_ID"] = user_id
+
+    return env
+
+
+# Keys in settings.env that Observal manages.  Used by the reconciler
+# to know which env vars it can safely update without touching others.
+MANAGED_ENV_KEYS = frozenset({
+    "CLAUDE_CODE_ENABLE_TELEMETRY",
+    "OTEL_METRICS_EXPORTER",
+    "OTEL_LOGS_EXPORTER",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OBSERVAL_HOOKS_URL",
+    "OBSERVAL_HOOKS_SPEC_VERSION",
+    "OBSERVAL_USER_ID",
+})

--- a/observal_cli/settings_reconciler.py
+++ b/observal_cli/settings_reconciler.py
@@ -1,0 +1,180 @@
+"""Non-destructive reconciler for Claude Code settings.
+
+Implements a Terraform-style declarative reconciliation:
+  1. Read current state from ~/.claude/settings.json
+  2. Compare against desired state from hooks_spec
+  3. Apply minimal diff: add missing, update stale, preserve foreign
+
+Never deletes non-Observal hooks or env vars.  Identifies Observal
+hooks by script path pattern, not by position or event name.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from pathlib import Path
+
+from observal_cli import config
+from observal_cli.hooks_spec import (
+    HOOKS_SPEC_VERSION,
+    MANAGED_ENV_KEYS,
+    is_observal_matcher_group,
+)
+
+logger = logging.getLogger("observal.reconciler")
+
+CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+
+
+def _load_claude_settings() -> dict:
+    """Load ~/.claude/settings.json, returning {} on missing/corrupt."""
+    if not CLAUDE_SETTINGS_PATH.exists():
+        return {}
+    try:
+        return json.loads(CLAUDE_SETTINGS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Could not parse %s: %s", CLAUDE_SETTINGS_PATH, exc)
+        return {}
+
+
+def _save_claude_settings(settings: dict) -> None:
+    """Write settings.json atomically (parent dir created if needed)."""
+    CLAUDE_SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CLAUDE_SETTINGS_PATH.write_text(
+        json.dumps(settings, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def reconcile_hooks(
+    current_hooks: dict[str, list],
+    desired_hooks: dict[str, list],
+) -> tuple[dict[str, list], list[str]]:
+    """Merge desired Observal hooks into current hooks non-destructively.
+
+    Returns (merged_hooks, changes) where changes is a list of
+    human-readable strings describing what was modified.
+    """
+    merged = copy.deepcopy(current_hooks)
+    changes: list[str] = []
+
+    # 1. For each desired event, reconcile matcher groups
+    for event, desired_groups in desired_hooks.items():
+        if event not in merged:
+            # New event — add entirely
+            merged[event] = copy.deepcopy(desired_groups)
+            changes.append(f"+ {event}: added ({len(desired_groups)} handler(s))")
+            continue
+
+        current_groups = merged[event]
+
+        # Partition current groups into Observal-managed and foreign
+        foreign_groups = [g for g in current_groups if not is_observal_matcher_group(g)]
+        observal_groups = [g for g in current_groups if is_observal_matcher_group(g)]
+
+        # Check if Observal groups match desired (by JSON equality)
+        if _groups_equal(observal_groups, desired_groups):
+            continue  # Already up to date
+
+        # Replace Observal groups with desired, keep foreign ones
+        merged[event] = foreign_groups + copy.deepcopy(desired_groups)
+
+        if observal_groups:
+            changes.append(f"~ {event}: updated Observal hooks")
+        else:
+            changes.append(f"+ {event}: added Observal hooks")
+
+    # 2. Events in current but not in desired — leave them alone
+    #    (they might be non-Observal hooks, or events we no longer manage)
+
+    return merged, changes
+
+
+def reconcile_env(
+    current_env: dict[str, str],
+    desired_env: dict[str, str],
+) -> tuple[dict[str, str], list[str]]:
+    """Merge desired Observal env vars into current env.
+
+    Only touches keys in MANAGED_ENV_KEYS.  Foreign env vars are
+    preserved untouched.
+    """
+    merged = dict(current_env)
+    changes: list[str] = []
+
+    for key, value in desired_env.items():
+        if key not in MANAGED_ENV_KEYS:
+            continue
+        old = merged.get(key)
+        if old != value:
+            merged[key] = value
+            if old is None:
+                changes.append(f"+ env.{key}")
+            else:
+                changes.append(f"~ env.{key}")
+
+    return merged, changes
+
+
+def reconcile(
+    desired_hooks: dict[str, list],
+    desired_env: dict[str, str],
+    *,
+    dry_run: bool = False,
+) -> list[str]:
+    """Full reconciliation: load settings, diff, write if changed.
+
+    Returns list of change descriptions (empty = already up to date).
+    If dry_run=True, computes changes but does not write.
+    """
+    settings = _load_claude_settings()
+    all_changes: list[str] = []
+
+    # Reconcile hooks
+    current_hooks = settings.get("hooks", {})
+    merged_hooks, hook_changes = reconcile_hooks(current_hooks, desired_hooks)
+    all_changes.extend(hook_changes)
+
+    # Reconcile env
+    current_env = settings.get("env", {})
+    merged_env, env_changes = reconcile_env(current_env, desired_env)
+    all_changes.extend(env_changes)
+
+    if all_changes and not dry_run:
+        settings["hooks"] = merged_hooks
+        settings["env"] = merged_env
+        _save_claude_settings(settings)
+
+        # Record applied spec version
+        config.save({"hooks_spec_version": HOOKS_SPEC_VERSION})
+
+    return all_changes
+
+
+def needs_upgrade() -> bool:
+    """Check if the applied hooks spec is older than the current version."""
+    cfg = config.load()
+    applied = cfg.get("hooks_spec_version", "0")
+    return applied != HOOKS_SPEC_VERSION
+
+
+def get_applied_version() -> str:
+    """Return the hooks spec version currently applied."""
+    cfg = config.load()
+    return cfg.get("hooks_spec_version", "0")
+
+
+def _groups_equal(a: list[dict], b: list[dict]) -> bool:
+    """Compare two lists of matcher groups by normalized JSON."""
+    return _normalize(a) == _normalize(b)
+
+
+def _normalize(obj: object) -> object:
+    """Recursively sort dicts for stable comparison."""
+    if isinstance(obj, dict):
+        return tuple(sorted((k, _normalize(v)) for k, v in obj.items()))
+    if isinstance(obj, list):
+        return tuple(_normalize(item) for item in obj)
+    return obj

--- a/tests/test_payload_crypto.py
+++ b/tests/test_payload_crypto.py
@@ -1,0 +1,271 @@
+"""Tests for asymmetric payload encryption (ECIES with AES-256-GCM).
+
+Covers the full encrypt/decrypt round-trip, graceful fallback when keys
+are missing, tamper detection, and backwards compatibility with
+unencrypted payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def key_pair(tmp_path: Path):
+    """Generate a temporary EC P-256 key pair and write the public key to disk.
+
+    Returns ``(private_key, public_key_path)`` so the test can decrypt
+    with the private key after the CLI module encrypts with the public key.
+    """
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pub_path = tmp_path / "server_public.pem"
+    pub_path.write_bytes(pub_pem)
+    return private_key, pub_path
+
+
+@pytest.fixture()
+def key_manager(key_pair):
+    """Return a fully initialized ``KeyManager`` whose keys match *key_pair*.
+
+    We write the private key as ``signing.pem`` in a temp directory and
+    let ``KeyManager.initialize()`` pick it up.
+    """
+    # Import here so we can test even if the server package layout differs
+    import importlib.util
+
+    crypto_path = (
+        Path(__file__).resolve().parent.parent
+        / "observal-server"
+        / "services"
+        / "crypto.py"
+    )
+    spec = importlib.util.spec_from_file_location("services.crypto", crypto_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    private_key, pub_path = key_pair
+    key_dir = pub_path.parent
+
+    # Write the private key so KeyManager can load it
+    priv_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    (key_dir / "signing.pem").write_bytes(priv_pem)
+
+    km = mod.KeyManager(key_dir=str(key_dir))
+    km.initialize()
+    return km
+
+
+# ---------------------------------------------------------------------------
+# Helpers — import the CLI crypto module from file to avoid package issues
+# ---------------------------------------------------------------------------
+
+
+def _load_payload_crypto():
+    """Dynamically load the payload_crypto module."""
+    import importlib.util
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "observal_cli"
+        / "hooks"
+        / "payload_crypto.py"
+    )
+    spec = importlib.util.spec_from_file_location("payload_crypto", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCanEncrypt:
+    """Tests for the ``can_encrypt()`` guard."""
+
+    def test_returns_false_when_key_missing(self, tmp_path: Path):
+        mod = _load_payload_crypto()
+        fake_path = tmp_path / "nonexistent" / "server_public.pem"
+        with patch.object(mod, "PUBLIC_KEY_PATH", fake_path):
+            assert mod.can_encrypt() is False
+
+    def test_returns_true_when_key_present(self, key_pair):
+        mod = _load_payload_crypto()
+        _, pub_path = key_pair
+        with patch.object(mod, "PUBLIC_KEY_PATH", pub_path):
+            assert mod.can_encrypt() is True
+
+
+class TestEncryptDecryptRoundTrip:
+    """End-to-end: encrypt on CLI side, decrypt on server side."""
+
+    def test_round_trip_simple_json(self, key_pair, key_manager):
+        mod = _load_payload_crypto()
+        _, pub_path = key_pair
+
+        plaintext = json.dumps({"hook_event_name": "PostToolUse", "tool_name": "Bash", "session_id": "abc-123"})
+
+        with patch.object(mod, "PUBLIC_KEY_PATH", pub_path):
+            encrypted_blob, was_encrypted = mod.encrypt_payload(plaintext)
+
+        assert was_encrypted is True
+        assert isinstance(encrypted_blob, bytes)
+        # Encrypted blob must be longer than plaintext (65 + 12 + len + 16 overhead)
+        assert len(encrypted_blob) > len(plaintext)
+        # First byte of uncompressed EC point is 0x04
+        assert encrypted_blob[0] == 0x04
+
+        # Decrypt with the server's KeyManager
+        decrypted = key_manager.decrypt_payload(encrypted_blob)
+        assert decrypted == plaintext
+        assert json.loads(decrypted) == json.loads(plaintext)
+
+    def test_round_trip_large_payload(self, key_pair, key_manager):
+        mod = _load_payload_crypto()
+        _, pub_path = key_pair
+
+        # Simulate a large tool_response payload
+        plaintext = json.dumps({
+            "hook_event_name": "Stop",
+            "tool_response": "x" * 50_000,
+            "session_id": "large-session",
+        })
+
+        with patch.object(mod, "PUBLIC_KEY_PATH", pub_path):
+            encrypted_blob, was_encrypted = mod.encrypt_payload(plaintext)
+
+        assert was_encrypted is True
+        decrypted = key_manager.decrypt_payload(encrypted_blob)
+        assert decrypted == plaintext
+
+    def test_round_trip_unicode(self, key_pair, key_manager):
+        mod = _load_payload_crypto()
+        _, pub_path = key_pair
+
+        plaintext = json.dumps({"message": "Hello \u4e16\u754c \U0001f600"})
+
+        with patch.object(mod, "PUBLIC_KEY_PATH", pub_path):
+            encrypted_blob, was_encrypted = mod.encrypt_payload(plaintext)
+
+        assert was_encrypted is True
+        decrypted = key_manager.decrypt_payload(encrypted_blob)
+        assert decrypted == plaintext
+
+
+class TestTamperDetection:
+    """Verify that AES-GCM rejects modified ciphertext."""
+
+    def test_flipped_byte_in_ciphertext_rejected(self, key_pair, key_manager):
+        mod = _load_payload_crypto()
+        _, pub_path = key_pair
+
+        plaintext = json.dumps({"event": "test"})
+
+        with patch.object(mod, "PUBLIC_KEY_PATH", pub_path):
+            encrypted_blob, _ = mod.encrypt_payload(plaintext)
+
+        # Flip a byte in the ciphertext portion (after 65 + 12 = 77 header bytes)
+        blob = bytearray(encrypted_blob)
+        if len(blob) > 78:
+            blob[78] ^= 0xFF
+        tampered = bytes(blob)
+
+        with pytest.raises(Exception):
+            # AES-GCM should reject tampered ciphertext (InvalidTag)
+            key_manager.decrypt_payload(tampered)
+
+    def test_truncated_blob_rejected(self, key_pair, key_manager):
+        mod = _load_payload_crypto()
+        _, pub_path = key_pair
+
+        plaintext = json.dumps({"event": "test"})
+
+        with patch.object(mod, "PUBLIC_KEY_PATH", pub_path):
+            encrypted_blob, _ = mod.encrypt_payload(plaintext)
+
+        # Truncate — remove the last 10 bytes (part of the GCM tag)
+        truncated = encrypted_blob[:-10]
+
+        with pytest.raises(Exception):
+            key_manager.decrypt_payload(truncated)
+
+
+class TestFallback:
+    """Verify graceful fallback to plaintext when encryption is unavailable."""
+
+    def test_encrypt_returns_plaintext_when_key_missing(self, tmp_path: Path):
+        mod = _load_payload_crypto()
+        fake_path = tmp_path / "nonexistent" / "server_public.pem"
+
+        plaintext = json.dumps({"event": "test"})
+
+        with patch.object(mod, "PUBLIC_KEY_PATH", fake_path):
+            data, was_encrypted = mod.encrypt_payload(plaintext)
+
+        assert was_encrypted is False
+        assert data == plaintext.encode("utf-8")
+
+
+class TestBackwardsCompatibility:
+    """Unencrypted (plaintext) payloads must still be accepted by the server
+    hook endpoint logic, which checks the ``X-Observal-Encrypted`` header."""
+
+    def test_unencrypted_json_parses_correctly(self):
+        """Simulate the server path for unencrypted payloads: just parse JSON."""
+        plaintext = json.dumps({"hook_event_name": "PostToolUse", "tool_name": "Read"})
+        body = json.loads(plaintext)
+        assert body["hook_event_name"] == "PostToolUse"
+        assert body["tool_name"] == "Read"
+
+    def test_encrypted_flag_zero_means_plaintext(self):
+        """In the SQLite buffer, encrypted=0 rows are sent as-is (no header)."""
+        # This is a logic test: when encrypted=0, flush_buffer should NOT
+        # set X-Observal-Encrypted. We verify the conditional logic.
+        encrypted = 0
+        assert not encrypted  # falsy — the ``if encrypted:`` branch is skipped
+
+
+class TestOutputFormat:
+    """Verify the wire format matches the spec:
+    ephemeral_pubkey (65 bytes) || nonce (12 bytes) || ciphertext || tag (16 bytes)
+    """
+
+    def test_output_structure(self, key_pair):
+        mod = _load_payload_crypto()
+        _, pub_path = key_pair
+
+        plaintext = json.dumps({"x": 1})
+
+        with patch.object(mod, "PUBLIC_KEY_PATH", pub_path):
+            blob, was_encrypted = mod.encrypt_payload(plaintext)
+
+        assert was_encrypted is True
+        # Minimum size: 65 (pubkey) + 12 (nonce) + 1 (min ciphertext) + 16 (tag)
+        assert len(blob) >= 65 + 12 + 1 + 16
+        # First byte is 0x04 (uncompressed EC point)
+        assert blob[0] == 0x04
+        # Ciphertext + tag length should be plaintext length + 16 (GCM tag)
+        ct_len = len(blob) - 65 - 12
+        assert ct_len == len(plaintext.encode("utf-8")) + 16

--- a/tests/test_payload_crypto.py
+++ b/tests/test_payload_crypto.py
@@ -8,15 +8,13 @@ unencrypted payloads.
 from __future__ import annotations
 
 import json
-import os
-import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -50,12 +48,7 @@ def key_manager(key_pair):
     # Import here so we can test even if the server package layout differs
     import importlib.util
 
-    crypto_path = (
-        Path(__file__).resolve().parent.parent
-        / "observal-server"
-        / "services"
-        / "crypto.py"
-    )
+    crypto_path = Path(__file__).resolve().parent.parent / "observal-server" / "services" / "crypto.py"
     spec = importlib.util.spec_from_file_location("services.crypto", crypto_path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -85,12 +78,7 @@ def _load_payload_crypto():
     """Dynamically load the payload_crypto module."""
     import importlib.util
 
-    path = (
-        Path(__file__).resolve().parent.parent
-        / "observal_cli"
-        / "hooks"
-        / "payload_crypto.py"
-    )
+    path = Path(__file__).resolve().parent.parent / "observal_cli" / "hooks" / "payload_crypto.py"
     spec = importlib.util.spec_from_file_location("payload_crypto", path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -147,11 +135,13 @@ class TestEncryptDecryptRoundTrip:
         _, pub_path = key_pair
 
         # Simulate a large tool_response payload
-        plaintext = json.dumps({
-            "hook_event_name": "Stop",
-            "tool_response": "x" * 50_000,
-            "session_id": "large-session",
-        })
+        plaintext = json.dumps(
+            {
+                "hook_event_name": "Stop",
+                "tool_response": "x" * 50_000,
+                "session_id": "large-session",
+            }
+        )
 
         with patch.object(mod, "PUBLIC_KEY_PATH", pub_path):
             encrypted_blob, was_encrypted = mod.encrypt_payload(plaintext)
@@ -192,7 +182,7 @@ class TestTamperDetection:
             blob[78] ^= 0xFF
         tampered = bytes(blob)
 
-        with pytest.raises(Exception):
+        with pytest.raises((InvalidTag, ValueError)):
             # AES-GCM should reject tampered ciphertext (InvalidTag)
             key_manager.decrypt_payload(tampered)
 
@@ -208,7 +198,7 @@ class TestTamperDetection:
         # Truncate — remove the last 10 bytes (part of the GCM tag)
         truncated = encrypted_blob[:-10]
 
-        with pytest.raises(Exception):
+        with pytest.raises((InvalidTag, ValueError)):
             key_manager.decrypt_payload(truncated)
 
 

--- a/tests/test_settings_reconciler.py
+++ b/tests/test_settings_reconciler.py
@@ -7,8 +7,11 @@ add new events, idempotent re-run, env reconciliation, and version tracking.
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import pytest
 
@@ -24,7 +27,6 @@ from observal_cli.settings_reconciler import (
     reconcile_env,
     reconcile_hooks,
 )
-
 
 # ── Fixtures ──────────────────────────────────────────────────
 
@@ -95,7 +97,9 @@ class TestHookIdentification:
 
     def test_desired_hooks_have_metadata(self):
         """get_desired_hooks injects _observal metadata into every matcher group."""
-        desired = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        desired = get_desired_hooks(
+            "/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks"
+        )
         for event, groups in desired.items():
             for group in groups:
                 assert "_observal" in group, f"Missing metadata in {event}"
@@ -108,7 +112,9 @@ class TestHookIdentification:
 class TestReconcileHooks:
     def test_fresh_install_adds_all_events(self):
         """On empty settings, all desired events are added."""
-        desired = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        desired = get_desired_hooks(
+            "/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks"
+        )
         merged, changes = reconcile_hooks({}, desired)
 
         assert set(merged.keys()) == set(desired.keys())
@@ -164,7 +170,9 @@ class TestReconcileHooks:
 
     def test_idempotent_rerun(self):
         """Running reconcile twice with same desired state produces no changes."""
-        desired = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        desired = get_desired_hooks(
+            "/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks"
+        )
 
         # First run: everything is new
         merged, changes1 = reconcile_hooks({}, desired)
@@ -200,7 +208,9 @@ class TestReconcileHooks:
 
     def test_stop_has_two_hooks(self):
         """Stop event should have both generic and stop-specific handlers."""
-        desired = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        desired = get_desired_hooks(
+            "/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks"
+        )
         stop_groups = desired["Stop"]
 
         # One matcher group with two hook handlers
@@ -260,7 +270,9 @@ class TestReconcileEnv:
 class TestFullReconcile:
     def test_fresh_install_writes_file(self, settings_path, config_path):
         """Full reconcile on empty settings creates the file."""
-        desired_hooks = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        desired_hooks = get_desired_hooks(
+            "/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks"
+        )
         desired_env = get_desired_env("http://localhost:8000", "test-key")
 
         changes = reconcile(desired_hooks, desired_env)
@@ -276,10 +288,15 @@ class TestFullReconcile:
     def test_preserves_non_hook_settings(self, settings_path, config_path):
         """Non-hook/env settings are preserved."""
         settings_path.parent.mkdir(parents=True, exist_ok=True)
-        settings_path.write_text(json.dumps({
-            "model": "opus",
-            "enabledPlugins": {"foo": True},
-        }), encoding="utf-8")
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "model": "opus",
+                    "enabledPlugins": {"foo": True},
+                }
+            ),
+            encoding="utf-8",
+        )
 
         desired_hooks = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
         desired_env = get_desired_env("http://localhost:8000", "test-key")
@@ -321,6 +338,7 @@ class TestFullReconcile:
 
         # Second reconcile — no changes
         import time
+
         time.sleep(0.01)
         changes = reconcile(desired_hooks, desired_env)
 

--- a/tests/test_settings_reconciler.py
+++ b/tests/test_settings_reconciler.py
@@ -1,0 +1,328 @@
+"""Tests for the declarative settings reconciler.
+
+Covers: fresh install, HTTP→command upgrade, preserve foreign hooks,
+add new events, idempotent re-run, env reconciliation, and version tracking.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from observal_cli.hooks_spec import (
+    HOOKS_SPEC_VERSION,
+    get_desired_env,
+    get_desired_hooks,
+    is_observal_hook_entry,
+    is_observal_matcher_group,
+)
+from observal_cli.settings_reconciler import (
+    reconcile,
+    reconcile_env,
+    reconcile_hooks,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def settings_path(tmp_path: Path):
+    """Patch CLAUDE_SETTINGS_PATH to a temp file."""
+    fake_path = tmp_path / ".claude" / "settings.json"
+    with patch("observal_cli.settings_reconciler.CLAUDE_SETTINGS_PATH", fake_path):
+        yield fake_path
+
+
+@pytest.fixture()
+def config_path(tmp_path: Path):
+    """Patch config module to use a temp dir."""
+    fake_config = tmp_path / ".observal" / "config.json"
+    fake_config.parent.mkdir(parents=True, exist_ok=True)
+    fake_config.write_text("{}", encoding="utf-8")
+
+    def fake_load():
+        return json.loads(fake_config.read_text(encoding="utf-8"))
+
+    def fake_save(updates):
+        current = fake_load()
+        current.update(updates)
+        fake_config.write_text(json.dumps(current), encoding="utf-8")
+
+    with (
+        patch("observal_cli.settings_reconciler.config.load", side_effect=fake_load),
+        patch("observal_cli.settings_reconciler.config.save", side_effect=fake_save),
+    ):
+        yield fake_config
+
+
+# ── Hook identification ───────────────────────────────────────
+
+
+class TestHookIdentification:
+    def test_command_hook_identified(self):
+        entry = {"type": "command", "command": "/path/to/observal-hook.sh"}
+        assert is_observal_hook_entry(entry)
+
+    def test_stop_hook_identified(self):
+        entry = {"type": "command", "command": "/path/to/observal-stop-hook.sh"}
+        assert is_observal_hook_entry(entry)
+
+    def test_http_hook_identified(self):
+        entry = {"type": "http", "url": "http://localhost:8000/api/v1/otel/hooks"}
+        assert is_observal_hook_entry(entry)
+
+    def test_foreign_hook_not_identified(self):
+        entry = {"type": "command", "command": "/usr/local/bin/my-custom-hook.sh"}
+        assert not is_observal_hook_entry(entry)
+
+    def test_metadata_marker_identifies_group(self):
+        """Primary identification: _observal metadata key."""
+        group = {"_observal": {"version": "3"}, "hooks": [{"type": "command", "command": "/any/path.sh"}]}
+        assert is_observal_matcher_group(group)
+
+    def test_legacy_path_identifies_group(self):
+        """Fallback: legacy path-based identification for pre-metadata installs."""
+        group = {"hooks": [{"type": "command", "command": "/path/observal-hook.sh"}]}
+        assert is_observal_matcher_group(group)
+
+    def test_matcher_group_without_observal(self):
+        group = {"hooks": [{"type": "command", "command": "/path/other-hook.sh"}]}
+        assert not is_observal_matcher_group(group)
+
+    def test_desired_hooks_have_metadata(self):
+        """get_desired_hooks injects _observal metadata into every matcher group."""
+        desired = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        for event, groups in desired.items():
+            for group in groups:
+                assert "_observal" in group, f"Missing metadata in {event}"
+                assert group["_observal"]["version"] == HOOKS_SPEC_VERSION
+
+
+# ── Hook reconciliation ──────────────────────────────────────
+
+
+class TestReconcileHooks:
+    def test_fresh_install_adds_all_events(self):
+        """On empty settings, all desired events are added."""
+        desired = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        merged, changes = reconcile_hooks({}, desired)
+
+        assert set(merged.keys()) == set(desired.keys())
+        assert len(changes) == len(desired)
+        assert all(c.startswith("+ ") for c in changes)
+
+    def test_preserves_foreign_hooks(self):
+        """Non-Observal hooks on the same event are kept."""
+        foreign_group = {"hooks": [{"type": "command", "command": "/usr/bin/my-linter.sh"}]}
+        current = {
+            "PreToolUse": [foreign_group],
+        }
+        desired = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+
+        merged, changes = reconcile_hooks(current, desired)
+
+        # Foreign group should still be there, plus the new Observal group
+        pre_tool_groups = merged["PreToolUse"]
+        assert len(pre_tool_groups) == 2
+        assert pre_tool_groups[0] == foreign_group  # Foreign first
+        assert is_observal_matcher_group(pre_tool_groups[1])  # Observal second
+
+    def test_upgrades_http_to_command(self):
+        """Old HTTP hooks (legacy, no metadata) get replaced with command hooks."""
+        old_http_group = {"hooks": [{"type": "http", "url": "http://localhost:8000/api/v1/otel/hooks"}]}
+        current = {
+            "SessionStart": [old_http_group],
+        }
+        desired = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+
+        merged, changes = reconcile_hooks(current, desired)
+
+        # Should have replaced the HTTP group with the command group
+        groups = merged["SessionStart"]
+        assert len(groups) == 1
+        assert groups[0]["hooks"][0]["type"] == "command"
+        assert "_observal" in groups[0]  # New group has metadata
+        assert "updated" in changes[0] or "added" in changes[0]
+
+    def test_upgrades_legacy_path_to_metadata(self):
+        """Pre-metadata Observal hooks (path-only) get replaced with metadata-bearing groups."""
+        old_path_group = {"hooks": [{"type": "command", "command": "/path/observal-hook.sh"}]}
+        current = {
+            "SessionStart": [old_path_group],
+        }
+        desired = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+
+        merged, changes = reconcile_hooks(current, desired)
+
+        groups = merged["SessionStart"]
+        assert len(groups) == 1
+        assert "_observal" in groups[0]
+
+    def test_idempotent_rerun(self):
+        """Running reconcile twice with same desired state produces no changes."""
+        desired = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+
+        # First run: everything is new
+        merged, changes1 = reconcile_hooks({}, desired)
+        assert len(changes1) > 0
+
+        # Second run: already up to date
+        _, changes2 = reconcile_hooks(merged, desired)
+        assert len(changes2) == 0
+
+    def test_foreign_events_preserved(self):
+        """Events not in the desired spec are left alone."""
+        current = {
+            "MyCustomEvent": [{"hooks": [{"type": "command", "command": "/custom.sh"}]}],
+        }
+        desired = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+
+        merged, _ = reconcile_hooks(current, desired)
+
+        assert "MyCustomEvent" in merged
+        assert merged["MyCustomEvent"] == current["MyCustomEvent"]
+
+    def test_adds_new_events(self):
+        """When the spec adds a new event type, it appears after reconcile."""
+        # Start with a partial set of events
+        desired_full = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+        partial = {k: v for k, v in desired_full.items() if k in ("SessionStart", "Stop")}
+
+        merged, _ = reconcile_hooks(partial, desired_full)
+
+        # All desired events should now be present
+        for event in desired_full:
+            assert event in merged
+
+    def test_stop_has_two_hooks(self):
+        """Stop event should have both generic and stop-specific handlers."""
+        desired = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        stop_groups = desired["Stop"]
+
+        # One matcher group with two hook handlers
+        assert len(stop_groups) == 1
+        hooks = stop_groups[0]["hooks"]
+        assert len(hooks) == 2
+        assert "observal-hook.sh" in hooks[0]["command"]
+        assert "observal-stop-hook.sh" in hooks[1]["command"]
+
+
+# ── Env reconciliation ───────────────────────────────────────
+
+
+class TestReconcileEnv:
+    def test_fresh_install_adds_all_keys(self):
+        desired = get_desired_env("http://localhost:8000", "test-key")
+        merged, changes = reconcile_env({}, desired)
+
+        assert "CLAUDE_CODE_ENABLE_TELEMETRY" in merged
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" in merged
+        assert len(changes) == len(desired)
+
+    def test_preserves_foreign_env(self):
+        """Non-Observal env vars are never touched."""
+        current = {
+            "MY_CUSTOM_VAR": "keep-me",
+            "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+        }
+        desired = get_desired_env("http://localhost:8000", "test-key")
+
+        merged, _ = reconcile_env(current, desired)
+
+        assert merged["MY_CUSTOM_VAR"] == "keep-me"
+
+    def test_updates_stale_key(self):
+        """Changed Observal env values are updated."""
+        current = {
+            "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer old-key",
+        }
+        desired = get_desired_env("http://localhost:8000", "new-key")
+
+        merged, changes = reconcile_env(current, desired)
+
+        assert "new-key" in merged["OTEL_EXPORTER_OTLP_HEADERS"]
+        assert any("~ env.OTEL_EXPORTER_OTLP_HEADERS" in c for c in changes)
+
+    def test_idempotent_env(self):
+        desired = get_desired_env("http://localhost:8000", "test-key")
+        merged, _ = reconcile_env({}, desired)
+        _, changes2 = reconcile_env(merged, desired)
+        assert len(changes2) == 0
+
+
+# ── Full reconciliation ──────────────────────────────────────
+
+
+class TestFullReconcile:
+    def test_fresh_install_writes_file(self, settings_path, config_path):
+        """Full reconcile on empty settings creates the file."""
+        desired_hooks = get_desired_hooks("/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks")
+        desired_env = get_desired_env("http://localhost:8000", "test-key")
+
+        changes = reconcile(desired_hooks, desired_env)
+
+        assert len(changes) > 0
+        assert settings_path.exists()
+
+        written = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert "hooks" in written
+        assert "env" in written
+        assert "SessionStart" in written["hooks"]
+
+    def test_preserves_non_hook_settings(self, settings_path, config_path):
+        """Non-hook/env settings are preserved."""
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps({
+            "model": "opus",
+            "enabledPlugins": {"foo": True},
+        }), encoding="utf-8")
+
+        desired_hooks = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+        desired_env = get_desired_env("http://localhost:8000", "test-key")
+
+        reconcile(desired_hooks, desired_env)
+
+        written = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert written["model"] == "opus"
+        assert written["enabledPlugins"] == {"foo": True}
+
+    def test_dry_run_does_not_write(self, settings_path, config_path):
+        """dry_run=True computes changes but doesn't write."""
+        desired_hooks = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+        desired_env = get_desired_env("http://localhost:8000", "test-key")
+
+        changes = reconcile(desired_hooks, desired_env, dry_run=True)
+
+        assert len(changes) > 0
+        assert not settings_path.exists()
+
+    def test_records_spec_version(self, settings_path, config_path):
+        """After reconcile, the applied version is recorded in config."""
+        desired_hooks = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+        desired_env = get_desired_env("http://localhost:8000", "test-key")
+
+        reconcile(desired_hooks, desired_env)
+
+        cfg = json.loads(config_path.read_text(encoding="utf-8"))
+        assert cfg["hooks_spec_version"] == HOOKS_SPEC_VERSION
+
+    def test_no_changes_skips_write(self, settings_path, config_path):
+        """When already up to date, the file is not rewritten."""
+        desired_hooks = get_desired_hooks("/path/observal-hook.sh", None, "http://localhost:8000/api/v1/otel/hooks")
+        desired_env = get_desired_env("http://localhost:8000", "test-key")
+
+        # First reconcile
+        reconcile(desired_hooks, desired_env)
+        mtime = settings_path.stat().st_mtime
+
+        # Second reconcile — no changes
+        import time
+        time.sleep(0.01)
+        changes = reconcile(desired_hooks, desired_env)
+
+        assert len(changes) == 0
+        assert settings_path.stat().st_mtime == mtime  # File untouched

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -28,6 +28,9 @@ import {
   GitBranch,
   LogIn,
   Users,
+  Info,
+  CheckCircle2,
+  XCircle,
 } from "lucide-react";
 import { PageHeader } from "@/components/layouts/page-header";
 import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
@@ -36,6 +39,7 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 /* ── Helpers ─────────────────────────────────────────────── */
 
@@ -95,6 +99,7 @@ function eventIcon(eventName: string) {
   if (eventName === "hook_subagentstart") return Play;
   if (eventName === "hook_subagentstop") return Square;
   if (eventName === "hook_assistant_response") return Bot;
+  if (eventName === "hook_assistant_thinking") return Bot;
   if (eventName === "hook_stop") return Square;
   if (eventName === "hook_stopfailure") return AlertTriangle;
   if (eventName === "hook_sessionstart") return LogIn;
@@ -117,6 +122,7 @@ function eventColor(eventName: string): string {
   if (eventName === "hook_posttoolusefailure" || eventName === "hook_stopfailure") return "text-red-500";
   if (eventName === "hook_subagentstart" || eventName === "hook_subagentstop") return "text-indigo-500";
   if (eventName === "hook_assistant_response") return "text-violet-500";
+  if (eventName === "hook_assistant_thinking") return "text-fuchsia-500";
   if (eventName === "hook_stop") return "text-rose-500";
   if (eventName === "hook_sessionstart") return "text-green-500";
   if (eventName === "hook_notification") return "text-yellow-500";
@@ -140,6 +146,7 @@ type FilterCategory = {
 const FILTER_CATEGORIES: FilterCategory[] = [
   { key: "prompts", label: "Prompts", match: (e) => e === "user_prompt" || e === "hook_userpromptsubmit", color: "bg-purple-500/10 text-purple-600 dark:text-purple-400 border-purple-500/20" },
   { key: "responses", label: "Responses", match: (e) => e === "hook_assistant_response", color: "bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20" },
+  { key: "thinking", label: "Thinking", match: (e) => e === "hook_assistant_thinking", color: "bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400 border-fuchsia-500/20" },
   { key: "tools", label: "Tools", match: (e) => ["tool_result", "tool_decision", "hook_posttooluse", "hook_pretooluse", "hook_posttoolusefailure"].includes(e), color: "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 border-cyan-500/20" },
   { key: "api", label: "API", match: (e) => e === "api_request", color: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20" },
   { key: "agents", label: "Agents", match: (e) => e === "hook_subagentstart" || e === "hook_subagentstop", color: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/20" },
@@ -162,6 +169,7 @@ interface AgentScope {
 interface Turn {
   promptEvent?: RawOtelEvent;           // The user prompt that started this turn
   responseEvent?: RawOtelEvent;         // The assistant response text
+  thinkingEvents: RawOtelEvent[];       // Assistant thinking/reasoning blocks
   stopEvent?: RawOtelEvent;             // The stop/end event
   topLevelEvents: RawOtelEvent[];       // Events not inside any subagent
   agents: AgentScope[];                 // Subagent scopes with their events
@@ -269,6 +277,7 @@ function buildEventTree(events: RawOtelEvent[]): { turns: Turn[]; preSessionEven
       }
       currentTurn = {
         promptEvent: evt,
+        thinkingEvents: [],
         topLevelEvents: [],
         agents: [],
         allEvents: [evt],
@@ -309,6 +318,12 @@ function buildEventTree(events: RawOtelEvent[]): { turns: Turn[]; preSessionEven
         // Unmatched stop — add to top level
         currentTurn.topLevelEvents.push(evt);
       }
+      continue;
+    }
+
+    // Assistant thinking: collect on the turn
+    if (eName === "hook_assistant_thinking") {
+      currentTurn.thinkingEvents.push(evt);
       continue;
     }
 
@@ -771,6 +786,48 @@ function AssistantResponseBlock({ event }: { event: RawOtelEvent }) {
   );
 }
 
+/* ── Thinking block (chain-of-thought) ────────────────────── */
+
+function ThinkingBlock({ event }: { event: RawOtelEvent }) {
+  const [expanded, setExpanded] = useState(false);
+  const attrs = event.attributes ?? {};
+  const fullText = attrs.tool_response || "";
+  const seq = attrs.message_sequence;
+  const total = attrs.message_total;
+  const seqLabel = seq && total ? ` (${seq}/${total})` : "";
+  const lines = fullText.split("\n");
+  const isLong = lines.length > 8;
+  const shown = isLong && !expanded ? lines.slice(0, 8).join("\n") + "\n…" : fullText;
+
+  if (!fullText) return null;
+
+  return (
+    <div className="mx-3 mt-2 mb-1 rounded-md border border-fuchsia-500/20 bg-fuchsia-500/5 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-fuchsia-500/10">
+        <Bot className="h-3 w-3 text-fuchsia-500" />
+        <span className="text-[11px] font-medium text-fuchsia-600 dark:text-fuchsia-400">Thinking{seqLabel}</span>
+        {event.timestamp && (
+          <span className="ml-auto text-[10px] text-muted-foreground tabular-nums">
+            {new Date(event.timestamp).toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+      <div className="px-3 py-2 text-sm text-foreground/80 whitespace-pre-wrap break-words leading-relaxed max-h-[300px] overflow-auto italic">
+        {shown}
+      </div>
+      {isLong && (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="w-full text-center py-1 text-[11px] text-fuchsia-500 hover:underline border-t border-fuchsia-500/10"
+        >
+          {expanded ? "Show less" : `Show all ${lines.length} lines`}
+        </button>
+      )}
+    </div>
+  );
+}
+
 /* ── Friendly event label ────────────────────────────────── */
 
 function eventLabel(evt: RawOtelEvent): string {
@@ -1036,6 +1093,11 @@ function TurnNode({ turn, index, expandedSet, onToggleEvent, activeFilters, sear
             />
           ))}
 
+          {/* Thinking blocks (before response, chronological) */}
+          {turn.thinkingEvents.length > 0 && turn.thinkingEvents.map((evt, ti) => (
+            <ThinkingBlock key={`turn-${index}-think-${ti}`} event={evt} />
+          ))}
+
           {/* Assistant response */}
           {turn.responseEvent && <AssistantResponseBlock event={turn.responseEvent} />}
 
@@ -1097,7 +1159,7 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
 
       if (isHookEvent(eName)) {
         hookEvents++;
-        if (attrs.tool_name && attrs.tool_name !== "user_prompt" && attrs.tool_name !== "assistant_response") {
+        if (attrs.tool_name && attrs.tool_name !== "user_prompt" && attrs.tool_name !== "assistant_response" && attrs.tool_name !== "assistant_thinking") {
           const tn = attrs.tool_name;
           tools[tn] = (tools[tn] || 0) + 1;
         }
@@ -1162,6 +1224,163 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/* ── Session Info tab ─────────────────────────────────────── */
+
+/** All hook event types we know about, grouped by category. */
+const HOOK_CAPABILITIES: { category: string; hooks: { event: string; label: string; description: string }[] }[] = [
+  {
+    category: "Capture",
+    hooks: [
+      { event: "hook_userpromptsubmit", label: "User Prompts", description: "Captures what the user sends to Claude" },
+      { event: "hook_assistant_response", label: "Assistant Responses", description: "Captures Claude's text replies" },
+      { event: "hook_assistant_thinking", label: "Assistant Thinking", description: "Captures Claude's chain-of-thought reasoning" },
+    ],
+  },
+  {
+    category: "Tool Use",
+    hooks: [
+      { event: "hook_pretooluse", label: "Pre Tool Use", description: "Fires before each tool call" },
+      { event: "hook_posttooluse", label: "Post Tool Use", description: "Captures tool input/output after execution" },
+      { event: "hook_posttoolusefailure", label: "Tool Failures", description: "Captures failed tool executions" },
+    ],
+  },
+  {
+    category: "Agents",
+    hooks: [
+      { event: "hook_subagentstart", label: "Subagent Start", description: "Fires when a subagent is spawned" },
+      { event: "hook_subagentstop", label: "Subagent Stop", description: "Fires when a subagent finishes" },
+    ],
+  },
+  {
+    category: "Lifecycle",
+    hooks: [
+      { event: "hook_sessionstart", label: "Session Start", description: "Session initialization and resumption" },
+      { event: "hook_stop", label: "Stop", description: "Turn/session end events" },
+      { event: "hook_notification", label: "Notifications", description: "System notifications from Claude" },
+      { event: "hook_taskcreated", label: "Task Created", description: "Task tracking events" },
+      { event: "hook_taskcompleted", label: "Task Completed", description: "Task completion events" },
+      { event: "hook_precompact", label: "Pre Compact", description: "Before context compaction" },
+      { event: "hook_postcompact", label: "Post Compact", description: "After context compaction" },
+    ],
+  },
+];
+
+function SessionInfoTab({ events, sessionId, serviceName }: { events: RawOtelEvent[]; sessionId: string; serviceName: string }) {
+  // Derive active hooks from events actually present in this session
+  const activeHookEvents = useMemo(() => {
+    const seen = new Set<string>();
+    for (const evt of events) {
+      const eName = getEventName(evt);
+      if (isHookEvent(eName)) seen.add(eName);
+    }
+    return seen;
+  }, [events]);
+
+  // Extract session metadata from SessionStart event
+  const sessionMeta = useMemo(() => {
+    const startEvt = events.find((e) => getEventName(e) === "hook_sessionstart");
+    const attrs = startEvt?.attributes ?? {};
+    const firstEvt = events[0];
+    const lastEvt = events[events.length - 1];
+    const duration = firstEvt?.timestamp && lastEvt?.timestamp
+      ? new Date(lastEvt.timestamp).getTime() - new Date(firstEvt.timestamp).getTime()
+      : 0;
+
+    return {
+      source: attrs.session_source || "startup",
+      resumed: attrs.session_resumed === "true" || attrs.session_resumed === "True",
+      cwd: attrs.cwd || "",
+      permissionMode: attrs.permission_mode || "",
+      startTime: firstEvt?.timestamp ? new Date(firstEvt.timestamp).toLocaleString() : "",
+      endTime: lastEvt?.timestamp ? new Date(lastEvt.timestamp).toLocaleString() : "",
+      duration,
+      totalEvents: events.length,
+    };
+  }, [events]);
+
+  return (
+    <div className="space-y-6">
+      {/* Session metadata */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold flex items-center gap-1.5">
+          <Info className="h-4 w-4 text-muted-foreground" />
+          Session Details
+        </h3>
+        <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm bg-surface-sunken rounded-lg p-4">
+          <span className="text-muted-foreground">Session ID</span>
+          <span className="font-[family-name:var(--font-mono)] text-xs">{sessionId}</span>
+          <span className="text-muted-foreground">Service</span>
+          <span>{serviceName || "unknown"}</span>
+          <span className="text-muted-foreground">Source</span>
+          <span className="capitalize">{sessionMeta.source}{sessionMeta.resumed ? " (resumed)" : ""}</span>
+          {sessionMeta.cwd && <>
+            <span className="text-muted-foreground">Working Dir</span>
+            <span className="font-[family-name:var(--font-mono)] text-xs truncate">{sessionMeta.cwd}</span>
+          </>}
+          {sessionMeta.permissionMode && <>
+            <span className="text-muted-foreground">Permission Mode</span>
+            <span>{sessionMeta.permissionMode}</span>
+          </>}
+          <span className="text-muted-foreground">Started</span>
+          <span className="tabular-nums">{sessionMeta.startTime}</span>
+          <span className="text-muted-foreground">Last Event</span>
+          <span className="tabular-nums">{sessionMeta.endTime}</span>
+          <span className="text-muted-foreground">Duration</span>
+          <span className="tabular-nums">{sessionMeta.duration > 0 ? formatDuration(sessionMeta.duration) : "-"}</span>
+          <span className="text-muted-foreground">Total Events</span>
+          <span className="tabular-nums">{sessionMeta.totalEvents}</span>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* Active hooks */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold flex items-center gap-1.5">
+          <Zap className="h-4 w-4 text-orange-500" />
+          Active Hooks
+        </h3>
+        <p className="text-xs text-muted-foreground">
+          Hook types detected in this session. Missing hooks mean those event types were not captured — check your hook configuration.
+        </p>
+        <div className="space-y-4">
+          {HOOK_CAPABILITIES.map((group) => (
+            <div key={group.category} className="space-y-2">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{group.category}</h4>
+              <div className="grid gap-1.5">
+                {group.hooks.map((hook) => {
+                  const active = activeHookEvents.has(hook.event);
+                  return (
+                    <div
+                      key={hook.event}
+                      className={`flex items-center gap-2.5 rounded-md px-3 py-2 text-sm ${
+                        active
+                          ? "bg-emerald-500/5 border border-emerald-500/20"
+                          : "bg-muted/30 border border-transparent opacity-60"
+                      }`}
+                    >
+                      {active
+                        ? <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+                        : <XCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />}
+                      <div className="flex-1 min-w-0">
+                        <span className="font-medium">{hook.label}</span>
+                        <span className="text-xs text-muted-foreground ml-2">{hook.description}</span>
+                      </div>
+                      {active && (
+                        <Badge variant="success">{events.filter((e) => getEventName(e) === hook.event).length}</Badge>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -1289,101 +1508,110 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
             <SessionStats events={events} />
             <Separator />
 
-            {/* Events tree */}
+            {/* Tabbed content */}
             {events.length === 0 ? (
               <EmptyState icon={FileText} title="No events in this session" description="Events will appear here once telemetry data is recorded." />
             ) : (
-              <div className="animate-in stagger-1 space-y-2">
-                {/* Search + Filter bar */}
-                <div className="space-y-2 mb-3">
-                  <div className="flex items-center gap-2">
-                    <div className="relative flex-1 max-w-sm">
-                      <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                      <Input
-                        placeholder="Search events, tools, content..."
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        className="pl-8 h-8 text-sm"
-                      />
-                      {searchQuery && (
-                        <button type="button" onClick={() => setSearchQuery("")} className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground">
-                          <X className="h-3.5 w-3.5" />
+              <Tabs defaultValue="traces" className="animate-in stagger-1">
+                <TabsList>
+                  <TabsTrigger value="traces">Traces</TabsTrigger>
+                  <TabsTrigger value="info">Session Info</TabsTrigger>
+                </TabsList>
+                <TabsContent value="traces" className="space-y-2 mt-4">
+                  {/* Search + Filter bar */}
+                  <div className="space-y-2 mb-3">
+                    <div className="flex items-center gap-2">
+                      <div className="relative flex-1 max-w-sm">
+                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                        <Input
+                          placeholder="Search events, tools, content..."
+                          value={searchQuery}
+                          onChange={(e) => setSearchQuery(e.target.value)}
+                          className="pl-8 h-8 text-sm"
+                        />
+                        {searchQuery && (
+                          <button type="button" onClick={() => setSearchQuery("")} className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground">
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </div>
+                      <Button variant="ghost" size="sm" onClick={expandAllTurns} className="h-8 text-xs gap-1">
+                        <ChevronsUpDown className="h-3 w-3" />
+                        Toggle turns
+                      </Button>
+                    </div>
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      <Filter className="h-3 w-3 text-muted-foreground shrink-0" />
+                      {FILTER_CATEGORIES.filter((cat) => filterCounts[cat.key] > 0).map((cat) => (
+                        <button
+                          type="button"
+                          key={cat.key}
+                          onClick={() => toggleFilter(cat.key)}
+                          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border transition-all ${
+                            activeFilters.has(cat.key) ? cat.color + " border-current" : "bg-muted/50 text-muted-foreground border-transparent hover:bg-muted"
+                          }`}
+                        >
+                          {cat.label}
+                          <span className="opacity-60">{filterCounts[cat.key]}</span>
+                        </button>
+                      ))}
+                      {(activeFilters.size > 0 || searchQuery) && (
+                        <button type="button" onClick={clearFilters} className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground">
+                          <X className="h-3 w-3" /> Clear
                         </button>
                       )}
                     </div>
-                    <Button variant="ghost" size="sm" onClick={expandAllTurns} className="h-8 text-xs gap-1">
-                      <ChevronsUpDown className="h-3 w-3" />
-                      Toggle turns
-                    </Button>
                   </div>
-                  <div className="flex items-center gap-1.5 flex-wrap">
-                    <Filter className="h-3 w-3 text-muted-foreground shrink-0" />
-                    {FILTER_CATEGORIES.filter((cat) => filterCounts[cat.key] > 0).map((cat) => (
-                      <button
-                        type="button"
-                        key={cat.key}
-                        onClick={() => toggleFilter(cat.key)}
-                        className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border transition-all ${
-                          activeFilters.has(cat.key) ? cat.color + " border-current" : "bg-muted/50 text-muted-foreground border-transparent hover:bg-muted"
-                        }`}
-                      >
-                        {cat.label}
-                        <span className="opacity-60">{filterCounts[cat.key]}</span>
-                      </button>
-                    ))}
-                    {(activeFilters.size > 0 || searchQuery) && (
-                      <button type="button" onClick={clearFilters} className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground">
-                        <X className="h-3 w-3" /> Clear
-                      </button>
-                    )}
-                  </div>
-                </div>
 
-                {/* Turn count */}
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {visibleTurns.length === tree.turns.length
-                      ? `${tree.turns.length} turn${tree.turns.length !== 1 ? "s" : ""}`
-                      : `${visibleTurns.length} of ${tree.turns.length} turns`}
-                    {" · "}{allDeduped.length} events (deduped from {events.length})
-                  </span>
-                </div>
-
-                {/* Pre-session events */}
-                {tree.preSessionEvents.length > 0 && (
-                  <div className="rounded-lg border border-border/50 p-2 space-y-0.5">
-                    <span className="text-[10px] text-muted-foreground uppercase tracking-wide px-2">Pre-session</span>
-                    {tree.preSessionEvents.map((evt, i) => {
-                      const key = `pre-${i}`;
-                      return (
-                        <LeafEvent key={key} event={evt} isExpanded={expandedSet.has(key)} onToggle={() => onToggleEvent(key)} depth={0} />
-                      );
-                    })}
+                  {/* Turn count */}
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {visibleTurns.length === tree.turns.length
+                        ? `${tree.turns.length} turn${tree.turns.length !== 1 ? "s" : ""}`
+                        : `${visibleTurns.length} of ${tree.turns.length} turns`}
+                      {" · "}{allDeduped.length} events (deduped from {events.length})
+                    </span>
                   </div>
-                )}
 
-                {/* Turn nodes */}
-                {visibleTurns.length === 0 ? (
-                  <div className="text-center py-8 text-sm text-muted-foreground">No turns match your filters.</div>
-                ) : (
-                  <div className="space-y-2">
-                    {visibleTurns.map((turn) => {
-                      const originalIndex = tree.turns.indexOf(turn);
-                      return (
-                        <TurnNode
-                          key={`turn-${originalIndex}`}
-                          turn={turn}
-                          index={originalIndex}
-                          expandedSet={expandedSet}
-                          onToggleEvent={onToggleEvent}
-                          activeFilters={activeFilters}
-                          searchQuery={searchQuery}
-                        />
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
+                  {/* Pre-session events */}
+                  {tree.preSessionEvents.length > 0 && (
+                    <div className="rounded-lg border border-border/50 p-2 space-y-0.5">
+                      <span className="text-[10px] text-muted-foreground uppercase tracking-wide px-2">Pre-session</span>
+                      {tree.preSessionEvents.map((evt, i) => {
+                        const key = `pre-${i}`;
+                        return (
+                          <LeafEvent key={key} event={evt} isExpanded={expandedSet.has(key)} onToggle={() => onToggleEvent(key)} depth={0} />
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  {/* Turn nodes */}
+                  {visibleTurns.length === 0 ? (
+                    <div className="text-center py-8 text-sm text-muted-foreground">No turns match your filters.</div>
+                  ) : (
+                    <div className="space-y-2">
+                      {visibleTurns.map((turn) => {
+                        const originalIndex = tree.turns.indexOf(turn);
+                        return (
+                          <TurnNode
+                            key={`turn-${originalIndex}`}
+                            turn={turn}
+                            index={originalIndex}
+                            expandedSet={expandedSet}
+                            onToggleEvent={onToggleEvent}
+                            activeFilters={activeFilters}
+                            searchQuery={searchQuery}
+                          />
+                        );
+                      })}
+                    </div>
+                  )}
+                </TabsContent>
+                <TabsContent value="info" className="mt-4">
+                  <SessionInfoTab events={events} sessionId={id} serviceName={session.service_name} />
+                </TabsContent>
+              </Tabs>
             )}
           </>
         )}

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -414,7 +414,10 @@ function EventSummary({ event }: { event: RawOtelEvent }) {
         {attrs.input_tokens && parseInt(attrs.input_tokens) > 1 && <Stat label="in" value={formatTokens(attrs.input_tokens)} />}
         {attrs.output_tokens && <Stat label="out" value={formatTokens(attrs.output_tokens)} />}
         {attrs.cache_read_tokens && parseInt(attrs.cache_read_tokens) > 0 && (
-          <Stat label="cache" value={formatTokens(attrs.cache_read_tokens)} />
+          <Stat label="cache read" value={formatTokens(attrs.cache_read_tokens)} />
+        )}
+        {attrs.cache_creation_tokens && parseInt(attrs.cache_creation_tokens) > 0 && (
+          <Stat label="cache write" value={formatTokens(attrs.cache_creation_tokens)} />
         )}
       </div>
     );
@@ -1133,6 +1136,7 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let totalCacheRead = 0;
+    let totalCacheWrite = 0;
     let apiCalls = 0;
     let toolCalls = 0;
     let hookEvents = 0;
@@ -1153,6 +1157,7 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
         if (attrs.input_tokens) totalInputTokens += parseInt(attrs.input_tokens, 10);
         if (attrs.output_tokens) totalOutputTokens += parseInt(attrs.output_tokens, 10);
         if (attrs.cache_read_tokens) totalCacheRead += parseInt(attrs.cache_read_tokens, 10);
+        if (attrs.cache_creation_tokens) totalCacheWrite += parseInt(attrs.cache_creation_tokens, 10);
         if (attrs.model) models.add(attrs.model);
       }
 
@@ -1175,13 +1180,13 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
       }
     }
 
-    return { totalInputTokens, totalOutputTokens, totalCacheRead, apiCalls, toolCalls, hookEvents, credits, isKiro, models, tools };
+    return { totalInputTokens, totalOutputTokens, totalCacheRead, totalCacheWrite, apiCalls, toolCalls, hookEvents, credits, isKiro, models, tools };
   }, [events]);
 
   const formatCredits = (c: number) => c < 0.01 ? c.toFixed(4) : c.toFixed(2);
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+    <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-4">
       {stats.isKiro && stats.credits > 0 ? (
         <div className="space-y-1">
           <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Credits</p>
@@ -1200,6 +1205,10 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
           <div className="space-y-1">
             <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Read</p>
             <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheRead)}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Write</p>
+            <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheWrite)}</p>
           </div>
         </>
       )}

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -154,6 +154,8 @@ const FILTER_CATEGORIES: FilterCategory[] = [
   { key: "tasks", label: "Tasks", match: (e) => e === "hook_taskcreated" || e === "hook_taskcompleted", color: "bg-lime-500/10 text-lime-600 dark:text-lime-400 border-lime-500/20" },
   { key: "mcp", label: "MCP", match: (e) => e === "hook_elicitation" || e === "hook_elicitationresult", color: "bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20" },
   { key: "errors", label: "Errors", match: (e) => e === "hook_posttoolusefailure" || e === "hook_stopfailure", color: "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20" },
+  { key: "notifications", label: "Notifications", match: (e) => e === "hook_notification", color: "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border-yellow-500/20" },
+  { key: "worktree", label: "Worktrees", match: (e) => e === "hook_worktreecreate" || e === "hook_worktreeremove", color: "bg-amber-400/10 text-amber-600 dark:text-amber-300 border-amber-400/20" },
 ];
 
 /* ── Tree data structures ────────────────────────────────── */
@@ -845,6 +847,12 @@ function eventLabel(evt: RawOtelEvent): string {
   if (eName === "hook_elicitationresult") return "MCP reply";
   if (eName === "hook_notification") return "notify";
   if (eName === "hook_sessionstart") return "session";
+  if (eName === "hook_userpromptsubmit") return "prompt";
+  if (eName === "hook_assistant_response") return "response";
+  if (eName === "hook_assistant_thinking") return "thinking";
+  if (eName === "hook_subagentstart") return attrs.agent_type || "agent+";
+  if (eName === "hook_subagentstop") return attrs.agent_type || "agent-";
+  if (eName === "hook_stop") return attrs.stop_reason || "end_turn";
   if (isHookEvent(eName)) return attrs.tool_name || eName.replace("hook_", "");
   return eName;
 }

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -207,13 +207,14 @@ function deduplicateEvents(events: RawOtelEvent[]): RawOtelEvent[] {
   for (const evt of events) {
     const eName = getEventName(evt);
 
-    // Drop OTEL user_prompt when hooks have the richer version.
-    // But keep hook-sourced user_prompt events (they have hook_event attr
-    // or prompt_length — these were stored before the event name fix).
+    // Drop ALL user_prompt events when hooks are present.
+    // hook_userpromptsubmit carries the same (or richer) data.
+    // Legacy hook events stored before the event-name fix also resolved
+    // as "user_prompt" with prompt_length/tool_name set — keeping those
+    // caused duplicate turn boundaries alongside the properly-named
+    // hook_userpromptsubmit event for the same prompt.
     if (eName === "user_prompt" && hasHooks) {
-      const a = evt.attributes ?? {};
-      const isFromHook = a.hook_event || a.prompt_length || a.tool_name === "user_prompt";
-      if (!isFromHook) continue;
+      continue;
     }
 
     // Drop OTEL tool_decision / tool_result — their metadata gets merged into hooks below


### PR DESCRIPTION
## Summary

- **Declarative settings reconciler** (Closes #270): Replaces nuclear `settings["hooks"] = {...}` with Terraform-style non-destructive reconciliation. Observal hooks are identified by `_observal` metadata markers (with legacy path fallback). Foreign hooks/env vars are preserved. Fixes ECONNREFUSED for users with pre-existing hooks.
- **`observal hook sync` CLI command** (Closes #271): Standalone hook upgrade with `--dry-run` support — no need to re-run `observal auth login` when hook specs change between releases.
- **Stop hook rewrite** (Closes #272): Fixes zero assistant response/thinking capture across all sessions. Removes `set -eu`, uses process substitution to avoid subshell scoping, adds thinking block extraction.
- **Thinking spans in session detail UI** (Closes #273): `hook_assistant_thinking` events render as fuchsia-styled collapsible blocks within turns, chronologically before the response.
- **Session Info tab** (Closes #274): New tab alongside Traces showing session metadata and active hooks with event counts. Missing hooks are dimmed — immediately answers "why no thinking traces?" without digging into hook config.
- **Buffer payload encryption** (Closes #253): ECIES encryption (ephemeral EC P-256 + ECDH + HKDF + AES-256-GCM) for telemetry payloads in the local SQLite buffer. Encrypted at write, decrypted server-side on flush. Graceful fallback to plaintext when cryptography library or server public key unavailable. Tamper rejection via AES-GCM AEAD.
- **Fix duplicate/empty turns** (Closes #275): The dedup carve-out for legacy `user_prompt` events created duplicate turn boundaries alongside `hook_userpromptsubmit`. Now drops all `user_prompt` events when hooks are present.
- **Cache write tokens in stats** (Closes #276): Display `cache_creation_tokens` in the session summary card and per-API-request inline stats.

## Files changed

| File | What |
|---|---|
| `observal_cli/hooks_spec.py` | Declarative hook/env spec, `_observal` metadata, `HOOKS_SPEC_VERSION` |
| `observal_cli/settings_reconciler.py` | Non-destructive merge engine with version tracking |
| `observal_cli/cmd_auth.py` | Refactored `_configure_claude_code()` to use reconciler + fetch server public key |
| `observal_cli/cmd_hook.py` | New `hook sync` command with `--dry-run` |
| `observal_cli/hooks/observal-stop-hook.sh` | Rewritten stop hook with thinking capture |
| `observal_cli/hooks/payload_crypto.py` | ECIES encryption: ephemeral EC key + AES-256-GCM |
| `observal_cli/hooks/buffer_event.py` | Encrypts payloads before SQLite storage |
| `observal_cli/hooks/flush_buffer.py` | Sends `X-Observal-Encrypted` header for encrypted rows |
| `observal-server/api/routes/otel_dashboard.py` | `hook_assistant_thinking` event type, crypto endpoint, encrypted payload handling |
| `observal-server/services/crypto.py` | Server-side ECIES decryption, public key PEM endpoint |
| `web/src/app/(admin)/traces/[id]/page.tsx` | ThinkingBlock, Session Info tab, dedup fix, cache write stat |
| `tests/test_settings_reconciler.py` | 25 tests: fresh install, upgrade, preservation, idempotency |
| `tests/test_payload_crypto.py` | 11 tests: round-trip, tamper detection, fallback, format validation |

## Test plan

- [x] `pytest tests/test_settings_reconciler.py` — 25/25 passing
- [x] `pytest tests/test_payload_crypto.py` — 11/11 passing
- [x] Full test suite — 985/985 passing
- [x] `ruff check` + `ruff format --check` — clean
- [x] `tsc --noEmit` — clean
- [ ] Manual: verify cache write tokens appear in session stats
- [ ] Manual: verify duplicate empty turns are gone in session detail
- [ ] Manual: verify thinking blocks appear in session detail after stop hook fires
- [ ] Manual: verify Session Info tab shows active hooks with correct counts

Closes #253, Closes #270, Closes #271, Closes #272, Closes #273, Closes #274, Closes #275, Closes #276