### PR TITLE
feat(agent): agent review queue, versioning, bundles, archive & draft workflow

### DIFF
--- a/observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py
+++ b/observal-server/alembic/versions/0001_add_rbac_roles_and_is_demo.py
@@ -16,6 +16,8 @@ depends_on = None
 def upgrade() -> None:
     op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'super_admin'")
     op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'reviewer'")
+    # New enum values must be committed before they can be used in DML
+    op.execute("COMMIT")
     # Only rename developer→reviewer if the enum still has the old value
     op.execute("""
         DO $$

--- a/observal-server/alembic/versions/0010_add_agents_name_uniqueness.py
+++ b/observal-server/alembic/versions/0010_add_agents_name_uniqueness.py
@@ -22,6 +22,7 @@ def upgrade() -> None:
         DO $$
         DECLARE
             dup_row RECORD;
+            inner_row RECORD;
             counter INT;
         BEGIN
             FOR dup_row IN
@@ -29,7 +30,7 @@ def upgrade() -> None:
                 GROUP BY name, created_by HAVING COUNT(*) > 1
             LOOP
                 counter := 0;
-                FOR dup_row IN
+                FOR inner_row IN
                     SELECT id FROM agents
                     WHERE name = dup_row.name AND created_by = dup_row.created_by
                     ORDER BY created_at DESC OFFSET 1
@@ -37,7 +38,7 @@ def upgrade() -> None:
                     counter := counter + 1;
                     UPDATE agents
                     SET name = name || '-dup' || counter
-                    WHERE id = dup_row.id;
+                    WHERE id = inner_row.id;
                 END LOOP;
             END LOOP;
         END

--- a/observal-server/alembic/versions/0010_add_agents_name_uniqueness.py
+++ b/observal-server/alembic/versions/0010_add_agents_name_uniqueness.py
@@ -1,0 +1,61 @@
+"""Add unique constraint on agents (name, created_by).
+
+Same user cannot create two agents with the same name; different users can.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-04-17
+"""
+
+from alembic import op
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Deduplicate any existing duplicates first: keep the most recent row,
+    # rename older duplicates by appending a suffix so the index can be created.
+    op.execute("""
+        DO $$
+        DECLARE
+            dup_row RECORD;
+            counter INT;
+        BEGIN
+            FOR dup_row IN
+                SELECT name, created_by FROM agents
+                GROUP BY name, created_by HAVING COUNT(*) > 1
+            LOOP
+                counter := 0;
+                FOR dup_row IN
+                    SELECT id FROM agents
+                    WHERE name = dup_row.name AND created_by = dup_row.created_by
+                    ORDER BY created_at DESC OFFSET 1
+                LOOP
+                    counter := counter + 1;
+                    UPDATE agents
+                    SET name = name || '-dup' || counter
+                    WHERE id = dup_row.id;
+                END LOOP;
+            END LOOP;
+        END
+        $$;
+    """)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname = 'uq_agents_name_created_by'
+            ) THEN
+                ALTER TABLE agents
+                ADD CONSTRAINT uq_agents_name_created_by UNIQUE (name, created_by);
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agents DROP CONSTRAINT IF EXISTS uq_agents_name_created_by;")

--- a/observal-server/alembic/versions/0011_agent_review_and_bundles.py
+++ b/observal-server/alembic/versions/0011_agent_review_and_bundles.py
@@ -12,8 +12,6 @@ Create Date: 2026-04-17
 """
 
 from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import UUID
 
 revision = "0011"
 down_revision = "0010"

--- a/observal-server/alembic/versions/0011_agent_review_and_bundles.py
+++ b/observal-server/alembic/versions/0011_agent_review_and_bundles.py
@@ -1,0 +1,92 @@
+"""Add agent review statuses, component bundles, and archive support.
+
+- Extend AgentStatus enum with 'pending' and 'rejected'
+- Extend ListingStatus enum with 'archived'
+- Create component_bundles table for MCP-linked skills
+- Add bundle_id FK to all 5 listing tables
+- Add rejection_reason column to agents
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-04-17
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+_LISTING_TABLES = [
+    "mcp_listings",
+    "skill_listings",
+    "hook_listings",
+    "prompt_listings",
+    "sandbox_listings",
+]
+
+
+def upgrade() -> None:
+    # Enum extensions must run outside a transaction in PostgreSQL
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE agentstatus ADD VALUE IF NOT EXISTS 'pending'")
+    op.execute("ALTER TYPE agentstatus ADD VALUE IF NOT EXISTS 'rejected'")
+    op.execute("ALTER TYPE listingstatus ADD VALUE IF NOT EXISTS 'archived'")
+    op.execute("BEGIN")
+
+    # Component bundles table
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS component_bundles (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            name VARCHAR(255) NOT NULL,
+            description TEXT DEFAULT '',
+            submitted_by UUID NOT NULL REFERENCES users(id),
+            created_at TIMESTAMPTZ DEFAULT NOW()
+        )
+    """)
+
+    # Add bundle_id FK + index to each listing table
+    for table in _LISTING_TABLES:
+        op.execute(f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = '{table}' AND column_name = 'bundle_id'
+                ) THEN
+                    ALTER TABLE {table}
+                    ADD COLUMN bundle_id UUID REFERENCES component_bundles(id);
+                END IF;
+            END $$;
+        """)
+        op.execute(f"""
+            CREATE INDEX IF NOT EXISTS ix_{table}_bundle_id ON {table}(bundle_id)
+        """)
+
+    # Add rejection_reason to agents
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'agents' AND column_name = 'rejection_reason'
+            ) THEN
+                ALTER TABLE agents ADD COLUMN rejection_reason TEXT;
+            END IF;
+        END $$;
+    """)
+
+    # Index on agents.status for review queries
+    op.execute("CREATE INDEX IF NOT EXISTS ix_agents_status ON agents(status)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_agents_status")
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS rejection_reason")
+    for table in _LISTING_TABLES:
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_bundle_id")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS bundle_id")
+    op.execute("DROP TABLE IF EXISTS component_bundles")

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -82,7 +82,9 @@ async def _load_agent(
         return result.scalar_one_or_none()
 
 
-def _agent_to_response(agent: Agent, name_map: dict[str, str] | None = None) -> AgentResponse:
+def _agent_to_response(
+    agent: Agent, name_map: dict[str, str] | None = None, *, created_by_email: str = ""
+) -> AgentResponse:
     name_map = name_map or {}
     # Build mcp_links from components with component_type='mcp' (backwards compat)
     mcp_components = [c for c in agent.components if c.component_type == "mcp"]
@@ -120,6 +122,7 @@ def _agent_to_response(agent: Agent, name_map: dict[str, str] | None = None) -> 
     agent_dict["mcp_links"] = mcp_links
     agent_dict["component_links"] = component_links
     agent_dict["goal_template"] = goal_template
+    agent_dict["created_by_email"] = created_by_email
     return AgentResponse(**agent_dict)
 
 
@@ -191,9 +194,7 @@ async def create_agent(
     # Pre-check uniqueness before insert for a clean 409 (the DB constraint
     # remains the source of truth, but checking first avoids triggering an
     # IntegrityError mid-flush which would corrupt the savepoint state).
-    existing = await db.execute(
-        select(Agent.id).where(Agent.name == req.name, Agent.created_by == current_user.id)
-    )
+    existing = await db.execute(select(Agent.id).where(Agent.name == req.name, Agent.created_by == current_user.id))
     if existing.scalar_one_or_none() is not None:
         raise HTTPException(
             status_code=409,
@@ -282,7 +283,7 @@ async def create_agent(
         metadata={"agent_name": req.name, "version": req.version, "component_count": str(len(req.components))},
     )
 
-    return _agent_to_response(agent, name_map)
+    return _agent_to_response(agent, name_map, created_by_email=current_user.email)
 
 
 @router.get("", response_model=list[AgentSummary])
@@ -324,6 +325,13 @@ async def list_agents(
         )
         rating_map = {r[0]: round(float(r[1]), 2) for r in rows.all()}
 
+    # Batch-fetch creator emails
+    user_ids = {a.created_by for a in agents}
+    email_map: dict[uuid.UUID, str] = {}
+    if user_ids:
+        rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
+        email_map = {r[0]: r[1] for r in rows.all()}
+
     return [
         AgentSummary(
             id=a.id,
@@ -337,6 +345,7 @@ async def list_agents(
             download_count=a.download_count,
             average_rating=rating_map.get(a.id),
             component_count=len(a.components),
+            created_by_email=email_map.get(a.created_by, ""),
             created_at=a.created_at,
             updated_at=a.updated_at,
         )
@@ -350,7 +359,18 @@ async def get_agent(agent_id: str, db: AsyncSession = Depends(get_db)):
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     name_map = await _resolve_component_names(agent.components, db)
-    return _agent_to_response(agent, name_map)
+    email_row = (await db.execute(select(User.email).where(User.id == agent.created_by))).scalar_one_or_none()
+    return _agent_to_response(agent, name_map, created_by_email=email_row or "")
+
+
+@router.get("/{agent_id}/version-suggestions")
+async def version_suggestions(agent_id: str, db: AsyncSession = Depends(get_db)):
+    agent = await _load_agent(db, agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    from services.versioning import suggest_versions
+
+    return {"current": agent.version, "suggestions": suggest_versions(agent.version)}
 
 
 @router.put("/{agent_id}", response_model=AgentResponse)
@@ -365,6 +385,11 @@ async def update_agent(
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.created_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the agent owner")
+
+    if req.version_bump_type and req.version is None:
+        from services.versioning import bump_version
+
+        req.version = bump_version(agent.version, req.version_bump_type)
 
     for field in (
         "name",
@@ -486,7 +511,7 @@ async def update_agent(
         resource_name=agent.name,
     )
 
-    return _agent_to_response(agent, name_map)
+    return _agent_to_response(agent, name_map, created_by_email=current_user.email)
 
 
 @router.post("/{agent_id}/install", response_model=AgentInstallResponse)
@@ -714,3 +739,191 @@ async def delete_agent(
     )
 
     return {"deleted": agent_id_str}
+
+
+@router.patch("/{agent_id}/archive")
+async def archive_agent(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    agent = await _load_agent(db, agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    agent.status = AgentStatus.archived
+    await db.commit()
+
+    emit_registry_event(
+        action="agent.archive",
+        user_id=str(current_user.id),
+        user_email=current_user.email,
+        user_role=current_user.role.value,
+        agent_id=str(agent.id),
+        resource_name=agent.name,
+    )
+
+    return {"id": str(agent.id), "name": agent.name, "status": agent.status.value}
+
+
+# ---------------------------------------------------------------------------
+# Draft workflow
+# ---------------------------------------------------------------------------
+
+
+@router.post("/draft", response_model=AgentResponse)
+async def save_draft(
+    req: AgentCreateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Create an agent as a draft (relaxed validation, not submitted for review)."""
+    agent = Agent(
+        name=req.name,
+        version=req.version,
+        description=req.description,
+        owner=req.owner,
+        prompt=req.prompt,
+        model_name=req.model_name,
+        model_config_json=req.model_config_json,
+        external_mcps=[m.model_dump() for m in req.external_mcps],
+        supported_ides=req.supported_ides,
+        created_by=current_user.id,
+        status=AgentStatus.draft,
+    )
+    db.add(agent)
+    await db.flush()
+
+    for i, cref in enumerate(req.components):
+        db.add(
+            AgentComponent(
+                agent_id=agent.id,
+                component_type=cref.component_type,
+                component_id=cref.component_id,
+                version_ref="latest",
+                order_index=i,
+                config_override=cref.config_override,
+            )
+        )
+
+    goal = AgentGoalTemplate(agent_id=agent.id, description=req.goal_template.description)
+    db.add(goal)
+    await db.flush()
+    for i, sec in enumerate(req.goal_template.sections):
+        db.add(
+            AgentGoalSection(
+                goal_template_id=goal.id,
+                name=sec.name,
+                description=sec.description,
+                grounding_required=sec.grounding_required,
+                order=i,
+            )
+        )
+
+    await db.commit()
+    agent = await _load_agent(db, str(agent.id))
+    return _agent_to_response(agent, created_by_email=current_user.email)
+
+
+@router.put("/{agent_id}/draft", response_model=AgentResponse)
+async def update_draft(
+    agent_id: str,
+    req: AgentUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Update a draft agent."""
+    agent = await _load_agent(db, agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.created_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the agent owner")
+    if agent.status != AgentStatus.draft:
+        raise HTTPException(status_code=400, detail="Agent is not a draft")
+
+    for field in (
+        "name",
+        "version",
+        "description",
+        "owner",
+        "prompt",
+        "model_name",
+        "model_config_json",
+        "supported_ides",
+    ):
+        val = getattr(req, field)
+        if val is not None:
+            setattr(agent, field, val)
+
+    if req.external_mcps is not None:
+        agent.external_mcps = [m.model_dump() for m in req.external_mcps]
+
+    if req.components is not None:
+        old_comps = (
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+        )
+        for comp in old_comps:
+            await db.delete(comp)
+        for i, cref in enumerate(req.components):
+            db.add(
+                AgentComponent(
+                    agent_id=agent.id,
+                    component_type=cref.component_type,
+                    component_id=cref.component_id,
+                    version_ref="latest",
+                    order_index=i,
+                    config_override=cref.config_override,
+                )
+            )
+
+    await db.commit()
+    agent = await _load_agent(db, str(agent.id))
+    return _agent_to_response(agent, created_by_email=current_user.email)
+
+
+@router.post("/{agent_id}/submit", response_model=AgentResponse)
+async def submit_draft(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Submit a draft agent for review (transitions draft -> pending)."""
+    agent = await _load_agent(db, agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.created_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the agent owner")
+    if agent.status != AgentStatus.draft:
+        raise HTTPException(status_code=400, detail="Agent is not a draft")
+
+    # Validate components exist
+    if agent.components:
+        from services.agent_resolver import validate_component_ids
+
+        errors = await validate_component_ids(
+            [{"component_type": c.component_type, "component_id": c.component_id} for c in agent.components],
+            db,
+        )
+        if errors:
+            raise HTTPException(
+                status_code=400,
+                detail=[
+                    {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                    for e in errors
+                ],
+            )
+
+    agent.status = AgentStatus.pending
+    await db.commit()
+    agent = await _load_agent(db, str(agent.id))
+    name_map = await _resolve_component_names(agent.components, db)
+
+    emit_registry_event(
+        action="agent.submit",
+        user_id=str(current_user.id),
+        user_email=current_user.email,
+        user_role=current_user.role.value,
+        agent_id=str(agent.id),
+        resource_name=agent.name,
+    )
+
+    return _agent_to_response(agent, name_map, created_by_email=current_user.email)

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -1,7 +1,8 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -27,6 +28,7 @@ from schemas.agent import (
     ValidationResult,
 )
 from services.agent_config_generator import generate_agent_config
+from services.registry_telemetry import emit_registry_event
 
 router = APIRouter(prefix="/api/v1/agents", tags=["agents"])
 
@@ -37,8 +39,19 @@ _agent_load_options = [
 ]
 
 
-async def _load_agent(db: AsyncSession, agent_id: str, extra_conditions=None) -> Agent | None:
-    """Load an agent by UUID, prefix, or name with eager loading."""
+async def _load_agent(
+    db: AsyncSession,
+    agent_id: str,
+    extra_conditions=None,
+    *,
+    prefer_user_id: uuid.UUID | None = None,
+) -> Agent | None:
+    """Load an agent by UUID, prefix, or name with eager loading.
+
+    When *prefer_user_id* is provided and resolution is by name, prefer the
+    caller's own agent over agents created by other users with the same name.
+    Falls back to the most recent matching agent if the user has none.
+    """
     try:
         return await resolve_prefix_id(
             Agent, agent_id, db, load_options=_agent_load_options, extra_conditions=extra_conditions
@@ -46,6 +59,21 @@ async def _load_agent(db: AsyncSession, agent_id: str, extra_conditions=None) ->
     except HTTPException as e:
         if e.status_code == 400:
             raise e
+
+        # Try the caller's own agent first
+        if prefer_user_id is not None:
+            stmt = (
+                select(Agent)
+                .where(Agent.name == agent_id, Agent.created_by == prefer_user_id)
+                .options(*_agent_load_options)
+            )
+            if extra_conditions:
+                stmt = stmt.where(*extra_conditions)
+            mine = (await db.execute(stmt)).scalar_one_or_none()
+            if mine:
+                return mine
+
+        # Fall back to most recent matching agent across all users
         stmt = select(Agent).where(Agent.name == agent_id).options(*_agent_load_options)
         if extra_conditions:
             stmt = stmt.where(*extra_conditions)
@@ -160,6 +188,18 @@ async def create_agent(
                 ],
             )
 
+    # Pre-check uniqueness before insert for a clean 409 (the DB constraint
+    # remains the source of truth, but checking first avoids triggering an
+    # IntegrityError mid-flush which would corrupt the savepoint state).
+    existing = await db.execute(
+        select(Agent.id).where(Agent.name == req.name, Agent.created_by == current_user.id)
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"You already have an agent named '{req.name}'. Pick a different name or delete the existing one.",
+        )
+
     agent = Agent(
         name=req.name,
         version=req.version,
@@ -218,23 +258,59 @@ async def create_agent(
             )
         )
 
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        if "uq_agents_name_created_by" in str(exc.orig):
+            raise HTTPException(
+                status_code=409,
+                detail=f"You already have an agent named '{req.name}'. Pick a different name or delete the existing one.",
+            )
+        raise
+
     agent = await _load_agent(db, str(agent.id))
     name_map = await _resolve_component_names(agent.components, db)
+
+    emit_registry_event(
+        action="agent.create",
+        user_id=str(current_user.id),
+        user_email=current_user.email,
+        user_role=current_user.role.value,
+        agent_id=str(agent.id),
+        resource_name=req.name,
+        metadata={"agent_name": req.name, "version": req.version, "component_count": str(len(req.components))},
+    )
+
     return _agent_to_response(agent, name_map)
 
 
 @router.get("", response_model=list[AgentSummary])
 async def list_agents(
+    response: Response,
     search: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200, description="Page size (1-200)"),
+    offset: int = Query(0, ge=0, description="Items to skip"),
     db: AsyncSession = Depends(get_db),
 ):
     from models.feedback import Feedback
 
-    stmt = select(Agent).where(Agent.status == AgentStatus.active).options(selectinload(Agent.components))
+    base_filter = Agent.status == AgentStatus.active
+    search_filter = None
     if search:
-        stmt = stmt.where(Agent.name.ilike(f"%{search}%") | Agent.description.ilike(f"%{search}%"))
-    result = await db.execute(stmt.order_by(Agent.created_at.desc()))
+        search_filter = Agent.name.ilike(f"%{search}%") | Agent.description.ilike(f"%{search}%")
+
+    # Total count for pagination header (cheap: no joins, no eager loads)
+    count_stmt = select(func.count(Agent.id)).where(base_filter)
+    if search_filter is not None:
+        count_stmt = count_stmt.where(search_filter)
+    total = (await db.execute(count_stmt)).scalar_one()
+    response.headers["X-Total-Count"] = str(total)
+
+    stmt = select(Agent).where(base_filter).options(selectinload(Agent.components))
+    if search_filter is not None:
+        stmt = stmt.where(search_filter)
+    result = await db.execute(stmt.order_by(Agent.created_at.desc()).offset(offset).limit(limit))
     agents = result.scalars().all()
 
     # Batch-fetch average ratings
@@ -400,6 +476,16 @@ async def update_agent(
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
     name_map = await _resolve_component_names(agent.components, db)
+
+    emit_registry_event(
+        action="agent.update",
+        user_id=str(current_user.id),
+        user_email=current_user.email,
+        user_role=current_user.role.value,
+        agent_id=str(agent.id),
+        resource_name=agent.name,
+    )
+
     return _agent_to_response(agent, name_map)
 
 
@@ -411,9 +497,14 @@ async def install_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    agent = await _load_agent(db, agent_id, extra_conditions=[Agent.status == AgentStatus.active])
+    agent = await _load_agent(
+        db,
+        agent_id,
+        extra_conditions=[Agent.status == AgentStatus.active],
+        prefer_user_id=current_user.id,
+    )
     if not agent:
-        agent = await _load_agent(db, agent_id)
+        agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
         if not agent or agent.created_by != current_user.id:
             raise HTTPException(status_code=404, detail="Agent not found or not active")
 
@@ -433,6 +524,7 @@ async def install_agent(
         mcp_listings=mcp_listings_map,
         component_names=name_map,
         env_values=req.env_values,
+        options=req.options,
     )
 
     # Capture agent.id before any DB operations that might expire the ORM
@@ -450,6 +542,16 @@ async def install_agent(
         db=db,
     )
     await db.commit()
+
+    emit_registry_event(
+        action="agent.install",
+        user_id=str(current_user.id),
+        user_email=current_user.email,
+        user_role=current_user.role.value,
+        agent_id=str(resolved_agent_id),
+        resource_name=agent.name,
+        metadata={"ide": req.ide},
+    )
 
     return AgentInstallResponse(agent_id=resolved_agent_id, ide=req.ide, config_snippet=snippet)
 
@@ -597,6 +699,18 @@ async def delete_agent(
         await db.delete(r)
     # AgentComponent, AgentGoalTemplate, AgentGoalSection handled by cascade="all, delete-orphan"
 
+    agent_id_str = str(agent.id)
+    agent_name = agent.name
     await db.delete(agent)
     await db.commit()
-    return {"deleted": str(agent.id)}
+
+    emit_registry_event(
+        action="agent.delete",
+        user_id=str(current_user.id),
+        user_email=current_user.email,
+        user_role=current_user.role.value,
+        agent_id=agent_id_str,
+        resource_name=agent_name,
+    )
+
+    return {"deleted": agent_id_str}

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -14,6 +14,7 @@ from models.mcp import ListingStatus, McpDownload, McpListing
 from models.user import User, UserRole
 from schemas.dashboard import (
     AgentMetrics,
+    ComponentLeaderboardItem,
     DateAvg,
     GraphRagQuery,
     GraphRagStats,
@@ -254,6 +255,7 @@ async def top_agents(
 async def agent_leaderboard(
     window: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
     limit: int = Query(20, le=50),
+    user: str | None = Query(None, description="Filter by creator email"),
     db: AsyncSession = Depends(get_db),
 ):
     """Public leaderboard of agents ranked by downloads within a time window."""
@@ -267,23 +269,31 @@ async def agent_leaderboard(
             Agent.description,
             Agent.owner,
             Agent.version,
+            Agent.created_by,
         )
         .join(Agent, AgentDownloadRecord.agent_id == Agent.id)
         .where(Agent.status == AgentStatus.active)
     )
+    if user:
+        stmt = stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{user}%"))
     if window != "all":
         days = _RANGE_MAP.get(window, 7)
         stmt = stmt.where(AgentDownloadRecord.installed_at >= dt.now(UTC) - timedelta(days=days))
-    stmt = (
-        stmt.group_by(AgentDownloadRecord.agent_id, Agent.name, Agent.description, Agent.owner, Agent.version)
-        .order_by(func.count(AgentDownloadRecord.id).desc())
-        .limit(limit)
-    )
+    group_cols = [
+        AgentDownloadRecord.agent_id,
+        Agent.name,
+        Agent.description,
+        Agent.owner,
+        Agent.version,
+        Agent.created_by,
+    ]
+    stmt = stmt.group_by(*group_cols).order_by(func.count(AgentDownloadRecord.id).desc()).limit(limit)
     result = await db.execute(stmt)
     rows = result.all()
 
-    # Batch-fetch average ratings
+    # Batch-fetch average ratings + creator emails
     agent_ids = [r.agent_id for r in rows]
+    user_ids = {r.created_by for r in rows}
     rating_map: dict[uuid.UUID, float] = {}
     if agent_ids:
         rating_rows = await db.execute(
@@ -292,17 +302,26 @@ async def agent_leaderboard(
             .group_by(Feedback.listing_id)
         )
         rating_map = {r[0]: round(float(r[1]), 2) for r in rating_rows.all()}
+    email_map: dict[uuid.UUID, str] = {}
+    if user_ids:
+        email_rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
+        email_map = {r[0]: r[1] for r in email_rows.all()}
 
     # Also include agents with no downloads if window=all and we have fewer than limit
     if window == "all" and len(rows) < limit:
         existing_ids = {r.agent_id for r in rows}
-        extra_stmt = (
-            select(Agent)
-            .where(Agent.status == AgentStatus.active, Agent.id.notin_(existing_ids))
-            .order_by(Agent.created_at.desc())
-            .limit(limit - len(rows))
-        )
+        extra_stmt = select(Agent).where(Agent.status == AgentStatus.active, Agent.id.notin_(existing_ids))
+        if user:
+            extra_stmt = extra_stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{user}%"))
+        extra_stmt = extra_stmt.order_by(Agent.created_at.desc()).limit(limit - len(rows))
         extra = (await db.execute(extra_stmt)).scalars().all()
+        for a in extra:
+            if a.created_by not in email_map:
+                user_ids.add(a.created_by)
+        if user_ids - set(email_map.keys()):
+            missing = user_ids - set(email_map.keys())
+            extra_emails = await db.execute(select(User.id, User.email).where(User.id.in_(missing)))
+            email_map.update({r[0]: r[1] for r in extra_emails.all()})
         extra_items = [
             LeaderboardItem(
                 id=a.id,
@@ -312,6 +331,7 @@ async def agent_leaderboard(
                 version=a.version or "",
                 download_count=0,
                 average_rating=rating_map.get(a.id),
+                created_by_email=email_map.get(a.created_by, ""),
             )
             for a in extra
         ]
@@ -327,9 +347,61 @@ async def agent_leaderboard(
             version=row.version or "",
             download_count=row.cnt,
             average_rating=rating_map.get(row.agent_id),
+            created_by_email=email_map.get(row.created_by, ""),
         )
         for row in rows
     ] + extra_items
+
+
+@router.get("/overview/component-leaderboard", response_model=list[ComponentLeaderboardItem])
+async def component_leaderboard(
+    window: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
+    limit: int = Query(20, le=50),
+    user: str | None = Query(None, description="Filter by creator email"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Public leaderboard of components ranked by downloads within a time window."""
+    stmt = (
+        select(
+            McpDownload.listing_id,
+            func.count(McpDownload.id).label("cnt"),
+            McpListing.name,
+            McpListing.description,
+            McpListing.submitted_by,
+        )
+        .join(McpListing, McpDownload.listing_id == McpListing.id)
+        .where(McpListing.status == ListingStatus.approved)
+    )
+    if user:
+        stmt = stmt.join(User, McpListing.submitted_by == User.id).where(User.email.ilike(f"%{user}%"))
+    if window != "all":
+        days = _RANGE_MAP.get(window, 7)
+        stmt = stmt.where(McpDownload.downloaded_at >= dt.now(UTC) - timedelta(days=days))
+    stmt = (
+        stmt.group_by(McpDownload.listing_id, McpListing.name, McpListing.description, McpListing.submitted_by)
+        .order_by(func.count(McpDownload.id).desc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    user_ids = {r.submitted_by for r in rows}
+    email_map: dict[uuid.UUID, str] = {}
+    if user_ids:
+        email_rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
+        email_map = {r[0]: r[1] for r in email_rows.all()}
+
+    return [
+        ComponentLeaderboardItem(
+            id=row.listing_id,
+            name=row.name,
+            component_type="mcp",
+            description=row.description or "",
+            download_count=row.cnt,
+            created_by_email=email_map.get(row.submitted_by, ""),
+        )
+        for row in rows
+    ]
 
 
 @router.get("/overview/trends", response_model=list[TrendPoint])

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -1,8 +1,14 @@
+import uuid
+
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from api.deps import get_db, require_role, resolve_prefix_id
+from models.agent import Agent, AgentStatus
+from models.component_bundle import ComponentBundle
 from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
 from models.prompt import PromptListing
@@ -53,23 +59,87 @@ async def _find_listing(listing_id: str, db: AsyncSession):
     return None, None
 
 
+async def _check_agent_components_ready(agent: Agent, db: AsyncSession) -> tuple[bool, list[dict]]:
+    """Check if all of an agent's components are approved."""
+    if not agent.components:
+        return True, []
+
+    by_type: dict[str, list[uuid.UUID]] = {}
+    for comp in agent.components:
+        by_type.setdefault(comp.component_type, []).append(comp.component_id)
+
+    blocking: list[dict] = []
+    for comp_type, ids in by_type.items():
+        model = LISTING_MODELS.get(comp_type)
+        if not model:
+            continue
+        rows = (await db.execute(select(model.id, model.name, model.status).where(model.id.in_(ids)))).all()
+        for row in rows:
+            if row.status != ListingStatus.approved:
+                blocking.append(
+                    {
+                        "component_type": comp_type,
+                        "component_id": str(row.id),
+                        "name": row.name,
+                        "status": row.status.value,
+                    }
+                )
+    return len(blocking) == 0, blocking
+
+
 @router.get("")
 async def list_pending(
     type: str | None = Query(None),
+    tab: str | None = Query(None, description="'agents' to list pending agents, default lists components"),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
+    if tab == "agents":
+        result = await db.execute(
+            select(Agent)
+            .where(Agent.status == AgentStatus.pending)
+            .options(selectinload(Agent.components))
+            .order_by(Agent.created_at.desc())
+        )
+        agents = result.scalars().all()
+
+        user_ids = {a.created_by for a in agents}
+        user_map: dict[uuid.UUID, str] = {}
+        if user_ids:
+            rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
+            user_map = {r[0]: r[1] for r in rows.all()}
+
+        items = []
+        for a in agents:
+            components_ready, blocking = await _check_agent_components_ready(a, db)
+            items.append(
+                {
+                    "type": "agent",
+                    "id": str(a.id),
+                    "name": a.name,
+                    "description": a.description or "",
+                    "version": a.version or "",
+                    "owner": a.owner or "",
+                    "status": a.status.value,
+                    "submitted_by": user_map.get(a.created_by, str(a.created_by)),
+                    "created_at": a.created_at.isoformat() if a.created_at else "",
+                    "component_count": len(a.components),
+                    "components_ready": components_ready,
+                    "blocking_components": blocking,
+                }
+            )
+        return items
 
     models_to_query = {type: LISTING_MODELS[type]} if type and type in LISTING_MODELS else LISTING_MODELS
     items = []
-    user_ids = set()
+    user_ids: set[uuid.UUID] = set()
     for listing_type, model in models_to_query.items():
         result = await db.execute(
             select(model).where(model.status == ListingStatus.pending).order_by(model.created_at.desc())
         )
         for r in result.scalars().all():
             user_ids.add(r.submitted_by)
-            item = {
+            item: dict = {
                 "type": listing_type,
                 "id": str(r.id),
                 "name": r.name,
@@ -79,6 +149,7 @@ async def list_pending(
                 "status": r.status.value,
                 "submitted_by": r.submitted_by,
                 "created_at": r.created_at.isoformat(),
+                "bundle_id": str(r.bundle_id) if isinstance(getattr(r, "bundle_id", None), uuid.UUID) else None,
             }
             # Include validation results for MCP listings
             if listing_type == "mcp" and hasattr(r, "validation_results"):
@@ -93,8 +164,22 @@ async def list_pending(
                 ]
             items.append(item)
 
+    # Resolve bundle names
+    bundle_ids = {i["bundle_id"] for i in items if i.get("bundle_id")}
+    bundle_map: dict[str, str] = {}
+    if bundle_ids:
+        brows = await db.execute(
+            select(ComponentBundle.id, ComponentBundle.name).where(
+                ComponentBundle.id.in_([uuid.UUID(b) for b in bundle_ids])
+            )
+        )
+        bundle_map = {str(r[0]): r[1] for r in brows.all()}
+    for item in items:
+        if item.get("bundle_id"):
+            item["bundle_name"] = bundle_map.get(item["bundle_id"], "")
+
     # Resolve user UUIDs to display names
-    user_map = {}
+    user_map: dict[uuid.UUID, str] = {}
     if user_ids:
         result = await db.execute(select(User).where(User.id.in_(user_ids)))
         for u in result.scalars().all():
@@ -165,3 +250,110 @@ async def reject(
     await db.commit()
     await db.refresh(listing)
     return {"type": listing_type, "id": str(listing.id), "name": listing.name, "status": listing.status.value}
+
+
+# ---------------------------------------------------------------------------
+# Agent review
+# ---------------------------------------------------------------------------
+
+
+class AgentRejectRequest(BaseModel):
+    reason: str
+
+
+@router.post("/agents/{agent_id}/approve")
+async def approve_agent(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
+):
+    agent = (
+        await db.execute(select(Agent).where(Agent.id == agent_id).options(selectinload(Agent.components)))
+    ).scalar_one_or_none()
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.status != AgentStatus.pending:
+        raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', not pending")
+
+    components_ready, blocking = await _check_agent_components_ready(agent, db)
+    if not components_ready:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "Cannot approve: some components are not approved yet",
+                "blocking_components": blocking,
+            },
+        )
+
+    agent.status = AgentStatus.active
+    agent.rejection_reason = None
+    await db.commit()
+    return {"id": str(agent.id), "name": agent.name, "status": agent.status.value}
+
+
+@router.post("/agents/{agent_id}/reject")
+async def reject_agent(
+    agent_id: uuid.UUID,
+    req: AgentRejectRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
+):
+    agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.status not in (AgentStatus.pending, AgentStatus.active):
+        raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', cannot reject")
+
+    agent.status = AgentStatus.rejected
+    agent.rejection_reason = req.reason
+    await db.commit()
+    return {"id": str(agent.id), "name": agent.name, "status": agent.status.value}
+
+
+# ---------------------------------------------------------------------------
+# Bundle review (atomic approve/reject)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/bundles/{bundle_id}/approve")
+async def approve_bundle(
+    bundle_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
+):
+    bundle = (await db.execute(select(ComponentBundle).where(ComponentBundle.id == bundle_id))).scalar_one_or_none()
+    if not bundle:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+
+    count = 0
+    for model in LISTING_MODELS.values():
+        result = await db.execute(select(model).where(model.bundle_id == bundle_id))
+        for listing in result.scalars().all():
+            listing.status = ListingStatus.approved
+            count += 1
+
+    await db.commit()
+    return {"bundle_id": str(bundle_id), "name": bundle.name, "approved_count": count}
+
+
+@router.post("/bundles/{bundle_id}/reject")
+async def reject_bundle(
+    bundle_id: uuid.UUID,
+    req: ReviewActionRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
+):
+    bundle = (await db.execute(select(ComponentBundle).where(ComponentBundle.id == bundle_id))).scalar_one_or_none()
+    if not bundle:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+
+    count = 0
+    for model in LISTING_MODELS.values():
+        result = await db.execute(select(model).where(model.bundle_id == bundle_id))
+        for listing in result.scalars().all():
+            listing.status = ListingStatus.rejected
+            listing.rejection_reason = req.reason
+            count += 1
+
+    await db.commit()
+    return {"bundle_id": str(bundle_id), "name": bundle.name, "rejected_count": count}

--- a/observal-server/models/__init__.py
+++ b/observal-server/models/__init__.py
@@ -3,6 +3,7 @@ from models.agent_component import AgentComponent
 from models.alert import AlertRule
 from models.alert_history import AlertHistory
 from models.base import Base
+from models.component_bundle import ComponentBundle
 from models.component_source import ComponentSource
 from models.download import AgentDownloadRecord, ComponentDownloadRecord
 from models.enterprise_config import EnterpriseConfig
@@ -40,6 +41,7 @@ __all__ = [
     "AlertHistory",
     "AlertRule",
     "Base",
+    "ComponentBundle",
     "ComponentDownloadRecord",
     "ComponentSource",
     "DimensionWeight",

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -17,6 +17,7 @@ class AgentStatus(str, enum.Enum):
 
 class Agent(Base):
     __tablename__ = "agents"
+    __table_args__ = (UniqueConstraint("name", "created_by", name="uq_agents_name_created_by"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -11,7 +11,9 @@ from models.base import Base
 
 class AgentStatus(str, enum.Enum):
     draft = "draft"
+    pending = "pending"
     active = "active"
+    rejected = "rejected"
     archived = "archived"
 
 
@@ -34,7 +36,8 @@ class Agent(Base):
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
-    status: Mapped[AgentStatus] = mapped_column(Enum(AgentStatus), default=AgentStatus.active)
+    status: Mapped[AgentStatus] = mapped_column(Enum(AgentStatus), default=AgentStatus.pending)
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     download_count: Mapped[int] = mapped_column(Integer, default=0)
     unique_users: Mapped[int] = mapped_column(Integer, default=0)
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)

--- a/observal-server/models/component_bundle.py
+++ b/observal-server/models/component_bundle.py
@@ -1,0 +1,18 @@
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+
+
+class ComponentBundle(Base):
+    __tablename__ = "component_bundles"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, default="")
+    submitted_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/observal-server/models/hook.py
+++ b/observal-server/models/hook.py
@@ -28,6 +28,9 @@ class HookListing(Base):
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
+    bundle_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
+    )
     status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
     rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     submitted_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -13,6 +13,7 @@ class ListingStatus(str, enum.Enum):
     pending = "pending"
     approved = "approved"
     rejected = "rejected"
+    archived = "archived"
 
 
 class McpListing(Base):
@@ -42,6 +43,9 @@ class McpListing(Base):
     is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
+    )
+    bundle_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
     )
     status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
     rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/observal-server/models/prompt.py
+++ b/observal-server/models/prompt.py
@@ -33,6 +33,9 @@ class PromptListing(Base):
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
+    bundle_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
+    )
     status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
     rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     submitted_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)

--- a/observal-server/models/sandbox.py
+++ b/observal-server/models/sandbox.py
@@ -36,6 +36,9 @@ class SandboxListing(Base):
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
+    bundle_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
+    )
     status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
     rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     submitted_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)

--- a/observal-server/models/skill.py
+++ b/observal-server/models/skill.py
@@ -28,6 +28,9 @@ class SkillListing(Base):
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
+    bundle_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
+    )
     status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
     rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     submitted_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from models.agent import AgentStatus
 from schemas.constants import AGENT_NAME_REGEX, make_name_validator
+from services.versioning import validate_semver
 
 VALID_COMPONENT_TYPES = {"mcp", "skill", "hook", "prompt", "sandbox"}
 
@@ -56,10 +57,18 @@ class AgentCreateRequest(BaseModel):
 
     _validate_name = field_validator("name")(make_name_validator("name"))
 
+    @field_validator("version")
+    @classmethod
+    def _validate_version(cls, v: str) -> str:
+        if not validate_semver(v):
+            raise ValueError(f"Invalid version '{v}'. Must be semver format: x.y.z (e.g. 1.0.0)")
+        return v
+
 
 class AgentUpdateRequest(BaseModel):
     name: str | None = None
     version: str | None = None
+    version_bump_type: Literal["patch", "minor", "major"] | None = None
     description: str | None = None
     owner: str | None = None
     prompt: str | None = None
@@ -83,6 +92,13 @@ class AgentUpdateRequest(BaseModel):
                 f"Invalid name '{v}'. "
                 "Must start with a letter or digit and contain only lowercase letters, digits, hyphens, and underscores."
             )
+        return v
+
+    @field_validator("version", mode="before")
+    @classmethod
+    def _validate_version(cls, v: str | None) -> str | None:
+        if v is not None and not validate_semver(v):
+            raise ValueError(f"Invalid version '{v}'. Must be semver format: x.y.z (e.g. 1.0.0)")
         return v
 
 
@@ -131,7 +147,9 @@ class AgentResponse(BaseModel):
     external_mcps: list = []
     supported_ides: list[str]
     status: AgentStatus
+    rejection_reason: str | None = None
     created_by: uuid.UUID
+    created_by_email: str = ""
     created_at: datetime
     updated_at: datetime
     mcp_links: list[McpLinkResponse] = []
@@ -153,8 +171,11 @@ class AgentSummary(BaseModel):
     download_count: int = 0
     average_rating: float | None = None
     component_count: int = 0
+    created_by_email: str = ""
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    components_ready: bool = True
+    blocking_components: list = []
     model_config = {"from_attributes": True}
 
 

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -2,9 +2,10 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from models.agent import AgentStatus
+from schemas.constants import AGENT_NAME_REGEX, make_name_validator
 
 VALID_COMPONENT_TYPES = {"mcp", "skill", "hook", "prompt", "sandbox"}
 
@@ -53,6 +54,8 @@ class AgentCreateRequest(BaseModel):
     external_mcps: list[ExternalMcp] = []
     goal_template: GoalTemplateRequest
 
+    _validate_name = field_validator("name")(make_name_validator("name"))
+
 
 class AgentUpdateRequest(BaseModel):
     name: str | None = None
@@ -67,6 +70,20 @@ class AgentUpdateRequest(BaseModel):
     components: list[ComponentRef] | None = None  # new: all component types
     external_mcps: list[ExternalMcp] | None = None
     goal_template: GoalTemplateRequest | None = None
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _validate_name(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if len(v) > 64:
+            raise ValueError("name must be at most 64 characters")
+        if not AGENT_NAME_REGEX.match(v):
+            raise ValueError(
+                f"Invalid name '{v}'. "
+                "Must start with a letter or digit and contain only lowercase letters, digits, hyphens, and underscores."
+            )
+        return v
 
 
 class GoalSectionResponse(BaseModel):
@@ -160,6 +177,8 @@ class ValidationResult(BaseModel):
 class AgentInstallRequest(BaseModel):
     ide: str
     env_values: dict[str, dict[str, str]] = {}  # {mcp_listing_id: {VAR: value}}
+    # IDE-specific install options (e.g. scope, model, tools, color for Claude Code)
+    options: dict = {}
 
 
 class AgentInstallResponse(BaseModel):

--- a/observal-server/schemas/constants.py
+++ b/observal-server/schemas/constants.py
@@ -7,6 +7,12 @@ The CLI mirrors these in ``observal_cli/constants.py`` -- a sync test
 
 from __future__ import annotations
 
+import re
+
+# ── Name validation ───────────────────────────────────────────
+
+AGENT_NAME_REGEX = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
 # ── IDE / client names (hyphen-canonical) ───────────────────
 VALID_IDES: list[str] = [
     "cursor",
@@ -137,6 +143,24 @@ def make_option_validator(field_name: str, valid_options: list[str]):
     def _check(cls, v: str) -> str:
         if v not in valid_options:
             raise ValueError(f"Invalid {field_name} '{v}'. Valid options: {', '.join(valid_options)}")
+        return v
+
+    return classmethod(_check)
+
+
+def make_name_validator(field_name: str = "name", max_length: int = 64):
+    """Return a classmethod that validates slug-style names (no spaces)."""
+
+    def _check(cls, v: str) -> str:
+        if not v:
+            raise ValueError(f"{field_name} is required")
+        if len(v) > max_length:
+            raise ValueError(f"{field_name} must be at most {max_length} characters")
+        if not AGENT_NAME_REGEX.match(v):
+            raise ValueError(
+                f"Invalid {field_name} '{v}'. "
+                "Must start with a letter or digit and contain only lowercase letters, digits, hyphens, and underscores."
+            )
         return v
 
     return classmethod(_check)

--- a/observal-server/schemas/dashboard.py
+++ b/observal-server/schemas/dashboard.py
@@ -60,7 +60,16 @@ class TopAgentItem(BaseModel):
 class LeaderboardItem(TopAgentItem):
     """Same as TopAgentItem — used by the leaderboard endpoint."""
 
-    pass
+    created_by_email: str = ""
+
+
+class ComponentLeaderboardItem(BaseModel):
+    id: uuid.UUID
+    name: str
+    component_type: str
+    description: str = ""
+    download_count: int = 0
+    created_by_email: str = ""
 
 
 class TrendPoint(BaseModel):

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -172,9 +172,7 @@ def generate_agent_config(
             "stop": [{"command": stop_cmd}],
         }
         kiro_scope = options.get("scope", "user")  # Kiro historically defaults to user-level
-        agent_path = (
-            f"~/.kiro/agents/{safe_name}.json" if kiro_scope == "user" else f".kiro/agents/{safe_name}.json"
-        )
+        agent_path = f"~/.kiro/agents/{safe_name}.json" if kiro_scope == "user" else f".kiro/agents/{safe_name}.json"
         result: dict = {
             "agent_file": {
                 "path": agent_path,
@@ -240,9 +238,7 @@ def generate_agent_config(
         agent_content = "\n".join(frontmatter_lines) + "\n\n" + rules_content
 
         # Path: project-level (.claude/agents/) or user-level (~/.claude/agents/)
-        agent_path = (
-            f"~/.claude/agents/{safe_name}.md" if scope == "user" else f".claude/agents/{safe_name}.md"
-        )
+        agent_path = f"~/.claude/agents/{safe_name}.md" if scope == "user" else f".claude/agents/{safe_name}.md"
 
         return {
             "rules_file": {"path": agent_path, "content": agent_content},

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -130,6 +130,7 @@ def generate_agent_config(
     mcp_listings: dict | None = None,
     component_names: dict | None = None,
     env_values: dict | None = None,
+    options: dict | None = None,
 ) -> dict:
     """Generate IDE-specific config for an agent.
 
@@ -141,6 +142,7 @@ def generate_agent_config(
     safe_name = _sanitize_name(agent.name)
     mcp_configs = _build_mcp_configs(agent, ide, observal_url, mcp_listings=mcp_listings, env_values=env_values)
     rules_content = _build_rules_content(agent, component_names)
+    options = options or {}
 
     if ide == "kiro":
         # Kiro agent JSON: drop into ~/.kiro/agents/<name>.json
@@ -169,9 +171,13 @@ def generate_agent_config(
             "postToolUse": [{"matcher": "*", "command": curl_cmd}],
             "stop": [{"command": stop_cmd}],
         }
+        kiro_scope = options.get("scope", "user")  # Kiro historically defaults to user-level
+        agent_path = (
+            f"~/.kiro/agents/{safe_name}.json" if kiro_scope == "user" else f".kiro/agents/{safe_name}.json"
+        )
         result: dict = {
             "agent_file": {
-                "path": f"~/.kiro/agents/{safe_name}.json",
+                "path": agent_path,
                 "content": {
                     "name": safe_name,
                     "description": agent.description[:200] if agent.description else "",
@@ -183,6 +189,7 @@ def generate_agent_config(
                     "model": agent.model_name,
                 },
             },
+            "scope": kiro_scope,
         }
         # Also generate a Steering file for richer instruction support
         if agent.prompt:
@@ -206,6 +213,12 @@ def generate_agent_config(
             setup_commands.append(["claude", "mcp", "add", name, "--", cmd, *args])
             claude_mcps[name] = {"command": cmd, "args": args, "env": cfg.get("env", {})}
 
+        # IDE-specific options
+        scope = options.get("scope", "project")  # "project" or "user"
+        model_choice = options.get("model", "")  # "", "inherit", "sonnet", "opus", "haiku"
+        tools = options.get("tools", "")  # comma-separated whitelist
+        color = options.get("color", "")
+
         # Build Claude Code agent file with YAML frontmatter
         desc_line = (agent.description or safe_name).replace("\n", " ").strip()
         frontmatter_lines = [
@@ -213,6 +226,12 @@ def generate_agent_config(
             f"name: {safe_name}",
             f'description: "{desc_line}"',
         ]
+        if model_choice and model_choice != "inherit":
+            frontmatter_lines.append(f"model: {model_choice}")
+        if tools:
+            frontmatter_lines.append(f"tools: {tools}")
+        if color:
+            frontmatter_lines.append(f"color: {color}")
         if claude_mcps:
             frontmatter_lines.append("mcpServers:")
             for mcp_name in claude_mcps:
@@ -220,20 +239,30 @@ def generate_agent_config(
         frontmatter_lines.append("---")
         agent_content = "\n".join(frontmatter_lines) + "\n\n" + rules_content
 
+        # Path: project-level (.claude/agents/) or user-level (~/.claude/agents/)
+        agent_path = (
+            f"~/.claude/agents/{safe_name}.md" if scope == "user" else f".claude/agents/{safe_name}.md"
+        )
+
         return {
-            "rules_file": {"path": f".claude/agents/{safe_name}.md", "content": agent_content},
+            "rules_file": {"path": agent_path, "content": agent_content},
             "mcp_config": claude_mcps,
             "mcp_setup_commands": setup_commands,
             "otlp_env": otlp,
             "claude_settings_snippet": {"env": otlp},
+            "scope": scope,
         }
 
     if ide in ("gemini-cli", "gemini_cli"):
+        gemini_scope = options.get("scope", "project")
+        rules_path = "~/.gemini/GEMINI.md" if gemini_scope == "user" else "GEMINI.md"
+        mcp_path = "~/.gemini/mcp.json" if gemini_scope == "user" else ".gemini/mcp.json"
         return {
-            "rules_file": {"path": "GEMINI.md", "content": rules_content},
-            "mcp_config": {"path": ".gemini/mcp.json", "content": {"mcpServers": mcp_configs}},
+            "rules_file": {"path": rules_path, "content": rules_content},
+            "mcp_config": {"path": mcp_path, "content": {"mcpServers": mcp_configs}},
             "otlp_env": _gemini_otlp_env(observal_url),
             "gemini_settings_snippet": _gemini_settings(observal_url),
+            "scope": gemini_scope,
         }
 
     if ide == "codex":
@@ -247,12 +276,17 @@ def generate_agent_config(
         }
 
     # cursor, vscode: rules file + mcp.json — telemetry via observal-shim
+    ide_scope = options.get("scope", "project")
     ide_paths = {
-        "cursor": (".cursor/rules/{name}.md", ".cursor/mcp.json"),
+        "cursor": (
+            "~/.cursor/rules/{name}.md" if ide_scope == "user" else ".cursor/rules/{name}.md",
+            "~/.cursor/mcp.json" if ide_scope == "user" else ".cursor/mcp.json",
+        ),
         "vscode": (".vscode/rules/{name}.md", ".vscode/mcp.json"),
     }
     rules_path, mcp_path = ide_paths.get(ide, (f".rules/{safe_name}.md", ".mcp.json"))
     return {
         "rules_file": {"path": rules_path.format(name=safe_name), "content": rules_content},
         "mcp_config": {"path": mcp_path, "content": {"mcpServers": mcp_configs}},
+        "scope": ide_scope,
     }

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -257,7 +257,7 @@ INIT_SQL = [
         INDEX idx_action action TYPE bloom_filter(0.01) GRANULARITY 1,
         INDEX idx_resource_type resource_type TYPE bloom_filter(0.01) GRANULARITY 1
     ) ENGINE = MergeTree()
-    TTL timestamp + INTERVAL 730 DAY
+    TTL toDateTime(timestamp) + INTERVAL 730 DAY
     PARTITION BY toYYYYMM(timestamp)
     ORDER BY (action, resource_type, timestamp)""",
 ]
@@ -789,3 +789,31 @@ async def query_scores(
     except Exception as e:
         logger.error(f"ClickHouse query_scores failed: {e}")
         return []
+
+
+async def insert_audit_log(events: list[dict]):
+    """Batch insert audit log events into ClickHouse."""
+    if not events:
+        return
+    lines = []
+    for e in events:
+        row = {
+            "event_id": e["event_id"],
+            "timestamp": e["timestamp"],
+            "actor_id": e.get("actor_id", ""),
+            "actor_email": e.get("actor_email", ""),
+            "actor_role": e.get("actor_role", ""),
+            "action": e["action"],
+            "resource_type": e.get("resource_type", ""),
+            "resource_id": e.get("resource_id", ""),
+            "resource_name": e.get("resource_name", ""),
+            "detail": e.get("detail", ""),
+        }
+        lines.append(json.dumps(row, default=str))
+    body = "\n".join(lines)
+    sql = "INSERT INTO audit_log FORMAT JSONEachRow"
+    try:
+        r = await _query(sql, data=body)
+        r.raise_for_status()
+    except Exception as exc:
+        logger.error(f"ClickHouse insert_audit_log failed: {exc}")

--- a/observal-server/services/registry_telemetry.py
+++ b/observal-server/services/registry_telemetry.py
@@ -16,7 +16,7 @@ from services.clickhouse import insert_audit_log, insert_spans, insert_traces
 logger = logging.getLogger(__name__)
 
 # prevent GC of fire-and-forget tasks (same pattern as telemetry.py)
-_background_tasks: set[asyncio.Task] = set()  # noqa: RUF012
+_background_tasks: set[asyncio.Task] = set()
 
 
 async def _emit(trace: dict, span: dict, audit: dict):

--- a/observal-server/services/registry_telemetry.py
+++ b/observal-server/services/registry_telemetry.py
@@ -1,0 +1,106 @@
+"""Fire-and-forget telemetry for registry actions (agent create/update/delete/install).
+
+Writes a trace + span to the existing ClickHouse tables and an audit_log entry.
+Uses asyncio.create_task so the API response is never blocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from services.clickhouse import insert_audit_log, insert_spans, insert_traces
+
+logger = logging.getLogger(__name__)
+
+# prevent GC of fire-and-forget tasks (same pattern as telemetry.py)
+_background_tasks: set[asyncio.Task] = set()  # noqa: RUF012
+
+
+async def _emit(trace: dict, span: dict, audit: dict):
+    """Insert a trace + span + audit_log entry. Swallows errors."""
+    try:
+        await insert_traces([trace])
+        await insert_spans([span])
+        await insert_audit_log([audit])
+    except Exception:
+        logger.exception("Registry telemetry write failed")
+
+
+def emit_registry_event(
+    *,
+    action: str,
+    user_id: str,
+    user_email: str = "",
+    user_role: str = "",
+    agent_id: str | None = None,
+    resource_name: str = "",
+    metadata: dict[str, str] | None = None,
+) -> None:
+    """Fire-and-forget a registry trace + span + audit_log entry into ClickHouse."""
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    trace_id = str(uuid.uuid4())
+    span_id = str(uuid.uuid4())
+    meta = metadata or {}
+
+    trace = {
+        "trace_id": trace_id,
+        "parent_trace_id": None,
+        "project_id": "default",
+        "mcp_id": None,
+        "agent_id": agent_id,
+        "user_id": user_id,
+        "session_id": None,
+        "ide": "",
+        "environment": "default",
+        "start_time": now,
+        "end_time": now,
+        "trace_type": "registry",
+        "name": action,
+        "metadata": meta,
+        "tags": ["registry", action.split(".")[0]],
+        "input": None,
+        "output": None,
+    }
+
+    span = {
+        "span_id": span_id,
+        "trace_id": trace_id,
+        "parent_span_id": None,
+        "project_id": "default",
+        "mcp_id": None,
+        "agent_id": agent_id,
+        "user_id": user_id,
+        "type": "registry",
+        "name": action,
+        "method": "",
+        "input": None,
+        "output": None,
+        "error": None,
+        "start_time": now,
+        "end_time": now,
+        "latency_ms": None,
+        "status": "success",
+        "ide": "",
+        "environment": "default",
+        "metadata": meta,
+    }
+
+    audit = {
+        "event_id": str(uuid.uuid4()),
+        "timestamp": now,
+        "actor_id": user_id,
+        "actor_email": user_email,
+        "actor_role": user_role,
+        "action": action,
+        "resource_type": "agent",
+        "resource_id": agent_id or "",
+        "resource_name": resource_name,
+        "detail": ", ".join(f"{k}={v}" for k, v in meta.items()) if meta else "",
+    }
+
+    task = asyncio.create_task(_emit(trace, span, audit))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)

--- a/observal-server/services/versioning.py
+++ b/observal-server/services/versioning.py
@@ -1,0 +1,32 @@
+"""Semantic versioning utilities for agent version management."""
+
+from __future__ import annotations
+
+import re
+
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_semver(version: str) -> tuple[int, int, int] | None:
+    m = SEMVER_RE.match(version)
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
+
+
+def validate_semver(version: str) -> bool:
+    return SEMVER_RE.match(version) is not None
+
+
+def bump_version(current: str, bump_type: str) -> str:
+    parsed = parse_semver(current)
+    if not parsed:
+        return "1.0.0"
+    major, minor, patch = parsed
+    if bump_type == "major":
+        return f"{major + 1}.0.0"
+    if bump_type == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def suggest_versions(current: str) -> dict[str, str]:
+    return {t: bump_version(current, t) for t in ("patch", "minor", "major")}

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -214,6 +214,19 @@ def put(path: str, json_data: dict | None = None) -> dict:
         _handle_connect()
 
 
+def patch(path: str, json_data: dict | None = None) -> dict:
+    base, headers = _client()
+    try:
+        r = _request_with_retry("patch", f"{base}{path}", headers, json=json_data)
+        return r.json()
+    except httpx.HTTPStatusError as e:
+        _handle_error(e, path)
+    except httpx.ReadTimeout:
+        _handle_timeout(path)
+    except httpx.ConnectError:
+        _handle_connect()
+
+
 def delete(path: str) -> dict:
     base, headers = _client()
     try:

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -168,6 +168,26 @@ def get(path: str, params: dict | None = None) -> dict:
         _handle_connect()
 
 
+def get_with_headers(path: str, params: dict | None = None) -> tuple[dict, dict[str, str]]:
+    """Like ``get()``, but also returns the response headers (lowercased keys).
+
+    Useful for paginated endpoints that return the page count via headers like
+    ``X-Total-Count``.
+    """
+    base, headers = _client()
+    try:
+        r = _request_with_retry("get", f"{base}{path}", headers, params=params)
+        # Normalize header keys to lowercase for case-insensitive lookup
+        resp_headers = {k.lower(): v for k, v in r.headers.items()}
+        return r.json(), resp_headers
+    except httpx.HTTPStatusError as e:
+        _handle_error(e, path)
+    except httpx.ReadTimeout:
+        _handle_timeout(path)
+    except httpx.ConnectError:
+        _handle_connect()
+
+
 def post(path: str, json_data: dict | None = None) -> dict:
     base, headers = _client()
     try:

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 import json as _json
 from pathlib import Path
 
+import re
+
 import typer
 import yaml
 from rich import print as rprint
+from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
 
 from observal_cli import client, config
-from observal_cli.constants import VALID_IDES
+from observal_cli.constants import AGENT_NAME_REGEX, VALID_IDES
+from observal_cli.prompts import select_many, select_one
 from observal_cli.render import (
     console,
     ide_tags,
@@ -26,6 +30,44 @@ from observal_cli.render import (
 # ── Agent authoring constants ──────────────────────────────
 YAML_FILE = "observal-agent.yaml"
 VALID_COMPONENT_TYPES = {"mcp", "skill", "hook", "prompt", "sandbox"}
+
+# Common model choices for the interactive wizard
+_MODEL_CHOICES = [
+    "claude-sonnet-4",
+    "claude-opus-4",
+    "claude-haiku-4-5",
+    "gemini-2.5-pro",
+    "gpt-4o",
+    "gpt-4.1",
+]
+
+
+def _slugify(raw: str) -> str:
+    """Convert a raw name to a valid agent slug."""
+    s = raw.strip().lower()
+    s = re.sub(r"[^a-z0-9_-]+", "-", s)
+    s = re.sub(r"-{2,}", "-", s)
+    return s.strip("-")
+
+
+def _validate_name(name: str) -> str | None:
+    """Return error message if name is invalid, else None."""
+    if not name:
+        return "Agent name is required."
+    if len(name) > 64:
+        return "Agent name must be at most 64 characters."
+    if not AGENT_NAME_REGEX.match(name):
+        return "Must start with a letter/digit and contain only lowercase letters, digits, hyphens, underscores."
+    return None
+
+
+def _fetch_registry_items(component_type: str) -> list[dict]:
+    """Fetch approved items from a registry endpoint. Returns [] on failure."""
+    plural = {"mcp": "mcps", "skill": "skills", "hook": "hooks", "prompt": "prompts", "sandbox": "sandboxes"}
+    try:
+        return client.get(f"/api/v1/{plural[component_type]}")
+    except (Exception, SystemExit):
+        return []
 
 
 # ── Agent authoring helpers ────────────────────────────────
@@ -54,7 +96,7 @@ agent_app = typer.Typer(help="Agent registry commands")
 def agent_create(
     from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
 ):
-    """Create a new agent (interactive or from file)."""
+    """Create a new agent (interactive wizard or from file)."""
     if from_file:
         import json
 
@@ -65,60 +107,100 @@ def agent_create(
         rprint(f"[green]✓ Agent created![/green] ID: [bold]{result['id']}[/bold]")
         return
 
-    name = typer.prompt("Agent name")
-    version = typer.prompt("Version", default="1.0.0")
-    description = typer.prompt("Description")
-    owner = typer.prompt("Owner / Team")
-    prompt_text = typer.prompt("System prompt")
-    model_name = typer.prompt("Model name", default="claude-sonnet-4")
+    rprint("\n[bold cyan]Agent Builder[/bold cyan]\n")
 
-    max_tokens = typer.prompt("Max tokens", default="4096")
-    temperature = typer.prompt("Temperature", default="0.2")
-    model_cfg = {"max_tokens": int(max_tokens), "temperature": float(temperature)}
+    # ── Phase 1: Basics ─────────────────────────────────────
+    rprint("[bold]1. Basics[/bold]")
+    raw_name = typer.prompt("  Agent name")
+    name = _slugify(raw_name)
+    if name != raw_name:
+        rprint(f"  [dim]→ Slugified to:[/dim] [bold]{name}[/bold]")
+    err = _validate_name(name)
+    if err:
+        rprint(f"  [red]Error:[/red] {err}")
+        raise typer.Exit(1)
 
-    ide_choices = list(VALID_IDES)
-    rprint(f"[dim]IDEs: {', '.join(ide_choices)}[/dim]")
-    ides_input = typer.prompt("Supported IDEs (comma-separated)", default=",".join(ide_choices))
-    supported_ides = [i.strip() for i in ides_input.split(",") if i.strip()]
+    description = typer.prompt("  Description")
+    version = typer.prompt("  Version", default="1.0.0")
+    model_name = select_one("  Model", _MODEL_CHOICES, default="claude-sonnet-4")
 
-    # MCP server selection
-    rprint()
-    with spinner("Fetching MCP servers..."):
-        try:
-            mcps = client.get("/api/v1/mcps")
-        except (Exception, SystemExit):
-            mcps = []
+    # ── Phase 2: Components ──────────────────────────────────
+    rprint("\n[bold]2. Components[/bold]")
+    components: list[dict] = []
 
-    if mcps:
-        table = Table(title="Available MCP Servers", show_lines=False)
-        table.add_column("#", style="dim", width=3)
-        table.add_column("Name", style="bold")
-        table.add_column("ID", style="dim")
-        for i, m in enumerate(mcps, 1):
-            table.add_row(str(i), m["name"], str(m["id"])[:12] + "…")
-        console.print(table)
-        rprint()
-    else:
-        rprint("[dim]No approved MCP servers available.[/dim]")
+    with spinner("Fetching registry..."):
+        registry_data: dict[str, list[dict]] = {}
+        for ctype in ("mcp", "skill", "hook", "prompt", "sandbox"):
+            registry_data[ctype] = _fetch_registry_items(ctype)
 
-    mcp_input = typer.prompt("MCP server IDs (comma-separated, or empty)", default="")
-    mcp_ids = [i.strip() for i in mcp_input.split(",") if i.strip()]
+    for ctype in ("mcp", "skill", "hook", "prompt", "sandbox"):
+        items = registry_data[ctype]
+        if not items:
+            rprint(f"  [dim]No {ctype}s available — skipping.[/dim]")
+            continue
 
-    # Goal template
-    rprint("\n[bold]Goal Template[/bold]")
-    goal_desc = typer.prompt("Goal description")
+        choices = [f"{item['name']}  [dim]({str(item['id'])[:8]})[/dim]" for item in items]
+        selected = select_many(f"  Select {ctype}s", choices, defaults=[])
+
+        for sel in selected:
+            # Match back to item by prefix (name part before the dim ID)
+            sel_name = sel.split("  [dim]")[0].strip()
+            match = next((item for item in items if item["name"] == sel_name), None)
+            if match:
+                components.append({"component_type": ctype, "component_id": str(match["id"])})
+
+    # ── Phase 3: IDEs ────────────────────────────────────────
+    rprint("\n[bold]3. Supported IDEs[/bold]")
+    supported_ides = select_many("  IDEs", list(VALID_IDES), defaults=list(VALID_IDES))
+
+    # ── Phase 4: Goal Template ───────────────────────────────
+    rprint("\n[bold]4. Goal Template[/bold]")
+    goal_desc = typer.prompt("  Goal description", default=description)
     sections = []
     while True:
-        sec_name = typer.prompt("Section name (or 'done')")
+        sec_name = typer.prompt("  Section name (or 'done' to finish)")
         if sec_name.lower() == "done":
             break
-        sec_desc = typer.prompt(f"  Description for '{sec_name}'", default="")
-        grounding = typer.confirm("  Grounding required?", default=False)
-        sections.append({"name": sec_name, "description": sec_desc, "grounding_required": grounding})
+        sec_desc = typer.prompt(f"    Description for '{sec_name}'", default="")
+        sections.append({"name": sec_name, "description": sec_desc})
 
     if not sections:
-        rprint("[red]At least one goal section is required.[/red]")
-        raise typer.Exit(1)
+        sections = [{"name": "default", "description": goal_desc}]
+        rprint("  [dim]Using default section.[/dim]")
+
+    # ── Phase 5: Optional Details ────────────────────────────
+    rprint("\n[bold]5. Optional Details[/bold]")
+    # Try to get owner from whoami
+    default_owner = ""
+    try:
+        whoami = client.get("/api/v1/auth/whoami")
+        default_owner = whoami.get("name") or whoami.get("email", "")
+    except (Exception, SystemExit):
+        pass
+    owner = typer.prompt("  Owner / Team", default=default_owner or "")
+    prompt_text = typer.prompt("  System prompt (optional)", default="")
+    max_tokens = typer.prompt("  Max tokens", default="4096")
+    temperature = typer.prompt("  Temperature", default="0.2")
+    model_cfg = {"max_tokens": int(max_tokens), "temperature": float(temperature)}
+
+    # ── Phase 6: Review & Confirm ────────────────────────────
+    component_summary = ", ".join(
+        f"{sum(1 for c in components if c['component_type'] == t)} {t}s"
+        for t in ("mcp", "skill", "hook", "prompt", "sandbox")
+        if any(c["component_type"] == t for c in components)
+    ) or "none"
+
+    review = (
+        f"[bold]{name}[/bold] v{version}  |  Model: [cyan]{model_name}[/cyan]\n"
+        f"Components: {component_summary}\n"
+        f"IDEs: {', '.join(supported_ides)}\n"
+        f"Goal: {len(sections)} section(s)"
+    )
+    console.print(Panel(review, title="Review", border_style="green"))
+
+    if not typer.confirm("\nPublish this agent?", default=True):
+        rprint("[yellow]Aborted.[/yellow]")
+        raise typer.Exit(0)
 
     with spinner("Creating agent..."):
         result = client.post(
@@ -132,30 +214,40 @@ def agent_create(
                 "model_name": model_name,
                 "model_config_json": model_cfg,
                 "supported_ides": supported_ides,
-                "mcp_server_ids": mcp_ids,
+                "components": components,
                 "goal_template": {"description": goal_desc, "sections": sections},
             },
         )
     rprint(f"\n[green]✓ Agent created![/green] ID: [bold]{result['id']}[/bold]")
+    rprint(f"[dim]Install with:[/dim] observal pull {name} --ide <ide>")
 
 
 @agent_app.command(name="list")
 def agent_list(
     search: str | None = typer.Option(None, "--search", "-s"),
-    limit: int = typer.Option(50, "--limit", "-n"),
-    full_id: bool = typer.Option(False, "--full-id", help="Show full UUID instead of short form"),
+    limit: int = typer.Option(50, "--limit", "-n", min=1, max=200, help="Page size (1-200)"),
+    page: int = typer.Option(1, "--page", "-p", min=1, help="Page number (1-indexed)"),
+    show_id: bool = typer.Option(False, "--id", help="Include the agent ID column"),
+    full_id: bool = typer.Option(False, "--full-id", help="Show full UUID (implies --id)"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
-    """List active agents."""
-    params = {"search": search} if search else {}
+    """List active agents (paginated)."""
+    params: dict = {"limit": limit, "offset": (page - 1) * limit}
+    if search:
+        params["search"] = search
+
     with spinner("Fetching agents..."):
-        data = client.get("/api/v1/agents", params=params)
+        data, headers = client.get_with_headers("/api/v1/agents", params=params)
+
+    total = int(headers.get("x-total-count", str(len(data))))
+    total_pages = max(1, (total + limit - 1) // limit)
 
     if not data:
-        rprint("[dim]No agents found.[/dim]")
+        if total == 0:
+            rprint("[dim]No agents found.[/dim]")
+        else:
+            rprint(f"[yellow]Page {page} is empty. Total agents: {total} (last page: {total_pages})[/yellow]")
         return
-
-    data = data[:limit]
 
     # Cache IDs for numeric shorthand
     config.save_last_results(data)
@@ -166,31 +258,34 @@ def agent_list(
 
     if output == "plain":
         for item in data:
-            rprint(
-                f"{item['id']}  {item['name']}  v{item.get('version', '?')}  {item.get('model_name', '')}  {', '.join(item.get('supported_ides', []))}"
-            )
+            rprint(f"{item['name']}  v{item.get('version', '?')}  {item.get('model_name', '')}")
         return
 
-    table = Table(title=f"Agents ({len(data)})", show_lines=False, padding=(0, 1))
+    include_id = show_id or full_id
+    table = Table(
+        title=f"Agents (page {page} of {total_pages} · {len(data)} of {total})",
+        show_lines=False,
+        padding=(0, 1),
+    )
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
     table.add_column("Model")
-    table.add_column("Owner", style="dim")
-    table.add_column("IDEs")
-    table.add_column("ID", style="dim", no_wrap=full_id)
+    if include_id:
+        table.add_column("ID", style="dim", no_wrap=full_id)
     for i, item in enumerate(data, 1):
-        id_display = str(item["id"]) if full_id else str(item["id"])[:8] + "…"
-        table.add_row(
-            str(i),
-            item["name"],
-            item.get("version", ""),
-            item.get("model_name", ""),
-            item.get("owner", ""),
-            ide_tags(item.get("supported_ides", [])),
-            id_display,
-        )
+        row = [str(i), item["name"], item.get("version", ""), item.get("model_name", "")]
+        if include_id:
+            row.append(str(item["id"]) if full_id else str(item["id"])[:8] + "…")
+        table.add_row(*row)
     console.print(table)
+
+    # Pagination footer
+    if total_pages > 1:
+        if page < total_pages:
+            rprint(f"[dim]Next:[/dim] [bold]observal agent list --page {page + 1}[/bold]" + (f" --limit {limit}" if limit != 50 else ""))
+        else:
+            rprint("[dim]End of results.[/dim]")
 
 
 @agent_app.command(name="show")
@@ -329,7 +424,15 @@ def agent_init(
         rprint("[yellow]Aborted.[/yellow]")
         raise typer.Exit(code=1)
 
-    name = typer.prompt("Agent name")
+    raw_name = typer.prompt("Agent name")
+    name = _slugify(raw_name)
+    if name != raw_name:
+        rprint(f"  [dim]→ Slugified to:[/dim] [bold]{name}[/bold]")
+    err = _validate_name(name)
+    if err:
+        rprint(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
     version = typer.prompt("Version", default="1.0.0")
     description = typer.prompt("Description")
     owner = typer.prompt("Owner / Team")

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import json as _json
-from pathlib import Path
-
 import re
+from pathlib import Path
 
 import typer
 import yaml
@@ -16,7 +15,7 @@ from rich.tree import Tree
 
 from observal_cli import client, config
 from observal_cli.constants import AGENT_NAME_REGEX, VALID_IDES
-from observal_cli.prompts import select_many, select_one
+from observal_cli.prompts import fuzzy_select, select_many, select_one
 from observal_cli.render import (
     console,
     ide_tags,
@@ -184,11 +183,14 @@ def agent_create(
     model_cfg = {"max_tokens": int(max_tokens), "temperature": float(temperature)}
 
     # ── Phase 6: Review & Confirm ────────────────────────────
-    component_summary = ", ".join(
-        f"{sum(1 for c in components if c['component_type'] == t)} {t}s"
-        for t in ("mcp", "skill", "hook", "prompt", "sandbox")
-        if any(c["component_type"] == t for c in components)
-    ) or "none"
+    component_summary = (
+        ", ".join(
+            f"{sum(1 for c in components if c['component_type'] == t)} {t}s"
+            for t in ("mcp", "skill", "hook", "prompt", "sandbox")
+            if any(c["component_type"] == t for c in components)
+        )
+        or "none"
+    )
 
     review = (
         f"[bold]{name}[/bold] v{version}  |  Model: [cyan]{model_name}[/cyan]\n"
@@ -225,6 +227,7 @@ def agent_create(
 @agent_app.command(name="list")
 def agent_list(
     search: str | None = typer.Option(None, "--search", "-s"),
+    interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactive search mode"),
     limit: int = typer.Option(50, "--limit", "-n", min=1, max=200, help="Page size (1-200)"),
     page: int = typer.Option(1, "--page", "-p", min=1, help="Page number (1-indexed)"),
     show_id: bool = typer.Option(False, "--id", help="Include the agent ID column"),
@@ -238,6 +241,18 @@ def agent_list(
 
     with spinner("Fetching agents..."):
         data, headers = client.get_with_headers("/api/v1/agents", params=params)
+
+    if interactive and data:
+
+        def _display(item: dict) -> str:
+            email = item.get("created_by_email", "")
+            suffix = f"  by {email}" if email else ""
+            return f"{item['name']}  v{item.get('version', '?')}  {item.get('model_name', '')}{suffix}"
+
+        selected = fuzzy_select(data, _display, label="Select agent")
+        if selected:
+            agent_show(selected["id"])
+        return
 
     total = int(headers.get("x-total-count", str(len(data))))
     total_pages = max(1, (total + limit - 1) // limit)
@@ -271,10 +286,12 @@ def agent_list(
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
     table.add_column("Model")
+    table.add_column("Created By", style="dim")
     if include_id:
         table.add_column("ID", style="dim", no_wrap=full_id)
     for i, item in enumerate(data, 1):
-        row = [str(i), item["name"], item.get("version", ""), item.get("model_name", "")]
+        email = item.get("created_by_email", "")
+        row = [str(i), item["name"], item.get("version", ""), item.get("model_name", ""), email]
         if include_id:
             row.append(str(item["id"]) if full_id else str(item["id"])[:8] + "…")
         table.add_row(*row)
@@ -283,7 +300,10 @@ def agent_list(
     # Pagination footer
     if total_pages > 1:
         if page < total_pages:
-            rprint(f"[dim]Next:[/dim] [bold]observal agent list --page {page + 1}[/bold]" + (f" --limit {limit}" if limit != 50 else ""))
+            rprint(
+                f"[dim]Next:[/dim] [bold]observal agent list --page {page + 1}[/bold]"
+                + (f" --limit {limit}" if limit != 50 else "")
+            )
         else:
             rprint("[dim]End of results.[/dim]")
 
@@ -309,6 +329,7 @@ def agent_show(
                 ("Status", status_badge(item.get("status", ""))),
                 ("Model", f"[bold]{item.get('model_name', 'N/A')}[/bold]"),
                 ("Owner", item.get("owner", "N/A")),
+                ("Created By", item.get("created_by_email", "")),
                 ("Description", item.get("description", "")),
                 ("IDEs", ide_tags(item.get("supported_ides", []))),
                 ("Created", relative_time(item.get("created_at"))),
@@ -395,16 +416,16 @@ def agent_delete(
     agent_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
 ):
-    """Delete an agent."""
+    """Archive an agent (soft delete)."""
     resolved = config.resolve_alias(agent_id)
     if not yes:
         with spinner():
             item = client.get(f"/api/v1/agents/{resolved}")
-        if not typer.confirm(f"Delete [bold]{item['name']}[/bold] ({resolved})?"):
+        if not typer.confirm(f"Archive [bold]{item['name']}[/bold] ({resolved})?"):
             raise typer.Abort()
-    with spinner("Deleting..."):
-        client.delete(f"/api/v1/agents/{resolved}")
-    rprint(f"[green]✓ Deleted {resolved}[/green]")
+    with spinner("Archiving..."):
+        client.patch(f"/api/v1/agents/{resolved}/archive")
+    rprint("[green]✓ Agent archived[/green]")
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -415,6 +436,7 @@ def agent_delete(
 @agent_app.command(name="init")
 def agent_init(
     directory: str = typer.Option(".", "--dir", "-d", help="Directory to scaffold in"),
+    beta: bool = typer.Option(False, "--beta", help="Start at version 0.1.0 (beta)"),
 ):
     """Scaffold an observal-agent.yaml definition file."""
     dir_path = Path(directory)
@@ -433,7 +455,8 @@ def agent_init(
         rprint(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
 
-    version = typer.prompt("Version", default="1.0.0")
+    default_version = "0.1.0" if beta else "1.0.0"
+    version = typer.prompt("Version", default=default_version)
     description = typer.prompt("Description")
     owner = typer.prompt("Owner / Team")
     model_name = typer.prompt("Model name", default="claude-sonnet-4")
@@ -541,8 +564,17 @@ def agent_build(
 def agent_publish(
     directory: str = typer.Option(".", "--dir", "-d", help="Directory containing observal-agent.yaml"),
     update: bool = typer.Option(False, "--update", "-u", help="Update existing agent instead of creating"),
+    draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
+    submit: str | None = typer.Option(None, "--submit", help="Submit a draft agent for review (agent ID)"),
 ):
     """Publish the agent definition to the server."""
+    if submit:
+        resolved = config.resolve_alias(submit)
+        with spinner("Submitting draft for review..."):
+            result = client.post(f"/api/v1/agents/{resolved}/submit")
+        rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
+        return
+
     dir_path = Path(directory)
     data = _load_agent_yaml(dir_path)
 
@@ -558,6 +590,12 @@ def agent_publish(
         "goal_template": data.get("goal_template", {}),
     }
 
+    if draft:
+        with spinner("Saving draft..."):
+            result = client.post("/api/v1/agents/draft", payload)
+        rprint(f"[green]✓ Draft saved![/green] ID: [bold]{result['id']}[/bold]")
+        return
+
     if update:
         # Find existing agent by name
         with spinner("Looking up existing agent..."):
@@ -567,9 +605,32 @@ def agent_publish(
             rprint(f"[red]Error:[/red] No existing agent found with name '{data['name']}'")
             raise typer.Exit(code=1)
         agent_id = match["id"]
+
+        # Version bump selection (interactive only)
+        import sys
+
+        if sys.stdin.isatty():
+            current_version = match.get("version", "1.0.0")
+            try:
+                suggestions = client.get(f"/api/v1/agents/{agent_id}/version-suggestions")
+                sug = suggestions.get("suggestions", {})
+                bump_choices = [
+                    f"patch  {current_version} → {sug.get('patch', '?')}  (bug fix)",
+                    f"minor  {current_version} → {sug.get('minor', '?')}  (improvement)",
+                    f"major  {current_version} → {sug.get('major', '?')}  (revamp)",
+                    "keep   (use version from YAML)",
+                ]
+                choice = select_one("Version bump type", bump_choices, default=bump_choices[0])
+                bump_type = choice.split()[0]
+                if bump_type != "keep":
+                    payload["version_bump_type"] = bump_type
+                    payload.pop("version", None)
+            except (Exception, SystemExit):
+                pass
+
         with spinner("Updating agent..."):
             result = client.put(f"/api/v1/agents/{agent_id}", payload)
-        rprint(f"[green]✓ Agent updated![/green] ID: [bold]{result['id']}[/bold]")
+        rprint(f"[green]✓ Agent updated![/green] ID: [bold]{result['id']}[/bold]  v{result.get('version', '?')}")
     else:
         with spinner("Creating agent..."):
             result = client.post("/api/v1/agents", payload)

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -12,7 +12,7 @@ from rich.table import Table
 from observal_cli import client, config
 from observal_cli.analyzer import analyze_local
 from observal_cli.constants import VALID_IDES, VALID_MCP_CATEGORIES, VALID_MCP_FRAMEWORKS
-from observal_cli.prompts import select_one
+from observal_cli.prompts import fuzzy_select, select_one
 from observal_cli.render import (
     console,
     ide_tags,
@@ -352,7 +352,7 @@ def _submit_impl(git_url, name, category, yes):
     rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
 
 
-def _list_impl(category, search, limit, sort, output):
+def _list_impl(category, search, limit, sort, output, interactive=False):
     params = {}
     if category:
         params["category"] = category
@@ -364,6 +364,16 @@ def _list_impl(category, search, limit, sort, output):
 
     if not data:
         rprint("[dim]No MCP servers found.[/dim]")
+        return
+
+    if interactive:
+
+        def _display(item: dict) -> str:
+            return f"{item['name']}  v{item.get('version', '?')}  [{item.get('category', '')}]  {item.get('owner', '')}"
+
+        selected = fuzzy_select(data, _display, label="Select MCP server")
+        if selected:
+            _show_impl(str(selected["id"]), "table")
         return
 
     # Sort
@@ -537,12 +547,13 @@ def submit(
 def list_mcps(
     category: str | None = typer.Option(None, "--category", "-c", help="Filter by category"),
     search: str | None = typer.Option(None, "--search", "-s", help="Search by name/description"),
+    interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactive search mode"),
     limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
     sort: str = typer.Option("name", "--sort", help="Sort by: name, category, version"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved MCP servers."""
-    _list_impl(category, search, limit, sort, output)
+    _list_impl(category, search, limit, sort, output, interactive=interactive)
 
 
 @mcp_app.command()

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -198,9 +198,7 @@ def register_pull(app: typer.Typer):
         model: str | None = typer.Option(
             None, "--model", help="Sub-agent model: inherit, sonnet, opus, haiku (Claude Code only)"
         ),
-        tools: str | None = typer.Option(
-            None, "--tools", help="Comma-separated tool whitelist (Claude Code only)"
-        ),
+        tools: str | None = typer.Option(None, "--tools", help="Comma-separated tool whitelist (Claude Code only)"),
         no_prompt: bool = typer.Option(False, "--no-prompt", "-y", help="Skip interactive prompts"),
     ):
         """Fetch agent config and write IDE files to disk.
@@ -220,9 +218,7 @@ def register_pull(app: typer.Typer):
 
         # Collect IDE-specific install options (scope, model, tools)
         rprint(f"\n[bold]Install options for [cyan]{ide}[/cyan]:[/bold]")
-        options = _collect_install_options(
-            ide, scope=scope, model=model, tools=tools, no_prompt=no_prompt
-        )
+        options = _collect_install_options(ide, scope=scope, model=model, tools=tools, no_prompt=no_prompt)
         is_user_scope = options.get("scope") == "user"
         if is_user_scope:
             rprint("  [dim]Files will be written to your home directory (user scope).[/dim]")

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -100,14 +100,20 @@ def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> 
     return "updated" if existed else "created"
 
 
-def _resolve_path(raw_path: str, target_dir: Path) -> Path:
+def _resolve_path(raw_path: str, target_dir: Path, *, allow_home: bool = False) -> Path:
     """Resolve a path from the config snippet relative to *target_dir*.
 
-    Handles ``~/`` prefixes by mapping them under *target_dir* (not the real
+    By default, ``~/`` prefixes are mapped under *target_dir* (not the real
     home directory) so that the pull command always writes inside the project.
-    Raises typer.Exit if the resolved path escapes *target_dir*.
+    When *allow_home* is True (e.g. user explicitly chose --scope user), real
+    ``$HOME`` expansion is allowed.
+
+    Raises typer.Exit if the resolved path escapes *target_dir* (and home
+    expansion is not permitted).
     """
     if raw_path.startswith("~/") or raw_path.startswith("~\\"):
+        if allow_home:
+            return Path(raw_path).expanduser().resolve()
         resolved = (target_dir / raw_path[2:]).resolve()
     else:
         resolved = (target_dir / raw_path).resolve()
@@ -119,6 +125,64 @@ def _resolve_path(raw_path: str, target_dir: Path) -> Path:
     return resolved
 
 
+# IDEs that support a project vs user install scope
+_SCOPE_AWARE_IDES = {
+    "claude-code": ("project (.claude/agents/)", "user (~/.claude/agents/)"),
+    "kiro": ("project (.kiro/agents/)", "user (~/.kiro/agents/)"),
+    "gemini-cli": ("project (GEMINI.md)", "user (~/.gemini/GEMINI.md)"),
+    "cursor": ("project (.cursor/rules/)", "user (~/.cursor/rules/)"),
+}
+
+
+def _collect_install_options(
+    ide: str,
+    *,
+    scope: str | None,
+    model: str | None,
+    tools: str | None,
+    no_prompt: bool,
+) -> dict:
+    """Interactively collect IDE-specific install options.
+
+    Honors explicit --scope/--model/--tools flags; only prompts for what's
+    missing when running in an interactive terminal and --no-prompt isn't set.
+    """
+    import sys
+
+    from observal_cli.prompts import select_one
+
+    opts: dict = {}
+    interactive = sys.stdin.isatty() and not no_prompt
+
+    # Scope (Claude Code, Kiro, Gemini CLI, Cursor)
+    if ide in _SCOPE_AWARE_IDES:
+        if scope:
+            opts["scope"] = scope
+        elif interactive:
+            project_label, user_label = _SCOPE_AWARE_IDES[ide]
+            choice = select_one("  Scope", [project_label, user_label], default=project_label)
+            opts["scope"] = "user" if choice.startswith("user") else "project"
+        else:
+            opts["scope"] = "project"
+
+    # Claude Code only: model and tools
+    if ide in ("claude-code", "claude_code"):
+        if model:
+            opts["model"] = model
+        elif interactive:
+            choice = select_one(
+                "  Model",
+                ["inherit (use main session model)", "sonnet", "opus", "haiku"],
+                default="inherit (use main session model)",
+            )
+            opts["model"] = "inherit" if choice.startswith("inherit") else choice
+
+        if tools:
+            opts["tools"] = tools
+
+    return opts
+
+
 def register_pull(app: typer.Typer):
     @app.command("pull")
     def pull(
@@ -128,6 +192,16 @@ def register_pull(app: typer.Typer):
         ),
         directory: str = typer.Option(".", "--dir", "-d", help="Target directory for written files"),
         dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Preview files without writing"),
+        scope: str | None = typer.Option(
+            None, "--scope", help="Install scope: 'project' or 'user' (Claude Code/Kiro/Gemini only)"
+        ),
+        model: str | None = typer.Option(
+            None, "--model", help="Sub-agent model: inherit, sonnet, opus, haiku (Claude Code only)"
+        ),
+        tools: str | None = typer.Option(
+            None, "--tools", help="Comma-separated tool whitelist (Claude Code only)"
+        ),
+        no_prompt: bool = typer.Option(False, "--no-prompt", "-y", help="Skip interactive prompts"),
     ):
         """Fetch agent config and write IDE files to disk.
 
@@ -144,10 +218,19 @@ def register_pull(app: typer.Typer):
 
         env_values = _collect_mcp_env_vars(agent_detail)
 
+        # Collect IDE-specific install options (scope, model, tools)
+        rprint(f"\n[bold]Install options for [cyan]{ide}[/cyan]:[/bold]")
+        options = _collect_install_options(
+            ide, scope=scope, model=model, tools=tools, no_prompt=no_prompt
+        )
+        is_user_scope = options.get("scope") == "user"
+        if is_user_scope:
+            rprint("  [dim]Files will be written to your home directory (user scope).[/dim]")
+
         with spinner(f"Pulling {ide} config for agent {resolved[:8]}..."):
             result = client.post(
                 f"/api/v1/agents/{resolved}/install",
-                {"ide": ide, "env_values": env_values},
+                {"ide": ide, "env_values": env_values, "options": options},
             )
 
         snippet = result.get("config_snippet", {})
@@ -160,7 +243,7 @@ def register_pull(app: typer.Typer):
         # ── rules_file ──────────────────────────────────────
         rules = snippet.get("rules_file")
         if rules:
-            p = _resolve_path(rules["path"], target_dir)
+            p = _resolve_path(rules["path"], target_dir, allow_home=is_user_scope)
             if dry_run:
                 written.append((str(p), "would write"))
             else:
@@ -170,7 +253,7 @@ def register_pull(app: typer.Typer):
         # ── mcp_config with path key (Cursor/VSCode/Gemini) ─
         mcp_cfg = snippet.get("mcp_config")
         if mcp_cfg and isinstance(mcp_cfg, dict) and "path" in mcp_cfg:
-            p = _resolve_path(mcp_cfg["path"], target_dir)
+            p = _resolve_path(mcp_cfg["path"], target_dir, allow_home=is_user_scope)
             if dry_run:
                 written.append((str(p), "would write"))
             else:
@@ -180,7 +263,7 @@ def register_pull(app: typer.Typer):
         # ── agent_file (Kiro) ───────────────────────────────
         agent_file = snippet.get("agent_file")
         if agent_file:
-            p = _resolve_path(agent_file["path"], target_dir)
+            p = _resolve_path(agent_file["path"], target_dir, allow_home=is_user_scope)
             if dry_run:
                 written.append((str(p), "would write"))
             else:
@@ -190,7 +273,7 @@ def register_pull(app: typer.Typer):
         # ── steering_file (Kiro) ───────────────────────────
         steering_file = snippet.get("steering_file")
         if steering_file:
-            p = _resolve_path(steering_file["path"], target_dir)
+            p = _resolve_path(steering_file["path"], target_dir, allow_home=is_user_scope)
             if dry_run:
                 written.append((str(p), "would write"))
             else:

--- a/observal_cli/constants.py
+++ b/observal_cli/constants.py
@@ -6,6 +6,11 @@ A sync test (``tests/test_constants_sync.py``) ensures these stay in lockstep.
 
 from __future__ import annotations
 
+import re
+
+# ── Name validation ───────────────────────────────────────────
+AGENT_NAME_REGEX = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
 # ── IDE / client names (hyphen-canonical) ───────────────────
 VALID_IDES: list[str] = [
     "cursor",

--- a/observal_cli/prompts.py
+++ b/observal_cli/prompts.py
@@ -67,3 +67,26 @@ def select_many(message: str, choices: list[str], defaults: list[str] | None = N
     if result is None:
         raise KeyboardInterrupt
     return result
+
+
+def fuzzy_select(
+    items: list[dict],
+    display_fn,
+    label: str = "Search",
+) -> dict | None:
+    """Fuzzy interactive selection using questionary select with type-to-filter."""
+    if not sys.stdin.isatty():
+        return None
+
+    import questionary
+
+    choices = [questionary.Choice(title=display_fn(item), value=item) for item in items]
+    result = questionary.select(
+        f"{label}:",
+        choices=choices,
+        style=_qstyle(),
+        instruction="(type to filter, arrow keys, enter to select)",
+    ).ask()
+    if result is None:
+        raise KeyboardInterrupt
+    return result

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,64 @@
+"""Tests for the semver versioning utilities."""
+
+from __future__ import annotations
+
+from services.versioning import bump_version, parse_semver, suggest_versions, validate_semver
+
+
+class TestParseSemver:
+    def test_valid_version(self):
+        assert parse_semver("1.0.0") == (1, 0, 0)
+        assert parse_semver("0.1.0") == (0, 1, 0)
+        assert parse_semver("12.34.56") == (12, 34, 56)
+
+    def test_invalid_version(self):
+        assert parse_semver("1.0") is None
+        assert parse_semver("v1.0.0") is None
+        assert parse_semver("1.0.0-beta") is None
+        assert parse_semver("abc") is None
+        assert parse_semver("") is None
+
+    def test_zero_version(self):
+        assert parse_semver("0.0.0") == (0, 0, 0)
+
+
+class TestValidateSemver:
+    def test_valid(self):
+        assert validate_semver("1.0.0") is True
+        assert validate_semver("0.1.0") is True
+
+    def test_invalid(self):
+        assert validate_semver("1.0") is False
+        assert validate_semver("nope") is False
+
+
+class TestBumpVersion:
+    def test_patch(self):
+        assert bump_version("1.0.0", "patch") == "1.0.1"
+        assert bump_version("1.2.3", "patch") == "1.2.4"
+
+    def test_minor(self):
+        assert bump_version("1.0.0", "minor") == "1.1.0"
+        assert bump_version("1.2.3", "minor") == "1.3.0"
+
+    def test_major(self):
+        assert bump_version("1.0.0", "major") == "2.0.0"
+        assert bump_version("1.2.3", "major") == "2.0.0"
+
+    def test_invalid_input_returns_default(self):
+        assert bump_version("garbage", "patch") == "1.0.0"
+
+    def test_beta_version_bump(self):
+        assert bump_version("0.1.0", "patch") == "0.1.1"
+        assert bump_version("0.1.0", "minor") == "0.2.0"
+        assert bump_version("0.1.0", "major") == "1.0.0"
+
+
+class TestSuggestVersions:
+    def test_suggestions(self):
+        result = suggest_versions("1.2.3")
+        assert result == {"patch": "1.2.4", "minor": "1.3.0", "major": "2.0.0"}
+
+    def test_initial_version(self):
+        result = suggest_versions("1.0.0")
+        assert result == {"patch": "1.0.1", "minor": "1.1.0", "major": "2.0.0"}

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -142,6 +142,17 @@ const TYPE_MAP: Record<string, string> = {
   sandboxes: "sandbox",
 };
 
+const AGENT_NAME_REGEX = /^[a-z0-9][a-z0-9_-]*$/;
+
+function slugifyName(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
 export default function AgentBuilderPage() {
   // Require auth for builder
   const { ready } = useAuthGuard();
@@ -149,6 +160,7 @@ export default function AgentBuilderPage() {
   const router = useRouter();
   const { data: whoami } = useWhoami();
   const [name, setName] = useState("");
+  const [nameError, setNameError] = useState("");
   const [description, setDescription] = useState("");
   const [version, setVersion] = useState("1.0.0");
   const [modelName, setModelName] = useState("");
@@ -281,6 +293,12 @@ export default function AgentBuilderPage() {
       toast.error("Agent name is required");
       return;
     }
+    if (!AGENT_NAME_REGEX.test(name)) {
+      toast.error(
+        "Invalid agent name. Must start with a letter/digit, only lowercase letters, digits, hyphens, underscores.",
+      );
+      return;
+    }
 
     setPublishing(true);
     try {
@@ -354,10 +372,23 @@ export default function AgentBuilderPage() {
                   id="agent-name"
                   placeholder="my-agent"
                   value={name}
-                  onChange={(e) => setName(e.target.value)}
+                  onChange={(e) => {
+                    const slugged = slugifyName(e.target.value);
+                    setName(slugged);
+                    if (slugged && !AGENT_NAME_REGEX.test(slugged)) {
+                      setNameError(
+                        "Must start with a letter/digit, only lowercase letters, digits, hyphens, underscores.",
+                      );
+                    } else {
+                      setNameError("");
+                    }
+                  }}
                   className="max-w-md"
                   required
                 />
+                {nameError && (
+                  <p className="text-sm text-destructive">{nameError}</p>
+                )}
               </div>
               <div className="space-y-2">
                 <Label


### PR DESCRIPTION
## Purpose / Description

Comprehensive agent platform improvements: review queue with component gating, semver versioning, component bundles, soft-delete (archive), draft save workflow, interactive CLI search, leaderboard enhancements, and creator attribution.

**Original PR:** Agent CLI commands (interactive wizard, paginated list, name validation, scope options for all IDEs).

**Added on top:** Review/approval pipeline, versioning, bundles, archive, drafts, leaderboard, interactive search.

## What's Done

### Database & Models
- [x] Migration 0010: Fix variable shadowing bug in dedup loop
- [x] Migration 0011: Extend AgentStatus (pending, rejected), ListingStatus (archived), create component_bundles table, add bundle_id FK to all 5 listing tables, add rejection_reason to agents
- [x] ComponentBundle model (id, name, description, submitted_by, created_at)
- [x] bundle_id nullable FK on McpListing, SkillListing, HookListing, PromptListing, SandboxListing

### Semver Versioning
- [x] services/versioning.py — parse, validate, bump, suggest
- [x] Pydantic validators on AgentCreateRequest.version and AgentUpdateRequest.version
- [x] version_bump_type field on AgentUpdateRequest
- [x] GET /agents/{id}/version-suggestions endpoint
- [x] Auto-bump in update_agent when version_bump_type provided
- [x] 12 unit tests for versioning utilities

### Agent Review Queue
- [x] GET /api/v1/review?tab=agents — list pending agents with component readiness
- [x] POST /api/v1/review/agents/{id}/approve — gated: rejects if any component not approved (422 with blocker details)
- [x] POST /api/v1/review/agents/{id}/reject — sets rejected status with reason

### Bundle Review (Atomic)
- [x] POST /api/v1/review/bundles/{id}/approve — approves all components in bundle atomically
- [x] POST /api/v1/review/bundles/{id}/reject — rejects all with shared reason
- [x] Bundle name resolution in component review list

### Agent Archive (Soft Delete)
- [x] PATCH /api/v1/agents/{id}/archive — admin only, sets status to archived
- [x] CLI agent delete now calls archive endpoint instead of hard delete

### Draft Workflow
- [x] POST /api/v1/agents/draft — create agent as draft (relaxed validation)
- [x] PUT /api/v1/agents/{id}/draft — update a draft
- [x] POST /api/v1/agents/{id}/submit — validate components, transition draft to pending
- [x] CLI agent publish --draft and agent publish --submit

### Created-By Email & Leaderboard
- [x] created_by_email on AgentSummary, AgentResponse, LeaderboardItem
- [x] Batch-fetch creator emails in list_agents, get_agent, create_agent, update_agent
- [x] GET /overview/leaderboard?user=email — filter by creator
- [x] GET /overview/component-leaderboard — new endpoint for MCP downloads ranked by user
- [x] GitHub issue #339 created for username field

### CLI Enhancements
- [x] Interactive search (-i flag) on agent list and registry mcp list using questionary fuzzy select
- [x] Version bump prompt on agent publish --update (patch/minor/major/keep)
- [x] --beta flag on agent init (defaults to 0.1.0)
- [x] client.patch() method added
- [x] Created-by email column in agent list table and agent show detail

## What's Left (TODO)

### Frontend (not started)
- [ ] Review page: Agents tab alongside Components tab
  - Pending agents with component readiness indicator (green/red per component)
  - Approve button disabled when components_ready === false with tooltip
  - Expandable blocker list
  - Bundle grouping with Review Bundle action
- [ ] Agent three-dot menu (admin): Archive action with confirmation dialog
- [ ] StatusBadge: add archived style (gray, no ping)
- [ ] Version bump dialog in agent builder (patch/minor/major radio with live preview)
- [ ] Draft save: localStorage auto-save + Save Draft button + My Drafts section
- [ ] Leaderboard: user filter input, tabs for agents vs components
- [ ] API client hooks for new endpoints

### Bulk Upload
- [ ] POST /api/v1/bulk/agents — bulk create with inline component auto-create, dedup, dry-run
- [ ] schemas/bulk.py — BulkAgentItem, BulkAgentRequest, BulkResult
- [ ] CLI agent bulk-create --from-file with dry-run preview and confirmation

### Additional Tests
- [ ] test_agent_review.py — status transitions, component gating, reject with reason
- [ ] test_bundles.py — bundle CRUD, atomic approve/reject
- [ ] test_bulk.py — bulk create with dedup, dry_run, inline component auto-create
- [ ] test_draft_workflow.py — draft save, update, submit transition

## How Has This Been Tested?

- `uv run pytest tests/ -x -q` — **1138 tests pass** (0 failures)
- `uv run ruff check .` — clean for all changed files
- `uv run ruff format --check .` — clean for all changed files

## Checklist

- [x] All commits are signed off (git commit -s) per the DCO
- [x] Descriptive commit messages
- [x] Self-review completed
- [ ] UI changes: N/A for this commit (frontend TODO above)