### PR TITLE
fix(docker): harden containers for production deployment

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.7.12 /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -10,6 +10,12 @@ COPY observal-server/pyproject.toml observal-server/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY observal-server/ .
+
+RUN groupadd --system --gid 1001 appgroup && \
+    useradd --system --uid 1001 --gid appgroup appuser && \
+    chown -R appuser:appgroup /app
+
+USER appuser
 
 EXPOSE 8000
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,22 @@ services:
         condition: service_healthy
       observal-redis:
         condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\""]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     networks:
       - observal-net
 
@@ -37,11 +53,15 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     networks:
       - observal-net
 
   observal-clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:24.8
     ports:
       - "8123:8123"
     env_file:
@@ -55,6 +75,10 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     networks:
       - observal-net
 
@@ -69,6 +93,10 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     networks:
       - observal-net
 
@@ -91,6 +119,16 @@ services:
         condition: service_healthy
       observal-clickhouse:
         condition: service_started
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     networks:
       - observal-net
 
@@ -104,11 +142,21 @@ services:
       - NEXT_PUBLIC_API_URL=http://observal-api:8000
     depends_on:
       - observal-api
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     networks:
       - observal-net
 
   observal-otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.115.0
     command: ["--config", "/etc/otelcol/config.yaml"]
     restart: on-failure
     ports:
@@ -119,6 +167,12 @@ services:
     depends_on:
       observal-clickhouse:
         condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     networks:
       - observal-net
 


### PR DESCRIPTION
## Summary

- **Dockerfile.api**: Pin uv to v0.7.12, add non-root `appuser` (uid 1001), chown app files, and switch to `USER appuser` before CMD
- **docker-compose.yml**: Pin ClickHouse to 24.8 LTS and OTEL Collector to 0.115.0; add `restart: unless-stopped` to api/worker/web; add healthcheck to api service; add memory limits to all services; add `security_opt: [no-new-privileges:true]` to api/worker/web/otel-collector; add `read_only: true` with tmpfs to api/worker/web
- **Dockerfile.web**: Already hardened with non-root user — no changes needed

Closes #187

## Test plan

- [ ] Run `cd docker && docker compose config` to validate compose syntax (done, passes)
- [ ] Run `docker compose build` to verify Dockerfile.api builds with the new non-root user
- [ ] Run `docker compose up` and verify all services start and pass healthchecks
- [ ] Verify the API container runs as uid 1001 (`docker exec observal-api id`)
- [ ] Verify `read_only` enforcement: writing to `/app` inside api/worker/web containers should fail, writing to `/tmp` should succeed
- [ ] Verify memory limits are applied: `docker stats` should show limits