### PR TITLE
ci: add auto-deploy workflow for EC2 server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-ec2
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script_stop: true
+          script: |
+            cd ~/Observal
+            git pull origin main
+
+            cd docker
+            docker compose up -d --build --remove-orphans
+
+            # Wait for API health check
+            for i in $(seq 1 30); do
+              if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+                echo "API is healthy"
+                exit 0
+              fi
+              echo "Waiting for API... ($i/30)"
+              sleep 5
+            done
+
+            echo "API failed health check"
+            docker compose logs observal-api --tail 30
+            exit 1


### PR DESCRIPTION
## Purpose / Description
Currently the shared EC2 server (used by all 10 team members) requires manual SSH + git pull + docker compose rebuild whenever code is merged to main. This adds a GitHub Actions workflow that automates deployment on every push to main, so the server stays up to date without manual intervention.

## Fixes
* N/A — new feature

## Approach
Uses `appleboy/ssh-action@v1` to SSH into the EC2 instance and run `git pull` + `docker compose up -d --build`. Key design decisions:
- **Data preservation**: only rebuilds containers, never touches Docker volumes — agents, traces, users, and all ClickHouse data persist across deploys
- **Concurrency control**: `concurrency` group prevents overlapping deploys
- **Health check**: waits up to 2.5 minutes for the API `/health` endpoint to respond before marking the deploy as successful
- **Manual trigger**: `workflow_dispatch` allows manual deploys from the Actions tab
- Requires two repository secrets: `EC2_HOST` and `EC2_SSH_KEY`

## How Has This Been Tested?

- Verified the workflow YAML is valid via `actionlint`-style review
- Confirmed `docker compose up -d --build` preserves volumes by running it locally and on the EC2 server multiple times — all agents, traces, and user accounts survived rebuilds
- Health check logic tested manually: API responds within 15-20 seconds after rebuild

## Learning (optional, can help others)
- `appleboy/ssh-action` is the most widely used GitHub Action for SSH deploys (~15k stars), handles key management and connection cleanup
- `docker compose up -d --build` only rebuilds images that changed — unchanged services (postgres, redis, clickhouse) restart instantly from cache
- `--remove-orphans` cleans up containers from services that may have been removed from docker-compose.yml

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
