### PR TITLE
feat: add resilience patterns for ClickHouse, Redis, and HTTP clients (#193)

### DIFF
--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -217,7 +217,7 @@ async def liveness():
 
 @app.get("/health")
 async def readiness(db: AsyncSession = Depends(get_db)):
-    """K8s readiness probe. Checks DB connectivity and enterprise config."""
+    """K8s readiness probe. Checks DB connectivity, ClickHouse, and enterprise config."""
     checks: dict[str, object] = {"status": "ok"}
 
     try:
@@ -226,6 +226,15 @@ async def readiness(db: AsyncSession = Depends(get_db)):
     except Exception:
         checks["status"] = "unhealthy"
         return JSONResponse(content=checks, status_code=503)
+
+    # ClickHouse health
+    from services.clickhouse import clickhouse_health
+
+    if not await clickhouse_health():
+        checks["clickhouse"] = "unreachable"
+        checks["status"] = "degraded"
+    else:
+        checks["clickhouse"] = "ok"
 
     if settings.DEPLOYMENT_MODE == "enterprise":
         issues = getattr(app.state, "enterprise_issues", [])

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "slowapi",
     "PyJWT>=2.8.0",
     "aiosqlite>=0.22.1",
+    "tenacity>=8.0.0",
 ]
 
 [dependency-groups]

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from urllib.parse import urlparse
 
 import httpx
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from config import settings
 
@@ -25,6 +26,12 @@ def _get_client() -> httpx.AsyncClient:
     return _client
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.5, min=0.5, max=5),
+    retry=retry_if_exception_type((httpx.ConnectError, httpx.ConnectTimeout)),
+    reraise=True,
+)
 async def _query(sql: str, params: dict | None = None, *, data: str | None = None):
     """Execute a ClickHouse query via HTTP.
 
@@ -47,6 +54,15 @@ async def _query(sql: str, params: dict | None = None, *, data: str | None = Non
         query_params.update(params)
     body = f"{sql}\n{data}" if data else sql
     return await client.post(CLICKHOUSE_HTTP, content=body, params=query_params)
+
+
+async def clickhouse_health() -> bool:
+    """Check ClickHouse connectivity. Returns True if healthy."""
+    try:
+        resp = await _query("SELECT 1")
+        return resp.status_code == 200
+    except Exception:
+        return False
 
 
 INIT_SQL = [
@@ -224,12 +240,19 @@ INIT_SQL = [
 
 
 async def init_clickhouse():
-    """Create ClickHouse tables if they don't exist."""
+    """Create ClickHouse tables if they don't exist.
+
+    Raises on unreachable server so startup fails fast.
+    """
+    # Verify ClickHouse is reachable before running DDL
+    if not await clickhouse_health():
+        raise RuntimeError(f"ClickHouse unreachable at {CLICKHOUSE_HTTP}")
+
     for stmt in INIT_SQL:
         try:
             await _query(stmt)
         except Exception as e:
-            logger.warning(f"ClickHouse init failed: {e}")
+            logger.warning(f"ClickHouse init statement failed: {e}")
 
 
 async def insert_tool_call(event: dict):

--- a/observal-server/services/redis.py
+++ b/observal-server/services/redis.py
@@ -25,28 +25,53 @@ def get_redis() -> aioredis.Redis:
 
 async def publish(channel: str, data: dict):
     """Publish a message to a Redis pub/sub channel (for GraphQL subscriptions)."""
+    import asyncio
+
     r = get_redis()
-    try:
-        await r.publish(channel, json.dumps(data))
-    except Exception as e:
-        logger.warning(f"Redis publish failed: {e}")
+    attempts = 0
+    max_attempts = 3
+    while attempts < max_attempts:
+        try:
+            await r.publish(channel, json.dumps(data))
+            return
+        except (ConnectionError, OSError) as e:
+            attempts += 1
+            if attempts >= max_attempts:
+                logger.warning(f"Redis publish failed after {max_attempts} attempts: {e}")
+                return
+            logger.debug(f"Redis publish attempt {attempts} failed, retrying: {e}")
+            await asyncio.sleep(0.5 * attempts)
 
 
 async def subscribe(channel: str):
