### PR TITLE
feat(clickhouse): add data retention TTL policy and configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ OAUTH_SERVER_METADATA_URL=
 # Enterprise mode: SSO-only login, SCIM provisioning, no self-registration
 DEPLOYMENT_MODE=local
 
+# ClickHouse data retention (days). Set to 0 to disable TTL.
+DATA_RETENTION_DAYS=90
+
 # Demo accounts — seeded on first startup when no real users exist.
 # Automatically cleaned up when a real super_admin is created.
 # Set all 8 vars to enable, or leave unset to skip demo seeding.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - AWS_REGION=${AWS_REGION:-us-east-1}
       # Enterprise deployment mode
       - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-local}
+      # ClickHouse data retention
+      - DATA_RETENTION_DAYS=${DATA_RETENTION_DAYS:-90}
       # Demo accounts (seeded on first startup when no real users exist)
       - DEMO_SUPER_ADMIN_EMAIL=${DEMO_SUPER_ADMIN_EMAIL:-super@demo.local}
       - DEMO_SUPER_ADMIN_PASSWORD=${DEMO_SUPER_ADMIN_PASSWORD:-super-changeme}

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -33,6 +34,18 @@ class Settings(BaseSettings):
     # Rate limiting
     RATE_LIMIT_AUTH: str = "10/minute"
     RATE_LIMIT_AUTH_STRICT: str = "5/minute"
