### PR TITLE
fix(cli/web): fix prompt submit endpoint and add custom prompts to builder

### DIFF
--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -52,7 +52,7 @@ def prompt_submit(
             "template": typer.prompt("Template"),
         }
     with spinner("Submitting prompt..."):
-        result = client.post("/api/v1/prompts", payload)
+        result = client.post("/api/v1/prompts/submit", payload)
     rprint(f"[green]✓ Prompt submitted![/green] ID: [bold]{result['id']}[/bold]")
 
 

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   ArrowRight,
   Save,
+  FileText,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
@@ -50,6 +51,12 @@ const COMPONENT_TYPES: { value: RegistryType; label: string }[] = [
   { value: "prompts", label: "Prompts" },
   { value: "sandboxes", label: "Sandboxes" },
 ];
+
+interface CustomPrompt {
+  id: string;
+  title: string;
+  content: string;
+}
 
 interface GoalSection {
   id: string;
@@ -352,6 +359,9 @@ function AgentBuilderInner() {
     sandboxes: [],
   });
 
+  // Custom inline prompts
+  const [customPrompts, setCustomPrompts] = useState<CustomPrompt[]>([]);
+
   // Goal template sections
   const [goalSections, setGoalSections] = useState<GoalSection[]>([
     { id: generateId(), title: "", content: "" },
@@ -606,6 +616,26 @@ function AgentBuilderInner() {
     }));
   }, []);
 
