### PR TITLE
fix(cli): always prompt for framework, show it after submission

### DIFF
--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -211,8 +211,6 @@ def _submit_impl(git_url, name, category, yes):
     else:
         if detected_name:
             rprint(f"  Server name:  [cyan]{detected_name}[/cyan]")
-        if detected_framework:
-            rprint(f"  Framework:    [cyan]{detected_framework}[/cyan]")
         if detected_desc:
             rprint(f"  Description:  [dim]{detected_desc[:80]}{'...' if len(detected_desc) > 80 else ''}[/dim]")
         if tools:
@@ -298,12 +296,12 @@ def _submit_impl(git_url, name, category, yes):
 
         _category = category or select_one("Category", VALID_MCP_CATEGORIES, default="general")
 
-        # Framework: how should this MCP server be executed?
-        if _detected_fw:
-            rprint(f"  Framework:   [cyan]{_detected_fw}[/cyan] [dim](from analysis)[/dim]")
-            _framework = _detected_fw
-        else:
-            _framework = select_one("Execution framework", VALID_MCP_FRAMEWORKS, default="python")
+        # Framework: always prompt — analysis can misdetect
+        _framework = select_one(
+            "Execution framework",
+            VALID_MCP_FRAMEWORKS,
+            default=_detected_fw or "python",
+        )
 
         _docker_image = None
         if _framework == "docker":
@@ -342,6 +340,7 @@ def _submit_impl(git_url, name, category, yes):
     with spinner("Submitting..."):
         result = client.post("/api/v1/mcps/submit", submit_payload)
     rprint(f"\n[green]✓ Submitted![/green] ID: [bold]{result['id']}[/bold]")
+    rprint(f"  Framework: [cyan]{_framework}[/cyan]")
     rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
 
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Analysis can misdetect the framework (e.g. Python server classified as TypeScript). Remove framework from the analysis summary since it's unreliable,

## Approach
Always show the framework selector with the detected value as default, and display the user's chosen framework in the submission confirmation.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->