### PR TITLE
fix(deps): bump Mako to >=1.3.11 to fix path traversal

### DIFF
--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "aiosqlite>=0.22.1",
     "tenacity>=8.0.0",
     "python-multipart>=0.0.26",
+    "mako>=1.3.11",
 ]
 
 [dependency-groups]

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -670,14 +670,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
 ]
 
 [[package]]
@@ -772,6 +772,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "httpx" },
     { name = "itsdangerous" },
+    { name = "mako" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -806,6 +807,7 @@ requires-dist = [
     { name = "gitpython" },
     { name = "httpx" },
     { name = "itsdangerous" },
+    { name = "mako", specifier = ">=1.3.11" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", specifier = ">=2.8.0" },


### PR DESCRIPTION
## Purpose / Description
`Mako` v1.3.10 (transitive dependency via Alembic) has a path traversal vulnerability. `TemplateLookup.get_template()` inconsistently strips leading slashes compared to `Template.__init__`, allowing URIs like `//../../../../etc/passwd` to bypass directory checks and read arbitrary files.

## Fixes
* Fixes Dependabot alert for Mako path traversal vulnerability

## Approach
Pin `Mako>=1.3.11` as a direct dependency in `pyproject.toml` and update `uv.lock`. Version 1.3.11 changes `Template.__init__` to use `lstrip("/")` so both code paths handle leading slashes consistently.

## How Has This Been Tested?

- Verified `uv lock` resolves to `Mako==1.3.11`
- Confirmed the server starts and runs migrations normally with the updated dependency
- No breaking API changes between 1.3.10 and 1.3.11

## Learning (optional, can help others)
- `Mako` is a transitive dependency pulled in by Alembic for migration template rendering
- The vulnerability is exploitable at the library API level — HTTP exploitation is mitigated by Python's `BaseHTTPRequestHandler` which normalizes double-slash prefixes, but other HTTP servers may not

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
