### PR TITLE
fix(deps): bump python-multipart to >=0.0.26 to fix DoS vulnerability

### DIFF
--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "PyJWT>=2.8.0",
     "aiosqlite>=0.22.1",
     "tenacity>=8.0.0",
+    "python-multipart>=0.0.26",
 ]
 
 [dependency-groups]

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -776,6 +776,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "redis", extra = ["hiredis"] },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -809,6 +810,7 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "python-dotenv" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "redis", extras = ["hiredis"] },
     { name = "slowapi" },
     { name = "sqlalchemy", extras = ["asyncio"] },
@@ -1046,11 +1048,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose / Description
`python-multipart` v0.0.22 (transitive dependency via FastAPI) has a CPU exhaustion DoS vulnerability. Parsing crafted `multipart/form-data` requests with large preamble or epilogue sections causes excessive CPU time, degrading server availability.

## Fixes
* Fixes #6

## Approach
Pin `python-multipart>=0.0.26` as a direct dependency in `pyproject.toml` and update `uv.lock`. Version 0.0.26 skips ahead to the next boundary candidate when processing leading CR/LF data and immediately discards epilogue data after the closing boundary.

## How Has This Been Tested?

- Verified `uv lock` resolves to `python-multipart==0.0.26`
- Confirmed the server starts and handles multipart requests normally with the updated dependency
- No breaking API changes between 0.0.22 and 0.0.26

## Learning (optional, can help others)
- `python-multipart` is a transitive dependency pulled in by FastAPI for file uploads and form data parsing
- Even transitive dependencies can introduce vulnerabilities — pinning minimum safe versions as direct deps is a valid mitigation strategy
- CVE details: two inefficient parsing paths in the multipart boundary scanner allowed attacker-controlled input to cause linear CPU growth

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
