### PR TITLE
fix(deps): bump strawberry-graphql to >=0.314.0 for WS DoS fix

### DIFF
--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "boto3",
     "redis[hiredis]",
     "arq",
-    "strawberry-graphql[fastapi]",
+    "strawberry-graphql[fastapi]>=0.314.0",
     "authlib>=1.6.11",
     "itsdangerous",
     "cryptography>=43.0.0",

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -829,7 +829,7 @@ requires-dist = [
     { name = "redis", extras = ["hiredis"] },
     { name = "slowapi" },
     { name = "sqlalchemy", extras = ["asyncio"] },
-    { name = "strawberry-graphql", extras = ["fastapi"] },
+    { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.314.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "uvicorn", extras = ["standard"] },
 ]
@@ -1258,7 +1258,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.312.2"
+version = "0.314.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cross-web" },
@@ -1267,9 +1267,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/90/ffc198d3691fbcdaff3751552a9e360e3cfb0c80577fe6326724008178a5/strawberry_graphql-0.312.2.tar.gz", hash = "sha256:e545681441842a64203bb78010e6a56737340da5022864da3df58602a718fb2b", size = 215123, upload-time = "2026-03-25T16:57:46.546Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/4d/df1240ee4d8fe925d0b6f0eff15cf9947f0345ab44c39eb58355b6026425/strawberry_graphql-0.314.3.tar.gz", hash = "sha256:2a841c35af61e9d5df1e215ca991cfac364c00a05fc192d9f38d0733da163097", size = 222131, upload-time = "2026-04-08T18:04:42.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/6d/f22f1cc6c2faf4307c96f8f2a58a031ebf42a8ee0f9fa046bf6304f3dc0e/strawberry_graphql-0.312.2-py3-none-any.whl", hash = "sha256:fac534323c9fe57600c3ce6f64d02e6bd0a0b8c5e865ef07c061060fc9a46923", size = 312679, upload-time = "2026-03-25T16:57:47.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/25/13773a2944cc5975d44db58233b3610ddc88d4be49e6576adf7ed4b62250/strawberry_graphql-0.314.3-py3-none-any.whl", hash = "sha256:4ef4442cea79014487acd7a0d1a2ce55c9d2a42dcd34a307d4c01f2ab477ecfa", size = 324471, upload-time = "2026-04-08T18:04:44.088Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Purpose / Description
`strawberry-graphql` v0.312.2 has a DoS vulnerability in its WebSocket subscription handlers. Both `graphql-transport-ws` and legacy `graphql-ws` protocols allocate an `asyncio.Task` for every incoming `subscribe` message without enforcing any limit. An attacker can open a single WebSocket connection, send `connection_init`, and flood `subscribe` messages to cause OOM or event loop saturation.


## Approach
Pin `strawberry-graphql[fastapi]>=0.314.0` in `pyproject.toml` and update `uv.lock`. Resolved to v0.314.3 which includes the subscription rate limiting fix.

## How Has This Been Tested?

- Verified `uv lock` resolves to `strawberry-graphql==0.314.3`
- Confirmed no breaking API changes between 0.312.2 and 0.314.3
- GraphQL schema and resolvers are unchanged

## Learning (optional, can help others)
- WebSocket-based GraphQL subscriptions need server-side limits on concurrent subscriptions per connection
- A single unauthenticated WebSocket connection can be enough to crash a server without rate limiting
- The fix enforces a configurable maximum number of active subscriptions per WebSocket connection

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
