### PR TITLE
fix(db): resolve duplicate migration revision 0010

### DIFF
--- a/observal-server/alembic/versions/0012_add_username_to_users.py
+++ b/observal-server/alembic/versions/0012_add_username_to_users.py
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision = "0010"
-down_revision = "0009"
+revision = "0012"
+down_revision = "0011"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Purpose / Description
Two migrations landed on main with the same Alembic revision ID `0010` — `0010_add_agents_name_uniqueness.py` and `0010_add_username_to_users.py`. Both claim `down_revision = "0009"`, creating a branched migration history. This causes `docker compose up` to crash on any fresh clone with: `Multiple head revisions are present for given argument 'head'`.

## Fixes
* Fixes migration conflict blocking server startup on fresh deployments

## Approach
Renumber the username migration from `0010` to `0012` and update its `down_revision` from `0009` to `0011`, so the chain becomes linear: `0009 → 0010 (agents name uniqueness) → 0011 (agent review & bundles) → 0012 (username)`. The migration itself is idempotent (uses `information_schema` checks), so the reorder is safe.

## How Has This Been Tested?

- Ran `docker compose up` locally with a fresh database — all 12 migrations run cleanly in sequence
- Health check returns `{"status":"ok","initialized":true,"clickhouse":"ok"}`
- Verified the migration chain has a single head: `0009 → 0010 → 0011 → 0012`

## Learning (optional, can help others)
- When two PRs targeting the same `down_revision` merge independently, Alembic ends up with multiple heads and refuses to run
- Alembic's `information_schema` checks in the username migration make it safe to reorder — it won't fail if the column already exists
- This is a common issue in teams where multiple people add migrations concurrently — consider using Alembic's `merge` command or a CI check that validates single-head history

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
