### PR TITLE
feat(kiro): isolate IDE-specific hook ingestion and fix session bugs

### DIFF
--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -44,20 +44,16 @@ async def list_sessions(
 ):
     rows = await _ch_json(
         "SELECT "
-        # For Kiro sessions with a conversation_id, group by that instead of
-        # the ephemeral $PPID-based session_id.  This merges resumed sessions.
-        "if(LogAttributes['conversation_id'] != '', "
-        "   LogAttributes['conversation_id'], "
-        "   LogAttributes['session.id']) AS session_id, "
+        "LogAttributes['session.id'] AS session_id, "
         "min(Timestamp) AS first_event_time, "
         "max(Timestamp) AS last_event_time, "
         "(max(Timestamp) > now('UTC') - INTERVAL 30 MINUTE "
         " AND argMax("
-        "   if(LogAttributes['event.name'] != '', LogAttributes['event.name'], EventName),"
+        "   LogAttributes['event.name'],"
         "   Timestamp"
         " ) NOT IN ('hook_stop', 'hook_stopfailure')"
         ") AS is_active, "
-        "countIf(EventName = 'user_prompt' OR LogAttributes['event.name'] = 'user_prompt' OR LogAttributes['event.name'] = 'hook_userpromptsubmit') AS prompt_count, "
+        "countIf(LogAttributes['event.name'] = 'user_prompt' OR LogAttributes['event.name'] = 'hook_userpromptsubmit') AS prompt_count, "
         "countIf(LogAttributes['event.name'] = 'api_request') AS api_request_count, "
         "countIf(LogAttributes['event.name'] = 'tool_result') AS tool_result_count, "
         "countIf(LogAttributes['event.name'] LIKE 'hook_%') AS hook_event_count, "
@@ -88,12 +84,12 @@ async def get_session(session_id: str, current_user: User = Depends(require_role
     events = await _ch_json(
         "SELECT "
         "Timestamp AS timestamp, "
-        "if(LogAttributes['event.name'] != '', LogAttributes['event.name'], EventName) AS event_name, "
+        "LogAttributes['event.name'] AS event_name, "
         "Body AS body, "
         "LogAttributes AS attributes, "
         "ServiceName AS service_name "
         "FROM otel_logs "
-        "WHERE (LogAttributes['session.id'] = {sid:String} OR LogAttributes['conversation_id'] = {sid:String}) "
+        "WHERE LogAttributes['session.id'] = {sid:String} "
         "ORDER BY Timestamp ASC",
         {"param_sid": session_id},
     )
@@ -187,7 +183,7 @@ async def list_errors(current_user: User = Depends(require_role(UserRole.admin))
     rows = await _ch_json(
         "SELECT "
         "Timestamp AS timestamp, "
-        "if(LogAttributes['event.name'] != '', LogAttributes['event.name'], EventName) AS event_name, "
+        "LogAttributes['event.name'] AS event_name, "
         "Body AS body, "
         "LogAttributes['session.id'] AS session_id, "
         "LogAttributes['tool_name'] AS tool_name, "
@@ -201,7 +197,6 @@ async def list_errors(current_user: User = Depends(require_role(UserRole.admin))
         "FROM otel_logs "
         "WHERE LogAttributes['event.name'] IN "
         "('hook_posttoolusefailure', 'hook_stopfailure', 'api_error') "
-        "OR EventName = 'api_error' "
         "ORDER BY Timestamp DESC "
         "LIMIT 200"
     )
@@ -213,7 +208,7 @@ async def otel_stats(current_user: User = Depends(require_role(UserRole.admin)))
     log_rows = await _ch_json(
         "SELECT "
         "count(DISTINCT LogAttributes['session.id']) AS total_sessions, "
-        "countIf(EventName = 'user_prompt' OR LogAttributes['event.name'] = 'user_prompt' OR LogAttributes['event.name'] = 'hook_userpromptsubmit') AS total_prompts, "
+        "countIf(LogAttributes['event.name'] = 'user_prompt' OR LogAttributes['event.name'] = 'hook_userpromptsubmit') AS total_prompts, "
         "countIf(LogAttributes['event.name'] = 'api_request') AS total_api_requests, "
         "countIf(LogAttributes['event.name'] = 'tool_result') AS total_tool_calls, "
         "sum(toUInt64OrZero(LogAttributes['input_tokens'])) AS total_input_tokens, "
@@ -283,6 +278,167 @@ _KIRO_FIELD_MAP = {
 }
 
 
+# ── IDE-specific extraction helpers ──────────────────────────────────
+
+
+def _extract_kiro(body: dict, hook_event: str, attrs: dict[str, str]) -> None:
+    """Extract Kiro-specific fields into *attrs*.
+
+    Kiro sends: ``prompt`` on agentSpawn/userPromptSubmit,
+    ``assistant_response`` on stop, and ``tool_input``/``tool_response``
+    as dicts (not strings).
+    """
+    tool_input_raw = body.get("tool_input")
+    tool_response_raw = body.get("tool_response")
+
+    if tool_input_raw is not None:
+        attrs["tool_input"] = _truncate(_safe_json(tool_input_raw))
+    if tool_response_raw is not None:
+        attrs["tool_response"] = _truncate(_safe_json(tool_response_raw))
+
+    # Kiro uses ``prompt`` for the user's message
+    if body.get("prompt") and not attrs.get("tool_input"):
+        attrs["tool_input"] = _truncate(str(body["prompt"]))
+    # ``assistant_response`` arrives on Stop payloads
+    if body.get("assistant_response") and not attrs.get("tool_response"):
+        attrs["tool_response"] = _truncate(str(body["assistant_response"]))
+
+    if hook_event == "UserPromptSubmit":
+        prompt_text = body.get("prompt") or body.get("user_prompt") or ""
+        if prompt_text:
+            attrs["tool_input"] = _truncate(prompt_text)
+            attrs["prompt_length"] = str(len(prompt_text))
+        attrs["tool_name"] = "user_prompt"
+
+    if hook_event == "SessionStart":
+        prompt_text = body.get("prompt") or ""
+        if prompt_text:
+            attrs["tool_input"] = _truncate(prompt_text)
+        attrs["event.name"] = "hook_sessionstart"
+
+    if hook_event == "Stop":
+        if body.get("stop_reason"):
+            attrs["stop_reason"] = body["stop_reason"]
+        # Kiro packs assistant_response into the Stop payload.
+        # Keep event.name as hook_stop (lifecycle), content in tool_response.
+        if body.get("assistant_response"):
+            attrs["tool_response"] = _truncate(str(body["assistant_response"]))
+
+    if hook_event == "PostToolUseFailure" and body.get("error"):
+        attrs["error"] = _truncate(str(body["error"]))
+
+    # Enriched fields from kiro_stop_hook.py SQLite extraction
+    for enriched_field in (
+        "input_tokens",
+        "output_tokens",
+        "turn_count",
+        "credits",
+        "tools_used",
+        "conversation_id",
+    ):
+        if body.get(enriched_field):
+            attrs[enriched_field] = str(body[enriched_field])
+
+
+def _extract_claude_code(body: dict, hook_event: str, attrs: dict[str, str]) -> None:
+    """Extract Claude Code-specific fields into *attrs*.
+
+    Claude Code sends rich per-event payloads with ``tool_input`` /
+    ``tool_response`` as strings, per-message Stop events with
+    ``tool_name`` discriminators, subagent events, task tracking,
+    compaction, worktrees, elicitations, and notifications.
+    """
+    tool_name = attrs.get("tool_name", "")
+    tool_input_raw = body.get("tool_input")
+    tool_response_raw = body.get("tool_response")
+
+    if tool_input_raw is not None:
+        attrs["tool_input"] = _truncate(_safe_json(tool_input_raw))
+    if tool_response_raw is not None:
+        attrs["tool_response"] = _truncate(_safe_json(tool_response_raw))
+
+    # UserPromptSubmit
+    if hook_event == "UserPromptSubmit":
+        prompt_text = body.get("user_prompt") or body.get("prompt") or ""
+        if prompt_text:
+            attrs["tool_input"] = _truncate(prompt_text)
+            attrs["prompt_length"] = str(len(prompt_text))
+        attrs["tool_name"] = "user_prompt"
+
+    # SessionStart
+    if hook_event == "SessionStart":
+        prompt_text = body.get("prompt") or ""
+        if prompt_text:
+            attrs["tool_input"] = _truncate(prompt_text)
+        attrs["event.name"] = "hook_sessionstart"
+        source = body.get("source", "")
+        if source:
+            attrs["session_source"] = source
+        if source in ("resume", "compact") or body.get("resume"):
+            attrs["session_resumed"] = "true"
+
+    # SubagentStart / SubagentStop
+    if hook_event == "SubagentStart" and body.get("last_assistant_message"):
+        attrs["tool_input"] = _truncate(body["last_assistant_message"])
+    if hook_event == "SubagentStop" and body.get("last_assistant_message"):
+        attrs["tool_response"] = _truncate(body["last_assistant_message"])
+
+    # PostToolUseFailure
+    if hook_event == "PostToolUseFailure" and body.get("error"):
+        attrs["error"] = _truncate(str(body["error"]))
+
+    # Stop — Claude Code fires per-message Stop events discriminated by tool_name
+    if hook_event == "Stop":
+        if body.get("stop_reason"):
+            attrs["stop_reason"] = body["stop_reason"]
+        if tool_name == "assistant_response" and tool_response_raw:
+            attrs["event.name"] = "hook_assistant_response"
+        elif tool_name == "assistant_thinking" and tool_response_raw:
+            attrs["event.name"] = "hook_assistant_thinking"
+        if body.get("message_sequence") is not None:
+            attrs["message_sequence"] = str(body["message_sequence"])
+        if body.get("message_total") is not None:
+            attrs["message_total"] = str(body["message_total"])
+
+    # StopFailure
+    if hook_event == "StopFailure":
+        if body.get("error"):
+            attrs["error"] = _truncate(str(body["error"]))
+        if body.get("stop_reason"):
+            attrs["stop_reason"] = body["stop_reason"]
+
+    # Notification
+    if hook_event == "Notification":
+        if body.get("message"):
+            attrs["tool_response"] = _truncate(str(body["message"]))
+        if body.get("title"):
+            attrs["notification_title"] = str(body["title"])
+
+    # TaskCreated / TaskCompleted
+    if hook_event in ("TaskCreated", "TaskCompleted"):
+        for field in ("task_id", "task_subject", "task_status"):
+            if body.get(field):
+                attrs[field] = str(body[field])
+
+    # PreCompact / PostCompact
+    if hook_event in ("PreCompact", "PostCompact") and body.get("summary"):
+        attrs["tool_response"] = _truncate(str(body["summary"]))
+
+    # WorktreeCreate / WorktreeRemove
+    if hook_event in ("WorktreeCreate", "WorktreeRemove"):
+        if body.get("worktree_path"):
+            attrs["worktree_path"] = str(body["worktree_path"])
+        if body.get("branch"):
+            attrs["branch"] = str(body["branch"])
+
+    # Elicitation / ElicitationResult
+    if hook_event in ("Elicitation", "ElicitationResult"):
+        for field in ("mcp_server_name", "message", "response", "elicitation_id"):
+            if body.get(field):
+                key = "tool_input" if field == "message" else ("tool_response" if field == "response" else field)
+                attrs[key] = _truncate(str(body[field]))
+
+
 @router.post("/hooks")
 async def ingest_hook(request: Request):
     """Ingest hook events from Claude Code / Kiro and store in otel_logs.
@@ -314,6 +470,17 @@ async def ingest_hook(request: Request):
     # ── Normalize Kiro camelCase event names to PascalCase ──
     raw_event = body.get("hook_event_name", "unknown")
     hook_event = _KIRO_TO_CC_EVENT.get(raw_event, raw_event)
+
+    # Kiro postToolUse with tool_response.success=false → remap to PostToolUseFailure
+    if hook_event == "PostToolUse":
+        tool_resp = body.get("tool_response")
+        if isinstance(tool_resp, dict) and tool_resp.get("success") is False:
+            hook_event = "PostToolUseFailure"
+            # Extract error info from the failed result
+            result = tool_resp.get("result", "")
+            if result and not body.get("error"):
+                body["error"] = _truncate(str(result))
+
     body["hook_event_name"] = hook_event
 
     session_id = body.get("session_id", "")
@@ -346,137 +513,23 @@ async def ingest_hook(request: Request):
     if user_id:
         attrs["user.id"] = user_id
 
-    # Capture full content — this is the Langfuse-equivalent visibility
-    tool_input_raw = body.get("tool_input")
-    tool_response_raw = body.get("tool_response")
+    # ── IDE-specific extraction ──
+    # Detect IDE from service_name, then delegate to the right handler.
+    # This keeps Kiro and Claude Code logic fully isolated so they can't
+    # overwrite each other's fields.
+    is_kiro = service_name in ("kiro-cli", "kiro")
+    if is_kiro:
+        _extract_kiro(body, hook_event, attrs)
+    else:
+        _extract_claude_code(body, hook_event, attrs)
 
-    if tool_input_raw is not None:
-        attrs["tool_input"] = _truncate(_safe_json(tool_input_raw))
-    if tool_response_raw is not None:
-        attrs["tool_response"] = _truncate(_safe_json(tool_response_raw))
-
-    # ── Kiro-specific field extraction ──
-    # Kiro sends `prompt` on agentSpawn/userPromptSubmit,
-    # `assistant_response` on stop, and tool_input/tool_response as dicts.
-    if body.get("prompt") and not attrs.get("tool_input"):
-        attrs["tool_input"] = _truncate(str(body["prompt"]))
-    if body.get("assistant_response") and not attrs.get("tool_response"):
-        attrs["tool_response"] = _truncate(str(body["assistant_response"]))
-        attrs["event.name"] = "hook_assistant_response"
-
-    # UserPromptSubmit — capture the actual user prompt
-    if hook_event == "UserPromptSubmit":
-        prompt_text = body.get("prompt") or body.get("user_prompt") or ""
-        if prompt_text:
-            attrs["tool_input"] = _truncate(prompt_text)
-            attrs["prompt_length"] = str(len(prompt_text))
-        attrs["tool_name"] = "user_prompt"
-        # Keep as hook_userpromptsubmit — the frontend uses this to start
-        # new turns. "user_prompt" gets deduped away when hooks are present.
-
-    # SessionStart / agentSpawn — capture initial prompt and mark as session start
-    if hook_event == "SessionStart":
-        prompt_text = body.get("prompt") or ""
-        if prompt_text:
-            attrs["tool_input"] = _truncate(prompt_text)
-        attrs["event.name"] = "hook_sessionstart"
-
-    # SubagentStart — capture agent spawn
-    if hook_event == "SubagentStart" and body.get("last_assistant_message"):
-        attrs["tool_input"] = _truncate(body["last_assistant_message"])
-
-    # SubagentStop — capture agent final output
-    if hook_event == "SubagentStop" and body.get("last_assistant_message"):
-        attrs["tool_response"] = _truncate(body["last_assistant_message"])
-
-    # PostToolUseFailure — tool failure (critical for debugging)
-    if hook_event == "PostToolUseFailure" and body.get("error"):
-        attrs["error"] = _truncate(str(body["error"]))
-
-    # Stop — session/turn end (command hook sends assistant response text)
-    if hook_event == "Stop":
-        if body.get("stop_reason"):
-            attrs["stop_reason"] = body["stop_reason"]
-        # Kiro sends assistant_response directly; Claude Code sends via tool_response
-        if body.get("assistant_response"):
-            attrs["tool_response"] = _truncate(str(body["assistant_response"]))
-            attrs["event.name"] = "hook_assistant_response"
-        elif tool_name == "assistant_response" and tool_response_raw:
-            attrs["event.name"] = "hook_assistant_response"
-        elif tool_name == "assistant_thinking" and tool_response_raw:
-            attrs["event.name"] = "hook_assistant_thinking"
-        # Sequence metadata for interleaving with tool calls
-        if body.get("message_sequence") is not None:
-            attrs["message_sequence"] = str(body["message_sequence"])
-        if body.get("message_total") is not None:
-            attrs["message_total"] = str(body["message_total"])
-
-    # StopFailure — API error on turn end
-    if hook_event == "StopFailure":
-        if body.get("error"):
-            attrs["error"] = _truncate(str(body["error"]))
-        if body.get("stop_reason"):
-            attrs["stop_reason"] = body["stop_reason"]
-
-    # SessionStart — session lifecycle
-    # Claude Code sends "source" field: startup, resume, clear, compact
-    session_source = body.get("source", "")
-    if hook_event == "SessionStart":
-        if session_source:
-            attrs["session_source"] = session_source
-        if session_source in ("resume", "compact") or body.get("resume"):
-            attrs["session_resumed"] = "true"
-
-    # Notification
-    if hook_event == "Notification":
-        if body.get("message"):
-            attrs["tool_response"] = _truncate(str(body["message"]))
-        if body.get("title"):
-            attrs["notification_title"] = str(body["title"])
-
-    # TaskCreated / TaskCompleted
-    if hook_event in ("TaskCreated", "TaskCompleted"):
-        for field in ("task_id", "task_subject", "task_status"):
-            if body.get(field):
-                attrs[field] = str(body[field])
-
-    # PreCompact / PostCompact — context compaction
-    if hook_event in ("PreCompact", "PostCompact") and body.get("summary"):
-        attrs["tool_response"] = _truncate(str(body["summary"]))
-
-    # WorktreeCreate / WorktreeRemove
-    if hook_event in ("WorktreeCreate", "WorktreeRemove"):
-        if body.get("worktree_path"):
-            attrs["worktree_path"] = str(body["worktree_path"])
-        if body.get("branch"):
-            attrs["branch"] = str(body["branch"])
-
-    # Elicitation / ElicitationResult — MCP server interactions
-    if hook_event in ("Elicitation", "ElicitationResult"):
-        for field in ("mcp_server_name", "message", "response", "elicitation_id"):
-            if body.get(field):
-                key = "tool_input" if field == "message" else ("tool_response" if field == "response" else field)
-                attrs[key] = _truncate(str(body[field]))
-
-    # Extra context fields (present on most events)
+    # Extra context fields (present on most events, all IDEs)
     if body.get("tool_use_id"):
         attrs["tool_use_id"] = body["tool_use_id"]
     if body.get("cwd"):
         attrs["cwd"] = body["cwd"]
     if body.get("permission_mode"):
         attrs["permission_mode"] = body["permission_mode"]
-
-    # ── Enriched fields from Kiro SQLite DB (sent by kiro_stop_hook.py) ──
-    for enriched_field in (
-        "input_tokens",
-        "output_tokens",
-        "turn_count",
-        "credits",
-        "tools_used",
-        "conversation_id",
-    ):
-        if body.get(enriched_field):
-            attrs[enriched_field] = str(body[enriched_field])
 
     # Build the Body as a readable summary
     agent_prefix = f"[{attrs.get('agent_type', '')}] " if attrs.get("agent_id") else ""
@@ -526,9 +579,6 @@ async def ingest_hook(request: Request):
     else:
         body_text = f"{agent_prefix}hook: {hook_event}"
 
-    # Event name for the EventName column (used by list_sessions countIf)
-    event_name = attrs.get("event.name", f"hook_{hook_event.lower()}")
-
     # ── Redact secrets from user-content fields before storage ──
     for _redact_field in ("tool_input", "tool_response", "error"):
         if _redact_field in attrs:
@@ -536,16 +586,18 @@ async def ingest_hook(request: Request):
     body_text = redact_secrets(body_text)
 
     # INSERT into otel_logs using JSONEachRow (safe against injection)
+    # Note: The otel_logs table is created by the OTEL collector with its
+    # standard schema — there is no EventName column.  Event names live in
+    # LogAttributes['event.name'] (already set above).
     row = {
         "Timestamp": now,
-        "EventName": event_name,
         "Body": body_text,
         "LogAttributes": attrs,
         "ServiceName": service_name,
         "SeverityText": "INFO",
         "SeverityNumber": 9,
     }
-    sql = "INSERT INTO otel_logs (Timestamp, EventName, Body, LogAttributes, ServiceName, SeverityText, SeverityNumber) FORMAT JSONEachRow"
+    sql = "INSERT INTO otel_logs (Timestamp, Body, LogAttributes, ServiceName, SeverityText, SeverityNumber) FORMAT JSONEachRow"
 
     try:
         r = await _query(sql, data=json.dumps(row, default=str))

--- a/observal-server/services/hook_materializer.py
+++ b/observal-server/services/hook_materializer.py
@@ -86,7 +86,6 @@ async def _fetch_session_events(session_id: str) -> list[dict]:
         "ServiceName AS service_name "
         "FROM otel_logs "
         "WHERE LogAttributes['session.id'] = {sid:String} "
-        "OR LogAttributes['conversation_id'] = {sid:String} "
         "ORDER BY Timestamp ASC "
         "FORMAT JSON"
     )

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import typer
 from rich import print as rprint
 
+from observal_cli import config, settings_reconciler
+from observal_cli.hooks_spec import get_desired_env, get_desired_hooks
+
 doctor_app = typer.Typer(help="Diagnose IDE settings for Observal compatibility")
 
 
@@ -205,9 +208,9 @@ def _check_kiro_installation(issues: list, warnings: list):
 def _check_cursor(path: Path, data: dict, issues: list, warnings: list):
     """Check Cursor MCP config for Observal conflicts."""
     servers = data.get("mcpServers", {})
-    for name, config in servers.items():
-        cmd = config.get("command", "")
-        args = config.get("args", [])
+    for name, srv_cfg in servers.items():
+        cmd = srv_cfg.get("command", "")
+        args = srv_cfg.get("args", [])
         full_cmd = f"{cmd} {' '.join(str(a) for a in args)}"
         # Check if MCP is wrapped with observal-shim
         if "observal-shim" not in full_cmd and "observal-proxy" not in full_cmd:
@@ -220,9 +223,9 @@ def _check_cursor(path: Path, data: dict, issues: list, warnings: list):
 def _check_gemini(path: Path, data: dict, issues: list, warnings: list):
     """Check Gemini CLI settings for Observal conflicts."""
     servers = data.get("mcpServers", {})
-    for name, config in servers.items():
-        cmd = config.get("command", "")
-        args = config.get("args", [])
+    for name, srv_cfg in servers.items():
+        cmd = srv_cfg.get("command", "")
+        args = srv_cfg.get("args", [])
         full_cmd = f"{cmd} {' '.join(str(a) for a in args)}"
         if "observal-shim" not in full_cmd and "observal-proxy" not in full_cmd:
             warnings.append(
@@ -234,9 +237,9 @@ def _check_gemini(path: Path, data: dict, issues: list, warnings: list):
 def _check_mcp_json(path: Path, data: dict, issues: list, warnings: list):
     """Check .mcp.json for unwrapped servers."""
     servers = data.get("mcpServers", {})
-    for name, config in servers.items():
-        cmd = config.get("command", "")
-        args = config.get("args", [])
+    for name, srv_cfg in servers.items():
+        cmd = srv_cfg.get("command", "")
+        args = srv_cfg.get("args", [])
         full_cmd = f"{cmd} {' '.join(str(a) for a in args)}"
         if "observal-shim" not in full_cmd and "observal-proxy" not in full_cmd:
             warnings.append(
@@ -304,10 +307,13 @@ def _check_environment(issues: list, warnings: list):
 
 @doctor_app.callback(invoke_without_command=True)
 def doctor(
+    ctx: typer.Context,
     ide: str = typer.Option(None, help="Check specific IDE only (claude-code, kiro, cursor, gemini-cli)"),
     fix: bool = typer.Option(False, help="Show suggested fixes"),
 ):
     """Diagnose IDE and Observal settings for compatibility issues."""
+    if ctx.invoked_subcommand is not None:
+        return  # Let the subcommand handle it
     issues: list[str] = []
     warnings: list[str] = []
 
@@ -406,3 +412,219 @@ def doctor(
                 rprint("  Run: observal scan --ide kiro")
 
     raise typer.Exit(1 if issues else 0)
+
+
+# ── SLI: reinstall hooks ──────────────────────────────────
+
+# Kiro camelCase event mapping and all supported events
+_KIRO_EVENT_MAP = {
+    "SessionStart": "agentSpawn",
+    "UserPromptSubmit": "userPromptSubmit",
+    "PreToolUse": "preToolUse",
+    "PostToolUse": "postToolUse",
+    "Stop": "stop",
+}
+
+# All Claude Code events that should have hooks
+_ALL_EVENTS = [
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "SubagentStart",
+    "SubagentStop",
+    "Stop",
+    "StopFailure",
+    "Notification",
+    "TaskCreated",
+    "TaskCompleted",
+    "PreCompact",
+    "PostCompact",
+    "WorktreeCreate",
+    "WorktreeRemove",
+    "Elicitation",
+    "ElicitationResult",
+]
+
+
+def _find_hook_script(name: str) -> str | None:
+    """Locate a hook script by filename."""
+    candidates = [
+        Path(__file__).parent / "hooks" / name,
+        Path(shutil.which(name) or ""),
+    ]
+    for p in candidates:
+        if p.is_file():
+            return str(p.resolve())
+    return None
+
+
+def _install_claude_code_hooks(server_url: str, api_key: str) -> list[str]:
+    """Reconcile Claude Code hooks into ~/.claude/settings.json."""
+    hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
+    hook_script = _find_hook_script("observal-hook.sh")
+    stop_script = _find_hook_script("observal-stop-hook.sh")
+    cfg = config.load()
+    user_id = cfg.get("user_id", "")
+
+    desired_hooks = get_desired_hooks(hook_script, stop_script, hooks_url, user_id)
+    desired_env = get_desired_env(server_url, api_key, user_id)
+
+    return settings_reconciler.reconcile(desired_hooks, desired_env)
+
+
+def _install_kiro_hooks(server_url: str) -> tuple[list[str], bool]:
+    """Install Observal hooks into all Kiro agent configs.
+
+    Returns (messages, changed) where changed is True if any file was modified.
+    """
+    agents_dir = Path.home() / ".kiro" / "agents"
+    changes: list[str] = []
+    changed = False
+
+    if not agents_dir.exists():
+        return ["[dim]~/.kiro/agents/ not found — skipping Kiro[/dim]"], False
+
+    agent_files = list(agents_dir.glob("*.json"))
+    if not agent_files:
+        return ["[dim]No Kiro agent configs found — skipping[/dim]"], False
+
+    hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
+
+    # Locate the Kiro hook scripts
+    hook_py = Path(__file__).parent / "hooks" / "kiro_hook.py"
+    stop_py = Path(__file__).parent / "hooks" / "kiro_stop_hook.py"
+
+    if not hook_py.is_file() or not stop_py.is_file():
+        return ["[red]Cannot find kiro_hook.py / kiro_stop_hook.py — reinstall Observal CLI[/red]"], False
+
+    hook_py_str = str(hook_py.resolve())
+    stop_py_str = str(stop_py.resolve())
+
+    for af in agent_files:
+        agent_name = af.stem
+        try:
+            data = json.loads(af.read_text())
+        except (json.JSONDecodeError, OSError):
+            changes.append(f"[yellow]⚠ {agent_name}: could not parse, skipped[/yellow]")
+            continue
+
+        # Build per-agent sed prefix (includes agent_name)
+        # Must produce: cat | sed 's/^{/{"session_id":"kiro-'$PPID'","service_name":"kiro-cli","agent_name":"<name>",/'
+        sed_prefix = (
+            'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'",'
+            '"service_name":"kiro-cli",'
+            '"agent_name":"' + agent_name + "\",/' "
+        )
+        generic_cmd = sed_prefix + "| python3 " + hook_py_str + " --url " + hooks_url
+        stop_cmd = sed_prefix + "| python3 " + stop_py_str + " --url " + hooks_url
+
+        desired_kiro_hooks: dict[str, list[dict]] = {}
+        for event in _ALL_EVENTS:
+            kiro_event = _KIRO_EVENT_MAP.get(event)
+            if not kiro_event:
+                continue
+            if kiro_event == "stop":
+                desired_kiro_hooks[kiro_event] = [{"command": stop_cmd}]
+            else:
+                entry: dict = {"command": generic_cmd}
+                if kiro_event in ("preToolUse", "postToolUse"):
+                    entry["matcher"] = "*"
+                desired_kiro_hooks[kiro_event] = [entry]
+
+        current_hooks = data.get("hooks", {})
+        updated = False
+
+        for kiro_event, desired_entries in desired_kiro_hooks.items():
+            existing = current_hooks.get(kiro_event, [])
+            # Check if Observal hook already present
+            has_observal = any(
+                "observal" in h.get("command", "") or "otel/hooks" in h.get("command", "") for h in existing
+            )
+            if not has_observal:
+                # Append our hooks, keep existing ones
+                current_hooks[kiro_event] = existing + desired_entries
+                updated = True
+
+        if updated:
+            data["hooks"] = current_hooks
+            af.write_text(json.dumps(data, indent=2) + "\n")
+            changes.append(f"+ {agent_name}: added Observal hooks")
+            changed = True
+        else:
+            changes.append(f"[dim]  {agent_name}: already has Observal hooks[/dim]")
+
+    return changes, changed
+
+
+@doctor_app.command(name="sli")
+def doctor_sli(
+    ide: str = typer.Option(
+        None,
+        "--ide",
+        "-i",
+        help="Target IDE only (claude-code, kiro). Default: both.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show changes without applying"),
+):
+    """Re-install Observal telemetry hooks into Claude Code and/or Kiro.
+
+    Repairs missing or outdated hooks non-destructively — your existing
+    hooks and settings are preserved.
+    """
+    cfg = config.load()
+    server_url = cfg.get("server_url")
+    api_key = cfg.get("api_key", "")
+
+    if not server_url:
+        rprint("[red]Not configured. Run [bold]observal auth login[/bold] first.[/red]")
+        raise typer.Exit(1)
+
+    targets = [ide] if ide else ["claude-code", "kiro"]
+    any_changes = False
+
+    for target in targets:
+        if target == "claude-code":
+            claude_dir = Path.home() / ".claude"
+            if not claude_dir.is_dir() and not shutil.which("claude"):
+                rprint("[dim]Claude Code not detected — skipping[/dim]")
+                continue
+
+            rprint("[cyan]Claude Code[/cyan]")
+            if dry_run:
+                hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
+                hook_script = _find_hook_script("observal-hook.sh")
+                stop_script = _find_hook_script("observal-stop-hook.sh")
+                user_id = cfg.get("user_id", "")
+                desired_hooks = get_desired_hooks(hook_script, stop_script, hooks_url, user_id)
+                desired_env = get_desired_env(server_url, api_key, user_id)
+                changes = settings_reconciler.reconcile(desired_hooks, desired_env, dry_run=True)
+            else:
+                changes = _install_claude_code_hooks(server_url, api_key)
+
+            if changes:
+                any_changes = True
+                for c in changes:
+                    rprint(f"  {c}")
+            else:
+                rprint("  [dim]Already up to date[/dim]")
+
+        elif target in ("kiro", "kiro-cli"):
+            rprint("[cyan]Kiro[/cyan]")
+            if dry_run:
+                rprint("  [yellow]Dry run not supported for Kiro — use without --dry-run[/yellow]")
+                continue
+
+            messages, kiro_changed = _install_kiro_hooks(server_url)
+            if kiro_changed:
+                any_changes = True
+            for c in messages:
+                rprint(f"  {c}")
+        else:
+            rprint(f"[yellow]Unknown IDE: {target}. Use 'claude-code' or 'kiro'.[/yellow]")
+
+    if any_changes:
+        rprint("\n[green]✓ Hooks installed.[/green] Restart your IDE session to pick up changes.")
+    elif not dry_run:
+        rprint("\n[dim]All hooks already up to date.[/dim]")

--- a/observal_cli/hooks/flush_buffer.py
+++ b/observal_cli/hooks/flush_buffer.py
@@ -89,6 +89,20 @@ def main() -> None:
 
                 with urllib.request.urlopen(req, timeout=5) as resp:
                     if resp.status < 300:
+                        # Verify the server actually ingested the event.
+                        # The hook endpoint returns {"ingested": 0} on
+                        # insert failure with HTTP 200 — treat that as a
+                        # retryable failure so we don't lose events.
+                        try:
+                            body = resp.read()
+                            import json as _json
+
+                            result = _json.loads(body)
+                            if result.get("ingested", 0) < 1:
+                                failed_ids.append(row_id)
+                                continue
+                        except Exception:
+                            pass
                         sent_ids.append(row_id)
                     else:
                         failed_ids.append(row_id)

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -61,6 +61,10 @@ def main():
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
+    # Ensure service_name is set (sed prefix may be overwritten by Kiro's
+    # native fields due to JSON duplicate-key semantics — last key wins).
+    payload.setdefault("service_name", "kiro-cli")
+
     payload = _add_conversation_id(payload)
 
     data = json.dumps(payload).encode("utf-8")

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -143,6 +143,8 @@ def main():
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
+    payload.setdefault("service_name", "kiro-cli")
+
     # Enrich with SQLite data
     payload = _enrich(payload)
 

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -339,6 +339,12 @@ function buildEventTree(events: RawOtelEvent[]): { turns: Turn[]; preSessionEven
     // Stop events: mark turn end
     if (eName === "hook_stop" || eName === "hook_stopfailure") {
       currentTurn.stopEvent = evt;
+      // Kiro sends assistant_response inside the stop event (no separate
+      // hook_assistant_response). Promote it to responseEvent so the UI
+      // renders the response text.
+      if (!currentTurn.responseEvent && attrs.tool_response) {
+        currentTurn.responseEvent = evt;
+      }
       continue;
     }
 
@@ -1248,14 +1254,16 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
 
 /* ── Session Info tab ─────────────────────────────────────── */
 
-/** All hook event types we know about, grouped by category. */
-const HOOK_CAPABILITIES: { category: string; hooks: { event: string; label: string; description: string }[] }[] = [
+/** Hook capability definitions per IDE. Kiro only supports 5 native events. */
+type HookCapGroup = { category: string; hooks: { event: string; label: string; description: string }[] };
+
+const CLAUDE_CODE_HOOK_CAPABILITIES: HookCapGroup[] = [
   {
     category: "Capture",
     hooks: [
-      { event: "hook_userpromptsubmit", label: "User Prompts", description: "Captures what the user sends to Claude" },
-      { event: "hook_assistant_response", label: "Assistant Responses", description: "Captures Claude's text replies" },
-      { event: "hook_assistant_thinking", label: "Assistant Thinking", description: "Captures Claude's chain-of-thought reasoning" },
+      { event: "hook_userpromptsubmit", label: "User Prompts", description: "Captures what the user sends to the assistant" },
+      { event: "hook_assistant_response", label: "Assistant Responses", description: "Captures the assistant's text replies" },
+      { event: "hook_assistant_thinking", label: "Assistant Thinking", description: "Captures chain-of-thought reasoning" },
     ],
   },
   {
@@ -1278,7 +1286,7 @@ const HOOK_CAPABILITIES: { category: string; hooks: { event: string; label: stri
     hooks: [
       { event: "hook_sessionstart", label: "Session Start", description: "Session initialization and resumption" },
       { event: "hook_stop", label: "Stop", description: "Turn/session end events" },
-      { event: "hook_notification", label: "Notifications", description: "System notifications from Claude" },
+      { event: "hook_notification", label: "Notifications", description: "System notifications" },
       { event: "hook_taskcreated", label: "Task Created", description: "Task tracking events" },
       { event: "hook_taskcompleted", label: "Task Completed", description: "Task completion events" },
       { event: "hook_precompact", label: "Pre Compact", description: "Before context compaction" },
@@ -1287,7 +1295,40 @@ const HOOK_CAPABILITIES: { category: string; hooks: { event: string; label: stri
   },
 ];
 
+const KIRO_HOOK_CAPABILITIES: HookCapGroup[] = [
+  {
+    category: "Capture",
+    hooks: [
+      { event: "hook_userpromptsubmit", label: "User Prompts", description: "Captures prompts submitted by the user" },
+      { event: "hook_assistant_response", label: "Response Capture", description: "Extracted from stop-hook enrichment" },
+    ],
+  },
+  {
+    category: "Tool Use",
+    hooks: [
+      { event: "hook_pretooluse", label: "Pre Tool Use", description: "Fires before each tool call — can validate and block" },
+      { event: "hook_posttooluse", label: "Post Tool Use", description: "Captures tool results after execution" },
+      { event: "hook_posttoolusefailure", label: "Tool Failures", description: "Auto-detected from failed tool responses" },
+    ],
+  },
+  {
+    category: "Lifecycle",
+    hooks: [
+      { event: "hook_sessionstart", label: "Agent Spawn", description: "Fires when the agent is activated" },
+      { event: "hook_stop", label: "Stop", description: "Fires when the assistant finishes responding" },
+    ],
+  },
+];
+
+function getHookCapabilities(serviceName: string): HookCapGroup[] {
+  if (serviceName === "kiro-cli" || serviceName === "kiro") return KIRO_HOOK_CAPABILITIES;
+  return CLAUDE_CODE_HOOK_CAPABILITIES;
+}
+
 function SessionInfoTab({ events, sessionId, serviceName }: { events: RawOtelEvent[]; sessionId: string; serviceName: string }) {
+  const isKiro = serviceName === "kiro-cli" || serviceName === "kiro";
+  const hookCapabilities = useMemo(() => getHookCapabilities(serviceName), [serviceName]);
+
   // Derive active hooks from events actually present in this session
   const activeHookEvents = useMemo(() => {
     const seen = new Set<string>();
@@ -1363,10 +1404,13 @@ function SessionInfoTab({ events, sessionId, serviceName }: { events: RawOtelEve
           Active Hooks
         </h3>
         <p className="text-xs text-muted-foreground">
-          Hook types detected in this session. Missing hooks mean those event types were not captured — check your hook configuration.
+          Hook types detected in this session.{" "}
+          {isKiro
+            ? "Kiro supports 5 native hook events. Missing hooks mean those event types were not captured."
+            : "Missing hooks mean those event types were not captured — check your hook configuration."}
         </p>
         <div className="space-y-4">
-          {HOOK_CAPABILITIES.map((group) => (
+          {hookCapabilities.map((group) => (
             <div key={group.category} className="space-y-2">
               <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{group.category}</h4>
               <div className="grid gap-1.5">

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -250,7 +250,7 @@ export default function TracesPage() {
           <EmptyState
             icon={Activity}
             title="No sessions yet"
-            description="Sessions will appear here once telemetry data is collected from Claude Code."
+            description="Sessions will appear here once telemetry data is collected from your IDE."
           />
         ) : (
           <div className="animate-in space-y-3">


### PR DESCRIPTION
## Purpose / Description

Kiro CLI hook events were processed through the same code path as Claude Code, causing field overwrites, misclassified events, and session splitting. This PR isolates each IDE hook ingestion into dedicated extraction functions and fixes several session-level bugs.

## Fixes
* Closes #141
* Closes #143
* Closes #144
* Closes #152

## Approach

**Server-side:** Split ingest_hook() into _extract_kiro() and _extract_claude_code() -- IDE detected via service_name, each handler runs in isolation. Removed conversation_id from session queries. Kiro Stop keeps hook_stop event name; Claude Code Stop reclassifies via tool_name.

**CLI:** Added observal doctor sli for hook reinstallation. Kiro hook scripts use setdefault for service_name. Flush buffer verifies response body.

**Frontend:** Kiro stop events promoted to responseEvent for rendering. IDE-aware hook capabilities. Removed Claude Code references from Kiro sessions.

## How Has This Been Tested?

- ruff check + ruff format pass
- 1058 pytest tests pass
- Manual Kiro CLI sessions verified (single session, stop events, response rendering)
- Claude Code sessions verified unaffected

## Checklist

- [x] All commits are signed off (git commit -s) per the DCO
- [x] Descriptive commit messages with short titles
- [x] Code commented in hard-to-understand areas
- [x] Self-reviewed