### PR TITLE
feat(grafana): add dashboard templates and data source provisioning

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       observal-redis:
         condition: service_healthy
       observal-clickhouse:
-        condition: service_started
+        condition: service_healthy
     restart: unless-stopped
     read_only: true
     tmpfs:
@@ -190,10 +190,29 @@ services:
     networks:
       - observal-net
 
+  observal-grafana:
+    image: grafana/grafana-oss:latest
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+    volumes:
+      - ../grafana/provisioning:/etc/grafana/provisioning
+      - ../grafana/dashboards:/var/lib/grafana/dashboards
+      - grafanadata:/var/lib/grafana
+    depends_on:
+      observal-clickhouse:
+        condition: service_healthy
+    networks:
+      - observal-net
+
 volumes:
   pgdata:
   chdata:
   redisdata:
+  grafanadata:
 
 networks:
   observal-net:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -191,20 +191,26 @@ services:
       - observal-net
 
   observal-grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:11.6.0
     ports:
       - "3001:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-clickhouse}
     volumes:
-      - ../grafana/provisioning:/etc/grafana/provisioning
-      - ../grafana/dashboards:/var/lib/grafana/dashboards
+      - ../grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafanadata:/var/lib/grafana
     depends_on:
       observal-clickhouse:
         condition: service_healthy
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     networks:
       - observal-net
 

--- a/grafana/dashboards/agent-activity.json
+++ b/grafana/dashboards/agent-activity.json
@@ -1,7 +1,7 @@
 {
-  "uid": "observal-tool-call-frequency",
-  "title": "Observal \u2014 Tool Call Frequency",
-  "description": "Tool call volume by name and MCP server",
+  "uid": "observal-agent-activity",
+  "title": "Observal \u2014 Agent Activity",
+  "description": "Agent usage, performance, and interaction metrics",
   "tags": [
     "observal"
   ],
@@ -26,7 +26,7 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "observal-clickhouse"
         },
-        "query": "SELECT DISTINCT project_id FROM spans FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "query": "SELECT DISTINCT project_id FROM traces FINAL WHERE is_deleted = 0 AND agent_id IS NOT NULL ORDER BY project_id",
         "current": {
           "selected": true,
           "text": "All",
@@ -46,7 +46,7 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "observal-clickhouse"
         },
-        "query": "SELECT DISTINCT environment FROM spans FINAL WHERE is_deleted = 0 ORDER BY environment",
+        "query": "SELECT DISTINCT environment FROM traces FINAL WHERE is_deleted = 0 ORDER BY environment",
         "current": {
           "selected": true,
           "text": "All",
@@ -63,7 +63,7 @@
   "panels": [
     {
       "id": 1,
-      "title": "Tool Call Volume Over Time",
+      "title": "Agent Traces Over Time",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -107,7 +107,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  count() AS tool_calls\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_call'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  count() AS agent_traces\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND agent_id IS NOT NULL AND agent_id != ''\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -115,7 +115,7 @@
     },
     {
       "id": 2,
-      "title": "Total Tool Calls",
+      "title": "Active Agents",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -163,7 +163,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT count() AS total\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_call'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "rawSql": "SELECT count(DISTINCT agent_id) AS active_agents\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND agent_id IS NOT NULL AND agent_id != ''\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
           "refId": "A",
           "format": 1
         }
@@ -171,7 +171,7 @@
     },
     {
       "id": 3,
-      "title": "Avg Latency (ms)",
+      "title": "Avg Spans per Agent Trace",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -187,14 +187,15 @@
         "defaults": {
           "color": {
             "mode": "fixed",
-            "fixedColor": "yellow"
+            "fixedColor": "blue"
           },
-          "unit": "ms",
+          "unit": "short",
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "yellow",
+                "color": "blue",
                 "value": null
               }
             ]
@@ -219,7 +220,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT avg(latency_ms) AS avg_latency\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_call'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND latency_ms IS NOT NULL",
+          "rawSql": "SELECT round(avg(span_count), 1) AS avg_spans\nFROM (\n  SELECT\n    s.trace_id,\n    count() AS span_count\n  FROM spans AS s FINAL\n  INNER JOIN traces AS t FINAL ON s.trace_id = t.trace_id AND s.project_id = t.project_id AND t.is_deleted = 0\n  WHERE s.is_deleted = 0\n    AND t.agent_id IS NOT NULL AND t.agent_id != ''\n    AND $__timeFilter(s.start_time)\n    AND ('${project_id}' = '1' OR s.project_id IN (${project_id:singlequote}))\n    AND ('${environment}' = '1' OR s.environment IN (${environment:singlequote}))\n  GROUP BY s.trace_id\n)",
           "refId": "A",
           "format": 1
         }
@@ -227,7 +228,7 @@
     },
     {
       "id": 4,
-      "title": "Tool Calls by Name",
+      "title": "Top Agents by Trace Count",
       "type": "barchart",
       "gridPos": {
         "h": 8,
@@ -265,7 +266,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  name AS tool_name,\n  count() AS calls\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_call'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY tool_name\nORDER BY calls DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  agent_id,\n  count() AS traces\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND agent_id IS NOT NULL AND agent_id != ''\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY agent_id\nORDER BY traces DESC\nLIMIT 15",
           "refId": "A",
           "format": 1
         }
@@ -273,8 +274,8 @@
     },
     {
       "id": 5,
-      "title": "Tool Calls by MCP Server",
-      "type": "piechart",
+      "title": "Agent Error Rate",
+      "type": "barchart",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -290,27 +291,18 @@
           "color": {
             "mode": "palette-classic"
           },
-          "unit": "short"
+          "unit": "percent"
         },
         "overrides": []
       },
       "options": {
+        "orientation": "horizontal",
         "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "values": [
-            "value",
-            "percent"
-          ]
+          "displayMode": "list",
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
         }
       },
       "targets": [
@@ -320,7 +312,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  t.mcp_id AS mcp_server,\n  count() AS calls\nFROM spans AS s FINAL\nINNER JOIN traces AS t FINAL ON s.trace_id = t.trace_id AND s.project_id = t.project_id AND t.is_deleted = 0\nWHERE s.is_deleted = 0\n  AND s.type = 'tool_call'\n  AND $__timeFilter(s.start_time)\n  AND ('${project_id}' = '1' OR s.project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR s.environment IN (${environment:singlequote}))\n  AND t.mcp_id IS NOT NULL AND t.mcp_id != ''\nGROUP BY mcp_server\nORDER BY calls DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  s.agent_id,\n  round(countIf(s.status = 'error') / nullIf(count(), 0) * 100, 2) AS error_rate,\n  count() AS total_spans\nFROM spans AS s FINAL\nWHERE s.is_deleted = 0\n  AND s.agent_id IS NOT NULL AND s.agent_id != ''\n  AND $__timeFilter(s.start_time)\n  AND ('${project_id}' = '1' OR s.project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR s.environment IN (${environment:singlequote}))\nGROUP BY s.agent_id\nHAVING total_spans >= 5\nORDER BY error_rate DESC\nLIMIT 15",
           "refId": "A",
           "format": 1
         }
