### PR TITLE
fix: make host ports configurable to avoid port conflicts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,13 @@ DEMO_REVIEWER_EMAIL=reviewer@demo.example
 DEMO_REVIEWER_PASSWORD=reviewer-changeme
 DEMO_USER_EMAIL=user@demo.example
 DEMO_USER_PASSWORD=user-changeme
+
+# Host port mappings (change these if defaults conflict with other services)
+# API_HOST_PORT=8000
+# POSTGRES_HOST_PORT=5432
+# CLICKHOUSE_HOST_PORT=8123
+# REDIS_HOST_PORT=6379
+# WEB_HOST_PORT=3000
+# OTEL_GRPC_HOST_PORT=4317
+# OTEL_HTTP_HOST_PORT=4318
+# GRAFANA_HOST_PORT=3001

--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ observal auth login            # auto-creates admin on fresh server
 
 That's it. The `.env.example` ships with working defaults for every setting. The server starts 8 services (API, web UI, PostgreSQL, ClickHouse, Redis, background worker, OpenTelemetry collector, Grafana) and creates all database tables on first boot.
 
+
+> **Port conflicts?** If `docker compose up` fails with `port is already allocated`, another service is using the default ports. Check and resolve before starting:
+> ```bash
+> # Check for occupied default ports (macOS/Linux)
+> lsof -nP -iTCP:5432 -sTCP:LISTEN   # PostgreSQL
+> lsof -nP -iTCP:6379 -sTCP:LISTEN   # Redis
+>
+> # Windows (PowerShell)
+> netstat -ano | findstr :5432
+> netstat -ano | findstr :6379
+> ```
+> Either stop the conflicting services, or remap Observal's host ports:
+> ```bash
+> POSTGRES_HOST_PORT=5433 REDIS_HOST_PORT=6380 docker compose up --build -d
+> ```
+> If you already started with a port conflict, fully recreate the stack:
+> ```bash
+> docker compose down && docker compose up -d
+> ```
+> See `.env.example` for all configurable port variables.
+
+
 Already have MCP servers in your IDE? Instrument them in one command:
 
 ```bash

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,11 @@
+
 services:
   observal-api:
     build:
       context: ..
       dockerfile: docker/Dockerfile.api
     ports:
-      - "8000:8000"
+      - "${API_HOST_PORT:-8000}:8000"
     env_file:
       - ../.env
     environment:
@@ -57,7 +58,7 @@ services:
   observal-db:
     image: postgres:16
     ports:
-      - "5432:5432"
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
     env_file:
       - ../.env
     environment:
@@ -79,7 +80,7 @@ services:
   observal-clickhouse:
     image: clickhouse/clickhouse-server:26.3
     ports:
-      - "8123:8123"
+      - "${CLICKHOUSE_HOST_PORT:-8123}:8123"
     env_file:
       - ../.env
     environment:
@@ -101,7 +102,7 @@ services:
   observal-redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - redisdata:/data
     healthcheck:
@@ -154,7 +155,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.web
     ports:
-      - "3000:3000"
+      - "${WEB_HOST_PORT:-3000}:3000"
     environment:
       - NEXT_PUBLIC_API_URL=http://observal-api:8000
     depends_on:
@@ -177,8 +178,8 @@ services:
     command: ["--config", "/etc/otelcol/config.yaml"]
     restart: on-failure
     ports:
-      - "4317:4317"
-      - "4318:4318"
+      - "${OTEL_GRPC_HOST_PORT:-4317}:4317"
+      - "${OTEL_HTTP_HOST_PORT:-4318}:4318"
     volumes:
       - ../otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
     depends_on:
@@ -196,7 +197,7 @@ services:
   observal-grafana:
     image: grafana/grafana-oss:11.6.5
     ports:
-      - "3001:3000"
+      - "${GRAFANA_HOST_PORT:-3001}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}


### PR DESCRIPTION
## Purpose / Description
`docker compose up` fails with `port is already allocated` when another service (e.g., local Postgres, another Docker project) is already bound to default ports like **5432** or **6379**. 

After resolving the conflict, simply retrying `docker compose up -d` can leave the API in a crash-loop due to stale Docker network state, requiring a full `docker compose down && docker compose up -d` to recover. 

This PR makes host ports configurable and documents the issue to improve the onboarding experience for new developers.

## Fixes 
* Fixes #`349`

---

## Approach

### **1. Compose Ergonomics**
* **Variable Mapping:** All 8 host port mappings in `docker-compose.yml` now use `${VAR:-default}` syntax (e.g., `${POSTGRES_HOST_PORT:-5432}:5432`).
* **Environment Configuration:** Added port variables to `.env.example` (commented out, with defaults documented).
* **Flexibility:** Users can now resolve conflicts via environment variables without modifying core compose files:
  ```bash
  POSTGRES_HOST_PORT=5433 REDIS_HOST_PORT=6380 docker compose up --build -d
  ```

### **2. Documentation Hardening (README)**
* Added a **"Port conflicts?"** callout after the Quick Start section:
  * Provided port check commands for **macOS/Linux** (`lsof`) and **Windows** (`netstat`).
  * Documented how to remap ports via `.env` overrides.
  * Explained the `docker compose down && docker compose up -d` workaround for stale network states.

---

## How Has This Been Tested?
1. **Simulated Conflict:** Started dummy Postgres and Redis containers on default ports `5432` and `6379`.
2. **Environment Override:** Launched Observal using `POSTGRES_HOST_PORT=5433 REDIS_HOST_PORT=6380`.
3. **Concurrency Check:** Confirmed all 10 containers (8 Observal + 2 dummy) ran simultaneously without conflicts.
4. **Health Check:** API reported healthy; auth endpoint responded correctly.
5. **Regression Check:** Verified defaults still work perfectly when no environment variables are present.

---

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] Descriptive commit message with a short title (first line, max 50 chars).
- [x] Commented code in hard-to-understand areas.
- [x] Performed a self-review of my own code.
- [ ] UI changes: (N/A - No frontend changes)


| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->