### PR TITLE
feat(alerts): add evaluation engine, webhook delivery, and audit history

### DIFF
--- a/observal-server/alembic/versions/0003_add_alert_history.py
+++ b/observal-server/alembic/versions/0003_add_alert_history.py
@@ -1,0 +1,66 @@
+"""Add alert_history table.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_name = 'alert_history'
+            ) THEN
+                CREATE TABLE alert_history (
+                    id UUID PRIMARY KEY,
+                    alert_rule_id UUID NOT NULL REFERENCES alert_rules(id),
+                    metric_value DOUBLE PRECISION NOT NULL,
+                    threshold DOUBLE PRECISION NOT NULL,
+                    condition VARCHAR(10) NOT NULL,
+                    fired_at TIMESTAMPTZ NOT NULL,
+                    delivery_status VARCHAR(20) DEFAULT 'pending',
+                    response_code INTEGER,
+                    error VARCHAR(1024),
+                    created_at TIMESTAMPTZ DEFAULT now()
+                );
+            END IF;
+        END
+        $$;
+    """)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_indexes
+                WHERE indexname = 'ix_alert_history_alert_rule_id'
+            ) THEN
+                CREATE INDEX ix_alert_history_alert_rule_id ON alert_history (alert_rule_id);
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_name = 'alert_history'
+            ) THEN
+                DROP TABLE alert_history;
+            END IF;
+        END
+        $$;
+    """)

--- a/observal-server/api/routes/alert.py
+++ b/observal-server/api/routes/alert.py
@@ -1,4 +1,5 @@
 import uuid
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
@@ -6,10 +7,22 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, require_role
 from models.alert import AlertRule
+from models.alert_history import AlertHistory
 from models.user import User, UserRole
-from schemas.alert import AlertRuleCreate, AlertRuleResponse, AlertRuleUpdate
+from schemas.alert import AlertHistoryResponse, AlertRuleCreate, AlertRuleResponse, AlertRuleUpdate
+from services.alert_evaluator import is_private_url
 
 router = APIRouter(prefix="/api/v1/alerts", tags=["alerts"])
+
+
+def _validate_webhook_url(url: str) -> None:
+    if not url:
+        return  # empty URL is OK (no webhook)
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(400, "webhook_url must use http or https")
+    if is_private_url(url):
+        raise HTTPException(400, "webhook_url must not point to private/internal networks")
 
 
 @router.get("", response_model=list[AlertRuleResponse])
@@ -17,7 +30,6 @@ async def list_alerts(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    # Admins and above see all alerts; lower roles only see their own
     stmt = select(AlertRule).order_by(AlertRule.created_at.desc())
     if ROLE_HIERARCHY.get(current_user.role, 999) > ROLE_HIERARCHY[UserRole.admin]:
         stmt = stmt.where(AlertRule.created_by == current_user.id)
@@ -31,6 +43,7 @@ async def create_alert(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
+    _validate_webhook_url(body.webhook_url)
     rule = AlertRule(
         name=body.name,
         metric=body.metric,
@@ -60,7 +73,11 @@ async def update_alert(
     is_admin_or_above = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if rule.created_by != current_user.id and not is_admin_or_above:
         raise HTTPException(403, "Not authorized to modify this alert rule")
-    rule.status = body.status
+    if body.status is not None:
+        rule.status = body.status
+    if body.webhook_url is not None:
+        _validate_webhook_url(body.webhook_url)
+        rule.webhook_url = body.webhook_url
     await db.commit()
     await db.refresh(rule)
     return rule
@@ -80,3 +97,29 @@ async def delete_alert(
         raise HTTPException(403, "Not authorized to delete this alert rule")
     await db.delete(rule)
     await db.commit()
+
+
+@router.get("/{alert_id}/history", response_model=list[AlertHistoryResponse])
+async def get_alert_history(
+    alert_id: uuid.UUID,
+    limit: int = 50,
+    offset: int = 0,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    rule = await db.get(AlertRule, alert_id)
+    if not rule:
+        raise HTTPException(404, "Alert rule not found")
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
+    if rule.created_by != current_user.id and not is_admin:
+        raise HTTPException(403, "Not authorized")
+
+    stmt = (
+        select(AlertHistory)
+        .where(AlertHistory.alert_rule_id == alert_id)
+        .order_by(AlertHistory.fired_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    result = await db.execute(stmt)
+    return result.scalars().all()

--- a/observal-server/models/__init__.py
+++ b/observal-server/models/__init__.py
@@ -1,6 +1,7 @@
 from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus
 from models.agent_component import AgentComponent
 from models.alert import AlertRule
+from models.alert_history import AlertHistory
 from models.base import Base
 from models.component_source import ComponentSource
 from models.download import AgentDownloadRecord, ComponentDownloadRecord
@@ -38,6 +39,7 @@ __all__ = [
     "AgentGoalSection",
     "AgentGoalTemplate",
     "AgentStatus",
+    "AlertHistory",
     "AlertRule",
     "Base",
     "ComponentDownloadRecord",

--- a/observal-server/models/alert_history.py
+++ b/observal-server/models/alert_history.py
@@ -12,23 +12,13 @@ class AlertHistory(Base):
     __tablename__ = "alert_history"
     __table_args__ = (Index("ix_alert_history_alert_rule_id", "alert_rule_id"),)
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), default=uuid.uuid4, primary_key=True
-    )
-    alert_rule_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("alert_rules.id"), nullable=False
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), default=uuid.uuid4, primary_key=True)
+    alert_rule_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("alert_rules.id"), nullable=False)
     metric_value: Mapped[float] = mapped_column(Float, nullable=False)
     threshold: Mapped[float] = mapped_column(Float, nullable=False)
     condition: Mapped[str] = mapped_column(String(10), nullable=False)
-    fired_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
-    delivery_status: Mapped[str] = mapped_column(
-        String(20), default="pending"
-    )  # pending|delivered|failed
+    fired_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    delivery_status: Mapped[str] = mapped_column(String(20), default="pending")  # pending|delivered|failed
     response_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
     error: Mapped[str | None] = mapped_column(String(1024), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(UTC)
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/observal-server/models/alert_history.py
+++ b/observal-server/models/alert_history.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+
+
+class AlertHistory(Base):
+    __tablename__ = "alert_history"
+    __table_args__ = (Index("ix_alert_history_alert_rule_id", "alert_rule_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), default=uuid.uuid4, primary_key=True
+    )
+    alert_rule_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("alert_rules.id"), nullable=False
+    )
+    metric_value: Mapped[float] = mapped_column(Float, nullable=False)
+    threshold: Mapped[float] = mapped_column(Float, nullable=False)
+    condition: Mapped[str] = mapped_column(String(10), nullable=False)
+    fired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    delivery_status: Mapped[str] = mapped_column(
+        String(20), default="pending"
+    )  # pending|delivered|failed
+    response_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )

--- a/observal-server/schemas/alert.py
+++ b/observal-server/schemas/alert.py
@@ -15,7 +15,8 @@ class AlertRuleCreate(BaseModel):
 
 
 class AlertRuleUpdate(BaseModel):
-    status: str  # active | paused
+    status: str | None = None
+    webhook_url: str | None = None
 
 
 class AlertRuleResponse(BaseModel):
@@ -29,6 +30,21 @@ class AlertRuleResponse(BaseModel):
     webhook_url: str
     status: str
     last_triggered: datetime | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AlertHistoryResponse(BaseModel):
+    id: UUID
+    alert_rule_id: UUID
+    metric_value: float
+    threshold: float
+    condition: str
+    fired_at: datetime
+    delivery_status: str
+    response_code: int | None
+    error: str | None
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/observal-server/services/alert_evaluator.py
+++ b/observal-server/services/alert_evaluator.py
@@ -40,9 +40,7 @@ def is_private_url(url: str) -> bool:
         addr = ipaddress.ip_address(hostname)
     except ValueError:
         try:
-            resolved = socket.getaddrinfo(
-                hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM
-            )
+            resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
             if not resolved:
                 return True
             addr = ipaddress.ip_address(resolved[0][4][0])
@@ -51,9 +49,7 @@ def is_private_url(url: str) -> bool:
     return any(addr in cidr for cidr in _PRIVATE_CIDRS)
 
 
-async def _query_error_rate(
-    target_type: str, target_id: str, lookback_minutes: int
-) -> float | None:
+async def _query_error_rate(target_type: str, target_id: str, lookback_minutes: int) -> float | None:
     """Query the error rate from ClickHouse spans table."""
     sql = (
         "SELECT countIf(status='error') / count(*) AS error_rate "
@@ -79,9 +75,7 @@ async def _query_error_rate(
         return None
 
 
-async def _query_latency_p99(
-    target_type: str, target_id: str, lookback_minutes: int
-) -> float | None:
+async def _query_latency_p99(target_type: str, target_id: str, lookback_minutes: int) -> float | None:
     """Query the p99 latency from ClickHouse spans table."""
     sql = (
         "SELECT quantile(0.99)(latency_ms) AS latency_p99 "
@@ -107,9 +101,7 @@ async def _query_latency_p99(
         return None
 
 
-async def _query_token_usage(
-    target_type: str, target_id: str, lookback_minutes: int
-) -> float | None:
+async def _query_token_usage(target_type: str, target_id: str, lookback_minutes: int) -> float | None:
     """Query total token usage from ClickHouse spans table."""
     sql = (
         "SELECT sum(token_count_total) AS token_usage "
@@ -135,9 +127,7 @@ async def _query_token_usage(
         return None
 
 
-async def _query_metric(
-    metric: str, target_type: str, target_id: str, lookback_minutes: int
-) -> float | None:
+async def _query_metric(metric: str, target_type: str, target_id: str, lookback_minutes: int) -> float | None:
     """Dispatch to the appropriate metric query helper."""
     if metric == "error_rate":
         return await _query_error_rate(target_type, target_id, lookback_minutes)
@@ -150,9 +140,7 @@ async def _query_metric(
         return None
 
 
-async def _deliver_webhook(
-    url: str, payload: dict
-) -> tuple[int | None, str | None]:
+async def _deliver_webhook(url: str, payload: dict) -> tuple[int | None, str | None]:
     """POST JSON payload to a webhook URL with SSRF protection and retry."""
     if not url:
         return None, "empty webhook URL"
@@ -166,9 +154,7 @@ async def _deliver_webhook(
                 return resp.status_code, None
             except Exception as e:
                 last_error = f"attempt {attempt + 1}: {e}"
-                logger.warning(
-                    "Webhook delivery to %s failed (%s)", url, last_error
-                )
+                logger.warning("Webhook delivery to %s failed (%s)", url, last_error)
     return None, last_error
 
 
@@ -219,9 +205,7 @@ async def evaluate_alerts(ctx: dict) -> None:
                         "target_id": rule.target_id,
                         "fired_at": now.isoformat(),
                     }
-                    status_code, error = await _deliver_webhook(
-                        rule.webhook_url, payload
-                    )
+                    status_code, error = await _deliver_webhook(rule.webhook_url, payload)
                     delivery_status = "delivered" if error is None else "failed"
                 else:
                     delivery_status = "delivered"
@@ -251,7 +235,5 @@ async def evaluate_alerts(ctx: dict) -> None:
                     delivery_status,
                 )
             except Exception as e:
-                logger.exception(
-                    "Error evaluating alert rule %s: %s", rule.id, e
-                )
+                logger.exception("Error evaluating alert rule %s: %s", rule.id, e)
     logger.info("Alert evaluation cycle complete")

--- a/observal-server/services/alert_evaluator.py
+++ b/observal-server/services/alert_evaluator.py
@@ -1,0 +1,257 @@
+"""Alert evaluation engine: periodic metric checks and webhook delivery."""
+
+import ipaddress
+import logging
+import socket
+import uuid
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+import httpx
+from sqlalchemy import select
+
+from database import async_session
+from models.alert import AlertRule
+from models.alert_history import AlertHistory
+from services.clickhouse import _query
+
+logger = logging.getLogger(__name__)
+
+_PRIVATE_CIDRS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+]
+
+LOOKBACK_MINUTES = 5
+WEBHOOK_TIMEOUT = 5
+
+
+def is_private_url(url: str) -> bool:
+    """Check if a URL resolves to a private/internal IP address (SSRF protection)."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return True
+    try:
+        addr = ipaddress.ip_address(hostname)
+    except ValueError:
+        try:
+            resolved = socket.getaddrinfo(
+                hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM
+            )
+            if not resolved:
+                return True
+            addr = ipaddress.ip_address(resolved[0][4][0])
+        except (socket.gaierror, OSError):
+            return True
+    return any(addr in cidr for cidr in _PRIVATE_CIDRS)
+
+
+async def _query_error_rate(
+    target_type: str, target_id: str, lookback_minutes: int
+) -> float | None:
+    """Query the error rate from ClickHouse spans table."""
+    sql = (
+        "SELECT countIf(status='error') / count(*) AS error_rate "
+        "FROM spans "
+        "WHERE start_time > now() - INTERVAL {lookback:UInt32} MINUTE"
+    )
+    params: dict[str, str] = {"param_lookback": str(lookback_minutes)}
+    if target_type == "agent":
+        sql += " AND agent_id = {target_id:String}"
+        params["param_target_id"] = target_id
+    elif target_type == "mcp":
+        sql += " AND mcp_id = {target_id:String}"
+        params["param_target_id"] = target_id
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        text = r.text.strip()
+        if not text:
+            return None
+        return float(text)
+    except Exception as e:
+        logger.error("ClickHouse error_rate query failed: %s", e)
+        return None
+
+
+async def _query_latency_p99(
+    target_type: str, target_id: str, lookback_minutes: int
+) -> float | None:
+    """Query the p99 latency from ClickHouse spans table."""
+    sql = (
+        "SELECT quantile(0.99)(latency_ms) AS latency_p99 "
+        "FROM spans "
+        "WHERE start_time > now() - INTERVAL {lookback:UInt32} MINUTE"
+    )
+    params: dict[str, str] = {"param_lookback": str(lookback_minutes)}
+    if target_type == "agent":
+        sql += " AND agent_id = {target_id:String}"
+        params["param_target_id"] = target_id
+    elif target_type == "mcp":
+        sql += " AND mcp_id = {target_id:String}"
+        params["param_target_id"] = target_id
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        text = r.text.strip()
+        if not text:
+            return None
+        return float(text)
+    except Exception as e:
+        logger.error("ClickHouse latency_p99 query failed: %s", e)
+        return None
+
+
+async def _query_token_usage(
+    target_type: str, target_id: str, lookback_minutes: int
+) -> float | None:
+    """Query total token usage from ClickHouse spans table."""
+    sql = (
+        "SELECT sum(token_count_total) AS token_usage "
+        "FROM spans "
+        "WHERE start_time > now() - INTERVAL {lookback:UInt32} MINUTE"
+    )
+    params: dict[str, str] = {"param_lookback": str(lookback_minutes)}
+    if target_type == "agent":
+        sql += " AND agent_id = {target_id:String}"
+        params["param_target_id"] = target_id
+    elif target_type == "mcp":
+        sql += " AND mcp_id = {target_id:String}"
+        params["param_target_id"] = target_id
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        text = r.text.strip()
+        if not text:
+            return None
+        return float(text)
+    except Exception as e:
+        logger.error("ClickHouse token_usage query failed: %s", e)
+        return None
+
+
+async def _query_metric(
+    metric: str, target_type: str, target_id: str, lookback_minutes: int
+) -> float | None:
+    """Dispatch to the appropriate metric query helper."""
+    if metric == "error_rate":
+        return await _query_error_rate(target_type, target_id, lookback_minutes)
+    elif metric == "latency_p99":
+        return await _query_latency_p99(target_type, target_id, lookback_minutes)
+    elif metric == "token_usage":
+        return await _query_token_usage(target_type, target_id, lookback_minutes)
+    else:
+        logger.warning("Unknown metric: %s", metric)
+        return None
+
+
+async def _deliver_webhook(
+    url: str, payload: dict
+) -> tuple[int | None, str | None]:
+    """POST JSON payload to a webhook URL with SSRF protection and retry."""
+    if not url:
+        return None, "empty webhook URL"
+    if is_private_url(url):
+        return None, "SSRF: webhook URL resolves to private network"
+    async with httpx.AsyncClient(timeout=WEBHOOK_TIMEOUT) as client:
+        last_error: str | None = None
+        for attempt in range(2):
+            try:
+                resp = await client.post(url, json=payload)
+                return resp.status_code, None
+            except Exception as e:
+                last_error = f"attempt {attempt + 1}: {e}"
+                logger.warning(
+                    "Webhook delivery to %s failed (%s)", url, last_error
+                )
+    return None, last_error
+
+
+def _condition_met(condition: str, value: float, threshold: float) -> bool:
+    """Check if the alert condition is met."""
+    if condition == "above":
+        return value > threshold
+    elif condition == "below":
+        return value < threshold
+    return False
+
+
+async def evaluate_alerts(ctx: dict) -> None:
+    """Main arq cron job: evaluate all active alert rules and fire webhooks."""
+    logger.info("Starting alert evaluation cycle")
+    async with async_session() as db:
+        stmt = select(AlertRule).where(AlertRule.status == "active")
+        result = await db.execute(stmt)
+        rules = result.scalars().all()
+
+        for rule in rules:
+            try:
+                value = await _query_metric(
+                    rule.metric,
+                    rule.target_type,
+                    rule.target_id,
+                    LOOKBACK_MINUTES,
+                )
+                if value is None:
+                    continue
+                if not _condition_met(rule.condition, value, rule.threshold):
+                    continue
+
+                now = datetime.now(UTC)
+                status_code: int | None = None
+                error: str | None = None
+                delivery_status = "pending"
+
+                if rule.webhook_url:
+                    payload = {
+                        "alert_rule_id": str(rule.id),
+                        "alert_name": rule.name,
+                        "metric": rule.metric,
+                        "metric_value": value,
+                        "threshold": rule.threshold,
+                        "condition": rule.condition,
+                        "target_type": rule.target_type,
+                        "target_id": rule.target_id,
+                        "fired_at": now.isoformat(),
+                    }
+                    status_code, error = await _deliver_webhook(
+                        rule.webhook_url, payload
+                    )
+                    delivery_status = "delivered" if error is None else "failed"
+                else:
+                    delivery_status = "delivered"
+
+                history = AlertHistory(
+                    id=uuid.uuid4(),
+                    alert_rule_id=rule.id,
+                    metric_value=value,
+                    threshold=rule.threshold,
+                    condition=rule.condition,
+                    fired_at=now,
+                    delivery_status=delivery_status,
+                    response_code=status_code,
+                    error=error,
+                )
+                db.add(history)
+                rule.last_triggered = now
+                await db.commit()
+
+                logger.info(
+                    "Alert '%s' fired: %s=%s (threshold=%s, condition=%s, delivery=%s)",
+                    rule.name,
+                    rule.metric,
+                    value,
+                    rule.threshold,
+                    rule.condition,
+                    delivery_status,
+                )
+            except Exception as e:
+                logger.exception(
+                    "Error evaluating alert rule %s: %s", rule.id, e
+                )
+    logger.info("Alert evaluation cycle complete")

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -6,6 +6,7 @@ from arq.connections import RedisSettings
 from arq.cron import cron
 
 from config import settings