@@ -328,7 +320,7 @@
     },
     {
       "id": 6,
-      "title": "Tool Call Latency Percentiles",
+      "title": "Agent Latency Percentiles",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -418,7 +410,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  quantile(0.50)(latency_ms) AS p50,\n  quantile(0.95)(latency_ms) AS p95,\n  quantile(0.99)(latency_ms) AS p99\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_call'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND latency_ms IS NOT NULL\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(s.start_time) AS time,\n  quantile(0.50)(s.latency_ms) AS p50,\n  quantile(0.95)(s.latency_ms) AS p95,\n  quantile(0.99)(s.latency_ms) AS p99\nFROM spans AS s FINAL\nWHERE s.is_deleted = 0\n  AND s.agent_id IS NOT NULL AND s.agent_id != ''\n  AND s.latency_ms IS NOT NULL\n  AND $__timeFilter(s.start_time)\n  AND ('${project_id}' = '1' OR s.project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR s.environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -426,7 +418,7 @@
     },
     {
       "id": 7,
-      "title": "Top Tools by Latency",
+      "title": "Top Agents by Latency",
       "type": "table",
       "gridPos": {
         "h": 8,
@@ -458,7 +450,47 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  name AS tool_name,\n  count() AS calls,\n  round(avg(latency_ms)) AS avg_ms,\n  round(quantile(0.95)(latency_ms)) AS p95_ms,\n  round(max(latency_ms)) AS max_ms\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_call'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND latency_ms IS NOT NULL\nGROUP BY tool_name\nORDER BY p95_ms DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  agent_id,\n  count() AS spans,\n  round(avg(latency_ms)) AS avg_ms,\n  round(quantile(0.95)(latency_ms)) AS p95_ms,\n  round(max(latency_ms)) AS max_ms\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND agent_id IS NOT NULL AND agent_id != ''\n  AND latency_ms IS NOT NULL\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY agent_id\nORDER BY p95_ms DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 2
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Recent Agent Traces",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "start_time",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  trace_id,\n  agent_id,\n  session_id,\n  name,\n  trace_type,\n  ide,\n  environment,\n  start_time,\n  end_time\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND agent_id IS NOT NULL AND agent_id != ''\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nORDER BY start_time DESC\nLIMIT 50",
           "refId": "A",
           "format": 2
         }

--- a/grafana/dashboards/audit-log.json
+++ b/grafana/dashboards/audit-log.json
@@ -1,9 +1,10 @@
 {
-  "uid": "observal-token-usage",
-  "title": "Observal \u2014 Token Usage",
-  "description": "Input, output, and total token consumption over time",
+  "uid": "observal-audit-log",
+  "title": "Observal \u2014 Audit Log",
+  "description": "Enterprise audit trail: actions, actors, and resource access",
   "tags": [
-    "observal"
+    "observal",
+    "enterprise"
   ],
   "timezone": "browser",
   "schemaVersion": 39,
@@ -12,21 +13,21 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "time": {
-    "from": "now-24h",
+    "from": "now-7d",
     "to": "now"
   },
-  "refresh": "30s",
+  "refresh": "1m",
   "templating": {
     "list": [
       {
-        "name": "project_id",
-        "label": "Project",
+        "name": "action",
+        "label": "Action",
         "type": "query",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "observal-clickhouse"
         },
-        "query": "SELECT DISTINCT project_id FROM spans FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "query": "SELECT DISTINCT action FROM audit_log ORDER BY action",
         "current": {
           "selected": true,
           "text": "All",
@@ -39,14 +40,14 @@
         "sort": 1
       },
       {
-        "name": "environment",
-        "label": "Environment",
+        "name": "resource_type",
+        "label": "Resource Type",
         "type": "query",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "observal-clickhouse"
         },
-        "query": "SELECT DISTINCT environment FROM spans FINAL WHERE is_deleted = 0 ORDER BY environment",
+        "query": "SELECT DISTINCT resource_type FROM audit_log ORDER BY resource_type",
         "current": {
           "selected": true,
           "text": "All",
@@ -63,10 +64,10 @@
   "panels": [
     {
       "id": 1,
-      "title": "Input vs Output Tokens Over Time",
+      "title": "Audit Events Over Time",
       "type": "timeseries",
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 16,
         "x": 0,
         "y": 0
@@ -78,51 +79,18 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "fixed",
+            "fixedColor": "blue"
           },
           "custom": {
             "lineWidth": 2,
-            "fillOpacity": 20,
+            "fillOpacity": 15,
             "spanNulls": false,
-            "stacking": {
-              "mode": "normal"
-            },
             "axisBorderShow": false
           },
           "unit": "short"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "input_tokens"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "output_tokens"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "options": {
         "tooltip": {
@@ -141,7 +109,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND token_count_total > 0\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(timestamp) AS time,\n  count() AS events\nFROM audit_log\nWHERE $__timeFilter(timestamp)\n  AND ('${action}' = '1' OR action IN (${action:singlequote}))\n  AND ('${resource_type}' = '1' OR resource_type IN (${resource_type:singlequote}))\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -149,10 +117,10 @@
     },
     {
       "id": 2,
-      "title": "Total Input Tokens",
+      "title": "Total Events",
       "type": "stat",
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 4,
         "x": 16,
         "y": 0
@@ -197,7 +165,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT sum(token_count_input) AS total_input\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "rawSql": "SELECT count() AS total\nFROM audit_log\nWHERE $__timeFilter(timestamp)\n  AND ('${action}' = '1' OR action IN (${action:singlequote}))\n  AND ('${resource_type}' = '1' OR resource_type IN (${resource_type:singlequote}))",
           "refId": "A",
           "format": 1
         }
@@ -205,10 +173,10 @@
     },
     {
       "id": 3,
-      "title": "Total Output Tokens",
+      "title": "Unique Actors",
       "type": "stat",
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 4,
         "x": 20,
         "y": 0
@@ -221,70 +189,14 @@
         "defaults": {
           "color": {
             "mode": "fixed",
-            "fixedColor": "orange"
+            "fixedColor": "purple"
           },
           "unit": "short",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "orange",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-clickhouse-datasource",
-            "uid": "observal-clickhouse"
-          },
-          "queryType": "sql",
-          "rawSql": "SELECT sum(token_count_output) AS total_output\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
-          "refId": "A",
-          "format": 1
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "title": "Total Tokens (All)",
-      "type": "stat",
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 5
-      },
-      "datasource": {
-        "type": "grafana-clickhouse-datasource",
-        "uid": "observal-clickhouse"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "green"
-          },
-          "unit": "short",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
+                "color": "purple",
                 "value": null
               }
             ]
@@ -309,7 +221,62 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT sum(token_count_total) AS total_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "rawSql": "SELECT count(DISTINCT actor_id) AS unique_actors\nFROM audit_log\nWHERE $__timeFilter(timestamp)\n  AND ('${action}' = '1' OR action IN (${action:singlequote}))\n  AND ('${resource_type}' = '1' OR resource_type IN (${resource_type:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Events by Action",
+      "type": "piechart",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  action,\n  count() AS count\nFROM audit_log\nWHERE $__timeFilter(timestamp)\n  AND ('${resource_type}' = '1' OR resource_type IN (${resource_type:singlequote}))\nGROUP BY action\nORDER BY count DESC",
           "refId": "A",
           "format": 1
         }
@@ -317,13 +284,13 @@
     },
     {
       "id": 5,
-      "title": "Token Usage by Span Type",
+      "title": "Events by Resource Type",
       "type": "barchart",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
-        "y": 10
+        "y": 8
       },
       "datasource": {
         "type": "grafana-clickhouse-datasource",
@@ -346,8 +313,7 @@
         },
         "tooltip": {
           "mode": "single"
-        },
-        "stacking": "normal"
+        }
       },
       "targets": [
         {
@@ -356,7 +322,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  type,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND token_count_total > 0\nGROUP BY type\nORDER BY input_tokens + output_tokens DESC\nLIMIT 10",
+          "rawSql": "SELECT\n  resource_type,\n  count() AS count\nFROM audit_log\nWHERE $__timeFilter(timestamp)\n  AND ('${action}' = '1' OR action IN (${action:singlequote}))\nGROUP BY resource_type\nORDER BY count DESC\nLIMIT 15",
           "refId": "A",
           "format": 1
         }
@@ -364,13 +330,114 @@
     },
     {
       "id": 6,
-      "title": "Top Token Consumers",
-      "type": "table",
+      "title": "Top Actors",
+      "type": "barchart",
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 10
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  actor_email,\n  actor_role,\n  count() AS events\nFROM audit_log\nWHERE $__timeFilter(timestamp)\n  AND ('${action}' = '1' OR action IN (${action:singlequote}))\n  AND ('${resource_type}' = '1' OR resource_type IN (${resource_type:singlequote}))\nGROUP BY actor_email, actor_role\nORDER BY events DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Events by HTTP Method",
+      "type": "piechart",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  http_method,\n  count() AS count\nFROM audit_log\nWHERE $__timeFilter(timestamp)\n  AND http_method != ''\n  AND ('${action}' = '1' OR action IN (${action:singlequote}))\n  AND ('${resource_type}' = '1' OR resource_type IN (${resource_type:singlequote}))\nGROUP BY http_method\nORDER BY count DESC",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Recent Audit Events",
+      "type": "table",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 20
       },
       "datasource": {
         "type": "grafana-clickhouse-datasource",
@@ -384,7 +451,7 @@
         "showHeader": true,
         "sortBy": [
           {
-            "displayName": "total_tokens",
+            "displayName": "timestamp",
             "desc": true
           }
         ]
@@ -396,7 +463,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  name,\n  type,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens,\n  sum(token_count_total) AS total_tokens,\n  count() AS invocations\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND token_count_total > 0\nGROUP BY name, type\nORDER BY total_tokens DESC\nLIMIT 20",
+          "rawSql": "SELECT\n  timestamp,\n  actor_email,\n  actor_role,\n  action,\n  resource_type,\n  resource_name,\n  http_method,\n  http_path,\n  status_code,\n  ip_address,\n  detail\nFROM audit_log\nWHERE $__timeFilter(timestamp)\n  AND ('${action}' = '1' OR action IN (${action:singlequote}))\n  AND ('${resource_type}' = '1' OR resource_type IN (${resource_type:singlequote}))\nORDER BY timestamp DESC\nLIMIT 100",
           "refId": "A",
           "format": 2
         }

