### PR TITLE
fix(web): resolve React hydration and DOM nesting errors

### DIFF
--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -15,7 +15,7 @@ import {
   Activity,
   Trash2,
 } from "lucide-react";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
@@ -288,13 +288,20 @@ export default function AgentDetailPage({
 
   const { data: whoami } = useWhoami();
 
-  const isAuthenticated =
-    typeof window !== "undefined" &&
-    !!localStorage.getItem("observal_access_token");
-
-  const isAdmin =
-    typeof window !== "undefined" &&
-    hasMinRole(getUserRole(), "admin");
+  const storeSub = useCallback((cb: () => void) => {
+    window.addEventListener("storage", cb);
+    return () => window.removeEventListener("storage", cb);
+  }, []);
+  const isAuthenticated = useSyncExternalStore(
+    storeSub,
+    () => !!localStorage.getItem("observal_access_token"),
+    () => false,
+  );
+  const isAdmin = useSyncExternalStore(
+    storeSub,
+    () => hasMinRole(getUserRole(), "admin"),
+    () => false,
+  );
 
   const a = agent as unknown as AgentDetail | undefined;
   const canDelete = isAdmin || (whoami?.id && a?.created_by && whoami.id === String(a.created_by));

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -298,16 +298,6 @@ export default function AgentDetailPage({
 
   const a = agent as unknown as AgentDetail | undefined;
   const canDelete = isAdmin || (whoami?.id && a?.created_by && whoami.id === String(a.created_by));
-
-  // Debug logging
-  if (typeof window !== "undefined" && a) {
-    console.log("[Delete Debug]", {
-      isAdmin,
-      whoamiId: whoami?.id,
-      createdBy: a?.created_by,
-      canDelete
-    });
-  }
   const components: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];
   const goalTemplate = a?.goal_template;
   const agentName = a?.name ?? id.slice(0, 8);

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { Suspense, useState, useEffect, useRef, useMemo, useCallback, useSyncExternalStore } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -49,12 +49,17 @@ import type { RegistryItem } from "@/lib/types";
 
 type ViewMode = "table" | "grid";
 
+const roleSub = (cb: () => void) => {
+  window.addEventListener("storage", cb);
+  return () => window.removeEventListener("storage", cb);
+};
+
 function DeleteAgentButton({ agent }: { agent: RegistryItem }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const qc = useQueryClient();
   const { data: whoami } = useWhoami();
-  const isAdmin = hasMinRole(getUserRole(), "admin");
+  const isAdmin = useSyncExternalStore(roleSub, () => hasMinRole(getUserRole(), "admin"), () => false);
   const canDelete = isAdmin || (whoami?.id && agent.created_by && whoami.id === String(agent.created_by));
 
   async function handleDelete(e: React.MouseEvent) {
@@ -226,6 +231,14 @@ const columns: ColumnDef<RegistryItem>[] = [
 ];
 
 export default function AgentListPage() {
+  return (
+    <Suspense>
+      <AgentListContent />
+    </Suspense>
+  );
+}
+
+function AgentListContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const initialSearch = searchParams.get("search") ?? "";

--- a/web/src/app/(registry)/components/[id]/page.tsx
+++ b/web/src/app/(registry)/components/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use } from "react";
 import { useSearchParams } from "next/navigation";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useSyncExternalStore } from "react";
 import { Star, Check, Copy, ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 import { useRegistryItem, useFeedback, useFeedbackSummary, useRegistryMetrics } from "@/hooks/use-api";
@@ -35,9 +35,15 @@ export default function ComponentDetailPage({ params }: { params: Promise<{ id: 
   const { data: feedbackSummary, refetch: refetchSummary } = useFeedbackSummary(id);
   const { data: rawMetrics } = useRegistryMetrics(type, id);
 
-  const isAuthenticated =
-    typeof window !== "undefined" &&
-    !!localStorage.getItem("observal_access_token");
+  const storeSub = useCallback((cb: () => void) => {
+    window.addEventListener("storage", cb);
+    return () => window.removeEventListener("storage", cb);
+  }, []);
+  const isAuthenticated = useSyncExternalStore(
+    storeSub,
+    () => !!localStorage.getItem("observal_access_token"),
+    () => false,
+  );
 
   const componentName = item?.name ?? id.slice(0, 8);
   const avgRating = feedbackSummary?.average_rating;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -38,6 +38,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={`${archivo.variable} ${albertSans.variable} ${jetbrainsMono.variable} min-h-svh antialiased`}
+        suppressHydrationWarning
       >
         <Providers>{children}</Providers>
       </body>

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -10,7 +10,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange themes={["light", "dark", "midnight", "forest", "sunset"]}>
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        disableTransitionOnChange
+        themes={["light", "dark", "midnight", "forest", "sunset"]}
+      >
         {children}
       </ThemeProvider>
     </QueryClientProvider>

--- a/web/src/components/layouts/auth-guard.tsx
+++ b/web/src/components/layouts/auth-guard.tsx
@@ -2,8 +2,9 @@
 import { useAuthGuard, useOptionalAuth } from "@/hooks/use-auth";
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { ready } = useAuthGuard();
-  if (!ready) return null;
+  useAuthGuard();
+  // Render children immediately to prevent hydration mismatch
+  // The useAuthGuard hook handles redirects via side effects
   return <>{children}</>;
 }
 
@@ -12,7 +13,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
  * Resolves role for authenticated users so sidebar can show/hide admin items.
  */
 export function OptionalAuthGuard({ children }: { children: React.ReactNode }) {
-  const { ready } = useOptionalAuth();
-  if (!ready) return null;
+  useOptionalAuth();
+  // Render children immediately to prevent hydration mismatch
   return <>{children}</>;
 }

--- a/web/src/components/layouts/role-guard.tsx
+++ b/web/src/components/layouts/role-guard.tsx
@@ -3,7 +3,8 @@
 import { useRoleGuard, type Role } from "@/hooks/use-role-guard";
 
 export function RoleGuard({ minRole, children }: { minRole: Role; children: React.ReactNode }) {
-  const { ready } = useRoleGuard(minRole);
-  if (!ready) return null;
+  useRoleGuard(minRole);
+  // Render children immediately to prevent hydration mismatch
+  // The useRoleGuard hook handles redirects via side effects
   return <>{children}</>;
 }

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -31,6 +31,7 @@ import {
   Settings,
   AlertTriangle,
 } from "lucide-react";
+import { useSyncExternalStore } from "react";
 import { getUserRole, getUserName, getUserEmail } from "@/lib/api";
 import { hasMinRole, type Role } from "@/hooks/use-role-guard";
 
@@ -63,12 +64,19 @@ export const allNavItems = [
   { group: "Admin", items: adminNav },
 ];
 
+const storeSub = (cb: () => void) => {
+  window.addEventListener("storage", cb);
+  return () => window.removeEventListener("storage", cb);
+};
+const getAuthSnap = () =>
+  `${localStorage.getItem("observal_access_token") ?? ""}|${getUserRole() ?? ""}|${getUserName() ?? ""}|${getUserEmail() ?? ""}`;
+const getServerSnap = () => "|||";
+
 export function RegistrySidebar() {
   const pathname = usePathname();
-  const role = getUserRole();
-  const userName = getUserName();
-  const userEmail = getUserEmail();
-  const isAuthenticated = typeof window !== "undefined" && !!localStorage.getItem("observal_access_token");
+  const snap = useSyncExternalStore(storeSub, getAuthSnap, getServerSnap);
+  const [token, role, userName, userEmail] = snap.split("|");
+  const isAuthenticated = !!token;
 
   function isActive(href: string) {
     if (href === "/") return pathname === "/";

--- a/web/src/components/ui/breadcrumb.tsx
+++ b/web/src/components/ui/breadcrumb.tsx
@@ -56,10 +56,10 @@ const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWit
 )
 BreadcrumbPage.displayName = "BreadcrumbPage"
 
-const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentProps<"li">) => (
-  <li role="presentation" aria-hidden="true" className={cn("[&>svg]:h-3.5 [&>svg]:w-3.5", className)} {...props}>
+const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentProps<"span">) => (
+  <span role="presentation" aria-hidden="true" className={cn("[&>svg]:h-3.5 [&>svg]:w-3.5", className)} {...props}>
     {children ?? <ChevronRight />}
-  </li>
+  </span>
 )
 BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
 

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -99,6 +99,7 @@ const SidebarProvider = React.forwardRef<
           data-sidebar-state={state}
           style={{ "--sidebar-width": SIDEBAR_WIDTH, "--sidebar-width-icon": SIDEBAR_WIDTH_ICON, ...style } as React.CSSProperties}
           className={cn("flex h-dvh w-full", className)}
+          suppressHydrationWarning
           {...props}
         >
           {children}

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -1,47 +1,49 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { auth, setUserRole, getUserRole, clearSession } from "@/lib/api";
 
-function initGuardState(): { ready: boolean; role: string | null } {
-  if (typeof window === "undefined") return { ready: false, role: null };
+function subscribe(cb: () => void) {
+  window.addEventListener("storage", cb);
+  return () => window.removeEventListener("storage", cb);
+}
+
+function getAuthSnapshot() {
   const key = localStorage.getItem("observal_access_token");
-  if (!key) {
-    clearSession();
-    return { ready: false, role: null };
-  }
   const role = getUserRole();
-  return { ready: !!role, role };
+  return key ? (role || "pending") : "";
+}
+
+function getServerSnapshot() {
+  return "";
 }
 
 export function useAuthGuard() {
   const router = useRouter();
   const pathname = usePathname();
-  const [{ ready, role }, setState] = useState(initGuardState);
+  const snapshot = useSyncExternalStore(subscribe, getAuthSnapshot, getServerSnapshot);
+  const hasToken = snapshot !== "";
+  const ready = hasToken && snapshot !== "pending";
+  const role = ready ? snapshot : null;
 
   useEffect(() => {
-    const key = localStorage.getItem("observal_access_token");
-    if (!key) {
-      if (pathname !== "/login") {
-        router.replace("/login");
-      }
+    if (!hasToken && pathname !== "/login") {
+      router.replace("/login");
       return;
     }
+    if (!hasToken) return;
 
-    if (getUserRole()) return;
-
-    auth
-      .whoami()
-      .then((user) => {
+    if (snapshot === "pending") {
+      auth.whoami().then((user) => {
         setUserRole(user.role);
-        setState({ ready: true, role: user.role });
-      })
-      .catch(() => {
+        window.dispatchEvent(new Event("storage"));
+      }).catch(() => {
         clearSession();
-        setState({ ready: false, role: null });
+        window.dispatchEvent(new Event("storage"));
         router.replace("/login");
       });
-  }, [pathname, router]);
+    }
+  }, [hasToken, snapshot, pathname, router]);
 
   return { ready, role };
 }
@@ -52,39 +54,23 @@ export function useAuthGuard() {
  * Does NOT redirect to login.
  */
 export function useOptionalAuth() {
-  const [ready, setReady] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const key = localStorage.getItem("observal_access_token");
-    if (!key) return true;
-    return !!getUserRole();
-  });
-  const [role, setRole] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return getUserRole();
-  });
-  const [isAuthenticated, setIsAuthenticated] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return !!getUserRole();
-  });
+  const snapshot = useSyncExternalStore(subscribe, getAuthSnapshot, getServerSnapshot);
+  const hasToken = snapshot !== "";
+  const ready = !hasToken || snapshot !== "pending";
+  const role = (hasToken && snapshot !== "pending") ? snapshot : null;
+  const isAuthenticated = hasToken && snapshot !== "pending";
 
   useEffect(() => {
-    const key = localStorage.getItem("observal_access_token");
-    if (!key) return;
-    if (getUserRole()) return;
-
-    auth
-      .whoami()
-      .then((user) => {
+    if (hasToken && snapshot === "pending") {
+      auth.whoami().then((user) => {
         setUserRole(user.role);
-        setRole(user.role);
-        setIsAuthenticated(true);
-        setReady(true);
-      })
-      .catch(() => {
+        window.dispatchEvent(new Event("storage"));
+      }).catch(() => {
         clearSession();
-        setReady(true);
+        window.dispatchEvent(new Event("storage"));
       });
-  }, []);
+    }
+  }, [hasToken, snapshot]);
 
   return { ready, role, isAuthenticated };
 }

--- a/web/src/hooks/use-role-guard.ts
+++ b/web/src/hooks/use-role-guard.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { getUserRole } from "@/lib/api";
@@ -24,9 +24,21 @@ export function hasMinRole(userRole: string | null, minRole: Role): boolean {
   if (!userRole) return false;
   const userIdx = ROLE_HIERARCHY.indexOf(userRole as Role);
   const minIdx = ROLE_HIERARCHY.indexOf(minRole);
-  // Lower index = higher privilege. Unknown roles fail closed.
   if (userIdx === -1) return false;
   return userIdx <= minIdx;
+}
+
+function subscribe(cb: () => void) {
+  window.addEventListener("storage", cb);
+  return () => window.removeEventListener("storage", cb);
+}
+
+function getRoleSnapshot() {
+  return getUserRole() || "";
+}
+
+function getServerSnapshot() {
+  return "";
 }
 
 /**
@@ -35,17 +47,15 @@ export function hasMinRole(userRole: string | null, minRole: Role): boolean {
  */
 export function useRoleGuard(minRole: Role) {
   const router = useRouter();
-  const [ready] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return hasMinRole(getUserRole(), minRole);
-  });
+  const role = useSyncExternalStore(subscribe, getRoleSnapshot, getServerSnapshot);
+  const ready = role !== "" && hasMinRole(role, minRole);
 
   useEffect(() => {
-    if (!ready) {
+    if (role !== "" && !hasMinRole(role, minRole)) {
       toast.error("You do not have permission to access this page.");
       router.replace("/");
     }
-  }, [ready, router]);
+  }, [role, minRole, router]);
 
   return { ready };
 }


### PR DESCRIPTION
  Description:                                                                                                             
  Fixes hydration mismatches and invalid HTML errors in Next.js dev mode.                                                  

  - Replace all render-time `localStorage`/`typeof window` checks with `useSyncExternalStore` for SSR-safe state (use-auth,
   use-role-guard, registry-sidebar, agent detail, agent list, component detail pages)
  - Change `BreadcrumbSeparator` from `<li>` to `<span>` to fix invalid nested `<li>` HTML
  - Remove conditional null returns in AuthGuard/RoleGuard that caused server/client tree mismatch
  - Add `suppressHydrationWarning` to body and SidebarProvider for browser extension compatibility

  Fixes #363