+  const addCustomPrompt = useCallback(() => {
+    setCustomPrompts((prev) => [
+      ...prev,
+      { id: generateId(), title: "", content: "" },
+    ]);
+  }, []);
+
+  const updateCustomPrompt = useCallback(
+    (id: string, field: "title" | "content", value: string) => {
+      setCustomPrompts((prev) =>
+        prev.map((p) => (p.id === id ? { ...p, [field]: value } : p)),
+      );
+    },
+    [],
+  );
+
+  const removeCustomPrompt = useCallback((id: string) => {
+    setCustomPrompts((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
   const handleReorder = useCallback(
     (type: string) => (items: { id: string; name: string }[]) => {
       setSelectedComponents((prev) => {
@@ -658,11 +688,21 @@ function AgentBuilderInner() {
 
     const goalDescription = description.trim() || name.trim();
 
+    // Build prompt field from custom inline prompts
+    const promptParts = customPrompts
+      .filter((p) => p.content.trim())
+      .map((p) =>
+        p.title.trim()
+          ? `## ${p.title.trim()}\n${p.content.trim()}`
+          : p.content.trim(),
+      );
+
     return {
       name: name.trim(),
       version: (versionOverride ?? version).trim() || "1.0.0",
       description: description.trim(),
       owner: whoami?.name || whoami?.email || "unknown",
+      prompt: promptParts.join("\n\n"),
       model_name: modelName,
       components: components.length > 0 ? components : [],
       goal_template: {
@@ -854,7 +894,9 @@ function AgentBuilderInner() {
               >
                 <TabsList>
                   {COMPONENT_TYPES.map((ct) => {
-                    const count = (selectedComponents[ct.value] ?? []).length;
+                    const count =
+                      (selectedComponents[ct.value] ?? []).length +
+                      (ct.value === "prompts" ? customPrompts.length : 0);
                     return (
                       <TabsTrigger key={ct.value} value={ct.value}>
                         {ct.label}
@@ -886,6 +928,75 @@ function AgentBuilderInner() {
                           onReorder={handleReorder(ct.value)}
                           onRemove={(id) => removeComponent(ct.value, id)}
                         />
+                      </div>
+                    )}
+
+                    {/* Custom prompt input — Prompts tab only */}
+                    {ct.value === "prompts" && (
+                      <div className="mt-4 space-y-3">
+                        <div className="flex items-center gap-3">
+                          <Separator className="flex-1" />
+                          <span className="shrink-0 text-xs text-muted-foreground">
+                            or add custom prompt text
+                          </span>
+                          <Separator className="flex-1" />
+                        </div>
+
+                        {customPrompts.map((prompt) => (
+                          <div
+                            key={prompt.id}
+                            className="rounded-md border bg-muted/20 p-4 space-y-3"
+                          >
+                            <div className="flex items-center gap-2">
+                              <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+                              <Input
+                                placeholder="Prompt title (optional)"
+                                value={prompt.title}
+                                onChange={(e) =>
+                                  updateCustomPrompt(
+                                    prompt.id,
+                                    "title",
+                                    e.target.value,
+                                  )
+                                }
+                                className="h-8 max-w-xs text-sm font-medium"
+                              />
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => removeCustomPrompt(prompt.id)}
+                                className="ml-auto h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                            <Textarea
+                              placeholder="Enter prompt text..."
+                              value={prompt.content}
+                              onChange={(e) =>
+                                updateCustomPrompt(
+                                  prompt.id,
+                                  "content",
+                                  e.target.value,
+                                )
+                              }
+                              rows={4}
+                              className="resize-y text-sm"
+                            />
+                          </div>
+                        ))}
+
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={addCustomPrompt}
+                          className="h-8"
+                        >
+                          <Plus className="mr-1 h-3.5 w-3.5" />
+                          Add Custom Prompt
+                        </Button>
                       </div>
                     )}
                   </TabsContent>
@@ -1020,6 +1131,7 @@ function AgentBuilderInner() {
                   ),
                 )}
                 goalSections={goalSections}
+                customPrompts={customPrompts}
                 validationResult={validationResult}
               />
             </div>

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -23,6 +23,7 @@ interface PreviewPanelProps {
   modelName?: string;
   selectedComponents: Record<string, { id: string; name: string }[]>;
   goalSections: { id: string; title: string; content: string }[];
+  customPrompts?: { id: string; title: string; content: string }[];
   validationResult: ValidationResult | null;
 }
 
@@ -32,6 +33,7 @@ function buildMarkdownBody(
   description: string,
   selectedComponents: Record<string, { id: string; name: string }[]>,
   goalSections: { id: string; title: string; content: string }[],
+  customPrompts?: { id: string; title: string; content: string }[],
 ): string {
   const lines: string[] = [];
 
@@ -49,6 +51,21 @@ function buildMarkdownBody(
     lines.push(`## ${heading}`);
     lines.push("");
     items.forEach((item) => lines.push(`- **${item.name}**`));
+  }
+
+  const nonEmptyPrompts = (customPrompts ?? []).filter(
+    (p) => p.content.trim(),
+  );
+  if (nonEmptyPrompts.length > 0) {
+    lines.push("");
+    lines.push("## Custom Prompts");
+    lines.push("");
+    nonEmptyPrompts.forEach((prompt) => {
+      if (prompt.title.trim()) {
+        lines.push(`### ${prompt.title.trim()}`);
+      }
+      lines.push(prompt.content.trim());
+    });
   }
 
   const nonEmptyGoals = goalSections.filter((s) => s.title || s.content);
@@ -225,12 +242,13 @@ export function PreviewPanel({
   modelName,
   selectedComponents,
   goalSections,
+  customPrompts,
   validationResult,
 }: PreviewPanelProps) {
   const [ide, setIde] = useState<Ide>("claude-code");
 
   const mcps = selectedComponents.mcps ?? [];
-  const body = buildMarkdownBody(description, selectedComponents, goalSections);
+  const body = buildMarkdownBody(description, selectedComponents, goalSections, customPrompts);
 
   let files: PreviewFile[];
   switch (ide) {


### PR DESCRIPTION
## Purpose / Description

Two fixes related to the prompt workflow:

1. **CLI prompt submit was broken** — the CLI posted to `/api/v1/prompts` (the list endpoint) instead of `/api/v1/prompts/submit`, causing a 405 Method Not Allowed.
2. **Builder Prompts tab had no way to add custom prompt text** — only registry prompts were supported (and none exist yet). Users can now type inline prompt text directly in the builder.

## Fixes

* Fixes the CLI `observal prompt submit` command hitting the wrong endpoint
* Adds custom/inline prompt input to the agent builder Prompts tab

## Approach

**Commit 1 — CLI fix:** One-line change in `observal_cli/cmd_prompt.py` to use `/api/v1/prompts/submit` instead of `/api/v1/prompts`.

**Commit 2 — Builder custom prompts:**
- Added `CustomPrompt` interface and `customPrompts` state to the builder page
- Added "Add Custom Prompt" button with inline cards (title + textarea) below the registry picker in the Prompts tab, separated by an "or add custom prompt text" divider
- Custom prompts are serialized into the agent's `prompt` field on publish via `buildRequestBody`
- Tab badge count includes custom prompts
- Preview panel renders custom prompts in the markdown body under a "Custom Prompts" heading

No backend changes — `AgentCreateRequest.prompt` already accepts a string.

## How Has This Been Tested?

- Built and ran Docker containers (`make rebuild`) — API healthy, web served
- Verified the Prompts tab shows the "Add Custom Prompt" button and custom prompt cards render correctly
- TypeScript compiles with zero errors (`npx tsc --noEmit`)
- `ruff check` passes on the CLI change

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)