--- a/grafana/dashboards/audit-log.json
+++ b/grafana/dashboards/audit-log.json
@@ -1,10 +1,9 @@
 {
   "uid": "observal-audit-log",
   "title": "Observal \u2014 Audit Log",
-  "description": "Enterprise audit trail: actions, actors, and resource access",
+  "description": "Audit trail: actions, actors, and resource access",
   "tags": [
-    "observal",
-    "enterprise"
+    "observal"
   ],
   "timezone": "browser",
   "schemaVersion": 39,

--- a/grafana/dashboards/cost-tracking.json
+++ b/grafana/dashboards/cost-tracking.json
@@ -37,6 +37,26 @@
         "multi": true,
         "refresh": 2,
         "sort": 1
+      },
+      {
+        "name": "environment",
+        "label": "Environment",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT environment FROM spans FINAL WHERE is_deleted = 0 ORDER BY environment",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
       }
     ]
   },
@@ -88,7 +108,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  time,\n  sum(daily_cost) OVER (ORDER BY time) AS cumulative_cost\nFROM (\n  SELECT\n    $__timeInterval(start_time) AS time,\n    sum(cost) AS daily_cost\n  FROM spans FINAL\n  WHERE is_deleted = 0\n    AND $__timeFilter(start_time)\n    AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n    AND cost IS NOT NULL AND cost > 0\n  GROUP BY time\n  ORDER BY time\n)\nORDER BY time",
+          "rawSql": "SELECT\n  time,\n  sum(daily_cost) OVER (ORDER BY time) AS cumulative_cost\nFROM (\n  SELECT\n    $__timeInterval(start_time) AS time,\n    sum(cost) AS daily_cost\n  FROM spans FINAL\n  WHERE is_deleted = 0\n    AND $__timeFilter(start_time)\n    AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n    AND cost IS NOT NULL AND cost > 0\n  GROUP BY time\n  ORDER BY time\n)\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -144,7 +164,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT sum(cost) AS total_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND cost IS NOT NULL AND cost > 0",
+          "rawSql": "SELECT sum(cost) AS total_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND cost IS NOT NULL AND cost > 0",
           "refId": "A",
           "format": 1
         }
