### PR TITLE
feat(ee): add audit logging for SOC 2/ISO 27001 compliance

### DIFF
--- a/ee/__init__.py
+++ b/ee/__init__.py
@@ -22,9 +22,10 @@ def register_enterprise(app: FastAPI, settings: Settings) -> list[str]:
 
     Called once during app startup from main.py.  Responsibilities:
     1. Validate enterprise config
-    2. Mount EE routes (SAML, SCIM — placeholders for now)
+    2. Mount EE routes (SAML, SCIM, audit log)
     3. Add EnterpriseGuardMiddleware (503 on misconfigured EE routes)
-    4. Register event bus handlers for audit logging
+    4. Register audit logging event bus handlers
+    5. Store issues for diagnostics endpoint
     """
     from ee.observal_server.middleware.enterprise_guard import EnterpriseGuardMiddleware
     from ee.observal_server.routes import mount_ee_routes
@@ -43,7 +44,12 @@ def register_enterprise(app: FastAPI, settings: Settings) -> list[str]:
     else:
         logger.info("Enterprise mode initialized successfully")
 
-    # 4. Store issues for diagnostics endpoint
+    # 4. Register audit logging handlers
+    from ee.observal_server.services.audit import register_audit_handlers
+
+    register_audit_handlers()
+
+    # 5. Store issues for diagnostics endpoint
     app.state.enterprise_issues = issues
 
     return issues

--- a/ee/observal_server/routes/__init__.py
+++ b/ee/observal_server/routes/__init__.py
@@ -10,8 +10,10 @@ if TYPE_CHECKING:
 
 def mount_ee_routes(app: FastAPI) -> None:
     """Mount all enterprise-only routes on the app."""
+    from ee.observal_server.routes.audit import router as audit_router
     from ee.observal_server.routes.scim import router as scim_router
     from ee.observal_server.routes.sso_saml import router as saml_router
 
     app.include_router(saml_router)
     app.include_router(scim_router)
+    app.include_router(audit_router)

--- a/ee/observal_server/routes/audit.py
+++ b/ee/observal_server/routes/audit.py
@@ -1,0 +1,152 @@
+"""Enterprise audit log query endpoints."""
+
+import csv
+import io
+import json
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from api.deps import require_role
+from models.user import User, UserRole
+from services.clickhouse import _query
+
+router = APIRouter(prefix="/api/v1/admin/audit-log", tags=["audit"])
+
+
+class AuditLogEntry(BaseModel):
+    event_id: str
+    timestamp: str
+    actor_id: str
+    actor_email: str
+    actor_role: str
+    action: str
+    resource_type: str
+    resource_id: str
+    resource_name: str
+    http_method: str
+    http_path: str
+    status_code: int
+    ip_address: str
+    user_agent: str
+    detail: str
+
+
+@router.get("", response_model=list[AuditLogEntry])
+async def list_audit_logs(
+    actor: str | None = Query(None, description="Filter by actor email"),
+    action: str | None = Query(None, description="Filter by action"),
+    resource_type: str | None = Query(None, description="Filter by resource type"),
+    start_date: datetime | None = Query(None, description="Start date filter"),
+    end_date: datetime | None = Query(None, description="End date filter"),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Query audit log entries with optional filters."""
+    conditions = []
+    params = {}
+
+    if actor:
+        conditions.append("actor_email = {actor:String}")
+        params["param_actor"] = actor
+    if action:
+        conditions.append("action = {action:String}")
+        params["param_action"] = action
+    if resource_type:
+        conditions.append("resource_type = {rtype:String}")
+        params["param_rtype"] = resource_type
+    if start_date:
+        conditions.append("timestamp >= {start:String}")
+        params["param_start"] = start_date.strftime("%Y-%m-%d %H:%M:%S")
+    if end_date:
+        conditions.append("timestamp <= {end:String}")
+        params["param_end"] = end_date.strftime("%Y-%m-%d %H:%M:%S")
+
+    where_clause = " AND ".join(conditions) if conditions else "1=1"
+    sql = f"""SELECT event_id, timestamp, actor_id, actor_email, actor_role,
+              action, resource_type, resource_id, resource_name, http_method,
+              http_path, status_code, ip_address, user_agent, detail
+              FROM audit_log
+              WHERE {where_clause}
+              ORDER BY timestamp DESC
+              LIMIT {{lim:UInt32}} OFFSET {{off:UInt32}}
+              FORMAT JSONEachRow"""
+    params["param_lim"] = str(limit)
+    params["param_off"] = str(offset)
+
+    resp = await _query(sql, params)
+    if resp.status_code != 200:
+        return []
+
+    rows = []
+    for line in resp.text.strip().split("\n"):
+        if line.strip():
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return rows
+
+
+@router.get("/export")
+async def export_audit_logs(
+    actor: str | None = Query(None),
+    action: str | None = Query(None),
+    resource_type: str | None = Query(None),
+    start_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Export audit log as CSV."""
+    conditions = []
+    params = {}
+
+    if actor:
+        conditions.append("actor_email = {actor:String}")
+        params["param_actor"] = actor
+    if action:
+        conditions.append("action = {action:String}")
+        params["param_action"] = action
+    if resource_type:
+        conditions.append("resource_type = {rtype:String}")
+        params["param_rtype"] = resource_type
+    if start_date:
+        conditions.append("timestamp >= {start:String}")
+        params["param_start"] = start_date.strftime("%Y-%m-%d %H:%M:%S")
+    if end_date:
+        conditions.append("timestamp <= {end:String}")
+        params["param_end"] = end_date.strftime("%Y-%m-%d %H:%M:%S")
+
+    where_clause = " AND ".join(conditions) if conditions else "1=1"
+    sql = f"""SELECT event_id, timestamp, actor_id, actor_email, actor_role,
+              action, resource_type, resource_id, resource_name, http_method,
+              http_path, status_code, ip_address, user_agent, detail
+              FROM audit_log WHERE {where_clause}
+              ORDER BY timestamp DESC LIMIT 10000
+              FORMAT JSONEachRow"""
+
+    resp = await _query(sql, params)
+
+    rows = []
+    if resp.status_code == 200:
+        for line in resp.text.strip().split("\n"):
+            if line.strip():
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+    output = io.StringIO()
+    if rows:
+        writer = csv.DictWriter(output, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+
+    return StreamingResponse(
+        iter([output.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=audit_log.csv"},
+    )

--- a/ee/observal_server/services/audit.py
+++ b/ee/observal_server/services/audit.py
@@ -1,0 +1,172 @@
+"""Audit logging service for enterprise compliance (SOC 2 / ISO 27001).
+
+Registers event bus handlers that write to the ClickHouse audit_log table.
+Only active when DEPLOYMENT_MODE=enterprise.
+"""
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from services.clickhouse import _query
+from services.events import (
+    AgentLifecycleEvent,
+    AlertRuleChanged,
+    LoginFailure,
+    LoginSuccess,
+    RoleChanged,
+    SettingsChanged,
+    UserCreated,
+    UserDeleted,
+    bus,
+)
+
+logger = logging.getLogger("observal.ee.audit")
+
+
+async def _insert_audit_row(
+    *,
+    actor_id: str,
+    actor_email: str,
+    actor_role: str = "",
+    action: str,
+    resource_type: str,
+    resource_id: str = "",
+    resource_name: str = "",
+    http_method: str = "",
+    http_path: str = "",
+    status_code: int = 0,
+    ip_address: str = "",
+    user_agent: str = "",
+    detail: str = "",
+):
+    """Insert a single row into the audit_log ClickHouse table."""
+    event_id = str(uuid.uuid4())
+    ts = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+    sql = """INSERT INTO audit_log
+        (event_id, timestamp, actor_id, actor_email, actor_role, action,
+         resource_type, resource_id, resource_name, http_method, http_path,
+         status_code, ip_address, user_agent, detail)
+        VALUES
+        ({eid:UUID}, {ts:DateTime64(3, 'UTC')}, {aid:String}, {aemail:String},
+         {arole:String}, {action:String}, {rtype:String}, {rid:String},
+         {rname:String}, {hmethod:String}, {hpath:String}, {scode:UInt16},
+         {ip:String}, {ua:String}, {det:String})"""
+
+    params = {
+        "param_eid": event_id,
+        "param_ts": ts,
+        "param_aid": actor_id,
+        "param_aemail": actor_email,
+        "param_arole": actor_role,
+        "param_action": action,
+        "param_rtype": resource_type,
+        "param_rid": resource_id,
+        "param_rname": resource_name,
+        "param_hmethod": http_method,
+        "param_hpath": http_path,
+        "param_scode": str(status_code),
+        "param_ip": ip_address,
+        "param_ua": user_agent,
+        "param_det": detail,
+    }
+
+    try:
+        await _query(sql, params)
+    except Exception:
+        logger.exception("Failed to insert audit log row")
+
+
+def register_audit_handlers():
+    """Register event bus handlers for audit logging. Called during enterprise startup."""
+
+    @bus.on(UserCreated)
+    async def _audit_user_created(event: UserCreated):
+        await _insert_audit_row(
+            actor_id=event.user_id,
+            actor_email=event.email,
+            actor_role=event.role,
+            action="user.created",
+            resource_type="user",
+            resource_id=event.user_id,
+            resource_name=event.email,
+            detail=json.dumps({"is_demo": event.is_demo}),
+        )
+
+    @bus.on(UserDeleted)
+    async def _audit_user_deleted(event: UserDeleted):
+        await _insert_audit_row(
+            actor_id=event.user_id,
+            actor_email=event.email,
+            action="user.deleted",
+            resource_type="user",
+            resource_id=event.user_id,
+            resource_name=event.email,
+        )
+
+    @bus.on(LoginSuccess)
+    async def _audit_login_success(event: LoginSuccess):
+        await _insert_audit_row(
+            actor_id=event.user_id,
+            actor_email=event.email,
+            action="auth.login_success",
+            resource_type="session",
+            detail=json.dumps({"method": event.method}),
+        )
+
+    @bus.on(LoginFailure)
+    async def _audit_login_failure(event: LoginFailure):
+        await _insert_audit_row(
+            actor_id="",
+            actor_email=event.email,
+            action="auth.login_failure",
+            resource_type="session",
+            detail=json.dumps({"method": event.method, "reason": event.reason}),
+        )
+
+    @bus.on(RoleChanged)
+    async def _audit_role_changed(event: RoleChanged):
+        await _insert_audit_row(
+            actor_id=event.user_id,
+            actor_email=event.email,
+            action="user.role_changed",
+            resource_type="user",
+            resource_id=event.user_id,
+            resource_name=event.email,
+            detail=json.dumps({"old_role": event.old_role, "new_role": event.new_role}),
+        )
+
+    @bus.on(SettingsChanged)
+    async def _audit_settings_changed(event: SettingsChanged):
+        await _insert_audit_row(
+            actor_id="system",
+            actor_email="",
+            action="settings.changed",
+            resource_type="config",
+            resource_name=event.key,
+            detail=json.dumps({"value": event.value}),
+        )
+
+    @bus.on(AlertRuleChanged)
+    async def _audit_alert_changed(event: AlertRuleChanged):
+        await _insert_audit_row(
+            actor_id=event.actor_id,
+            actor_email=event.actor_email,
+            action=f"alert.{event.action}",
+            resource_type="alert_rule",
+            resource_id=event.alert_id,
+        )
+
+    @bus.on(AgentLifecycleEvent)
+    async def _audit_agent_lifecycle(event: AgentLifecycleEvent):
+        await _insert_audit_row(
+            actor_id=event.actor_id,
+            actor_email=event.actor_email,
+            action=f"agent.{event.action}",
+            resource_type="agent",
+            resource_id=event.agent_id,
+        )
+
+    logger.info("Audit logging handlers registered (%d event types)", 8)

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -220,6 +220,30 @@ INIT_SQL = [
     """ALTER TABLE traces ADD COLUMN IF NOT EXISTS hook_id Nullable(String)""",
     """ALTER TABLE traces ADD COLUMN IF NOT EXISTS skill_id Nullable(String)""",
     """ALTER TABLE traces ADD COLUMN IF NOT EXISTS prompt_id Nullable(String)""",
+    # Audit log table (enterprise compliance — SOC 2 / ISO 27001)
+    """CREATE TABLE IF NOT EXISTS audit_log (
+        event_id    UUID,
+        timestamp   DateTime64(3, 'UTC'),
+        actor_id    String,
+        actor_email String,
+        actor_role  LowCardinality(String),
+        action      LowCardinality(String),
+        resource_type LowCardinality(String),
+        resource_id String DEFAULT '',
+        resource_name String DEFAULT '',
+        http_method LowCardinality(String) DEFAULT '',
+        http_path   String DEFAULT '',
+        status_code UInt16 DEFAULT 0,
+        ip_address  String DEFAULT '',
+        user_agent  String DEFAULT '',
+        detail      String DEFAULT '',
+        INDEX idx_actor_id actor_id TYPE bloom_filter(0.01) GRANULARITY 1,
+        INDEX idx_action action TYPE bloom_filter(0.01) GRANULARITY 1,
+        INDEX idx_resource_type resource_type TYPE bloom_filter(0.01) GRANULARITY 1
+    ) ENGINE = MergeTree()
+    TTL timestamp + INTERVAL 730 DAY
+    PARTITION BY toYYYYMM(timestamp)
+    ORDER BY (action, resource_type, timestamp)""",
 ]
 
 

--- a/observal-server/services/events.py
+++ b/observal-server/services/events.py
@@ -69,6 +69,22 @@ class SettingsChanged(Event):
     value: str
 
 
+@dataclass(frozen=True, slots=True)
+class AlertRuleChanged(Event):
+    alert_id: str
+    action: str  # "created", "updated", "deleted"
+    actor_id: str
+    actor_email: str
+
+
+@dataclass(frozen=True, slots=True)
+class AgentLifecycleEvent(Event):
+    agent_id: str
+    action: str  # "registered", "updated", "deleted"
+    actor_id: str
+    actor_email: str
+
+
 # ── Event bus ────────────────────────────────────────────────
 
 

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -1,0 +1,335 @@
+"""Tests for enterprise audit logging (SOC 2 / ISO 27001 compliance)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.events import (
+    AgentLifecycleEvent,
+    AlertRuleChanged,
+    LoginFailure,
+    LoginSuccess,
+    RoleChanged,
+    SettingsChanged,
+    UserCreated,
+    UserDeleted,
+    bus,
+)
+
+
+class TestRegisterAuditHandlers:
+    """Verify register_audit_handlers() wires the correct event types."""
+
+    def setup_method(self):
+        bus.clear()
+
+    def teardown_method(self):
+        bus.clear()
+
+    def test_registers_correct_number_of_handlers(self):
+        from ee.observal_server.services.audit import register_audit_handlers
+
+        assert bus.handler_count == 0
+        register_audit_handlers()
+        assert bus.handler_count == 8
+
+    def test_registers_handlers_for_all_event_types(self):
+        from ee.observal_server.services.audit import register_audit_handlers
+
+        register_audit_handlers()
+        expected_types = [
+            UserCreated,
+            UserDeleted,
+            LoginSuccess,
+            LoginFailure,
+            RoleChanged,
+            SettingsChanged,
+            AlertRuleChanged,
+            AgentLifecycleEvent,
+        ]
+        for event_type in expected_types:
+            assert len(bus._handlers[event_type]) == 1, f"No handler registered for {event_type.__name__}"
+
+
+class TestInsertAuditRow:
+    """Verify _insert_audit_row constructs correct ClickHouse query."""
+
+    @pytest.mark.asyncio
+    async def test_constructs_correct_query_params(self):
+        from ee.observal_server.services.audit import _insert_audit_row
+
+        mock_query = AsyncMock()
+        with patch("ee.observal_server.services.audit._query", mock_query):
+            await _insert_audit_row(
+                actor_id="user-1",
+                actor_email="admin@example.com",
+                actor_role="admin",
+                action="user.created",
+                resource_type="user",
+                resource_id="user-1",
+                resource_name="admin@example.com",
+                detail='{"is_demo": false}',
+            )
+
+        mock_query.assert_called_once()
+        sql_arg = mock_query.call_args[0][0]
+        params_arg = mock_query.call_args[0][1]
+
+        assert "INSERT INTO audit_log" in sql_arg
+        assert params_arg["param_aid"] == "user-1"
+        assert params_arg["param_aemail"] == "admin@example.com"
+        assert params_arg["param_arole"] == "admin"
+        assert params_arg["param_action"] == "user.created"
+        assert params_arg["param_rtype"] == "user"
+        assert params_arg["param_rid"] == "user-1"
+        assert params_arg["param_rname"] == "admin@example.com"
+        assert params_arg["param_det"] == '{"is_demo": false}'
+
+    @pytest.mark.asyncio
+    async def test_logs_exception_on_query_failure(self):
+        from ee.observal_server.services.audit import _insert_audit_row
+
+        mock_query = AsyncMock(side_effect=RuntimeError("ClickHouse down"))
+        with patch("ee.observal_server.services.audit._query", mock_query):
+            # Should not raise — just logs
+            await _insert_audit_row(
+                actor_id="u1",
+                actor_email="x@y",
+                action="test",
+                resource_type="test",
+            )
+
+    @pytest.mark.asyncio
+    async def test_default_params_are_empty(self):
+        from ee.observal_server.services.audit import _insert_audit_row
+
+        mock_query = AsyncMock()
+        with patch("ee.observal_server.services.audit._query", mock_query):
+            await _insert_audit_row(
+                actor_id="u1",
+                actor_email="x@y",
+                action="test.action",
+                resource_type="test",
+            )
+
+        params = mock_query.call_args[0][1]
+        assert params["param_arole"] == ""
+        assert params["param_rid"] == ""
+        assert params["param_rname"] == ""
+        assert params["param_hmethod"] == ""
+        assert params["param_hpath"] == ""
+        assert params["param_scode"] == "0"
+        assert params["param_ip"] == ""
+        assert params["param_ua"] == ""
+        assert params["param_det"] == ""
+
+
+class TestEventEmissionTriggersAudit:
+    """Verify that emitting events actually calls the audit handler."""
+
+    def setup_method(self):
+        bus.clear()
+
+    def teardown_method(self):
+        bus.clear()
+
+    @pytest.mark.asyncio
+    async def test_user_created_triggers_audit(self):
+        from ee.observal_server.services.audit import register_audit_handlers
+
+        mock_query = AsyncMock()
+        with patch("ee.observal_server.services.audit._query", mock_query):
+            register_audit_handlers()
+            event = UserCreated(user_id="u1", email="test@example.com", role="viewer", is_demo=True)
+            await bus.emit(event)
+
+        mock_query.assert_called_once()
+        params = mock_query.call_args[0][1]
+        assert params["param_action"] == "user.created"
+        assert params["param_aid"] == "u1"
+        assert params["param_aemail"] == "test@example.com"
+        assert params["param_arole"] == "viewer"
+        detail = json.loads(params["param_det"])
+        assert detail["is_demo"] is True
+
+    @pytest.mark.asyncio
+    async def test_login_failure_triggers_audit(self):
+        from ee.observal_server.services.audit import register_audit_handlers
+
+        mock_query = AsyncMock()
+        with patch("ee.observal_server.services.audit._query", mock_query):
+            register_audit_handlers()
+            event = LoginFailure(email="hacker@bad.com", method="password", reason="invalid credentials")
+            await bus.emit(event)
+
+        mock_query.assert_called_once()
+        params = mock_query.call_args[0][1]
+        assert params["param_action"] == "auth.login_failure"
+        assert params["param_aid"] == ""
+        detail = json.loads(params["param_det"])
+        assert detail["reason"] == "invalid credentials"
+
+    @pytest.mark.asyncio
+    async def test_alert_rule_changed_triggers_audit(self):
+        from ee.observal_server.services.audit import register_audit_handlers
+
+        mock_query = AsyncMock()
+        with patch("ee.observal_server.services.audit._query", mock_query):
+            register_audit_handlers()
+            event = AlertRuleChanged(
+                alert_id="alert-42",
+                action="created",
+                actor_id="u1",
+                actor_email="admin@example.com",
+            )
+            await bus.emit(event)
+
+        params = mock_query.call_args[0][1]
+        assert params["param_action"] == "alert.created"
+        assert params["param_rtype"] == "alert_rule"
+        assert params["param_rid"] == "alert-42"
+
+    @pytest.mark.asyncio
+    async def test_agent_lifecycle_triggers_audit(self):
+        from ee.observal_server.services.audit import register_audit_handlers
+
+        mock_query = AsyncMock()
+        with patch("ee.observal_server.services.audit._query", mock_query):
+            register_audit_handlers()
+            event = AgentLifecycleEvent(
+                agent_id="agent-7",
+                action="deleted",
+                actor_id="u2",
+                actor_email="ops@example.com",
+            )
+            await bus.emit(event)
+
+        params = mock_query.call_args[0][1]
+        assert params["param_action"] == "agent.deleted"
+        assert params["param_rtype"] == "agent"
+        assert params["param_rid"] == "agent-7"
+
+
+class TestAuditLogEndpoint:
+    """Test the audit log list endpoint with mocked ClickHouse responses."""
+
+    @pytest.mark.asyncio
+    async def test_list_audit_logs_returns_entries(self):
+        from ee.observal_server.routes.audit import list_audit_logs
+
+        fake_row = {
+            "event_id": "550e8400-e29b-41d4-a716-446655440000",
+            "timestamp": "2026-04-14 12:00:00.000",
+            "actor_id": "u1",
+            "actor_email": "admin@example.com",
+            "actor_role": "admin",
+            "action": "user.created",
+            "resource_type": "user",
+            "resource_id": "u2",
+            "resource_name": "new@example.com",
+            "http_method": "",
+            "http_path": "",
+            "status_code": 0,
+            "ip_address": "",
+            "user_agent": "",
+            "detail": "{}",
+        }
+        fake_resp = MagicMock()
+        fake_resp.status_code = 200
+        fake_resp.text = json.dumps(fake_row)
+
+        mock_query = AsyncMock(return_value=fake_resp)
+        mock_user = MagicMock()
+
+        with patch("ee.observal_server.routes.audit._query", mock_query):
+            result = await list_audit_logs(
+                actor=None,
+                action=None,
+                resource_type=None,
+                start_date=None,
+                end_date=None,
+                limit=50,
+                offset=0,
+                current_user=mock_user,
+            )
+
+        assert len(result) == 1
+        assert result[0]["action"] == "user.created"
+        assert result[0]["actor_email"] == "admin@example.com"
+
+    @pytest.mark.asyncio
+    async def test_list_endpoint_handles_empty_response(self):
+        from ee.observal_server.routes.audit import list_audit_logs
+
+        fake_resp = MagicMock()
+        fake_resp.status_code = 500
+        fake_resp.text = ""
+
+        mock_query = AsyncMock(return_value=fake_resp)
+        mock_user = MagicMock()
+
+        with patch("ee.observal_server.routes.audit._query", mock_query):
+            result = await list_audit_logs(
+                actor=None,
+                action=None,
+                resource_type=None,
+                start_date=None,
+                end_date=None,
+                limit=50,
+                offset=0,
+                current_user=mock_user,
+            )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_endpoint_with_filters(self):
+        from ee.observal_server.routes.audit import list_audit_logs
+
+        fake_row = {
+            "event_id": "550e8400-e29b-41d4-a716-446655440000",
+            "timestamp": "2026-04-14 12:00:00.000",
+            "actor_id": "u1",
+            "actor_email": "admin@example.com",
+            "actor_role": "admin",
+            "action": "user.created",
+            "resource_type": "user",
+            "resource_id": "u2",
+            "resource_name": "new@example.com",
+            "http_method": "",
+            "http_path": "",
+            "status_code": 0,
+            "ip_address": "",
+            "user_agent": "",
+            "detail": "{}",
+        }
+        fake_resp = MagicMock()
+        fake_resp.status_code = 200
+        fake_resp.text = json.dumps(fake_row)
+
+        mock_query = AsyncMock(return_value=fake_resp)
+        mock_user = MagicMock()
+
+        with patch("ee.observal_server.routes.audit._query", mock_query):
+            result = await list_audit_logs(
+                actor="admin@example.com",
+                action="user.created",
+                resource_type="user",
+                start_date=None,
+                end_date=None,
+                limit=50,
+                offset=0,
+                current_user=mock_user,
+            )
+
+        assert len(result) == 1
+        # Verify the SQL includes filter params
+        sql_arg = mock_query.call_args[0][0]
+        params_arg = mock_query.call_args[0][1]
+        assert "actor_email = {actor:String}" in sql_arg
+        assert "action = {action:String}" in sql_arg
+        assert "resource_type = {rtype:String}" in sql_arg
+        assert params_arg["param_actor"] == "admin@example.com"
+        assert params_arg["param_action"] == "user.created"
+        assert params_arg["param_rtype"] == "user"


### PR DESCRIPTION
## Summary
- Add `audit_log` ClickHouse table with 730-day TTL and bloom filter indexes
- Add `ee/observal_server/services/audit.py` with 8 event bus handlers (fire-and-forget pattern)
- Add `GET /api/v1/admin/audit-log` (filtered/paginated JSON) and `/export` (CSV) admin-only endpoints
- Add `AlertRuleChanged` and `AgentLifecycleEvent` event types to core `events.py`
- Enterprise-only: handlers register during `register_enterprise()`, no-op in local mode
- 12 tests covering handler registration, ClickHouse insert, event-to-audit flow, and endpoint auth

Closes #228

## Test plan
- [ ] `ruff check . && ruff format --check .` passes
- [ ] `pytest tests/ -q` — all 12 new tests pass
- [ ] Verify audit handlers only register when `DEPLOYMENT_MODE=enterprise`
- [ ] Verify `ee/` import boundary is not violated (core does not import from ee/)