### PR TITLE
Kiro agent pull for Windows/Powershell

### DIFF
--- a/magic-agent.json
+++ b/magic-agent.json
@@ -1,0 +1,28 @@
+{
+  "name": "magic-agent",
+  "version": "1.0.0",
+  "description": "Agent with 21st.dev Magic MCP for UI component generation",
+  "owner": "admin",
+  "prompt": "You are a UI development assistant. Use the magic MCP server to generate beautiful UI components.",
+  "model_name": "claude-sonnet-4",
+  "model_config_json": {},
+  "supported_ides": ["kiro"],
+  "mcp_server_ids": [],
+  "components": [],
+  "external_mcps": [
+    {
+      "name": "magic-mcp",
+      "command": "npx",
+      "args": ["-y", "@21st-dev/magic-mcp"]
+    }
+  ],
+  "goal_template": {
+    "description": "UI component generation",
+    "sections": [
+      {
+        "name": "Task",
+        "description": "What UI component to build"
+      }
+    ]
+  }
+}

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -615,6 +615,7 @@ async def install_agent(
         component_names=name_map,
         env_values=req.env_values,
         options=req.options,
+        platform=req.platform,
     )
 
     # Capture agent.id before any DB operations that might expire the ORM

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -98,7 +98,7 @@ async def install_hook(
 
     from services.hook_config_generator import generate_hook_telemetry_config
 
-    config = generate_hook_telemetry_config(listing, req.ide)
+    config = generate_hook_telemetry_config(listing, req.ide, platform=req.platform)
     return HookInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
 
 

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -202,6 +202,7 @@ class AgentInstallRequest(BaseModel):
     env_values: dict[str, dict[str, str]] = {}  # {mcp_listing_id: {VAR: value}}
     # IDE-specific install options (e.g. scope, model, tools, color for Claude Code)
     options: dict = {}
+    platform: str = ""  # e.g. "win32", "darwin", "linux" — empty = Unix default
 
 
 class AgentInstallResponse(BaseModel):

--- a/observal-server/schemas/hook.py
+++ b/observal-server/schemas/hook.py
@@ -77,6 +77,7 @@ class HookListingSummary(BaseModel):
 
 class HookInstallRequest(BaseModel):
     ide: str
+    platform: str = ""  # e.g. "win32", "darwin", "linux" — empty = Unix default
 
 
 class HookInstallResponse(BaseModel):

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -131,6 +131,7 @@ def generate_agent_config(
     component_names: dict | None = None,
     env_values: dict | None = None,
     options: dict | None = None,
+    platform: str = "",
 ) -> dict:
     """Generate IDE-specific config for an agent.
 
@@ -138,6 +139,7 @@ def generate_agent_config(
         mcp_listings: optional {component_id: McpListing} map pre-loaded by caller.
         component_names: optional {component_id_str: name} map for all component types.
         env_values: optional {mcp_listing_id_str: {VAR: value}} map of user-supplied env var values.
+        platform: client platform string (e.g. "win32", "darwin", "linux"). Empty = Unix default.
     """
     safe_name = _sanitize_name(agent.name)
     mcp_configs = _build_mcp_configs(agent, ide, observal_url, mcp_listings=mcp_listings, env_values=env_values)
@@ -148,27 +150,41 @@ def generate_agent_config(
         # Kiro agent JSON: drop into ~/.kiro/agents/<name>.json
         # Telemetry collected via observal-shim + hook bridge
         model_field = f',\\"model\\":\\"{agent.model_name}\\"' if agent.model_name else ""
-        curl_cmd = (
-            f'cat | sed \'s/^{{/{{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
-            f'"agent_name":"{safe_name}"{model_field},/\' '
-            f"| curl -sf -X POST {observal_url}/api/v1/otel/hooks "
-            f'-H "Content-Type: application/json" '
-            f"-d @-"
-        )
-        # Stop hook: enrich with model/token data from Kiro SQLite DB.
-        # Uses the observal CLI's enrichment script if installed, otherwise
-        # falls back to the same curl command as other events.
-        stop_cmd = (
-            f'cat | sed \'s/^{{/{{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
-            f'"agent_name":"{safe_name}"{model_field},/\' '
-            f"| python3 -m observal_cli.hooks.kiro_stop_hook "
-            f"--url {observal_url}/api/v1/otel/hooks"
-        )
+
+        if platform == "win32":
+            # PowerShell-compatible: pipe stdin through the Python hook script.
+            # No cat/sed/curl/$PPID/$TERM/$SHELL — those don't exist in PowerShell.
+            model_arg = f" --model {agent.model_name}" if agent.model_name else ""
+            hook_cmd = (
+                f"python -m observal_cli.hooks.kiro_hook "
+                f"--url {observal_url}/api/v1/otel/hooks "
+                f"--agent-name {safe_name}{model_arg}"
+            )
+            stop_cmd = (
+                f"python -m observal_cli.hooks.kiro_stop_hook "
+                f"--url {observal_url}/api/v1/otel/hooks "
+                f"--agent-name {safe_name}{model_arg}"
+            )
+        else:
+            # Unix: cat | sed | curl pipeline (unchanged)
+            hook_cmd = (
+                f'cat | sed \'s/^{{/{{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+                f'"agent_name":"{safe_name}"{model_field},/\' '
+                f"| curl -sf -X POST {observal_url}/api/v1/otel/hooks "
+                f'-H "Content-Type: application/json" '
+                f"-d @-"
+            )
+            stop_cmd = (
+                f'cat | sed \'s/^{{/{{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+                f'"agent_name":"{safe_name}"{model_field},/\' '
+                f"| python3 -m observal_cli.hooks.kiro_stop_hook "
+                f"--url {observal_url}/api/v1/otel/hooks"
+            )
         hooks = {
-            "agentSpawn": [{"command": curl_cmd}],
-            "userPromptSubmit": [{"command": curl_cmd}],
-            "preToolUse": [{"matcher": "*", "command": curl_cmd}],
-            "postToolUse": [{"matcher": "*", "command": curl_cmd}],
+            "agentSpawn": [{"command": hook_cmd}],
+            "userPromptSubmit": [{"command": hook_cmd}],
+            "preToolUse": [{"matcher": "*", "command": hook_cmd}],
+            "postToolUse": [{"matcher": "*", "command": hook_cmd}],
             "stop": [{"command": stop_cmd}],
         }
         kiro_scope = options.get("scope", "user")  # Kiro historically defaults to user-level

--- a/observal-server/services/hook_config_generator.py
+++ b/observal-server/services/hook_config_generator.py
@@ -1,14 +1,7 @@
-def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "http://localhost:8000") -> dict:
+def generate_hook_telemetry_config(
+    hook_listing, ide: str, server_url: str = "http://localhost:8000", platform: str = ""
+) -> dict:
     if ide in ("kiro", "kiro-cli"):
-        # Kiro uses shell-command hooks, not HTTP hooks.
-        # Generate a runCommand hook that pipes STDIN JSON to the Observal API via curl.
-        curl_cmd = (
-            'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
-            '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
-            f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
-            f'-H "Content-Type: application/json" '
-            f"-d @-"
-        )
         event = str(hook_listing.event)
         # Map Claude Code PascalCase events to Kiro camelCase
         kiro_event_map = {
@@ -19,6 +12,28 @@ def generate_hook_telemetry_config(hook_listing, ide: str, server_url: str = "ht
             "Stop": "stop",
         }
         kiro_event = kiro_event_map.get(event, event)
+
+        if platform == "win32":
+            # PowerShell-compatible: pipe stdin through the Python hook script.
+            # No cat/sed/curl/$PPID/$TERM/$SHELL — those don't exist in PowerShell.
+            if kiro_event == "stop":
+                ps_stop_cmd = f"python -m observal_cli.hooks.kiro_stop_hook --url {server_url}/api/v1/otel/hooks"
+                return {"hooks": {kiro_event: [{"command": ps_stop_cmd}]}}
+
+            ps_cmd = f"python -m observal_cli.hooks.kiro_hook --url {server_url}/api/v1/otel/hooks"
+            hook_entry = {"command": ps_cmd}
+            if kiro_event in ("preToolUse", "postToolUse"):
+                hook_entry["matcher"] = "*"
+            return {"hooks": {kiro_event: [hook_entry]}}
+
+        # Unix: cat | sed | curl pipeline (unchanged)
+        curl_cmd = (
+            'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+            '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
+            f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
+            f'-H "Content-Type: application/json" '
+            f"-d @-"
+        )
 
         # For stop events, use the enrichment script to capture model/tokens
         if kiro_event == "stop":

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json as _json
+import sys
 
 import typer
 from rich import print as rprint
@@ -129,7 +130,7 @@ def hook_install(
     """Get install config for a hook."""
     resolved = config.resolve_alias(hook_id)
     with spinner(f"Generating {ide} config..."):
-        result = client.post(f"/api/v1/hooks/{resolved}/install", {"ide": ide})
+        result = client.post(f"/api/v1/hooks/{resolved}/install", {"ide": ide, "platform": sys.platform})
     snippet = result.get("config_snippet", result)
     if raw:
         print(_json.dumps(snippet, indent=2))

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -226,7 +227,7 @@ def register_pull(app: typer.Typer):
         with spinner(f"Pulling {ide} config for agent {resolved[:8]}..."):
             result = client.post(
                 f"/api/v1/agents/{resolved}/install",
-                {"ide": ide, "env_values": env_values, "options": options},
+                {"ide": ide, "env_values": env_values, "options": options, "platform": sys.platform},
             )
 
         snippet = result.get("config_snippet", {})

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -7,22 +7,32 @@ the full enrichment in ``kiro_stop_hook.py`` — it only reads the
 conversation_id column, not the multi-MB conversation JSON.
 
 Usage (in a Kiro agent hook):
-    cat | python3 /path/to/kiro_hook.py --url http://localhost:8000/api/v1/otel/hooks
+    Unix:    cat | python3 /path/to/kiro_hook.py --url http://localhost:8000/api/v1/otel/hooks
+    Windows: python -m observal_cli.hooks.kiro_hook --url http://localhost:8000/api/v1/otel/hooks --agent-name my-agent
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
 from pathlib import Path
 
-KIRO_DB = Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3"
+
+def _get_kiro_db() -> Path:
+    """Return the platform-appropriate path to the Kiro SQLite database."""
+    if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA") or ""
+        if local_app_data:
+            return Path(local_app_data) / "kiro-cli" / "data.sqlite3"
+    return Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3"
 
 
 def _add_conversation_id(payload: dict) -> dict:
     """Look up the conversation_id for this cwd and attach it."""
-    if not KIRO_DB.exists():
+    kiro_db = _get_kiro_db()
+    if not kiro_db.exists():
         return payload
 
     cwd = payload.get("cwd", "")
@@ -30,7 +40,7 @@ def _add_conversation_id(payload: dict) -> dict:
         return payload
 
     try:
-        conn = sqlite3.connect(f"file:{KIRO_DB}?mode=ro", uri=True)
+        conn = sqlite3.connect(f"file:{kiro_db}?mode=ro", uri=True)
         cur = conn.cursor()
         cur.execute(
             "SELECT conversation_id FROM conversations_v2 WHERE key = ? ORDER BY updated_at DESC LIMIT 1",
@@ -50,10 +60,16 @@ def main():
     import urllib.request
 
     url = "http://localhost:8000/api/v1/otel/hooks"
+    agent_name = ""
+    model = ""
     args = sys.argv[1:]
     for i, arg in enumerate(args):
         if arg == "--url" and i + 1 < len(args):
             url = args[i + 1]
+        elif arg == "--agent-name" and i + 1 < len(args):
+            agent_name = args[i + 1]
+        elif arg == "--model" and i + 1 < len(args):
+            model = args[i + 1]
 
     try:
         raw = sys.stdin.read()
@@ -64,6 +80,12 @@ def main():
     # Ensure service_name is set (sed prefix may be overwritten by Kiro's
     # native fields due to JSON duplicate-key semantics — last key wins).
     payload.setdefault("service_name", "kiro-cli")
+
+    # Inject metadata from CLI args (used on Windows where sed is unavailable)
+    if agent_name:
+        payload.setdefault("agent_name", agent_name)
+    if model:
+        payload.setdefault("model", model)
 
     payload = _add_conversation_id(payload)
 

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -3,35 +3,45 @@
 
 When a Kiro agent's ``stop`` hook fires, this script:
 1. Reads the hook JSON payload from stdin.
-2. Queries ``~/.local/share/kiro-cli/data.sqlite3`` for the most recent
+2. Queries the Kiro SQLite database for the most recent
    conversation matching the working directory (``cwd``).
 3. Extracts per-turn metadata: model_id, input/output char counts,
    credit usage, tools used, and context usage.
 4. Merges the enriched fields into the payload and POSTs to Observal.
 
 Usage (in a Kiro agent hook):
-    cat | python3 /path/to/kiro-stop-hook.py --url http://localhost:8000/api/v1/otel/hooks
+    Unix:    cat | python3 /path/to/kiro_stop_hook.py --url http://localhost:8000/api/v1/otel/hooks
+    Windows: python -m observal_cli.hooks.kiro_stop_hook --url http://localhost:8000/api/v1/otel/hooks --agent-name my-agent
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
 from pathlib import Path
 
-KIRO_DB = Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3"
+
+def _get_kiro_db() -> Path:
+    """Return the platform-appropriate path to the Kiro SQLite database."""
+    if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA") or ""
+        if local_app_data:
+            return Path(local_app_data) / "kiro-cli" / "data.sqlite3"
+    return Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3"
 
 
 def _enrich(payload: dict) -> dict:
     """Read the Kiro SQLite DB and merge session-level stats into *payload*."""
-    if not KIRO_DB.exists():
+    kiro_db = _get_kiro_db()
+    if not kiro_db.exists():
         return payload
 
     cwd = payload.get("cwd", "")
 
     try:
-        conn = sqlite3.connect(f"file:{KIRO_DB}?mode=ro", uri=True)
+        conn = sqlite3.connect(f"file:{kiro_db}?mode=ro", uri=True)
         cur = conn.cursor()
 
         # Find the most recent conversation for this cwd
@@ -129,12 +139,18 @@ def _enrich(payload: dict) -> dict:
 def main():
     import urllib.request
 
-    # Parse --url argument
+    # Parse --url and --agent-name arguments
     url = "http://localhost:8000/api/v1/otel/hooks"
+    agent_name = ""
+    model = ""
     args = sys.argv[1:]
     for i, arg in enumerate(args):
         if arg == "--url" and i + 1 < len(args):
             url = args[i + 1]
+        elif arg == "--agent-name" and i + 1 < len(args):
+            agent_name = args[i + 1]
+        elif arg == "--model" and i + 1 < len(args):
+            model = args[i + 1]
 
     # Read hook payload from stdin
     try:
@@ -144,6 +160,12 @@ def main():
         sys.exit(0)
 
     payload.setdefault("service_name", "kiro-cli")
+
+    # Inject metadata from CLI args (used on Windows where sed is unavailable)
+    if agent_name:
+        payload.setdefault("agent_name", agent_name)
+    if model:
+        payload.setdefault("model", model)
 
     # Enrich with SQLite data
     payload = _enrich(payload)

--- a/observal_cli/shim.py
+++ b/observal_cli/shim.py
@@ -8,7 +8,9 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import sys
+import threading
 import time
 import uuid
 from datetime import UTC, datetime
@@ -287,7 +289,7 @@ async def _relay_ide_to_mcp(
 
 async def _relay_mcp_to_ide(
     mcp_queue: asyncio.Queue,
-    ide_stdout: asyncio.StreamWriter,
+    ide_stdout: asyncio.StreamWriter | None,
     state: ShimState,
 ):
     """Relay messages from MCP to IDE, pairing responses to create spans."""
@@ -301,8 +303,13 @@ async def _relay_mcp_to_ide(
             if span:
                 await state.buffer_span(span)
         raw = json.dumps(msg) + "\n"
-        ide_stdout.write(raw.encode())
-        await ide_stdout.drain()
+        if ide_stdout is not None:
+            ide_stdout.write(raw.encode())
+            await ide_stdout.drain()
+        else:
+            # Windows fallback: write directly to stdout buffer
+            sys.stdout.buffer.write(raw.encode())
+            sys.stdout.buffer.flush()
 
 
 async def _periodic_flush(state: ShimState, interval: float = 5.0):
@@ -315,8 +322,33 @@ async def _periodic_flush(state: ShimState, interval: float = 5.0):
         pass
 
 
+def _thread_read_stdin(loop: asyncio.AbstractEventLoop, reader: asyncio.StreamReader):
+    """Read stdin in a thread and feed data to an asyncio StreamReader.
+
+    On Windows, asyncio's connect_read_pipe does not work with sys.stdin
+    (the Proactor event loop doesn't support it). This thread bridges the
+    gap by reading stdin synchronously and feeding lines into the reader.
+    """
+    try:
+        while True:
+            line = sys.stdin.buffer.readline()
+            if not line:
+                loop.call_soon_threadsafe(reader.feed_eof)
+                break
+            loop.call_soon_threadsafe(reader.feed_data, line)
+    except Exception:
+        loop.call_soon_threadsafe(reader.feed_eof)
+
+
 async def run_shim(mcp_id: str, command: list[str]):
     """Main shim entry point: spawn MCP process and relay stdio."""
+    # On Windows, asyncio.create_subprocess_exec cannot find .cmd/.bat
+    # scripts (like npx.cmd) by PATH alone. Resolve the executable first.
+    if sys.platform == "win32" and command:
+        resolved = shutil.which(command[0])
+        if resolved:
+            command = [resolved, *command[1:]]
+
     # Resolve auth
     access_token = os.environ.get("OBSERVAL_KEY", "")
     server_url = os.environ.get("OBSERVAL_SERVER", "")
@@ -346,15 +378,28 @@ async def run_shim(mcp_id: str, command: list[str]):
         stderr=asyncio.subprocess.PIPE,
     )
 
-    # Set up async readers
+    # Set up IDE stdin reader.
+    # On Windows, connect_read_pipe / connect_write_pipe don't work with
+    # regular file handles (stdin/stdout). Use a background thread instead.
     ide_reader = asyncio.StreamReader()
-    protocol = asyncio.StreamReaderProtocol(ide_reader)
-    await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin)
+    if sys.platform == "win32":
+        loop = asyncio.get_event_loop()
+        t = threading.Thread(target=_thread_read_stdin, args=(loop, ide_reader), daemon=True)
+        t.start()
+    else:
+        protocol = asyncio.StreamReaderProtocol(ide_reader)
+        await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin)
 
-    ide_writer_transport, ide_writer_protocol = await asyncio.get_event_loop().connect_write_pipe(
-        asyncio.streams.FlowControlMixin, sys.stdout
-    )
-    ide_stdout = asyncio.StreamWriter(ide_writer_transport, ide_writer_protocol, None, asyncio.get_event_loop())
+    # Set up IDE stdout writer.
+    if sys.platform == "win32":
+        # On Windows, write directly to stdout buffer instead of using
+        # connect_write_pipe which fails on the Proactor event loop.
+        ide_stdout = None  # sentinel — _relay_mcp_to_ide will write to sys.stdout
+    else:
+        ide_writer_transport, ide_writer_protocol = await asyncio.get_event_loop().connect_write_pipe(
+            asyncio.streams.FlowControlMixin, sys.stdout
+        )
+        ide_stdout = asyncio.StreamWriter(ide_writer_transport, ide_writer_protocol, None, asyncio.get_event_loop())
 
     ide_queue = await _read_messages(ide_reader)
     mcp_queue = await _read_messages(proc.stdout)

--- a/test-agent.json
+++ b/test-agent.json
@@ -1,0 +1,28 @@
+{
+  "name": "fs-agent",
+  "version": "1.0.0",
+  "description": "Test agent with filesystem MCP server",
+  "owner": "admin",
+  "prompt": "You are a helpful file management assistant.",
+  "model_name": "claude-sonnet-4",
+  "model_config_json": {},
+  "supported_ides": ["kiro"],
+  "mcp_server_ids": [],
+  "components": [],
+  "external_mcps": [
+    {
+      "name": "filesystem",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    }
+  ],
+  "goal_template": {
+    "description": "File management",
+    "sections": [
+      {
+        "name": "Task",
+        "description": "What to do"
+      }
+    ]
+  }
+}

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -672,3 +672,199 @@ class TestBuilderRulesMarkdown:
         assert "**srv-a**" in md_file.content
         assert "## Skills" in md_file.content
         assert "**skill-b**" in md_file.content
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Windows platform-aware Kiro config generation
+# ═══════════════════════════════════════════════════════════════════
+
+UNIX_FORBIDDEN_IN_WIN32 = ["cat |", "sed '", "$PPID", "$TERM", "$SHELL", "python3"]
+
+
+class TestGenerateKiroWin32:
+    """Fix checking: Windows Kiro configs must not contain Unix-only syntax."""
+
+    def _all_hook_commands(self, cfg: dict) -> list[str]:
+        """Extract all hook command strings from a Kiro agent config."""
+        hooks = cfg["agent_file"]["content"]["hooks"]
+        cmds = []
+        for _event, entries in hooks.items():
+            for entry in entries:
+                if "command" in entry:
+                    cmds.append(entry["command"])
+        return cmds
+
+    def test_win32_hooks_contain_no_unix_syntax(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "kiro", platform="win32")
+        cmds = self._all_hook_commands(cfg)
+        assert cmds, "Expected at least one hook command"
+        for cmd in cmds:
+            for forbidden in UNIX_FORBIDDEN_IN_WIN32:
+                assert forbidden not in cmd, f"Found Unix-only '{forbidden}' in win32 hook: {cmd}"
+
+    def test_win32_hooks_use_python_not_python3(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "kiro", platform="win32")
+        cmds = self._all_hook_commands(cfg)
+        for cmd in cmds:
+            assert "python3" not in cmd
+            assert "python " in cmd or "python -m" in cmd
+
+    def test_win32_hooks_include_agent_name(self):
+        agent = _make_agent(name="my-cool-agent")
+        cfg = generate_agent_config(agent, "kiro", platform="win32")
+        cmds = self._all_hook_commands(cfg)
+        for cmd in cmds:
+            assert "--agent-name my-cool-agent" in cmd
+
+    def test_win32_hooks_include_model_when_present(self):
+        agent = _make_agent(model_name="claude-sonnet-4")
+        cfg = generate_agent_config(agent, "kiro", platform="win32")
+        cmds = self._all_hook_commands(cfg)
+        for cmd in cmds:
+            assert "--model claude-sonnet-4" in cmd
+
+    def test_win32_hooks_omit_model_when_empty(self):
+        agent = _make_agent(model_name="")
+        cfg = generate_agent_config(agent, "kiro", platform="win32")
+        cmds = self._all_hook_commands(cfg)
+        for cmd in cmds:
+            assert "--model" not in cmd
+
+    def test_win32_still_has_all_hook_events(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "kiro", platform="win32")
+        hooks = cfg["agent_file"]["content"]["hooks"]
+        for event in ("agentSpawn", "userPromptSubmit", "preToolUse", "postToolUse", "stop"):
+            assert event in hooks
+
+    def test_win32_agent_file_path_unchanged(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "kiro", platform="win32")
+        assert cfg["agent_file"]["path"] == "~/.kiro/agents/test-agent.json"
+
+
+class TestGenerateKiroPreservation:
+    """Preservation checking: Unix Kiro configs must be identical with or without platform."""
+
+    def test_no_platform_matches_linux(self):
+        agent = _make_agent()
+        cfg_default = generate_agent_config(agent, "kiro")
+        cfg_linux = generate_agent_config(agent, "kiro", platform="linux")
+        assert cfg_default == cfg_linux
+
+    def test_darwin_matches_default(self):
+        agent = _make_agent()
+        cfg_default = generate_agent_config(agent, "kiro")
+        cfg_darwin = generate_agent_config(agent, "kiro", platform="darwin")
+        assert cfg_default == cfg_darwin
+
+    def test_empty_platform_matches_default(self):
+        agent = _make_agent()
+        cfg_default = generate_agent_config(agent, "kiro")
+        cfg_empty = generate_agent_config(agent, "kiro", platform="")
+        assert cfg_default == cfg_empty
+
+    def test_unix_hooks_still_use_cat_sed_curl(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "kiro", platform="linux")
+        hooks = cfg["agent_file"]["content"]["hooks"]
+        spawn_cmd = hooks["agentSpawn"][0]["command"]
+        assert "cat |" in spawn_cmd
+        assert "sed '" in spawn_cmd
+        assert "curl" in spawn_cmd
+
+    def test_non_kiro_ides_unaffected_by_platform(self):
+        agent = _make_agent()
+        for ide in ("cursor", "vscode", "codex", "copilot"):
+            cfg_default = generate_agent_config(agent, ide)
+            cfg_win32 = generate_agent_config(agent, ide, platform="win32")
+            assert cfg_default == cfg_win32, f"{ide} config changed with platform=win32"
+
+
+class TestHookConfigGeneratorWin32:
+    """Fix checking: hook_config_generator Windows output has no Unix syntax."""
+
+    def test_win32_kiro_hook_no_unix_syntax(self):
+        from services.hook_config_generator import generate_hook_telemetry_config
+
+        listing = MagicMock()
+        listing.event = "UserPromptSubmit"
+        cfg = generate_hook_telemetry_config(listing, "kiro", platform="win32")
+        cmd = cfg["hooks"]["userPromptSubmit"][0]["command"]
+        for forbidden in UNIX_FORBIDDEN_IN_WIN32:
+            assert forbidden not in cmd, f"Found Unix-only '{forbidden}' in win32 hook: {cmd}"
+        assert "python " in cmd or "python -m" in cmd
+
+    def test_win32_kiro_stop_hook_no_unix_syntax(self):
+        from services.hook_config_generator import generate_hook_telemetry_config
+
+        listing = MagicMock()
+        listing.event = "Stop"
+        cfg = generate_hook_telemetry_config(listing, "kiro", platform="win32")
+        cmd = cfg["hooks"]["stop"][0]["command"]
+        for forbidden in UNIX_FORBIDDEN_IN_WIN32:
+            assert forbidden not in cmd, f"Found Unix-only '{forbidden}' in win32 hook: {cmd}"
+        assert "python " in cmd or "python -m" in cmd
+
+    def test_unix_kiro_hook_preserved(self):
+        from services.hook_config_generator import generate_hook_telemetry_config
+
+        listing = MagicMock()
+        listing.event = "UserPromptSubmit"
+        cfg_default = generate_hook_telemetry_config(listing, "kiro")
+        cfg_linux = generate_hook_telemetry_config(listing, "kiro", platform="linux")
+        assert cfg_default == cfg_linux
+
+    def test_unix_kiro_stop_hook_preserved(self):
+        from services.hook_config_generator import generate_hook_telemetry_config
+
+        listing = MagicMock()
+        listing.event = "Stop"
+        cfg_default = generate_hook_telemetry_config(listing, "kiro")
+        cfg_linux = generate_hook_telemetry_config(listing, "kiro", platform="linux")
+        assert cfg_default == cfg_linux
+
+    def test_non_kiro_ides_unaffected(self):
+        from services.hook_config_generator import generate_hook_telemetry_config
+
+        listing = MagicMock()
+        listing.event = "PreToolUse"
+        cfg_default = generate_hook_telemetry_config(listing, "claude-code")
+        cfg_win32 = generate_hook_telemetry_config(listing, "claude-code", platform="win32")
+        assert cfg_default == cfg_win32
+
+
+class TestGetKiroDb:
+    """Test platform-aware Kiro DB path resolution."""
+
+    def test_unix_path(self):
+        import unittest.mock
+
+        from observal_cli.hooks.kiro_hook import _get_kiro_db
+
+        with unittest.mock.patch("observal_cli.hooks.kiro_hook.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            db = _get_kiro_db()
+            assert ".local" in str(db)
+            assert "kiro-cli" in str(db)
+            assert "data.sqlite3" in str(db)
+
+    def test_win32_path_with_localappdata(self):
+        import unittest.mock
+
+        from observal_cli.hooks.kiro_hook import _get_kiro_db
+
+        with (
+            unittest.mock.patch("observal_cli.hooks.kiro_hook.sys") as mock_sys,
+            unittest.mock.patch("observal_cli.hooks.kiro_hook.os") as mock_os,
+        ):
+            mock_sys.platform = "win32"
+            mock_os.environ.get = lambda key, default="": (
+                "C:\\Users\\test\\AppData\\Local" if key == "LOCALAPPDATA" else default
+            )
+            db = _get_kiro_db()
+            assert "AppData" in str(db)
+            assert "kiro-cli" in str(db)
+            assert "data.sqlite3" in str(db)


### PR DESCRIPTION
**Problem**
`observal pull --ide kiro` generates agent configs with Unix-only shell commands and a hardcoded Linux DB path. None of this works on Windows/PowerShell, so the entire Kiro hook telemetry pipeline was broken for Windows users. On top of that, the `observal-shim` couldn't spawn MCP servers on Windows because `asyncio.create_subprocess_exec` can't find `.cmd` executables and `connect_read_pipe/connect_write_pipe` don't work on the Windows Proactor event loop.

**Fix**
The CLI now sends `sys.platform` to the server via a new optional platform field on the install request. When platform == "win32", the server generates PowerShell-compatible hook commands using `python -m observal_cli.hooks.kiro_hook --url ... --agent-name ...` instead of the Unix pipeline. The hook scripts now resolve the Kiro SQLite DB path at runtime (`%LOCALAPPDATA%` on Windows, `~/.local/share` on Unix). The shim uses `shutil.which()` to resolve `.cmd` executables and a thread-based stdin reader to replace the broken asyncio pipe handling on Windows. All changes are gated behind `sys.platform == "win32"` — macOS/Linux behavior is completely unchanged. The pull command should be used with `--dir ~` to write the agent file to the home directory where Kiro can find it.

**Extra fixes and additions**
`observal-shim` couldn't find `npx.cmd` on Windows — fixed with `shutil.which()`
`observal-shim` crashed on Windows due to asyncio pipe incompatibility — fixed with thread-based stdin relay and direct stdout writes
Cleaned up a duplicate `run_shim` function that was left behind during editing
Added 19 new tests covering Windows fix checking, Unix preservation, hook config generator, and platform-aware DB path resolution — all 126 tests pass


**Known issue** 
Traces don't show up in the Observal UI when using kiro-cli. After investigation, kiro-cli displays the hook commands in its UI panel but doesn't actually execute them when events fire. The hook commands are correct and work when run manually — kiro-cli just doesn't trigger them. Not exactly sure how to fix this...