@@ -201,7 +221,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT avg(cost) AS avg_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND cost IS NOT NULL AND cost > 0",
+          "rawSql": "SELECT avg(cost) AS avg_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND cost IS NOT NULL AND cost > 0",
           "refId": "A",
           "format": 1
         }
@@ -247,7 +267,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  t.agent_id AS agent,\n  round(sum(s.cost), 4) AS total_cost\nFROM spans AS s FINAL\nINNER JOIN traces AS t FINAL ON s.trace_id = t.trace_id AND t.is_deleted = 0\nWHERE s.is_deleted = 0\n  AND $__timeFilter(s.start_time)\n  AND ('${project_id}' = '1' OR s.project_id IN (${project_id:singlequote}))\n  AND s.cost IS NOT NULL AND s.cost > 0\n  AND t.agent_id IS NOT NULL\nGROUP BY agent\nORDER BY total_cost DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  t.agent_id AS agent,\n  round(sum(s.cost), 4) AS total_cost\nFROM spans AS s FINAL\nINNER JOIN traces AS t FINAL ON s.trace_id = t.trace_id AND s.project_id = t.project_id AND t.is_deleted = 0\nWHERE s.is_deleted = 0\n  AND $__timeFilter(s.start_time)\n  AND ('${project_id}' = '1' OR s.project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR s.environment IN (${environment:singlequote}))\n  AND s.cost IS NOT NULL AND s.cost > 0\n  AND t.agent_id IS NOT NULL\nGROUP BY agent\nORDER BY total_cost DESC\nLIMIT 15",
           "refId": "A",
           "format": 1
         }
@@ -293,7 +313,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  project_id,\n  round(sum(cost), 4) AS total_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY project_id\nORDER BY total_cost DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  project_id,\n  round(sum(cost), 4) AS total_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY project_id\nORDER BY total_cost DESC\nLIMIT 15",
           "refId": "A",
           "format": 1
         }
@@ -346,7 +366,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  toStartOfDay(start_time) AS time,\n  round(sum(cost), 4) AS daily_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfDay(start_time) AS time,\n  round(sum(cost), 4) AS daily_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -415,7 +435,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  toDate(start_time) AS date,\n  count() AS spans,\n  round(sum(cost), 4) AS total_cost,\n  round(avg(cost), 6) AS avg_cost,\n  sum(token_count_total) AS total_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY date\nORDER BY date DESC",
+          "rawSql": "SELECT\n  toDate(start_time) AS date,\n  count() AS spans,\n  round(sum(cost), 4) AS total_cost,\n  round(avg(cost), 6) AS avg_cost,\n  sum(token_count_total) AS total_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY date\nORDER BY date DESC",
           "refId": "A",
           "format": 2
         }

