### PR TITLE
Fix/env var filter noise

### DIFF
--- a/observal-server/alembic/versions/0004_add_mcp_framework_column.py
+++ b/observal-server/alembic/versions/0004_add_mcp_framework_column.py
@@ -1,0 +1,43 @@
+"""Add framework column to mcp_listings.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-15
+"""
+
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'mcp_listings' AND column_name = 'framework'
+            ) THEN
+                ALTER TABLE mcp_listings ADD COLUMN framework VARCHAR(100);
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'mcp_listings' AND column_name = 'framework'
+            ) THEN
+                ALTER TABLE mcp_listings DROP COLUMN framework;
+            END IF;
+        END
+        $$;
+    """)

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -40,6 +40,9 @@ async def _store_client_analysis(listing: McpListing, analysis: ClientAnalysis, 
     tool_count = len(analysis.tools)
     issue_count = len(analysis.issues)
 
+    if analysis.framework:
+        listing.framework = analysis.framework
+
     if has_entry:
         detail = "Client-side analysis: found entry point"
         if analysis.framework:

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -31,6 +31,7 @@ class McpListing(Base):
     category: Mapped[str] = mapped_column(String(100), nullable=False)
     owner: Mapped[str] = mapped_column(String(255), nullable=False)
     transport: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    framework: Mapped[str | None] = mapped_column(String(100), nullable=True)
     mcp_validated: Mapped[bool] = mapped_column(Boolean, default=False)
     tools_schema: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     environment_variables: Mapped[list | None] = mapped_column(JSON, nullable=True)

--- a/observal-server/schemas/mcp.py
+++ b/observal-server/schemas/mcp.py
@@ -71,6 +71,7 @@ class McpListingResponse(BaseModel):
     environment_variables: list[McpEnvVar] = []
     setup_instructions: str | None
     changelog: str | None
+    framework: str | None = None
     mcp_validated: bool = False
 
     _coerce_env = field_validator("environment_variables", mode="before")(_coerce_env_vars)

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -2,6 +2,7 @@ import re
 
 from models.agent import Agent
 from services.config_generator import (
+    _build_run_command,
     _claude_otlp_env,
     _gemini_otlp_env,
     _gemini_settings,
@@ -57,7 +58,8 @@ def _build_mcp_configs(
             # agent file gets proper mcpServers frontmatter.
             safe = _sanitize_name(listing.name)
             mcp_id = str(listing.id)
-            shim_args = ["--mcp-id", mcp_id, "--", "python", "-m", safe]
+            run_cmd = _build_run_command(safe, listing.framework)
+            shim_args = ["--mcp-id", mcp_id, "--", *run_cmd]
             mcp_configs[safe] = {"command": "observal-shim", "args": shim_args, "env": {}}
 
     for ext in agent.external_mcps or []:

--- a/observal-server/services/config_generator.py
+++ b/observal-server/services/config_generator.py
@@ -56,6 +56,21 @@ def _gemini_settings(observal_url: str) -> dict:
     }
 
 
+def _build_run_command(name: str, framework: str | None) -> list[str]:
+    """Return the appropriate run command based on the MCP framework.
+
+    - TypeScript: npx -y <name>
+    - Go: <name> (assumes binary on PATH)
+    - Python / unknown: python -m <name>
+    """
+    fw = (framework or "").lower()
+    if "typescript" in fw or "ts" in fw:
+        return ["npx", "-y", name]
+    if "go" in fw:
+        return [name]
+    return ["python", "-m", name]
+
+
 def _build_server_env(listing: McpListing, env_values: dict[str, str] | None = None) -> dict[str, str]:
     """Build env dict from the listing's declared environment_variables and user-supplied values."""
     env: dict[str, str] = {}
