### PR TITLE
feat(docker): wire enterprise env vars into Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,20 @@ AWS_REGION=us-east-1
 OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRET=
 OAUTH_SERVER_METADATA_URL=
+
+# Deployment mode: "local" (default) or "enterprise"
+# Local mode: self-registration, bootstrap endpoint, built-in account creation
+# Enterprise mode: SSO-only login, SCIM provisioning, no self-registration
+DEPLOYMENT_MODE=local
+
+# Demo accounts — seeded on first startup when no real users exist.
+# Automatically cleaned up when a real super_admin is created.
+# Set all 8 vars to enable, or leave unset to skip demo seeding.
+DEMO_SUPER_ADMIN_EMAIL=super@demo.local
+DEMO_SUPER_ADMIN_PASSWORD=super-changeme
+DEMO_ADMIN_EMAIL=admin@demo.local
+DEMO_ADMIN_PASSWORD=admin-changeme
+DEMO_REVIEWER_EMAIL=reviewer@demo.local
+DEMO_REVIEWER_PASSWORD=reviewer-changeme
+DEMO_USER_EMAIL=user@demo.local
+DEMO_USER_PASSWORD=user-changeme

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,17 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_REGION=${AWS_REGION:-us-east-1}
+      # Enterprise deployment mode
+      - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-local}
+      # Demo accounts (seeded on first startup when no real users exist)
+      - DEMO_SUPER_ADMIN_EMAIL=${DEMO_SUPER_ADMIN_EMAIL:-super@demo.local}
+      - DEMO_SUPER_ADMIN_PASSWORD=${DEMO_SUPER_ADMIN_PASSWORD:-super-changeme}
+      - DEMO_ADMIN_EMAIL=${DEMO_ADMIN_EMAIL:-admin@demo.local}
+      - DEMO_ADMIN_PASSWORD=${DEMO_ADMIN_PASSWORD:-admin-changeme}
+      - DEMO_REVIEWER_EMAIL=${DEMO_REVIEWER_EMAIL:-reviewer@demo.local}
+      - DEMO_REVIEWER_PASSWORD=${DEMO_REVIEWER_PASSWORD:-reviewer-changeme}
+      - DEMO_USER_EMAIL=${DEMO_USER_EMAIL:-user@demo.local}
+      - DEMO_USER_PASSWORD=${DEMO_USER_PASSWORD:-user-changeme}
     depends_on:
       observal-db:
         condition: service_healthy
@@ -84,6 +95,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_REGION=${AWS_REGION:-us-east-1}
+      - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-local}
     depends_on:
       observal-db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Completes **Phase 5** of the enterprise deployment mode plan, the 3rd and final PR in the enterprise mode series.

- Wire `DEPLOYMENT_MODE` into both `observal-api` and `observal-worker` service environment blocks with `local` default
- Add all 8 `DEMO_*` account variables to `observal-api` with sensible demo defaults
- Document all new env vars in `.env.example` with comments explaining local vs enterprise behavior

**Previous PRs in this series:**
- PR #265 — RBAC, Alembic, require_role, frontend guards (Phase 1 + 4)
- PR #266 — Deployment guards, event bus, demo accounts, ee/ scaffold (Phase 2 + 3)

Closes #277

## Test plan

- [ ] `docker compose config` validates with no errors
- [ ] Fresh `docker compose up` seeds demo accounts (check API logs for "Demo accounts seeded" warning)
- [ ] Setting `DEPLOYMENT_MODE=enterprise` in `.env` activates enterprise mode (bootstrap/register return 403)
- [ ] Overriding `DEMO_*` vars in `.env` uses custom demo credentials instead of defaults
- [ ] Unsetting all `DEMO_*` vars skips demo seeding entirely