--- a/grafana/dashboards/cost-tracking.json
+++ b/grafana/dashboards/cost-tracking.json
@@ -1,0 +1,425 @@
+{
+  "uid": "observal-cost-tracking",
+  "title": "Observal \u2014 Cost Tracking",
+  "description": "Cumulative cost, cost by agent and project",
+  "tags": [
+    "observal"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "refresh": "1m",
+  "templating": {
+    "list": [
+      {
+        "name": "project_id",
+        "label": "Project",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT project_id FROM spans FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Cumulative Cost Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  time,\n  sum(daily_cost) OVER (ORDER BY time) AS cumulative_cost\nFROM (\n  SELECT\n    $__timeInterval(start_time) AS time,\n    sum(cost) AS daily_cost\n  FROM spans FINAL\n  WHERE is_deleted = 0\n    AND $__timeFilter(start_time)\n    AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n    AND cost IS NOT NULL AND cost > 0\n  GROUP BY time\n  ORDER BY time\n)\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Total Cost",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          },
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT sum(cost) AS total_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND cost IS NOT NULL AND cost > 0",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Avg Cost per Span",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          },
+          "unit": "currencyUSD",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT avg(cost) AS avg_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND cost IS NOT NULL AND cost > 0",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Cost by Agent",
+      "type": "barchart",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  t.agent_id AS agent,\n  round(sum(s.cost), 4) AS total_cost\nFROM spans AS s FINAL\nINNER JOIN traces AS t FINAL ON s.trace_id = t.trace_id AND t.is_deleted = 0\nWHERE s.is_deleted = 0\n  AND $__timeFilter(s.start_time)\n  AND ('${project_id}' = '1' OR s.project_id IN (${project_id:singlequote}))\n  AND s.cost IS NOT NULL AND s.cost > 0\n  AND t.agent_id IS NOT NULL\nGROUP BY agent\nORDER BY total_cost DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Cost by Project",
+      "type": "barchart",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  project_id,\n  round(sum(cost), 4) AS total_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY project_id\nORDER BY total_cost DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Daily Cost Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "drawStyle": "bars",
+            "axisBorderShow": false
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  toStartOfDay(start_time) AS time,\n  round(sum(cost), 4) AS daily_cost\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Daily Cost Breakdown",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total_cost"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "avg_cost"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              },
+              {
+                "id": "decimals",
+                "value": 4
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "date",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  toDate(start_time) AS date,\n  count() AS spans,\n  round(sum(cost), 4) AS total_cost,\n  round(avg(cost), 6) AS avg_cost,\n  sum(token_count_total) AS total_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND cost IS NOT NULL AND cost > 0\nGROUP BY date\nORDER BY date DESC",
+          "refId": "A",
+          "format": 2
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/error-rates.json
+++ b/grafana/dashboards/error-rates.json
@@ -1,0 +1,460 @@
+{
+  "uid": "observal-error-rates",
+  "title": "Observal \u2014 Error Rates",
+  "description": "Error rate by span type and status breakdown",
+  "tags": [
+    "observal"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "project_id",
+        "label": "Project",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT project_id FROM spans FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Error Rate Over Time (%)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Total Errors",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT countIf(status = 'error') AS total_errors\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Overall Error Rate",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Status Breakdown",
+      "type": "piechart",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "timeout"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  status,\n  count() AS count\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY status\nORDER BY count DESC",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Error Rate by Span Type",
+      "type": "barchart",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  type,\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate,\n  count() AS total_spans\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY type\nHAVING total_spans > 0\nORDER BY error_rate DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Timeout Rate Over Time (%)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "percent",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  round(countIf(status = 'timeout') / count() * 100, 2) AS timeout_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Recent Errors",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "start_time",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  span_id,\n  trace_id,\n  type,\n  name,\n  status,\n  error,\n  latency_ms,\n  start_time\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND status != 'success'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nORDER BY start_time DESC\nLIMIT 50",
+          "refId": "A",
+          "format": 2
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/error-rates.json
+++ b/grafana/dashboards/error-rates.json
@@ -37,6 +37,26 @@
         "multi": true,
         "refresh": 2,
         "sort": 1
+      },
+      {
+        "name": "environment",
+        "label": "Environment",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT environment FROM spans FINAL WHERE is_deleted = 0 ORDER BY environment",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
       }
     ]
   },
@@ -90,7 +110,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -146,7 +166,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT countIf(status = 'error') AS total_errors\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "rawSql": "SELECT countIf(status = 'error') AS total_errors\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
           "refId": "A",
           "format": 1
         }
@@ -209,7 +229,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "rawSql": "SELECT\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
           "refId": "A",
           "format": 1
         }
@@ -310,7 +330,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  status,\n  count() AS count\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY status\nORDER BY count DESC",
+          "rawSql": "SELECT\n  status,\n  count() AS count\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY status\nORDER BY count DESC",
           "refId": "A",
           "format": 1
         }
@@ -356,7 +376,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  type,\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate,\n  count() AS total_spans\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY type\nHAVING total_spans > 0\nORDER BY error_rate DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  type,\n  round(countIf(status = 'error') / count() * 100, 2) AS error_rate,\n  count() AS total_spans\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY type\nHAVING total_spans > 0\nORDER BY error_rate DESC\nLIMIT 15",
           "refId": "A",
           "format": 1
         }
@@ -410,7 +430,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  round(countIf(status = 'timeout') / count() * 100, 2) AS timeout_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  round(countIf(status = 'timeout') / count() * 100, 2) AS timeout_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -450,7 +470,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  span_id,\n  trace_id,\n  type,\n  name,\n  status,\n  error,\n  latency_ms,\n  start_time\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND status != 'success'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nORDER BY start_time DESC\nLIMIT 50",
+          "rawSql": "SELECT\n  span_id,\n  trace_id,\n  type,\n  name,\n  status,\n  error,\n  latency_ms,\n  start_time\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND status != 'success'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nORDER BY start_time DESC\nLIMIT 50",
           "refId": "A",
           "format": 2
         }

