### PR TITLE
docs: add Discord link to CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thank you for considering contributing to Observal! Contributions of all kinds a
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+If you have questions about contributing or want to discuss your ideas before opening a PR, join the [Observal Discord](https://discord.observal.io) to chat with the maintainers.
+
 ## Table of Contents
 
 - [Getting Started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ All tests mock external services. No Docker needed.
 
 Have a question, idea, or want to share what you've built? Head to [GitHub Discussions](https://github.com/BlazeUp-AI/Observal/discussions). Please use Discussions for questions instead of opening issues. Issues are reserved for bug reports and feature requests.
 
+Join the [Observal Discord](https://discord.observal.io) to chat directly with the maintainers and other community members.
+
 ## Security
 
 To report a vulnerability, please use [GitHub Private Vulnerability Reporting](https://github.com/BlazeUp-AI/Observal/security/advisories) or email contact@blazeup.app. **Do not open a public issue.** See [SECURITY.md](SECURITY.md) for full details.


### PR DESCRIPTION
## Summary

- Add a reference to the Observal Discord server (`discord.observal.io`) to the Community section in `README.md`
- Add a Discord link to `CONTRIBUTING.md` so new contributors know where to discuss ideas with maintainers

Closes #295

## Test plan

- [x] Verify both links point to `discord.observal.io`
- [x] Verify no existing content was modified
- [x] Commit is signed off (DCO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)