+from services.alert_evaluator import evaluate_alerts
 from services.redis import publish
 
 logger = logging.getLogger(__name__)
@@ -111,8 +112,11 @@ async def shutdown(ctx: dict):
 class WorkerSettings:
     """arq worker configuration."""
 
-    functions = [run_eval, sync_component_sources]
-    cron_jobs = [cron(sync_component_sources, hour={0, 6, 12, 18})]  # Every 6 hours
+    functions = [run_eval, sync_component_sources, evaluate_alerts]
+    cron_jobs = [
+        cron(sync_component_sources, hour={0, 6, 12, 18}),  # Every 6 hours
+        cron(evaluate_alerts, second={0}, timeout=55),  # Every minute
+    ]
     on_startup = startup
     on_shutdown = shutdown
     redis_settings = _redis_settings()

--- a/tests/test_alert_evaluator.py
+++ b/tests/test_alert_evaluator.py
@@ -182,9 +182,7 @@ class TestDeliverWebhook:
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
-            code, err = await _deliver_webhook(
-                "https://example.com/hook", {"test": True}
-            )
+            code, err = await _deliver_webhook("https://example.com/hook", {"test": True})
         assert code == 200
         assert err is None
 
@@ -193,9 +191,7 @@ class TestDeliverWebhook:
         from services.alert_evaluator import _deliver_webhook
 
         with patch("services.alert_evaluator.is_private_url", return_value=True):
