### PR TITLE
feat(auth): add username field to User model (#339)

### DIFF
--- a/observal-server/alembic/versions/0010_add_username_to_users.py
+++ b/observal-server/alembic/versions/0010_add_username_to_users.py
@@ -1,0 +1,39 @@
+"""Add username column to users table.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-04-18
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text("SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'username'")
+    )
+    if not result.fetchone():
+        op.add_column("users", sa.Column("username", sa.String(32), nullable=True))
+
+    # Check if constraint already exists
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.table_constraints "
+            "WHERE constraint_name = 'uq_users_username' AND table_name = 'users'"
+        )
+    )
+    if not result.fetchone():
+        op.create_unique_constraint("uq_users_username", "users", ["username"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_users_username", "users", type_="unique")
+    op.drop_column("users", "username")

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -180,7 +180,7 @@ async def create_user(
 
     password = req.password or await _generate_unique_password(db)
 
-    user = User(email=req.email, name=req.name, role=role)
+    user = User(email=req.email, username=req.username, name=req.name, role=role)
     user.set_password(password)
     db.add(user)
     try:
@@ -193,6 +193,7 @@ async def create_user(
     return UserCreateResponse(
         id=user.id,
         email=user.email,
+        username=user.username,
         name=user.name,
         role=user.role.value,
         password=password,

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -83,7 +83,11 @@ async def _load_agent(
 
 
 def _agent_to_response(
-    agent: Agent, name_map: dict[str, str] | None = None, *, created_by_email: str = ""
+    agent: Agent,
+    name_map: dict[str, str] | None = None,
+    *,
+    created_by_email: str = "",
+    created_by_username: str | None = None,
 ) -> AgentResponse:
     name_map = name_map or {}
     # Build mcp_links from components with component_type='mcp' (backwards compat)
@@ -123,6 +127,7 @@ def _agent_to_response(
     agent_dict["component_links"] = component_links
     agent_dict["goal_template"] = goal_template
     agent_dict["created_by_email"] = created_by_email
+    agent_dict["created_by_username"] = created_by_username
     return AgentResponse(**agent_dict)
 
 
@@ -283,7 +288,9 @@ async def create_agent(
         metadata={"agent_name": req.name, "version": req.version, "component_count": str(len(req.components))},
     )
 
-    return _agent_to_response(agent, name_map, created_by_email=current_user.email)
+    return _agent_to_response(
+        agent, name_map, created_by_email=current_user.email, created_by_username=current_user.username
+    )
 
 
 @router.get("", response_model=list[AgentSummary])
@@ -325,12 +332,15 @@ async def list_agents(
         )
         rating_map = {r[0]: round(float(r[1]), 2) for r in rows.all()}
 
-    # Batch-fetch creator emails
+    # Batch-fetch creator emails and usernames
     user_ids = {a.created_by for a in agents}
     email_map: dict[uuid.UUID, str] = {}
+    username_map: dict[uuid.UUID, str | None] = {}
     if user_ids:
-        rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
-        email_map = {r[0]: r[1] for r in rows.all()}
+        rows = await db.execute(select(User.id, User.email, User.username).where(User.id.in_(user_ids)))
+        for r in rows.all():
+            email_map[r[0]] = r[1]
+            username_map[r[0]] = r[2]
 
     return [
         AgentSummary(
@@ -346,6 +356,7 @@ async def list_agents(
             average_rating=rating_map.get(a.id),
             component_count=len(a.components),
             created_by_email=email_map.get(a.created_by, ""),
+            created_by_username=username_map.get(a.created_by),
             created_at=a.created_at,
             updated_at=a.updated_at,
         )
@@ -359,8 +370,13 @@ async def get_agent(agent_id: str, db: AsyncSession = Depends(get_db)):
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     name_map = await _resolve_component_names(agent.components, db)
-    email_row = (await db.execute(select(User.email).where(User.id == agent.created_by))).scalar_one_or_none()
-    return _agent_to_response(agent, name_map, created_by_email=email_row or "")
+    user_row = (await db.execute(select(User.email, User.username).where(User.id == agent.created_by))).first()
+    return _agent_to_response(
+        agent,
+        name_map,
+        created_by_email=user_row[0] if user_row else "",
+        created_by_username=user_row[1] if user_row else None,
+    )
 
 
 @router.get("/{agent_id}/version-suggestions")
@@ -511,7 +527,9 @@ async def update_agent(
         resource_name=agent.name,
     )
 
-    return _agent_to_response(agent, name_map, created_by_email=current_user.email)
+    return _agent_to_response(
+        agent, name_map, created_by_email=current_user.email, created_by_username=current_user.username
+    )
 
 
 @router.post("/{agent_id}/install", response_model=AgentInstallResponse)
@@ -821,7 +839,7 @@ async def save_draft(
 
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
-    return _agent_to_response(agent, created_by_email=current_user.email)
+    return _agent_to_response(agent, created_by_email=current_user.email, created_by_username=current_user.username)
 
 
 @router.put("/{agent_id}/draft", response_model=AgentResponse)
@@ -877,7 +895,7 @@ async def update_draft(
 
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
-    return _agent_to_response(agent, created_by_email=current_user.email)
+    return _agent_to_response(agent, created_by_email=current_user.email, created_by_username=current_user.username)
 
 
 @router.post("/{agent_id}/submit", response_model=AgentResponse)
@@ -926,4 +944,6 @@ async def submit_draft(
         resource_name=agent.name,
     )
 
-    return _agent_to_response(agent, name_map, created_by_email=current_user.email)
+    return _agent_to_response(
+        agent, name_map, created_by_email=current_user.email, created_by_username=current_user.username
+    )

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -24,6 +24,7 @@ from schemas.auth import (
     RevokeRequest,
     TokenRequest,
     TokenResponse,
+    UsernameUpdateRequest,
     UserResponse,
 )
 from services.jwt_service import create_access_token, create_refresh_token, decode_refresh_token
@@ -70,6 +71,7 @@ async def init_admin(req: InitRequest, db: AsyncSession = Depends(get_db)):
 
     user = User(
         email=req.email,
+        username=req.username,
         name=req.name,
         role=UserRole.admin,
     )
@@ -80,7 +82,7 @@ async def init_admin(req: InitRequest, db: AsyncSession = Depends(get_db)):
         await db.commit()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="System already initialized or email already exists")
+        raise HTTPException(status_code=409, detail="System already initialized or email/username already exists")
     await db.refresh(user)
 
     access_token, refresh_token, expires_in = await _issue_tokens(user)
@@ -136,6 +138,7 @@ async def register(request: Request, req: RegisterRequest, db: AsyncSession = De
 
     user = User(
         email=req.email,
+        username=req.username,
         name=req.name,
         role=UserRole.user,
     )
@@ -145,7 +148,7 @@ async def register(request: Request, req: RegisterRequest, db: AsyncSession = De
         await db.commit()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="Email already registered")
+        raise HTTPException(status_code=409, detail="Email or username already registered")
     await db.refresh(user)
 
     access_token, refresh_token, expires_in = await _issue_tokens(user)
@@ -389,6 +392,27 @@ async def revoke_token(request: Request, req: RevokeRequest):
     await redis.delete(f"refresh_jti:{jti}")
 
     return {"detail": "Token revoked"}
+
+
+@router.put("/profile/username", response_model=UserResponse)
+async def set_username(
+    req: UsernameUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Set or update the current user's username."""
+    existing = await db.execute(select(User).where(User.username == req.username))
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="Username already taken")
+
+    current_user.username = req.username
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Username already taken")
+    await db.refresh(current_user)
+    return UserResponse.model_validate(current_user)
 
 
 @router.post("/hooks-token")

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -303,9 +303,12 @@ async def agent_leaderboard(
         )
         rating_map = {r[0]: round(float(r[1]), 2) for r in rating_rows.all()}
     email_map: dict[uuid.UUID, str] = {}
