### PR TITLE
fix(auth): normalize email to lowercase to prevent duplicate accounts…

### DIFF
--- a/observal-server/alembic/versions/0004_normalize_email_case.py
+++ b/observal-server/alembic/versions/0004_normalize_email_case.py
@@ -1,0 +1,29 @@
+"""Normalize email to lowercase and add case-insensitive unique index.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-15
+"""
+
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Lowercase all existing emails
+    op.execute("UPDATE users SET email = LOWER(TRIM(email))")
+
+    # Drop the existing case-sensitive unique constraint and replace with
+    # a functional unique index on LOWER(email) so that 'User@Example.com'
+    # and 'user@example.com' are treated as the same address.
+    op.drop_constraint("users_email_key", "users", type_="unique")
+    op.execute("CREATE UNIQUE INDEX ix_users_email_lower ON users (LOWER(email))")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX ix_users_email_lower")
+    op.create_unique_constraint("users_email_key", "users", ["email"])

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -209,6 +209,8 @@ async def oauth_callback(request: Request, db: AsyncSession = Depends(get_db)):
     if not email:
         raise HTTPException(status_code=400, detail="Email claim is missing from ID token")
 
+    email = email.strip().lower()
+
     # Check if user exists
     result = await db.execute(select(User).where(User.email == email))
     user = result.scalar_one_or_none()

--- a/observal-server/schemas/admin.py
+++ b/observal-server/schemas/admin.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class EnterpriseConfigResponse(BaseModel):
@@ -31,6 +31,11 @@ class UserCreateRequest(BaseModel):
     email: str
     name: str
     role: str = "reviewer"
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize_email(cls, v: str) -> str:
+        return v.strip().lower() if isinstance(v, str) else v
 
 
 class UserCreateResponse(BaseModel):

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -1,9 +1,14 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, model_validator
+from pydantic import BaseModel, EmailStr, field_validator, model_validator
 
 from models.user import UserRole
+
+
+def _normalize_email(v: str) -> str:
+    """Lowercase and strip whitespace so email lookups are case-insensitive."""
+    return v.strip().lower() if isinstance(v, str) else v
 
 
 class InitRequest(BaseModel):
@@ -11,11 +16,21 @@ class InitRequest(BaseModel):
     name: str
     password: str | None = None
 
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str) -> str:
+        return _normalize_email(v)
+
 
 class LoginRequest(BaseModel):
     api_key: str | None = None
     email: EmailStr | None = None
     password: str | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str | None) -> str | None:
+        return _normalize_email(v) if v is not None else v
 
     @model_validator(mode="after")
     def _require_credentials(self):
@@ -30,6 +45,11 @@ class RegisterRequest(BaseModel):
     email: EmailStr
     name: str
     password: str
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str) -> str:
+        return _normalize_email(v)
 
 
 class UserResponse(BaseModel):
@@ -54,17 +74,32 @@ class CodeExchangeRequest(BaseModel):
 class RequestResetRequest(BaseModel):
     email: EmailStr
 
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str) -> str:
+        return _normalize_email(v)
+
 
 class ResetPasswordRequest(BaseModel):
     email: EmailStr
     token: str
     new_password: str
 
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str) -> str:
+        return _normalize_email(v)
+
 
 class TokenRequest(BaseModel):
     api_key: str | None = None
     email: EmailStr | None = None
     password: str | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str | None) -> str | None:
+        return _normalize_email(v) if v is not None else v
 
     @model_validator(mode="after")
     def _require_credentials(self):

--- a/observal-server/services/demo_accounts.py
+++ b/observal-server/services/demo_accounts.py
@@ -47,6 +47,7 @@ async def seed_demo_accounts(db: AsyncSession) -> int:
         password = getattr(settings, f"{prefix}_PASSWORD", None)
         if not email or not password:
             continue
+        email = email.strip().lower()
 
         # Idempotent: skip if already exists
         exists = await db.scalar(select(func.count()).select_from(User).where(User.email == email))


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
No case sensitivity for emails.

## Fixes
* Fixes #309 

## Approach
Emails are now lowercased and trimmed at the Pydantic schema layer before any database lookup or write. This covers register, login, init, token, password reset, admin user create, OAuth callback, and demo account seeding.

A migration lowercases existing rows and replaces the case-sensitive unique constraint with a LOWER(email) functional index.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->