--- a/grafana/dashboards/performance-resources.json
+++ b/grafana/dashboards/performance-resources.json
@@ -1,0 +1,661 @@
+{
+  "uid": "observal-performance-resources",
+  "title": "Observal \u2014 Performance & Resources",
+  "description": "CPU, memory, network, disk, OOM, and sandbox execution metrics",
+  "tags": [
+    "observal"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "project_id",
+        "label": "Project",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT project_id FROM spans FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "environment",
+        "label": "Environment",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT environment FROM spans FINAL WHERE is_deleted = 0 ORDER BY environment",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU Usage Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  avg(cpu_ms) AS avg_cpu_ms,\n  quantile(0.95)(cpu_ms) AS p95_cpu_ms\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND cpu_ms IS NOT NULL\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Memory Usage Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  avg(memory_mb) AS avg_memory_mb,\n  quantile(0.95)(memory_mb) AS p95_memory_mb\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND memory_mb IS NOT NULL\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "OOM Killed Events",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT countIf(oom_killed = 1) AS oom_events\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Total Retries",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT sum(retry_count) AS total_retries\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND retry_count IS NOT NULL AND retry_count > 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Non-Zero Exit Codes",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT countIf(exit_code IS NOT NULL AND exit_code != 0) AS failed_exits\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'sandbox_exec'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Network I/O Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bytes_in"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bytes_out"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  sum(network_bytes_in) AS bytes_in,\n  sum(network_bytes_out) AS bytes_out\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND (network_bytes_in IS NOT NULL OR network_bytes_out IS NOT NULL)\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Disk I/O Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "read_bytes"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "write_bytes"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  sum(disk_read_bytes) AS read_bytes,\n  sum(disk_write_bytes) AS write_bytes\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND (disk_read_bytes IS NOT NULL OR disk_write_bytes IS NOT NULL)\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Retry Rate Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  round(countIf(retry_count IS NOT NULL AND retry_count > 0) / nullIf(count(), 0) * 100, 2) AS retry_rate\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Hook Blocked Events",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  countIf(hook_blocked = 1) AS blocked,\n  countIf(hook_blocked = 0 OR hook_blocked IS NULL) AS allowed\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'hook'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Resource-Heavy Spans",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "cpu_ms",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  span_id,\n  trace_id,\n  type,\n  name,\n  cpu_ms,\n  memory_mb,\n  exit_code,\n  oom_killed,\n  retry_count,\n  container_id,\n  latency_ms,\n  start_time\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND (cpu_ms IS NOT NULL OR memory_mb IS NOT NULL)\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nORDER BY cpu_ms DESC NULLS LAST\nLIMIT 50",
+          "refId": "A",
+          "format": 2
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/scores-eval.json
+++ b/grafana/dashboards/scores-eval.json
@@ -1,7 +1,7 @@
 {
-  "uid": "observal-token-usage",
-  "title": "Observal \u2014 Token Usage",
-  "description": "Input, output, and total token consumption over time",
+  "uid": "observal-scores-eval",
+  "title": "Observal \u2014 Scores & Evaluations",
+  "description": "Score distributions, evaluation trends, and quality metrics",
   "tags": [
     "observal"
   ],
@@ -26,7 +26,7 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "observal-clickhouse"
         },
-        "query": "SELECT DISTINCT project_id FROM spans FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "query": "SELECT DISTINCT project_id FROM scores FINAL WHERE is_deleted = 0 ORDER BY project_id",
         "current": {
           "selected": true,
           "text": "All",
@@ -46,7 +46,7 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "observal-clickhouse"
         },
-        "query": "SELECT DISTINCT environment FROM spans FINAL WHERE is_deleted = 0 ORDER BY environment",
+        "query": "SELECT DISTINCT environment FROM scores FINAL WHERE is_deleted = 0 ORDER BY environment",
         "current": {
           "selected": true,
           "text": "All",
@@ -63,10 +63,10 @@
   "panels": [
     {
       "id": 1,
-      "title": "Input vs Output Tokens Over Time",
+      "title": "Score Volume Over Time",
       "type": "timeseries",
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 16,
         "x": 0,
         "y": 0
@@ -82,47 +82,13 @@
           },
           "custom": {
             "lineWidth": 2,
-            "fillOpacity": 20,
+            "fillOpacity": 15,
             "spanNulls": false,
-            "stacking": {
-              "mode": "normal"
-            },
             "axisBorderShow": false
           },
           "unit": "short"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "input_tokens"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "output_tokens"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "options": {
         "tooltip": {
@@ -141,7 +107,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND token_count_total > 0\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(timestamp) AS time,\n  count() AS scores\nFROM scores FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(timestamp)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -149,10 +115,10 @@
     },
     {
       "id": 2,
-      "title": "Total Input Tokens",
+      "title": "Total Scores",
       "type": "stat",
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 4,
         "x": 16,
         "y": 0
@@ -197,7 +163,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT sum(token_count_input) AS total_input\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "rawSql": "SELECT count() AS total_scores\nFROM scores FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(timestamp)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
           "refId": "A",
           "format": 1
         }
@@ -205,10 +171,10 @@
     },
     {
       "id": 3,
-      "title": "Total Output Tokens",
+      "title": "Avg Score Value",
       "type": "stat",
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 4,
         "x": 20,
         "y": 0
@@ -220,72 +186,23 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "fixed",
-            "fixedColor": "orange"
+            "mode": "thresholds"
           },
-          "unit": "short",
+          "decimals": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "orange",
+                "color": "red",
                 "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-clickhouse-datasource",
-            "uid": "observal-clickhouse"
-          },
-          "queryType": "sql",
-          "rawSql": "SELECT sum(token_count_output) AS total_output\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
-          "refId": "A",
-          "format": 1
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "title": "Total Tokens (All)",
-      "type": "stat",
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 5
-      },
-      "datasource": {
-        "type": "grafana-clickhouse-datasource",
-        "uid": "observal-clickhouse"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "green"
-          },
-          "unit": "short",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
               {
                 "color": "green",
-                "value": null
+                "value": 0.8
               }
             ]
           }
@@ -309,7 +226,59 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT sum(token_count_total) AS total_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "rawSql": "SELECT round(avg(value), 3) AS avg_score\nFROM scores FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(timestamp)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Score Trend by Name",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(timestamp) AS time,\n  name,\n  round(avg(value), 3) AS avg_value\nFROM scores FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(timestamp)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time, name\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -317,13 +286,13 @@
     },
     {
       "id": 5,
-      "title": "Token Usage by Span Type",
-      "type": "barchart",
+      "title": "Scores by Source",
+      "type": "piechart",
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 10
+        "w": 8,
+        "x": 16,
+        "y": 4
       },
       "datasource": {
         "type": "grafana-clickhouse-datasource",
@@ -339,15 +308,23 @@
         "overrides": []
       },
       "options": {
-        "orientation": "horizontal",
         "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
         },
         "tooltip": {
           "mode": "single"
         },
-        "stacking": "normal"
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "targets": [
         {
@@ -356,7 +333,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  type,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND token_count_total > 0\nGROUP BY type\nORDER BY input_tokens + output_tokens DESC\nLIMIT 10",
+          "rawSql": "SELECT\n  source,\n  count() AS count\nFROM scores FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(timestamp)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY source\nORDER BY count DESC",
           "refId": "A",
           "format": 1
         }
@@ -364,13 +341,58 @@
     },
     {
       "id": 6,
-      "title": "Top Token Consumers",
+      "title": "Score Distribution by Name",
+      "type": "barchart",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  name,\n  count() AS count,\n  round(avg(value), 3) AS avg_value,\n  round(min(value), 3) AS min_value,\n  round(max(value), 3) AS max_value\nFROM scores FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(timestamp)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY name\nORDER BY count DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Eval Runs",
       "type": "table",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 10
+        "y": 16
       },
       "datasource": {
         "type": "grafana-clickhouse-datasource",
@@ -384,7 +406,7 @@
         "showHeader": true,
         "sortBy": [
           {
-            "displayName": "total_tokens",
+            "displayName": "latest",
             "desc": true
           }
         ]
@@ -396,7 +418,47 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  name,\n  type,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens,\n  sum(token_count_total) AS total_tokens,\n  count() AS invocations\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND token_count_total > 0\nGROUP BY name, type\nORDER BY total_tokens DESC\nLIMIT 20",
+          "rawSql": "SELECT\n  eval_run_id,\n  eval_template_id,\n  count() AS scores,\n  round(avg(value), 3) AS avg_value,\n  min(timestamp) AS earliest,\n  max(timestamp) AS latest\nFROM scores FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(timestamp)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND eval_run_id IS NOT NULL\nGROUP BY eval_run_id, eval_template_id\nORDER BY latest DESC\nLIMIT 25",
+          "refId": "A",
+          "format": 2
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Recent Scores",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "timestamp",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  score_id,\n  trace_id,\n  span_id,\n  name,\n  source,\n  data_type,\n  value,\n  string_value,\n  comment,\n  agent_id,\n  timestamp\nFROM scores FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(timestamp)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nORDER BY timestamp DESC\nLIMIT 50",
           "refId": "A",
           "format": 2
         }