+    username_map: dict[uuid.UUID, str | None] = {}
     if user_ids:
-        email_rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
-        email_map = {r[0]: r[1] for r in email_rows.all()}
+        email_rows = await db.execute(select(User.id, User.email, User.username).where(User.id.in_(user_ids)))
+        for r in email_rows.all():
+            email_map[r[0]] = r[1]
+            username_map[r[0]] = r[2]
 
     # Also include agents with no downloads if window=all and we have fewer than limit
     if window == "all" and len(rows) < limit:
@@ -315,13 +318,14 @@ async def agent_leaderboard(
             extra_stmt = extra_stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{user}%"))
         extra_stmt = extra_stmt.order_by(Agent.created_at.desc()).limit(limit - len(rows))
         extra = (await db.execute(extra_stmt)).scalars().all()
-        for a in extra:
-            if a.created_by not in email_map:
-                user_ids.add(a.created_by)
-        if user_ids - set(email_map.keys()):
-            missing = user_ids - set(email_map.keys())
-            extra_emails = await db.execute(select(User.id, User.email).where(User.id.in_(missing)))
-            email_map.update({r[0]: r[1] for r in extra_emails.all()})
+        missing_ids = {a.created_by for a in extra} - set(email_map.keys())
+        if missing_ids:
+            extra_user_rows = await db.execute(
+                select(User.id, User.email, User.username).where(User.id.in_(missing_ids))
+            )
+            for r in extra_user_rows.all():
+                email_map[r[0]] = r[1]
+                username_map[r[0]] = r[2]
         extra_items = [
             LeaderboardItem(
                 id=a.id,
@@ -332,6 +336,7 @@ async def agent_leaderboard(
                 download_count=0,
                 average_rating=rating_map.get(a.id),
                 created_by_email=email_map.get(a.created_by, ""),
+                created_by_username=username_map.get(a.created_by),
             )
             for a in extra
         ]
@@ -348,6 +353,7 @@ async def agent_leaderboard(
             download_count=row.cnt,
             average_rating=rating_map.get(row.agent_id),
             created_by_email=email_map.get(row.created_by, ""),
+            created_by_username=username_map.get(row.created_by),
         )
         for row in rows
     ] + extra_items

--- a/observal-server/models/user.py
+++ b/observal-server/models/user.py
@@ -23,6 +23,7 @@ class User(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    username: Mapped[str | None] = mapped_column(String(32), unique=True, nullable=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.user)
     password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/observal-server/schemas/admin.py
+++ b/observal-server/schemas/admin.py
@@ -17,6 +17,7 @@ class EnterpriseConfigUpdate(BaseModel):
 class UserAdminResponse(BaseModel):
     id: uuid.UUID
     email: str
+    username: str | None = None
     name: str
     role: str
     created_at: datetime | None = None
@@ -30,6 +31,7 @@ class UserRoleUpdate(BaseModel):
 class UserCreateRequest(BaseModel):
     email: str
     name: str
+    username: str | None = None
     role: str = "reviewer"
     password: str | None = None
 
@@ -42,6 +44,7 @@ class UserCreateRequest(BaseModel):
 class UserCreateResponse(BaseModel):
     id: uuid.UUID
     email: str
+    username: str | None = None
     name: str
     role: str
     password: str

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -150,6 +150,7 @@ class AgentResponse(BaseModel):
     rejection_reason: str | None = None
     created_by: uuid.UUID
     created_by_email: str = ""
+    created_by_username: str | None = None
     created_at: datetime
     updated_at: datetime
     mcp_links: list[McpLinkResponse] = []
@@ -172,6 +173,7 @@ class AgentSummary(BaseModel):
     average_rating: float | None = None
     component_count: int = 0
     created_by_email: str = ""
+    created_by_username: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
     components_ready: bool = True

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from datetime import datetime
 
@@ -5,21 +6,38 @@ from pydantic import BaseModel, EmailStr, field_validator
 
 from models.user import UserRole
 
+USERNAME_RE = re.compile(r"^[a-z0-9][a-z0-9\-]{1,30}[a-z0-9]$")
+
 
 def _normalize_email(v: str) -> str:
     """Lowercase and strip whitespace so email lookups are case-insensitive."""
     return v.strip().lower() if isinstance(v, str) else v
 
 
+def _validate_username(v: str | None) -> str | None:
+    if v is None:
+        return None
+    v = v.strip().lower()
+    if not USERNAME_RE.match(v):
+        raise ValueError("Username must be 3-32 chars, lowercase alphanumeric and hyphens only")
+    return v
+
+
 class InitRequest(BaseModel):
     email: EmailStr
     name: str
+    username: str | None = None
     password: str | None = None
 
     @field_validator("email", mode="before")
     @classmethod
     def _normalize(cls, v: str) -> str:
         return _normalize_email(v)
+
+    @field_validator("username", mode="before")
+    @classmethod
+    def _validate_un(cls, v: str | None) -> str | None:
+        return _validate_username(v)
 
 
 class LoginRequest(BaseModel):
@@ -35,6 +53,7 @@ class LoginRequest(BaseModel):
 class RegisterRequest(BaseModel):
     email: EmailStr
     name: str
+    username: str | None = None
     password: str
 
     @field_validator("email", mode="before")
@@ -42,10 +61,16 @@ class RegisterRequest(BaseModel):
     def _normalize(cls, v: str) -> str:
         return _normalize_email(v)
 
+    @field_validator("username", mode="before")
+    @classmethod
+    def _validate_un(cls, v: str | None) -> str | None:
+        return _validate_username(v)
+
 
 class UserResponse(BaseModel):
     id: uuid.UUID
     email: str
+    username: str | None = None
     name: str
     role: UserRole
     created_at: datetime
@@ -87,3 +112,15 @@ class RefreshRequest(BaseModel):
 
 class RevokeRequest(BaseModel):
     refresh_token: str
+
+
+class UsernameUpdateRequest(BaseModel):
+    username: str
+
+    @field_validator("username", mode="before")
+    @classmethod
+    def _validate_un(cls, v: str) -> str:
+        result = _validate_username(v)
+        if result is None:
+            raise ValueError("Username is required")
+        return result

--- a/observal-server/schemas/dashboard.py
+++ b/observal-server/schemas/dashboard.py
@@ -52,6 +52,7 @@ class TopAgentItem(BaseModel):
     name: str
     description: str = ""
     owner: str = ""
+    created_by_username: str | None = None
     version: str = ""
     download_count: int = 0
     average_rating: float | None = None
@@ -61,6 +62,7 @@ class LeaderboardItem(TopAgentItem):
     """Same as TopAgentItem — used by the leaderboard endpoint."""
 
     created_by_email: str = ""
+    created_by_username: str | None = None
 
 
 class ComponentLeaderboardItem(BaseModel):

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -290,8 +290,8 @@ def agent_list(
     if include_id:
         table.add_column("ID", style="dim", no_wrap=full_id)
     for i, item in enumerate(data, 1):
-        email = item.get("created_by_email", "")
-        row = [str(i), item["name"], item.get("version", ""), item.get("model_name", ""), email]
+        creator = item.get("created_by_username") or item.get("created_by_email", "")
+        row = [str(i), item["name"], item.get("version", ""), item.get("model_name", ""), creator]
         if include_id:
             row.append(str(item["id"]) if full_id else str(item["id"])[:8] + "…")
         table.add_row(*row)
@@ -329,7 +329,7 @@ def agent_show(
                 ("Status", status_badge(item.get("status", ""))),
                 ("Model", f"[bold]{item.get('model_name', 'N/A')}[/bold]"),
                 ("Owner", item.get("owner", "N/A")),
-                ("Created By", item.get("created_by_email", "")),
+                ("Created By", item.get("created_by_username") or item.get("created_by_email", "")),
                 ("Description", item.get("description", "")),
                 ("IDEs", ide_tags(item.get("supported_ides", []))),
                 ("Created", relative_time(item.get("created_at"))),

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -218,6 +218,7 @@ def whoami(
         kv_panel(
             user["name"],
             [
+                ("Username", f"@{user['username']}" if user.get("username") else "[dim]not set[/dim]"),
                 ("Email", user["email"]),
                 ("Role", status_badge(user.get("role", "user"))),
                 ("ID", f"[dim]{user['id']}[/dim]"),

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -127,6 +127,7 @@ export default function UsersPage() {
                 <TableHeader>
                   <TableRow className="hover:bg-transparent">
                     <TableHead className="h-8 text-xs">Name</TableHead>
+                    <TableHead className="h-8 text-xs">Username</TableHead>
                     <TableHead className="h-8 text-xs">Email</TableHead>
                     <TableHead className="h-8 text-xs">Role</TableHead>
                     <TableHead className="h-8 text-xs text-right">Joined</TableHead>
@@ -137,7 +138,10 @@ export default function UsersPage() {
                   {(users ?? []).map((u: AdminUser) => (
                     <TableRow key={u.id}>
                       <TableCell className="py-1.5">
-                        <span className="text-sm font-medium">{u.name ?? u.username ?? "-"}</span>
+                        <span className="text-sm font-medium">{u.name ?? "-"}</span>
+                      </TableCell>
+                      <TableCell className="py-1.5 text-sm text-muted-foreground">
+                        {u.username ? `@${u.username}` : "-"}
                       </TableCell>
                       <TableCell className="py-1.5 text-sm text-muted-foreground font-[family-name:var(--font-mono)]">
                         {u.email ?? "-"}

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -27,8 +27,9 @@ function LoginContent() {
   const [showPassword, setShowPassword] = useState(false);
 
   useEffect(() => {
-    // If the user is already authenticated, redirect to the home page
-    if (typeof window !== "undefined" && getUserRole()) {
+    if (typeof window === "undefined") return;
+    const hasToken = !!localStorage.getItem("observal_access_token");
+    if (hasToken && getUserRole()) {
       router.replace("/");
     }
   }, [router]);

--- a/web/src/app/(registry)/agents/leaderboard/page.tsx
+++ b/web/src/app/(registry)/agents/leaderboard/page.tsx
@@ -86,7 +86,7 @@ export default function LeaderboardPage() {
                     {item.name}
                   </span>
                   <span className="text-xs text-muted-foreground/70 truncate block">
-                    {item.owner}
+                    {item.created_by_username ? `@${item.created_by_username}` : item.owner}
                     {item.description && ` — ${item.description}`}
                   </span>
                 </div>

--- a/web/src/components/registry/agent-card.tsx
+++ b/web/src/components/registry/agent-card.tsx
@@ -11,6 +11,7 @@ interface AgentCardProps {
   description?: string;
   model_name?: string;
   owner?: string;
+  created_by_username?: string | null;
   downloads?: number;
   score?: number;
   version?: string;
@@ -24,6 +25,7 @@ export function AgentCard({
   name,
   description,
   owner,
+  created_by_username,
   downloads,
   score,
   version,
@@ -58,9 +60,9 @@ export function AgentCard({
         </p>
       )}
 
-      {owner && (
+      {(created_by_username || owner) && (
         <p className="mt-2 text-[11px] text-muted-foreground/70 truncate">
-          {owner}
+          {created_by_username ? `@${created_by_username}` : owner}
         </p>
       )}
 

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -1,46 +1,46 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
-import { auth, setUserRole, getUserRole } from "@/lib/api";
+import { auth, setUserRole, getUserRole, clearSession } from "@/lib/api";
+
+function initGuardState(): { ready: boolean; role: string | null } {
+  if (typeof window === "undefined") return { ready: false, role: null };
+  const key = localStorage.getItem("observal_access_token");
+  if (!key) {
+    clearSession();
+    return { ready: false, role: null };
+  }
+  const role = getUserRole();
+  return { ready: !!role, role };
+}
 
 export function useAuthGuard() {
   const router = useRouter();
   const pathname = usePathname();
-  const [ready, setReady] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const key = localStorage.getItem("observal_access_token");
-    if (!key) return false;
-    return !!getUserRole();
-  });
-  const [role, setRole] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return getUserRole();
-  });
+  const [{ ready, role }, setState] = useState(initGuardState);
 
   useEffect(() => {
     const key = localStorage.getItem("observal_access_token");
-    if (!key && pathname !== "/login") {
-      router.replace("/login");
-      return;
-    }
     if (!key) {
-      // Already ready from initial state
+      if (pathname !== "/login") {
+        router.replace("/login");
+      }
       return;
     }
 
-    const cached = getUserRole();
-    if (cached) {
-      // Already ready from initial state
-      return;
-    }
+    if (getUserRole()) return;
 
-    auth.whoami().then((user) => {
-      setUserRole(user.role);
-      setRole(user.role);
-      setReady(true);
-    }).catch(() => {
-      router.replace("/login");
-    });
+    auth
+      .whoami()
+      .then((user) => {
+        setUserRole(user.role);
+        setState({ ready: true, role: user.role });
+      })
+      .catch(() => {
+        clearSession();
+        setState({ ready: false, role: null });
+        router.replace("/login");
+      });
   }, [pathname, router]);
 
   return { ready, role };
@@ -69,26 +69,21 @@ export function useOptionalAuth() {
 
   useEffect(() => {
     const key = localStorage.getItem("observal_access_token");
-    if (!key) {
-      // Already ready from initial state
-      return;
-    }
+    if (!key) return;
+    if (getUserRole()) return;
 
-    const cached = getUserRole();
-    if (cached) {
-      // Already ready from initial state
-      return;
-    }
-
-    auth.whoami().then((user) => {
-      setUserRole(user.role);
-      setRole(user.role);
-      setIsAuthenticated(true);
-      setReady(true);
-    }).catch(() => {
-      // API key invalid — treat as unauthenticated
-      setReady(true);
-    });
+    auth
+      .whoami()
+      .then((user) => {
+        setUserRole(user.role);
+        setRole(user.role);
+        setIsAuthenticated(true);
+        setReady(true);
+      })
+      .catch(() => {
+        clearSession();
+        setReady(true);
+      });
   }, []);
 
   return { ready, role, isAuthenticated };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -187,7 +187,7 @@ export async function graphql<T = unknown>(
 
 // ── Auth ────────────────────────────────────────────────────────────
 type AuthResponse = {
-  user: { id: string; email: string; name: string; role: string; created_at: string };
+  user: { id: string; email: string; username?: string | null; name: string; role: string; created_at: string };
   access_token: string;
   refresh_token: string;
   expires_in: number;
@@ -200,7 +200,7 @@ export const auth = {
     post<AuthResponse>("/auth/register", body),
   login: (body: { email: string; password: string }) =>
     post<AuthResponse>("/auth/login", body),
-  whoami: () => get<{ id: string; email: string; name: string; role: string }>("/auth/whoami"),
+  whoami: () => get<{ id: string; email: string; username?: string | null; name: string; role: string }>("/auth/whoami"),
   exchangeCode: (body: { code: string }) =>
     post<AuthResponse>("/auth/exchange", body),
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -97,6 +97,7 @@ export interface TopAgentItem {
   name: string;
   description: string;
   owner: string;
+  created_by_username?: string | null;
   version: string;
   download_count: number;
   average_rating: number | null;


### PR DESCRIPTION
## Purpose / Description

Adds a `username` field to the User model so users can have a human-readable identity (e.g. `@lokesh`) displayed across the platform instead of UUIDs or emails. Also fixes a pre-existing login page redirect loop caused by stale `localStorage` state.

## Fixes
* Fixes #339

## Approach

**Username feature:**
- Added `username` column to `users` table (nullable, unique, `String(32)`) with idempotent Alembic migration (`0010`)
- Pydantic validation enforces 3-32 chars, lowercase alphanumeric + hyphens, must start/end with alphanumeric
- New `PUT /api/v1/auth/profile/username` endpoint with 409 conflict handling for duplicates
- Backend batch-fetches `created_by_username` alongside existing `created_by_email` on agent list, detail, and leaderboard endpoints — no N+1 queries
- CLI prefers `created_by_username` over `created_by_email` in `agent list`, `agent show`, and `auth whoami`
- Frontend shows `@username` on agent cards, leaderboard rows, and admin users table

**Auth redirect fix:**
- `useAuthGuard` now calls `clearSession()` when no access token exists, preventing stale `observal_user_role` in localStorage from triggering a redirect loop between `/login` and `/`
- Login page checks for both token AND role before redirecting authenticated users

## How Has This Been Tested?

1. Started Observal via `docker compose up` (API, web, DB, ClickHouse, Redis)
2. Logged in as demo admin via CLI (`observal auth login`)
3. Set username via API: `PUT /api/v1/auth/profile/username` with `{"username": "lokesh"}` — confirmed 200 response
4. `observal agent list` — verified "Created By" column shows `lokesh` instead of email
5. `observal auth whoami` — verified username row displays `@lokesh`
6. Tested leaderboard endpoint (`GET /api/v1/overview/leaderboard?window=all`) — confirmed `created_by_username` field present in response
7. Tested duplicate username returns 409
8. Verified login page no longer loops when localStorage has stale role without token

## Learning

- `information_schema` checks in Alembic migrations make them idempotent — safe to re-run when `Base.metadata.create_all` in the entrypoint has already created the column
- Batch-fetching usernames in a single query alongside emails (selecting `User.id, User.email, User.username`) avoids adding extra DB round-trips

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
