### PR TITLE
fix(cli): lazy-import asyncpg to unbreak all CLI commands

### DIFF
--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -1,5 +1,7 @@
 """observal migrate: PostgreSQL shallow-copy migration tools."""
 
+from __future__ import annotations
+
 import asyncio
 import hashlib
 import json
@@ -12,9 +14,12 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import asyncpg
 import typer
+
+if TYPE_CHECKING:
+    import asyncpg
 from rich import print as rprint
 
 from observal_cli import client
@@ -186,6 +191,8 @@ def _sha256_file(path: Path) -> str:
 
 async def _connect(db_url: str) -> asyncpg.Connection:
     """Establish asyncpg connection, verify alembic_version table exists."""
+    import asyncpg
+
     # Strip SQLAlchemy dialect suffixes (e.g. postgresql+asyncpg:// → postgresql://)
     clean_url = (
         db_url.split("+")[0] + db_url[db_url.index("://") :] if "+asyncpg" in db_url or "+psycopg" in db_url else db_url
@@ -257,6 +264,8 @@ async def _flush_batch(
     batch: list[dict],
 ) -> tuple[int, int]:
     """Flush a batch of rows to the database. Returns (inserted, skipped)."""
+    import asyncpg
+
     if not batch:
         return 0, 0
 


### PR DESCRIPTION
## Purpose / Description
PR #384 (`cmd_migrate.py`) added a top-level `import asyncpg`, and `main.py` imports `cmd_migrate` unconditionally. This means **every** CLI command (`observal auth login`, `observal registry mcp list`, etc.) crashes with `ModuleNotFoundError: No module named 'asyncpg'` for any user who doesn't have `asyncpg` installed locally — which is all CLI users, since `asyncpg` is a server-side dependency.

CI didn't catch this because `asyncpg` was added to the CI test runner in the same batch of commits.

## Fixes
* Regression introduced by #384

## Approach
- Added `from __future__ import annotations` so type annotations like `asyncpg.Connection` become lazy strings (no runtime import needed).
- Moved `import asyncpg` behind `TYPE_CHECKING` for static analysis / ruff.
- Added runtime `import asyncpg` inside the two functions that actually call asyncpg APIs (`_connect()` and `_flush_batch()`).
- The `observal migrate` subcommand still works identically when `asyncpg` is installed; all other commands no longer require it.

## How Has This Been Tested?
1. `uv run observal --help` — loads without error
2. `uv run observal auth logout` — works (was crashing before)
3. `uvx ruff check observal_cli/cmd_migrate.py` — all checks passed
4. `uv run python -c "from observal_cli.main import app"` — imports cleanly

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code