@@ -100,7 +115,8 @@ def generate_config(
         return {"mcpServers": {name: {"url": proxy_url, "env": server_env}}}
 
     # Stdio transport: shim wraps the original command
-    shim_args = ["--mcp-id", mcp_id, "--", "python", "-m", name]
+    run_cmd = _build_run_command(name, listing.framework)
+    shim_args = ["--mcp-id", mcp_id, "--", *run_cmd]
 
     if ide == "claude-code":
         otlp = _claude_otlp_env(observal_url)

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -290,6 +290,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
 
     if entry_point:
         listing.mcp_validated = True
+        listing.framework = "python-mcp"
         db.add(
             McpValidationResult(
                 listing_id=listing.id,
@@ -305,6 +306,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
     non_python_framework = _detect_non_python_mcp(tmp_dir)
     if non_python_framework:
         listing.mcp_validated = True
+        listing.framework = non_python_framework
         db.add(
             McpValidationResult(
                 listing_id=listing.id,

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -99,19 +99,62 @@ _INTERNAL_ENV_VARS = frozenset(
         "TMPDIR",
         "PYTHONPATH",
         "PYTHONDONTWRITEBYTECODE",
+        "PYTHONUSERBASE",
+        "PYTHONHOME",
+        "PYTHONUNBUFFERED",
         "VIRTUAL_ENV",
         "NODE_ENV",
+        "NODE_PATH",
+        "NODE_OPTIONS",
         "PORT",
         "HOST",
         "DEBUG",
         "LOG_LEVEL",
         "LOGGING_LEVEL",
+        "HOSTNAME",
+        "DISPLAY",
+        "EDITOR",
+        "PAGER",
+        "TZ",
+        "LC_ALL",
+        "LC_CTYPE",
     }
 )
 
+# Prefix patterns for build/CI/infrastructure env vars that are never user-facing
+_FILTERED_PREFIXES = (
+    "CI_",
+    "GITHUB_",
+    "GITLAB_",
+    "CIRCLECI_",
+    "TRAVIS_",
+    "JENKINS_",
+    "BUILDKITE_",
+    "DOCKER_",
+    "BUILDKIT_",
+    "COMPOSE_",
+    "NPM_",
+    "PIP_",
+    "UV_",
+    "OTEL_",
+    "MCP_LOG_",
+)
+
+
+def _is_filtered_env_var(name: str) -> bool:
+    """Return True if the env var is internal/infrastructure and should not be prompted."""
+    if name in _INTERNAL_ENV_VARS:
+        return True
+    return any(name.startswith(prefix) for prefix in _FILTERED_PREFIXES)
+
 
 def _detect_env_vars(tmp_dir: str) -> list[dict]:
-    """Scan repo files for required environment variables (os.environ, os.getenv, .env, Dockerfile)."""
+    """Scan repo files for required environment variables.
+
+    Scans Python source (os.environ/os.getenv) and .env.example files.
+    Dockerfile ENV/ARG directives are intentionally skipped — they contain
+    build-time variables that are not user-facing configuration.
+    """
     root = Path(tmp_dir)
     found: dict[str, str] = {}  # name -> description hint
 
@@ -121,7 +164,7 @@ def _detect_env_vars(tmp_dir: str) -> list[dict]:
             content = py_file.read_text(errors="ignore")
             for m in _ENV_VAR_PATTERN.finditer(content):
                 name = m.group(1) or m.group(2)
-                if name and name not in _INTERNAL_ENV_VARS:
+                if name and not _is_filtered_env_var(name):
                     found.setdefault(name, "")
         except Exception:
             continue
@@ -136,24 +179,8 @@ def _detect_env_vars(tmp_dir: str) -> list[dict]:
                 if not line or line.startswith("#"):
                     continue
                 key = line.split("=", 1)[0].strip()
-                if key and key == key.upper() and key not in _INTERNAL_ENV_VARS:
+                if key and key == key.upper() and not _is_filtered_env_var(key):
                     found.setdefault(key, "")
-        except Exception:
-            continue
-
-    # Scan Dockerfile for ENV / ARG directives
-    for dockerfile in (root / "Dockerfile", root / "dockerfile"):
-        if not dockerfile.exists():
-            continue
-        try:
-            for line in dockerfile.read_text(errors="ignore").splitlines():
-                stripped = line.strip()
-                if stripped.startswith(("ENV ", "ARG ")):
-                    parts = stripped.split(None, 2)
-                    if len(parts) >= 2:
-                        key = parts[1].split("=", 1)[0]
-                        if key and key == key.upper() and key not in _INTERNAL_ENV_VARS:
-                            found.setdefault(key, "")
         except Exception:
             continue
 

--- a/observal_cli/analyzer.py
+++ b/observal_cli/analyzer.py
@@ -52,14 +52,45 @@ _INTERNAL_ENV_VARS = frozenset(
         "TMPDIR",
         "PYTHONPATH",
         "PYTHONDONTWRITEBYTECODE",
+        "PYTHONUSERBASE",
+        "PYTHONHOME",
+        "PYTHONUNBUFFERED",
         "VIRTUAL_ENV",
         "NODE_ENV",
+        "NODE_PATH",
+        "NODE_OPTIONS",
         "PORT",
         "HOST",
         "DEBUG",
         "LOG_LEVEL",
         "LOGGING_LEVEL",
+        "HOSTNAME",
+        "DISPLAY",
+        "EDITOR",
+        "PAGER",
+        "TZ",
+        "LC_ALL",
+        "LC_CTYPE",
     }
+)
+
+# Prefix patterns for build/CI/infrastructure env vars that are never user-facing
+_FILTERED_PREFIXES = (
+    "CI_",
+    "GITHUB_",
+    "GITLAB_",
+    "CIRCLECI_",
+    "TRAVIS_",
+    "JENKINS_",
+    "BUILDKITE_",
+    "DOCKER_",
+    "BUILDKIT_",
+    "COMPOSE_",
+    "NPM_",
+    "PIP_",
+    "UV_",
+    "OTEL_",
+    "MCP_LOG_",
 )
 
 # ---------------------------------------------------------------------------
@@ -92,47 +123,46 @@ def _clone_repo(git_url: str, dest: str) -> str | None:
     return None
 
 
+def _is_filtered_env_var(name: str) -> bool:
+    """Return True if the env var is internal/infrastructure and should not be prompted."""
+    if name in _INTERNAL_ENV_VARS:
+        return True
+    return any(name.startswith(prefix) for prefix in _FILTERED_PREFIXES)
+
+
 def _detect_env_vars(tmp_dir: str) -> list[dict]:
-    """Scan repo files for required environment variables."""
+    """Scan repo files for required environment variables.
+
+    Scans Python source (os.environ/os.getenv) and .env.example files.
+    Dockerfile ENV/ARG directives are intentionally skipped — they contain
+    build-time variables that are not user-facing configuration.
+    """
     root = Path(tmp_dir)
     found: dict[str, str] = {}
 
+    # Scan Python files for os.environ / os.getenv
     for py_file in root.rglob("*.py"):
         try:
             content = py_file.read_text(errors="ignore")
             for m in _ENV_VAR_PATTERN.finditer(content):
                 name = m.group(1) or m.group(2)
-                if name and name not in _INTERNAL_ENV_VARS:
+                if name and not _is_filtered_env_var(name):
                     found.setdefault(name, "")
         except Exception:
             continue
 
+    # Scan .env.example / .env.sample for documented env vars
     for env_file in root.glob(".env*"):
         if env_file.name in (".env", ".env.local"):
-            continue
+            continue  # skip actual secrets
         try:
             for line in env_file.read_text(errors="ignore").splitlines():
                 line = line.strip()
                 if not line or line.startswith("#"):
                     continue
                 key = line.split("=", 1)[0].strip()
-                if key and key == key.upper() and key not in _INTERNAL_ENV_VARS:
+                if key and key == key.upper() and not _is_filtered_env_var(key):
                     found.setdefault(key, "")
-        except Exception:
-            continue
-
-    for dockerfile in (root / "Dockerfile", root / "dockerfile"):
-        if not dockerfile.exists():
-            continue
-        try:
-            for line in dockerfile.read_text(errors="ignore").splitlines():
-                stripped = line.strip()
-                if stripped.startswith(("ENV ", "ARG ")):
-                    parts = stripped.split(None, 2)
-                    if len(parts) >= 2:
-                        key = parts[1].split("=", 1)[0]
-                        if key and key == key.upper() and key not in _INTERNAL_ENV_VARS:
-                            found.setdefault(key, "")
         except Exception:
             continue
 

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import typer
 from rich import print as rprint
 from rich.table import Table
@@ -21,6 +24,145 @@ from observal_cli.render import (
 )
 
 mcp_app = typer.Typer(help="MCP server registry commands")
+
+
+# ── Env var configuration helpers ────────────────────────────
+
+
+def _parse_env_file(file_path: str) -> list[dict]:
+    """Parse a .env-style file and return env var dicts."""
+    path = Path(file_path).expanduser().resolve()
+    if not path.exists():
+        rprint(f"[red]File not found:[/red] {path}")
+        return []
+
+    env_vars: list[dict] = []
+    for line in path.read_text(errors="ignore").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key = line.split("=", 1)[0].strip()
+        if key and key == key.upper():
+            env_vars.append({"name": key, "description": "", "required": True})
+    return env_vars
+
+
+def _configure_env_vars_interactive(detected: list[dict]) -> list[dict]:
+    """Interactive env var configuration at submit time.
+
+    Offers three paths:
+      1. Review and edit auto-detected vars
+      2. Load from an env file path
+      3. Enter manually
+    """
+    is_tty = sys.stdin.isatty()
+
+    if detected:
+        rprint(f"\n[bold]Auto-detected {len(detected)} env var(s):[/bold]")
+        for ev in detected:
+            rprint(f"  [cyan]*[/cyan] {ev['name']}")
+
+    rprint("\n[bold]How would you like to configure environment variables?[/bold]")
+
+    if is_tty:
+        choices = []
+        if detected:
+            choices.append("Review auto-detected vars")
+        choices.extend(["Load from .env file", "Enter manually", "Skip (no env vars)"])
+        choice = select_one("Env var configuration", choices)
+    else:
+        if detected:
+            rprint("  1. Review auto-detected vars")
+            rprint("  2. Load from .env file")
+            rprint("  3. Enter manually")
+            rprint("  4. Skip (no env vars)")
+            raw = typer.prompt("Choose", default="1")
+        else:
+            rprint("  1. Load from .env file")
+            rprint("  2. Enter manually")
+            rprint("  3. Skip (no env vars)")
+            raw = typer.prompt("Choose", default="3")
+        choice_map = {
+            "1": "Review auto-detected vars" if detected else "Load from .env file",
+            "2": "Load from .env file" if detected else "Enter manually",
+            "3": "Enter manually" if detected else "Skip (no env vars)",
+            "4": "Skip (no env vars)",
+        }
+        choice = choice_map.get(raw, "Skip (no env vars)")
+
+    if choice == "Skip (no env vars)":
+        return []
+
+    if choice == "Load from .env file":
+        file_path = typer.prompt("Path to .env file (e.g. .env.example)")
+        env_vars = _parse_env_file(file_path)
+        if not env_vars:
+            rprint("[yellow]No variables found in file.[/yellow]")
+            return []
+        rprint(f"\n[green]Loaded {len(env_vars)} var(s) from file.[/green]")
+        return _review_env_vars(env_vars)
+
+    if choice == "Enter manually":
+        return _enter_env_vars_manually()
+
+    # Review auto-detected
+    return _review_env_vars(detected)
+
+
+def _review_env_vars(env_vars: list[dict]) -> list[dict]:
+    """Let the developer review, remove, and annotate each env var."""
+    reviewed: list[dict] = []
+
+    rprint("\n[bold]Review each variable[/bold] [dim](enter to keep, 'r' to remove, 'o' for optional)[/dim]\n")
+
+    for ev in env_vars:
+        action = typer.prompt(
+            f"  {ev['name']} [required]",
+            default="",
+            show_default=False,
+        )
+        action = action.strip().lower()
+
+        if action == "r":
+            rprint("    [dim]removed[/dim]")
+            continue
+
+        required = action != "o"
+        desc = ev.get("description", "")
+        if not desc:
+            desc = typer.prompt(f"    Description for {ev['name']} (optional)", default="")
+
+        reviewed.append({"name": ev["name"], "description": desc, "required": required})
+        status = "[green]required[/green]" if required else "[yellow]optional[/yellow]"
+        rprint(f"    {status}")
+
+    # Offer to add more
+    while True:
+        add_more = typer.prompt("\n  Add another env var? (name or Enter to finish)", default="")
+        if not add_more:
+            break
+        desc = typer.prompt(f"    Description for {add_more} (optional)", default="")
+        req = typer.confirm("    Required?", default=True)
+        reviewed.append({"name": add_more.strip().upper(), "description": desc, "required": req})
+
+    return reviewed
+
+
+def _enter_env_vars_manually() -> list[dict]:
+    """Prompt the developer to enter env vars one by one."""
+    env_vars: list[dict] = []
+    rprint("\n[bold]Enter env vars one at a time[/bold] [dim](empty name to finish)[/dim]\n")
+
+    while True:
+        name = typer.prompt("  Variable name (or Enter to finish)", default="")
+        if not name:
+            break
+        name = name.strip().upper()
+        desc = typer.prompt(f"    Description for {name} (optional)", default="")
+        req = typer.confirm("    Required?", default=True)
+        env_vars.append({"name": name, "description": desc, "required": req})
+
+    return env_vars
 
 
 # ── Implementation functions (shared by canonical + deprecated) ──
@@ -140,9 +282,9 @@ def _submit_impl(git_url, name, category, yes):
         _setup = typer.prompt("Setup instructions (optional, press Enter to skip)", default="")
         _changelog = typer.prompt("Changelog", default="Initial release")
 
-        # Env vars are auto-included from analysis — users are prompted
-        # for actual values during `install`, not here.
-        env_vars = list(detected_env_vars)
+        # Interactive env var configuration — developer reviews, edits,
+        # or provides env vars instead of blindly including auto-detected ones.
+        env_vars = _configure_env_vars_interactive(detected_env_vars)
 
     submit_payload = {
         "git_url": git_url,

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -12,7 +12,7 @@ from rich.table import Table
 from observal_cli import client, config
 from observal_cli.analyzer import analyze_local
 from observal_cli.constants import VALID_IDES, VALID_MCP_CATEGORIES
-from observal_cli.prompts import select_many, select_one
+from observal_cli.prompts import select_one
 from observal_cli.render import (
     console,
     ide_tags,
@@ -241,13 +241,15 @@ def _submit_impl(git_url, name, category, yes):
     rprint("[bold]------------------------[/bold]\n")
 
     # ── Auto-accept detected fields, only prompt for missing/required ──
+    # MCP servers are IDE-agnostic — config generation handles all IDEs.
+    supported_ides = list(VALID_IDES)
+
     if yes:
         _name = name or detected_name
         _version = detected_ver
         _desc = detected_desc
         _owner = "default"
         _category = category or "general"
-        supported_ides = list(VALID_IDES)
         _setup = ""
         _changelog = "Initial release"
         env_vars = detected_env_vars
@@ -278,7 +280,6 @@ def _submit_impl(git_url, name, category, yes):
         rprint()
 
         _category = category or select_one("Category", VALID_MCP_CATEGORIES, default="general")
-        supported_ides = select_many("Supported IDEs", VALID_IDES, defaults=VALID_IDES)
         _setup = typer.prompt("Setup instructions (optional, press Enter to skip)", default="")
         _changelog = typer.prompt("Changelog", default="Initial release")
 

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -234,9 +234,10 @@ def register_pull(app: typer.Typer):
             for cmd in setup_cmds:
                 rprint(f"  [cyan]$ {' '.join(cmd)}[/cyan]")
 
-        # ── OTLP env vars (Claude Code) ─────────────────────
+        # ── OTLP env vars (Observal telemetry — optional) ──
         otlp_env = snippet.get("otlp_env")
         if otlp_env:
-            rprint("\n[bold]Set these environment variables:[/bold]")
+            rprint("\n[bold dim]Observal telemetry (optional):[/bold dim]")
+            rprint("[dim]These enable usage tracking via Observal — not required by the MCP server itself.[/dim]")
             for k, v in otlp_env.items():
-                rprint(f"  [cyan]{k}[/cyan]={v}")
+                rprint(f"  [dim]{k}={v}[/dim]")


### PR DESCRIPTION
 > [!NOTE]
> PR was written using claude since I was too tired
 
 ## Purpose / Description
  MCP server submit and install flow had several end-to-end issues:
  1. CI/Docker build env vars (e.g. `GITHUB_*`, `DOCKER_*`, `OTEL_*`) were detected during analysis and prompted to end users at install time     
  2. IDE selection during submit was unnecessary since MCP servers are IDE-agnostic                                                               
  3. Config generator hardcoded `python -m <name>` for all servers, breaking TypeScript and Go MCPs                                               
  4. OTEL telemetry env vars displayed during `pull` looked like MCP server requirements                                                          
                                                                                                                                                  
  ## Fixes                                                                                                                                        
  * Fixes #312                                                                                                                                    
                                                                                                                                                  
## Approach
  - **Env var filtering**: Expanded internal env var blocklist, added prefix-based filtering for CI/build/infrastructure vars (`CI_`, `GITHUB_`,  
  `DOCKER_`, `OTEL_`, etc.), removed Dockerfile ENV/ARG scanning. Added interactive env var configuration at submit time with three paths: review 
  auto-detected, load from `.env` file, or enter manually.
  - **IDE selection removal**: Removed the `select_many` IDE prompt from submit. All submissions now set `supported_ides` to the full IDE list    
  automatically since MCP is IDE-agnostic.                                                                                                        
  - **Framework-aware commands**: Added `framework` column to `McpListing` (migration 0004). Framework is stored during submit (from client
  analysis) and server-side validation. Config generator uses it to pick the right run command: `npx -y` for TypeScript, binary name for Go,      
  `python -m` for Python/unknown.
  - **OTEL display**: Relabeled OTEL env vars in `pull` output as "Observal telemetry (optional)" with dimmed styling to distinguish from MCP     
  server requirements.                                                                                                                                                                                                       
                                                                                                                                                  
  ## Checklist    
  - [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)                                             
  - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
  - [x] You have commented your code, particularly in hard-to-understand areas                                                                    
  - [x] You have performed a self-review of your own code                                                                                         
  - [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)