### PR TITLE
fix(cli): prompt for MCP env vars during observal pull

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -427,7 +427,9 @@ async def install_agent(
     # Resolve all component names for rules file content
     name_map = await _resolve_component_names(agent.components, db)
 
-    snippet = generate_agent_config(agent, req.ide, mcp_listings=mcp_listings_map, component_names=name_map)
+    snippet = generate_agent_config(
+        agent, req.ide, mcp_listings=mcp_listings_map, component_names=name_map, env_values=req.env_values,
+    )
 
     # Capture agent.id before any DB operations that might expire the ORM
     # instance (e.g. savepoint rollback on duplicate download).

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -159,6 +159,7 @@ class ValidationResult(BaseModel):
 
 class AgentInstallRequest(BaseModel):
     ide: str
+    env_values: dict[str, dict[str, str]] = {}  # {mcp_listing_id: {VAR: value}}
 
 
 class AgentInstallResponse(BaseModel):

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -25,16 +25,21 @@ def _inject_agent_id(mcp_config: dict, agent_id: str):
             cfg["env"]["OBSERVAL_AGENT_ID"] = agent_id
 
 
-def _build_mcp_configs(agent: Agent, ide: str, observal_url: str, mcp_listings: dict | None = None) -> dict:
+def _build_mcp_configs(
+    agent: Agent, ide: str, observal_url: str, mcp_listings: dict | None = None, env_values: dict | None = None,
+) -> dict:
     """Build MCP server configs from registry components + external MCPs.
 
     Args:
         mcp_listings: optional {component_id: McpListing} map. When provided,
             used to look up MCP listings for each component. The install route
             pre-loads these to avoid N+1 queries in a sync context.
+        env_values: optional {mcp_listing_id_str: {VAR: value}} map of user-supplied
+            environment variable values for each MCP.
     """
     mcp_configs = {}
     mcp_listings = mcp_listings or {}
+    env_values = env_values or {}
 
     for comp in agent.components:
         if comp.component_type != "mcp":
@@ -42,7 +47,8 @@ def _build_mcp_configs(agent: Agent, ide: str, observal_url: str, mcp_listings: 
         listing = mcp_listings.get(comp.component_id)
         if not listing:
             continue
-        cfg = generate_config(listing, ide, observal_url=observal_url)
+        mcp_env = env_values.get(str(listing.id), {})
+        cfg = generate_config(listing, ide, observal_url=observal_url, env_values=mcp_env)
         if "mcpServers" in cfg:
             mcp_configs.update(cfg["mcpServers"])
         elif ide in ("claude-code", "claude_code"):
@@ -117,15 +123,17 @@ def generate_agent_config(
     observal_url: str = "http://localhost:8000",
     mcp_listings: dict | None = None,
     component_names: dict | None = None,
+    env_values: dict | None = None,
 ) -> dict:
     """Generate IDE-specific config for an agent.
 
     Args:
         mcp_listings: optional {component_id: McpListing} map pre-loaded by caller.
         component_names: optional {component_id_str: name} map for all component types.
+        env_values: optional {mcp_listing_id_str: {VAR: value}} map of user-supplied env var values.
     """
     safe_name = _sanitize_name(agent.name)
-    mcp_configs = _build_mcp_configs(agent, ide, observal_url, mcp_listings=mcp_listings)
+    mcp_configs = _build_mcp_configs(agent, ide, observal_url, mcp_listings=mcp_listings, env_values=env_values)
     rules_content = _build_rules_content(agent, component_names)
 
     if ide == "kiro":

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -13,6 +13,65 @@ from observal_cli import client, config
 from observal_cli.render import spinner
 
 
+def _collect_mcp_env_vars(agent_detail: dict) -> dict[str, dict[str, str]]:
+    """Discover MCP env vars from agent components and prompt the user for values.
+
+    Returns {mcp_listing_id: {VAR_NAME: value}} for all MCPs that have env vars.
+    """
+    env_values: dict[str, dict[str, str]] = {}
+
+    # Collect MCP component IDs from both mcp_links and component_links
+    mcp_ids: list[tuple[str, str]] = []  # (listing_id, display_name)
+    for link in agent_detail.get("mcp_links", []):
+        mcp_ids.append((str(link["mcp_listing_id"]), link.get("mcp_name", "")))
+    for link in agent_detail.get("component_links", []):
+        if link.get("component_type") == "mcp":
+            cid = str(link["component_id"])
+            # Avoid duplicates if already in mcp_links
+            if not any(mid == cid for mid, _ in mcp_ids):
+                mcp_ids.append((cid, link.get("component_name", "")))
+
+    if not mcp_ids:
+        return env_values
+
+    # Fetch each MCP listing to get its environment_variables
+    for listing_id, display_name in mcp_ids:
+        try:
+            listing = client.get(f"/api/v1/mcps/{listing_id}")
+        except (Exception, SystemExit):
+            continue
+
+        ev_list = listing.get("environment_variables") or []
+        if not ev_list:
+            continue
+
+        required = [ev for ev in ev_list if ev.get("required", True)]
+        optional = [ev for ev in ev_list if not ev.get("required", True)]
+        mcp_name = display_name or listing.get("name", listing_id[:8])
+        mcp_env: dict[str, str] = {}
+
+        if required:
+            rprint(f"\n[bold]{mcp_name}[/bold] requires {len(required)} environment variable(s):")
+            for ev in required:
+                desc = f" [dim]({ev['description']})[/dim]" if ev.get("description") else ""
+                val = typer.prompt(f"  {ev['name']}{desc}")
+                mcp_env[ev["name"]] = val
+
+        if optional:
+            rprint(f"\n[dim]{mcp_name}: {len(optional)} optional env var(s):[/dim]")
+            for ev in optional:
+                desc = f" [dim]({ev['description']})[/dim]" if ev.get("description") else ""
+                val = typer.prompt(f"  {ev['name']}{desc} (press Enter to skip)", default="")
+                if val:
+                    mcp_env[ev["name"]] = val
+
+        if mcp_env:
+            env_values[listing_id] = mcp_env
+
+    # Warn about MCPs that had env vars but user skipped all of them
+    return env_values
+
+
 def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> str:
     """Write content to a file path, creating parent dirs as needed.
 
@@ -79,8 +138,16 @@ def register_pull(app: typer.Typer):
         resolved = config.resolve_alias(agent_id)
         target_dir = Path(directory).resolve()
 
+        # Fetch agent details to discover MCP env vars
+        with spinner("Fetching agent details..."):
+            agent_detail = client.get(f"/api/v1/agents/{resolved}")
+
+        env_values = _collect_mcp_env_vars(agent_detail)
+
         with spinner(f"Pulling {ide} config for agent {resolved[:8]}..."):
-            result = client.post(f"/api/v1/agents/{resolved}/install", {"ide": ide})
+            result = client.post(
+                f"/api/v1/agents/{resolved}/install", {"ide": ide, "env_values": env_values},
+            )
 
         snippet = result.get("config_snippet", {})
         if not snippet:

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -41,6 +41,20 @@ def _patch_post(return_value: dict):
     return patch("observal_cli.client.post", return_value=return_value)
 
 
+# Agent detail with no MCP env vars — used by pull to check for env var prompts
+_AGENT_DETAIL_NO_ENV = {
+    "id": "abc123",
+    "name": "my-agent",
+    "mcp_links": [],
+    "component_links": [],
+}
+
+
+def _patch_get_agent(detail: dict = _AGENT_DETAIL_NO_ENV):
+    """Patch client.get to return a canned agent detail response."""
+    return patch("observal_cli.client.get", return_value=detail)
+
+
 # ── Fixtures for common server responses ─────────────────────
 
 
@@ -166,7 +180,7 @@ def _copilot_snippet() -> dict:
 
 class TestPullCursor:
     def test_writes_rules_and_mcp(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_cursor_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -182,7 +196,7 @@ class TestPullCursor:
         assert data["mcpServers"]["my-server"]["command"] == "npx"
 
     def test_output_lists_written_files(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_cursor_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path)])
 
         assert "Pulled cursor config" in result.output
@@ -194,7 +208,7 @@ class TestPullCursor:
 
 class TestPullVSCode:
     def test_writes_rules_and_mcp(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_vscode_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_vscode_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "vscode", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -209,7 +223,7 @@ class TestPullVSCode:
 
 class TestPullClaudeCode:
     def test_writes_agent_file(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_claude_code_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_claude_code_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "claude-code", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -222,13 +236,13 @@ class TestPullClaudeCode:
         assert "Claude Code Agent" in content
 
     def test_auto_runs_setup_commands(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_claude_code_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_claude_code_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "claude-code", "--dir", str(tmp_path)])
 
         assert "Registering MCP servers" in result.output
 
     def test_dry_run_shows_setup_commands_without_running(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_claude_code_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_claude_code_snippet()):
             result = runner.invoke(
                 cli_app, ["pull", "abc123", "--ide", "claude-code", "--dir", str(tmp_path), "--dry-run"]
             )
@@ -237,7 +251,7 @@ class TestPullClaudeCode:
         assert "claude mcp add" in result.output
 
     def test_shows_otlp_env(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_claude_code_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_claude_code_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "claude-code", "--dir", str(tmp_path)])
 
         assert "OTEL_EXPORTER_OTLP_ENDPOINT" in result.output
@@ -245,7 +259,7 @@ class TestPullClaudeCode:
 
     def test_mcp_config_without_path_not_written(self, tmp_path: Path):
         """Claude Code mcp_config has no 'path' key — should not write a file for it."""
-        with _patch_config(), _patch_post(_claude_code_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_claude_code_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "claude-code", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0
@@ -262,7 +276,7 @@ class TestPullClaudeCode:
 
 class TestPullGemini:
     def test_writes_rules_and_mcp(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_gemini_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_gemini_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "gemini-cli", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -283,7 +297,7 @@ class TestPullGemini:
 
 class TestPullKiro:
     def test_writes_agent_file(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_kiro_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_kiro_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "kiro", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -301,7 +315,7 @@ class TestPullKiro:
 
 class TestPullCodex:
     def test_writes_agents_md(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_codex_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_codex_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "codex", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -317,7 +331,7 @@ class TestPullCodex:
 
 class TestPullCopilot:
     def test_writes_copilot_instructions(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_copilot_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_copilot_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "copilot", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -340,7 +354,7 @@ class TestPullMcpMerge:
             json.dumps({"mcpServers": {"existing-server": {"command": "old-cmd", "args": ["--old"]}}}, indent=2)
         )
 
-        with _patch_config(), _patch_post(_cursor_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -357,7 +371,7 @@ class TestPullMcpMerge:
         mcp_path.parent.mkdir(parents=True)
         mcp_path.write_text(json.dumps({"mcpServers": {"my-server": {"command": "old", "args": []}}}, indent=2))
 
-        with _patch_config(), _patch_post(_cursor_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
@@ -370,7 +384,7 @@ class TestPullMcpMerge:
         mcp_path.parent.mkdir(parents=True)
         mcp_path.write_text(json.dumps({"mcpServers": {}}, indent=2))
 
-        with _patch_config(), _patch_post(_cursor_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path)])
 
         assert "merged" in result.output
@@ -383,7 +397,7 @@ class TestPullMcpMerge:
 
 class TestPullDryRun:
     def test_dry_run_does_not_write_files(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_cursor_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path), "--dry-run"])
 
         assert result.exit_code == 0, result.output
@@ -395,7 +409,7 @@ class TestPullDryRun:
         assert not (tmp_path / ".cursor" / "mcp.json").exists()
 
     def test_dry_run_still_shows_paths(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_cursor_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_cursor_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path), "--dry-run"])
 
         # Rich may wrap long absolute paths; strip all whitespace for path checks
@@ -404,7 +418,7 @@ class TestPullDryRun:
         assert "mcp.json" in flat
 
     def test_dry_run_kiro(self, tmp_path: Path):
-        with _patch_config(), _patch_post(_kiro_snippet()):
+        with _patch_config(), _patch_get_agent(), _patch_post(_kiro_snippet()):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "kiro", "--dir", str(tmp_path), "--dry-run"])
 
         assert result.exit_code == 0
@@ -432,7 +446,7 @@ class TestPullEdgeCases:
 
     def test_empty_snippet_exits(self, tmp_path: Path):
         """An empty config_snippet from the server should exit non-zero."""
-        with _patch_config(), _patch_post({"config_snippet": {}}):
+        with _patch_config(), _patch_get_agent(), _patch_post({"config_snippet": {}}):
             result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path)])
         assert result.exit_code != 0
         assert "empty config snippet" in result.output.lower()
@@ -441,6 +455,7 @@ class TestPullEdgeCases:
         """The command should call config.resolve_alias for the agent_id."""
         with (
             _patch_config(),
+            _patch_get_agent(),
             _patch_post(_codex_snippet()),
             patch("observal_cli.cmd_pull.config.resolve_alias", return_value="real-uuid") as mock_resolve,
         ):
@@ -451,7 +466,84 @@ class TestPullEdgeCases:
 
 
 # ═══════════════════════════════════════════════════════════════
-# 10. Help text
+# 10. Env var prompting during pull
+# ═══════════════════════════════════════════════════════════════
+
+
+_AGENT_WITH_MCP = {
+    "id": "agent-uuid",
+    "name": "my-agent",
+    "mcp_links": [{"mcp_listing_id": "mcp-uuid-1", "mcp_name": "my-mcp", "order": 0}],
+    "component_links": [],
+}
+
+_MCP_LISTING_WITH_ENV = {
+    "id": "mcp-uuid-1",
+    "name": "my-mcp",
+    "environment_variables": [
+        {"name": "API_KEY", "description": "Your API key", "required": True},
+        {"name": "REGION", "description": "AWS region", "required": False},
+    ],
+}
+
+
+class TestPullEnvVarPrompting:
+    def test_prompts_for_required_env_vars(self, tmp_path: Path):
+        """Pull should prompt for MCP env vars and send them to install."""
+
+        def mock_get(path, **kwargs):
+            if "/mcps/" in path:
+                return _MCP_LISTING_WITH_ENV
+            return _AGENT_WITH_MCP
+
+        with _patch_config(), patch("observal_cli.client.get", side_effect=mock_get), _patch_post(
+            _cursor_snippet()
+        ) as mock_post:
+            result = runner.invoke(
+                cli_app,
+                ["pull", "agent-uuid", "--ide", "cursor", "--dir", str(tmp_path)],
+                input="sk-test-123\nus-east-1\n",
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "requires 1 environment variable" in result.output
+        assert "API_KEY" in result.output
+
+        # Verify env_values were sent to the install endpoint
+        call_args = mock_post.call_args
+        payload = call_args[0][1]
+        assert "env_values" in payload
+        assert payload["env_values"]["mcp-uuid-1"]["API_KEY"] == "sk-test-123"
+
+    def test_no_prompts_when_no_env_vars(self, tmp_path: Path):
+        """Pull should not prompt when agent MCPs have no env vars."""
+        agent_no_env = {
+            "id": "agent-uuid",
+            "name": "my-agent",
+            "mcp_links": [{"mcp_listing_id": "mcp-uuid-2", "mcp_name": "simple-mcp", "order": 0}],
+            "component_links": [],
+        }
+        mcp_no_env = {"id": "mcp-uuid-2", "name": "simple-mcp", "environment_variables": []}
+
+        def mock_get(path, **kwargs):
+            if "/mcps/" in path:
+                return mcp_no_env
+            return agent_no_env
+
+        with _patch_config(), patch("observal_cli.client.get", side_effect=mock_get), _patch_post(
+            _cursor_snippet()
+        ):
+            result = runner.invoke(
+                cli_app,
+                ["pull", "agent-uuid", "--ide", "cursor", "--dir", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "environment variable" not in result.output
+
+
+# ═══════════════════════════════════════════════════════════════
+# 11. Help text
 # ═══════════════════════════════════════════════════════════════
 
 


### PR DESCRIPTION
## Purpose / Description

`observal pull` wrote empty strings for MCP environment variables in the generated IDE config. Users had to manually open the config file and fill in values after pulling — defeating the purpose of an automated install flow.

## Fixes

* Fixes #305

## Approach

Threads env var prompting through the entire agent install pipeline:

1. **`AgentInstallRequest`** — Added `env_values: dict[str, dict[str, str]]` field (keyed by MCP listing ID)
2. **`install_agent` endpoint** — Passes `req.env_values` through to `generate_agent_config`
3. **`_build_mcp_configs`** — Looks up per-MCP env values and forwards to `generate_config`
4. **`cmd_pull.py`** — New `_collect_mcp_env_vars()` function:
   - Fetches agent details to discover MCP components
   - For each MCP with env vars, shows a pretext (`<name> requires N environment variable(s):`) and prompts for each with its description
   - Required vars are prompted without default; optional vars can be skipped with Enter
   - Collected values are sent to the server in the install request

This matches the existing behavior of `observal registry mcp install`, which already prompted correctly.

## How Has This Been Tested?

| Test | Result |
|------|--------|
| Unit tests: 38 pull/agent CLI tests pass (including 2 new env var tests) | Pass |
| E2E: Created MCP with 3 env vars → agent → `observal pull` prompts for all 3 | Pass |
| E2E: Generated `.cursor/mcp.json` contains user-provided values, not empty strings | Pass |
| E2E: Agent with no MCP env vars — no prompts, works as before | Pass |
| `observal registry mcp install` still works independently | Pass |

## Learning

The `observal pull` command was introduced after the MCP install flow. The MCP install command (`cmd_mcp.py:_install_impl`) already had env var prompting, but `cmd_pull.py` called the agent install endpoint which had no env_values support — the two install paths were never connected.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)