### PR TITLE
fix: prevent CRLF line endings from breaking Docker on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for shell scripts (prevents CRLF breakage in Docker on Windows)
+*.sh text eol=lf

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -11,6 +11,7 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 COPY observal-server/ .
 COPY docker/entrypoint.sh /app/entrypoint.sh
+RUN sed -i 's/\r$//' /app/entrypoint.sh
 
 RUN groupadd --system --gid 1001 appgroup && \
     useradd --system --uid 1001 --gid appgroup appuser && \


### PR DESCRIPTION

 ## Purpose / Description
 
  On Windows, Git's default `core.autocrlf=true` converts LF → CRLF on checkout. This causes `docker/entrypoint.sh` to get CRLF line endings,  and the Linux container's shell interpreter can't parse the `\r` in the shebang (`#!/bin/sh\r`), failing with:
 
  exec /app/entrypoint.sh: no such file or directory
 
  The API container crash-loops with exit code 255, making the project completely unusable for Windows users out of the box.
 
  ## Fixes
  * Fixes #362 
 
  ## Approach
 
  Two-layer defense in depth:
 
  1. **`.gitattributes`** — forces `*.sh` files to always checkout with LF line endings regardless of OS or Git config
  2. **`Dockerfile.api`** — adds `sed -i 's/\r$//'` as a safety net after copying `entrypoint.sh`, catching cases where users already have CRLF files in their Git cache
 
  ## How Has This Been Tested?
 
  - Fresh clone on Windows 11 (Git Bash / MINGW64) with default Git settings (`core.autocrlf=true`)
  - **Before fix:** `docker compose up --build -d` → API container crash-loops with `Restarting (255)`, logs show `exec /app/entrypoint.sh: no  
  such file or directory`
  - **After fix:** `docker compose up --build -d` → all 8 services start successfully, API container shows `Up (healthy)`, `curl
  http://localhost:8000/health` returns OK
 
  ## Learning (optional, can help others)
 
  The `exec ... no such file or directory` error is misleading — the file exists, but the kernel can't find the interpreter specified in the    
  shebang because `\r` is treated as part of the path (`/bin/sh\r` doesn't exist). This is a common pitfall for any project that runs shell  scripts inside Docker containers when contributors use Windows.                                                                               
 
  - [Git docs on .gitattributes line endings](https://git-scm.com/docs/gitattributes#_end_of_line_conversion)
  - [Docker CRLF FAQ](https://docs.docker.com/build/building/best-practices/#run)                                                               
 
  