-            code, err = await _deliver_webhook(
-                "http://127.0.0.1/hook", {"test": True}
-            )
+            code, err = await _deliver_webhook("http://127.0.0.1/hook", {"test": True})
         assert code is None
         assert "SSRF" in err
 
@@ -434,8 +430,6 @@ class TestAlertRuleUpdateSchema:
     def test_both_fields(self):
         from schemas.alert import AlertRuleUpdate
 
-        update = AlertRuleUpdate(
-            status="active", webhook_url="https://example.com/hook"
-        )
+        update = AlertRuleUpdate(status="active", webhook_url="https://example.com/hook")
         assert update.status == "active"
         assert update.webhook_url == "https://example.com/hook"

--- a/tests/test_alert_evaluator.py
+++ b/tests/test_alert_evaluator.py
@@ -1,0 +1,441 @@
+"""Tests for alert evaluation engine, SSRF protection, and webhook delivery."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestIsPrivateUrl:
+    def test_localhost_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("http://localhost:8080/hook") is True
+
+    def test_127_0_0_1_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("http://127.0.0.1:9000/callback") is True
+
+    def test_10_x_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("http://10.0.0.5/hook") is True
+
+    def test_172_16_x_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("http://172.16.0.1/webhook") is True
+
+    def test_192_168_x_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("http://192.168.1.100:5000/alert") is True
+
+    def test_ipv6_loopback_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("http://[::1]:8080/hook") is True
+
+    def test_link_local_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("http://169.254.169.254/latest/meta-data/") is True
+
+    def test_public_ip_is_not_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("http://8.8.8.8/webhook") is False
+
+    def test_public_domain_is_not_private(self):
+        from services.alert_evaluator import is_private_url
+
+        with patch("services.alert_evaluator.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+            assert is_private_url("https://example.com/webhook") is False
+
+    def test_no_hostname_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        assert is_private_url("not-a-url") is True
+
+    def test_dns_failure_is_private(self):
+        from services.alert_evaluator import is_private_url
+
+        with patch(
+            "services.alert_evaluator.socket.getaddrinfo",
+            side_effect=OSError("DNS failed"),
+        ):
+            assert is_private_url("http://nonexistent.invalid/hook") is True
+
+
+class TestConditionMet:
+    def test_above_met(self):
+        from services.alert_evaluator import _condition_met
+
+        assert _condition_met("above", 0.15, 0.10) is True
+
+    def test_above_not_met(self):
+        from services.alert_evaluator import _condition_met
+
+        assert _condition_met("above", 0.05, 0.10) is False
+
+    def test_below_met(self):
+        from services.alert_evaluator import _condition_met
+
+        assert _condition_met("below", 0.05, 0.10) is True
+
+    def test_below_not_met(self):
+        from services.alert_evaluator import _condition_met
+
+        assert _condition_met("below", 0.15, 0.10) is False
+
+    def test_unknown_condition(self):
+        from services.alert_evaluator import _condition_met
+
+        assert _condition_met("equal", 0.10, 0.10) is False
+
+
+class TestQueryMetric:
+    @pytest.mark.asyncio
+    async def test_dispatches_error_rate(self):
+        from services.alert_evaluator import _query_metric
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = "0.05\n"
+        with patch(
+            "services.alert_evaluator._query",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ):
+            result = await _query_metric("error_rate", "agent", "agent-1", 5)
+        assert result == pytest.approx(0.05)
+
+    @pytest.mark.asyncio
+    async def test_dispatches_latency_p99(self):
+        from services.alert_evaluator import _query_metric
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = "250.5\n"
+        with patch(
+            "services.alert_evaluator._query",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ):
+            result = await _query_metric("latency_p99", "mcp", "mcp-1", 5)
+        assert result == pytest.approx(250.5)
+
+    @pytest.mark.asyncio
+    async def test_dispatches_token_usage(self):
+        from services.alert_evaluator import _query_metric
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = "50000\n"
+        with patch(
+            "services.alert_evaluator._query",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ):
+            result = await _query_metric("token_usage", "all", "", 5)
+        assert result == pytest.approx(50000.0)
+
+    @pytest.mark.asyncio
+    async def test_unknown_metric_returns_none(self):
+        from services.alert_evaluator import _query_metric
+
+        result = await _query_metric("unknown_metric", "all", "", 5)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_response_returns_none(self):
+        from services.alert_evaluator import _query_metric
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = ""
+        with patch(
+            "services.alert_evaluator._query",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ):
+            result = await _query_metric("error_rate", "all", "", 5)
+        assert result is None
+
+
+class TestDeliverWebhook:
+    @pytest.mark.asyncio
+    async def test_successful_delivery(self):
+        from services.alert_evaluator import _deliver_webhook
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with (
+            patch("services.alert_evaluator.is_private_url", return_value=False),
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+            code, err = await _deliver_webhook(
+                "https://example.com/hook", {"test": True}
+            )
+        assert code == 200
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_ssrf_rejected(self):
+        from services.alert_evaluator import _deliver_webhook
+
+        with patch("services.alert_evaluator.is_private_url", return_value=True):
+            code, err = await _deliver_webhook(
+                "http://127.0.0.1/hook", {"test": True}
+            )
+        assert code is None
+        assert "SSRF" in err
+
+    @pytest.mark.asyncio
+    async def test_empty_url(self):
+        from services.alert_evaluator import _deliver_webhook
+
+        code, err = await _deliver_webhook("", {"test": True})
+        assert code is None
+        assert "empty" in err
+
+
+class TestEvaluateAlerts:
+    @pytest.mark.asyncio
+    async def test_full_flow_fires_alert_and_records_history(self):
+        from services.alert_evaluator import evaluate_alerts
+
+        rule = MagicMock()
+        rule.id = uuid.uuid4()
+        rule.name = "High Error Rate"
+        rule.metric = "error_rate"
+        rule.threshold = 0.10
+        rule.condition = "above"
+        rule.target_type = "agent"
+        rule.target_id = "agent-1"
+        rule.webhook_url = "https://example.com/webhook"
+        rule.status = "active"
+        rule.last_triggered = None
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [rule]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "services.alert_evaluator.async_session",
+                return_value=mock_session_ctx,
+            ),
+            patch(
+                "services.alert_evaluator._query_metric",
+                new_callable=AsyncMock,
+                return_value=0.25,
+            ),
+            patch(
+                "services.alert_evaluator._deliver_webhook",
+                new_callable=AsyncMock,
+                return_value=(200, None),
+            ),
+        ):
+            await evaluate_alerts({})
+        mock_db.add.assert_called_once()
+        assert rule.last_triggered is not None
+
+    @pytest.mark.asyncio
+    async def test_condition_not_met_skips_webhook(self):
+        from services.alert_evaluator import evaluate_alerts
+
+        rule = MagicMock()
+        rule.id = uuid.uuid4()
+        rule.name = "Low Error Rate"
+        rule.metric = "error_rate"
+        rule.threshold = 0.50
+        rule.condition = "above"
+        rule.target_type = "all"
+        rule.target_id = ""
+        rule.webhook_url = "https://example.com/webhook"
+        rule.status = "active"
+        rule.last_triggered = None
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [rule]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "services.alert_evaluator.async_session",
+                return_value=mock_session_ctx,
+            ),
+            patch(
+                "services.alert_evaluator._query_metric",
+                new_callable=AsyncMock,
+                return_value=0.05,
+            ),
+            patch(
+                "services.alert_evaluator._deliver_webhook",
+                new_callable=AsyncMock,
+            ) as mock_deliver,
+        ):
+            await evaluate_alerts({})
+        mock_deliver.assert_not_called()
+        mock_db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_metric_none_skips_rule(self):
+        from services.alert_evaluator import evaluate_alerts
+
+        rule = MagicMock()
+        rule.id = uuid.uuid4()
+        rule.metric = "error_rate"
+        rule.threshold = 0.10
+        rule.condition = "above"
+        rule.target_type = "all"
+        rule.target_id = ""
+        rule.webhook_url = "https://example.com/webhook"
+        rule.status = "active"
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [rule]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "services.alert_evaluator.async_session",
+                return_value=mock_session_ctx,
+            ),
+            patch(
+                "services.alert_evaluator._query_metric",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            await evaluate_alerts({})
+        mock_db.add.assert_not_called()
+
+
+class TestAlertRouteSSRF:
+    def test_validate_webhook_url_rejects_private(self):
+        from api.routes.alert import _validate_webhook_url
+
+        with patch("api.routes.alert.is_private_url", return_value=True):
+            with pytest.raises(Exception) as exc_info:
+                _validate_webhook_url("http://10.0.0.1/hook")
+            assert exc_info.value.status_code == 400
+            assert "private" in exc_info.value.detail.lower()
+
+    def test_validate_webhook_url_rejects_non_http(self):
+        from api.routes.alert import _validate_webhook_url
+
+        with pytest.raises(Exception) as exc_info:
+            _validate_webhook_url("ftp://example.com/hook")
+        assert exc_info.value.status_code == 400
+        assert "http" in exc_info.value.detail.lower()
+
+    def test_validate_webhook_url_allows_empty(self):
+        from api.routes.alert import _validate_webhook_url
+
+        _validate_webhook_url("")
+
+    def test_validate_webhook_url_allows_public_https(self):
+        from api.routes.alert import _validate_webhook_url
+
+        with patch("api.routes.alert.is_private_url", return_value=False):
+            _validate_webhook_url("https://hooks.slack.com/services/T00/B00/xxx")
+
+
+class TestAlertHistorySchema:
+    def test_schema_from_attributes(self):
+        from schemas.alert import AlertHistoryResponse
+
+        data = {
+            "id": uuid.uuid4(),
+            "alert_rule_id": uuid.uuid4(),
+            "metric_value": 0.25,
+            "threshold": 0.10,
+            "condition": "above",
+            "fired_at": datetime.now(UTC),
+            "delivery_status": "delivered",
+            "response_code": 200,
+            "error": None,
+            "created_at": datetime.now(UTC),
+        }
+        resp = AlertHistoryResponse(**data)
+        assert resp.metric_value == 0.25
+        assert resp.delivery_status == "delivered"
+        assert resp.response_code == 200
+
+    def test_schema_nullable_fields(self):
+        from schemas.alert import AlertHistoryResponse
+
+        data = {
+            "id": uuid.uuid4(),
+            "alert_rule_id": uuid.uuid4(),
+            "metric_value": 500.0,
+            "threshold": 1000.0,
+            "condition": "below",
+            "fired_at": datetime.now(UTC),
+            "delivery_status": "failed",
+            "response_code": None,
+            "error": "connection refused",
+            "created_at": datetime.now(UTC),
+        }
+        resp = AlertHistoryResponse(**data)
+        assert resp.response_code is None
+        assert resp.error == "connection refused"
+
+
+class TestAlertRuleUpdateSchema:
+    def test_status_only(self):
+        from schemas.alert import AlertRuleUpdate
+
+        update = AlertRuleUpdate(status="paused")
+        assert update.status == "paused"
+        assert update.webhook_url is None
+
+    def test_webhook_url_only(self):
+        from schemas.alert import AlertRuleUpdate
+
+        update = AlertRuleUpdate(webhook_url="https://example.com/hook")
+        assert update.status is None
+        assert update.webhook_url == "https://example.com/hook"
+
+    def test_both_fields(self):
+        from schemas.alert import AlertRuleUpdate
+
+        update = AlertRuleUpdate(
+            status="active", webhook_url="https://example.com/hook"
+        )
+        assert update.status == "active"
+        assert update.webhook_url == "https://example.com/hook"


### PR DESCRIPTION
## Summary
- Add `AlertHistory` model and Alembic migration for alert audit trail
- Implement `evaluate_alerts` arq cron job (runs every 60s) that queries ClickHouse metrics (error_rate, latency_p99, token_usage) and fires webhooks
- SSRF protection: validate webhook URLs against private CIDRs before delivery
- Add `GET /api/v1/alerts/{id}/history` endpoint for alert firing history
- 36 tests covering SSRF, metric queries, webhook delivery, and evaluation flow

Closes #204

## Test plan
- [ ] `ruff check . && ruff format --check .` passes
- [ ] `pytest tests/ -q` — all 36 new tests pass
- [ ] Verify SSRF rejects localhost/10.x/172.16.x webhook URLs
- [ ] Verify arq worker picks up `evaluate_alerts` cron job