--- a/grafana/dashboards/session-overview.json
+++ b/grafana/dashboards/session-overview.json
@@ -37,6 +37,26 @@
         "multi": true,
         "refresh": 2,
         "sort": 1
+      },
+      {
+        "name": "environment",
+        "label": "Environment",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT environment FROM traces FINAL WHERE is_deleted = 0 ORDER BY environment",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
       }
     ]
   },
@@ -87,7 +107,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  count() AS traces\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  count() AS traces\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "format": 1
         }
@@ -150,7 +170,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  count(DISTINCT session_id) AS active_sessions\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND session_id IS NOT NULL",
+          "rawSql": "SELECT\n  count(DISTINCT session_id) AS active_sessions\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND session_id IS NOT NULL",
           "refId": "A",
           "format": 1
         }
@@ -205,7 +225,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  count() AS total_traces\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "rawSql": "SELECT\n  count() AS total_traces\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))",
           "refId": "A",
           "format": 1
         }
@@ -260,7 +280,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  trace_type,\n  count() AS count\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY trace_type\nORDER BY count DESC",
+          "rawSql": "SELECT\n  trace_type,\n  count() AS count\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nGROUP BY trace_type\nORDER BY count DESC",
           "refId": "A",
           "format": 1
         }
@@ -306,7 +326,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  ide,\n  count() AS count\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ide != ''\nGROUP BY ide\nORDER BY count DESC\nLIMIT 10",
+          "rawSql": "SELECT\n  ide,\n  count() AS count\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\n  AND ide != ''\nGROUP BY ide\nORDER BY count DESC\nLIMIT 10",
           "refId": "A",
           "format": 1
         }
@@ -346,7 +366,7 @@
             "uid": "observal-clickhouse"
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  trace_id,\n  project_id,\n  session_id,\n  trace_type,\n  name,\n  ide,\n  start_time,\n  end_time\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nORDER BY start_time DESC\nLIMIT 50",
+          "rawSql": "SELECT\n  trace_id,\n  project_id,\n  session_id,\n  trace_type,\n  name,\n  ide,\n  start_time,\n  end_time\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ('${environment}' = '1' OR environment IN (${environment:singlequote}))\nORDER BY start_time DESC\nLIMIT 50",
           "refId": "A",
           "format": 2
         }

