### PR TITLE
feat(cli): remove deprecated observal init command

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -262,15 +262,14 @@ def reset_password(
 
 
 @auth_app.command()
-def init(
-    server: str = typer.Option(None, "--server", "-s", help="Server URL"),
-    config_only: bool = typer.Option(False, "--config-only", help="Initialize config without server validation"),
-):
-    """First-run setup (alias for login)."""
-    if config_only:
-        _do_config_only_init(server)
-    else:
-        login(server=server, key=None, email=None, password=None, code=None, name=None)
+def init():
+    """[Removed] Use 'observal auth login' + 'observal pull' instead."""
+    rprint("[yellow]'observal auth init' has been removed.[/yellow]")
+    rprint()
+    rprint("Use these commands instead:")
+    rprint("  [bold]observal auth login[/bold]   — connect to your server")
+    rprint("  [bold]observal pull[/bold]          — pull your configuration")
+    raise typer.Exit(1)
 
 
 @auth_app.command()
@@ -372,16 +371,14 @@ def register_deprecated_auth(app: typer.Typer):
     """Register deprecated root-level aliases."""
 
     @app.command(name="init", hidden=True)
-    def deprecated_init(
-        server: str = typer.Option(None, "--server", "-s", help="Server URL"),
-        config_only: bool = typer.Option(False, "--config-only", help="Initialize config without server validation"),
-    ):
-        """[Deprecated] Use 'observal auth login' instead."""
-        _deprecation_notice("login")
-        if config_only:
-            _do_config_only_init(server)
-        else:
-            login(server=server, key=None, email=None, password=None, code=None, name=None)
+    def deprecated_init():
+        """[Removed] Use 'observal auth login' + 'observal pull' instead."""
+        rprint("[yellow]'observal init' has been removed.[/yellow]")
+        rprint()
+        rprint("Use these commands instead:")
+        rprint("  [bold]observal auth login[/bold]   — connect to your server")
+        rprint("  [bold]observal pull[/bold]          — pull your configuration")
+        raise typer.Exit(1)
 
     @app.command(name="login", hidden=True)
     def deprecated_login(

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -251,7 +251,7 @@ def _check_observal_config(issues: list, warnings: list):
     """Check Observal's own config."""
     config_path = Path.home() / ".observal" / "config.json"
     if not config_path.exists():
-        issues.append("~/.observal/config.json not found. Run `observal init` first.")
+        issues.append("~/.observal/config.json not found. Run `observal auth login` first.")
         return
 
     data = _load_json(config_path)
@@ -263,7 +263,7 @@ def _check_observal_config(issues: list, warnings: list):
         issues.append("No API key in ~/.observal/config.json. Run `observal login`.")
 
     if not data.get("server_url"):
-        issues.append("No server_url in ~/.observal/config.json. Run `observal init`.")
+        issues.append("No server_url in ~/.observal/config.json. Run `observal auth login`.")
 
     # Check server is reachable
     server_url = data.get("server_url", "")
@@ -391,8 +391,8 @@ def doctor(
                 rprint('  Add `"OBSERVAL_API_KEY"` to `httpHookAllowedEnvVars`')
             elif "allowManagedHooksOnly" in issue:
                 rprint("  Set `allowManagedHooksOnly: false` or add Observal hooks to managed config")
-            elif "observal init" in issue:
-                rprint("  Run: observal init")
+            elif "observal auth login" in issue:
+                rprint("  Run: observal auth login")
             elif "observal login" in issue:
                 rprint("  Run: observal login")
             elif "Cannot reach" in issue:

--- a/observal_cli/config.py
+++ b/observal_cli/config.py
@@ -50,7 +50,7 @@ def get_or_exit() -> dict:
         from rich import print as rprint
 
         rprint(
-            "[red]Not configured.[/red] Run [bold]observal init[/bold], [bold]observal login[/bold], or set the [bold]OBSERVAL_API_KEY[/bold] environment variable."
+            "[red]Not configured.[/red] Run [bold]observal auth login[/bold] or set the [bold]OBSERVAL_API_KEY[/bold] environment variable."
         )
         raise typer.Exit(1)
     return cfg


### PR DESCRIPTION
## Summary
- Replaced `observal auth init` and `observal init` commands with removal stubs that print a helpful message directing users to `observal auth login` + `observal pull`
- Updated error messages in `config.py` and `cmd_doctor.py` to reference `observal auth login` instead of the removed `observal init`
- Doctor fix suggestions now correctly point to `observal auth login`

Closes #254

## Test plan
- [ ] Run `observal auth init` and verify it prints the removal message and exits with code 1
- [ ] Run `observal init` and verify it prints the removal message and exits with code 1
- [ ] Run `observal doctor` on a system with no config and verify the message says `observal auth login` (not `observal init`)
- [ ] Verify `observal auth login` still works correctly end-to-end
- [ ] All existing tests pass (881 passed)