### PR TITLE
fix(web): protect registry routes with auth guard

### DIFF
--- a/web/src/app/(registry)/layout.tsx
+++ b/web/src/app/(registry)/layout.tsx
@@ -2,7 +2,7 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { RegistrySidebar } from "@/components/nav/registry-sidebar";
 import { CommandMenu } from "@/components/nav/command-menu";
 import { Toaster } from "@/components/ui/sonner";
-import { OptionalAuthGuard } from "@/components/layouts/auth-guard";
+import { AuthGuard } from "@/components/layouts/auth-guard";
 
 export default function RegistryLayout({
   children,
@@ -10,13 +10,13 @@ export default function RegistryLayout({
   children: React.ReactNode;
 }) {
   return (
-    <OptionalAuthGuard>
+    <AuthGuard>
       <SidebarProvider>
         <RegistrySidebar />
         <SidebarInset>{children}</SidebarInset>
         <CommandMenu />
         <Toaster visibleToasts={1} />
       </SidebarProvider>
-    </OptionalAuthGuard>
+    </AuthGuard>
   );
 }


### PR DESCRIPTION
fixes #315

### Summary
                                                                  
- Replaced `OptionalAuthGuard` with `AuthGuard` in the registry 
  layout
 
- Unauthenticated users navigating to `/` or any protected route
   are now redirected to `/login` instead of being granted viewer 
  access

- Fixes authentication bypass where removing `/login` from the  
  URL exposed protected pages without a valid session

### Testing
1) Log in, then manually remove `/login` from the URL
2) Verify redirect back to `/login` immediately

### note 
- the only actual code change is swapping the <AuthGuard> wrapper