### PR TITLE
feat: implement remaining PR #338 TODOs

### DIFF
--- a/observal-server/api/routes/bulk.py
+++ b/observal-server/api/routes/bulk.py
@@ -1,6 +1,6 @@
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,9 +18,7 @@ router = APIRouter(prefix="/api/v1/bulk", tags=["bulk"])
 
 async def _agent_name_exists(name: str, user_id, db: AsyncSession) -> bool:
     """Check whether the authenticated user already owns an agent with the given name."""
-    result = await db.execute(
-        select(Agent.id).where(Agent.name == name, Agent.created_by == user_id)
-    )
+    result = await db.execute(select(Agent.id).where(Agent.name == name, Agent.created_by == user_id))
     return result.scalar_one_or_none() is not None
 
 

--- a/observal-server/api/routes/bulk.py
+++ b/observal-server/api/routes/bulk.py
@@ -1,0 +1,143 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import get_db, require_role
+from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus
+from models.agent_component import AgentComponent
+from models.user import User, UserRole
+from schemas.bulk import BulkAgentItem, BulkAgentRequest, BulkResult, BulkResultItem
+from services.registry_telemetry import emit_registry_event
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/bulk", tags=["bulk"])
+
+
+async def _agent_name_exists(name: str, user_id, db: AsyncSession) -> bool:
+    """Check whether the authenticated user already owns an agent with the given name."""
+    result = await db.execute(
+        select(Agent.id).where(Agent.name == name, Agent.created_by == user_id)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _create_single_agent(
+    item: BulkAgentItem,
+    user: User,
+    db: AsyncSession,
+) -> Agent:
+    """Create a single Agent row (with components and goal template) from a BulkAgentItem."""
+    agent = Agent(
+        name=item.name,
+        version=item.version,
+        description=item.description,
+        owner=item.owner or user.email,
+        prompt=item.prompt,
+        model_name=item.model_name,
+        model_config_json=item.model_config_json,
+        external_mcps=item.external_mcps,
+        supported_ides=item.supported_ides,
+        created_by=user.id,
+        status=AgentStatus.pending,
+    )
+    db.add(agent)
+    await db.flush()
+
+    # Attach components
+    for i, comp in enumerate(item.components):
+        db.add(
+            AgentComponent(
+                agent_id=agent.id,
+                component_type=comp.get("component_type", "mcp"),
+                component_id=comp["component_id"],
+                version_ref="latest",
+                order_index=i,
+                config_override=comp.get("config_override"),
+            )
+        )
+
+    # Attach goal template when provided
+    if item.goal_template:
+        goal = AgentGoalTemplate(
+            agent_id=agent.id,
+            description=item.goal_template.get("description", ""),
+        )
+        db.add(goal)
+        await db.flush()
+
+        for j, sec in enumerate(item.goal_template.get("sections", [])):
+            db.add(
+                AgentGoalSection(
+                    goal_template_id=goal.id,
+                    name=sec.get("name", f"section-{j}"),
+                    description=sec.get("description"),
+                    grounding_required=sec.get("grounding_required", False),
+                    order=j,
+                )
+            )
+
+    return agent
+
+
+@router.post("/agents", response_model=BulkResult)
+async def bulk_create_agents(
+    request: BulkAgentRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Create multiple agents in a single request.
+
+    Duplicate names (agents already owned by the caller) are skipped.
+    When ``dry_run=True`` no agents are persisted — the response previews
+    what *would* happen.
+    """
+    results: list[BulkResultItem] = []
+    created = 0
+    skipped = 0
+    errors = 0
+
+    for item in request.agents:
+        # Check for duplicate name
+        if await _agent_name_exists(item.name, current_user.id, db):
+            results.append(
+                BulkResultItem(name=item.name, status="skipped", error="Agent with this name already exists")
+            )
+            skipped += 1
+            continue
+
+        if request.dry_run:
+            results.append(BulkResultItem(name=item.name, status="created"))
+            created += 1
+            continue
+
+        try:
+            agent = await _create_single_agent(item, current_user, db)
+            results.append(BulkResultItem(name=item.name, status="created", agent_id=agent.id))
+            created += 1
+        except Exception as exc:
+            logger.warning("bulk create failed for agent '%s': %s", item.name, exc)
+            results.append(BulkResultItem(name=item.name, status="error", error=str(exc)))
+            errors += 1
+
+    if not request.dry_run and created > 0:
+        await db.commit()
+
+        emit_registry_event(
+            action="agent.bulk_create",
+            user_id=str(current_user.id),
+            user_email=current_user.email,
+            user_role=current_user.role.value,
+            metadata={"total": str(len(request.agents)), "created": str(created), "skipped": str(skipped)},
+        )
+
+    return BulkResult(
+        total=len(request.agents),
+        created=created,
+        skipped=skipped,
+        errors=errors,
+        dry_run=request.dry_run,
+        results=results,
+    )

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -23,8 +23,8 @@ from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
 from api.routes.alert import router as alert_router
 from api.routes.auth import router as auth_router
-from api.routes.component_source import router as component_source_router
 from api.routes.bulk import router as bulk_router
+from api.routes.component_source import router as component_source_router
 from api.routes.config import router as config_router
 from api.routes.dashboard import router as dashboard_router
 from api.routes.eval import router as eval_router

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -24,6 +24,7 @@ from api.routes.agent import router as agent_router
 from api.routes.alert import router as alert_router
 from api.routes.auth import router as auth_router
 from api.routes.component_source import router as component_source_router
+from api.routes.bulk import router as bulk_router
 from api.routes.config import router as config_router
 from api.routes.dashboard import router as dashboard_router
 from api.routes.eval import router as eval_router
@@ -206,6 +207,7 @@ app.include_router(admin_router)
 app.include_router(alert_router)
 app.include_router(otel_dashboard_router)
 app.include_router(component_source_router)
+app.include_router(bulk_router)
 app.include_router(config_router)
 
 

--- a/observal-server/schemas/bulk.py
+++ b/observal-server/schemas/bulk.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, Field
+
+
+class BulkAgentItem(BaseModel):
+    """Single agent in a bulk create request. Extends AgentCreateRequest fields with relaxed defaults."""
+
+    name: str
+    version: str = "1.0.0"
+    description: str = ""
+    owner: str = ""
+    prompt: str = ""
+    model_name: str = "claude-sonnet-4"
+    model_config_json: dict = {}
+    supported_ides: list[str] = []
+    components: list[dict] = []  # [{component_type, component_id}]
+    external_mcps: list[dict] = []
+    goal_template: dict | None = None
+
+
+class BulkAgentRequest(BaseModel):
+    agents: list[BulkAgentItem] = Field(min_length=1, max_length=50)
+    dry_run: bool = False
+
+
+class BulkResultItem(BaseModel):
+    name: str
+    status: str  # "created", "skipped", "error"
+    agent_id: uuid.UUID | None = None
+    error: str | None = None
+
+
+class BulkResult(BaseModel):
+    total: int
+    created: int
+    skipped: int
+    errors: int
+    dry_run: bool
+    results: list[BulkResultItem]

--- a/observal-server/schemas/bulk.py
+++ b/observal-server/schemas/bulk.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import uuid
+import uuid  # noqa: TC003 — needed at runtime by Pydantic
 
 from pydantic import BaseModel, Field
 

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -254,7 +254,7 @@ def agent_bulk_create(
     elif isinstance(raw, dict) and "agents" in raw:
         agents = raw["agents"]
     else:
-        rprint("[red]Error:[/red] JSON must be {\"agents\": [...]} or a bare array.")
+        rprint('[red]Error:[/red] JSON must be {"agents": [...]} or a bare array.')
         raise typer.Exit(code=1)
 
     if not agents:
@@ -291,8 +291,10 @@ def agent_bulk_create(
         results_table.add_column("Error", style="red")
         for i, item in enumerate(result.get("results", []), 1):
             status = item.get("status", "")
-            badge = "[green]created[/green]" if status == "created" else (
-                "[yellow]skipped[/yellow]" if status == "skipped" else f"[red]{status}[/red]"
+            badge = (
+                "[green]created[/green]"
+                if status == "created"
+                else ("[yellow]skipped[/yellow]" if status == "skipped" else f"[red]{status}[/red]")
             )
             results_table.add_row(str(i), item.get("name", ""), badge, item.get("error", "") or "")
         console.print(results_table)
@@ -304,10 +306,9 @@ def agent_bulk_create(
         return
 
     # ── Confirmation ─────────────────────────────────────────
-    if not yes:
-        if not typer.confirm(f"\nCreate {len(agents)} agents?", default=False):
-            rprint("[yellow]Aborted.[/yellow]")
-            raise typer.Exit(0)
+    if not yes and not typer.confirm(f"\nCreate {len(agents)} agents?", default=False):
+        rprint("[yellow]Aborted.[/yellow]")
+        raise typer.Exit(0)
 
     # ── Create ───────────────────────────────────────────────
     with spinner("Creating agents..."):
@@ -321,8 +322,10 @@ def agent_bulk_create(
     results_table.add_column("Error", style="red")
     for i, item in enumerate(result.get("results", []), 1):
         status = item.get("status", "")
-        badge = "[green]created[/green]" if status == "created" else (
-            "[yellow]skipped[/yellow]" if status == "skipped" else f"[red]{status}[/red]"
+        badge = (
+            "[green]created[/green]"
+            if status == "created"
+            else ("[yellow]skipped[/yellow]" if status == "skipped" else f"[red]{status}[/red]")
         )
         agent_id = str(item["agent_id"])[:8] + "…" if item.get("agent_id") else ""
         results_table.add_row(str(i), item.get("name", ""), badge, agent_id, item.get("error", "") or "")

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -227,6 +227,114 @@ def agent_create(
     rprint(f"[yellow]Status: {status} — an admin must approve it before it becomes visible.[/yellow]")
 
 
+@agent_app.command(name="bulk-create")
+def agent_bulk_create(
+    file_path: str = typer.Option(..., "--from-file", help="JSON file with agent definitions"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without creating"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+):
+    """Bulk-create agents from a JSON file."""
+    import json
+
+    path = Path(file_path)
+    if not path.exists():
+        rprint(f"[red]Error:[/red] File not found: {file_path}")
+        raise typer.Exit(code=1)
+
+    try:
+        with open(path) as f:
+            raw = json.load(f)
+    except json.JSONDecodeError as exc:
+        rprint(f"[red]Error:[/red] Invalid JSON: {exc}")
+        raise typer.Exit(code=1)
+
+    # Accept {"agents": [...]} or bare [...]
+    if isinstance(raw, list):
+        agents = raw
+    elif isinstance(raw, dict) and "agents" in raw:
+        agents = raw["agents"]
+    else:
+        rprint("[red]Error:[/red] JSON must be {\"agents\": [...]} or a bare array.")
+        raise typer.Exit(code=1)
+
+    if not agents:
+        rprint("[yellow]No agents found in file.[/yellow]")
+        raise typer.Exit(code=1)
+
+    # ── Preview table ────────────────────────────────────────
+    preview = Table(title=f"Agents to create ({len(agents)})", show_lines=False, padding=(0, 1))
+    preview.add_column("#", style="dim", width=3)
+    preview.add_column("Name", style="bold cyan", no_wrap=True)
+    preview.add_column("Version", style="green")
+    preview.add_column("Components")
+    preview.add_column("Model")
+    for i, ag in enumerate(agents, 1):
+        comp_count = str(len(ag.get("components", [])))
+        preview.add_row(
+            str(i),
+            ag.get("name", "unnamed"),
+            ag.get("version", "1.0.0"),
+            comp_count,
+            ag.get("model_name", "claude-sonnet-4"),
+        )
+    console.print(preview)
+
+    # ── Dry-run mode ─────────────────────────────────────────
+    if dry_run:
+        with spinner("Running dry-run..."):
+            result = client.post("/api/v1/bulk/agents", {"agents": agents, "dry_run": True})
+
+        results_table = Table(title="Dry-run results", show_lines=False, padding=(0, 1))
+        results_table.add_column("#", style="dim", width=3)
+        results_table.add_column("Name", style="bold cyan", no_wrap=True)
+        results_table.add_column("Status")
+        results_table.add_column("Error", style="red")
+        for i, item in enumerate(result.get("results", []), 1):
+            status = item.get("status", "")
+            badge = "[green]created[/green]" if status == "created" else (
+                "[yellow]skipped[/yellow]" if status == "skipped" else f"[red]{status}[/red]"
+            )
+            results_table.add_row(str(i), item.get("name", ""), badge, item.get("error", "") or "")
+        console.print(results_table)
+
+        rprint(
+            f"\n[bold]Summary:[/bold] {result.get('created', 0)} would be created, "
+            f"{result.get('skipped', 0)} skipped, {result.get('errors', 0)} errors"
+        )
+        return
+
+    # ── Confirmation ─────────────────────────────────────────
+    if not yes:
+        if not typer.confirm(f"\nCreate {len(agents)} agents?", default=False):
+            rprint("[yellow]Aborted.[/yellow]")
+            raise typer.Exit(0)
+
+    # ── Create ───────────────────────────────────────────────
+    with spinner("Creating agents..."):
+        result = client.post("/api/v1/bulk/agents", {"agents": agents, "dry_run": False})
+
+    results_table = Table(title="Bulk create results", show_lines=False, padding=(0, 1))
+    results_table.add_column("#", style="dim", width=3)
+    results_table.add_column("Name", style="bold cyan", no_wrap=True)
+    results_table.add_column("Status")
+    results_table.add_column("Agent ID", style="dim")
+    results_table.add_column("Error", style="red")
+    for i, item in enumerate(result.get("results", []), 1):
+        status = item.get("status", "")
+        badge = "[green]created[/green]" if status == "created" else (
+            "[yellow]skipped[/yellow]" if status == "skipped" else f"[red]{status}[/red]"
+        )
+        agent_id = str(item["agent_id"])[:8] + "…" if item.get("agent_id") else ""
+        results_table.add_row(str(i), item.get("name", ""), badge, agent_id, item.get("error", "") or "")
+    console.print(results_table)
+
+    rprint(
+        f"\n[green]✓ Bulk create complete![/green] "
+        f"{result.get('created', 0)} created, {result.get('skipped', 0)} skipped, "
+        f"{result.get('errors', 0)} errors"
+    )
+
+
 @agent_app.command(name="list")
 def agent_list(
     search: str | None = typer.Option(None, "--search", "-s"),

--- a/tests/test_agent_review.py
+++ b/tests/test_agent_review.py
@@ -133,9 +133,7 @@ class TestAgentApprove:
         component_result = MagicMock()
         component_result.all.return_value = [blocking_row]
 
-        db.execute = AsyncMock(
-            side_effect=[_result_with_agent(agent), component_result]
-        )
+        db.execute = AsyncMock(side_effect=[_result_with_agent(agent), component_result])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(f"/api/v1/review/agents/{agent.id}/approve")

--- a/tests/test_agent_review.py
+++ b/tests/test_agent_review.py
@@ -1,0 +1,251 @@
+"""Tests for agent review workflow (approve/reject via review endpoints).
+
+Covers approval with component readiness checks, rejection with reason,
+and 404 handling for nonexistent agents.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import get_current_user, get_db
+from api.routes.review import router
+from models.agent import AgentStatus
+from models.user import User, UserRole
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+def _user(**kw):
+    u = MagicMock(spec=User)
+    u.id = kw.get("id", uuid.uuid4())
+    u.role = kw.get("role", UserRole.admin)
+    return u
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.delete = MagicMock()
+    return db
+
+
+def _app_with(user=None, db=None):
+    user = user or _user()
+    db = db or _mock_db()
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app, db, user
+
+
+def _agent_mock(status=AgentStatus.pending, **extra):
+    """Return a MagicMock that looks like an Agent ORM instance."""
+    m = MagicMock()
+    m.id = extra.get("id", uuid.uuid4())
+    m.name = extra.get("name", "test-agent")
+    m.version = extra.get("version", "1.0.0")
+    m.description = extra.get("description", "A test agent")
+    m.owner = extra.get("owner", "testowner")
+    m.status = status
+    m.rejection_reason = None
+    m.created_by = extra.get("created_by", uuid.uuid4())
+    m.created_at = datetime.now(UTC)
+    m.updated_at = datetime.now(UTC)
+    m.components = extra.get("components", [])
+    for k, v in extra.items():
+        setattr(m, k, v)
+    return m
+
+
+def _empty_result():
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = []
+    r.scalar_one_or_none.return_value = None
+    return r
+
+
+def _result_with_agent(agent):
+    """Return a mock result that yields the agent via scalar_one_or_none."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = agent
+    r.scalars.return_value.all.return_value = [agent]
+    return r
+
+
+# ═══════════════════════════════════════════════════════════
+# approve_agent (POST /api/v1/review/agents/{id}/approve)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestAgentApprove:
+    """Test agent approval via review endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_sets_status_to_active(self):
+        """Approving a pending agent with all components ready sets status to active."""
+        app, db, _ = _app_with()
+        agent = _agent_mock(status=AgentStatus.pending, components=[])
+
+        # First execute: select Agent -> returns agent
+        # The endpoint uses selectinload, so scalar_one_or_none is the path
+        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/review/agents/{agent.id}/approve")
+
+        assert r.status_code == 200
+        assert agent.status == AgentStatus.active
+        assert r.json()["status"] == "active"
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_422_when_components_not_ready(self):
+        """Approving an agent with unapproved components returns 422."""
+        app, db, _ = _app_with()
+
+        comp = MagicMock()
+        comp.component_type = "mcp"
+        comp.component_id = uuid.uuid4()
+        agent = _agent_mock(status=AgentStatus.pending, components=[comp])
+
+        # First call: select Agent -> agent
+        # Second call: select component status -> component not approved
+        blocking_row = MagicMock()
+        blocking_row.id = comp.component_id
+        blocking_row.name = "unapproved-mcp"
+        blocking_row.status = MagicMock()
+        blocking_row.status.value = "pending"
+        # The status comparison != ListingStatus.approved should be truthy
+        from models.mcp import ListingStatus
+
+        blocking_row.status = ListingStatus.pending
+
+        component_result = MagicMock()
+        component_result.all.return_value = [blocking_row]
+
+        db.execute = AsyncMock(
+            side_effect=[_result_with_agent(agent), component_result]
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/review/agents/{agent.id}/approve")
+
+        assert r.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_response_includes_id_and_name(self):
+        """Approval response includes agent id, name, and status."""
+        app, db, _ = _app_with()
+        agent = _agent_mock(status=AgentStatus.pending, name="my-agent", components=[])
+        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/review/agents/{agent.id}/approve")
+
+        data = r.json()
+        assert data["name"] == "my-agent"
+        assert data["id"] == str(agent.id)
+        assert data["status"] == "active"
+
+
+# ═══════════════════════════════════════════════════════════
+# reject_agent (POST /api/v1/review/agents/{id}/reject)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestAgentReject:
+    """Test agent rejection via review endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_sets_status_and_stores_reason(self):
+        """Rejecting a pending agent stores the rejection reason."""
+        app, db, _ = _app_with()
+        agent = _agent_mock(status=AgentStatus.pending)
+        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                f"/api/v1/review/agents/{agent.id}/reject",
+                json={"reason": "missing documentation"},
+            )
+
+        assert r.status_code == 200
+        assert agent.status == AgentStatus.rejected
+        assert agent.rejection_reason == "missing documentation"
+        assert r.json()["status"] == "rejected"
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reject_active_agent(self):
+        """An active agent can also be rejected."""
+        app, db, _ = _app_with()
+        agent = _agent_mock(status=AgentStatus.active)
+        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                f"/api/v1/review/agents/{agent.id}/reject",
+                json={"reason": "policy violation"},
+            )
+
+        assert r.status_code == 200
+        assert agent.status == AgentStatus.rejected
+
+    @pytest.mark.asyncio
+    async def test_reject_draft_agent_returns_400(self):
+        """Rejecting a draft agent is not allowed (status must be pending or active)."""
+        app, db, _ = _app_with()
+        agent = _agent_mock(status=AgentStatus.draft)
+        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                f"/api/v1/review/agents/{agent.id}/reject",
+                json={"reason": "nope"},
+            )
+
+        assert r.status_code == 400
+
+
+# ═══════════════════════════════════════════════════════════
+# Not found (404)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestAgentNotFound:
+    """Test 404 for nonexistent agent in review endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_approve_not_found(self):
+        """Approving a nonexistent agent returns 404."""
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/review/agents/{uuid.uuid4()}/approve")
+
+        assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_reject_not_found(self):
+        """Rejecting a nonexistent agent returns 404."""
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                f"/api/v1/review/agents/{uuid.uuid4()}/reject",
+                json={"reason": "bad"},
+            )
+
+        assert r.status_code == 404

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -7,7 +7,7 @@ and validation of empty requests.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -191,9 +191,7 @@ class TestBulkDedup:
         app, db, _ = _app_with()
 
         # First agent name exists, second does not
-        db.execute = AsyncMock(
-            side_effect=[_exists_result(), _empty_result()]
-        )
+        db.execute = AsyncMock(side_effect=[_exists_result(), _empty_result()])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -1,0 +1,265 @@
+"""Tests for bulk agent creation endpoint.
+
+Covers successful creation, dry-run preview, duplicate deduplication,
+and validation of empty requests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import get_current_user, get_db
+from api.routes.bulk import router
+from models.user import User, UserRole
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+def _user(**kw):
+    u = MagicMock(spec=User)
+    u.id = kw.get("id", uuid.uuid4())
+    u.role = kw.get("role", UserRole.user)
+    u.email = kw.get("email", "test@example.com")
+    u.name = kw.get("name", "Test User")
+    u.username = kw.get("username", "testuser")
+    return u
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.delete = MagicMock()
+    db.flush = AsyncMock()
+    return db
+
+
+def _app_with(user=None, db=None):
+    user = user or _user()
+    db = db or _mock_db()
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app, db, user
+
+
+def _empty_result():
+    """DB result that returns None for scalar_one_or_none (name not found)."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = None
+    return r
+
+
+def _exists_result():
+    """DB result that returns a truthy value (name already exists)."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = uuid.uuid4()
+    return r
+
+
+def _agent_item(name: str, **overrides) -> dict:
+    """Build a minimal bulk agent item dict."""
+    item = {"name": name}
+    item.update(overrides)
+    return item
+
+
+# ═══════════════════════════════════════════════════════════
+# bulk_create_agents (POST /api/v1/bulk/agents)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestBulkCreate:
+    """Test successful bulk agent creation."""
+
+    @pytest.mark.asyncio
+    async def test_creates_multiple_agents(self):
+        """Posting multiple agents returns correct created counts."""
+        app, db, _ = _app_with()
+
+        # Each agent triggers a name-existence check (returns not found)
+        # then _create_single_agent does flush calls
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/bulk/agents",
+                json={
+                    "agents": [
+                        _agent_item("agent-one"),
+                        _agent_item("agent-two"),
+                        _agent_item("agent-three"),
+                    ]
+                },
+            )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 3
+        assert data["created"] == 3
+        assert data["skipped"] == 0
+        assert data["errors"] == 0
+        assert data["dry_run"] is False
+        assert len(data["results"]) == 3
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_response_results_have_correct_status(self):
+        """Each result item shows status='created'."""
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/bulk/agents",
+                json={"agents": [_agent_item("new-agent")]},
+            )
+
+        assert r.status_code == 200
+        result = r.json()["results"][0]
+        assert result["name"] == "new-agent"
+        assert result["status"] == "created"
+
+
+# ═══════════════════════════════════════════════════════════
+# Dry run
+# ═══════════════════════════════════════════════════════════
+
+
+class TestBulkDryRun:
+    """Test dry_run=true returns preview without persisting."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_preview(self):
+        """With dry_run=True, agents are previewed but not committed."""
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/bulk/agents",
+                json={
+                    "agents": [_agent_item("preview-agent")],
+                    "dry_run": True,
+                },
+            )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["dry_run"] is True
+        assert data["created"] == 1
+        # Commit should NOT be called in dry-run mode
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_no_agent_ids(self):
+        """Dry-run results should not include agent_id values."""
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/bulk/agents",
+                json={
+                    "agents": [_agent_item("dry-agent")],
+                    "dry_run": True,
+                },
+            )
+
+        result = r.json()["results"][0]
+        assert result["agent_id"] is None
+
+
+# ═══════════════════════════════════════════════════════════
+# Deduplication
+# ═══════════════════════════════════════════════════════════
+
+
+class TestBulkDedup:
+    """Test that agents with duplicate names are skipped."""
+
+    @pytest.mark.asyncio
+    async def test_skips_duplicate_names(self):
+        """Agents with names that already exist for the user are skipped."""
+        app, db, _ = _app_with()
+
+        # First agent name exists, second does not
+        db.execute = AsyncMock(
+            side_effect=[_exists_result(), _empty_result()]
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/bulk/agents",
+                json={
+                    "agents": [
+                        _agent_item("existing-agent"),
+                        _agent_item("new-agent"),
+                    ]
+                },
+            )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["created"] == 1
+        assert data["skipped"] == 1
+        assert data["results"][0]["status"] == "skipped"
+        assert data["results"][1]["status"] == "created"
+
+    @pytest.mark.asyncio
+    async def test_skipped_result_includes_error_message(self):
+        """Skipped results include an error message explaining the skip."""
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_exists_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/bulk/agents",
+                json={"agents": [_agent_item("dup-agent")]},
+            )
+
+        result = r.json()["results"][0]
+        assert result["status"] == "skipped"
+        assert result["error"] is not None
+
+
+# ═══════════════════════════════════════════════════════════
+# Validation
+# ═══════════════════════════════════════════════════════════
+
+
+class TestBulkValidation:
+    """Test request validation for bulk endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_agent_list(self):
+        """An empty agents list returns 422."""
+        app, db, _ = _app_with()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/bulk/agents",
+                json={"agents": []},
+            )
+
+        assert r.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_agents_field(self):
+        """Missing agents field returns 422."""
+        app, db, _ = _app_with()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/bulk/agents",
+                json={},
+            )
+
+        assert r.status_code == 422

--- a/tests/test_bundles.py
+++ b/tests/test_bundles.py
@@ -1,0 +1,264 @@
+"""Tests for bundle review endpoints (atomic approve/reject).
+
+Covers approval and rejection of all listings in a bundle atomically,
+and 404 handling for nonexistent bundles.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import get_current_user, get_db
+from api.routes.review import router
+from models.mcp import ListingStatus
+from models.user import User, UserRole
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+def _user(**kw):
+    u = MagicMock(spec=User)
+    u.id = kw.get("id", uuid.uuid4())
+    u.role = kw.get("role", UserRole.admin)
+    return u
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.delete = MagicMock()
+    return db
+
+
+def _app_with(user=None, db=None):
+    user = user or _user()
+    db = db or _mock_db()
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app, db, user
+
+
+def _bundle_mock(**extra):
+    """Return a MagicMock that looks like a ComponentBundle ORM instance."""
+    m = MagicMock()
+    m.id = extra.get("id", uuid.uuid4())
+    m.name = extra.get("name", "test-bundle")
+    m.description = extra.get("description", "A test bundle")
+    m.submitted_by = extra.get("submitted_by", uuid.uuid4())
+    m.created_at = datetime.now(UTC)
+    return m
+
+
+def _listing_mock(status=ListingStatus.pending, **extra):
+    """Return a MagicMock that looks like a listing ORM instance."""
+    m = MagicMock()
+    m.id = extra.get("id", uuid.uuid4())
+    m.name = extra.get("name", "test-listing")
+    m.status = status
+    m.rejection_reason = None
+    m.bundle_id = extra.get("bundle_id", uuid.uuid4())
+    m.submitted_by = uuid.uuid4()
+    m.created_at = datetime.now(UTC)
+    m.updated_at = datetime.now(UTC)
+    return m
+
+
+def _empty_result():
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = []
+    r.scalar_one_or_none.return_value = None
+    return r
+
+
+def _result_with_one(obj):
+    """Result that returns obj via scalar_one_or_none."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = obj
+    r.scalars.return_value.all.return_value = [obj]
+    return r
+
+
+def _result_with_listings(*listings):
+    """Result that returns listings via scalars().all()."""
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = list(listings)
+    r.scalar_one_or_none.return_value = listings[0] if listings else None
+    return r
+
+
+# ═══════════════════════════════════════════════════════════
+# approve_bundle (POST /api/v1/review/bundles/{id}/approve)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestBundleApprove:
+    """Test bundle approval atomically approves all listings."""
+
+    @pytest.mark.asyncio
+    async def test_approves_all_listings(self):
+        """Approving a bundle sets all associated listings to approved."""
+        app, db, _ = _app_with()
+        bundle = _bundle_mock()
+        listing_a = _listing_mock(bundle_id=bundle.id, name="listing-a")
+        listing_b = _listing_mock(bundle_id=bundle.id, name="listing-b")
+
+        # First call: select bundle by id -> bundle found
+        # Next 5 calls: one per listing model type -> only first returns listings
+        db.execute = AsyncMock(
+            side_effect=[
+                _result_with_one(bundle),
+                _result_with_listings(listing_a, listing_b),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+            ]
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/review/bundles/{bundle.id}/approve")
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["bundle_id"] == str(bundle.id)
+        assert data["approved_count"] == 2
+        assert listing_a.status == ListingStatus.approved
+        assert listing_b.status == ListingStatus.approved
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_approve_empty_bundle_returns_zero_count(self):
+        """Approving a bundle with no listings returns approved_count=0."""
+        app, db, _ = _app_with()
+        bundle = _bundle_mock()
+
+        db.execute = AsyncMock(
+            side_effect=[
+                _result_with_one(bundle),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+            ]
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/review/bundles/{bundle.id}/approve")
+
+        assert r.status_code == 200
+        assert r.json()["approved_count"] == 0
+
+
+# ═══════════════════════════════════════════════════════════
+# reject_bundle (POST /api/v1/review/bundles/{id}/reject)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestBundleReject:
+    """Test bundle rejection atomically rejects all listings."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_all_with_shared_reason(self):
+        """Rejecting a bundle sets all listings to rejected with the given reason."""
+        app, db, _ = _app_with()
+        bundle = _bundle_mock()
+        listing_a = _listing_mock(bundle_id=bundle.id, name="listing-a")
+        listing_b = _listing_mock(bundle_id=bundle.id, name="listing-b")
+
+        db.execute = AsyncMock(
+            side_effect=[
+                _result_with_one(bundle),
+                _result_with_listings(listing_a, listing_b),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+            ]
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                f"/api/v1/review/bundles/{bundle.id}/reject",
+                json={"reason": "fails security review"},
+            )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["rejected_count"] == 2
+        assert listing_a.status == ListingStatus.rejected
+        assert listing_a.rejection_reason == "fails security review"
+        assert listing_b.status == ListingStatus.rejected
+        assert listing_b.rejection_reason == "fails security review"
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reject_with_no_reason(self):
+        """Rejecting with reason=None still transitions statuses."""
+        app, db, _ = _app_with()
+        bundle = _bundle_mock()
+        listing = _listing_mock(bundle_id=bundle.id)
+
+        db.execute = AsyncMock(
+            side_effect=[
+                _result_with_one(bundle),
+                _result_with_listings(listing),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+                _empty_result(),
+            ]
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                f"/api/v1/review/bundles/{bundle.id}/reject",
+                json={"reason": None},
+            )
+
+        assert r.status_code == 200
+        assert listing.status == ListingStatus.rejected
+
+
+# ═══════════════════════════════════════════════════════════
+# Not found (404)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestBundleNotFound:
+    """Test 404 for nonexistent bundle in review endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_approve_not_found(self):
+        """Approving a nonexistent bundle returns 404."""
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/review/bundles/{uuid.uuid4()}/approve")
+
+        assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_reject_not_found(self):
+        """Rejecting a nonexistent bundle returns 404."""
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                f"/api/v1/review/bundles/{uuid.uuid4()}/reject",
+                json={"reason": "bad"},
+            )
+
+        assert r.status_code == 404

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -1,0 +1,334 @@
+"""Tests for the draft agent lifecycle (save, update, submit).
+
+Covers creating a draft, updating it, submitting for review,
+and error handling when agent is not in draft status.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import get_current_user, get_db
+from api.routes.agent import router
+from models.agent import AgentStatus
+from models.user import User, UserRole
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+def _user(**kw):
+    u = MagicMock(spec=User)
+    u.id = kw.get("id", uuid.uuid4())
+    u.role = kw.get("role", UserRole.user)
+    u.email = kw.get("email", "test@example.com")
+    u.username = kw.get("username", "testuser")
+    return u
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.delete = MagicMock()
+    db.flush = AsyncMock()
+    return db
+
+
+def _app_with(user=None, db=None):
+    user = user or _user()
+    db = db or _mock_db()
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app, db, user
+
+
+def _agent_mock(status=AgentStatus.draft, created_by=None, **extra):
+    """Return a MagicMock that looks like an Agent ORM instance."""
+    m = MagicMock()
+    m.id = extra.get("id", uuid.uuid4())
+    m.name = extra.get("name", "test-agent")
+    m.version = extra.get("version", "1.0.0")
+    m.description = extra.get("description", "A test agent")
+    m.owner = extra.get("owner", "testowner")
+    m.prompt = extra.get("prompt", "Test prompt")
+    m.model_name = extra.get("model_name", "claude-sonnet-4")
+    m.model_config_json = {}
+    m.external_mcps = []
+    m.supported_ides = []
+    m.status = status
+    m.rejection_reason = None
+    m.download_count = 0
+    m.unique_users = 0
+    m.is_private = False
+    m.owner_org_id = None
+    m.git_url = None
+    m.created_by = created_by or uuid.uuid4()
+    m.created_at = datetime.now(UTC)
+    m.updated_at = datetime.now(UTC)
+    m.components = extra.get("components", [])
+    m.goal_template = extra.get("goal_template", None)
+    # Make __table__.columns iterable for _agent_to_response
+    col_keys = [
+        "id", "name", "version", "description", "owner", "git_url",
+        "prompt", "model_name", "model_config_json", "external_mcps",
+        "supported_ides", "is_private", "owner_org_id", "status",
+        "rejection_reason", "download_count", "unique_users",
+        "created_by", "created_at", "updated_at",
+    ]
+    cols = []
+    for key in col_keys:
+        col = MagicMock()
+        col.key = key
+        cols.append(col)
+    m.__table__ = MagicMock()
+    m.__table__.columns = cols
+    return m
+
+
+def _draft_request_body(**overrides) -> dict:
+    """Build a minimal AgentCreateRequest body for the draft endpoint."""
+    body = {
+        "name": "my-draft-agent",
+        "version": "1.0.0",
+        "description": "Draft agent",
+        "owner": "testowner",
+        "prompt": "Do things",
+        "model_name": "claude-sonnet-4",
+        "goal_template": {
+            "description": "Test goal",
+            "sections": [{"name": "section-1"}],
+        },
+    }
+    body.update(overrides)
+    return body
+
+
+def _empty_result():
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = []
+    r.scalar_one_or_none.return_value = None
+    return r
+
+
+def _result_with_agent(agent):
+    """Return a mock result that yields the agent via scalar_one_or_none."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = agent
+    r.scalars.return_value.all.return_value = [agent]
+    return r
+
+
+# ═══════════════════════════════════════════════════════════
+# save_draft (POST /api/v1/agents/draft)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDraftSave:
+    """Test creating a new draft agent."""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent._load_agent")
+    async def test_creates_agent_with_draft_status(self, mock_load):
+        """POST /agents/draft creates an agent in draft status."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/agents/draft",
+                json=_draft_request_body(),
+            )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "draft"
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent._load_agent")
+    async def test_response_includes_agent_fields(self, mock_load):
+        """Draft response includes id, name, and status fields."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, name="my-draft-agent", created_by=user.id)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/agents/draft",
+                json=_draft_request_body(),
+            )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["name"] == "my-draft-agent"
+        assert "id" in data
+
+
+# ═══════════════════════════════════════════════════════════
+# update_draft (PUT /api/v1/agents/{id}/draft)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDraftUpdate:
+    """Test updating a draft agent."""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent._load_agent")
+    async def test_updates_draft_fields(self, mock_load):
+        """PUT /agents/{id}/draft updates the draft agent."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(
+                f"/api/v1/agents/{agent.id}/draft",
+                json={"description": "Updated draft description"},
+            )
+
+        assert r.status_code == 200
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent._load_agent")
+    async def test_rejects_update_on_non_draft(self, mock_load):
+        """Updating a non-draft agent returns 400."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.pending, created_by=user.id)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(
+                f"/api/v1/agents/{agent.id}/draft",
+                json={"description": "Nope"},
+            )
+
+        assert r.status_code == 400
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent._load_agent")
+    async def test_rejects_update_by_non_owner(self, mock_load):
+        """Non-owner cannot update a draft agent (403)."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=uuid.uuid4())
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(
+                f"/api/v1/agents/{agent.id}/draft",
+                json={"description": "Not my agent"},
+            )
+
+        assert r.status_code == 403
+
+
+# ═══════════════════════════════════════════════════════════
+# submit_draft (POST /api/v1/agents/{id}/submit)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDraftSubmit:
+    """Test submitting a draft for review."""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent.emit_registry_event")
+    @patch("api.routes.agent._resolve_component_names")
+    @patch("api.routes.agent._load_agent")
+    async def test_transitions_to_pending(self, mock_load, mock_resolve, mock_emit):
+        """POST /agents/{id}/submit transitions a draft to pending status."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id, components=[])
+        mock_load.return_value = agent
+        mock_resolve.return_value = {}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        assert r.status_code == 200
+        assert agent.status == AgentStatus.pending
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent.emit_registry_event")
+    @patch("api.routes.agent._resolve_component_names")
+    @patch("api.routes.agent._load_agent")
+    async def test_submit_response_includes_status(self, mock_load, mock_resolve, mock_emit):
+        """Submit response body includes the new pending status."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id, components=[])
+        # After status change, _load_agent is called again; return the same agent
+        mock_load.return_value = agent
+        mock_resolve.return_value = {}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        data = r.json()
+        assert data["status"] == "pending"
+
+
+# ═══════════════════════════════════════════════════════════
+# Submit non-draft (error cases)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDraftSubmitNotDraft:
+    """Test submitting a non-draft agent returns an error."""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent._load_agent")
+    async def test_submit_pending_returns_400(self, mock_load):
+        """Submitting a pending agent returns 400."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.pending, created_by=user.id)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        assert r.status_code == 400
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent._load_agent")
+    async def test_submit_active_returns_400(self, mock_load):
+        """Submitting an active agent returns 400."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.active, created_by=user.id)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        assert r.status_code == 400
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent._load_agent")
+    async def test_submit_not_found_returns_404(self, mock_load):
+        """Submitting a nonexistent agent returns 404."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        mock_load.return_value = None
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{uuid.uuid4()}/submit")
+
+        assert r.status_code == 404

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -75,14 +75,29 @@ def _agent_mock(status=AgentStatus.draft, created_by=None, **extra):
     m.created_at = datetime.now(UTC)
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
-    m.goal_template = extra.get("goal_template", None)
+    m.goal_template = extra.get("goal_template")
     # Make __table__.columns iterable for _agent_to_response
     col_keys = [
-        "id", "name", "version", "description", "owner", "git_url",
-        "prompt", "model_name", "model_config_json", "external_mcps",
-        "supported_ides", "is_private", "owner_org_id", "status",
-        "rejection_reason", "download_count", "unique_users",
-        "created_by", "created_at", "updated_at",
+        "id",
+        "name",
+        "version",
+        "description",
+        "owner",
+        "git_url",
+        "prompt",
+        "model_name",
+        "model_config_json",
+        "external_mcps",
+        "supported_ides",
+        "is_private",
+        "owner_org_id",
+        "status",
+        "rejection_reason",
+        "download_count",
+        "unique_users",
+        "created_by",
+        "created_at",
+        "updated_at",
     ]
     cols = []
     for key in col_keys:

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -3,23 +3,44 @@ import { Page } from "@playwright/test";
 /** Base URL for the Observal API */
 export const API_BASE = process.env.API_BASE ?? "http://localhost:8000";
 
-/** Get the API key from the Observal config */
-export async function getApiKey(): Promise<string> {
-  const { execSync } = await import("child_process");
-  const config = JSON.parse(
-    execSync("cat ~/.observal/config.json", { encoding: "utf-8" }),
-  );
-  return config.api_key;
+let _cachedToken: string | null = null;
+
+/** Get an access token by logging in with demo admin credentials (cached per worker) */
+export async function getAccessToken(): Promise<string> {
+  if (_cachedToken) return _cachedToken;
+  const email = process.env.DEMO_ADMIN_EMAIL ?? "admin@demo.example";
+  const password = process.env.DEMO_ADMIN_PASSWORD ?? "admin-changeme";
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const res = await fetch(`${API_BASE}/api/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    const data = await res.json();
+    if (data.access_token) {
+      _cachedToken = data.access_token;
+      return _cachedToken;
+    }
+    if (res.status === 429) {
+      await new Promise((r) => setTimeout(r, 15_000));
+      continue;
+    }
+    throw new Error(`Login failed: ${JSON.stringify(data)}`);
+  }
+  throw new Error("Login failed after retries");
 }
+
+/** @deprecated Use getAccessToken */
+export const getApiKey = getAccessToken;
 
 /** Login to the web UI by setting localStorage */
 export async function loginToWebUI(page: Page) {
-  const apiKey = await getApiKey();
+  const token = await getAccessToken();
   await page.goto("/");
-  await page.evaluate((key) => {
-    localStorage.setItem("observal_api_key", key);
+  await page.evaluate((t) => {
+    localStorage.setItem("observal_access_token", t);
     localStorage.setItem("observal_user_role", "admin");
-  }, apiKey);
+  }, token);
   await page.reload();
 }
 

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -19,7 +19,7 @@ export async function getAccessToken(): Promise<string> {
     const data = await res.json();
     if (data.access_token) {
       _cachedToken = data.access_token;
-      return _cachedToken;
+      return data.access_token as string;
     }
     if (res.status === 429) {
       await new Promise((r) => setTimeout(r, 15_000));

--- a/web/e2e/kiro-cli.spec.ts
+++ b/web/e2e/kiro-cli.spec.ts
@@ -9,6 +9,17 @@ function run(cmd: string): string {
 }
 
 test.describe("Kiro CLI Commands", () => {
+  test.beforeAll(() => {
+    try {
+      execSync(
+        'observal auth login --server http://localhost:8000 --email admin@demo.example --password admin-changeme 2>&1',
+        { encoding: "utf-8", timeout: CLI_TIMEOUT, cwd: CWD },
+      );
+    } catch {
+      // login may fail if already configured — that's fine
+    }
+  });
+
   test("observal doctor --ide kiro runs without errors", () => {
     const output = run("observal doctor --ide kiro 2>&1 || true");
     // Doctor should run and produce output (may have warnings, but shouldn't crash)

--- a/web/e2e/kiro-hooks.spec.ts
+++ b/web/e2e/kiro-hooks.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { sendKiroHookEvent, API_BASE } from "./helpers";
+import { sendKiroHookEvent, getAccessToken, API_BASE } from "./helpers";
 
 test.describe("Kiro Hook Event Ingestion", () => {
   test("accepts PostToolUse hook event from Kiro", async () => {
@@ -116,10 +116,11 @@ test.describe("Kiro Hook Event Ingestion", () => {
       assistant_response: "test response",
     });
 
-    // Check sessions list
-    const sessions = await fetch(`${API_BASE}/api/v1/otel/sessions`).then(
-      (r) => r.json(),
-    );
+    // Check sessions list (requires auth)
+    const token = await getAccessToken();
+    const sessions = await fetch(`${API_BASE}/api/v1/otel/sessions`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((r) => r.json());
     const kiroSession = sessions.find(
       (s: Record<string, unknown>) => s.session_id === sessionId,
     );

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { CheckCircle2, X, LayoutGrid, TableProperties, AlertTriangle, ShieldCheck, ShieldX } from "lucide-react";
-import { useReviewList, useReviewAction } from "@/hooks/use-api";
+import { useState, useCallback, useMemo } from "react";
+import { CheckCircle2, X, LayoutGrid, TableProperties, AlertTriangle, ShieldCheck, ShieldX, AlertCircle } from "lucide-react";
+import { useReviewAgents, useReviewComponents, useReviewAction } from "@/hooks/use-api";
 import type { ReviewItem, McpValidationResult } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { PageHeader } from "@/components/layouts/page-header";
 import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -72,10 +74,35 @@ function ValidationDetails({ results }: { results?: McpValidationResult[] }) {
   );
 }
 
-function ReviewCard({ item, onApprove, onReject }: {
+function ComponentReadinessBadge({ item }: { item: ReviewItem }) {
+  if (item.components_ready !== false) return null;
+
+  return (
+    <div className="space-y-1.5">
+      <span className="inline-flex items-center gap-1 text-[10px] text-destructive bg-destructive/10 border border-destructive/25 rounded px-1.5 py-0.5">
+        <AlertCircle className="h-3 w-3" /> Components Not Ready
+      </span>
+      {item.component_blockers && item.component_blockers.length > 0 && (
+        <div className="p-2 rounded bg-destructive/5 border border-destructive/15 space-y-1">
+          <p className="text-[10px] font-medium text-destructive flex items-center gap-1">
+            <AlertCircle className="h-3 w-3" /> Blocking components ({item.component_blockers.length})
+          </p>
+          {item.component_blockers.map((b, i) => (
+            <p key={i} className="text-[10px] text-muted-foreground pl-4">
+              {b.name} ({b.component_type}) — {b.status}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReviewCard({ item, onApprove, onReject, disableApprove }: {
   item: ReviewItem;
   onApprove: (id: string, type?: string) => void;
   onReject: (id: string, reason: string, type?: string) => void;
+  disableApprove?: boolean;
 }) {
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
@@ -125,6 +152,7 @@ function ReviewCard({ item, onApprove, onReject }: {
       </div>
 
       <ValidationDetails results={item.validation_results} />
+      <ComponentReadinessBadge item={item} />
 
       {/* Reject reason input */}
       {showRejectInput && (
@@ -147,13 +175,34 @@ function ReviewCard({ item, onApprove, onReject }: {
       )}
 
       <div className="flex items-center gap-2">
-        <Button
-          size="sm"
-          className="h-7 text-xs flex-1 bg-success/10 hover:bg-success/20 text-success border border-success/25 shadow-none"
-          onClick={() => onApprove(item.id, item.type)}
-        >
-          Approve
-        </Button>
+        {disableApprove ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="flex-1">
+                  <Button
+                    size="sm"
+                    className="h-7 text-xs w-full bg-success/10 text-success border border-success/25 shadow-none opacity-50 cursor-not-allowed"
+                    disabled
+                  >
+                    Approve
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Cannot approve until all required components are ready</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <Button
+            size="sm"
+            className="h-7 text-xs flex-1 bg-success/10 hover:bg-success/20 text-success border border-success/25 shadow-none"
+            onClick={() => onApprove(item.id, item.type)}
+          >
+            Approve
+          </Button>
+        )}
         <Button
           size="sm"
           className="h-7 text-xs flex-1 bg-destructive/10 hover:bg-destructive/20 text-destructive border border-destructive/25 shadow-none"
@@ -166,10 +215,11 @@ function ReviewCard({ item, onApprove, onReject }: {
   );
 }
 
-function ReviewRow({ item, onApprove, onReject }: {
+function ReviewRow({ item, onApprove, onReject, disableApprove }: {
   item: ReviewItem;
   onApprove: (id: string, type?: string) => void;
   onReject: (id: string, reason: string, type?: string) => void;
+  disableApprove?: boolean;
 }) {
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
@@ -213,6 +263,7 @@ function ReviewRow({ item, onApprove, onReject }: {
             </p>
           )}
           <ValidationDetails results={item.validation_results} />
+          <ComponentReadinessBadge item={item} />
           <div className="flex items-center gap-3 text-xs text-muted-foreground">
             {item.submitted_by && <span>by {item.submitted_by}</span>}
             {(item.submitted_at || item.created_at) && (
@@ -247,13 +298,34 @@ function ReviewRow({ item, onApprove, onReject }: {
           </div>
         ) : (
           <div className="flex items-center gap-2 shrink-0">
-            <Button
-              size="sm"
-              className="h-8 text-xs bg-success/10 hover:bg-success/20 text-success border border-success/25 shadow-none"
-              onClick={() => onApprove(item.id, item.type)}
-            >
-              Approve
-            </Button>
+            {disableApprove ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button
+                        size="sm"
+                        className="h-8 text-xs bg-success/10 text-success border border-success/25 shadow-none opacity-50 cursor-not-allowed"
+                        disabled
+                      >
+                        Approve
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Cannot approve until all required components are ready</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <Button
+                size="sm"
+                className="h-8 text-xs bg-success/10 hover:bg-success/20 text-success border border-success/25 shadow-none"
+                onClick={() => onApprove(item.id, item.type)}
+              >
+                Approve
+              </Button>
+            )}
             <Button
               size="sm"
               className="h-8 text-xs bg-destructive/10 hover:bg-destructive/20 text-destructive border border-destructive/25 shadow-none"
@@ -268,12 +340,134 @@ function ReviewRow({ item, onApprove, onReject }: {
   );
 }
 
+function AgentItemList({
+  items,
+  view,
+  onApprove,
+  onReject,
+}: {
+  items: ReviewItem[];
+  view: ViewMode;
+  onApprove: (id: string, type?: string) => void;
+  onReject: (id: string, reason: string, type?: string) => void;
+}) {
+  const grouped = useMemo(() => {
+    const bundles = new Map<string, { name: string; items: ReviewItem[] }>();
+    const ungrouped: ReviewItem[] = [];
+    for (const item of items) {
+      if (item.bundle_id && item.bundle_name) {
+        const existing = bundles.get(item.bundle_id);
+        if (existing) {
+          existing.items.push(item);
+        } else {
+          bundles.set(item.bundle_id, { name: item.bundle_name, items: [item] });
+        }
+      } else {
+        ungrouped.push(item);
+      }
+    }
+    return { bundles: Array.from(bundles.values()), ungrouped };
+  }, [items]);
+
+  const renderItems = (list: ReviewItem[]) =>
+    view === "list" ? (
+      <div className="animate-in rounded-md border border-border overflow-hidden">
+        {list.map((item) => (
+          <ReviewRow
+            key={item.id}
+            item={item}
+            onApprove={onApprove}
+            onReject={onReject}
+            disableApprove={item.components_ready === false}
+          />
+        ))}
+      </div>
+    ) : (
+      <div className="animate-in grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {list.map((item) => (
+          <ReviewCard
+            key={item.id}
+            item={item}
+            onApprove={onApprove}
+            onReject={onReject}
+            disableApprove={item.components_ready === false}
+          />
+        ))}
+      </div>
+    );
+
+  if (grouped.bundles.length === 0) return renderItems(items);
+
+  return (
+    <div className="space-y-6">
+      {grouped.bundles.map((bundle) => (
+        <div key={bundle.name} className="space-y-3">
+          <h3 className="text-sm font-[family-name:var(--font-display)] font-semibold text-muted-foreground border-b border-border pb-2">
+            Bundle: {bundle.name}
+          </h3>
+          {renderItems(bundle.items)}
+        </div>
+      ))}
+      {grouped.ungrouped.length > 0 && (
+        <div className="space-y-3">
+          {grouped.bundles.length > 0 && (
+            <h3 className="text-sm font-[family-name:var(--font-display)] font-semibold text-muted-foreground border-b border-border pb-2">
+              Standalone Agents
+            </h3>
+          )}
+          {renderItems(grouped.ungrouped)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReviewItemList({
+  items,
+  view,
+  onApprove,
+  onReject,
+}: {
+  items: ReviewItem[];
+  view: ViewMode;
+  onApprove: (id: string, type?: string) => void;
+  onReject: (id: string, reason: string, type?: string) => void;
+}) {
+  return view === "list" ? (
+    <div className="animate-in rounded-md border border-border overflow-hidden">
+      {items.map((item) => (
+        <ReviewRow
+          key={item.id}
+          item={item}
+          onApprove={onApprove}
+          onReject={onReject}
+        />
+      ))}
+    </div>
+  ) : (
+    <div className="animate-in grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {items.map((item) => (
+        <ReviewCard
+          key={item.id}
+          item={item}
+          onApprove={onApprove}
+          onReject={onReject}
+        />
+      ))}
+    </div>
+  );
+}
+
 export default function ReviewPage() {
-  const { data: items, isLoading, isError, error, refetch } = useReviewList();
+  const { data: agents, isLoading: agentsLoading, isError: agentsError, error: agentsErr, refetch: refetchAgents } = useReviewAgents();
+  const { data: components, isLoading: componentsLoading, isError: componentsError, error: componentsErr, refetch: refetchComponents } = useReviewComponents();
   const reviewAction = useReviewAction();
   const [view, setView] = useState<ViewMode>("grid");
+  const [activeTab, setActiveTab] = useState("agents");
 
-  const pendingCount = (items ?? []).length;
+  const agentCount = (agents ?? []).length;
+  const componentCount = (components ?? []).length;
+  const totalPending = agentCount + componentCount;
 
   const handleApprove = useCallback(
     (id: string, type?: string) => reviewAction.mutate({ id, type, action: "approve" }),
@@ -295,9 +489,9 @@ export default function ReviewPage() {
         ]}
         actionButtonsRight={
           <div className="flex items-center gap-2">
-            {!isLoading && pendingCount > 0 && (
+            {!agentsLoading && !componentsLoading && totalPending > 0 && (
               <Badge variant="secondary" className="text-xs">
-                {pendingCount} pending
+                {totalPending} pending
               </Badge>
             )}
             <div className="flex items-center border border-border rounded-md overflow-hidden">
@@ -324,43 +518,66 @@ export default function ReviewPage() {
         }
       />
       <div className="p-6 w-full max-w-6xl mx-auto space-y-4">
-        {isLoading ? (
-          view === "list" ? (
-            <TableSkeleton rows={6} cols={4} />
-          ) : (
-            <CardSkeleton count={3} columns={3} />
-          )
-        ) : isError ? (
-          <ErrorState message={error?.message} onRetry={() => refetch()} />
-        ) : pendingCount === 0 ? (
-          <EmptyState
-            icon={CheckCircle2}
-            title="All clear"
-            description="All submissions have been reviewed. New items will appear here when agents or components are submitted."
-          />
-        ) : view === "list" ? (
-          <div className="animate-in rounded-md border border-border overflow-hidden">
-            {(items ?? []).map((item: ReviewItem) => (
-              <ReviewRow
-                key={item.id}
-                item={item}
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList>
+            <TabsTrigger value="agents">
+              Agents{!agentsLoading ? ` (${agentCount})` : ""}
+            </TabsTrigger>
+            <TabsTrigger value="components">
+              Components{!componentsLoading ? ` (${componentCount})` : ""}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="agents">
+            {agentsLoading ? (
+              view === "list" ? (
+                <TableSkeleton rows={6} cols={4} />
+              ) : (
+                <CardSkeleton count={3} columns={3} />
+              )
+            ) : agentsError ? (
+              <ErrorState message={agentsErr?.message} onRetry={() => refetchAgents()} />
+            ) : agentCount === 0 ? (
+              <EmptyState
+                icon={CheckCircle2}
+                title="No agents to review"
+                description="All agent submissions have been reviewed. New items will appear here when agents are submitted."
+              />
+            ) : (
+              <AgentItemList
+                items={agents!}
+                view={view}
                 onApprove={handleApprove}
                 onReject={handleReject}
               />
-            ))}
-          </div>
-        ) : (
-          <div className="animate-in grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {(items ?? []).map((item: ReviewItem) => (
-              <ReviewCard
-                key={item.id}
-                item={item}
+            )}
+          </TabsContent>
+
+          <TabsContent value="components">
+            {componentsLoading ? (
+              view === "list" ? (
+                <TableSkeleton rows={6} cols={4} />
+              ) : (
+                <CardSkeleton count={3} columns={3} />
+              )
+            ) : componentsError ? (
+              <ErrorState message={componentsErr?.message} onRetry={() => refetchComponents()} />
+            ) : componentCount === 0 ? (
+              <EmptyState
+                icon={CheckCircle2}
+                title="No components to review"
+                description="All component submissions have been reviewed. New items will appear here when components are submitted."
+              />
+            ) : (
+              <ReviewItemList
+                items={components!}
+                view={view}
                 onApprove={handleApprove}
                 onReject={handleReject}
               />
-            ))}
-          </div>
-        )}
+            )}
+          </TabsContent>
+        </Tabs>
       </div>
     </>
   );

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { Suspense, useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   Search,
@@ -300,6 +300,14 @@ function slugifyName(raw: string): string {
 }
 
 export default function AgentBuilderPage() {
+  return (
+    <Suspense>
+      <AgentBuilderInner />
+    </Suspense>
+  );
+}
+
+function AgentBuilderInner() {
   // Require auth for builder
   const { ready } = useAuthGuard();
 

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   Loader2,
   ArrowRight,
+  Save,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
@@ -22,11 +23,13 @@ import {
   TabsContent,
 } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/layouts/page-header";
-import { useRegistryList, useAgentValidation, useWhoami } from "@/hooks/use-api";
+import { useRegistryList, useAgentValidation, useWhoami, useSaveDraft, useUpdateDraft } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import { registry, type RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
 import type { ValidationResult } from "@/lib/types";
+
+const DRAFT_STORAGE_KEY = "observal_agent_draft";
 
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
 import { ValidationPanel } from "@/components/builder/validation-panel";
@@ -167,6 +170,14 @@ export default function AgentBuilderPage() {
   const [publishing, setPublishing] = useState(false);
   const [activeTab, setActiveTab] = useState<RegistryType>("mcps");
 
+  // Draft state
+  const [draftId, setDraftId] = useState<string | null>(null);
+  const [savingDraft, setSavingDraft] = useState(false);
+  const [showRestoreBanner, setShowRestoreBanner] = useState(false);
+  const saveDraft = useSaveDraft();
+  const updateDraft = useUpdateDraft();
+  const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
   // Selected components keyed by type
   const [selectedComponents, setSelectedComponents] = useState<
     Record<string, RegistryItem[]>
@@ -230,6 +241,138 @@ export default function AgentBuilderPage() {
       if (validateTimerRef.current) clearTimeout(validateTimerRef.current);
     };
   }, [selectedComponents]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Check for localStorage draft on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(DRAFT_STORAGE_KEY);
+      if (stored) {
+        setShowRestoreBanner(true);
+      }
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  // Debounced localStorage auto-save (2s)
+  useEffect(() => {
+    if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+
+    autoSaveTimerRef.current = setTimeout(() => {
+      const hasContent = name || description || modelName || version !== "1.0.0" ||
+        Object.values(selectedComponents).some((items) => items.length > 0) ||
+        goalSections.some((s) => s.title || s.content);
+
+      if (!hasContent) return;
+
+      try {
+        const draft = {
+          name,
+          description,
+          version,
+          model_name: modelName,
+          components: selectedComponents,
+          goal_sections: goalSections,
+          draft_id: draftId,
+          saved_at: new Date().toISOString(),
+        };
+        localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+      } catch {
+        // localStorage full or unavailable
+      }
+    }, 2000);
+
+    return () => {
+      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+    };
+  }, [name, description, version, modelName, selectedComponents, goalSections, draftId]);
+
+  function restoreLocalDraft() {
+    try {
+      const stored = localStorage.getItem(DRAFT_STORAGE_KEY);
+      if (!stored) return;
+      const draft = JSON.parse(stored);
+      if (draft.name) setName(draft.name);
+      if (draft.description) setDescription(draft.description);
+      if (draft.version) setVersion(draft.version);
+      if (draft.model_name) setModelName(draft.model_name);
+      if (draft.components) setSelectedComponents(draft.components);
+      if (draft.goal_sections) setGoalSections(draft.goal_sections);
+      if (draft.draft_id) setDraftId(draft.draft_id);
+      setShowRestoreBanner(false);
+      toast.success("Draft restored");
+    } catch {
+      toast.error("Failed to restore draft");
+    }
+  }
+
+  function discardLocalDraft() {
+    try {
+      localStorage.removeItem(DRAFT_STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+    setShowRestoreBanner(false);
+  }
+
+  async function handleSaveDraft() {
+    if (!name.trim()) {
+      toast.error("Agent name is required");
+      return;
+    }
+
+    setSavingDraft(true);
+    try {
+      const components: { component_type: string; component_id: string }[] = [];
+      for (const [type, items] of Object.entries(selectedComponents)) {
+        const singularType = TYPE_MAP[type] ?? type;
+        for (const item of items) {
+          components.push({ component_type: singularType, component_id: item.id });
+        }
+      }
+
+      const sections = goalSections
+        .filter((s) => s.title.trim())
+        .map((s) => ({
+          name: s.title.trim(),
+          description: s.content.trim() || null,
+        }));
+
+      const goalDescription = description.trim() || name.trim();
+
+      const body = {
+        name: name.trim(),
+        version: version.trim() || "1.0.0",
+        description: description.trim(),
+        owner: whoami?.name || whoami?.email || "unknown",
+        model_name: modelName,
+        components: components.length > 0 ? components : [],
+        goal_template: {
+          description: goalDescription,
+          sections: sections.length > 0 ? sections : [{ name: "Default", description: goalDescription }],
+        },
+      };
+
+      if (draftId) {
+        await updateDraft.mutateAsync({ id: draftId, body });
+      } else {
+        const created = await saveDraft.mutateAsync(body);
+        setDraftId(created.id);
+      }
+
+      // Clear localStorage on successful server save
+      try {
+        localStorage.removeItem(DRAFT_STORAGE_KEY);
+      } catch {
+        // ignore
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to save draft";
+      toast.error(msg);
+    } finally {
+      setSavingDraft(false);
+    }
+  }
 
   const handleToggle = useCallback(
     (type: string) => (item: RegistryItem) => {
@@ -359,6 +502,21 @@ export default function AgentBuilderPage() {
       />
 
       <div className="p-6 lg:p-8 w-full max-w-[1400px] mx-auto">
+        {/* Restore draft banner */}
+        {showRestoreBanner && (
+          <div className="mb-4 flex items-center gap-3 rounded-lg border border-blue-500/20 bg-blue-500/5 px-4 py-3">
+            <p className="flex-1 text-sm text-blue-700 dark:text-blue-300">
+              You have an unsaved draft.
+            </p>
+            <Button variant="outline" size="sm" onClick={restoreLocalDraft}>
+              Restore
+            </Button>
+            <Button variant="ghost" size="sm" onClick={discardLocalDraft}>
+              Discard
+            </Button>
+          </div>
+        )}
+
         <div className="flex flex-col gap-8 lg:flex-row">
           {/* Left column: Form */}
           <div className="min-w-0 flex-1 space-y-6 lg:max-w-[calc(66.667%-1rem)]">
@@ -583,6 +741,19 @@ export default function AgentBuilderPage() {
 
             {/* Publish */}
             <div className="flex items-center gap-3 animate-in stagger-3">
+              <Button
+                variant="outline"
+                onClick={handleSaveDraft}
+                disabled={savingDraft || !name.trim()}
+                className="min-w-[160px]"
+              >
+                {savingDraft ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="mr-2 h-4 w-4" />
+                )}
+                Save Draft
+              </Button>
               <Button
                 onClick={handlePublish}
                 disabled={publishing || !name.trim()}

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Search,
   Plus,
@@ -22,8 +22,16 @@ import {
   TabsTrigger,
   TabsContent,
 } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import { PageHeader } from "@/components/layouts/page-header";
-import { useRegistryList, useAgentValidation, useWhoami, useSaveDraft, useUpdateDraft } from "@/hooks/use-api";
+import { useRegistryList, useRegistryItem, useAgentValidation, useWhoami, useSaveDraft, useUpdateDraft } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import { registry, type RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
@@ -52,6 +60,133 @@ interface GoalSection {
 function generateId() {
   return Math.random().toString(36).slice(2, 10);
 }
+
+// ── Version bump utility ──────────────────────────────────────────
+
+type BumpType = "patch" | "minor" | "major";
+
+function bumpVersion(current: string, type: BumpType): string {
+  const parts = current.split(".").map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) return current;
+  if (type === "major") return `${parts[0] + 1}.0.0`;
+  if (type === "minor") return `${parts[0]}.${parts[1] + 1}.0`;
+  return `${parts[0]}.${parts[1]}.${parts[2] + 1}`;
+}
+
+// ── Version Bump Dialog ───────────────────────────────────────────
+
+function VersionBumpDialog({
+  open,
+  onOpenChange,
+  currentVersion,
+  onConfirm,
+  publishing,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentVersion: string;
+  onConfirm: (version: string) => void;
+  publishing: boolean;
+}) {
+  const [selection, setSelection] = useState<BumpType | "keep">("patch");
+
+  const previewVersion = useMemo(() => {
+    if (selection === "keep") return currentVersion;
+    return bumpVersion(currentVersion, selection);
+  }, [currentVersion, selection]);
+
+  const options: { value: BumpType | "keep"; label: string; description: string }[] = useMemo(() => [
+    {
+      value: "patch",
+      label: "Patch",
+      description: `${currentVersion} \u2192 ${bumpVersion(currentVersion, "patch")}`,
+    },
+    {
+      value: "minor",
+      label: "Minor",
+      description: `${currentVersion} \u2192 ${bumpVersion(currentVersion, "minor")}`,
+    },
+    {
+      value: "major",
+      label: "Major",
+      description: `${currentVersion} \u2192 ${bumpVersion(currentVersion, "major")}`,
+    },
+    {
+      value: "keep",
+      label: "Keep current",
+      description: currentVersion,
+    },
+  ], [currentVersion]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Version Bump</DialogTitle>
+          <DialogDescription>
+            Choose how to bump the version for this update.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2 py-2">
+          {options.map((opt) => (
+            <label
+              key={opt.value}
+              className={`flex cursor-pointer items-center gap-3 rounded-md border px-4 py-3 transition-colors ${
+                selection === opt.value
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:bg-muted/50"
+              }`}
+            >
+              <input
+                type="radio"
+                name="version-bump"
+                value={opt.value}
+                checked={selection === opt.value}
+                onChange={() => setSelection(opt.value)}
+                className="h-4 w-4 accent-primary"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-medium">{opt.label}</span>
+                <span className="block text-xs text-muted-foreground font-mono">
+                  {opt.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+
+        <div className="rounded-md bg-muted/50 px-4 py-2.5 text-center">
+          <span className="text-xs text-muted-foreground">New version: </span>
+          <span className="text-sm font-semibold font-mono">{previewVersion}</span>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={publishing}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onConfirm(previewVersion)}
+            disabled={publishing}
+          >
+            {publishing ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <ArrowRight className="mr-2 h-4 w-4" />
+            )}
+            Update Agent
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Component Picker ──────────────────────────────────────────────
 
 function ComponentPicker({
   type,
@@ -145,6 +280,14 @@ const TYPE_MAP: Record<string, string> = {
   sandboxes: "sandbox",
 };
 
+const REVERSE_TYPE_MAP: Record<string, string> = {
+  mcp: "mcps",
+  skill: "skills",
+  hook: "hooks",
+  prompt: "prompts",
+  sandbox: "sandboxes",
+};
+
 const AGENT_NAME_REGEX = /^[a-z0-9][a-z0-9_-]*$/;
 
 function slugifyName(raw: string): string {
@@ -161,7 +304,13 @@ export default function AgentBuilderPage() {
   const { ready } = useAuthGuard();
 
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const editId = searchParams.get("edit");
+  const isEditMode = !!editId;
+
   const { data: whoami } = useWhoami();
+  const { data: existingAgent } = useRegistryItem("agents", editId ?? undefined);
+
   const [name, setName] = useState("");
   const [nameError, setNameError] = useState("");
   const [description, setDescription] = useState("");
@@ -170,6 +319,9 @@ export default function AgentBuilderPage() {
   const [publishing, setPublishing] = useState(false);
   const [activeTab, setActiveTab] = useState<RegistryType>("mcps");
 
+  // Version bump dialog
+  const [showVersionDialog, setShowVersionDialog] = useState(false);
+
   // Draft state
   const [draftId, setDraftId] = useState<string | null>(null);
   const [savingDraft, setSavingDraft] = useState(false);
@@ -177,6 +329,9 @@ export default function AgentBuilderPage() {
   const saveDraft = useSaveDraft();
   const updateDraft = useUpdateDraft();
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Track whether we have loaded the existing agent data
+  const editLoadedRef = useRef(false);
 
   // Selected components keyed by type
   const [selectedComponents, setSelectedComponents] = useState<
@@ -199,6 +354,50 @@ export default function AgentBuilderPage() {
   const [validationResult, setValidationResult] =
     useState<ValidationResult | null>(null);
   const validateTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Load existing agent data when in edit mode
+  useEffect(() => {
+    if (!existingAgent || editLoadedRef.current) return;
+    editLoadedRef.current = true;
+
+    setName(existingAgent.name ?? "");
+    setDescription(existingAgent.description ?? "");
+    const agentVersion = (existingAgent as Record<string, unknown>).version;
+    if (typeof agentVersion === "string") setVersion(agentVersion);
+    const agentModel = (existingAgent as Record<string, unknown>).model_name;
+    if (typeof agentModel === "string") setModelName(agentModel);
+
+    // Load components if available
+    const agentComponents = (existingAgent as Record<string, unknown>).components;
+    if (Array.isArray(agentComponents)) {
+      const grouped: Record<string, RegistryItem[]> = {
+        mcps: [], skills: [], hooks: [], prompts: [], sandboxes: [],
+      };
+      for (const comp of agentComponents) {
+        const c = comp as Record<string, unknown>;
+        const pluralType = REVERSE_TYPE_MAP[c.component_type as string] ?? (c.component_type as string);
+        if (grouped[pluralType]) {
+          grouped[pluralType].push({
+            id: c.component_id as string,
+            name: (c.name as string) ?? (c.component_id as string),
+            description: c.description as string | undefined,
+          });
+        }
+      }
+      setSelectedComponents(grouped);
+    }
+
+    // Load goal template sections if available
+    const goalTemplate = (existingAgent as Record<string, unknown>).goal_template as Record<string, unknown> | undefined;
+    if (goalTemplate && Array.isArray(goalTemplate.sections)) {
+      const loadedSections = (goalTemplate.sections as Array<Record<string, unknown>>).map((s) => ({
+        id: generateId(),
+        title: (s.name as string) ?? "",
+        content: (s.description as string) ?? "",
+      }));
+      if (loadedSections.length > 0) setGoalSections(loadedSections);
+    }
+  }, [existingAgent]);
 
   // Compute selected IDs for quick lookup
   const selectedIds = useMemo(() => {
@@ -242,8 +441,9 @@ export default function AgentBuilderPage() {
     };
   }, [selectedComponents]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Check for localStorage draft on mount
+  // Check for localStorage draft on mount (skip if in edit mode)
   useEffect(() => {
+    if (isEditMode) return;
     try {
       const stored = localStorage.getItem(DRAFT_STORAGE_KEY);
       if (stored) {
@@ -252,10 +452,11 @@ export default function AgentBuilderPage() {
     } catch {
       // localStorage unavailable
     }
-  }, []);
+  }, [isEditMode]);
 
-  // Debounced localStorage auto-save (2s)
+  // Debounced localStorage auto-save (2s) — skip in edit mode
   useEffect(() => {
+    if (isEditMode) return;
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
 
     autoSaveTimerRef.current = setTimeout(() => {
@@ -285,7 +486,7 @@ export default function AgentBuilderPage() {
     return () => {
       if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
     };
-  }, [name, description, version, modelName, selectedComponents, goalSections, draftId]);
+  }, [name, description, version, modelName, selectedComponents, goalSections, draftId, isEditMode]);
 
   function restoreLocalDraft() {
     try {
@@ -431,6 +632,38 @@ export default function AgentBuilderPage() {
     [],
   );
 
+  function buildRequestBody(versionOverride?: string) {
+    const components: { component_type: string; component_id: string }[] = [];
+    for (const [type, items] of Object.entries(selectedComponents)) {
+      const singularType = TYPE_MAP[type] ?? type;
+      for (const item of items) {
+        components.push({ component_type: singularType, component_id: item.id });
+      }
+    }
+
+    const sections = goalSections
+      .filter((s) => s.title.trim())
+      .map((s) => ({
+        name: s.title.trim(),
+        description: s.content.trim() || null,
+      }));
+
+    const goalDescription = description.trim() || name.trim();
+
+    return {
+      name: name.trim(),
+      version: (versionOverride ?? version).trim() || "1.0.0",
+      description: description.trim(),
+      owner: whoami?.name || whoami?.email || "unknown",
+      model_name: modelName,
+      components: components.length > 0 ? components : [],
+      goal_template: {
+        description: goalDescription,
+        sections: sections.length > 0 ? sections : [{ name: "Default", description: goalDescription }],
+      },
+    };
+  }
+
   async function handlePublish() {
     if (!name.trim()) {
       toast.error("Agent name is required");
@@ -443,40 +676,15 @@ export default function AgentBuilderPage() {
       return;
     }
 
+    // In edit mode, show the version bump dialog instead of publishing directly
+    if (isEditMode) {
+      setShowVersionDialog(true);
+      return;
+    }
+
     setPublishing(true);
     try {
-      // Build components array with proper {component_type, component_id} format
-      const components: { component_type: string; component_id: string }[] = [];
-      for (const [type, items] of Object.entries(selectedComponents)) {
-        const singularType = TYPE_MAP[type] ?? type;
-        for (const item of items) {
-          components.push({ component_type: singularType, component_id: item.id });
-        }
-      }
-
-      // Build goal_template with sections
-      const sections = goalSections
-        .filter((s) => s.title.trim())
-        .map((s) => ({
-          name: s.title.trim(),
-          description: s.content.trim() || null,
-        }));
-
-      const goalDescription = description.trim() || name.trim();
-
-      const body = {
-        name: name.trim(),
-        version: version.trim() || "1.0.0",
-        description: description.trim(),
-        owner: whoami?.name || whoami?.email || "unknown",
-        model_name: modelName,
-        components: components.length > 0 ? components : [],
-        goal_template: {
-          description: goalDescription,
-          sections: sections.length > 0 ? sections : [{ name: "Default", description: goalDescription }],
-        },
-      };
-
+      const body = buildRequestBody();
       const created = await registry.create("agents", body);
       toast.success("Agent submitted for review. An admin must approve it before it becomes visible.");
       router.push(`/agents/${created.id}`);
@@ -488,16 +696,35 @@ export default function AgentBuilderPage() {
     }
   }
 
+  async function handleUpdateWithVersion(selectedVersion: string) {
+    if (!editId) return;
+
+    setPublishing(true);
+    try {
+      const body = buildRequestBody(selectedVersion);
+      await registry.updateDraft(editId, body);
+      setVersion(selectedVersion);
+      setShowVersionDialog(false);
+      toast.success("Agent updated and submitted for review.");
+      router.push(`/agents/${editId}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to update agent";
+      toast.error(msg);
+    } finally {
+      setPublishing(false);
+    }
+  }
+
   if (!ready) return null;
 
   return (
     <>
       <PageHeader
-        title="Agent Builder"
+        title={isEditMode ? "Edit Agent" : "Agent Builder"}
         breadcrumbs={[
           { label: "Registry", href: "/" },
           { label: "Agents", href: "/agents" },
-          { label: "Builder" },
+          { label: isEditMode ? "Edit" : "Builder" },
         ]}
       />
 
@@ -543,6 +770,7 @@ export default function AgentBuilderPage() {
                   }}
                   className="max-w-md"
                   required
+                  disabled={isEditMode}
                 />
                 {nameError && (
                   <p className="text-sm text-destructive">{nameError}</p>
@@ -741,19 +969,21 @@ export default function AgentBuilderPage() {
 
             {/* Publish */}
             <div className="flex items-center gap-3 animate-in stagger-3">
-              <Button
-                variant="outline"
-                onClick={handleSaveDraft}
-                disabled={savingDraft || !name.trim()}
-                className="min-w-[160px]"
-              >
-                {savingDraft ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <Save className="mr-2 h-4 w-4" />
-                )}
-                Save Draft
-              </Button>
+              {!isEditMode && (
+                <Button
+                  variant="outline"
+                  onClick={handleSaveDraft}
+                  disabled={savingDraft || !name.trim()}
+                  className="min-w-[160px]"
+                >
+                  {savingDraft ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Save className="mr-2 h-4 w-4" />
+                  )}
+                  Save Draft
+                </Button>
+              )}
               <Button
                 onClick={handlePublish}
                 disabled={publishing || !name.trim()}
@@ -764,7 +994,7 @@ export default function AgentBuilderPage() {
                 ) : (
                   <ArrowRight className="mr-2 h-4 w-4" />
                 )}
-                Submit for Review
+                {isEditMode ? "Update Agent" : "Submit for Review"}
               </Button>
             </div>
           </div>
@@ -788,6 +1018,15 @@ export default function AgentBuilderPage() {
           </aside>
         </div>
       </div>
+
+      {/* Version Bump Dialog — shown when updating an existing agent */}
+      <VersionBumpDialog
+        open={showVersionDialog}
+        onOpenChange={setShowVersionDialog}
+        currentVersion={version}
+        onConfirm={handleUpdateWithVersion}
+        publishing={publishing}
+      />
     </>
   );
 }

--- a/web/src/app/(registry)/agents/leaderboard/page.tsx
+++ b/web/src/app/(registry)/agents/leaderboard/page.tsx
@@ -1,24 +1,54 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   Trophy,
   ArrowDownToLine,
   Star,
+  Search,
+  Blocks,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { EmptyState } from "@/components/shared/empty-state";
-import { useLeaderboard } from "@/hooks/use-api";
+import { useLeaderboard, useComponentLeaderboard } from "@/hooks/use-api";
 import { compactNumber } from "@/lib/utils";
 import type { LeaderboardWindow } from "@/lib/types";
 
 export default function LeaderboardPage() {
+  const [activeTab, setActiveTab] = useState<"agents" | "components">("agents");
   const [window, setWindow] = useState<LeaderboardWindow>("7d");
-  const { data: leaderboard, isLoading } = useLeaderboard(window, 50);
+  const [userFilterInput, setUserFilterInput] = useState("");
+  const [userFilter, setUserFilter] = useState("");
+
+  // Debounce the user filter input by 300ms
+  useEffect(() => {
+    const timer = setTimeout(() => setUserFilter(userFilterInput), 300);
+    return () => clearTimeout(timer);
+  }, [userFilterInput]);
+
+  const { data: leaderboard, isLoading: agentsLoading } = useLeaderboard(
+    window,
+    50,
+    userFilter || undefined,
+  );
+  const { data: componentLeaderboard, isLoading: componentsLoading } =
+    useComponentLeaderboard();
+
+  // Memoize sorted component leaderboard (ranked by total_downloads desc)
+  const rankedComponents = useMemo(
+    () =>
+      componentLeaderboard
+        ? [...componentLeaderboard].sort(
+            (a, b) => b.total_downloads - a.total_downloads,
+          )
+        : [],
+    [componentLeaderboard],
+  );
 
   return (
     <>
@@ -32,94 +62,187 @@ export default function LeaderboardPage() {
       />
 
       <div className="p-6 lg:p-8 w-full max-w-[1200px] mx-auto space-y-6">
-        <div className="flex items-center justify-between flex-wrap gap-4">
-          <p className="text-sm text-muted-foreground">
-            Agents ranked by downloads within the selected time window.
-          </p>
-          <Tabs
-            value={window}
-            onValueChange={(v) => setWindow(v as LeaderboardWindow)}
-          >
+        {/* Top-level Agents / Components tab switcher */}
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as "agents" | "components")}
+        >
+          <div className="flex items-center justify-between flex-wrap gap-4">
             <TabsList>
-              <TabsTrigger value="24h">24h</TabsTrigger>
-              <TabsTrigger value="7d">7 days</TabsTrigger>
-              <TabsTrigger value="30d">30 days</TabsTrigger>
-              <TabsTrigger value="all">All time</TabsTrigger>
+              <TabsTrigger value="agents">Agents</TabsTrigger>
+              <TabsTrigger value="components">Components</TabsTrigger>
             </TabsList>
-          </Tabs>
-        </div>
 
-        {isLoading ? (
-          <TableSkeleton rows={10} cols={5} />
-        ) : !leaderboard || leaderboard.length === 0 ? (
-          <EmptyState
-            icon={Trophy}
-            title="No rankings yet"
-            description="Install agents via the CLI or web UI to populate the leaderboard."
-          />
-        ) : (
-          <div className="space-y-1 animate-in">
-            {/* Header */}
-            <div className="flex items-center gap-4 px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-              <span className="w-8 text-right">#</span>
-              <span className="flex-1">Agent</span>
-              <span className="w-24 text-right">Downloads</span>
-              <span className="w-16 text-right">Rating</span>
-              <span className="w-20 text-right">Version</span>
-            </div>
-
-            {leaderboard.map((item, i) => (
-              <Link
-                key={item.id}
-                href={`/agents/${item.id}`}
-                className="flex items-center gap-4 rounded-md px-3 py-3 transition-colors hover:bg-accent/40 group"
+            {/* Time window selector -- only for Agents tab */}
+            {activeTab === "agents" && (
+              <Tabs
+                value={window}
+                onValueChange={(v) => setWindow(v as LeaderboardWindow)}
               >
-                <span
-                  className={`w-8 text-right font-mono font-semibold ${
-                    i < 3 ? "text-foreground" : "text-muted-foreground"
-                  }`}
-                >
-                  {i + 1}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <span className="text-sm font-medium truncate block group-hover:underline underline-offset-4">
-                    {item.name}
-                  </span>
-                  <span className="text-xs text-muted-foreground/70 truncate block">
-                    {item.created_by_username ? `@${item.created_by_username}` : item.owner}
-                    {item.description && ` — ${item.description}`}
-                  </span>
-                </div>
-                <span className="w-24 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground font-mono">
-                  <ArrowDownToLine className="h-3 w-3" />
-                  {compactNumber(item.download_count)}
-                </span>
-                <span className="w-16 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground">
-                  {item.average_rating != null ? (
-                    <>
-                      <Star className="h-3 w-3" />
-                      {item.average_rating.toFixed(1)}
-                    </>
-                  ) : (
-                    "-"
-                  )}
-                </span>
-                <span className="w-20 text-right">
-                  {item.version ? (
-                    <Badge
-                      variant="secondary"
-                      className="text-[10px] px-1.5 py-0"
-                    >
-                      {item.version}
-                    </Badge>
-                  ) : (
-                    <span className="text-sm text-muted-foreground">-</span>
-                  )}
-                </span>
-              </Link>
-            ))}
+                <TabsList>
+                  <TabsTrigger value="24h">24h</TabsTrigger>
+                  <TabsTrigger value="7d">7 days</TabsTrigger>
+                  <TabsTrigger value="30d">30 days</TabsTrigger>
+                  <TabsTrigger value="all">All time</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            )}
           </div>
-        )}
+
+          {/* ── Agents tab ───────────────────────────────────── */}
+          <TabsContent value="agents">
+            <div className="space-y-4">
+              <div className="flex items-center justify-between flex-wrap gap-4">
+                <p className="text-sm text-muted-foreground">
+                  Agents ranked by downloads within the selected time window.
+                </p>
+                <div className="relative w-full sm:w-72">
+                  <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Filter by email or username..."
+                    value={userFilterInput}
+                    onChange={(e) => setUserFilterInput(e.target.value)}
+                    className="pl-9 h-9"
+                  />
+                </div>
+              </div>
+
+              {agentsLoading ? (
+                <TableSkeleton rows={10} cols={5} />
+              ) : !leaderboard || leaderboard.length === 0 ? (
+                <EmptyState
+                  icon={Trophy}
+                  title="No rankings yet"
+                  description="Install agents via the CLI or web UI to populate the leaderboard."
+                />
+              ) : (
+                <div className="space-y-1 animate-in">
+                  {/* Header */}
+                  <div className="flex items-center gap-4 px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    <span className="w-8 text-right">#</span>
+                    <span className="flex-1">Agent</span>
+                    <span className="w-24 text-right">Downloads</span>
+                    <span className="w-16 text-right">Rating</span>
+                    <span className="w-20 text-right">Version</span>
+                  </div>
+
+                  {leaderboard.map((item, i) => (
+                    <Link
+                      key={item.id}
+                      href={`/agents/${item.id}`}
+                      className="flex items-center gap-4 rounded-md px-3 py-3 transition-colors hover:bg-accent/40 group"
+                    >
+                      <span
+                        className={`w-8 text-right font-mono font-semibold ${
+                          i < 3 ? "text-foreground" : "text-muted-foreground"
+                        }`}
+                      >
+                        {i + 1}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <span className="text-sm font-medium truncate block group-hover:underline underline-offset-4">
+                          {item.name}
+                        </span>
+                        <span className="text-xs text-muted-foreground/70 truncate block">
+                          {item.created_by_username ? `@${item.created_by_username}` : item.owner}
+                          {item.description && ` — ${item.description}`}
+                        </span>
+                      </div>
+                      <span className="w-24 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground font-mono">
+                        <ArrowDownToLine className="h-3 w-3" />
+                        {compactNumber(item.download_count)}
+                      </span>
+                      <span className="w-16 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground">
+                        {item.average_rating != null ? (
+                          <>
+                            <Star className="h-3 w-3" />
+                            {item.average_rating.toFixed(1)}
+                          </>
+                        ) : (
+                          "-"
+                        )}
+                      </span>
+                      <span className="w-20 text-right">
+                        {item.version ? (
+                          <Badge
+                            variant="secondary"
+                            className="text-[10px] px-1.5 py-0"
+                          >
+                            {item.version}
+                          </Badge>
+                        ) : (
+                          <span className="text-sm text-muted-foreground">-</span>
+                        )}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          {/* ── Components tab ────────────────────────────────── */}
+          <TabsContent value="components">
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                MCP components ranked by total user downloads.
+              </p>
+
+              {componentsLoading ? (
+                <TableSkeleton rows={10} cols={4} />
+              ) : rankedComponents.length === 0 ? (
+                <EmptyState
+                  icon={Blocks}
+                  title="No component data yet"
+                  description="Component download metrics will appear here once users install MCP components."
+                />
+              ) : (
+                <div className="space-y-1 animate-in">
+                  {/* Header */}
+                  <div className="flex items-center gap-4 px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    <span className="w-8 text-right">#</span>
+                    <span className="flex-1">User</span>
+                    <span className="w-28 text-right">MCP Count</span>
+                    <span className="w-28 text-right">Downloads</span>
+                  </div>
+
+                  {rankedComponents.map((item, i) => (
+                    <div
+                      key={item.user}
+                      className="flex items-center gap-4 rounded-md px-3 py-3 transition-colors hover:bg-accent/40"
+                    >
+                      <span
+                        className={`w-8 text-right font-mono font-semibold ${
+                          i < 3 ? "text-foreground" : "text-muted-foreground"
+                        }`}
+                      >
+                        {i + 1}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <span className="text-sm font-medium truncate block">
+                          {item.username ? `@${item.username}` : item.user}
+                        </span>
+                        {item.username && (
+                          <span className="text-xs text-muted-foreground/70 truncate block">
+                            {item.user}
+                          </span>
+                        )}
+                      </div>
+                      <span className="w-28 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground font-mono">
+                        <Blocks className="h-3 w-3" />
+                        {item.mcp_count}
+                      </span>
+                      <span className="w-28 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground font-mono">
+                        <ArrowDownToLine className="h-3 w-3" />
+                        {compactNumber(item.total_downloads)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
     </>
   );

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -15,11 +15,12 @@ import {
   ArrowDown,
   Trash2,
   Clock,
+  Archive,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
-import { useRegistryList, useMyAgents, useWhoami } from "@/hooks/use-api";
+import { useRegistryList, useMyAgents, useWhoami, useArchiveAgent } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import {
@@ -105,6 +106,56 @@ function DeleteAgentButton({ agent }: { agent: RegistryItem }) {
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>Cancel</Button>
             <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
               {deleting ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function ArchiveAgentButton({ agent }: { agent: RegistryItem }) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const isAdmin = useSyncExternalStore(roleSub, () => hasMinRole(getUserRole(), "admin"), () => false);
+  const archiveMutation = useArchiveAgent();
+
+  if (!isAdmin || agent.status === "archived") return null;
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 w-7 p-0 text-muted-foreground hover:text-orange-600"
+        onClick={(e) => {
+          e.stopPropagation();
+          setConfirmOpen(true);
+        }}
+      >
+        <Archive className="h-3.5 w-3.5" />
+      </Button>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>Archive Agent</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This will hide the agent from the registry. The agent data will be preserved.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>Cancel</Button>
+            <Button
+              variant="destructive"
+              onClick={(e) => {
+                e.stopPropagation();
+                archiveMutation.mutate(agent.id, {
+                  onSuccess: () => setConfirmOpen(false),
+                });
+              }}
+              disabled={archiveMutation.isPending}
+            >
+              {archiveMutation.isPending ? "Archiving..." : "Archive"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -235,7 +286,12 @@ const columns: ColumnDef<RegistryItem>[] = [
   {
     id: "actions",
     header: "",
-    cell: ({ row }) => <DeleteAgentButton agent={row.original} />,
+    cell: ({ row }) => (
+      <div className="flex items-center gap-1">
+        <ArchiveAgentButton agent={row.original} />
+        <DeleteAgentButton agent={row.original} />
+      </div>
+    ),
   },
 ];
 

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -16,11 +16,15 @@ import {
   Trash2,
   Clock,
   Archive,
+  FileEdit,
+  Send,
+  ChevronDown,
+  ChevronRight,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
-import { useRegistryList, useMyAgents, useWhoami, useArchiveAgent } from "@/hooks/use-api";
+import { useRegistryList, useMyAgents, useWhoami, useArchiveAgent, useSubmitDraft } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import {
@@ -334,15 +338,23 @@ function AgentListContent() {
   );
 
   const { data: myAgents } = useMyAgents();
+  const submitDraft = useSubmitDraft();
+  const [draftsExpanded, setDraftsExpanded] = useState(true);
+  const [deletingDraftId, setDeletingDraftId] = useState<string | null>(null);
+  const qc = useQueryClient();
+
+  const drafts = useMemo(() => {
+    return (myAgents ?? []).filter((a) => a.status === "draft");
+  }, [myAgents]);
 
   const { filtered, pendingCount } = useMemo(() => {
     const active = agents ?? [];
     const activeIds = new Set(active.map((a) => a.id));
     const pending = (myAgents ?? []).filter(
-      (a) => a.status !== "active" && !activeIds.has(a.id),
+      (a) => a.status !== "active" && a.status !== "draft" && !activeIds.has(a.id),
     );
     return { filtered: [...pending, ...active], pendingCount: pending.length };
-  }, [agents, myAgents]);
+  }, [agents, myAgents, drafts]);
 
   const table = useReactTable({
     data: filtered,
@@ -359,6 +371,39 @@ function AgentListContent() {
     },
     [router],
   );
+
+  function handleEditDraft(draft: RegistryItem) {
+    // Store draft data in localStorage so the builder can pick it up
+    const draftData = {
+      name: draft.name,
+      description: draft.description ?? "",
+      version: (draft.version as string) ?? "1.0.0",
+      model_name: (draft.model_name as string) ?? "",
+      components: {},
+      goal_sections: [{ id: "1", title: "", content: "" }],
+      draft_id: draft.id,
+      saved_at: new Date().toISOString(),
+    };
+    try {
+      localStorage.setItem("observal_agent_draft", JSON.stringify(draftData));
+    } catch {
+      // ignore
+    }
+    router.push("/agents/builder");
+  }
+
+  async function handleDeleteDraft(id: string) {
+    setDeletingDraftId(id);
+    try {
+      await registry.delete("agents", id);
+      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
+      toast.success("Draft deleted");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete draft");
+    } finally {
+      setDeletingDraftId(null);
+    }
+  }
 
   return (
     <>
@@ -403,6 +448,78 @@ function AgentListContent() {
             </Button>
           </div>
         </div>
+
+        {/* My Drafts */}
+        {drafts.length > 0 && (
+          <div className="rounded-lg border border-border bg-card">
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm font-medium hover:bg-accent/40 transition-colors rounded-t-lg"
+              onClick={() => setDraftsExpanded((prev) => !prev)}
+            >
+              {draftsExpanded ? (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              )}
+              My Drafts
+              <span className="ml-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
+                {drafts.length}
+              </span>
+            </button>
+            {draftsExpanded && (
+              <div className="divide-y divide-border border-t">
+                {drafts.map((draft) => (
+                  <div key={draft.id} className="flex items-center gap-4 px-4 py-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium">{draft.name}</p>
+                      {draft.description && (
+                        <p className="truncate text-xs text-muted-foreground mt-0.5">
+                          {draft.description}
+                        </p>
+                      )}
+                      {draft.updated_at && (
+                        <p className="text-[11px] text-muted-foreground mt-1">
+                          Last updated {new Date(draft.updated_at).toLocaleDateString()}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => handleEditDraft(draft)}
+                      >
+                        <FileEdit className="mr-1 h-3 w-3" />
+                        Edit
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        disabled={submitDraft.isPending}
+                        onClick={() => submitDraft.mutate(draft.id)}
+                      >
+                        <Send className="mr-1 h-3 w-3" />
+                        Submit for Review
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                        disabled={deletingDraftId === draft.id}
+                        onClick={() => handleDeleteDraft(draft.id)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         {pendingCount > 0 && (
           <div className="flex items-start gap-3 rounded-lg border border-yellow-500/20 bg-yellow-500/5 px-4 py-3">

--- a/web/src/components/registry/status-badge.tsx
+++ b/web/src/components/registry/status-badge.tsx
@@ -11,6 +11,7 @@ const statusConfig: Record<string, { bg: string; text: string; dot?: string; pin
   running:   { bg: "bg-light-blue",   text: "text-dark-blue",   dot: "bg-dark-blue",   ping: true },
   completed: { bg: "bg-light-green",  text: "text-dark-green" },
   success:   { bg: "bg-light-green",  text: "text-dark-green" },
+  archived:  { bg: "bg-zinc-100 dark:bg-zinc-800", text: "text-zinc-600 dark:text-zinc-400" },
 };
 
 const fallback = { bg: "bg-muted", text: "text-muted-foreground" };

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -16,6 +16,7 @@ import {
   eval_,
   admin,
   telemetry,
+  bulk,
   graphql,
   type RegistryType,
 } from "@/lib/api";
@@ -368,10 +369,17 @@ export function useEvalAggregate(agentId: string) {
   });
 }
 
-export function useLeaderboard(window?: LeaderboardWindow, limit?: number) {
+export function useLeaderboard(window?: LeaderboardWindow, limit?: number, user?: string) {
   return useQuery({
-    queryKey: ["leaderboard", window, limit],
-    queryFn: () => dashboard.leaderboard(window, limit),
+    queryKey: ["leaderboard", window, limit, user],
+    queryFn: () => dashboard.leaderboard(window, limit, user),
+  });
+}
+
+export function useComponentLeaderboard() {
+  return useQuery({
+    queryKey: ["component-leaderboard"],
+    queryFn: dashboard.componentLeaderboard,
   });
 }
 
@@ -402,6 +410,129 @@ export function useEvalScorecard(scorecardId: string | undefined) {
     queryKey: ["eval", "scorecard", scorecardId],
     enabled: !!scorecardId,
     queryFn: () => eval_.show(scorecardId!),
+  });
+}
+
+// ── Archive ────────────────────────────────────────────────────────
+
+export function useArchiveAgent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.archive(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
+      toast.success("Agent archived");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to archive agent");
+    },
+  });
+}
+
+// ── Draft ──────────────────────────────────────────────────────────
+
+export function useSaveDraft() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: unknown) => registry.draft(body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
+      toast.success("Draft saved");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to save draft");
+    },
+  });
+}
+
+export function useUpdateDraft() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { id: string; body: unknown }) => registry.updateDraft(vars.id, vars.body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
+      toast.success("Draft updated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to update draft");
+    },
+  });
+}
+
+export function useSubmitDraft() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.submitDraft(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
+      qc.invalidateQueries({ queryKey: ["review"] });
+      toast.success("Agent submitted for review");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to submit draft");
+    },
+  });
+}
+
+// ── Version ────────────────────────────────────────────────────────
+
+export function useVersionSuggestions(id: string | undefined) {
+  return useQuery({
+    queryKey: ["version-suggestions", id],
+    enabled: !!id,
+    queryFn: () => registry.versionSuggestions(id!),
+  });
+}
+
+// ── Bundle Review ──────────────────────────────────────────────────
+
+export function useBundleReviewAction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { id: string; action: "approve" | "reject"; reason?: string }) =>
+      vars.action === "approve"
+        ? review.approveBundle(vars.id)
+        : review.rejectBundle(vars.id, { reason: vars.reason ?? "" }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ["review"] });
+      toast.success(vars.action === "approve" ? "Bundle approved" : "Bundle rejected");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Bundle review action failed");
+    },
+  });
+}
+
+// ── Bulk ───────────────────────────────────────────────────────────
+
+export function useBulkCreateAgents() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: bulk.createAgents,
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
+      toast.success(`Created ${data.created} agents`);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Bulk create failed");
+    },
+  });
+}
+
+// ── Review (agents-only list) ──────────────────────────────────────
+
+export function useReviewAgents() {
+  return useQuery({
+    queryKey: ["review", "agents"],
+    queryFn: () => review.listAgents(),
+  });
+}
+
+export function useReviewComponents(typeFilter?: string) {
+  const params = typeFilter ? { type: typeFilter } : undefined;
+  return useQuery({
+    queryKey: ["review", "components", params],
+    queryFn: () => review.list(params),
   });
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -23,6 +23,9 @@ import type {
   LeaderboardItem,
   LeaderboardWindow,
   ValidationResult,
+  VersionSuggestions,
+  BulkResult,
+  ComponentLeaderboardItem,
 } from "./types";
 
 const API = "/api/v1";
@@ -172,6 +175,9 @@ function put<T = unknown>(path: string, body?: unknown) {
 function del<T = unknown>(path: string) {
   return request<T>("DELETE", path);
 }
+function patch<T = unknown>(path: string, body?: unknown) {
+  return request<T>("PATCH", path, body);
+}
 
 export async function graphql<T = unknown>(
   query: string,
@@ -233,6 +239,12 @@ export const registry = {
   validate: (body: { components: { component_type: string; component_id: string }[] }) =>
     post<ValidationResult>("/agents/validate", body),
   my: () => get<RegistryItem[]>("/agents/my"),
+  archive: (id: string) => patch(`/agents/${id}/archive`),
+  draft: (body: unknown) => post<RegistryItem>("/agents/draft", body),
+  updateDraft: (id: string, body: unknown) => put<RegistryItem>(`/agents/${id}/draft`, body),
+  submitDraft: (id: string) => post(`/agents/${id}/submit`),
+  versionSuggestions: (id: string) =>
+    get<VersionSuggestions>(`/agents/${id}/version-suggestions`),
 };
 
 // ── Review ──────────────────────────────────────────────────────────
@@ -249,6 +261,9 @@ export const review = {
   approveAgent: (id: string) => post(`/review/agents/${id}/approve`),
   rejectAgent: (id: string, body: { reason: string }) =>
     post(`/review/agents/${id}/reject`, body),
+  approveBundle: (id: string) => post(`/review/bundles/${id}/approve`),
+  rejectBundle: (id: string, body: { reason: string }) =>
+    post(`/review/bundles/${id}/reject`, body),
 };
 
 // ── Telemetry ───────────────────────────────────────────────────────
@@ -262,13 +277,16 @@ export const dashboard = {
   stats: (range?: string) => get<OverviewStats>(`/overview/stats${range ? `?range=${range}` : ''}`),
   topMcps: () => get<TopItem[]>("/overview/top-mcps"),
   topAgents: (limit?: number) => get<TopAgentItem[]>(`/overview/top-agents${limit ? `?limit=${limit}` : ''}`),
-  leaderboard: (window?: LeaderboardWindow, limit?: number) => {
+  leaderboard: (window?: LeaderboardWindow, limit?: number, user?: string) => {
     const params = new URLSearchParams();
     if (window) params.set("window", window);
     if (limit) params.set("limit", String(limit));
+    if (user) params.set("user", user);
     const qs = params.toString();
     return get<LeaderboardItem[]>(`/overview/leaderboard${qs ? `?${qs}` : ''}`);
   },
+  componentLeaderboard: () =>
+    get<ComponentLeaderboardItem[]>("/overview/component-leaderboard"),
   trends: (range?: string) => get<TrendPoint[]>(`/overview/trends${range ? `?range=${range}` : ''}`),
   mcpMetrics: (id: string) => get<unknown>(`/mcps/${id}/metrics`),
   agentMetrics: (id: string) => get<unknown>(`/agents/${id}/metrics`),
@@ -342,6 +360,12 @@ export type PublicConfig = {
 
 export const config = {
   public: () => get<PublicConfig>("/config/public"),
+};
+
+// ── Bulk ───────────────────────────────────────────────────────────
+export const bulk = {
+  createAgents: (body: { agents: unknown[]; dry_run?: boolean }) =>
+    post<BulkResult>("/bulk/agents", body),
 };
 
 // ── Health ──────────────────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -106,6 +106,36 @@ export interface TopAgentItem {
 export type LeaderboardItem = TopAgentItem;
 export type LeaderboardWindow = "24h" | "7d" | "30d" | "all";
 
+export interface ComponentLeaderboardItem {
+  user: string;
+  username?: string | null;
+  mcp_count: number;
+  total_downloads: number;
+}
+
+export interface VersionSuggestions {
+  current: string;
+  patch: string;
+  minor: string;
+  major: string;
+}
+
+export interface BulkResultItem {
+  name: string;
+  status: "created" | "skipped" | "error";
+  agent_id?: string | null;
+  error?: string | null;
+}
+
+export interface BulkResult {
+  total: number;
+  created: number;
+  skipped: number;
+  errors: number;
+  dry_run: boolean;
+  results: BulkResultItem[];
+}
+
 export interface FeedbackSummary {
   listing_id: string;
   average_rating: number;
@@ -146,6 +176,11 @@ export interface ReviewItem {
   status?: string;
   mcp_validated?: boolean;
   validation_results?: McpValidationResult[];
+  components_ready?: boolean;
+  component_blockers?: { component_type: string; component_id: string; name: string; status: string }[];
+  bundle_id?: string;
+  bundle_name?: string;
+  rejection_reason?: string;
 }
 
 // ── Scores ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Purpose / Description

Implements all remaining TODOs from PR #338, adding agent lifecycle management features, review queue improvements, bulk operations, and e2e test fixes.

## Fixes
* Fixes #338

## Approach

Each feature was developed in isolated worktrees and committed atomically:

- **Agent archive**: PATCH endpoint + admin-only archive button with confirmation dialog
- **Draft workflow**: Save/edit/submit drafts with localStorage auto-save (2s debounce) and restore banner
- **Version bump dialog**: Patch/minor/major/keep options when editing existing agents, with semver utility
- **Review queue tabs**: Separate Agents and Components tabs with component-readiness badges and bundle grouping
- **Leaderboard enhancements**: User filter (300ms debounce) for agents tab + component leaderboard tab
- **Bulk agent upload**: Server endpoint (POST /bulk/agents) with dedup/dry-run + CLI `agent bulk-create` command
- **StatusBadge archived variant**: Zinc-colored badge without activity indicator
- **E2e test auth fixes**: Replaced legacy `getApiKey` (config file read) with `getAccessToken` (login endpoint), added token caching per worker, rate-limit retry, and CLI `beforeAll` login setup
- **Suspense boundary**: Wrapped agent builder page for Next.js static prerendering compatibility

## How Has This Been Tested?

**Unit/Integration tests:**
- `tests/test_agent_review.py` — 8 tests for agent approve/reject flows
- `tests/test_bundles.py` — 6 tests for bundle approve/reject
- `tests/test_bulk.py` — 8 tests for bulk create/dry-run/dedup/validation
- `tests/test_draft_workflow.py` — 10 tests for draft save/update/submit lifecycle

**Linting:**
- `ruff check` and `ruff format` pass cleanly

**E2E (Playwright):**
- Full suite: **36 passed, 0 failed, 9 skipped, 2 flaky** (eventual consistency)
- Previously failing `kiro-cli.spec.ts` whoami test — now passes
- Previously failing `kiro-hooks.spec.ts` sessions test — now passes

**Test configuration:** Docker Compose full stack (PostgreSQL, ClickHouse, Redis, API, Web)

## Learning (optional, can help others)

- `useSearchParams()` in Next.js App Router requires a `<Suspense>` boundary or static prerendering fails during Docker build
- Pydantic models need runtime imports (e.g. `uuid`) even if they look like type-only — moving to `TYPE_CHECKING` breaks model resolution
- Playwright workers each have their own module scope, so auth token caching is per-worker — rate limiting across workers requires retry logic

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)