### PR TITLE
feat: add dismissible GitHub star banner to page header

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -12,6 +12,7 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { cn } from "@/lib/utils";
+import { GitHubStarBanner } from "@/components/nav/github-star-banner";
 
 export interface BreadcrumbEntry {
   label: string;
@@ -69,6 +70,9 @@ export function PageHeader({
               </BreadcrumbList>
             </Breadcrumb>
           )}
+          <div className="ml-auto">
+            <GitHubStarBanner />
+          </div>
         </div>
       </div>
 

--- a/web/src/components/nav/github-star-banner.tsx
+++ b/web/src/components/nav/github-star-banner.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+import { Star, X } from "lucide-react";
+
+const DISMISSED_KEY = "observal_github_star_dismissed";
+
+function subscribe(cb: () => void) {
+  window.addEventListener("storage", cb);
+  return () => window.removeEventListener("storage", cb);
+}
+
+export function GitHubStarBanner() {
+  const dismissed = useSyncExternalStore(
+    subscribe,
+    () => localStorage.getItem(DISMISSED_KEY) === "1",
+    () => true,
+  );
+
+  const dismiss = useCallback(() => {
+    localStorage.setItem(DISMISSED_KEY, "1");
+    window.dispatchEvent(new StorageEvent("storage"));
+  }, []);
+
+  if (dismissed) return null;
+
+  return (
+    <div className="group/star flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground">
+      <a
+        href="https://github.com/BlazeUp-AI/Observal"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1.5"
+      >
+        <Star className="h-3.5 w-3.5 text-yellow-400 transition-colors group-hover/star:fill-yellow-400" />
+        <span>Star us on GitHub</span>
+      </a>
+      <button
+        onClick={dismiss}
+        className="ml-0.5 rounded-sm p-0.5 hover:bg-muted"
+        aria-label="Dismiss"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/sidebar";
 import { ThemeSwitcher } from "@/components/ui/theme-switcher";
 import { NavUser } from "@/components/nav/nav-user";
+
 import {
   Home,
   Bot,


### PR DESCRIPTION
## Purpose / Description

  Adds a dismissible "Star us on GitHub" prompt in the page header to encourage users to star the repo. The banner appears in the top-right of  the breadcrumb bar across all pages, with a yellow outline star that fills solid on hover. Users can dismiss it permanently via the X button. 

## Fixes
Fix #179 

## Approach
  - Created a GitHubStarBanner client component that reads/writes a localStorage flag (observal_github_star_dismissed) to track dismissal         - Placed it in the PageHeader breadcrumb row using ml-auto to push it to the far right, making it visible on every page without being
  - The banner starts hidden on SSR (avoids hydration mismatch), then shows via useEffect if not previously dismissed
  - Removed an earlier sidebar footer placement in registry-sidebar.tsx in favor of the header position


<img width="1600" height="787" alt="image" src="https://github.com/user-attachments/assets/f3e9eca3-611b-43a7-9a94-5102c3063a6f" />



Hovering : 

<img width="1600" height="795" alt="image" src="https://github.com/user-attachments/assets/487a8d1e-fe33-43f0-9689-d0286b5f6836" />