--- a/grafana/dashboards/session-overview.json
+++ b/grafana/dashboards/session-overview.json
@@ -1,0 +1,356 @@
+{
+  "uid": "observal-session-overview",
+  "title": "Observal \u2014 Session Overview",
+  "description": "Trace count, active sessions, and trace type breakdown",
+  "tags": [
+    "observal"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "project_id",
+        "label": "Project",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT project_id FROM traces FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Trace Count Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  count() AS traces\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Active Sessions",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  count(DISTINCT session_id) AS active_sessions\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND session_id IS NOT NULL",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Total Traces",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  count() AS total_traces\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Trace Type Breakdown",
+      "type": "piechart",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  trace_type,\n  count() AS count\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY trace_type\nORDER BY count DESC",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Traces by IDE",
+      "type": "barchart",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  ide,\n  count() AS count\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND ide != ''\nGROUP BY ide\nORDER BY count DESC\nLIMIT 10",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Recent Traces",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "start_time",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  trace_id,\n  project_id,\n  session_id,\n  trace_type,\n  name,\n  ide,\n  start_time,\n  end_time\nFROM traces FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nORDER BY start_time DESC\nLIMIT 50",
+          "refId": "A",
+          "format": 2
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/token-usage.json
+++ b/grafana/dashboards/token-usage.json
@@ -1,0 +1,386 @@
+{
+  "uid": "observal-token-usage",
+  "title": "Observal \u2014 Token Usage",
+  "description": "Input, output, and total token consumption over time",
+  "tags": [
+    "observal"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "project_id",
+        "label": "Project",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT project_id FROM spans FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Input vs Output Tokens Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 10,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            },
+            "axisBorderShow": false
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "input_tokens"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "output_tokens"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND token_count_total > 0\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Total Input Tokens",
+      "type": "stat",
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT sum(token_count_input) AS total_input\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Total Output Tokens",
+      "type": "stat",
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT sum(token_count_output) AS total_output\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Total Tokens (All)",
+      "type": "stat",
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 5
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT sum(token_count_total) AS total_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Token Usage by Span Type",
+      "type": "barchart",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "stacking": "normal"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  type,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND token_count_total > 0\nGROUP BY type\nORDER BY input_tokens + output_tokens DESC\nLIMIT 10",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Top Token Consumers",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "total_tokens",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  name,\n  type,\n  sum(token_count_input) AS input_tokens,\n  sum(token_count_output) AS output_tokens,\n  sum(token_count_total) AS total_tokens,\n  count() AS invocations\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND token_count_total > 0\nGROUP BY name, type\nORDER BY total_tokens DESC\nLIMIT 20",
+          "refId": "A",
+          "format": 2
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/tool-call-frequency.json
+++ b/grafana/dashboards/tool-call-frequency.json
@@ -1,0 +1,448 @@
+{
+  "uid": "observal-tool-call-frequency",
+  "title": "Observal \u2014 Tool Call Frequency",
+  "description": "Tool call volume by name and MCP server",
+  "tags": [
+    "observal"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "project_id",
+        "label": "Project",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "observal-clickhouse"
+        },
+        "query": "SELECT DISTINCT project_id FROM spans FINAL WHERE is_deleted = 0 ORDER BY project_id",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "allValue": "1",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Tool Call Volume Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  count() AS tool_calls\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_invoke'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Total Tool Calls",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT count() AS total\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_invoke'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Avg Latency (ms)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          },
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT avg(latency_ms) AS avg_latency\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_invoke'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND latency_ms IS NOT NULL",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Tool Calls by Name",
+      "type": "barchart",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  name AS tool_name,\n  count() AS calls\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_invoke'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\nGROUP BY tool_name\nORDER BY calls DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Tool Calls by MCP Server",
+      "type": "piechart",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  mcp_server_id,\n  count() AS calls\nFROM mcp_tool_calls\nWHERE $__timeFilter(timestamp)\nGROUP BY mcp_server_id\nORDER BY calls DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Tool Call Latency Percentiles",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "spanNulls": false,
+            "axisBorderShow": false
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  $__timeInterval(start_time) AS time,\n  quantile(0.50)(latency_ms) AS p50,\n  quantile(0.95)(latency_ms) AS p95,\n  quantile(0.99)(latency_ms) AS p99\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_invoke'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND latency_ms IS NOT NULL\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Top Tools by Latency",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "observal-clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "p95_ms",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "observal-clickhouse"
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  name AS tool_name,\n  count() AS calls,\n  round(avg(latency_ms)) AS avg_ms,\n  round(quantile(0.95)(latency_ms)) AS p95_ms,\n  round(max(latency_ms)) AS max_ms\nFROM spans FINAL\nWHERE is_deleted = 0\n  AND type = 'tool_invoke'\n  AND $__timeFilter(start_time)\n  AND ('${project_id}' = '1' OR project_id IN (${project_id:singlequote}))\n  AND latency_ms IS NOT NULL\nGROUP BY tool_name\nORDER BY p95_ms DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 2
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/provisioning/dashboards/default.yaml
+++ b/grafana/provisioning/dashboards/default.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Observal
+    orgId: 1
+    folder: Observal
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/datasources/clickhouse.yaml
+++ b/grafana/provisioning/datasources/clickhouse.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: Observal ClickHouse
+    type: grafana-clickhouse-datasource
+    uid: observal-clickhouse
+    access: proxy
+    isDefault: true
+    jsonData:
+      host: observal-clickhouse
+      port: 8123
+      protocol: http
+      defaultDatabase: observal
+      username: default
+    secureJsonData:
+      password: clickhouse
+    editable: true

--- a/grafana/provisioning/datasources/clickhouse.yaml
+++ b/grafana/provisioning/datasources/clickhouse.yaml
@@ -13,5 +13,5 @@ datasources:
       defaultDatabase: observal
       username: default
     secureJsonData:
-      password: clickhouse
+      password: $CLICKHOUSE_PASSWORD
     editable: true


### PR DESCRIPTION
## Purpose / Description
Observal stores rich agent telemetry in ClickHouse across 5 tables, but there is no way for teams using Grafana to visualize this data without writing queries from scratch. This PR ships ready-to-import Grafana dashboard JSON templates, ClickHouse data source provisioning, and a Grafana Docker service so teams can get observability dashboards out of the box.

## Fixes
* Fixes #210

## Approach
- Added 5 Grafana dashboard JSON templates under `grafana/dashboards/`: session overview, token usage, tool call frequency, error rates, and cost tracking
- Added ClickHouse data source provisioning config (`grafana/provisioning/datasources/clickhouse.yaml`) so the connection is pre-configured on startup
- Added dashboard auto-load provisioning (`grafana/provisioning/dashboards/default.yaml`) so all dashboards appear without manual import
- Added `observal-grafana` service to `docker/docker-compose.yml` exposed on port 3001, with the `grafana-clickhouse-datasource` plugin auto-installed
- All dashboards use template variables for `project_id` and time range for flexible filtering
- Merged with security hardening from `main` (resource limits, `no-new-privileges`, `read_only` filesystem) preserved for all existing services

## How Has This Been Tested?

- Validated compose syntax with `docker compose config`
- Verified all existing services (API, web, worker, ClickHouse, Postgres, Redis, OTel collector) start and pass healthchecks
- Verified Grafana service starts on port 3001 and is accessible
- Logged into Grafana (admin/admin) and confirmed all 5 dashboards are auto-provisioned
- Verified ClickHouse data source is pre-configured and connects successfully
- Verified dashboard template variables (`project_id`, time range) render and filter correctly

## Learning (optional, can help others)
- Grafana provisioning via YAML files (`provisioning/datasources/` and `provisioning/dashboards/`) allows fully automated dashboard and data source setup without manual UI configuration
- The `grafana-clickhouse-datasource` plugin is installed at container startup via the `GF_INSTALL_PLUGINS` environment variable

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## Proof

<img width="1512" height="982" alt="Screenshot 2026-04-14 at 1 18 43 AM" src="https://github.com/user-attachments/assets/97252986-d7de-4129-89a3-ee7409d2d65d" />
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 1 18 51 AM" src="https://github.com/user-attachments/assets/a6f40c00-8917-48dc-834f-71ab6f536c49" />
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 1 18 59 AM" src="https://github.com/user-attachments/assets/0f372846-83a0-4c9a-845f-058794233dce" />
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 1 19 07 AM" src="https://github.com/user-attachments/assets/1486bb0b-e0b5-4f86-a74c-e13916861c2f" />
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 1 19 20 AM" src="https://github.com/user-attachments/assets/f9f3edea-98c9-4722-9cff-ed06a84e2ec0" />
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 1 19 22 AM" src="https://github.com/user-attachments/assets/5264b9d2-a20d-420f-86b0-68019886cc07" />