### PR TITLE
fix(web): wire actual user name into dashboard sidebar

### DIFF
--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Eye, EyeOff, ArrowRight, Loader2, AlertCircle, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
-import { auth, setApiKey, setUserRole, getUserRole } from "@/lib/api";
+import { auth, setApiKey, setUserRole, getUserRole, setUserName, setUserEmail } from "@/lib/api";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -57,9 +57,11 @@ function LoginContent() {
           }
           return res.json();
         })
-        .then((data: { api_key: string; user: { role: string } }) => {
+        .then((data: { api_key: string; user: { role: string; name: string; email: string } }) => {
           setApiKey(data.api_key);
           setUserRole(data.user.role);
+          setUserName(data.user.name);
+          setUserEmail(data.user.email);
           toast.success("Signed in successfully via SSO");
           router.push("/");
         })
@@ -86,6 +88,8 @@ function LoginContent() {
       const res = await auth.login({ email, password });
       setApiKey(res.api_key);
       setUserRole(res.user.role);
+      setUserName(res.user.name);
+      setUserEmail(res.user.email);
       toast.success("Signed in successfully");
       router.push("/");
     } catch (e) {
@@ -104,6 +108,8 @@ function LoginContent() {
       const res = await auth.register({ email, name, password });
       setApiKey(res.api_key);
       setUserRole(res.user.role);
+      setUserName(res.user.name);
+      setUserEmail(res.user.email);
       toast.success("Account created");
       router.push("/");
     } catch (e) {
@@ -122,6 +128,8 @@ function LoginContent() {
       const res = await auth.login({ api_key: apiKey });
       setApiKey(res.api_key);
       setUserRole(res.user.role);
+      setUserName(res.user.name);
+      setUserEmail(res.user.email);
       toast.success("Signed in successfully");
       router.push("/");
     } catch (e) {
@@ -156,6 +164,8 @@ function LoginContent() {
       const res = await auth.resetPassword({ email, token: resetToken, new_password: newPassword });
       setApiKey(res.api_key);
       setUserRole(res.user.role);
+      setUserName(res.user.name);
+      setUserEmail(res.user.email);
       toast.success("Password reset successfully");
       router.push("/");
     } catch (e) {

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -31,7 +31,7 @@ import {
   Settings,
   AlertTriangle,
 } from "lucide-react";
-import { getUserRole } from "@/lib/api";
+import { getUserRole, getUserName, getUserEmail } from "@/lib/api";
 import { hasMinRole, type Role } from "@/hooks/use-role-guard";
 
 type NavItem = { title: string; href: string; icon: typeof Home; requiresAuth?: boolean; minRole?: Role };
@@ -66,6 +66,8 @@ export const allNavItems = [
 export function RegistrySidebar() {
   const pathname = usePathname();
   const role = getUserRole();
+  const userName = getUserName();
+  const userEmail = getUserEmail();
   const isAuthenticated = typeof window !== "undefined" && !!localStorage.getItem("observal_api_key");
 
   function isActive(href: string) {
@@ -161,7 +163,7 @@ export function RegistrySidebar() {
       </SidebarContent>
       <SidebarFooter>
         <ThemeSwitcher />
-        <NavUser user={{ name: "User", email: "" }} />
+        <NavUser user={{ name: userName || "User", email: userEmail || "" }} />
       </SidebarFooter>
       <SidebarRail />
     </Sidebar>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -39,6 +39,8 @@ export function setApiKey(key: string) {
 export function clearApiKey() {
   localStorage.removeItem("observal_api_key");
   localStorage.removeItem("observal_user_role");
+  localStorage.removeItem("observal_user_name");
+  localStorage.removeItem("observal_user_email");
 }
 
 export function setUserRole(role: string) {
@@ -50,9 +52,29 @@ export function getUserRole(): string | null {
   return localStorage.getItem("observal_user_role");
 }
 
+export function setUserName(name: string) {
+  localStorage.setItem("observal_user_name", name);
+}
+
+export function getUserName(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("observal_user_name");
+}
+
+export function setUserEmail(email: string) {
+  localStorage.setItem("observal_user_email", email);
+}
+
+export function getUserEmail(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("observal_user_email");
+}
+
 export function clearSession() {
   localStorage.removeItem("observal_api_key");
   localStorage.removeItem("observal_user_role");
+  localStorage.removeItem("observal_user_name");
+  localStorage.removeItem("observal_user_email");
 }
 
 async function request<T = unknown>(


### PR DESCRIPTION
## Summary
- Add `setUserName`, `getUserName`, `setUserEmail`, `getUserEmail` localStorage helpers to `web/src/lib/api.ts`
- Save user name and email to localStorage on every login path (password, register, API key, SSO callback, password reset)
- Update `clearApiKey` and `clearSession` to also clear name/email from localStorage
- Replace hardcoded `"User"` in `NavUser` sidebar component with the stored user name (falling back to `"User"` if not set)

Closes #261

## Test plan
- [ ] Log in via email/password and verify the sidebar shows your actual name and email
- [ ] Register a new account and verify the sidebar shows the new user's name and email
- [ ] Log in via API key and verify the sidebar shows the correct user info
- [ ] Reset password and verify user info is preserved in the sidebar
- [ ] Log out (clear session) and log back in; verify the sidebar updates correctly
- [ ] Verify that unauthenticated users still see "User" as the fallback