### PR TITLE
feat: add draft workflow and submission forms for all component types

### DIFF
--- a/observal-server/alembic/versions/0014_add_draft_to_listing_status.py
+++ b/observal-server/alembic/versions/0014_add_draft_to_listing_status.py
@@ -1,0 +1,33 @@
+"""Add 'draft' value to listing_status enum.
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-04-19
+"""
+
+from alembic import op
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_enum
+                WHERE enumlabel = 'draft'
+                AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'listingstatus')
+            ) THEN
+                ALTER TYPE listingstatus ADD VALUE 'draft' BEFORE 'pending';
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    pass

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -111,9 +111,7 @@ async def my_hooks(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     stmt = (
-        select(HookListing)
-        .where(HookListing.submitted_by == current_user.id)
-        .order_by(HookListing.created_at.desc())
+        select(HookListing).where(HookListing.submitted_by == current_user.id).order_by(HookListing.created_at.desc())
     )
     result = await db.execute(stmt)
     return [HookListingSummary.model_validate(r) for r in result.scalars().all()]
@@ -167,9 +165,21 @@ async def update_hook_draft(
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
-        "name", "version", "description", "owner", "event", "execution_mode",
-        "priority", "handler_type", "handler_config", "input_schema",
-        "output_schema", "scope", "tool_filter", "file_pattern", "supported_ides",
+        "name",
+        "version",
+        "description",
+        "owner",
+        "event",
+        "execution_mode",
+        "priority",
+        "handler_type",
+        "handler_config",
+        "input_schema",
+        "output_schema",
+        "scope",
+        "tool_filter",
+        "file_pattern",
+        "supported_ides",
     ):
         val = getattr(req, field)
         if val is not None:

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -7,11 +7,13 @@ from models.hook import HookDownload, HookListing
 from models.mcp import ListingStatus
 from models.user import User, UserRole
 from schemas.hook import (
+    HookDraftRequest,
     HookInstallRequest,
     HookInstallResponse,
     HookListingResponse,
     HookListingSummary,
     HookSubmitRequest,
+    HookUpdateRequest,
 )
 
 router = APIRouter(prefix="/api/v1/hooks", tags=["hooks"])
@@ -101,6 +103,104 @@ async def install_hook(
 
     config = generate_hook_telemetry_config(listing, req.ide, platform=req.platform)
     return HookInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
+
+
+@router.get("/my", response_model=list[HookListingSummary])
+async def my_hooks(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(HookListing)
+        .where(HookListing.submitted_by == current_user.id)
+        .order_by(HookListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [HookListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
+@router.post("/draft", response_model=HookListingResponse)
+async def save_hook_draft(
+    req: HookDraftRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = HookListing(
+        name=req.name,
+        version=req.version,
+        description=req.description,
+        owner=req.owner or current_user.username or current_user.email,
+        event=req.event,
+        execution_mode=req.execution_mode,
+        priority=req.priority,
+        handler_type=req.handler_type,
+        handler_config=req.handler_config,
+        input_schema=req.input_schema,
+        output_schema=req.output_schema,
+        scope=req.scope,
+        tool_filter=req.tool_filter,
+        file_pattern=req.file_pattern,
+        supported_ides=req.supported_ides,
+        status=ListingStatus.draft,
+        submitted_by=current_user.id,
+        owner_org_id=current_user.org_id,
+    )
+    db.add(listing)
+    await db.commit()
+    await db.refresh(listing)
+    return HookListingResponse.model_validate(listing)
+
+
+@router.put("/{listing_id}/draft", response_model=HookListingResponse)
+async def update_hook_draft(
+    listing_id: str,
+    req: HookUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(HookListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    for field in (
+        "name", "version", "description", "owner", "event", "execution_mode",
+        "priority", "handler_type", "handler_config", "input_schema",
+        "output_schema", "scope", "tool_filter", "file_pattern", "supported_ides",
+    ):
+        val = getattr(req, field)
+        if val is not None:
+            setattr(listing, field, val)
+
+    await db.commit()
+    await db.refresh(listing)
+    return HookListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/submit", response_model=HookListingResponse)
+async def submit_hook_draft(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(HookListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    if not listing.description:
+        raise HTTPException(status_code=400, detail="Description is required before submitting")
+
+    listing.status = ListingStatus.pending
+    await db.commit()
+    await db.refresh(listing)
+    return HookListingResponse.model_validate(listing)
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -204,11 +204,7 @@ async def my_mcps(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    stmt = (
-        select(McpListing)
-        .where(McpListing.submitted_by == current_user.id)
-        .order_by(McpListing.created_at.desc())
-    )
+    stmt = select(McpListing).where(McpListing.submitted_by == current_user.id).order_by(McpListing.created_at.desc())
     result = await db.execute(stmt)
     return [McpListingSummary.model_validate(r) for r in result.scalars().all()]
 
@@ -264,9 +260,22 @@ async def update_mcp_draft(
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
-        "name", "version", "description", "category", "owner", "git_url",
-        "framework", "docker_image", "command", "args", "url", "auto_approve",
-        "transport", "supported_ides", "setup_instructions", "changelog",
+        "name",
+        "version",
+        "description",
+        "category",
+        "owner",
+        "git_url",
+        "framework",
+        "docker_image",
+        "command",
+        "args",
+        "url",
+        "auto_approve",
+        "transport",
+        "supported_ides",
+        "setup_instructions",
+        "changelog",
     ):
         val = getattr(req, field)
         if val is not None:

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -12,11 +12,13 @@ from schemas.mcp import (
     ClientAnalysis,
     McpAnalyzeRequest,
     McpAnalyzeResponse,
+    McpDraftRequest,
     McpInstallRequest,
     McpInstallResponse,
     McpListingResponse,
     McpListingSummary,
     McpSubmitRequest,
+    McpUpdateRequest,
 )
 from services.config_generator import generate_config
 from services.mcp_validator import analyze_repo, run_validation
@@ -195,6 +197,114 @@ async def install_mcp(
 
     snippet = generate_config(listing, req.ide, env_values=req.env_values, header_values=req.header_values)
     return McpInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=snippet)
+
+
+@router.get("/my", response_model=list[McpListingSummary])
+async def my_mcps(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(McpListing)
+        .where(McpListing.submitted_by == current_user.id)
+        .order_by(McpListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [McpListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
+@router.post("/draft", response_model=McpListingResponse)
+async def save_mcp_draft(
+    req: McpDraftRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = McpListing(
+        name=req.name,
+        version=req.version,
+        git_url=req.git_url,
+        description=req.description,
+        category=req.category,
+        owner=req.owner or current_user.username or current_user.email,
+        framework=req.framework,
+        docker_image=req.docker_image,
+        command=req.command,
+        args=req.args,
+        url=req.url,
+        headers=[h.model_dump() for h in req.headers] if req.headers else None,
+        auto_approve=req.auto_approve,
+        transport=req.transport or ("sse" if req.url and not req.command else "stdio" if req.command else None),
+        supported_ides=req.supported_ides,
+        environment_variables=[ev.model_dump() for ev in req.environment_variables],
+        setup_instructions=req.setup_instructions,
+        changelog=req.changelog,
+        status=ListingStatus.draft,
+        submitted_by=current_user.id,
+        owner_org_id=current_user.org_id,
+    )
+    db.add(listing)
+    await db.commit()
+    await db.refresh(listing)
+    return McpListingResponse.model_validate(listing)
+
+
+@router.put("/{listing_id}/draft", response_model=McpListingResponse)
+async def update_mcp_draft(
+    listing_id: str,
+    req: McpUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(McpListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    for field in (
+        "name", "version", "description", "category", "owner", "git_url",
+        "framework", "docker_image", "command", "args", "url", "auto_approve",
+        "transport", "supported_ides", "setup_instructions", "changelog",
+    ):
+        val = getattr(req, field)
+        if val is not None:
+            setattr(listing, field, val)
+
+    if req.headers is not None:
+        listing.headers = [h.model_dump() for h in req.headers]
+    if req.environment_variables is not None:
+        listing.environment_variables = [ev.model_dump() for ev in req.environment_variables]
+
+    await db.commit()
+    await db.refresh(listing)
+    return McpListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/submit", response_model=McpListingResponse)
+async def submit_mcp_draft(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(McpListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    if not listing.description:
+        raise HTTPException(status_code=400, detail="Description is required before submitting")
+    if not listing.git_url and not listing.command and not listing.url:
+        raise HTTPException(status_code=400, detail="At least one of git_url, command, or url is required")
+
+    listing.status = ListingStatus.pending
+    await db.commit()
+    await db.refresh(listing)
+    return McpListingResponse.model_validate(listing)
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -10,11 +10,13 @@ from models.mcp import ListingStatus
 from models.prompt import PromptDownload, PromptListing
 from models.user import User, UserRole
 from schemas.prompt import (
+    PromptDraftRequest,
     PromptListingResponse,
     PromptListingSummary,
     PromptRenderRequest,
     PromptRenderResponse,
     PromptSubmitRequest,
+    PromptUpdateRequest,
 )
 
 router = APIRouter(prefix="/api/v1/prompts", tags=["prompts"])
@@ -151,6 +153,100 @@ async def render_prompt(
         pass
 
     return PromptRenderResponse(listing_id=listing.id, rendered=rendered)
+
+
+@router.get("/my", response_model=list[PromptListingSummary])
+async def my_prompts(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(PromptListing)
+        .where(PromptListing.submitted_by == current_user.id)
+        .order_by(PromptListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [PromptListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
+@router.post("/draft", response_model=PromptListingResponse)
+async def save_prompt_draft(
+    req: PromptDraftRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = PromptListing(
+        name=req.name,
+        version=req.version,
+        description=req.description,
+        owner=req.owner or current_user.username or current_user.email,
+        category=req.category,
+        template=req.template,
+        variables=req.variables,
+        model_hints=req.model_hints,
+        tags=req.tags,
+        supported_ides=req.supported_ides,
+        status=ListingStatus.draft,
+        submitted_by=current_user.id,
+        owner_org_id=current_user.org_id,
+    )
+    db.add(listing)
+    await db.commit()
+    await db.refresh(listing)
+    return PromptListingResponse.model_validate(listing)
+
+
+@router.put("/{listing_id}/draft", response_model=PromptListingResponse)
+async def update_prompt_draft(
+    listing_id: str,
+    req: PromptUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(PromptListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    for field in (
+        "name", "version", "description", "owner", "category",
+        "template", "variables", "model_hints", "tags", "supported_ides",
+    ):
+        val = getattr(req, field)
+        if val is not None:
+            setattr(listing, field, val)
+
+    await db.commit()
+    await db.refresh(listing)
+    return PromptListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/submit", response_model=PromptListingResponse)
+async def submit_prompt_draft(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(PromptListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    if not listing.description:
+        raise HTTPException(status_code=400, detail="Description is required before submitting")
+    if not listing.template:
+        raise HTTPException(status_code=400, detail="Template is required before submitting")
+
+    listing.status = ListingStatus.pending
+    await db.commit()
+    await db.refresh(listing)
+    return PromptListingResponse.model_validate(listing)
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -212,8 +212,16 @@ async def update_prompt_draft(
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
-        "name", "version", "description", "owner", "category",
-        "template", "variables", "model_hints", "tags", "supported_ides",
+        "name",
+        "version",
+        "description",
+        "owner",
+        "category",
+        "template",
+        "variables",
+        "model_hints",
+        "tags",
+        "supported_ides",
     ):
         val = getattr(req, field)
         if val is not None:

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -160,9 +160,19 @@ async def update_sandbox_draft(
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
-        "name", "version", "description", "owner", "runtime_type", "image",
-        "dockerfile_url", "resource_limits", "network_policy", "allowed_mounts",
-        "env_vars", "entrypoint", "supported_ides",
+        "name",
+        "version",
+        "description",
+        "owner",
+        "runtime_type",
+        "image",
+        "dockerfile_url",
+        "resource_limits",
+        "network_policy",
+        "allowed_mounts",
+        "env_vars",
+        "entrypoint",
+        "supported_ides",
     ):
         val = getattr(req, field)
         if val is not None:

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -7,11 +7,13 @@ from models.mcp import ListingStatus
 from models.sandbox import SandboxDownload, SandboxListing
 from models.user import User, UserRole
 from schemas.sandbox import (
+    SandboxDraftRequest,
     SandboxInstallRequest,
     SandboxInstallResponse,
     SandboxListingResponse,
     SandboxListingSummary,
     SandboxSubmitRequest,
+    SandboxUpdateRequest,
 )
 
 router = APIRouter(prefix="/api/v1/sandboxes", tags=["sandboxes"])
@@ -96,6 +98,104 @@ async def install_sandbox(
 
     config = generate_sandbox_config(listing, req.ide)
     return SandboxInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
+
+
+@router.get("/my", response_model=list[SandboxListingSummary])
+async def my_sandboxes(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(SandboxListing)
+        .where(SandboxListing.submitted_by == current_user.id)
+        .order_by(SandboxListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
+@router.post("/draft", response_model=SandboxListingResponse)
+async def save_sandbox_draft(
+    req: SandboxDraftRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = SandboxListing(
+        name=req.name,
+        version=req.version,
+        description=req.description,
+        owner=req.owner or current_user.username or current_user.email,
+        runtime_type=req.runtime_type,
+        image=req.image,
+        dockerfile_url=req.dockerfile_url,
+        resource_limits=req.resource_limits,
+        network_policy=req.network_policy,
+        allowed_mounts=req.allowed_mounts,
+        env_vars=req.env_vars,
+        entrypoint=req.entrypoint,
+        supported_ides=req.supported_ides,
+        status=ListingStatus.draft,
+        submitted_by=current_user.id,
+        owner_org_id=current_user.org_id,
+    )
+    db.add(listing)
+    await db.commit()
+    await db.refresh(listing)
+    return SandboxListingResponse.model_validate(listing)
+
+
+@router.put("/{listing_id}/draft", response_model=SandboxListingResponse)
+async def update_sandbox_draft(
+    listing_id: str,
+    req: SandboxUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(SandboxListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    for field in (
+        "name", "version", "description", "owner", "runtime_type", "image",
+        "dockerfile_url", "resource_limits", "network_policy", "allowed_mounts",
+        "env_vars", "entrypoint", "supported_ides",
+    ):
+        val = getattr(req, field)
+        if val is not None:
+            setattr(listing, field, val)
+
+    await db.commit()
+    await db.refresh(listing)
+    return SandboxListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/submit", response_model=SandboxListingResponse)
+async def submit_sandbox_draft(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(SandboxListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    if not listing.description:
+        raise HTTPException(status_code=400, detail="Description is required before submitting")
+    if not listing.image:
+        raise HTTPException(status_code=400, detail="Image is required before submitting")
+
+    listing.status = ListingStatus.pending
+    await db.commit()
+    await db.refresh(listing)
+    return SandboxListingResponse.model_validate(listing)
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -171,10 +171,23 @@ async def update_skill_draft(
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
-        "name", "version", "description", "owner", "git_url", "skill_path",
-        "target_agents", "task_type", "triggers", "slash_command",
-        "has_scripts", "has_templates", "supported_ides", "is_power",
-        "power_md", "mcp_server_config", "activation_keywords",
+        "name",
+        "version",
+        "description",
+        "owner",
+        "git_url",
+        "skill_path",
+        "target_agents",
+        "task_type",
+        "triggers",
+        "slash_command",
+        "has_scripts",
+        "has_templates",
+        "supported_ides",
+        "is_power",
+        "power_md",
+        "mcp_server_config",
+        "activation_keywords",
     ):
         val = getattr(req, field)
         if val is not None:

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -7,11 +7,13 @@ from models.mcp import ListingStatus
 from models.skill import SkillDownload, SkillListing
 from models.user import User, UserRole
 from schemas.skill import (
+    SkillDraftRequest,
     SkillInstallRequest,
     SkillInstallResponse,
     SkillListingResponse,
     SkillListingSummary,
     SkillSubmitRequest,
+    SkillUpdateRequest,
 )
 
 router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
@@ -103,6 +105,107 @@ async def install_skill(
 
     config = generate_skill_config(listing, req.ide)
     return SkillInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
+
+
+@router.get("/my", response_model=list[SkillListingSummary])
+async def my_skills(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(SkillListing)
+        .where(SkillListing.submitted_by == current_user.id)
+        .order_by(SkillListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [SkillListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
+@router.post("/draft", response_model=SkillListingResponse)
+async def save_skill_draft(
+    req: SkillDraftRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = SkillListing(
+        name=req.name,
+        version=req.version,
+        description=req.description,
+        owner=req.owner or current_user.username or current_user.email,
+        git_url=req.git_url,
+        skill_path=req.skill_path,
+        target_agents=req.target_agents,
+        task_type=req.task_type,
+        triggers=req.triggers,
+        slash_command=req.slash_command,
+        has_scripts=req.has_scripts,
+        has_templates=req.has_templates,
+        supported_ides=req.supported_ides,
+        is_power=req.is_power,
+        power_md=req.power_md,
+        mcp_server_config=req.mcp_server_config,
+        activation_keywords=req.activation_keywords,
+        status=ListingStatus.draft,
+        submitted_by=current_user.id,
+        owner_org_id=current_user.org_id,
+    )
+    db.add(listing)
+    await db.commit()
+    await db.refresh(listing)
+    return SkillListingResponse.model_validate(listing)
+
+
+@router.put("/{listing_id}/draft", response_model=SkillListingResponse)
+async def update_skill_draft(
+    listing_id: str,
+    req: SkillUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(SkillListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    for field in (
+        "name", "version", "description", "owner", "git_url", "skill_path",
+        "target_agents", "task_type", "triggers", "slash_command",
+        "has_scripts", "has_templates", "supported_ides", "is_power",
+        "power_md", "mcp_server_config", "activation_keywords",
+    ):
+        val = getattr(req, field)
+        if val is not None:
+            setattr(listing, field, val)
+
+    await db.commit()
+    await db.refresh(listing)
+    return SkillListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/submit", response_model=SkillListingResponse)
+async def submit_skill_draft(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(SkillListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    if listing.status != ListingStatus.draft:
+        raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    if not listing.description:
+        raise HTTPException(status_code=400, detail="Description is required before submitting")
+
+    listing.status = ListingStatus.pending
+    await db.commit()
+    await db.refresh(listing)
+    return SkillListingResponse.model_validate(listing)
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -10,6 +10,7 @@ from models.base import Base
 
 
 class ListingStatus(str, enum.Enum):
+    draft = "draft"
     pending = "pending"
     approved = "approved"
     rejected = "rejected"

--- a/observal-server/schemas/hook.py
+++ b/observal-server/schemas/hook.py
@@ -42,6 +42,44 @@ class HookSubmitRequest(BaseModel):
     _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
 
 
+class HookDraftRequest(BaseModel):
+    name: str
+    version: str = "0.1.0"
+    description: str = ""
+    owner: str = ""
+    event: str = "on_tool_call"
+    execution_mode: str = "async"
+    priority: int = 100
+    handler_type: str = "command"
+    handler_config: dict = {}
+    input_schema: dict | None = None
+    output_schema: dict | None = None
+    scope: str = "agent"
+    tool_filter: list[str] | None = None
+    file_pattern: list[str] | None = None
+    supported_ides: list[str] = []
+
+    _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
+
+
+class HookUpdateRequest(BaseModel):
+    name: str | None = None
+    version: str | None = None
+    description: str | None = None
+    owner: str | None = None
+    event: str | None = None
+    execution_mode: str | None = None
+    priority: int | None = None
+    handler_type: str | None = None
+    handler_config: dict | None = None
+    input_schema: dict | None = None
+    output_schema: dict | None = None
+    scope: str | None = None
+    tool_filter: list[str] | None = None
+    file_pattern: list[str] | None = None
+    supported_ides: list[str] | None = None
+
+
 class HookListingResponse(BaseModel):
     id: uuid.UUID
     name: str

--- a/observal-server/schemas/mcp.py
+++ b/observal-server/schemas/mcp.py
@@ -76,6 +76,51 @@ class McpSubmitRequest(BaseModel):
         return self
 
 
+class McpDraftRequest(BaseModel):
+    name: str
+    version: str = "0.1.0"
+    description: str = ""
+    category: str = "other"
+    owner: str = ""
+    git_url: str | None = None
+    framework: str | None = None
+    docker_image: str | None = None
+    command: str | None = None
+    args: list[str] | None = None
+    url: str | None = None
+    headers: list[McpHeader] | None = None
+    auto_approve: list[str] | None = None
+    transport: str | None = None
+    supported_ides: list[str] = []
+    environment_variables: list[McpEnvVar] = []
+    setup_instructions: str | None = None
+    changelog: str | None = None
+    client_analysis: ClientAnalysis | None = None
+
+    _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
+
+
+class McpUpdateRequest(BaseModel):
+    name: str | None = None
+    version: str | None = None
+    description: str | None = None
+    category: str | None = None
+    owner: str | None = None
+    git_url: str | None = None
+    framework: str | None = None
+    docker_image: str | None = None
+    command: str | None = None
+    args: list[str] | None = None
+    url: str | None = None
+    headers: list[McpHeader] | None = None
+    auto_approve: list[str] | None = None
+    transport: str | None = None
+    supported_ides: list[str] | None = None
+    environment_variables: list[McpEnvVar] | None = None
+    setup_instructions: str | None = None
+    changelog: str | None = None
+
+
 class McpCustomFieldResponse(BaseModel):
     field_name: str
     field_value: str

--- a/observal-server/schemas/prompt.py
+++ b/observal-server/schemas/prompt.py
@@ -23,6 +23,34 @@ class PromptSubmitRequest(BaseModel):
     _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
 
 
+class PromptDraftRequest(BaseModel):
+    name: str
+    version: str = "0.1.0"
+    description: str = ""
+    owner: str = ""
+    category: str = "general"
+    template: str = ""
+    variables: list[dict] = []
+    model_hints: dict | None = None
+    tags: list[str] = []
+    supported_ides: list[str] = []
+
+    _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
+
+
+class PromptUpdateRequest(BaseModel):
+    name: str | None = None
+    version: str | None = None
+    description: str | None = None
+    owner: str | None = None
+    category: str | None = None
+    template: str | None = None
+    variables: list[dict] | None = None
+    model_hints: dict | None = None
+    tags: list[str] | None = None
+    supported_ides: list[str] | None = None
+
+
 class PromptListingResponse(BaseModel):
     id: uuid.UUID
     name: str

--- a/observal-server/schemas/sandbox.py
+++ b/observal-server/schemas/sandbox.py
@@ -36,6 +36,40 @@ class SandboxSubmitRequest(BaseModel):
     _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
 
 
+class SandboxDraftRequest(BaseModel):
+    name: str
+    version: str = "0.1.0"
+    description: str = ""
+    owner: str = ""
+    runtime_type: str = "docker"
+    image: str = ""
+    dockerfile_url: str | None = None
+    resource_limits: dict = {}
+    network_policy: str = "none"
+    allowed_mounts: list[str] = []
+    env_vars: dict = {}
+    entrypoint: str | None = None
+    supported_ides: list[str] = []
+
+    _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
+
+
+class SandboxUpdateRequest(BaseModel):
+    name: str | None = None
+    version: str | None = None
+    description: str | None = None
+    owner: str | None = None
+    runtime_type: str | None = None
+    image: str | None = None
+    dockerfile_url: str | None = None
+    resource_limits: dict | None = None
+    network_policy: str | None = None
+    allowed_mounts: list[str] | None = None
+    env_vars: dict | None = None
+    entrypoint: str | None = None
+    supported_ides: list[str] | None = None
+
+
 class SandboxListingResponse(BaseModel):
     id: uuid.UUID
     name: str

--- a/observal-server/schemas/skill.py
+++ b/observal-server/schemas/skill.py
@@ -31,6 +31,48 @@ class SkillSubmitRequest(BaseModel):
     _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
 
 
+class SkillDraftRequest(BaseModel):
+    name: str
+    version: str = "0.1.0"
+    description: str = ""
+    owner: str = ""
+    git_url: str | None = None
+    skill_path: str = "/"
+    target_agents: list[str] = []
+    task_type: str = "general"
+    triggers: dict | None = None
+    slash_command: str | None = None
+    has_scripts: bool = False
+    has_templates: bool = False
+    supported_ides: list[str] = []
+    is_power: bool = False
+    power_md: str | None = None
+    mcp_server_config: dict | None = None
+    activation_keywords: list[str] | None = None
+
+    _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
+
+
+class SkillUpdateRequest(BaseModel):
+    name: str | None = None
+    version: str | None = None
+    description: str | None = None
+    owner: str | None = None
+    git_url: str | None = None
+    skill_path: str | None = None
+    target_agents: list[str] | None = None
+    task_type: str | None = None
+    triggers: dict | None = None
+    slash_command: str | None = None
+    has_scripts: bool | None = None
+    has_templates: bool | None = None
+    supported_ides: list[str] | None = None
+    is_power: bool | None = None
+    power_md: str | None = None
+    mcp_server_config: dict | None = None
+    activation_keywords: list[str] | None = None
+
+
 class SkillListingResponse(BaseModel):
     id: uuid.UUID
     name: str

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -25,8 +25,17 @@ def register_hook(app: typer.Typer):
 @hook_app.command(name="submit")
 def hook_submit(
     from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
+    draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
+    submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (hook ID)"),
 ):
     """Submit a new hook for review."""
+    if submit_draft:
+        resolved = config.resolve_alias(submit_draft)
+        with spinner("Submitting draft for review..."):
+            result = client.post(f"/api/v1/hooks/{resolved}/submit")
+        rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
+        return
+
     if from_file:
         with open(from_file) as f:
             payload = _json.load(f)
@@ -40,9 +49,15 @@ def hook_submit(
             "handler_type": select_one("Handler type", VALID_HOOK_HANDLER_TYPES),
             "handler_config": _json.loads(typer.prompt("Handler config (JSON)")),
         }
-    with spinner("Submitting hook..."):
-        result = client.post("/api/v1/hooks", payload)
-    rprint(f"[green]✓ Hook submitted![/green] ID: [bold]{result['id']}[/bold]")
+
+    if draft:
+        with spinner("Saving draft..."):
+            result = client.post("/api/v1/hooks/draft", payload)
+        rprint(f"[green]✓ Draft saved![/green] ID: [bold]{result['id']}[/bold]")
+    else:
+        with spinner("Submitting hook..."):
+            result = client.post("/api/v1/hooks/submit", payload)
+        rprint(f"[green]✓ Hook submitted![/green] ID: [bold]{result['id']}[/bold]")
 
 
 @hook_app.command(name="list")

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -892,6 +892,7 @@ def submit(
     """Submit an MCP server for review."""
     if submit_draft:
         from observal_cli import config as cfg
+
         resolved = cfg.resolve_alias(submit_draft)
         with spinner("Submitting draft for review..."):
             result = client.post(f"/api/v1/mcps/{resolved}/submit")

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -314,7 +314,7 @@ def _build_config_preview(server_name: str, parsed: dict) -> dict:
 # ── Implementation functions (shared by canonical + deprecated) ──
 
 
-def _submit_impl(git_url, name, category, yes, direct_config=False):
+def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False):
     # ── Path B/C: Direct JSON config (no git URL needed) ─────
     if direct_config:
         rprint("[bold]Paste your MCP server JSON config below.[/bold]")
@@ -391,9 +391,12 @@ def _submit_impl(git_url, name, category, yes, direct_config=False):
         if parsed.get("docker_image"):
             submit_payload["docker_image"] = parsed["docker_image"]
 
-        with spinner("Submitting..."):
-            result = client.post("/api/v1/mcps/submit", submit_payload)
-        rprint(f"\n[green]Submitted![/green] ID: [bold]{result['id']}[/bold]")
+        endpoint = "/api/v1/mcps/draft" if draft else "/api/v1/mcps/submit"
+        label = "Saving draft..." if draft else "Submitting..."
+        with spinner(label):
+            result = client.post(endpoint, submit_payload)
+        msg = "Draft saved!" if draft else "Submitted!"
+        rprint(f"\n[green]{msg}[/green] ID: [bold]{result['id']}[/bold]")
         rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
         return
 
@@ -659,9 +662,12 @@ def _submit_impl(git_url, name, category, yes, direct_config=False):
             "docker_image": prefill.get("docker_image"),
         }
 
-    with spinner("Submitting..."):
-        result = client.post("/api/v1/mcps/submit", submit_payload)
-    rprint(f"\n[green]Submitted![/green] ID: [bold]{result['id']}[/bold]")
+    endpoint = "/api/v1/mcps/draft" if draft else "/api/v1/mcps/submit"
+    label = "Saving draft..." if draft else "Submitting..."
+    with spinner(label):
+        result = client.post(endpoint, submit_payload)
+    msg = "Draft saved!" if draft else "Submitted!"
+    rprint(f"\n[green]{msg}[/green] ID: [bold]{result['id']}[/bold]")
     if _framework:
         rprint(f"  Framework: [cyan]{_framework}[/cyan]")
     rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
@@ -880,12 +886,21 @@ def submit(
     category: str = typer.Option(None, "--category", "-c", help="Skip category prompt"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Accept defaults from repo analysis"),
     config: bool = typer.Option(False, "--config", help="Submit via direct JSON config (paste mode)"),
+    draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
+    submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (MCP ID)"),
 ):
     """Submit an MCP server for review."""
+    if submit_draft:
+        from observal_cli import config as cfg
+        resolved = cfg.resolve_alias(submit_draft)
+        with spinner("Submitting draft for review..."):
+            result = client.post(f"/api/v1/mcps/{resolved}/submit")
+        rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
+        return
     if not git_url and not config:
         rprint("[red]Provide a git URL or use --config[/red]")
         raise typer.Exit(1)
-    _submit_impl(git_url, name, category, yes, config)
+    _submit_impl(git_url, name, category, yes, config, draft=draft)
 
 
 @mcp_app.command(name="list")

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -25,12 +25,20 @@ def prompt_submit(
     from_file: str | None = typer.Option(
         None, "--from-file", "-f", help="Create from JSON file or read template from file"
     ),
+    draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
+    submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (prompt ID)"),
 ):
     """Submit a new prompt for review."""
+    if submit_draft:
+        resolved = config.resolve_alias(submit_draft)
+        with spinner("Submitting draft for review..."):
+            result = client.post(f"/api/v1/prompts/{resolved}/submit")
+        rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
+        return
+
     if from_file:
         with open(from_file) as f:
             content = f.read()
-        # Try JSON first, fall back to treating file as template text
         try:
             payload = _json.loads(content)
         except _json.JSONDecodeError:
@@ -51,9 +59,15 @@ def prompt_submit(
             "category": select_one("Category", VALID_PROMPT_CATEGORIES),
             "template": typer.prompt("Template"),
         }
-    with spinner("Submitting prompt..."):
-        result = client.post("/api/v1/prompts/submit", payload)
-    rprint(f"[green]✓ Prompt submitted![/green] ID: [bold]{result['id']}[/bold]")
+
+    if draft:
+        with spinner("Saving draft..."):
+            result = client.post("/api/v1/prompts/draft", payload)
+        rprint(f"[green]✓ Draft saved![/green] ID: [bold]{result['id']}[/bold]")
+    else:
+        with spinner("Submitting prompt..."):
+            result = client.post("/api/v1/prompts/submit", payload)
+        rprint(f"[green]✓ Prompt submitted![/green] ID: [bold]{result['id']}[/bold]")
 
 
 @prompt_app.command(name="list")

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -23,8 +23,17 @@ def register_sandbox(app: typer.Typer):
 @sandbox_app.command(name="submit")
 def sandbox_submit(
     from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
+    draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
+    submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (sandbox ID)"),
 ):
     """Submit a new sandbox for review."""
+    if submit_draft:
+        resolved = config.resolve_alias(submit_draft)
+        with spinner("Submitting draft for review..."):
+            result = client.post(f"/api/v1/sandboxes/{resolved}/submit")
+        rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
+        return
+
     if from_file:
         with open(from_file) as f:
             payload = _json.load(f)
@@ -38,9 +47,15 @@ def sandbox_submit(
             "image": typer.prompt("Image"),
             "resource_limits": _json.loads(typer.prompt("Resource limits (JSON)")),
         }
-    with spinner("Submitting sandbox..."):
-        result = client.post("/api/v1/sandboxes", payload)
-    rprint(f"[green]✓ Sandbox submitted![/green] ID: [bold]{result['id']}[/bold]")
+
+    if draft:
+        with spinner("Saving draft..."):
+            result = client.post("/api/v1/sandboxes/draft", payload)
+        rprint(f"[green]✓ Draft saved![/green] ID: [bold]{result['id']}[/bold]")
+    else:
+        with spinner("Submitting sandbox..."):
+            result = client.post("/api/v1/sandboxes/submit", payload)
+        rprint(f"[green]✓ Sandbox submitted![/green] ID: [bold]{result['id']}[/bold]")
 
 
 @sandbox_app.command(name="list")

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -23,8 +23,17 @@ def register_skill(app: typer.Typer):
 @skill_app.command(name="submit")
 def skill_submit(
     from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
+    draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
+    submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (skill ID)"),
 ):
     """Submit a new skill for review."""
+    if submit_draft:
+        resolved = config.resolve_alias(submit_draft)
+        with spinner("Submitting draft for review..."):
+            result = client.post(f"/api/v1/skills/{resolved}/submit")
+        rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
+        return
+
     if from_file:
         with open(from_file) as f:
             payload = _json.load(f)
@@ -39,9 +48,15 @@ def skill_submit(
             "task_type": select_one("Task type", VALID_SKILL_TASK_TYPES),
             "target_agents": [a.strip() for a in agents_input.split(",") if a.strip()],
         }
-    with spinner("Submitting skill..."):
-        result = client.post("/api/v1/skills", payload)
-    rprint(f"[green]✓ Skill submitted![/green] ID: [bold]{result['id']}[/bold]")
+
+    if draft:
+        with spinner("Saving draft..."):
+            result = client.post("/api/v1/skills/draft", payload)
+        rprint(f"[green]✓ Draft saved![/green] ID: [bold]{result['id']}[/bold]")
+    else:
+        with spinner("Submitting skill..."):
+            result = client.post("/api/v1/skills/submit", payload)
+        rprint(f"[green]✓ Skill submitted![/green] ID: [bold]{result['id']}[/bold]")
 
 
 @skill_app.command(name="list")

--- a/web/src/app/(registry)/components/page.tsx
+++ b/web/src/app/(registry)/components/page.tsx
@@ -11,12 +11,24 @@ import {
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
+  Plus,
+  Send,
+  Trash2,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { useRegistryList } from "@/hooks/use-api";
+import {
+  useRegistryList,
+  useMyComponents,
+  useComponentSubmit,
+  useComponentSaveDraft,
+  useComponentSubmitDraft,
+  useComponentDelete,
+} from "@/hooks/use-api";
+import { useAuthGuard } from "@/hooks/use-auth";
 import type { RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
+import { SubmitComponentDialog } from "@/components/registry/submit-component-dialog";
 import {
   Table,
   TableBody,
@@ -142,11 +154,13 @@ function makeColumns(activeType: RegistryType): ColumnDef<RegistryItem>[] {
 
 export default function ComponentsPage() {
   const router = useRouter();
+  const { ready: authReady, role } = useAuthGuard();
   const [activeType, setActiveType] = useState<RegistryType>("mcps");
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [view, setView] = useState<ViewMode>("table");
   const [sorting, setSorting] = useState<SortingState>([]);
+  const [submitOpen, setSubmitOpen] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
@@ -162,6 +176,17 @@ export default function ComponentsPage() {
     activeType,
     debouncedSearch ? { search: debouncedSearch } : undefined,
   );
+
+  const { data: myItems } = useMyComponents(activeType);
+  const myDrafts = useMemo(
+    () => (myItems ?? []).filter((i) => i.status === "draft" || i.status === "pending" || i.status === "rejected"),
+    [myItems],
+  );
+
+  const submitMutation = useComponentSubmit(activeType);
+  const saveDraftMutation = useComponentSaveDraft(activeType);
+  const submitDraftMutation = useComponentSubmitDraft(activeType);
+  const deleteMutation = useComponentDelete(activeType);
 
   const items = useMemo(() => data ?? [], [data]);
 
@@ -205,6 +230,12 @@ export default function ComponentsPage() {
               className="pl-9 h-9"
             />
           </div>
+          {authReady && role && (
+            <Button size="sm" className="h-9" onClick={() => setSubmitOpen(true)}>
+              <Plus className="h-4 w-4 mr-1.5" />
+              Create
+            </Button>
+          )}
           <div className="flex items-center border border-border rounded-md overflow-hidden ml-auto">
             <Button
               variant={view === "table" ? "secondary" : "ghost"}
@@ -334,7 +365,79 @@ export default function ComponentsPage() {
             ))}
           </div>
         )}
+
+        {/* My Drafts / Submissions */}
+        {authReady && role && myDrafts.length > 0 && (
+          <div className="space-y-3 pt-4 border-t border-border">
+            <h3 className="text-sm font-medium text-muted-foreground">
+              My Submissions
+            </h3>
+            <div className="space-y-2">
+              {myDrafts.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex items-center justify-between rounded-lg border border-border px-4 py-3"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <StatusBadge status={item.status ?? "draft"} />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {item.name}
+                      </p>
+                      {item.description && (
+                        <p className="text-xs text-muted-foreground truncate max-w-xs">
+                          {item.description}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    {item.status === "draft" && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => submitDraftMutation.mutate(item.id)}
+                        disabled={submitDraftMutation.isPending}
+                      >
+                        <Send className="h-3 w-3 mr-1" />
+                        Submit
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => deleteMutation.mutate(item.id)}
+                      disabled={deleteMutation.isPending}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
+
+      <SubmitComponentDialog
+        open={submitOpen}
+        onOpenChange={setSubmitOpen}
+        type={activeType}
+        onSubmit={(body) => {
+          submitMutation.mutate(body, {
+            onSuccess: () => setSubmitOpen(false),
+          });
+        }}
+        onSaveDraft={(body) => {
+          saveDraftMutation.mutate(body, {
+            onSuccess: () => setSubmitOpen(false),
+          });
+        }}
+        isSubmitting={submitMutation.isPending}
+        isSavingDraft={saveDraftMutation.isPending}
+      />
     </>
   );
 }

--- a/web/src/components/registry/status-badge.tsx
+++ b/web/src/components/registry/status-badge.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 
 const statusConfig: Record<string, { bg: string; text: string; dot?: string; ping?: boolean }> = {
+  draft:     { bg: "bg-zinc-100 dark:bg-zinc-800", text: "text-zinc-600 dark:text-zinc-400", dot: "bg-zinc-400" },
   pending:   { bg: "bg-light-yellow", text: "text-dark-yellow", dot: "bg-dark-yellow", ping: true },
   approved:  { bg: "bg-light-green",  text: "text-dark-green",  dot: "bg-dark-green",  ping: true },
   active:    { bg: "bg-light-green",  text: "text-dark-green",  dot: "bg-dark-green",  ping: true },

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -1,0 +1,717 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2, Plus, X } from "lucide-react";
+import { toast } from "sonner";
+import type { RegistryType } from "@/lib/api";
+
+const MCP_CATEGORIES = [
+  "browser-automation", "cloud-platforms", "code-execution", "communication",
+  "databases", "developer-tools", "devops", "file-systems", "finance",
+  "knowledge-memory", "monitoring", "multimedia", "productivity", "search",
+  "security", "version-control", "ai-ml", "data-analytics", "general",
+];
+
+const MCP_FRAMEWORKS = ["python", "docker", "typescript", "go"];
+
+const MCP_TRANSPORTS = ["stdio", "sse", "streamable-http"];
+
+const VALID_IDES = [
+  "cursor", "kiro", "claude-code", "gemini-cli", "vscode", "codex", "copilot",
+];
+
+const SKILL_TASK_TYPES = [
+  "code-review", "code-generation", "testing", "documentation",
+  "debugging", "refactoring", "deployment", "security-audit",
+  "performance", "general",
+];
+
+const HOOK_EVENTS = [
+  "PreToolUse", "PostToolUse", "Notification", "Stop",
+  "SubagentStop", "SessionStart", "UserPromptSubmit",
+];
+
+const HOOK_HANDLER_TYPES = ["command", "http"];
+const HOOK_EXECUTION_MODES = ["async", "sync", "blocking"];
+const HOOK_SCOPES = ["agent", "session", "global"];
+
+const PROMPT_CATEGORIES = [
+  "system-prompt", "code-review", "code-generation", "testing",
+  "documentation", "debugging", "general",
+];
+
+const SANDBOX_RUNTIME_TYPES = ["docker", "lxc", "firecracker", "wasm"];
+const SANDBOX_NETWORK_POLICIES = ["none", "host", "bridge", "restricted"];
+
+interface EnvVar {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+interface SubmitComponentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  type: RegistryType;
+  onSubmit: (body: Record<string, unknown>) => void;
+  onSaveDraft: (body: Record<string, unknown>) => void;
+  isSubmitting: boolean;
+  isSavingDraft: boolean;
+}
+
+export function SubmitComponentDialog({
+  open,
+  onOpenChange,
+  type,
+  onSubmit,
+  onSaveDraft,
+  isSubmitting,
+  isSavingDraft,
+}: SubmitComponentDialogProps) {
+  // ── Common ──────────────────────────────────────────────
+  const [name, setName] = useState("");
+  const [version, setVersion] = useState("0.1.0");
+  const [description, setDescription] = useState("");
+  const [owner, setOwner] = useState("");
+  const [supportedIdes, setSupportedIdes] = useState<string[]>([]);
+
+  // ── MCP ─────────────────────────────────────────────────
+  const [category, setCategory] = useState("general");
+  const [gitUrl, setGitUrl] = useState("");
+  const [command, setCommand] = useState("");
+  const [args, setArgs] = useState("");
+  const [mcpUrl, setMcpUrl] = useState("");
+  const [transport, setTransport] = useState("");
+  const [framework, setFramework] = useState("");
+  const [dockerImage, setDockerImage] = useState("");
+  const [envVars, setEnvVars] = useState<EnvVar[]>([]);
+  const [setupInstructions, setSetupInstructions] = useState("");
+
+  // ── Skill ───────────────────────────────────────────────
+  const [taskType, setTaskType] = useState("general");
+  const [skillGitUrl, setSkillGitUrl] = useState("");
+  const [skillPath, setSkillPath] = useState("/");
+
+  // ── Hook ────────────────────────────────────────────────
+  const [event, setEvent] = useState("PreToolUse");
+  const [handlerType, setHandlerType] = useState("command");
+  const [executionMode, setExecutionMode] = useState("async");
+  const [hookScope, setHookScope] = useState("agent");
+  const [handlerConfig, setHandlerConfig] = useState("");
+
+  // ── Prompt ──────────────────────────────────────────────
+  const [promptCategory, setPromptCategory] = useState("general");
+  const [template, setTemplate] = useState("");
+
+  // ── Sandbox ─────────────────────────────────────────────
+  const [runtimeType, setRuntimeType] = useState("docker");
+  const [image, setImage] = useState("");
+  const [networkPolicy, setNetworkPolicy] = useState("none");
+  const [entrypoint, setEntrypoint] = useState("");
+
+  function reset() {
+    setName("");
+    setVersion("0.1.0");
+    setDescription("");
+    setOwner("");
+    setSupportedIdes([]);
+    setCategory("general");
+    setGitUrl("");
+    setCommand("");
+    setArgs("");
+    setMcpUrl("");
+    setTransport("");
+    setFramework("");
+    setDockerImage("");
+    setEnvVars([]);
+    setSetupInstructions("");
+    setTaskType("general");
+    setSkillGitUrl("");
+    setSkillPath("/");
+    setEvent("PreToolUse");
+    setHandlerType("command");
+    setExecutionMode("async");
+    setHookScope("agent");
+    setHandlerConfig("");
+    setPromptCategory("general");
+    setTemplate("");
+    setRuntimeType("docker");
+    setImage("");
+    setNetworkPolicy("none");
+    setEntrypoint("");
+  }
+
+  function buildBody(): Record<string, unknown> {
+    const base: Record<string, unknown> = {
+      name,
+      version,
+      description,
+      owner,
+    };
+    if (supportedIdes.length > 0) base.supported_ides = supportedIdes;
+
+    switch (type) {
+      case "mcps": {
+        const body: Record<string, unknown> = {
+          ...base,
+          category,
+        };
+        if (gitUrl) body.git_url = gitUrl;
+        if (command) body.command = command;
+        if (args.trim()) body.args = args.split(/\s+/).filter(Boolean);
+        if (mcpUrl) body.url = mcpUrl;
+        if (transport) body.transport = transport;
+        if (framework) body.framework = framework;
+        if (dockerImage) body.docker_image = dockerImage;
+        if (envVars.length > 0) body.environment_variables = envVars;
+        if (setupInstructions) body.setup_instructions = setupInstructions;
+        return body;
+      }
+      case "skills":
+        return {
+          ...base,
+          task_type: taskType,
+          git_url: skillGitUrl || undefined,
+          skill_path: skillPath || "/",
+        };
+      case "hooks": {
+        const body: Record<string, unknown> = {
+          ...base,
+          event,
+          handler_type: handlerType,
+          execution_mode: executionMode,
+          scope: hookScope,
+        };
+        if (handlerConfig.trim()) {
+          try {
+            body.handler_config = JSON.parse(handlerConfig);
+          } catch {
+            /* leave as default {} */
+          }
+        }
+        return body;
+      }
+      case "prompts":
+        return { ...base, category: promptCategory, template };
+      case "sandboxes":
+        return {
+          ...base,
+          runtime_type: runtimeType,
+          image,
+          network_policy: networkPolicy,
+          entrypoint: entrypoint || undefined,
+        };
+      default:
+        return base;
+    }
+  }
+
+  function validateForSubmit(): string | null {
+    if (!name) return "Name is required";
+    if (!description) return "Description is required";
+
+    if (type === "mcps" && !gitUrl && !command && !mcpUrl) {
+      return "At least one of Git URL, Command, or Server URL is required";
+    }
+    if (type === "prompts" && !template) {
+      return "Template is required";
+    }
+    if (type === "sandboxes" && !image) {
+      return "Image is required";
+    }
+    return null;
+  }
+
+  function handleSubmit() {
+    const err = validateForSubmit();
+    if (err) {
+      toast.error(err);
+      return;
+    }
+    onSubmit(buildBody());
+  }
+
+  function handleDraft() {
+    if (!name) {
+      toast.error("Name is required");
+      return;
+    }
+    onSaveDraft(buildBody());
+  }
+
+  function addEnvVar() {
+    setEnvVars((prev) => [...prev, { name: "", description: "", required: true }]);
+  }
+
+  function updateEnvVar(index: number, field: keyof EnvVar, value: string | boolean) {
+    setEnvVars((prev) =>
+      prev.map((ev, i) => (i === index ? { ...ev, [field]: value } : ev)),
+    );
+  }
+
+  function removeEnvVar(index: number) {
+    setEnvVars((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function toggleIde(ide: string) {
+    setSupportedIdes((prev) =>
+      prev.includes(ide) ? prev.filter((i) => i !== ide) : [...prev, ide],
+    );
+  }
+
+  const busy = isSubmitting || isSavingDraft;
+  const typeLabel =
+    type === "mcps" ? "MCP Server" :
+    type === "sandboxes" ? "Sandbox" :
+    type.charAt(0).toUpperCase() + type.slice(1, -1);
+
+  const submitError = validateForSubmit();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) reset();
+        onOpenChange(v);
+      }}
+    >
+      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Submit {typeLabel}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 pt-2">
+          {/* ── Common fields ──────────────────────────────── */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="comp-name">Name *</Label>
+              <Input
+                id="comp-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="my-component"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="comp-version">Version</Label>
+              <Input
+                id="comp-version"
+                value={version}
+                onChange={(e) => setVersion(e.target.value)}
+                placeholder="0.1.0"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="comp-owner">Owner</Label>
+            <Input
+              id="comp-owner"
+              value={owner}
+              onChange={(e) => setOwner(e.target.value)}
+              placeholder="your-username"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="comp-desc">Description *</Label>
+            <Textarea
+              id="comp-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this component do?"
+              rows={3}
+            />
+          </div>
+
+          {/* ── MCP-specific ──────────────────────────────── */}
+          {type === "mcps" && (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Category</Label>
+                  <Select value={category} onValueChange={setCategory}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {MCP_CATEGORIES.map((c) => (
+                        <SelectItem key={c} value={c}>{c}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Transport</Label>
+                  <Select value={transport || "auto"} onValueChange={(v) => setTransport(v === "auto" ? "" : v)}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="auto">Auto-detect</SelectItem>
+                      {MCP_TRANSPORTS.map((t) => (
+                        <SelectItem key={t} value={t}>{t}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="mcp-git-url">Git URL</Label>
+                <Input
+                  id="mcp-git-url"
+                  value={gitUrl}
+                  onChange={(e) => setGitUrl(e.target.value)}
+                  placeholder="https://github.com/user/mcp-server"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="mcp-command">Command</Label>
+                  <Input
+                    id="mcp-command"
+                    value={command}
+                    onChange={(e) => setCommand(e.target.value)}
+                    placeholder="npx, uvx, node..."
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="mcp-args">Args</Label>
+                  <Input
+                    id="mcp-args"
+                    value={args}
+                    onChange={(e) => setArgs(e.target.value)}
+                    placeholder="space-separated args"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="mcp-url">Server URL (SSE/HTTP)</Label>
+                <Input
+                  id="mcp-url"
+                  value={mcpUrl}
+                  onChange={(e) => setMcpUrl(e.target.value)}
+                  placeholder="http://localhost:3000/sse"
+                />
+              </div>
+
+              {!gitUrl && !command && !mcpUrl && (
+                <p className="text-xs text-destructive">
+                  At least one of Git URL, Command, or Server URL is required for submission.
+                </p>
+              )}
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Framework</Label>
+                  <Select value={framework || "none"} onValueChange={(v) => setFramework(v === "none" ? "" : v)}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">None</SelectItem>
+                      {MCP_FRAMEWORKS.map((f) => (
+                        <SelectItem key={f} value={f}>{f}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="mcp-docker">Docker Image</Label>
+                  <Input
+                    id="mcp-docker"
+                    value={dockerImage}
+                    onChange={(e) => setDockerImage(e.target.value)}
+                    placeholder="user/image:tag"
+                  />
+                </div>
+              </div>
+
+              {/* Environment Variables */}
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>Environment Variables</Label>
+                  <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={addEnvVar}>
+                    <Plus className="h-3 w-3 mr-1" /> Add
+                  </Button>
+                </div>
+                {envVars.map((ev, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <Input
+                      value={ev.name}
+                      onChange={(e) => updateEnvVar(i, "name", e.target.value)}
+                      placeholder="ENV_NAME"
+                      className="flex-1 h-8 text-xs font-mono"
+                    />
+                    <Input
+                      value={ev.description}
+                      onChange={(e) => updateEnvVar(i, "description", e.target.value)}
+                      placeholder="Description"
+                      className="flex-1 h-8 text-xs"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0 shrink-0"
+                      onClick={() => removeEnvVar(i)}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="mcp-setup">Setup Instructions</Label>
+                <Textarea
+                  id="mcp-setup"
+                  value={setupInstructions}
+                  onChange={(e) => setSetupInstructions(e.target.value)}
+                  placeholder="Steps to configure this MCP server..."
+                  rows={3}
+                  className="text-sm"
+                />
+              </div>
+            </>
+          )}
+
+          {/* ── Skill-specific ────────────────────────────── */}
+          {type === "skills" && (
+            <>
+              <div className="space-y-1.5">
+                <Label>Task Type</Label>
+                <Select value={taskType} onValueChange={setTaskType}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {SKILL_TASK_TYPES.map((t) => (
+                      <SelectItem key={t} value={t}>{t}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="skill-git-url">Git URL</Label>
+                  <Input
+                    id="skill-git-url"
+                    value={skillGitUrl}
+                    onChange={(e) => setSkillGitUrl(e.target.value)}
+                    placeholder="https://github.com/..."
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="skill-path">Skill Path</Label>
+                  <Input
+                    id="skill-path"
+                    value={skillPath}
+                    onChange={(e) => setSkillPath(e.target.value)}
+                    placeholder="/"
+                  />
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* ── Hook-specific ─────────────────────────────── */}
+          {type === "hooks" && (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Event</Label>
+                  <Select value={event} onValueChange={setEvent}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {HOOK_EVENTS.map((e) => (
+                        <SelectItem key={e} value={e}>{e}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Handler Type</Label>
+                  <Select value={handlerType} onValueChange={setHandlerType}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {HOOK_HANDLER_TYPES.map((h) => (
+                        <SelectItem key={h} value={h}>{h}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Execution Mode</Label>
+                  <Select value={executionMode} onValueChange={setExecutionMode}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {HOOK_EXECUTION_MODES.map((m) => (
+                        <SelectItem key={m} value={m}>{m}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Scope</Label>
+                  <Select value={hookScope} onValueChange={setHookScope}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {HOOK_SCOPES.map((s) => (
+                        <SelectItem key={s} value={s}>{s}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="hook-config">Handler Config (JSON)</Label>
+                <Textarea
+                  id="hook-config"
+                  value={handlerConfig}
+                  onChange={(e) => setHandlerConfig(e.target.value)}
+                  placeholder='{"command": "./my-hook.sh"}'
+                  rows={3}
+                  className="font-mono text-sm"
+                />
+              </div>
+            </>
+          )}
+
+          {/* ── Prompt-specific ───────────────────────────── */}
+          {type === "prompts" && (
+            <>
+              <div className="space-y-1.5">
+                <Label>Category</Label>
+                <Select value={promptCategory} onValueChange={setPromptCategory}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {PROMPT_CATEGORIES.map((c) => (
+                      <SelectItem key={c} value={c}>{c}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="prompt-template">Template *</Label>
+                <Textarea
+                  id="prompt-template"
+                  value={template}
+                  onChange={(e) => setTemplate(e.target.value)}
+                  placeholder={"You are a {{role}} that helps with {{task}}.\n\nUse {{variable}} syntax for template variables."}
+                  rows={6}
+                  className="font-mono text-sm"
+                />
+              </div>
+            </>
+          )}
+
+          {/* ── Sandbox-specific ──────────────────────────── */}
+          {type === "sandboxes" && (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Runtime Type</Label>
+                  <Select value={runtimeType} onValueChange={setRuntimeType}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {SANDBOX_RUNTIME_TYPES.map((r) => (
+                        <SelectItem key={r} value={r}>{r}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Network Policy</Label>
+                  <Select value={networkPolicy} onValueChange={setNetworkPolicy}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {SANDBOX_NETWORK_POLICIES.map((p) => (
+                        <SelectItem key={p} value={p}>{p}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="sandbox-image">Image *</Label>
+                  <Input
+                    id="sandbox-image"
+                    value={image}
+                    onChange={(e) => setImage(e.target.value)}
+                    placeholder="ubuntu:22.04"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="sandbox-entry">Entrypoint</Label>
+                  <Input
+                    id="sandbox-entry"
+                    value={entrypoint}
+                    onChange={(e) => setEntrypoint(e.target.value)}
+                    placeholder="/bin/bash"
+                  />
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* ── Supported IDEs (all types) ────────────────── */}
+          <div className="space-y-1.5">
+            <Label>Supported IDEs</Label>
+            <div className="flex flex-wrap gap-1.5">
+              {VALID_IDES.map((ide) => (
+                <button
+                  key={ide}
+                  type="button"
+                  onClick={() => toggleIde(ide)}
+                  className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                    supportedIdes.includes(ide)
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted/50 text-muted-foreground hover:bg-muted"
+                  }`}
+                >
+                  {ide}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Actions ───────────────────────────────────── */}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              variant="outline"
+              onClick={handleDraft}
+              disabled={busy || !name}
+            >
+              {isSavingDraft && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+              Save Draft
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={busy || !!submitError}
+              title={submitError ?? undefined}
+            >
+              {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+              Submit for Review
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -474,6 +474,88 @@ export function useSubmitDraft() {
   });
 }
 
+// ── Component Draft/Submit (generic) ──────────────────────────────
+
+export function useMyComponents(type: RegistryType) {
+  return useQuery({
+    queryKey: ["registry", type, "my"],
+    queryFn: () => registry.my(type),
+  });
+}
+
+export function useComponentSubmit(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: unknown) => registry.submit(type, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", type] });
+      qc.invalidateQueries({ queryKey: ["review"] });
+      toast.success("Submitted for review");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to submit");
+    },
+  });
+}
+
+export function useComponentSaveDraft(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: unknown) => registry.draft(body, type),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", type] });
+      toast.success("Draft saved");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to save draft");
+    },
+  });
+}
+
+export function useComponentUpdateDraft(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { id: string; body: unknown }) =>
+      registry.updateDraft(vars.id, vars.body, type),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", type] });
+      toast.success("Draft updated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to update draft");
+    },
+  });
+}
+
+export function useComponentSubmitDraft(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.submitDraft(id, type),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", type] });
+      qc.invalidateQueries({ queryKey: ["review"] });
+      toast.success("Submitted for review");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to submit");
+    },
+  });
+}
+
+export function useComponentDelete(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.delete(type, id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", type] });
+      toast.success("Deleted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to delete");
+    },
+  });
+}
+
 // ── Version ────────────────────────────────────────────────────────
 
 export function useVersionSuggestions(id: string | undefined) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -238,11 +238,16 @@ export const registry = {
     get<{ total: number; unique_users: number; recent_7d: number }>(`/agents/${id}/downloads`),
   validate: (body: { components: { component_type: string; component_id: string }[] }) =>
     post<ValidationResult>("/agents/validate", body),
-  my: () => get<RegistryItem[]>("/agents/my"),
+  my: (type?: RegistryType) => get<RegistryItem[]>(`/${type ?? "agents"}/my`),
   archive: (id: string) => patch(`/agents/${id}/archive`),
-  draft: (body: unknown) => post<RegistryItem>("/agents/draft", body),
-  updateDraft: (id: string, body: unknown) => put<RegistryItem>(`/agents/${id}/draft`, body),
-  submitDraft: (id: string) => post(`/agents/${id}/submit`),
+  draft: (body: unknown, type?: RegistryType) =>
+    post<RegistryItem>(`/${type ?? "agents"}/draft`, body),
+  updateDraft: (id: string, body: unknown, type?: RegistryType) =>
+    put<RegistryItem>(`/${type ?? "agents"}/${id}/draft`, body),
+  submitDraft: (id: string, type?: RegistryType) =>
+    post(`/${type ?? "agents"}/${id}/submit`),
+  submit: (type: RegistryType, body: unknown) =>
+    post<RegistryItem>(`/${type}/submit`, body),
   versionSuggestions: (id: string) =>
     get<VersionSuggestions>(`/agents/${id}/version-suggestions`),
 };


### PR DESCRIPTION
## Summary

- Add `draft` to `ListingStatus` enum (shared by all 5 component types) with Alembic migration
- Add `POST /draft`, `PUT /{id}/draft`, `POST /{id}/submit`, `GET /my` endpoints to MCPs, skills, hooks, prompts, and sandboxes — matching the existing agent draft pattern
- Add per-type `DraftRequest` (relaxed validation) and `UpdateRequest` (all fields optional) Pydantic schemas
- Add frontend `SubmitComponentDialog` with full per-type fields (MCP: category, transport, framework, docker image, env vars, setup instructions, args; Hook: execution mode, scope, handler config; Sandbox: network policy, entrypoint; etc.)
- Add `My Submissions` section to components listing page with submit/delete actions on drafts
- Add `--draft` and `--submit <id>` flags to all 5 CLI component submit commands
- Add generic React Query hooks: `useMyComponents`, `useComponentSubmit`, `useComponentSaveDraft`, `useComponentUpdateDraft`, `useComponentSubmitDraft`, `useComponentDelete`

Draft is **only** created when explicitly requested (Save Draft button on UI, `--draft` flag on CLI). The default submit path always creates with `pending` status.

## Test plan

- [ ] Verify `POST /api/v1/mcps/draft` creates a listing with `draft` status
- [ ] Verify `POST /api/v1/mcps/{id}/submit` transitions `draft` → `pending` and validates required fields
- [ ] Verify `GET /api/v1/mcps/my` returns only the current user's listings
- [ ] Verify `POST /api/v1/mcps/submit` still creates with `pending` status (not draft)
- [ ] Verify the Submit dialog validates MCP source requirement (git_url/command/url)
- [ ] Verify draft status badge renders correctly
- [ ] Verify CLI `--draft` flag saves as draft, no flag submits for review
- [ ] Verify CLI `--submit <id>` transitions draft to pending
- [ ] Verify review queue does not show drafts (only pending)
- [ ] Run existing backend tests (122 pass)