### PR TITLE
fix(auth): handle Redis unavailability gracefully in auth endpoints

### DIFF
--- a/observal-server/api/ratelimit.py
+++ b/observal-server/api/ratelimit.py
@@ -6,4 +6,5 @@ from config import settings
 limiter = Limiter(
     key_func=get_remote_address,
     storage_uri=settings.REDIS_URL or "memory://",
+    swallow_errors=True,
 )

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -6,6 +6,7 @@ import jwt as pyjwt
 from authlib.integrations.starlette_client import OAuth
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
+from redis.exceptions import RedisError
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -52,13 +53,17 @@ async def _issue_tokens(user: User) -> tuple[str, str, int]:
     """Issue JWT access + refresh tokens for a user, storing refresh JTI in Redis.
 
     Returns (access_token, refresh_token, expires_in).
+    Fails open: tokens are still returned if Redis is temporarily unreachable.
     """
     access_token, expires_in = create_access_token(user.id, user.role)
     refresh_token, jti = create_refresh_token(user.id, user.role)
 
-    redis = get_redis()
-    refresh_ttl = settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400
-    await redis.setex(f"refresh_jti:{jti}", refresh_ttl, str(user.id))
+    try:
+        redis = get_redis()
+        refresh_ttl = settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400
+        await redis.setex(f"refresh_jti:{jti}", refresh_ttl, str(user.id))
+    except RedisError as e:
+        logger.warning("Redis unavailable when storing refresh JTI, failing open: %s", e)
 
     return access_token, refresh_token, expires_in
 
@@ -252,20 +257,24 @@ async def oauth_callback(request: Request, db: AsyncSession = Depends(get_db)):
     # Generate a short-lived opaque code instead of exposing tokens in the URL.
     # The frontend will exchange this code for credentials via a POST request.
     code = secrets.token_urlsafe(32)
-    redis = get_redis()
-    await redis.setex(
-        f"oauth_code:{code}",
-        30,
-        json.dumps(
-            {
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-                "expires_in": expires_in,
-                "user_id": str(user.id),
-                "role": user.role.value,
-            }
-        ),
-    )
+    try:
+        redis = get_redis()
+        await redis.setex(
+            f"oauth_code:{code}",
+            30,
+            json.dumps(
+                {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "expires_in": expires_in,
+                    "user_id": str(user.id),
+                    "role": user.role.value,
+                }
+            ),
+        )
+    except RedisError as e:
+        logger.warning("Redis unavailable during OAuth callback: %s", e)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
 
     frontend_redirect = f"{settings.FRONTEND_URL}/login?code={code}"
     return RedirectResponse(url=frontend_redirect)
