### PR TITLE
fix: add :gitSignOff preset to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":gitSignOff"],
   "schedule": ["on saturday"],
   "labels": ["Dependency"],
   "packageRules": [


### PR DESCRIPTION
Closes #333

## Purpose / Description
Renovate-generated PRs are failing the DCO sign-off check because the Renovate config is missing the `:gitSignOff` preset. This causes all automated dependency update PRs to be blocked by CI.

## Fixes
* Fixes #333

## Approach
Added `:gitSignOff` to the `extends` array in `renovate.json`. This is Renovate's built-in preset that appends a `Signed-off-by:` line to every commit it generates, satisfying the DCO check.

Before: `"extends": ["config:recommended"]`
After: `"extends": ["config:recommended", ":gitSignOff"]`

## How Has This Been Tested?

- Validated JSON syntax
- Confirmed `:gitSignOff` is a documented Renovate preset: https://docs.renovatebot.com/presets-default/#gitsignoff
- Once merged, Renovate will rebase its open PRs with signed-off commits, which can be verified by checking the DCO status on existing Renovate PRs

## Learning (optional, can help others)

- Renovate's `:gitSignOff` preset uses the `commitBody` option under the hood to append `Signed-off-by: ...` to all commits
- Docs: https://docs.renovatebot.com/configuration-options/#commitbody
- Preset reference: https://docs.renovatebot.com/presets-default/#gitsignoff

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: N/A — config-only change
