### PR TITLE
Implemented migrate commands for shallow copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
           cd observal-server
           uv run \
             --python ${{ matrix.python-version }} \
+            --with asyncpg \
+            --with hypothesis \
             pytest ../tests/ -q
 
 # ── Job 3: Next.js lint + typecheck ───────────────────────────────────────────

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -1,0 +1,743 @@
+"""observal migrate: PostgreSQL shallow-copy migration tools."""
+
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import asyncpg
+import typer
+from rich import print as rprint
+
+from observal_cli import client
+from observal_cli.render import spinner
+
+# ── Constants ────────────────────────────────────────────
+
+CHUNK_SIZE = 500
+
+INSERT_ORDER: list[str] = [
+    # Tier 0 — no FK dependencies
+    "organizations",
+    "enterprise_config",
+    "component_sources",
+    "penalty_definitions",
+    # Tier 1 — FK to organizations
+    "users",
+    "exporter_configs",
+    # Tier 1.5 — FK to users
+    "component_bundles",
+    # Tier 2 — FK to orgs + users + component_bundles
+    "mcp_listings",
+    "skill_listings",
+    "hook_listings",
+    "prompt_listings",
+    "sandbox_listings",
+    "agents",
+    # Tier 3 — FK to listings/users
+    "mcp_validation_results",
+    "mcp_downloads",
+    "skill_downloads",
+    "hook_downloads",
+    "prompt_downloads",
+    "sandbox_downloads",
+    "submissions",
+    "alert_rules",
+    # Tier 4 — FK to agents
+    "agent_goal_templates",
+    "agent_download_records",
+    "component_download_records",
+    "dimension_weights",
+    # Tier 5 — FK to agent_goal_templates
+    "agent_goal_sections",
+    # Tier 6 — FK to agents (polymorphic component_id)
+    "agent_components",
+    # Tier 7 — FK to users (polymorphic listing_id)
+    "feedback",
+    # Tier 8 — FK to alert_rules
+    "alert_history",
+    # Tier 9 — FK to agents + users
+    "eval_runs",
+    # Tier 10 — FK to eval_runs
+    "scorecards",
+    # Tier 11 — FK to scorecards + penalty_definitions
+    "scorecard_dimensions",
+    "trace_penalties",
+]
+
+JSONB_COLUMNS: dict[str, list[str]] = {
+    "agents": ["model_config_json", "external_mcps", "supported_ides"],
+    "mcp_listings": ["tools_schema", "environment_variables", "supported_ides"],
+    "skill_listings": ["supported_ides", "target_agents", "triggers", "mcp_server_config", "activation_keywords"],
+    "hook_listings": ["supported_ides", "handler_config", "input_schema", "output_schema"],
+    "prompt_listings": ["variables", "model_hints", "tags", "supported_ides"],
+    "sandbox_listings": ["resource_limits", "allowed_mounts", "env_vars", "supported_ides"],
+    "scorecards": ["raw_output", "dimension_scores", "scoring_recommendations", "dimensions_skipped", "warnings"],
+    "agent_components": ["config_override"],
+    "exporter_configs": ["config"],
+}
+
+
+# ── PGEncoder ────────────────────────────────────────────
+
+
+class PGEncoder(json.JSONEncoder):
+    """Custom JSON encoder for PostgreSQL row data."""
+
+    def default(self, obj: object) -> object:
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        if isinstance(obj, timedelta):
+            return obj.total_seconds()
+        return super().default(obj)
+
+
+# ── Dataclasses ──────────────────────────────────────────
+
+
+@dataclass
+class ExportResult:
+    archive_path: str
+    migration_id: str
+    table_counts: dict[str, int]
+    checksums: dict[str, str]
+    duration_seconds: float
+    total_rows: int
+
+
+@dataclass
+class ImportResult:
+    migration_id: str
+    tables_imported: int
+    rows_inserted: dict[str, int]
+    rows_skipped: dict[str, int]
+    duration_seconds: float
+    warnings: list[str]
+
+
+@dataclass
+class ChecksumResult:
+    table_name: str
+    expected_checksum: str
+    actual_checksum: str
+    passed: bool
+
+
+@dataclass
+class ValidationResult:
+    archive_valid: bool
+    checksum_results: list[ChecksumResult]
+    cross_db_results: dict[str, tuple[int, int]] | None
+
+
+# ── Helper functions ─────────────────────────────────────
+
+
+def _require_admin() -> None:
+    """Verify the current user has admin or super_admin role. Exit if not."""
+    try:
+        user = client.get("/api/v1/auth/whoami")
+    except SystemExit:
+        rprint("[red]Authentication required.[/red]")
+        rprint("[dim]  Run [bold]observal auth login[/bold] first.[/dim]")
+        raise typer.Exit(1)
+    role = user.get("role", "")
+    if role not in ("admin", "super_admin"):
+        rprint("[red]Permission denied.[/red] The migrate command requires admin or super_admin role.")
+        rprint(f"[dim]  Current role: {role}[/dim]")
+        raise typer.Exit(1)
+
+
+def _build_select(table: str, columns: list[str]) -> str:
+    """Build SELECT query, casting JSONB columns to ::text."""
+    jsonb_cols = JSONB_COLUMNS.get(table, [])
+    if not jsonb_cols:
+        return f"SELECT * FROM {table}"
+    parts = []
+    for col in columns:
+        if col in jsonb_cols:
+            parts.append(f"{col}::text AS {col}")
+        else:
+            parts.append(col)
+    return f"SELECT {', '.join(parts)} FROM {table}"
+
+
+def _sha256_file(path: Path) -> str:
+    """Compute SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ── Async helpers ────────────────────────────────────────
+
+
+async def _connect(db_url: str) -> asyncpg.Connection:
+    """Establish asyncpg connection, verify alembic_version table exists."""
+    # Strip SQLAlchemy dialect suffixes (e.g. postgresql+asyncpg:// → postgresql://)
+    clean_url = (
+        db_url.split("+")[0] + db_url[db_url.index("://") :] if "+asyncpg" in db_url or "+psycopg" in db_url else db_url
+    )
+    try:
+        conn = await asyncpg.connect(clean_url)
+    except (asyncpg.InvalidCatalogNameError, asyncpg.InvalidPasswordError, OSError, Exception) as e:
+        rprint(f"[red]Database connection failed:[/red] {type(e).__name__}: {e}")
+        raise typer.Exit(1)
+    # Verify this is an Observal database
+    result = await conn.fetchval(
+        "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'alembic_version')"
+    )
+    if not result:
+        await conn.close()
+        rprint("[red]Database does not contain an Observal schema[/red] (alembic_version table not found).")
+        rprint("[dim]  Is this the right database?[/dim]")
+        raise typer.Exit(1)
+    return conn
+
+
+async def _get_column_types(conn: asyncpg.Connection, table: str) -> dict[str, str]:
+    """Get column name -> PostgreSQL type mapping for a table."""
+    rows = await conn.fetch(
+        "SELECT column_name, udt_name FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position",
+        table,
+    )
+    return {row["column_name"]: row["udt_name"] for row in rows}
+
+
+def _coerce_value(value: object, pg_type: str) -> object:
+    """Coerce a JSON-deserialized value to the correct Python type for asyncpg."""
+    if value is None:
+        return None
+    if pg_type == "uuid" and isinstance(value, str):
+        return uuid.UUID(value)
+    if pg_type in ("timestamptz", "timestamp") and isinstance(value, str):
+        return datetime.fromisoformat(value)
+    if pg_type == "interval" and isinstance(value, (int, float)):
+        return timedelta(seconds=value)
+    if pg_type in ("bool",) and isinstance(value, bool):
+        return value
+    if pg_type in ("int4", "int8", "int2") and isinstance(value, (int, float)):
+        return int(value)
+    if pg_type in ("float4", "float8", "numeric") and isinstance(value, (int, float)):
+        return float(value)
+    return value
+
+
+def _build_insert(table: str, columns: list[str], col_types: dict[str, str]) -> str:
+    """Build INSERT query with proper type casts for JSONB columns."""
+    cols_str = ", ".join(f'"{col}"' for col in columns)
+    parts = []
+    for i, col in enumerate(columns):
+        pg_type = col_types.get(col, "")
+        if pg_type in ("json", "jsonb"):
+            parts.append(f"${i + 1}::jsonb")
+        else:
+            parts.append(f"${i + 1}")
+    placeholders = ", ".join(parts)
+    return f'INSERT INTO {table} ({cols_str}) VALUES ({placeholders}) ON CONFLICT ("id") DO NOTHING'
+
+
+async def _flush_batch(
+    conn: asyncpg.Connection,
+    table: str,
+    columns: list[str],
+    col_types: dict[str, str],
+    batch: list[dict],
+) -> tuple[int, int]:
+    """Flush a batch of rows to the database. Returns (inserted, skipped)."""
+    if not batch:
+        return 0, 0
+
+    query = _build_insert(table, columns, col_types)
+
+    inserted = 0
+    skipped = 0
+
+    for row in batch:
+        values = [_coerce_value(row.get(col), col_types.get(col, "")) for col in columns]
+        try:
+            status = await conn.execute(query, *values)
+            # status is like "INSERT 0 1" (inserted) or "INSERT 0 0" (conflict)
+            count = int(status.split()[-1])
+            if count > 0:
+                inserted += 1
+            else:
+                skipped += 1
+        except asyncpg.ForeignKeyViolationError as e:
+            row_id = row.get("id", "unknown")
+            rprint(f"[yellow]  FK violation in {table}, row {row_id}: {e.constraint_name}[/yellow]")
+            skipped += 1
+
+    return inserted, skipped
+
+
+async def _insert_table(
+    conn: asyncpg.Connection,
+    table: str,
+    jsonl_path: Path,
+    col_types: dict[str, str],
+) -> tuple[int, int]:
+    """Insert rows from a JSONL file into a table. Returns (inserted, skipped)."""
+    inserted = 0
+    skipped = 0
+    batch: list[dict] = []
+    columns: list[str] | None = None
+
+    with open(jsonl_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+
+            if columns is None:
+                columns = list(row.keys())
+
+            batch.append(row)
+
+            if len(batch) >= CHUNK_SIZE:
+                ins, sk = await _flush_batch(conn, table, columns, col_types, batch)
+                inserted += ins
+                skipped += sk
+                batch = []
+
+    if batch and columns:
+        ins, sk = await _flush_batch(conn, table, columns, col_types, batch)
+        inserted += ins
+        skipped += sk
+
+    return inserted, skipped
+
+
+async def _import_archive(db_url: str, archive_path: Path) -> ImportResult:
+    """Import a migration archive into the target database."""
+    t0 = time.monotonic()
+    warnings: list[str] = []
+
+    staging_dir = Path(tempfile.mkdtemp())
+    os.chmod(staging_dir, 0o700)
+    try:
+        # Extract archive
+        with tarfile.open(archive_path, "r:gz") as tar:
+            tar.extractall(staging_dir, filter="data")
+
+        # Read manifest
+        manifest_path = staging_dir / "manifest.json"
+        if not manifest_path.exists():
+            rprint("[red]Archive does not contain manifest.json[/red]")
+            raise typer.Exit(1)
+        manifest = json.loads(manifest_path.read_text())
+        migration_id = manifest["migration_id"]
+
+        # Verify checksums BEFORE any DB operations
+        failed_checksums: list[str] = []
+        for table in INSERT_ORDER:
+            jsonl_path = staging_dir / "pg" / f"{table}.jsonl"
+            if not jsonl_path.exists():
+                failed_checksums.append(f"{table} (file missing)")
+                continue
+            expected = manifest["tables"][table]["checksum"]
+            actual = _sha256_file(jsonl_path)
+            if actual != expected:
+                failed_checksums.append(table)
+
+        if failed_checksums:
+            rprint("[red]Checksum verification failed:[/red]")
+            for name in failed_checksums:
+                rprint(f"  [red]✗[/red] {name}")
+            rprint("\n[dim]Archive may be corrupted or tampered. Re-export from source.[/dim]")
+            raise typer.Exit(1)
+
+        # Connect and verify schema version
+        conn = await _connect(db_url)
+        try:
+            target_version = await conn.fetchval("SELECT version_num FROM alembic_version LIMIT 1")
+            source_version = manifest["source_alembic_version"]
+            if target_version != source_version:
+                rprint("[red]Schema version mismatch:[/red]")
+                rprint(f"  Archive: {source_version}")
+                rprint(f"  Target:  {target_version}")
+                rprint("\n[dim]  Run: cd observal-server && alembic upgrade head[/dim]")
+                raise typer.Exit(1)
+
+            rows_inserted: dict[str, int] = {}
+            rows_skipped: dict[str, int] = {}
+
+            # Discover which tables exist on the target
+            existing_tables = {
+                row["table_name"]
+                for row in await conn.fetch(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"
+                )
+            }
+
+            for table in INSERT_ORDER:
+                jsonl_path = staging_dir / "pg" / f"{table}.jsonl"
+
+                # Skip tables that don't exist on target
+                if table not in existing_tables:
+                    rprint(f"[dim]  Skipping {table} (table does not exist on target)[/dim]")
+                    rows_inserted[table] = 0
+                    rows_skipped[table] = 0
+                    continue
+
+                # Get column types for proper coercion
+                col_types = await _get_column_types(conn, table)
+
+                ins, sk = await _insert_table(conn, table, jsonl_path, col_types)
+                rows_inserted[table] = ins
+                rows_skipped[table] = sk
+
+        finally:
+            await conn.close()
+
+        elapsed = time.monotonic() - t0
+        return ImportResult(
+            migration_id=migration_id,
+            tables_imported=len(INSERT_ORDER),
+            rows_inserted=rows_inserted,
+            rows_skipped=rows_skipped,
+            duration_seconds=round(elapsed, 2),
+            warnings=warnings,
+        )
+
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+async def _validate_archive(archive_path: Path, db_url: str | None) -> ValidationResult:
+    """Validate archive checksums and optionally compare against a database."""
+    staging_dir = Path(tempfile.mkdtemp())
+    os.chmod(staging_dir, 0o700)
+    try:
+        with tarfile.open(archive_path, "r:gz") as tar:
+            tar.extractall(staging_dir, filter="data")
+
+        manifest_path = staging_dir / "manifest.json"
+        if not manifest_path.exists():
+            rprint("[red]Archive does not contain manifest.json[/red]")
+            raise typer.Exit(1)
+        manifest = json.loads(manifest_path.read_text())
+
+        # Verify checksums
+        checksum_results: list[ChecksumResult] = []
+        for table in INSERT_ORDER:
+            jsonl_path = staging_dir / "pg" / f"{table}.jsonl"
+            expected = manifest["tables"][table]["checksum"]
+            if not jsonl_path.exists():
+                checksum_results.append(ChecksumResult(table, expected, "", False))
+                continue
+            actual = _sha256_file(jsonl_path)
+            checksum_results.append(ChecksumResult(table, expected, actual, actual == expected))
+
+        all_ok = all(r.passed for r in checksum_results)
+
+        # Optional cross-database validation
+        cross_db_results: dict[str, tuple[int, int]] | None = None
+        if db_url:
+            conn = await _connect(db_url)
+            try:
+                existing_tables = {
+                    row["table_name"]
+                    for row in await conn.fetch(
+                        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"
+                    )
+                }
+                cross_db_results = {}
+                for table in INSERT_ORDER:
+                    archive_count = manifest["tables"][table]["row_count"]
+                    if table not in existing_tables:
+                        cross_db_results[table] = (archive_count, -1)  # -1 signals table missing
+                        continue
+                    db_count = await conn.fetchval(f"SELECT count(*) FROM {table}")
+                    cross_db_results[table] = (archive_count, db_count)
+            finally:
+                await conn.close()
+
+        return ValidationResult(
+            archive_valid=all_ok,
+            checksum_results=checksum_results,
+            cross_db_results=cross_db_results,
+        )
+
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+async def _export_database(db_url: str, output_path: Path) -> ExportResult:
+    """Export all tables to JSONL files and pack into a tar.gz archive."""
+    t0 = time.monotonic()
+    migration_id = str(uuid.uuid4())
+
+    staging_dir = Path(tempfile.mkdtemp())
+    os.chmod(staging_dir, 0o700)
+    try:
+        pg_dir = staging_dir / "pg"
+        pg_dir.mkdir()
+
+        conn = await _connect(db_url)
+        try:
+            # Read alembic version
+            alembic_version = await conn.fetchval("SELECT version_num FROM alembic_version LIMIT 1")
+            if not alembic_version:
+                rprint("[red]Could not read alembic version from source database.[/red]")
+                raise typer.Exit(1)
+
+            table_counts: dict[str, int] = {}
+            file_hashes: dict[str, str] = {}
+            uuid_ranges: dict[str, dict[str, str]] = {}
+
+            # Open REPEATABLE READ transaction for consistent snapshot
+            async with conn.transaction(isolation="repeatable_read", readonly=True):
+                # Discover which tables actually exist in the database
+                existing_tables = {
+                    row["table_name"]
+                    for row in await conn.fetch(
+                        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"
+                    )
+                }
+
+                for table in INSERT_ORDER:
+                    dest = pg_dir / f"{table}.jsonl"
+
+                    # Skip tables that don't exist yet (DB on older migration)
+                    if table not in existing_tables:
+                        rprint(f"[dim]  Skipping {table} (table does not exist)[/dim]")
+                        # Write empty JSONL file so archive structure is consistent
+                        dest.write_text("")
+                        table_counts[table] = 0
+                        file_hashes[table] = _sha256_file(dest)
+                        continue
+
+                    # Discover columns via prepared statement
+                    stmt = await conn.prepare(f"SELECT * FROM {table} LIMIT 0")
+                    columns = [attr.name for attr in stmt.get_attributes()]
+
+                    query = _build_select(table, columns)
+
+                    row_count = 0
+                    min_id: str | None = None
+                    max_id: str | None = None
+
+                    with open(dest, "w", encoding="utf-8") as f:
+                        async for record in conn.cursor(query, prefetch=CHUNK_SIZE):
+                            row = dict(record)
+                            line = json.dumps(row, cls=PGEncoder)
+                            f.write(line + "\n")
+                            row_count += 1
+
+                            # Track UUID range
+                            row_id = row.get("id")
+                            if row_id is not None:
+                                id_str = str(row_id)
+                                if min_id is None or id_str < min_id:
+                                    min_id = id_str
+                                if max_id is None or id_str > max_id:
+                                    max_id = id_str
+
+                    table_counts[table] = row_count
+                    file_hashes[table] = _sha256_file(dest)
+
+                    if min_id is not None:
+                        uuid_ranges[table] = {"min_id": min_id, "max_id": max_id}
+
+        finally:
+            await conn.close()
+
+        # Write manifest.json
+        exported_at = datetime.now(UTC).isoformat()
+        manifest = {
+            "schema_version": "1.0",
+            "migration_id": migration_id,
+            "exported_at": exported_at,
+            "source_alembic_version": alembic_version,
+            "tables": {
+                table: {"checksum": file_hashes[table], "row_count": table_counts[table]} for table in INSERT_ORDER
+            },
+        }
+        manifest_path = staging_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+        # Write migration_manifest.json
+        db_url_hash = hashlib.sha256(db_url.encode()).hexdigest()
+        migration_manifest = {
+            "migration_id": migration_id,
+            "phase1_completed_at": exported_at,
+            "source_db_url_hash": db_url_hash,
+            "table_row_counts": dict(table_counts),
+            "uuid_ranges": uuid_ranges,
+        }
+        migration_manifest_path = staging_dir / "migration_manifest.json"
+        migration_manifest_path.write_text(json.dumps(migration_manifest, indent=2) + "\n")
+
+        # Ensure output parent directory exists
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Pack archive
+        with tarfile.open(output_path, "w:gz") as tar:
+            tar.add(str(manifest_path), arcname="manifest.json")
+            tar.add(str(migration_manifest_path), arcname="migration_manifest.json")
+            for table in INSERT_ORDER:
+                jsonl_file = pg_dir / f"{table}.jsonl"
+                tar.add(str(jsonl_file), arcname=f"pg/{table}.jsonl")
+
+        elapsed = time.monotonic() - t0
+        total_rows = sum(table_counts.values())
+
+        return ExportResult(
+            archive_path=str(output_path),
+            migration_id=migration_id,
+            table_counts=table_counts,
+            checksums=file_hashes,
+            duration_seconds=round(elapsed, 2),
+            total_rows=total_rows,
+        )
+
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+# ── Typer app ────────────────────────────────────────────
+
+migrate_app = typer.Typer(help="PostgreSQL shallow-copy migration tools")
+
+
+@migrate_app.command("export")
+def export_cmd(
+    db_url: str = typer.Option(..., "--db-url", help="Source PostgreSQL connection string"),
+    output: str | None = typer.Option(None, "--output", "-o", help="Output archive path"),
+) -> None:
+    """Export all PostgreSQL registry data to a portable archive."""
+    _require_admin()
+
+    # Default output filename
+    if output is None:
+        ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+        output = f"observal-export-{ts}.tar.gz"
+
+    output_path = Path(output)
+    if output_path.exists():
+        rprint(f"[red]Output file already exists:[/red] {output_path}")
+        rprint("[dim]  Choose a different path or remove the existing file.[/dim]")
+        raise typer.Exit(1)
+
+    rprint(f"[bold]Exporting to:[/bold] {output_path}")
+    with spinner("Connecting to source database..."):
+        result = asyncio.run(_export_database(db_url, output_path))
+
+    # Summary
+    archive_size = output_path.stat().st_size
+    size_mb = archive_size / (1024 * 1024)
+    rprint("\n[bold green]✓ Export complete[/bold green]")
+    rprint(f"  Archive:    {result.archive_path}")
+    rprint(f"  Migration:  {result.migration_id}")
+    rprint(f"  Tables:     {len(result.table_counts)}")
+    rprint(f"  Rows:       {result.total_rows:,}")
+    rprint(f"  Size:       {size_mb:.1f} MB")
+    rprint(f"  Duration:   {result.duration_seconds:.1f}s")
+
+    # Security warning
+    rprint()
+    rprint("[yellow]⚠  Archive contains hashed credentials (passwords, API keys).[/yellow]")
+    rprint("[yellow]   Store securely and delete after import.[/yellow]")
+
+
+@migrate_app.command("import")
+def import_cmd(
+    db_url: str = typer.Option(..., "--db-url", help="Target PostgreSQL connection string"),
+    archive: str = typer.Option(..., "--archive", "-a", help="Path to .tar.gz archive"),
+) -> None:
+    """Import a migration archive into the target database."""
+    _require_admin()
+
+    archive_path = Path(archive)
+    if not archive_path.exists():
+        rprint(f"[red]Archive not found:[/red] {archive_path}")
+        raise typer.Exit(1)
+
+    if not tarfile.is_tarfile(archive_path):
+        rprint(f"[red]Invalid archive format:[/red] {archive_path}")
+        rprint("[dim]  Expected a .tar.gz file.[/dim]")
+        raise typer.Exit(1)
+
+    rprint(f"[bold]Importing from:[/bold] {archive_path}")
+    with spinner("Importing..."):
+        result = asyncio.run(_import_archive(db_url, archive_path))
+
+    total_inserted = sum(result.rows_inserted.values())
+    total_skipped = sum(result.rows_skipped.values())
+
+    rprint("\n[bold green]✓ Import complete[/bold green]")
+    rprint(f"  Migration:  {result.migration_id}")
+    rprint(f"  Tables:     {result.tables_imported}")
+    rprint(f"  Inserted:   {total_inserted:,}")
+    rprint(f"  Skipped:    {total_skipped:,}")
+    rprint(f"  Duration:   {result.duration_seconds:.1f}s")
+
+    if result.warnings:
+        rprint("\n[yellow]Warnings:[/yellow]")
+        for w in result.warnings:
+            rprint(f"  [yellow]⚠[/yellow]  {w}")
+
+
+@migrate_app.command("validate")
+def validate_cmd(
+    archive: str = typer.Option(..., "--archive", "-a", help="Path to .tar.gz archive"),
+    db_url: str | None = typer.Option(None, "--db-url", help="Optional database for cross-validation"),
+) -> None:
+    """Validate archive integrity and optionally compare against a database."""
+    _require_admin()
+
+    archive_path = Path(archive)
+    if not archive_path.exists():
+        rprint(f"[red]Archive not found:[/red] {archive_path}")
+        raise typer.Exit(1)
+
+    if not tarfile.is_tarfile(archive_path):
+        rprint(f"[red]Invalid archive format:[/red] {archive_path}")
+        raise typer.Exit(1)
+
+    with spinner("Validating archive..."):
+        result = asyncio.run(_validate_archive(archive_path, db_url))
+
+    # Print checksum results
+    rprint("\n[bold]Checksum verification:[/bold]")
+    for cr in result.checksum_results:
+        status = "[green]✓[/green]" if cr.passed else "[red]✗[/red]"
+        rprint(f"  {status} {cr.table_name}")
+
+    if not result.archive_valid:
+        rprint("\n[red]Archive validation failed.[/red]")
+        raise typer.Exit(1)
+
+    rprint("\n[green]✓ All checksums valid[/green]")
+
+    # Cross-database comparison
+    if result.cross_db_results:
+        rprint("\n[bold]Row count comparison:[/bold]")
+        mismatches = 0
+        for table, (archive_count, db_count) in result.cross_db_results.items():
+            if db_count == -1:
+                rprint(f"  [dim]-[/dim] {table}: [dim]table not in database[/dim]")
+            elif archive_count == db_count:
+                rprint(f"  [green]✓[/green] {table}: {archive_count}")
+            else:
+                rprint(f"  [yellow]≠[/yellow] {table}: archive={archive_count}, db={db_count}")
+                mismatches += 1
+
+        if mismatches == 0:
+            rprint("\n[green]✓ All row counts match[/green]")
+        else:
+            rprint(f"\n[yellow]⚠  {mismatches} table(s) have different row counts[/yellow]")

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -51,6 +51,7 @@ from observal_cli.cmd_auth import auth_app, register_config
 from observal_cli.cmd_doctor import doctor_app
 from observal_cli.cmd_hook import hook_app
 from observal_cli.cmd_mcp import mcp_app
+from observal_cli.cmd_migrate import migrate_app
 from observal_cli.cmd_ops import (
     admin_app,
     ops_app,
@@ -97,6 +98,7 @@ app.add_typer(ops_app, name="ops")
 app.add_typer(admin_app, name="admin")
 app.add_typer(self_app, name="self")
 app.add_typer(doctor_app, name="doctor")
+app.add_typer(migrate_app, name="migrate")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "pyyaml>=6.0.3",
     "questionary>=2.0.0",
     "docker>=7.0.0",
+    "asyncpg>=0.29.0",
+    "hypothesis",
 ]
 
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,977 @@
+"""Unit tests for pg-shallow-copy: observal migrate CLI command group."""
+
+import hashlib
+import json
+import re
+import tempfile
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import click.exceptions
+import pytest
+from hypothesis import given
+from hypothesis import settings as hsettings
+from hypothesis import strategies as st
+from typer.testing import CliRunner
+
+from observal_cli.cmd_migrate import (
+    CHUNK_SIZE,
+    INSERT_ORDER,
+    JSONB_COLUMNS,
+    ChecksumResult,
+    ExportResult,
+    ImportResult,
+    PGEncoder,
+    ValidationResult,
+    _build_insert,
+    _build_select,
+    _coerce_value,
+    _require_admin,
+    _sha256_file,
+)
+from observal_cli.main import app as cli_app
+
+runner = CliRunner()
+
+
+# ── 1. CLI Registration Tests ────────────────────────────
+
+
+class TestCLIRegistration:
+    def test_migrate_command_group_exists(self):
+        result = runner.invoke(cli_app, ["migrate", "--help"])
+        assert result.exit_code == 0
+        assert "migrate" in result.output.lower()
+
+    def test_migrate_help_lists_subcommands(self):
+        result = runner.invoke(cli_app, ["migrate", "--help"])
+        assert result.exit_code == 0
+        assert "export" in result.output
+        assert "import" in result.output
+        assert "validate" in result.output
+
+    def test_export_subcommand_help(self):
+        result = runner.invoke(cli_app, ["migrate", "export", "--help"])
+        assert result.exit_code == 0
+        assert "--db-url" in result.output
+
+    def test_import_subcommand_help(self):
+        result = runner.invoke(cli_app, ["migrate", "import", "--help"])
+        assert result.exit_code == 0
+        assert "--db-url" in result.output
+        assert "--archive" in result.output
+
+    def test_validate_subcommand_help(self):
+        result = runner.invoke(cli_app, ["migrate", "validate", "--help"])
+        assert result.exit_code == 0
+        assert "--archive" in result.output
+
+
+# ── 2. PGEncoder Tests ───────────────────────────────────
+
+
+class TestPGEncoder:
+    def test_uuid_serialization(self):
+        test_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        result = json.dumps(test_uuid, cls=PGEncoder)
+        assert result == '"12345678-1234-5678-1234-567812345678"'
+
+    def test_datetime_serialization(self):
+        dt = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
+        result = json.dumps(dt, cls=PGEncoder)
+        parsed = json.loads(result)
+        assert "2026-01-15" in parsed
+        assert "10:30:00" in parsed
+
+    def test_timedelta_serialization(self):
+        td = timedelta(hours=2, minutes=30)
+        result = json.dumps(td, cls=PGEncoder)
+        assert json.loads(result) == 9000.0
+
+    def test_none_passthrough(self):
+        assert json.dumps(None, cls=PGEncoder) == "null"
+
+    def test_str_passthrough(self):
+        assert json.dumps("hello", cls=PGEncoder) == '"hello"'
+
+    def test_int_passthrough(self):
+        assert json.dumps(42, cls=PGEncoder) == "42"
+
+    def test_float_passthrough(self):
+        assert json.dumps(3.14, cls=PGEncoder) == "3.14"
+
+    def test_bool_passthrough(self):
+        assert json.dumps(True, cls=PGEncoder) == "true"
+        assert json.dumps(False, cls=PGEncoder) == "false"
+
+    def test_round_trip_uuid(self):
+        original = uuid.uuid4()
+        encoded = json.dumps(original, cls=PGEncoder)
+        decoded = json.loads(encoded)
+        assert uuid.UUID(decoded) == original
+
+    def test_round_trip_datetime(self):
+        original = datetime(2026, 6, 15, 14, 30, 22, 123456, tzinfo=UTC)
+        encoded = json.dumps(original, cls=PGEncoder)
+        decoded = json.loads(encoded)
+        restored = datetime.fromisoformat(decoded)
+        assert restored == original
+
+    def test_round_trip_timedelta(self):
+        original = timedelta(days=1, hours=3, seconds=45)
+        encoded = json.dumps(original, cls=PGEncoder)
+        decoded = json.loads(encoded)
+        restored = timedelta(seconds=decoded)
+        assert restored == original
+
+    def test_mixed_row(self):
+        row = {
+            "id": uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            "name": "test-org",
+            "count": 42,
+            "active": True,
+            "score": 3.14,
+            "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+            "interval": timedelta(hours=1),
+            "notes": None,
+        }
+        encoded = json.dumps(row, cls=PGEncoder)
+        decoded = json.loads(encoded)
+        assert decoded["id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert decoded["name"] == "test-org"
+        assert decoded["count"] == 42
+        assert decoded["active"] is True
+        assert decoded["score"] == 3.14
+        assert decoded["notes"] is None
+        assert isinstance(decoded["interval"], float)
+
+
+# ── 3. Constants Tests ───────────────────────────────────
+
+
+class TestConstants:
+    def test_insert_order_has_33_entries(self):
+        assert len(INSERT_ORDER) == 33
+
+    def test_insert_order_no_duplicates(self):
+        assert len(INSERT_ORDER) == len(set(INSERT_ORDER))
+
+    def test_insert_order_contains_key_tables(self):
+        key_tables = [
+            "organizations",
+            "users",
+            "agents",
+            "mcp_listings",
+            "feedback",
+            "eval_runs",
+            "scorecards",
+            "alert_rules",
+            "alert_history",
+            "component_bundles",
+        ]
+        for table in key_tables:
+            assert table in INSERT_ORDER, f"Missing table: {table}"
+
+    def test_jsonb_columns_tables_in_insert_order(self):
+        for table in JSONB_COLUMNS:
+            assert table in INSERT_ORDER, f"JSONB table '{table}' not in INSERT_ORDER"
+
+    def test_chunk_size_is_500(self):
+        assert CHUNK_SIZE == 500
+
+
+# ── 4. _build_select Tests ──────────────────────────────
+
+
+class TestBuildSelect:
+    def test_table_with_jsonb_columns(self):
+        columns = ["id", "name", "model_config_json", "external_mcps", "supported_ides", "created_at"]
+        sql = _build_select("agents", columns)
+        assert "model_config_json::text AS model_config_json" in sql
+        assert "external_mcps::text AS external_mcps" in sql
+        assert "supported_ides::text AS supported_ides" in sql
+        # Non-JSONB columns should not have ::text
+        assert "id::text" not in sql
+        assert "name::text" not in sql
+
+    def test_table_without_jsonb_columns(self):
+        sql = _build_select("organizations", ["id", "name", "slug"])
+        assert sql == "SELECT * FROM organizations"
+
+    def test_agents_produces_correct_sql(self):
+        columns = ["id", "name", "model_config_json"]
+        sql = _build_select("agents", columns)
+        assert sql.startswith("SELECT ")
+        assert "FROM agents" in sql
+        assert "model_config_json::text AS model_config_json" in sql
+        assert ", id," not in sql or "id" in sql  # id should be plain
+
+    def test_all_jsonb_tables_produce_casts(self):
+        for table, jsonb_cols in JSONB_COLUMNS.items():
+            # Use JSONB columns plus a non-JSONB column
+            columns = ["id", *jsonb_cols]
+            sql = _build_select(table, columns)
+            for col in jsonb_cols:
+                assert f"{col}::text AS {col}" in sql, f"Missing cast for {col} in {table}"
+
+
+# ── 5. _require_admin Tests ─────────────────────────────
+
+
+class TestRequireAdmin:
+    @patch("observal_cli.cmd_migrate.client")
+    def test_admin_role_allowed(self, mock_client):
+        mock_client.get.return_value = {"role": "admin"}
+        _require_admin()  # Should not raise
+
+    @patch("observal_cli.cmd_migrate.client")
+    def test_super_admin_role_allowed(self, mock_client):
+        mock_client.get.return_value = {"role": "super_admin"}
+        _require_admin()  # Should not raise
+
+    @patch("observal_cli.cmd_migrate.client")
+    def test_user_role_rejected(self, mock_client):
+        mock_client.get.return_value = {"role": "user"}
+        with pytest.raises((SystemExit, click.exceptions.Exit)):
+            _require_admin()
+
+    @patch("observal_cli.cmd_migrate.client")
+    def test_reviewer_role_rejected(self, mock_client):
+        mock_client.get.return_value = {"role": "reviewer"}
+        with pytest.raises((SystemExit, click.exceptions.Exit)):
+            _require_admin()
+
+    @patch("observal_cli.cmd_migrate.client")
+    def test_unauthenticated_rejected(self, mock_client):
+        mock_client.get.side_effect = SystemExit(1)
+        with pytest.raises((SystemExit, click.exceptions.Exit)):
+            _require_admin()
+
+
+# ── 6. _sha256_file Tests ───────────────────────────────
+
+
+class TestSha256File:
+    def test_known_content_known_hash(self):
+        expected = hashlib.sha256(b"hello world\n").hexdigest()
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            f.write(b"hello world\n")
+            f.flush()
+            path = Path(f.name)
+        try:
+            assert _sha256_file(path) == expected
+        finally:
+            path.unlink()
+
+    def test_same_content_same_hash(self):
+        content = b"deterministic content for hashing"
+        paths = []
+        try:
+            for _ in range(2):
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+                    f.write(content)
+                    f.flush()
+                    paths.append(Path(f.name))
+            assert _sha256_file(paths[0]) == _sha256_file(paths[1])
+        finally:
+            for p in paths:
+                p.unlink()
+
+    def test_different_content_different_hash(self):
+        paths = []
+        try:
+            for content in [b"content A", b"content B"]:
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+                    f.write(content)
+                    f.flush()
+                    paths.append(Path(f.name))
+            assert _sha256_file(paths[0]) != _sha256_file(paths[1])
+        finally:
+            for p in paths:
+                p.unlink()
+
+
+# ── 7. _coerce_value Tests ──────────────────────────────
+
+
+class TestCoerceValue:
+    def test_uuid_string_to_uuid(self):
+        val = "12345678-1234-5678-1234-567812345678"
+        result = _coerce_value(val, "uuid")
+        assert isinstance(result, uuid.UUID)
+        assert str(result) == val
+
+    def test_iso_datetime_to_datetime(self):
+        val = "2026-01-15T10:30:00+00:00"
+        result = _coerce_value(val, "timestamptz")
+        assert isinstance(result, datetime)
+        assert result.year == 2026
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_float_to_timedelta(self):
+        result = _coerce_value(9000.0, "interval")
+        assert isinstance(result, timedelta)
+        assert result.total_seconds() == 9000.0
+
+    def test_none_returns_none(self):
+        assert _coerce_value(None, "uuid") is None
+        assert _coerce_value(None, "timestamptz") is None
+        assert _coerce_value(None, "text") is None
+
+    def test_string_text_unchanged(self):
+        result = _coerce_value("hello", "text")
+        assert result == "hello"
+        assert isinstance(result, str)
+
+    def test_bool_preserved(self):
+        assert _coerce_value(True, "bool") is True
+        assert _coerce_value(False, "bool") is False
+
+    def test_int_coercion(self):
+        result = _coerce_value(42, "int4")
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_float_coercion(self):
+        result = _coerce_value(3.14, "float8")
+        assert result == 3.14
+        assert isinstance(result, float)
+
+
+# ── 8. _build_insert Tests ──────────────────────────────
+
+
+class TestBuildInsert:
+    def test_table_with_jsonb_columns(self):
+        columns = ["id", "name", "model_config_json"]
+        col_types = {"id": "uuid", "name": "text", "model_config_json": "jsonb"}
+        sql = _build_insert("agents", columns, col_types)
+        assert "$1" in sql
+        assert "$2" in sql
+        assert "$3::jsonb" in sql
+        assert 'ON CONFLICT ("id") DO NOTHING' in sql
+
+    def test_table_without_jsonb_columns(self):
+        columns = ["id", "name", "slug"]
+        col_types = {"id": "uuid", "name": "text", "slug": "text"}
+        sql = _build_insert("organizations", columns, col_types)
+        assert "$1" in sql
+        assert "$2" in sql
+        assert "$3" in sql
+        assert "::jsonb" not in sql
+        assert 'ON CONFLICT ("id") DO NOTHING' in sql
+
+    def test_on_conflict_present(self):
+        columns = ["id"]
+        col_types = {"id": "uuid"}
+        sql = _build_insert("users", columns, col_types)
+        assert 'ON CONFLICT ("id") DO NOTHING' in sql
+
+    def test_insert_column_list(self):
+        columns = ["id", "name", "email"]
+        col_types = {"id": "uuid", "name": "text", "email": "text"}
+        sql = _build_insert("users", columns, col_types)
+        assert 'INSERT INTO users ("id", "name", "email")' in sql
+
+    def test_multiple_jsonb_columns(self):
+        columns = ["id", "tools_schema", "environment_variables", "supported_ides"]
+        col_types = {
+            "id": "uuid",
+            "tools_schema": "jsonb",
+            "environment_variables": "jsonb",
+            "supported_ides": "jsonb",
+        }
+        sql = _build_insert("mcp_listings", columns, col_types)
+        assert "$2::jsonb" in sql
+        assert "$3::jsonb" in sql
+        assert "$4::jsonb" in sql
+
+
+# ── 9. Manifest Structure Tests ──────────────────────────
+
+
+class TestManifestStructure:
+    def test_manifest_required_fields(self):
+        manifest = {
+            "schema_version": "1.0",
+            "migration_id": str(uuid.uuid4()),
+            "exported_at": datetime.now(UTC).isoformat(),
+            "source_alembic_version": "0012",
+            "tables": {
+                table: {"checksum": hashlib.sha256(b"test").hexdigest(), "row_count": 0} for table in INSERT_ORDER
+            },
+        }
+        assert "schema_version" in manifest
+        assert "migration_id" in manifest
+        assert "exported_at" in manifest
+        assert "source_alembic_version" in manifest
+        assert "tables" in manifest
+        assert manifest["schema_version"] == "1.0"
+
+    def test_migration_manifest_required_fields(self):
+        migration_id = str(uuid.uuid4())
+        migration_manifest = {
+            "migration_id": migration_id,
+            "phase1_completed_at": datetime.now(UTC).isoformat(),
+            "source_db_url_hash": hashlib.sha256(b"postgres://...").hexdigest(),
+            "table_row_counts": {table: 0 for table in INSERT_ORDER},
+            "uuid_ranges": {},
+        }
+        assert "migration_id" in migration_manifest
+        assert "phase1_completed_at" in migration_manifest
+        assert "source_db_url_hash" in migration_manifest
+        assert "table_row_counts" in migration_manifest
+        assert "uuid_ranges" in migration_manifest
+
+    def test_manifest_json_round_trip(self):
+        manifest = {
+            "schema_version": "1.0",
+            "migration_id": str(uuid.uuid4()),
+            "exported_at": datetime.now(UTC).isoformat(),
+            "source_alembic_version": "0012",
+            "tables": {"organizations": {"checksum": "abc123", "row_count": 5}},
+        }
+        serialized = json.dumps(manifest)
+        deserialized = json.loads(serialized)
+        assert deserialized == manifest
+
+
+# ── 10. Error Path Tests (CLI) ───────────────────────────
+
+
+class TestErrorPaths:
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_import_nonexistent_archive(self, mock_admin):
+        result = runner.invoke(
+            cli_app,
+            ["migrate", "import", "--db-url", "postgres://x", "--archive", "/nonexistent/archive.tar.gz"],
+        )
+        assert result.exit_code != 0
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_validate_nonexistent_archive(self, mock_admin):
+        result = runner.invoke(
+            cli_app,
+            ["migrate", "validate", "--archive", "/nonexistent/archive.tar.gz"],
+        )
+        assert result.exit_code != 0
+
+    def test_export_missing_db_url(self):
+        """Export without --db-url should fail (required option)."""
+        result = runner.invoke(cli_app, ["migrate", "export"])
+        assert result.exit_code != 0
+
+
+# ── 11. Security Tests ──────────────────────────────────
+
+
+class TestSecurity:
+    @patch("observal_cli.cmd_migrate._require_admin")
+    @patch("observal_cli.cmd_migrate.asyncio")
+    def test_db_url_not_in_export_output(self, mock_asyncio, mock_admin):
+        """The --db-url value should never appear in CLI output."""
+        secret_url = "postgres://secret_user:secret_pass@secret-host:5432/secret_db"
+        mock_asyncio.run.side_effect = SystemExit(1)
+        result = runner.invoke(
+            cli_app,
+            ["migrate", "export", "--db-url", secret_url],
+        )
+        assert secret_url not in result.output
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_db_url_not_in_import_output(self, mock_admin):
+        """The --db-url value should never appear in CLI output for import."""
+        secret_url = "postgres://secret_user:secret_pass@secret-host:5432/secret_db"
+        result = runner.invoke(
+            cli_app,
+            ["migrate", "import", "--db-url", secret_url, "--archive", "/nonexistent.tar.gz"],
+        )
+        assert secret_url not in result.output
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_db_url_not_in_validate_output(self, mock_admin):
+        """The --db-url value should never appear in CLI output for validate."""
+        secret_url = "postgres://secret_user:secret_pass@secret-host:5432/secret_db"
+        result = runner.invoke(
+            cli_app,
+            ["migrate", "validate", "--archive", "/nonexistent.tar.gz", "--db-url", secret_url],
+        )
+        assert secret_url not in result.output
+
+
+# ── 12. Dataclass Tests ─────────────────────────────────
+
+
+class TestDataclasses:
+    def test_export_result_fields(self):
+        result = ExportResult(
+            archive_path="/tmp/test.tar.gz",
+            migration_id="abc-123",
+            table_counts={"users": 10},
+            checksums={"users": "sha256hex"},
+            duration_seconds=1.5,
+            total_rows=10,
+        )
+        assert result.archive_path == "/tmp/test.tar.gz"
+        assert result.total_rows == 10
+
+    def test_import_result_fields(self):
+        result = ImportResult(
+            migration_id="abc-123",
+            tables_imported=33,
+            rows_inserted={"users": 10},
+            rows_skipped={"users": 2},
+            duration_seconds=2.0,
+            warnings=[],
+        )
+        assert result.tables_imported == 33
+        assert result.rows_inserted["users"] == 10
+
+    def test_checksum_result_fields(self):
+        result = ChecksumResult(
+            table_name="users",
+            expected_checksum="abc",
+            actual_checksum="abc",
+            passed=True,
+        )
+        assert result.passed is True
+
+    def test_validation_result_fields(self):
+        result = ValidationResult(
+            archive_valid=True,
+            checksum_results=[],
+            cross_db_results=None,
+        )
+        assert result.archive_valid is True
+        assert result.cross_db_results is None
+
+
+# ── 13. INSERT_ORDER Dependency Tests ────────────────────
+
+
+class TestInsertOrderDependencies:
+    """Verify that FK parent tables appear before child tables in INSERT_ORDER."""
+
+    KNOWN_FK_PAIRS = [
+        # (child, parent) — parent must come before child
+        ("users", "organizations"),
+        ("exporter_configs", "organizations"),
+        ("agents", "organizations"),
+        ("mcp_listings", "organizations"),
+        ("agent_components", "agents"),
+        ("agent_goal_templates", "agents"),
+        ("eval_runs", "agents"),
+        ("scorecards", "eval_runs"),
+        ("scorecard_dimensions", "scorecards"),
+        ("feedback", "users"),
+        ("alert_history", "alert_rules"),
+        ("agent_goal_sections", "agent_goal_templates"),
+        ("mcp_downloads", "mcp_listings"),
+        ("skill_downloads", "skill_listings"),
+        ("hook_downloads", "hook_listings"),
+        ("prompt_downloads", "prompt_listings"),
+        ("sandbox_downloads", "sandbox_listings"),
+    ]
+
+    @pytest.mark.parametrize("child,parent", KNOWN_FK_PAIRS)
+    def test_parent_before_child(self, child, parent):
+        parent_idx = INSERT_ORDER.index(parent)
+        child_idx = INSERT_ORDER.index(child)
+        assert parent_idx < child_idx, f"{parent} (idx={parent_idx}) should come before {child} (idx={child_idx})"
+
+
+# ══════════════════════════════════════════════════════════
+# Property-Based Tests (Hypothesis)
+# ══════════════════════════════════════════════════════════
+
+# Hypothesis strategies for common PostgreSQL types
+uuids = st.uuids()
+tz_datetimes = st.datetimes(
+    min_value=datetime(2000, 1, 1),
+    max_value=datetime(2099, 12, 31),
+    timezones=st.just(UTC),
+)
+timedeltas = st.timedeltas(
+    min_value=timedelta(seconds=0),
+    max_value=timedelta(days=365 * 10),
+)
+primitives = st.one_of(
+    st.text(min_size=0, max_size=200),
+    st.integers(min_value=-(2**31), max_value=2**31),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.booleans(),
+    st.none(),
+)
+
+
+# ── Property 1: PGEncoder round-trip ────────────────────
+
+
+class TestPGEncoderRoundTripProperty:
+    """Property 1: For any valid row, encode→decode→coerce produces equivalent values."""
+
+    @given(val=uuids)
+    @hsettings(max_examples=100)
+    def test_uuid_round_trip(self, val):
+        encoded = json.dumps(val, cls=PGEncoder)
+        decoded = json.loads(encoded)
+        assert uuid.UUID(decoded) == val
+
+    @given(val=tz_datetimes)
+    @hsettings(max_examples=100)
+    def test_datetime_round_trip(self, val):
+        encoded = json.dumps(val, cls=PGEncoder)
+        decoded = json.loads(encoded)
+        restored = datetime.fromisoformat(decoded)
+        assert restored == val
+
+    @given(val=timedeltas)
+    @hsettings(max_examples=100)
+    def test_timedelta_round_trip(self, val):
+        encoded = json.dumps(val, cls=PGEncoder)
+        decoded = json.loads(encoded)
+        restored = timedelta(seconds=decoded)
+        # Compare total_seconds to handle floating point
+        assert abs(restored.total_seconds() - val.total_seconds()) < 1e-6
+
+    @given(
+        row=st.fixed_dictionaries(
+            {
+                "id": uuids,
+                "name": st.text(min_size=1, max_size=50),
+                "count": st.integers(min_value=0, max_value=10000),
+                "active": st.booleans(),
+                "created_at": tz_datetimes,
+                "interval": timedeltas,
+                "notes": st.one_of(st.none(), st.text(min_size=0, max_size=100)),
+            }
+        )
+    )
+    @hsettings(max_examples=100)
+    def test_mixed_row_round_trip(self, row):
+        encoded = json.dumps(row, cls=PGEncoder)
+        decoded = json.loads(encoded)
+        # Verify each field round-trips correctly
+        assert uuid.UUID(decoded["id"]) == row["id"]
+        assert decoded["name"] == row["name"]
+        assert decoded["count"] == row["count"]
+        assert decoded["active"] == row["active"]
+        assert datetime.fromisoformat(decoded["created_at"]) == row["created_at"]
+        assert abs(decoded["interval"] - row["interval"].total_seconds()) < 1e-6
+        assert decoded["notes"] == row["notes"]
+
+
+# ── Property 2: PGEncoder format correctness ────────────
+
+
+UUID_REGEX = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+class TestPGEncoderFormatProperty:
+    """Property 2: PGEncoder produces correctly formatted output for each type."""
+
+    @given(val=uuids)
+    @hsettings(max_examples=100)
+    def test_uuid_format_lowercase_hyphenated(self, val):
+        encoded = json.loads(json.dumps(val, cls=PGEncoder))
+        assert UUID_REGEX.match(encoded), f"UUID {encoded} doesn't match expected format"
+
+    @given(val=tz_datetimes)
+    @hsettings(max_examples=100)
+    def test_datetime_format_iso8601_parseable(self, val):
+        encoded = json.loads(json.dumps(val, cls=PGEncoder))
+        restored = datetime.fromisoformat(encoded)
+        assert restored.tzinfo is not None, "Timezone info must be preserved"
+        assert restored == val
+
+    @given(val=timedeltas)
+    @hsettings(max_examples=100)
+    def test_timedelta_format_total_seconds(self, val):
+        encoded = json.loads(json.dumps(val, cls=PGEncoder))
+        assert isinstance(encoded, float)
+        assert abs(encoded - val.total_seconds()) < 1e-6
+
+
+# ── Property 3: JSONB cast in SELECT queries ────────────
+
+
+class TestJSONBCastProperty:
+    """Property 3: JSONB columns get ::text cast, non-JSONB tables get SELECT *."""
+
+    @given(table=st.sampled_from(INSERT_ORDER))
+    @hsettings(max_examples=100)
+    def test_jsonb_tables_get_casts_others_get_star(self, table):
+        jsonb_cols = JSONB_COLUMNS.get(table, [])
+        # Build a column list: id + any JSONB cols + a fake non-JSONB col
+        columns = ["id"] + jsonb_cols + (["created_at"] if jsonb_cols else [])
+        sql = _build_select(table, columns)
+
+        if not jsonb_cols:
+            assert sql == f"SELECT * FROM {table}"
+        else:
+            for col in jsonb_cols:
+                assert f"{col}::text AS {col}" in sql
+            # Non-JSONB columns should NOT have ::text
+            assert "id::text" not in sql
+
+
+# ── Property 4: Checksum integrity ──────────────────────
+
+
+class TestChecksumIntegrityProperty:
+    """Property 4: SHA-256 is deterministic — same bytes always produce same hash."""
+
+    @given(data=st.binary(min_size=0, max_size=10000))
+    @hsettings(max_examples=100)
+    def test_sha256_deterministic(self, data):
+        paths = []
+        try:
+            for _ in range(2):
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".bin") as f:
+                    f.write(data)
+                    f.flush()
+                    paths.append(Path(f.name))
+            assert _sha256_file(paths[0]) == _sha256_file(paths[1])
+        finally:
+            for p in paths:
+                p.unlink(missing_ok=True)
+
+    @given(
+        data_a=st.binary(min_size=1, max_size=1000),
+        data_b=st.binary(min_size=1, max_size=1000),
+    )
+    @hsettings(max_examples=100)
+    def test_sha256_different_content_different_hash(self, data_a, data_b):
+        """Different content should (almost always) produce different hashes."""
+        if data_a == data_b:
+            return  # Skip identical inputs
+        hash_a = hashlib.sha256(data_a).hexdigest()
+        hash_b = hashlib.sha256(data_b).hexdigest()
+        assert hash_a != hash_b
+
+
+# ── Property 5: Idempotent import ───────────────────────
+
+
+class TestIdempotentImportProperty:
+    """Property 5: ON CONFLICT (id) DO NOTHING means second import inserts zero rows."""
+
+    @given(
+        rows=st.lists(
+            st.fixed_dictionaries(
+                {
+                    "id": st.uuids(),
+                    "name": st.text(min_size=1, max_size=50),
+                }
+            ),
+            min_size=1,
+            max_size=20,
+        )
+    )
+    @hsettings(max_examples=100)
+    def test_on_conflict_do_nothing_sql_is_idempotent(self, rows):
+        """Verify the INSERT query structure guarantees idempotency."""
+        columns = list(rows[0].keys())
+        col_types = {"id": "uuid", "name": "text"}
+        sql = _build_insert("test_table", columns, col_types)
+        # The SQL must contain ON CONFLICT ("id") DO NOTHING
+        assert 'ON CONFLICT ("id") DO NOTHING' in sql
+        # The SQL must be a valid INSERT with all columns
+        for col in columns:
+            assert col in sql
+
+
+# ── Property 6: UUID preservation ───────────────────────
+
+
+class TestUUIDPreservationProperty:
+    """Property 6: UUIDs survive PGEncoder encode→decode byte-identical."""
+
+    @given(val=uuids)
+    @hsettings(max_examples=100)
+    def test_uuid_preserved_through_encode_decode(self, val):
+        # Simulate export: UUID → PGEncoder → JSON string
+        encoded = json.dumps({"id": val}, cls=PGEncoder)
+        # Simulate import: JSON string → json.loads → _coerce_value
+        decoded = json.loads(encoded)
+        restored = _coerce_value(decoded["id"], "uuid")
+        assert isinstance(restored, uuid.UUID)
+        assert restored == val
+        assert str(restored) == str(val)
+
+
+# ── Property 7: Manifest JSON round-trip ────────────────
+
+
+class TestManifestRoundTripProperty:
+    """Property 7: Manifest dicts survive JSON serialize→deserialize exactly."""
+
+    @given(
+        migration_id=st.uuids(),
+        alembic_version=st.text(min_size=1, max_size=20, alphabet="0123456789"),
+        row_counts=st.dictionaries(
+            keys=st.sampled_from(INSERT_ORDER[:5]),
+            values=st.integers(min_value=0, max_value=100000),
+            min_size=1,
+            max_size=5,
+        ),
+    )
+    @hsettings(max_examples=100)
+    def test_manifest_round_trip(self, migration_id, alembic_version, row_counts):
+        manifest = {
+            "schema_version": "1.0",
+            "migration_id": str(migration_id),
+            "exported_at": datetime.now(UTC).isoformat(),
+            "source_alembic_version": alembic_version,
+            "tables": {
+                table: {"checksum": hashlib.sha256(f"{table}{count}".encode()).hexdigest(), "row_count": count}
+                for table, count in row_counts.items()
+            },
+        }
+        serialized = json.dumps(manifest)
+        deserialized = json.loads(serialized)
+        assert deserialized == manifest
+
+    @given(
+        migration_id=st.uuids(),
+        row_counts=st.dictionaries(
+            keys=st.sampled_from(INSERT_ORDER[:5]),
+            values=st.integers(min_value=0, max_value=100000),
+            min_size=1,
+            max_size=5,
+        ),
+    )
+    @hsettings(max_examples=100)
+    def test_migration_manifest_round_trip(self, migration_id, row_counts):
+        migration_manifest = {
+            "migration_id": str(migration_id),
+            "phase1_completed_at": datetime.now(UTC).isoformat(),
+            "source_db_url_hash": hashlib.sha256(b"postgres://test").hexdigest(),
+            "table_row_counts": row_counts,
+            "uuid_ranges": {table: {"min_id": str(uuid.uuid4()), "max_id": str(uuid.uuid4())} for table in row_counts},
+        }
+        serialized = json.dumps(migration_manifest)
+        deserialized = json.loads(serialized)
+        assert deserialized == migration_manifest
+
+
+# ── Property 8: INSERT_ORDER FK ordering ────────────────
+
+
+class TestInsertOrderFKProperty:
+    """Property 8: For all FK pairs, parent index < child index in INSERT_ORDER."""
+
+    # Complete FK pairs derived from the SQLAlchemy models
+    ALL_FK_PAIRS = [
+        ("users", "organizations"),
+        ("exporter_configs", "organizations"),
+        ("component_bundles", "users"),
+        ("mcp_listings", "users"),
+        ("mcp_listings", "organizations"),
+        ("mcp_listings", "component_bundles"),
+        ("skill_listings", "users"),
+        ("skill_listings", "organizations"),
+        ("skill_listings", "component_bundles"),
+        ("hook_listings", "users"),
+        ("hook_listings", "organizations"),
+        ("hook_listings", "component_bundles"),
+        ("prompt_listings", "users"),
+        ("prompt_listings", "organizations"),
+        ("prompt_listings", "component_bundles"),
+        ("sandbox_listings", "users"),
+        ("sandbox_listings", "organizations"),
+        ("sandbox_listings", "component_bundles"),
+        ("agents", "users"),
+        ("agents", "organizations"),
+        ("mcp_validation_results", "mcp_listings"),
+        ("mcp_downloads", "mcp_listings"),
+        ("mcp_downloads", "users"),
+        ("skill_downloads", "skill_listings"),
+        ("skill_downloads", "users"),
+        ("hook_downloads", "hook_listings"),
+        ("hook_downloads", "users"),
+        ("prompt_downloads", "prompt_listings"),
+        ("prompt_downloads", "users"),
+        ("sandbox_downloads", "sandbox_listings"),
+        ("sandbox_downloads", "users"),
+        ("submissions", "users"),
+        ("alert_rules", "users"),
+        ("agent_goal_templates", "agents"),
+        ("agent_download_records", "agents"),
+        ("agent_download_records", "users"),
+        ("component_download_records", "agents"),
+        ("dimension_weights", "agents"),
+        ("agent_goal_sections", "agent_goal_templates"),
+        ("agent_components", "agents"),
+        ("feedback", "users"),
+        ("alert_history", "alert_rules"),
+        ("eval_runs", "agents"),
+        ("eval_runs", "users"),
+        ("scorecards", "agents"),
+        ("scorecards", "eval_runs"),
+        ("scorecard_dimensions", "scorecards"),
+        ("trace_penalties", "scorecards"),
+        ("trace_penalties", "penalty_definitions"),
+    ]
+
+    @given(pair=st.sampled_from(ALL_FK_PAIRS))
+    @hsettings(max_examples=100)
+    def test_fk_parent_before_child(self, pair):
+        child, parent = pair
+        parent_idx = INSERT_ORDER.index(parent)
+        child_idx = INSERT_ORDER.index(child)
+        assert parent_idx < child_idx, f"{parent} (idx={parent_idx}) must come before {child} (idx={child_idx})"
+
+
+# ── Property 9: migration_id consistency ────────────────
+
+
+class TestMigrationIdConsistencyProperty:
+    """Property 9: migration_id is identical in both manifest files."""
+
+    @given(migration_id=st.uuids())
+    @hsettings(max_examples=100)
+    def test_migration_id_matches_across_manifests(self, migration_id):
+        mid = str(migration_id)
+        manifest = {
+            "schema_version": "1.0",
+            "migration_id": mid,
+            "exported_at": datetime.now(UTC).isoformat(),
+            "source_alembic_version": "0009",
+            "tables": {},
+        }
+        migration_manifest = {
+            "migration_id": mid,
+            "phase1_completed_at": datetime.now(UTC).isoformat(),
+            "source_db_url_hash": "abc",
+            "table_row_counts": {},
+            "uuid_ranges": {},
+        }
+        # Serialize and deserialize both
+        m1 = json.loads(json.dumps(manifest))
+        m2 = json.loads(json.dumps(migration_manifest))
+        assert m1["migration_id"] == m2["migration_id"]
+        assert m1["migration_id"] == mid
+
+
+# ── Property 10: Admin role authorization gate ──────────
+
+
+class TestAdminRoleGateProperty:
+    """Property 10: Only admin and super_admin roles pass the gate."""
+
+    ALLOWED_ROLES = {"admin", "super_admin"}
+
+    @given(role=st.sampled_from(["admin", "super_admin", "user", "reviewer", "", "moderator", "guest", "operator"]))
+    @hsettings(max_examples=100)
+    def test_role_gate(self, role):
+        with patch("observal_cli.cmd_migrate.client") as mock_client:
+            mock_client.get.return_value = {"role": role}
+            if role in self.ALLOWED_ROLES:
+                _require_admin()  # Should not raise
+            else:
+                with pytest.raises((SystemExit, click.exceptions.Exit)):
+                    _require_admin()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -35,6 +35,12 @@ from observal_cli.main import app as cli_app
 
 runner = CliRunner()
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
 
 # ── 1. CLI Registration Tests ────────────────────────────
 
@@ -43,30 +49,32 @@ class TestCLIRegistration:
     def test_migrate_command_group_exists(self):
         result = runner.invoke(cli_app, ["migrate", "--help"])
         assert result.exit_code == 0
-        assert "migrate" in result.output.lower()
+        assert "migrate" in _plain(result.output).lower()
 
     def test_migrate_help_lists_subcommands(self):
         result = runner.invoke(cli_app, ["migrate", "--help"])
         assert result.exit_code == 0
-        assert "export" in result.output
-        assert "import" in result.output
-        assert "validate" in result.output
+        out = _plain(result.output)
+        assert "export" in out
+        assert "import" in out
+        assert "validate" in out
 
     def test_export_subcommand_help(self):
         result = runner.invoke(cli_app, ["migrate", "export", "--help"])
         assert result.exit_code == 0
-        assert "--db-url" in result.output
+        assert "--db-url" in _plain(result.output)
 
     def test_import_subcommand_help(self):
         result = runner.invoke(cli_app, ["migrate", "import", "--help"])
         assert result.exit_code == 0
-        assert "--db-url" in result.output
-        assert "--archive" in result.output
+        out = _plain(result.output)
+        assert "--db-url" in out
+        assert "--archive" in out
 
     def test_validate_subcommand_help(self):
         result = runner.invoke(cli_app, ["migrate", "validate", "--help"])
         assert result.exit_code == 0
-        assert "--archive" in result.output
+        assert "--archive" in _plain(result.output)
 
 
 # ── 2. PGEncoder Tests ───────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,54 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159, upload-time = "2025-11-24T23:25:36.443Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157, upload-time = "2025-11-24T23:25:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051, upload-time = "2025-11-24T23:25:39.461Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640, upload-time = "2025-11-24T23:25:41.512Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050, upload-time = "2025-11-24T23:25:43.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574, upload-time = "2025-11-24T23:25:44.942Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076, upload-time = "2025-11-24T23:25:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980, upload-time = "2025-11-24T23:25:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -267,6 +315,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.152.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/b1/c32bcddb9aab9e3abc700f1f56faf14e7655c64a16ca47701a57362276ea/hypothesis-6.152.1.tar.gz", hash = "sha256:4f4ed934eee295dd84ee97592477d23e8dc03e9f12ae0ee30a4e7c9ef3fca3b0", size = 465029, upload-time = "2026-04-14T22:29:24.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl", hash = "sha256:40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e", size = 530752, upload-time = "2026-04-14T22:29:20.893Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -310,8 +370,10 @@ name = "observal-cli"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "asyncpg" },
     { name = "docker" },
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pyyaml" },
@@ -331,8 +393,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "docker", specifier = ">=7.0.0" },
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -699,6 +763,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Added `observal migrate` command group with three subcommands (`export`, `import`, `validate`) for migrating all PostgreSQL registry data between Observal instances. 

**The subcommands:**

1. **observal migrate export** - exports all tables to a .tar.gz archive
2. **observal migrate import** - imports an archive into a target database
3. **observal migrate validate** - verify the archive integrity, or compare against a database

**Example for execution:**
```
uv tool install --editable . --force

 #1. Export from your running Observal instance
observal migrate export \
  --db-url "postgresql://postgres:postgres@localhost:5432/observal" \
  --output migration.tar.gz

# 2. Validate the archive (offline)
observal migrate validate --archive migration.tar.gz

# 3. Create a target database and copy the schema
docker exec observal-db psql -U postgres -c "CREATE DATABASE observal_target;"
docker exec observal-db bash -c "pg_dump -U postgres --schema-only observal | psql -U postgres observal_target"
docker exec observal-db psql -U postgres -d observal_target \
  -c "INSERT INTO alembic_version (version_num) VALUES ('0009');"

# 4. Import into the target
observal migrate import \
  --db-url "postgresql://postgres:postgres@localhost:5432/observal_target" \
  --archive migration.tar.gz

# 5. Validate the import
observal migrate validate \
  --archive migration.tar.gz \
  --db-url "postgresql://postgres:postgres@localhost:5432/observal_target"

# 6. Test idempotency (run import again — should show 0 inserted)
observal migrate import \
  --db-url "postgresql://postgres:postgres@localhost:5432/observal_target" \
  --archive migration.tar.gz

# 7. Clean up
docker exec observal-db psql -U postgres -c "DROP DATABASE observal_target;"
del migration.tar.gz
```
