### PR TITLE
chore: add migration chain validation and generator scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,16 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
 
+  # ── Alembic migrations ─────────────────────────────────
+  - repo: local
+    hooks:
+      - id: check-migrations
+        name: check alembic migration chain
+        entry: python3 scripts/check_migrations.py
+        language: system
+        files: ^observal-server/alembic/versions/.*\.py$
+        pass_filenames: false
+
   # ── Docker ─────────────────────────────────────────────
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate
+.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration
 
 # ── Linting ──────────────────────────────────────────────
 
@@ -46,6 +46,13 @@ down:  ## Stop Docker stack
 
 migrate:  ## Run database migrations
 	docker compose -f docker/docker-compose.yml exec observal-api /app/.venv/bin/python -m alembic upgrade head
+
+check-migrations:  ## Validate alembic migration chain (no duplicates, no forks)
+	python3 scripts/check_migrations.py
+
+new-migration:  ## Create a new migration: make new-migration MSG="add foo to bar"
+	@test -n "$(MSG)" || (echo 'Usage: make new-migration MSG="description"' && exit 1)
+	./scripts/new_migration.sh "$(MSG)"
 
 rebuild:  ## Rebuild and restart Docker stack (runs migrations automatically)
 	cd docker && docker compose up --build -d

--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate alembic migration chain integrity.
+
+Checks:
+  1. No duplicate revision IDs
+  2. No multiple heads (branches that fork and never merge)
+  3. Every down_revision references an existing revision
+  4. Linear chain from root to head with no orphans
+
+Run: python scripts/check_migrations.py
+Exit code 0 = clean, 1 = problems found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+VERSIONS_DIR = Path(__file__).resolve().parent.parent / "observal-server" / "alembic" / "versions"
+
+RE_REVISION = re.compile(r'^revision\s*=\s*["\'](.+?)["\']', re.MULTILINE)
+RE_DOWN = re.compile(r"^down_revision\s*=\s*(.+)", re.MULTILINE)
+
+
+def parse_revision(text: str) -> str | None:
+    m = RE_REVISION.search(text)
+    return m.group(1) if m else None
+
+
+def parse_down_revision(text: str) -> str | None:
+    m = RE_DOWN.search(text)
+    if not m:
+        return None
+    raw = m.group(1).strip().rstrip(",")
+    if raw == "None":
+        return None
+    return raw.strip("\"'")
+
+
+def main() -> int:
+    if not VERSIONS_DIR.is_dir():
+        print(f"ERROR: versions directory not found: {VERSIONS_DIR}")
+        return 1
+
+    migrations: dict[str, Path] = {}
+    down_map: dict[str, str | None] = {}
+    errors: list[str] = []
+
+    for path in sorted(VERSIONS_DIR.glob("*.py")):
+        if path.name.startswith("__"):
+            continue
+        text = path.read_text()
+        rev = parse_revision(text)
+        down = parse_down_revision(text)
+
+        if rev is None:
+            errors.append(f"{path.name}: no 'revision' found")
+            continue
+
+        if rev in migrations:
+            errors.append(f"DUPLICATE revision '{rev}' in:\n  - {migrations[rev].name}\n  - {path.name}")
+        else:
+            migrations[rev] = path
+            down_map[rev] = down
+
+    for rev, down in down_map.items():
+        if down is not None and down not in migrations:
+            errors.append(f"{migrations[rev].name}: down_revision '{down}' not found in any migration file")
+
+    # Revisions that nothing else points to as its down_revision = heads
+    all_downs = set(down_map.values()) - {None}
+    heads = [rev for rev in migrations if rev not in all_downs]
+    if len(heads) > 1:
+        head_files = [f"  - {migrations[h].name} (revision='{h}')" for h in heads]
+        errors.append("MULTIPLE HEADS detected (parallel branches):\n" + "\n".join(head_files))
+
+    roots = [rev for rev, down in down_map.items() if down is None]
+    if len(roots) > 1:
+        root_files = [f"  - {migrations[r].name} (revision='{r}')" for r in roots]
+        errors.append("MULTIPLE ROOTS detected:\n" + "\n".join(root_files))
+
+    if len(roots) == 1 and len(heads) == 1:
+        visited = set()
+        reverse_map = {down: rev for rev, down in down_map.items() if down is not None}
+        current: str | None = roots[0]
+        while current:
+            visited.add(current)
+            current = reverse_map.get(current)
+        orphans = set(migrations.keys()) - visited
+        if orphans:
+            orphan_files = [f"  - {migrations[o].name} (revision='{o}')" for o in orphans]
+            errors.append("ORPHAN migrations not reachable from root:\n" + "\n".join(orphan_files))
+
+    if errors:
+        print(f"Migration chain validation FAILED ({len(errors)} issue(s)):\n")
+        for e in errors:
+            print(f"  {e}\n")
+        return 1
+
+    print(f"Migration chain OK: {len(migrations)} migrations, head='{heads[0]}', linear chain intact.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/new_migration.sh
+++ b/scripts/new_migration.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Create a new alembic migration with the correct next revision ID.
+#
+# Usage:
+#   ./scripts/new_migration.sh "add foo column to bar table"
+#
+# Reads the current head from the versions directory, increments it,
+# and writes a skeleton migration file.
+
+set -euo pipefail
+
+VERSIONS_DIR="$(cd "$(dirname "$0")/../observal-server/alembic/versions" && pwd)"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 \"description of the migration\""
+    echo "  e.g. $0 \"add foo column to bar table\""
+    exit 1
+fi
+
+DESCRIPTION="$1"
+
+# Find the current head revision (highest numeric prefix)
+CURRENT_HEAD=$(
+    grep -rh '^revision' "$VERSIONS_DIR"/*.py 2>/dev/null \
+    | sed 's/revision *= *["'"'"']\(.*\)["'"'"'].*/\1/' \
+    | sort -V \
+    | tail -1
+)
+
+if [ -z "$CURRENT_HEAD" ]; then
+    echo "ERROR: Could not determine current head revision from $VERSIONS_DIR"
+    exit 1
+fi
+
+# Increment: strip leading zeros, add 1, re-pad to 4 digits
+NEXT_NUM=$(printf "%04d" $(( 10#$CURRENT_HEAD + 1 )))
+
+# Slugify description for filename
+SLUG=$(echo "$DESCRIPTION" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g' | sed 's/__*/_/g' | sed 's/^_//;s/_$//')
+FILENAME="${NEXT_NUM}_${SLUG}.py"
+FILEPATH="$VERSIONS_DIR/$FILENAME"
+
+TODAY=$(date +%Y-%m-%d)
+
+cat > "$FILEPATH" << PYEOF
+"""${DESCRIPTION}.
+
+Revision ID: ${NEXT_NUM}
+Revises: ${CURRENT_HEAD}
+Create Date: ${TODAY}
+"""
+
+from alembic import op
+
+revision = "${NEXT_NUM}"
+down_revision = "${CURRENT_HEAD}"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass  # TODO: implement
+
+
+def downgrade() -> None:
+    pass  # TODO: implement
+PYEOF
+
+echo "Created: $FILEPATH"
+echo "  revision = \"$NEXT_NUM\""
+echo "  down_revision = \"$CURRENT_HEAD\""
+echo ""
+echo "Edit the upgrade() and downgrade() functions, then run:"
+echo "  make check-migrations"


### PR DESCRIPTION
Prevents duplicate alembic revision IDs from reaching deployment:
- scripts/check_migrations.py validates the chain (duplicates, forks, orphans)
- scripts/new_migration.sh auto-generates the next revision with correct ID
- Pre-commit hook runs check on any commit touching migration files
- Makefile targets: make check-migrations, make new-migration MSG="...