-    """Subscribe to a Redis pub/sub channel. Yields parsed messages."""
-    r = get_redis()
-    pubsub = r.pubsub()
-    await pubsub.subscribe(channel)
-    try:
-        async for message in pubsub.listen():
-            if message["type"] == "message":
-                try:
-                    yield json.loads(message["data"])
-                except (json.JSONDecodeError, TypeError):
-                    continue
-    finally:
-        await pubsub.unsubscribe(channel)
-        await pubsub.close()
+    """Subscribe to a Redis pub/sub channel. Yields parsed messages. Auto-reconnects."""
+    import asyncio
+
+    max_reconnects = 5
+    reconnect_count = 0
+    while reconnect_count < max_reconnects:
+        r = get_redis()
+        pubsub = r.pubsub()
+        try:
+            await pubsub.subscribe(channel)
+            async for message in pubsub.listen():
+                reconnect_count = 0  # Reset on successful message
+                if message["type"] == "message":
+                    try:
+                        yield json.loads(message["data"])
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+        except (ConnectionError, OSError) as e:
+            reconnect_count += 1
+            logger.warning(f"Redis subscribe reconnecting ({reconnect_count}/{max_reconnects}): {e}")
+            await asyncio.sleep(1.0 * reconnect_count)
+        finally:
+            try:
+                await pubsub.unsubscribe(channel)
+                await pubsub.close()
+            except Exception:
+                pass
+    logger.error(f"Redis subscribe gave up after {max_reconnects} reconnects on channel {channel}")
 
 
 async def enqueue_eval(agent_id: str, trace_id: str | None = None):

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -98,10 +98,7 @@ def _request_with_retry(
             return r
         # Honor Retry-After header if present
         retry_after = r.headers.get("Retry-After")
-        if retry_after:
-            delay = float(retry_after)
-        else:
-            delay = 0.5 * (2**attempt)
+        delay = float(retry_after) if retry_after else 0.5 * (2**attempt)
         logger.debug(f"Retrying {method.upper()} {url} (attempt {attempt + 1}, delay {delay:.1f}s)")
         time.sleep(delay)
     return r  # unreachable but satisfies type checker

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 import httpx
@@ -8,8 +9,7 @@ from rich.console import Console
 from observal_cli import config
 
 console = Console(stderr=True)
-
-_TIMEOUT = 30
+logger = logging.getLogger(__name__)
 
 
 def _client() -> tuple[str, dict]:
@@ -17,71 +17,114 @@ def _client() -> tuple[str, dict]:
     return cfg["server_url"].rstrip("/"), {"X-API-Key": cfg["api_key"]}
 
 
-def _handle_error(e: httpx.HTTPStatusError):
+def _handle_error(e: httpx.HTTPStatusError, path: str = ""):
+    """Handle HTTP errors with actionable messages."""
     ct = e.response.headers.get("content-type", "")
     detail = e.response.json().get("detail", e.response.text) if "application/json" in ct else e.response.text
     code = e.response.status_code
+
+    path_info = f" ({path})" if path else ""
+
     if code == 401:
-        rprint("[red]Authentication failed.[/red] Run [bold]observal login[/bold] to re-authenticate.")
+        rprint(f"[red]Authentication failed{path_info}.[/red]")
+        rprint("[dim]  Run [bold]observal auth login[/bold] to re-authenticate.[/dim]")
     elif code == 403:
-        rprint("[red]Permission denied.[/red] This action requires a higher role.")
+        rprint(f"[red]Permission denied{path_info}.[/red]")
+        rprint("[dim]  This action requires a higher role (admin or super_admin).[/dim]")
     elif code == 404:
-        rprint("[red]Not found.[/red]")
+        rprint(f"[red]Not found{path_info}.[/red]")
+        rprint(
+            "[dim]  Check that the resource ID is correct, or use [bold]observal registry mcp list[/bold] to browse.[/dim]"
+        )
+    elif code == 429:
+        rprint(f"[red]Rate limited{path_info}.[/red]")
+        retry_after = e.response.headers.get("Retry-After", "a few seconds")
+        rprint(f"[dim]  Try again in {retry_after}.[/dim]")
+    elif code >= 500:
+        rprint(f"[red]Server error {code}{path_info}.[/red]")
+        rprint("[dim]  Check server logs or run [bold]observal doctor[/bold] for diagnostics.[/dim]")
     else:
-        rprint(f"[red]Error {code}:[/red] {detail}")
+        rprint(f"[red]Error {code}{path_info}:[/red] {detail}")
+
     raise typer.Exit(code=1)
 
 
 def _handle_connect():
-    rprint("[red]Connection failed.[/red] Is the server running?")
-    rprint(f"[dim]Server URL: {config.load().get('server_url', 'not set')}[/dim]")
+    """Handle connection errors."""
+    cfg = config.load()
+    server_url = cfg.get("server_url", "not set")
+    rprint("[red]Connection failed.[/red] Cannot reach the Observal server.")
+    rprint(f"[dim]  Server URL: {server_url}[/dim]")
+    rprint("[dim]  Is the server running? Try [bold]observal doctor[/bold] to diagnose.[/dim]")
+    raise typer.Exit(code=1)
+
+
+def _handle_timeout(path: str = ""):
+    """Handle request timeout."""
+    timeout = config.get_timeout()
+    path_info = f" ({path})" if path else ""
+    rprint(f"[red]Request timed out{path_info}.[/red]")
+    rprint(f"[dim]  Timeout: {timeout}s. Increase with [bold]OBSERVAL_TIMEOUT[/bold] env var or config.[/dim]")
+    rprint("[dim]  Check server health with [bold]observal doctor[/bold].[/dim]")
     raise typer.Exit(code=1)
 
 
 def get(path: str, params: dict | None = None) -> dict:
     base, headers = _client()
+    timeout = config.get_timeout()
     try:
-        r = httpx.get(f"{base}{path}", headers=headers, params=params, timeout=_TIMEOUT)
+        r = httpx.get(f"{base}{path}", headers=headers, params=params, timeout=timeout)
         r.raise_for_status()
         return r.json()
     except httpx.HTTPStatusError as e:
-        _handle_error(e)
+        _handle_error(e, path)
+    except httpx.ReadTimeout:
+        _handle_timeout(path)
     except httpx.ConnectError:
         _handle_connect()
 
 
 def post(path: str, json_data: dict | None = None) -> dict:
     base, headers = _client()
+    timeout = config.get_timeout()
     try:
-        r = httpx.post(f"{base}{path}", headers=headers, json=json_data, timeout=_TIMEOUT)
+        r = httpx.post(f"{base}{path}", headers=headers, json=json_data, timeout=timeout)
         r.raise_for_status()
         return r.json()
     except httpx.HTTPStatusError as e:
-        _handle_error(e)
+        _handle_error(e, path)
+    except httpx.ReadTimeout:
+        _handle_timeout(path)
     except httpx.ConnectError:
         _handle_connect()
 
 
 def put(path: str, json_data: dict | None = None) -> dict:
     base, headers = _client()
+    timeout = config.get_timeout()
     try:
-        r = httpx.put(f"{base}{path}", headers=headers, json=json_data, timeout=_TIMEOUT)
+        r = httpx.put(f"{base}{path}", headers=headers, json=json_data, timeout=timeout)
         r.raise_for_status()
         return r.json()
     except httpx.HTTPStatusError as e:
-        _handle_error(e)
+        _handle_error(e, path)
+    except httpx.ReadTimeout:
+        _handle_timeout(path)
     except httpx.ConnectError:
         _handle_connect()
 
 
 def delete(path: str) -> dict:
     base, headers = _client()
+    timeout = config.get_timeout()
     try:
-        r = httpx.delete(f"{base}{path}", headers=headers, timeout=_TIMEOUT)
+        r = httpx.delete(f"{base}{path}", headers=headers, timeout=timeout)
         r.raise_for_status()
         return r.json()
     except httpx.HTTPStatusError as e:
-        _handle_error(e)
+        _handle_error(e, path)
+    except httpx.ReadTimeout:
+        _handle_timeout(path)
     except httpx.ConnectError:
         _handle_connect()
 

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -69,12 +69,48 @@ def _handle_timeout(path: str = ""):
     raise typer.Exit(code=1)
 
 
+_MAX_RETRIES = 3
+_RETRY_STATUSES = {429, 503, 504}
+
+
+def _request_with_retry(
+    method: str,
+    url: str,
+    headers: dict,
+    *,
+    params: dict | None = None,
+    json: dict | None = None,
+) -> httpx.Response:
+    """Execute an HTTP request with retries on 429/503/504 and Retry-After support."""
+    timeout = config.get_timeout()
+    func = getattr(httpx, method)
+
+    kwargs: dict = {"headers": headers, "timeout": timeout}
+    if params is not None:
+        kwargs["params"] = params
+    if json is not None:
+        kwargs["json"] = json
+
+    for attempt in range(_MAX_RETRIES):
+        r = func(url, **kwargs)
+        if r.status_code not in _RETRY_STATUSES or attempt == _MAX_RETRIES - 1:
+            r.raise_for_status()
+            return r
+        # Honor Retry-After header if present
+        retry_after = r.headers.get("Retry-After")
+        if retry_after:
+            delay = float(retry_after)
+        else:
+            delay = 0.5 * (2**attempt)
+        logger.debug(f"Retrying {method.upper()} {url} (attempt {attempt + 1}, delay {delay:.1f}s)")
+        time.sleep(delay)
+    return r  # unreachable but satisfies type checker
+
+
 def get(path: str, params: dict | None = None) -> dict:
     base, headers = _client()
-    timeout = config.get_timeout()
     try:
-        r = httpx.get(f"{base}{path}", headers=headers, params=params, timeout=timeout)
-        r.raise_for_status()
+        r = _request_with_retry("get", f"{base}{path}", headers, params=params)
         return r.json()
     except httpx.HTTPStatusError as e:
         _handle_error(e, path)
@@ -86,10 +122,8 @@ def get(path: str, params: dict | None = None) -> dict:
 
 def post(path: str, json_data: dict | None = None) -> dict:
     base, headers = _client()
-    timeout = config.get_timeout()
     try:
-        r = httpx.post(f"{base}{path}", headers=headers, json=json_data, timeout=timeout)
-        r.raise_for_status()
+        r = _request_with_retry("post", f"{base}{path}", headers, json=json_data)
         return r.json()
     except httpx.HTTPStatusError as e:
         _handle_error(e, path)
@@ -101,10 +135,8 @@ def post(path: str, json_data: dict | None = None) -> dict:
 
 def put(path: str, json_data: dict | None = None) -> dict:
     base, headers = _client()
-    timeout = config.get_timeout()
     try:
-        r = httpx.put(f"{base}{path}", headers=headers, json=json_data, timeout=timeout)
-        r.raise_for_status()
+        r = _request_with_retry("put", f"{base}{path}", headers, json=json_data)
         return r.json()
     except httpx.HTTPStatusError as e:
         _handle_error(e, path)
@@ -116,10 +148,8 @@ def put(path: str, json_data: dict | None = None) -> dict:
 
 def delete(path: str) -> dict:
     base, headers = _client()
-    timeout = config.get_timeout()
     try:
-        r = httpx.delete(f"{base}{path}", headers=headers, timeout=timeout)
-        r.raise_for_status()
+        r = _request_with_retry("delete", f"{base}{path}", headers)
         return r.json()
     except httpx.HTTPStatusError as e:
         _handle_error(e, path)

--- a/observal_cli/config.py
+++ b/observal_cli/config.py
@@ -56,6 +56,13 @@ def get_or_exit() -> dict:
     return cfg
 
 
+def get_timeout() -> int:
+    """Return the request timeout in seconds. Configurable via OBSERVAL_TIMEOUT env var."""
+    import os
+
+    return int(os.environ.get("OBSERVAL_TIMEOUT", "30"))
+
+
 # ── Aliases ──────────────────────────────────────────────
 
 

--- a/observal_cli/proxy.py
+++ b/observal_cli/proxy.py
@@ -44,30 +44,40 @@ async def _handle_request(
     # Forward headers, skip hop-by-hop
     fwd_headers = {k: v for k, v in headers.items() if k.lower() not in ("host", "transfer-encoding")}
 
-    start = time.monotonic()
-    try:
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.request(method, url, headers=fwd_headers, content=body)
-        latency_ms = int((time.monotonic() - start) * 1000)
-        resp_body = resp.content
-        resp_headers = dict(resp.headers)
+    max_attempts = 2
+    for attempt in range(max_attempts):
+        start = time.monotonic()
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.request(method, url, headers=fwd_headers, content=body)
+            latency_ms = int((time.monotonic() - start) * 1000)
+            resp_body = resp.content
+            resp_headers = dict(resp.headers)
 
-        # Try to capture JSON-RPC telemetry
-        req_msg = _parse_jsonrpc_body(body)
-        resp_msg = _parse_jsonrpc_body(resp_body)
+            # Try to capture JSON-RPC telemetry
+            req_msg = _parse_jsonrpc_body(body)
+            resp_msg = _parse_jsonrpc_body(resp_body)
 
-        if req_msg and isinstance(req_msg, dict) and "method" in req_msg:
-            state.on_request(req_msg)
-        if resp_msg and isinstance(resp_msg, dict):
-            span = state.on_response(resp_msg)
-            if span:
-                span["latency_ms"] = latency_ms
-                await state.buffer_span(span)
+            if req_msg and isinstance(req_msg, dict) and "method" in req_msg:
+                state.on_request(req_msg)
+            if resp_msg and isinstance(resp_msg, dict):
+                span = state.on_response(resp_msg)
+                if span:
+                    span["latency_ms"] = latency_ms
+                    await state.buffer_span(span)
 
-        return resp.status_code, resp_headers, resp_body
-    except Exception as e:
-        latency_ms = int((time.monotonic() - start) * 1000)
-        return 502, {"content-type": "application/json"}, json.dumps({"error": str(e)}).encode()
+            return resp.status_code, resp_headers, resp_body
+        except httpx.ConnectError:
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(1)
+                continue
+            return (
+                502,
+                {"content-type": "application/json"},
+                json.dumps({"error": "upstream connection failed"}).encode(),
+            )
+        except Exception as e:
+            return 502, {"content-type": "application/json"}, json.dumps({"error": str(e)}).encode()
 
 
 async def run_proxy(mcp_id: str, target_url: str, port: int = 0):

--- a/tests/test_clickhouse_phase1.py
+++ b/tests/test_clickhouse_phase1.py
@@ -141,7 +141,7 @@ class TestInitClickhouse:
         with patch("services.clickhouse._query", new_callable=AsyncMock) as mock_q:
             mock_q.return_value = _mock_response()
             await init_clickhouse()
-            assert mock_q.call_count == len(INIT_SQL)
+            assert mock_q.call_count == len(INIT_SQL) + 1  # +1 for health check
 
 
 # --- Insert tests (JSONEachRow format) ---

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -39,11 +39,13 @@ class TestReadiness:
 
         app.dependency_overrides[get_db] = _mock_get_db
         try:
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-                r = await ac.get("/health")
+            with patch("services.clickhouse.clickhouse_health", new_callable=AsyncMock, return_value=True):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                    r = await ac.get("/health")
             assert r.status_code == 200
             data = r.json()
             assert data["status"] == "ok"
+            assert data["clickhouse"] == "ok"
             assert data["initialized"] is True
         finally:
             app.dependency_overrides.clear()

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,262 @@
+"""Tests for resilience patterns: retries, health checks, and timeouts."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+# ---------------------------------------------------------------------------
+# ClickHouse _query retries on ConnectError
+# ---------------------------------------------------------------------------
+
+
+class TestClickHouseRetry:
+    """Verify _query retries on transient connection errors."""
+
+    @pytest.mark.asyncio
+    async def test_query_retries_on_connect_error(self):
+        """_query should retry up to 3 times on ConnectError."""
+        from services.clickhouse import _query
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_client.post = AsyncMock(
+            side_effect=[
+                httpx.ConnectError("conn refused"),
+                httpx.ConnectError("conn refused"),
+                mock_resp,
+            ]
+        )
+
+        with patch("services.clickhouse._get_client", return_value=mock_client):
+            resp = await _query("SELECT 1")
+            assert resp.status_code == 200
+            assert mock_client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_query_raises_after_max_retries(self):
+        """_query should reraise ConnectError after exhausting retries."""
+        from services.clickhouse import _query
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("conn refused"))
+
+        with patch("services.clickhouse._get_client", return_value=mock_client):
+            with pytest.raises(httpx.ConnectError):
+                await _query("SELECT 1")
+            assert mock_client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_query_retries_on_connect_timeout(self):
+        """_query should retry on ConnectTimeout."""
+        from services.clickhouse import _query
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_client.post = AsyncMock(side_effect=[httpx.ConnectTimeout("timeout"), mock_resp])
+
+        with patch("services.clickhouse._get_client", return_value=mock_client):
+            resp = await _query("SELECT 1")
+            assert resp.status_code == 200
+            assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_query_does_not_retry_on_other_errors(self):
+        """_query should NOT retry on non-transient errors like ReadError."""
+        from services.clickhouse import _query
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=httpx.ReadError("broken pipe"))
+
+        with patch("services.clickhouse._get_client", return_value=mock_client):
+            with pytest.raises(httpx.ReadError):
+                await _query("SELECT 1")
+            assert mock_client.post.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse clickhouse_health()
+# ---------------------------------------------------------------------------
+
+
+class TestClickHouseHealth:
+    """Verify clickhouse_health returns True/False."""
+
+    @pytest.mark.asyncio
+    async def test_health_returns_true_on_success(self):
+        from services.clickhouse import clickhouse_health
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        with patch("services.clickhouse._query", new_callable=AsyncMock, return_value=mock_resp):
+            assert await clickhouse_health() is True
+
+    @pytest.mark.asyncio
+    async def test_health_returns_false_on_error(self):
+        from services.clickhouse import clickhouse_health
+
+        with patch(
+            "services.clickhouse._query",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("unreachable"),
+        ):
+            assert await clickhouse_health() is False
+
+    @pytest.mark.asyncio
+    async def test_health_returns_false_on_non_200(self):
+        from services.clickhouse import clickhouse_health
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+
+        with patch("services.clickhouse._query", new_callable=AsyncMock, return_value=mock_resp):
+            assert await clickhouse_health() is False
+
+
+# ---------------------------------------------------------------------------
+# Redis publish() retries on ConnectionError
+# ---------------------------------------------------------------------------
+
+
+class TestRedisPublishRetry:
+    """Verify publish retries on ConnectionError."""
+
+    @pytest.mark.asyncio
+    async def test_publish_retries_on_connection_error(self):
+        from services.redis import publish
+
+        mock_redis = MagicMock()
+        mock_redis.publish = AsyncMock(side_effect=[ConnectionError("reset"), None])
+
+        with (
+            patch("services.redis.get_redis", return_value=mock_redis),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await publish("test-channel", {"msg": "hello"})
+            assert mock_redis.publish.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_publish_gives_up_after_max_attempts(self):
+        from services.redis import publish
+
+        mock_redis = MagicMock()
+        mock_redis.publish = AsyncMock(side_effect=ConnectionError("persistent failure"))
+
+        with (
+            patch("services.redis.get_redis", return_value=mock_redis),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await publish("test-channel", {"msg": "hello"})
+            assert mock_redis.publish.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_publish_retries_on_os_error(self):
+        from services.redis import publish
+
+        mock_redis = MagicMock()
+        mock_redis.publish = AsyncMock(side_effect=[OSError("network down"), None])
+
+        with (
+            patch("services.redis.get_redis", return_value=mock_redis),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await publish("test-channel", {"msg": "hello"})
+            assert mock_redis.publish.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI _request_with_retry()
+# ---------------------------------------------------------------------------
+
+
+class TestCliRetry:
+    """Verify CLI _request_with_retry retries on 429/503/504."""
+
+    def test_retries_on_429(self):
+        from observal_cli.client import _request_with_retry
+
+        mock_resp_429 = MagicMock(spec=httpx.Response)
+        mock_resp_429.status_code = 429
+        mock_resp_429.headers = {}
+
+        mock_resp_200 = MagicMock(spec=httpx.Response)
+        mock_resp_200.status_code = 200
+        mock_resp_200.headers = {}
+        mock_resp_200.raise_for_status = MagicMock()
+
+        with patch("httpx.get", side_effect=[mock_resp_429, mock_resp_200]), patch("time.sleep"):
+            r = _request_with_retry("get", "http://test/api", {"X-API-Key": "key"})
+            assert r.status_code == 200
+
+    def test_retries_on_503(self):
+        from observal_cli.client import _request_with_retry
+
+        mock_resp_503 = MagicMock(spec=httpx.Response)
+        mock_resp_503.status_code = 503
+        mock_resp_503.headers = {}
+
+        mock_resp_200 = MagicMock(spec=httpx.Response)
+        mock_resp_200.status_code = 200
+        mock_resp_200.headers = {}
+        mock_resp_200.raise_for_status = MagicMock()
+
+        with patch("httpx.get", side_effect=[mock_resp_503, mock_resp_200]), patch("time.sleep"):
+            r = _request_with_retry("get", "http://test/api", {"X-API-Key": "key"})
+            assert r.status_code == 200
+
+    def test_honors_retry_after_header(self):
+        from observal_cli.client import _request_with_retry
+
+        mock_resp_429 = MagicMock(spec=httpx.Response)
+        mock_resp_429.status_code = 429
+        mock_resp_429.headers = {"Retry-After": "3"}
+
+        mock_resp_200 = MagicMock(spec=httpx.Response)
+        mock_resp_200.status_code = 200
+        mock_resp_200.headers = {}
+        mock_resp_200.raise_for_status = MagicMock()
+
+        with (
+            patch("httpx.get", side_effect=[mock_resp_429, mock_resp_200]),
+            patch("time.sleep") as mock_sleep,
+        ):
+            r = _request_with_retry("get", "http://test/api", {"X-API-Key": "key"})
+            assert r.status_code == 200
+            mock_sleep.assert_called_once_with(3.0)
+
+    def test_does_not_retry_on_400(self):
+        """Non-retryable status codes should raise immediately."""
+        from observal_cli.client import _request_with_retry
+
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 400
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {"detail": "bad request"}
+        mock_resp.text = "bad request"
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("bad", request=MagicMock(), response=mock_resp)
+        )
+
+        with patch("httpx.get", return_value=mock_resp), pytest.raises(httpx.HTTPStatusError):
+            _request_with_retry("get", "http://test/api", {"X-API-Key": "key"})
+
+
+# ---------------------------------------------------------------------------
+# Shim explicit timeout
+# ---------------------------------------------------------------------------
+
+
+class TestShimTimeout:
+    """Verify the shim uses an explicit timeout on httpx calls."""
+
+    def test_shim_send_has_explicit_timeout(self):
+        """ShimState._send should use httpx.AsyncClient with a timeout."""
+        import inspect
+
+        from observal_cli.shim import ShimState
+
+        source = inspect.getsource(ShimState._send)
+        assert "timeout=" in source, "ShimState._send must specify an explicit timeout on httpx calls"

--- a/tests/test_worker_phase5.py
+++ b/tests/test_worker_phase5.py
@@ -33,7 +33,7 @@ class TestPublish:
     @pytest.mark.asyncio
     async def test_silent_on_error(self):
         mock_redis = AsyncMock()
-        mock_redis.publish.side_effect = Exception("connection refused")
+        mock_redis.publish.side_effect = ConnectionError("connection refused")
         with patch("services.redis.get_redis", return_value=mock_redis):
             await publish("ch", {})  # should not raise
 


### PR DESCRIPTION
## Summary

- **ClickHouse**: tenacity-based retry (3 attempts, exponential backoff) on `ConnectError`/`ConnectTimeout`, `clickhouse_health()` function, fail-fast `init_clickhouse()` with health pre-check
- **Redis**: `publish()` retries 3x on `ConnectionError`/`OSError` with backoff, `subscribe()` auto-reconnects up to 5 times
- **CLI client**: `_request_with_retry()` with exponential backoff for 429/503/504 responses, Retry-After header support, configurable timeout via `OBSERVAL_TIMEOUT`
- **Proxy**: retry once on upstream `ConnectError` before returning 502
- **Health endpoint**: `/health` now includes ClickHouse connectivity status (ok/unreachable/degraded)
- **Tests**: 15 new tests in `test_resilience.py`, 3 existing tests updated for new behavior

## Test plan

- [x] All 1000 tests pass (`uv run pytest tests/ -x -q`)
- [x] ruff lint and format clean
- [ ] Manual smoke test: verify `/health` returns `clickhouse: ok` when ClickHouse is running
- [ ] Manual smoke test: verify CLI retries on 429/503 responses
- [ ] Manual smoke test: verify proxy retries on upstream `ConnectError`

Closes #193