### PR TITLE
feat: live session updates via GraphQL subscriptions

### DIFF
--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -490,9 +490,7 @@ class Subscription:
             yield _row_to_span(data)
 
     @strawberry.subscription
-    async def session_updated(
-        self, session_id: str | None = None
-    ) -> AsyncGenerator[SessionEvent, None]:
+    async def session_updated(self, session_id: str | None = None) -> AsyncGenerator[SessionEvent, None]:
         channel = "sessions:updated"
         async for data in subscribe(channel):
             sid = data.get("session_id", "")

--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -464,6 +464,12 @@ class Query:
 
 
 @strawberry.type
+class SessionEvent:
+    session_id: str
+    event_name: str
+
+
+@strawberry.type
 class Subscription:
     @strawberry.subscription
     async def trace_created(
@@ -482,6 +488,20 @@ class Subscription:
         channel = f"spans:{trace_id}"
         async for data in subscribe(channel):
             yield _row_to_span(data)
+
+    @strawberry.subscription
+    async def session_updated(
+        self, session_id: str | None = None
+    ) -> AsyncGenerator[SessionEvent, None]:
+        channel = "sessions:updated"
+        async for data in subscribe(channel):
+            sid = data.get("session_id", "")
+            if session_id and sid != session_id:
+                continue
+            yield SessionEvent(
+                session_id=sid,
+                event_name=data.get("event_name", ""),
+            )
 
 
 # --- Schema ---

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -615,9 +615,7 @@ async def ingest_hook(request: Request):
 
     # Notify subscribers (fire-and-forget — don't block the response)
     if session_id:
-        task = asyncio.create_task(
-            publish("sessions:updated", {"session_id": session_id, "event_name": hook_event})
-        )
+        task = asyncio.create_task(publish("sessions:updated", {"session_id": session_id, "event_name": hook_event}))
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
 

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime
@@ -7,6 +8,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from api.deps import require_role
 from models.user import User, UserRole
 from services.clickhouse import _query
+from services.redis import publish
 from services.secrets_redactor import redact_secrets
 
 logger = logging.getLogger(__name__)
@@ -607,5 +609,11 @@ async def ingest_hook(request: Request):
     except Exception as e:
         logger.warning(f"Hook insert failed: {e}")
         return {"ingested": 0, "error": str(e)}
+
+    # Notify subscribers (fire-and-forget — don't block the response)
+    if session_id:
+        asyncio.create_task(
+            publish("sessions:updated", {"session_id": session_id, "event_name": hook_event})
+        )
 
     return {"ingested": 1, "session_id": session_id, "event": hook_event}

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -14,6 +14,9 @@ from services.secrets_redactor import redact_secrets
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/otel", tags=["otel-dashboard"])
 
+# Background tasks that must survive until completion (prevent GC)
+_background_tasks: set[asyncio.Task] = set()
+
 
 @router.get("/crypto/public-key")
 async def get_public_key():
@@ -612,8 +615,10 @@ async def ingest_hook(request: Request):
 
     # Notify subscribers (fire-and-forget — don't block the response)
     if session_id:
-        asyncio.create_task(
+        task = asyncio.create_task(
             publish("sessions:updated", {"session_id": session_id, "event_name": hook_event})
         )
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     return {"ingested": 1, "session_id": session_id, "event": hook_event}

--- a/tests/eval/test_eval_phase8.py
+++ b/tests/eval/test_eval_phase8.py
@@ -101,7 +101,9 @@ class TestRunEvalOnTrace:
     @pytest.mark.asyncio
     async def test_no_spans_returns_empty(self):
         with (
-            patch("services.eval.eval_engine.query_trace_by_id", new_callable=AsyncMock, return_value={"trace_id": "t1"}),
+            patch(
+                "services.eval.eval_engine.query_trace_by_id", new_callable=AsyncMock, return_value={"trace_id": "t1"}
+            ),
             patch("services.eval.eval_engine.query_spans", new_callable=AsyncMock, return_value=[]),
         ):
             result = await run_eval_on_trace("agent-1", "t1")

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "graphql-ws": "^6.0.8",
     "lucide-react": "^1.7.0",
     "next": "16.2.2",
     "next-themes": "^0.4.6",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      graphql-ws:
+        specifier: ^6.0.8
+        version: 6.0.8(graphql@16.13.2)
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
@@ -2092,6 +2095,26 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql-ws@6.0.8:
+    resolution: {integrity: sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@fastify/websocket': ^10 || ^11
+      crossws: ~0.3
+      graphql: ^15.10.1 || ^16
+      ws: ^8
+    peerDependenciesMeta:
+      '@fastify/websocket':
+        optional: true
+      crossws:
+        optional: true
+      ws:
+        optional: true
+
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -5038,6 +5061,12 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql-ws@6.0.8(graphql@16.13.2):
+    dependencies:
+      graphql: 16.13.2
+
+  graphql@16.13.2: {}
 
   has-bigints@1.1.0: {}
 

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useState, useCallback, useMemo, createElement } from "react";
-import { useOtelSession } from "@/hooks/use-api";
+import { useOtelSession, useSessionSubscription } from "@/hooks/use-api";
 import type { OtelSessionData, RawOtelEvent } from "@/lib/types";
 import {
   FileText,
@@ -1452,6 +1452,7 @@ function SessionInfoTab({ events, sessionId, serviceName }: { events: RawOtelEve
 export default function TraceDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { data, isLoading, isError, error, refetch } = useOtelSession(id);
+  useSessionSubscription();
 
   const session = data as OtelSessionData;
   const events: RawOtelEvent[] = useMemo(() => session?.events ?? [], [session]);

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Activity, Search, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
-import { useOtelSessions } from "@/hooks/use-api";
+import { useOtelSessions, useSessionSubscription } from "@/hooks/use-api";
 import {
   useReactTable,
   getCoreRowModel,
@@ -195,8 +195,9 @@ function SortIcon({ sorted }: { sorted: false | "asc" | "desc" }) {
 export default function TracesPage() {
   const [tab, setTab] = useState<"all" | "active">("all");
   const { data: sessions, isLoading, isError, error, refetch } = useOtelSessions({
-    refetchInterval: tab === "active" ? 10_000 : false,
+    refetchInterval: 30_000,
   });
+  useSessionSubscription();
   const router = useRouter();
 
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -336,7 +337,7 @@ export default function TracesPage() {
 
             <p className="text-sm text-muted-foreground">
               {table.getFilteredRowModel().rows.length} session{table.getFilteredRowModel().rows.length !== 1 ? "s" : ""}
-              {tab === "active" && " \u00b7 auto-refreshing every 10s"}
+              {" \u00b7 live updates"}
             </p>
           </div>
         )}

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import {
   useQuery,
   useMutation,
@@ -294,6 +295,30 @@ export function useOtelStats() {
 }
 export function useOtelErrors() {
   return useQuery({ queryKey: ['otel', 'errors'], queryFn: dashboard.otelErrors });
+}
+
+export function useSessionSubscription() {
+  const qc = useQueryClient();
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+
+    import("@/lib/graphql-ws").then(({ subscribeToSessionUpdates }) => {
+      unsubscribe = subscribeToSessionUpdates((sessionId) => {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => {
+          qc.invalidateQueries({ queryKey: ["otel", "sessions"] });
+          qc.invalidateQueries({ queryKey: ["otel", "session", sessionId] });
+        }, 300);
+      });
+    });
+
+    return () => {
+      clearTimeout(debounceRef.current);
+      unsubscribe?.();
+    };
+  }, [qc]);
 }
 
 // ── Agent-specific ──────────────────────────────────────────────────

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -299,23 +299,25 @@ export function useOtelErrors() {
 
 export function useSessionSubscription() {
   const qc = useQueryClient();
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const listDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
 
     import("@/lib/graphql-ws").then(({ subscribeToSessionUpdates }) => {
       unsubscribe = subscribeToSessionUpdates((sessionId) => {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = setTimeout(() => {
+        // Debounce the list refetch (many events → one list refresh)
+        clearTimeout(listDebounceRef.current);
+        listDebounceRef.current = setTimeout(() => {
           qc.invalidateQueries({ queryKey: ["otel", "sessions"] });
-          qc.invalidateQueries({ queryKey: ["otel", "session", sessionId] });
         }, 300);
+        // Session detail: invalidate immediately so new turns appear
+        qc.invalidateQueries({ queryKey: ["otel", "session", sessionId] });
       });
     });
 
     return () => {
-      clearTimeout(debounceRef.current);
+      clearTimeout(listDebounceRef.current);
       unsubscribe?.();
     };
   }, [qc]);

--- a/web/src/lib/graphql-ws.ts
+++ b/web/src/lib/graphql-ws.ts
@@ -1,0 +1,58 @@
+import { createClient, type Client } from "graphql-ws";
+
+function getWsUrl(): string {
+  const api =
+    process.env.NEXT_PUBLIC_API_URL ||
+    (typeof window !== "undefined"
+      ? `http://${window.location.hostname}:8000`
+      : "http://localhost:8000");
+  return api.replace(/^http/, "ws") + "/api/v1/graphql";
+}
+
+function getToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("observal_access_token");
+}
+
+let client: Client | null = null;
+
+function getClient(): Client {
+  if (!client) {
+    client = createClient({
+      url: getWsUrl(),
+      connectionParams: () => {
+        const token = getToken();
+        return token ? { authorization: `Bearer ${token}` } : {};
+      },
+      lazy: true,
+      retryAttempts: 5,
+    });
+  }
+  return client;
+}
+
+export function subscribeToSessionUpdates(
+  onEvent: (sessionId: string, eventName: string) => void,
+): () => void {
+  return getClient().subscribe(
+    {
+      query: `subscription SessionUpdated($sessionId: String) {
+        sessionUpdated(sessionId: $sessionId) {
+          sessionId
+          eventName
+        }
+      }`,
+    },
+    {
+      next: (value) => {
+        const data = (value.data as { sessionUpdated?: { sessionId: string; eventName: string } })
+          ?.sessionUpdated;
+        if (data) {
+          onEvent(data.sessionId, data.eventName);
+        }
+      },
+      error: () => {},
+      complete: () => {},
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Replace polling with push-based updates on the sessions/traces pages using GraphQL subscriptions over WebSocket
- Backend publishes lightweight `{session_id, event_name}` notifications to Redis after hook ingestion, Strawberry streams them via `session_updated` subscription
- Frontend receives notifications, debounces (300ms), and invalidates React Query cache for a background refetch (notify-and-refetch pattern)
- Both `/traces` list and `/traces/[id]` detail pages get live updates (~200-300ms latency)
- 30s fallback poll remains as safety net if WebSocket disconnects

## Changes
- **`observal-server/api/graphql.py`** — `SessionEvent` type + `session_updated` subscription
- **`observal-server/api/routes/otel_dashboard.py`** — Fire-and-forget Redis publish after hook ingestion
- **`web/src/lib/graphql-ws.ts`** — New WebSocket client (lazy, auto-reconnect)
- **`web/src/hooks/use-api.ts`** — `useSessionSubscription()` hook with debounced invalidation
- **`web/src/app/(admin)/traces/page.tsx`** — Wired up subscription, 30s fallback poll
- **`web/src/app/(admin)/traces/[id]/page.tsx`** — Wired up subscription for live detail updates

## Test plan
- [ ] Start Redis + backend + frontend
- [ ] Open `/traces` in browser
- [ ] Trigger hook events from CLI (Claude Code or Kiro)
- [ ] Verify sessions appear/update within ~200-300ms without page reload
- [ ] Open a session detail (`/traces/[id]`) and verify events stream in live
- [ ] Kill Redis and verify 30s fallback polling still works
- [ ] Run `pnpm typecheck` in `web/` — passes clean