@@ -278,15 +287,22 @@ async def exchange_code(req: CodeExchangeRequest, db: AsyncSession = Depends(get
     The code is stored in Redis with a 30-second TTL and is deleted after
     a single successful use, preventing replay attacks.
     """
-    redis = get_redis()
-    redis_key = f"oauth_code:{req.code}"
-    data = await redis.get(redis_key)
+    try:
+        redis = get_redis()
+        redis_key = f"oauth_code:{req.code}"
+        data = await redis.get(redis_key)
+    except RedisError as e:
+        logger.warning("Redis unavailable during code exchange: %s", e)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
 
     if not data:
         raise HTTPException(status_code=400, detail="Invalid or expired code")
 
     # Delete immediately to enforce single-use
-    await redis.delete(redis_key)
+    try:
+        await redis.delete(redis_key)
+    except RedisError:
+        pass
 
     try:
         payload = json.loads(data)
@@ -355,13 +371,21 @@ async def refresh_token(request: Request, req: RefreshRequest, db: AsyncSession 
         raise HTTPException(status_code=401, detail="Invalid refresh token claims")
 
     # Check that the JTI has not been revoked
-    redis = get_redis()
-    stored = await redis.get(f"refresh_jti:{jti}")
+    try:
+        redis = get_redis()
+        stored = await redis.get(f"refresh_jti:{jti}")
+    except RedisError as e:
+        logger.warning("Redis unavailable during token refresh: %s", e)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+
     if stored is None:
         raise HTTPException(status_code=401, detail="Refresh token has been revoked or expired")
 
     # Revoke the old refresh token (one-time use / rotation)
-    await redis.delete(f"refresh_jti:{jti}")
+    try:
+        await redis.delete(f"refresh_jti:{jti}")
+    except RedisError:
+        pass
 
     # Look up the user to ensure they still exist
     result = await db.execute(select(User).where(User.id == user_id))
@@ -373,8 +397,11 @@ async def refresh_token(request: Request, req: RefreshRequest, db: AsyncSession 
     access_token, expires_in = create_access_token(user.id, user.role)
     new_refresh_token, new_jti = create_refresh_token(user.id, user.role)
 
-    refresh_ttl = settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400
-    await redis.setex(f"refresh_jti:{new_jti}", refresh_ttl, str(user.id))
+    try:
+        refresh_ttl = settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400
+        await redis.setex(f"refresh_jti:{new_jti}", refresh_ttl, str(user.id))
+    except RedisError as e:
+        logger.warning("Redis unavailable when storing new refresh JTI: %s", e)
 
     return TokenResponse(
         access_token=access_token,
@@ -396,8 +423,12 @@ async def revoke_token(request: Request, req: RevokeRequest):
     if not jti:
         raise HTTPException(status_code=401, detail="Invalid refresh token claims")
 
-    redis = get_redis()
-    await redis.delete(f"refresh_jti:{jti}")
+    try:
+        redis = get_redis()
+        await redis.delete(f"refresh_jti:{jti}")
+    except RedisError as e:
+        logger.warning("Redis unavailable during token revocation: %s", e)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
 
     return {"detail": "Token revoked"}
 


### PR DESCRIPTION
## Purpose / Description
Auth endpoints crash with `500 Internal Server Error` when Redis is temporarily unreachable (e.g. after a Docker network recreate). The rate-limit middleware and direct Redis calls in the auth routes had no error handling for transient connectivity failures, causing `redis.exceptions.ConnectionError` to propagate as unhandled 500s.

This PR adds industry-standard fail-open handling (matching Django `RATELIMIT_FAIL_OPEN`, Express `passOnStoreError`, Cloudflare/AWS patterns) so that transient Redis outages degrade gracefully instead of blocking all authentication.

## Fixes
* Closes #349 (remaining auth resiliency portion — port conflicts were addressed in #383)

---

## Approach

### 1. Rate limiter fail-open
* Enabled `swallow_errors=True` on the slowapi `Limiter` in `api/ratelimit.py`. When Redis is unreachable, rate-limit decorators allow requests through instead of raising unhandled exceptions.

### 2. Direct Redis call resilience in `api/routes/auth.py`
All 6 direct Redis call sites are now wrapped with `try/except RedisError`:

| Call site | Strategy | Rationale |
|-----------|----------|-----------|
| `_issue_tokens` (JTI store) | **Fail-open** — log warning, return tokens | Don't block login/register over a transient Redis issue |
| OAuth callback (code store) | **503 Service Unavailable** | Can't complete OAuth flow without storing the code |
| Code exchange (code read) | **503 Service Unavailable** | Can't retrieve code without Redis |
| Code exchange (code delete) | **Silent catch** | Best-effort cleanup; TTL handles expiry anyway |
| Token refresh (JTI read) | **503 Service Unavailable** | Can't verify revocation status without Redis |
| Token refresh (old JTI delete, new JTI store) | **Silent catch / Fail-open** | Best-effort cleanup and non-blocking token issuance |
| Token revoke | **503 Service Unavailable** | Can't revoke without Redis |

---

## How Has This Been Tested?
1. All 122 existing tests pass (`uv run python -m pytest tests/ -x -q` — 122 passed).
2. Code review verified that every `get_redis()` + `await redis.*` call in auth routes is now wrapped.
3. `swallow_errors=True` is a well-tested slowapi feature confirmed by inspecting the library source.

---

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] Descriptive commit message with a short title (first line, max 50 chars).
- [x] Performed a self-review of my own code.
- [ ] UI changes: (N/A — backend only)