+
+    # ClickHouse data retention
+    DATA_RETENTION_DAYS: int = 90
+
+    @field_validator("DATA_RETENTION_DAYS")
+    @classmethod
+    def validate_retention_days(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("DATA_RETENTION_DAYS must be >= 0 (0 disables retention)")
+        if 0 < v < 7:
+            raise ValueError("DATA_RETENTION_DAYS must be >= 7 to prevent accidental data loss")
+        return v
 
     # Deployment mode
     DEPLOYMENT_MODE: Literal["local", "enterprise"] = "local"

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -264,7 +264,7 @@ INIT_SQL = [
 
 
 async def init_clickhouse():
-    """Create ClickHouse tables if they don't exist.
+    """Create ClickHouse tables if they don't exist and configure retention.
 
     Raises on unreachable server so startup fails fast.
     """
@@ -277,6 +277,30 @@ async def init_clickhouse():
             await _query(stmt)
         except Exception as e:
             logger.warning(f"ClickHouse init statement failed: {e}")
+
+    # Apply data retention TTL if configured
+    retention_days = settings.DATA_RETENTION_DAYS
+    if retention_days > 0:
+        ttl_stmts = [
+            f"ALTER TABLE traces MODIFY TTL toDate(start_time) + INTERVAL {retention_days} DAY",
+            f"ALTER TABLE spans MODIFY TTL toDate(start_time) + INTERVAL {retention_days} DAY",
+            f"ALTER TABLE scores MODIFY TTL toDate(timestamp) + INTERVAL {retention_days} DAY",
+            f"ALTER TABLE mcp_tool_calls MODIFY TTL toDate(timestamp) + INTERVAL {retention_days} DAY",
+            f"ALTER TABLE agent_interactions MODIFY TTL toDate(timestamp) + INTERVAL {retention_days} DAY",
+        ]
+        applied = 0
+        for stmt in ttl_stmts:
+            try:
+                await _query(stmt)
+                applied += 1
+            except Exception as e:
+                logger.warning(f"ClickHouse TTL configuration failed: {e}")
+        if applied == len(ttl_stmts):
+            logger.info("ClickHouse retention set to %d days", retention_days)
+        else:
+            logger.warning("ClickHouse retention partially applied: %d/%d tables", applied, len(ttl_stmts))
+    else:
+        logger.info("ClickHouse data retention disabled (DATA_RETENTION_DAYS=0)")
 
 
 async def insert_tool_call(event: dict):

--- a/tests/test_clickhouse_phase1.py
+++ b/tests/test_clickhouse_phase1.py
@@ -141,7 +141,8 @@ class TestInitClickhouse:
         with patch("services.clickhouse._query", new_callable=AsyncMock) as mock_q:
             mock_q.return_value = _mock_response()
             await init_clickhouse()
-            assert mock_q.call_count == len(INIT_SQL) + 1  # +1 for health check
+            # +1 health check + 5 TTL ALTER statements (default retention=90)
+            assert mock_q.call_count == len(INIT_SQL) + 1 + 5
 
 
 # --- Insert tests (JSONEachRow format) ---

--- a/tests/test_clickhouse_retention.py
+++ b/tests/test_clickhouse_retention.py
@@ -1,0 +1,84 @@
+"""Tests for ClickHouse data retention TTL configuration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _mock_response(status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_retention_ttl_applied():
+    """init_clickhouse applies TTL when DATA_RETENTION_DAYS > 0."""
+    with (
+        patch("services.clickhouse.settings") as mock_settings,
+        patch("services.clickhouse._query", new_callable=AsyncMock) as mock_query,
+    ):
+        mock_settings.DATA_RETENTION_DAYS = 90
+        mock_settings.CLICKHOUSE_URL = "clickhouse://localhost:8123/observal"
+        mock_query.return_value = _mock_response()
+
+        from services.clickhouse import init_clickhouse
+
+        await init_clickhouse()
+
+        # Check TTL ALTER statements were called
+        ttl_calls = [call for call in mock_query.call_args_list if "MODIFY TTL" in str(call)]
+        assert len(ttl_calls) == 5, f"Expected 5 TTL statements, got {len(ttl_calls)}"
+
+        # Verify retention days in the SQL
+        for call in ttl_calls:
+            assert "INTERVAL 90 DAY" in call.args[0]
+
+
+@pytest.mark.asyncio
+async def test_retention_disabled_when_zero():
+    """init_clickhouse skips TTL when DATA_RETENTION_DAYS=0."""
+    with (
+        patch("services.clickhouse.settings") as mock_settings,
+        patch("services.clickhouse._query", new_callable=AsyncMock) as mock_query,
+    ):
+        mock_settings.DATA_RETENTION_DAYS = 0
+        mock_settings.CLICKHOUSE_URL = "clickhouse://localhost:8123/observal"
+        mock_query.return_value = _mock_response()
+
+        from services.clickhouse import init_clickhouse
+
+        await init_clickhouse()
+
+        ttl_calls = [call for call in mock_query.call_args_list if "MODIFY TTL" in str(call)]
+        assert len(ttl_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_retention_tables_covered():
+    """All five ClickHouse tables get TTL statements."""
+    expected_tables = {"traces", "spans", "scores", "mcp_tool_calls", "agent_interactions"}
+
+    with (
+        patch("services.clickhouse.settings") as mock_settings,
+        patch("services.clickhouse._query", new_callable=AsyncMock) as mock_query,
+    ):
+        mock_settings.DATA_RETENTION_DAYS = 30
+        mock_settings.CLICKHOUSE_URL = "clickhouse://localhost:8123/observal"
+        mock_query.return_value = _mock_response()
+
+        from services.clickhouse import init_clickhouse
+
+        await init_clickhouse()
+
+        ttl_tables = set()
+        for call in mock_query.call_args_list:
+            sql = call.args[0] if call.args else ""
+            if "MODIFY TTL" in sql:
+                # Extract table name: "ALTER TABLE <name> MODIFY TTL"
+                parts = sql.split()
+                table_idx = parts.index("TABLE") + 1
+                ttl_tables.add(parts[table_idx])
+
+        assert ttl_tables == expected_tables


### PR DESCRIPTION
## Summary
- Add `DATA_RETENTION_DAYS` setting (default 90, set to 0 to disable)
- Apply `ALTER TABLE ... MODIFY TTL` on startup for all 5 ClickHouse tables (traces, spans, scores, mcp_tool_calls, agent_interactions)
- Add setting to `.env.example` and `docker-compose.yml`
- 3 tests verifying TTL application, disable-when-zero, and table coverage

Closes #203

## Test plan
- [ ] `ruff check . && ruff format --check .` passes
- [ ] `pytest tests/ -q` — all tests pass including 3 new retention tests
- [ ] Verify `DATA_RETENTION_DAYS=0` skips TTL statements
- [ ] Verify all 5 tables receive TTL on startup