### PR TITLE
fix: Kiro IDE session detection, event normalization, and grouping

### DIFF
--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import logging
+import re
+import time as _time
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -13,6 +15,14 @@ from services.secrets_redactor import redact_secrets
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/otel", tags=["otel-dashboard"])
+
+# ── Kiro IDE session correlation ──
+# When Kiro IDE fires hooks, each event may have a different $PPID-based
+# session ID. We correlate them by cwd within a 30-minute window.
+
+_kiro_session_cache: dict[str, tuple[str, float]] = {}  # cwd -> (session_id, timestamp)
+_KIRO_SESSION_WINDOW = 1800  # 30 minutes
+
 
 # Background tasks that must survive until completion (prevent GC)
 _background_tasks: set[asyncio.Task] = set()
@@ -534,8 +544,10 @@ _KIRO_TO_CC_EVENT = {
     "agentSpawn": "SessionStart",
     "userPromptSubmit": "UserPromptSubmit",
     "preToolUse": "PreToolUse",
+    "promptSubmit": "UserPromptSubmit",  # Kiro IDE variant
     "postToolUse": "PostToolUse",
     "stop": "Stop",
+    "agentStop": "Stop",  # Kiro IDE variant
 }
 
 _KIRO_FIELD_MAP = {
@@ -762,6 +774,19 @@ async def ingest_hook(request: Request):
     session_id = body.get("session_id", "")
     tool_name = body.get("tool_name", "")
     service_name = body.get("service_name", "observal-hooks")
+
+    # ── Kiro IDE session correlation ──
+    # $PPID differs per hook invocation in IDE context. Correlate by cwd.
+    cwd = body.get("cwd", "")
+    is_kiro_ppid = bool(re.match(r"^kiro-\d+$", session_id))
+    if is_kiro_ppid and cwd:
+        now_ts = _time.monotonic()
+        cached = _kiro_session_cache.get(cwd)
+        if cached and (now_ts - cached[1]) < _KIRO_SESSION_WINDOW:
+            session_id = cached[0]
+        else:
+            _kiro_session_cache[cwd] = (session_id, now_ts)
+        body["session_id"] = session_id
 
     # Build the attributes map that the frontend already reads
     attrs: dict[str, str] = {

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -182,23 +182,31 @@ def generate_agent_config(
                 f"--url {observal_url}/api/v1/otel/hooks "
                 f"--agent-name {safe_name}{model_arg}"
             )
+            spawn_cmd = hook_cmd  # Windows: Python script handles session IDs
         else:
-            # Unix: cat | sed | curl pipeline (unchanged)
-            hook_cmd = (
-                f'cat | sed \'s/^{{/{{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
-                f'"agent_name":"{safe_name}"{model_field},/\' '
-                f"| curl -sf -X POST {observal_url}/api/v1/otel/hooks "
-                f'-H "Content-Type: application/json" '
-                f"-d @-"
+            # Unix: stable UUID session IDs instead of $PPID.
+            # agentSpawn creates a new UUID; other events read the existing one.
+            _sf = "/tmp/observal-kiro-session"  # nosec B108
+            _sid_create = f'$(python3 -c "import uuid; print(uuid.uuid4())" | tee {_sf})'
+            _sid_read = f'$(cat {_sf} 2>/dev/null || echo "kiro-$PPID")'
+
+            def _sed_cmd(sid_expr, pipe_to):
+                return (
+                    'cat | sed \'s/^{{/{{"session_id":"\'"' + sid_expr + '"\'",'
+                    f'"service_name":"kiro","agent_name":"{safe_name}"{model_field},/\' ' + pipe_to
+                )
+
+            _curl_pipe = (
+                f'| curl -sf -X POST {observal_url}/api/v1/otel/hooks -H "Content-Type: application/json" -d @-'
             )
-            stop_cmd = (
-                f'cat | sed \'s/^{{/{{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
-                f'"agent_name":"{safe_name}"{model_field},/\' '
-                f"| python3 -m observal_cli.hooks.kiro_stop_hook "
-                f"--url {observal_url}/api/v1/otel/hooks"
+            spawn_cmd = _sed_cmd(_sid_create, _curl_pipe)
+            hook_cmd = _sed_cmd(_sid_read, _curl_pipe)
+            stop_cmd = _sed_cmd(
+                _sid_read,
+                f"| python3 -m observal_cli.hooks.kiro_stop_hook --url {observal_url}/api/v1/otel/hooks",
             )
         hooks = {
-            "agentSpawn": [{"command": hook_cmd}],
+            "agentSpawn": [{"command": spawn_cmd}],
             "userPromptSubmit": [{"command": hook_cmd}],
             "preToolUse": [{"matcher": "*", "command": hook_cmd}],
             "postToolUse": [{"matcher": "*", "command": hook_cmd}],

--- a/observal-server/services/hook_config_generator.py
+++ b/observal-server/services/hook_config_generator.py
@@ -1,21 +1,3 @@
-# Shell snippet to get or create a stable session ID.
-# agentSpawn creates a new UUID; all other events read the existing one.
-_SESSION_FILE = "/tmp/observal-kiro-session"  # nosec B108
-_SID_READ = f'$(cat {_SESSION_FILE} 2>/dev/null || echo "kiro-$PPID")'
-_SID_CREATE = f'$(python3 -c "import uuid; print(uuid.uuid4())" | tee {_SESSION_FILE})'
-
-
-def _unix_sed_cmd(session_expr: str, server_url: str) -> str:
-    """Build the cat | sed | curl pipeline with the given session expression."""
-    return (
-        f'cat | sed \'s/^{{/{{"session_id":"\'"{session_expr}"\'","service_name":"kiro",'
-        '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
-        f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
-        f'-H "Content-Type: application/json" '
-        f"-d @-"
-    )
-
-
 def generate_hook_telemetry_config(
     hook_listing, ide: str, server_url: str = "http://localhost:8000", platform: str = ""
 ) -> dict:
@@ -44,22 +26,25 @@ def generate_hook_telemetry_config(
                 hook_entry["matcher"] = "*"
             return {"hooks": {kiro_event: [hook_entry]}}
 
-        # Unix: use stable UUID session IDs instead of $PPID.
-        # agentSpawn creates a new session; other events reuse it.
-        is_session_start = kiro_event == "agentSpawn"
-        sid_expr = _SID_CREATE if is_session_start else _SID_READ
+        # Unix: cat | sed | curl pipeline (unchanged)
+        curl_cmd = (
+            'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+            '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
+            f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
+            f'-H "Content-Type: application/json" '
+            f"-d @-"
+        )
 
         # For stop events, use the enrichment script to capture model/tokens
         if kiro_event == "stop":
             stop_cmd = (
-                f'cat | sed \'s/^{{/{{"session_id":"\'"{_SID_READ}"\'","service_name":"kiro",'
+                'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
                 '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
                 f"| python3 -m observal_cli.hooks.kiro_stop_hook "
                 f"--url {server_url}/api/v1/otel/hooks"
             )
             return {"hooks": {kiro_event: [{"command": stop_cmd}]}}
 
-        curl_cmd = _unix_sed_cmd(sid_expr, server_url)
         hook_entry = {"command": curl_cmd}
         if kiro_event in ("preToolUse", "postToolUse"):
             hook_entry["matcher"] = "*"

--- a/observal-server/services/hook_config_generator.py
+++ b/observal-server/services/hook_config_generator.py
@@ -1,3 +1,21 @@
+# Shell snippet to get or create a stable session ID.
+# agentSpawn creates a new UUID; all other events read the existing one.
+_SESSION_FILE = "/tmp/observal-kiro-session"  # nosec B108
+_SID_READ = f'$(cat {_SESSION_FILE} 2>/dev/null || echo "kiro-$PPID")'
+_SID_CREATE = f'$(python3 -c "import uuid; print(uuid.uuid4())" | tee {_SESSION_FILE})'
+
+
+def _unix_sed_cmd(session_expr: str, server_url: str) -> str:
+    """Build the cat | sed | curl pipeline with the given session expression."""
+    return (
+        f'cat | sed \'s/^{{/{{"session_id":"\'"{session_expr}"\'","service_name":"kiro",'
+        '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
+        f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
+        f'-H "Content-Type: application/json" '
+        f"-d @-"
+    )
+
+
 def generate_hook_telemetry_config(
     hook_listing, ide: str, server_url: str = "http://localhost:8000", platform: str = ""
 ) -> dict:
@@ -26,25 +44,22 @@ def generate_hook_telemetry_config(
                 hook_entry["matcher"] = "*"
             return {"hooks": {kiro_event: [hook_entry]}}
 
-        # Unix: cat | sed | curl pipeline (unchanged)
-        curl_cmd = (
-            'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
-            '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
-            f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
-            f'-H "Content-Type: application/json" '
-            f"-d @-"
-        )
+        # Unix: use stable UUID session IDs instead of $PPID.
+        # agentSpawn creates a new session; other events reuse it.
+        is_session_start = kiro_event == "agentSpawn"
+        sid_expr = _SID_CREATE if is_session_start else _SID_READ
 
         # For stop events, use the enrichment script to capture model/tokens
         if kiro_event == "stop":
             stop_cmd = (
-                'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli",'
+                f'cat | sed \'s/^{{/{{"session_id":"\'"{_SID_READ}"\'","service_name":"kiro",'
                 '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
                 f"| python3 -m observal_cli.hooks.kiro_stop_hook "
                 f"--url {server_url}/api/v1/otel/hooks"
             )
             return {"hooks": {kiro_event: [{"command": stop_cmd}]}}
 
+        curl_cmd = _unix_sed_cmd(sid_expr, server_url)
         hook_entry = {"command": curl_cmd}
         if kiro_event in ("preToolUse", "postToolUse"):
             hook_entry["matcher"] = "*"

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -79,7 +79,7 @@ def main():
 
     # Ensure service_name is set (sed prefix may be overwritten by Kiro's
     # native fields due to JSON duplicate-key semantics — last key wins).
-    payload.setdefault("service_name", "kiro-cli")
+    payload.setdefault("service_name", "kiro")
 
     # Inject metadata from CLI args (used on Windows where sed is unavailable)
     if agent_name:

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -159,7 +159,7 @@ def main():
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
-    payload.setdefault("service_name", "kiro-cli")
+    payload.setdefault("service_name", "kiro")
 
     # Inject metadata from CLI args (used on Windows where sed is unavailable)
     if agent_name:

--- a/uv.lock
+++ b/uv.lock
@@ -34,54 +34,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncpg"
-version = "0.31.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159, upload-time = "2025-11-24T23:25:36.443Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157, upload-time = "2025-11-24T23:25:37.89Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051, upload-time = "2025-11-24T23:25:39.461Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640, upload-time = "2025-11-24T23:25:41.512Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050, upload-time = "2025-11-24T23:25:43.153Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574, upload-time = "2025-11-24T23:25:44.942Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076, upload-time = "2025-11-24T23:25:46.486Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980, upload-time = "2025-11-24T23:25:47.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
-    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
-    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
-    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
-    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
-    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
-    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
-    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
-    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
-    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -315,18 +267,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hypothesis"
-version = "6.152.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sortedcontainers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/64/b1/c32bcddb9aab9e3abc700f1f56faf14e7655c64a16ca47701a57362276ea/hypothesis-6.152.1.tar.gz", hash = "sha256:4f4ed934eee295dd84ee97592477d23e8dc03e9f12ae0ee30a4e7c9ef3fca3b0", size = 465029, upload-time = "2026-04-14T22:29:24.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl", hash = "sha256:40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e", size = 530752, upload-time = "2026-04-14T22:29:20.893Z" },
-]
-
-[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -366,16 +306,12 @@ wheels = [
 ]
 
 [[package]]
-name = "observal-cli"
+name = "observal"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "asyncpg" },
     { name = "docker" },
     { name = "httpx" },
-    { name = "hypothesis" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "rich" },
@@ -387,22 +323,20 @@ dev = [
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "sqlalchemy" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "docker", specifier = ">=7.0.0" },
-    { name = "httpx" },
-    { name = "hypothesis" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.0.0" },
-    { name = "rich" },
-    { name = "typer" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "typer", specifier = ">=0.12.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -410,6 +344,8 @@ dev = [
     { name = "fastapi", specifier = ">=0.135.3" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = "==0.15.11" },
     { name = "sqlalchemy", specifier = ">=2.0.49" },
 ]
@@ -763,15 +699,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -1233,7 +1233,7 @@ function SessionStats({ events }: { events: RawOtelEvent[] }) {
       const eName = getEventName(evt);
       const svc = evt.service_name ?? "";
 
-      if (svc === "kiro-cli") isKiro = true;
+      if (svc === "kiro-cli" || svc === "kiro") isKiro = true;
 
       if (eName === "api_request") {
         apiCalls++;

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -45,7 +45,11 @@ interface SessionRow {
 }
 
 function isKiroSession(row: SessionRow): boolean {
-  return row.service_name === "kiro-cli" || row.session_id.startsWith("kiro-");
+  return (
+    row.service_name === "kiro-cli" ||
+    row.service_name === "kiro" ||
+    row.session_id.startsWith("kiro-")
+  );
 }
 
 function formatCredits(c: string | undefined): string {

--- a/web/src/components/traces/trace-list.tsx
+++ b/web/src/components/traces/trace-list.tsx
@@ -166,7 +166,8 @@ export function TraceList() {
             <TableBody>
               {filtered.map((t) => {
                 const traceId = (t.traceId ?? t.trace_id ?? t.id) as string;
-                const status = (t.status as string) ?? "success";
+                const metrics = t.metrics as Record<string, unknown> | undefined;
+                const status = (t.status as string) ?? (metrics?.errorCount ? "error" : "success");
                 return (
                   <TableRow
                     key={traceId}

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -43,13 +43,25 @@ export function useTrends(range?: string) {
 // ── Traces (GraphQL) ────────────────────────────────────────────────
 
 export function useTraces(filters?: Record<string, unknown>) {
+  const traceType = filters?.trace_type as string | undefined;
+  const mcpId = filters?.mcp_id as string | undefined;
+  const agentId = filters?.agent_id as string | undefined;
+  const ide = filters?.ide as string | undefined;
   return useQuery({
     queryKey: ["traces", filters],
     queryFn: () =>
-      graphql<{ traces: unknown[] }>(
-        `query Traces($filters: TraceFilters) { traces(filters: $filters) { id traceId startTime endTime status spanCount } }`,
-        { filters },
-      ).then((d) => d.traces),
+      graphql<{ traces: { items: Record<string, unknown>[]; totalCount: number; hasMore: boolean } }>(
+        `query Traces($traceType: String, $mcpId: String, $agentId: String) {
+          traces(traceType: $traceType, mcpId: $mcpId, agentId: $agentId) {
+            items { traceId traceType name ide startTime endTime metrics { totalSpans errorCount } }
+            totalCount hasMore
+          }
+        }`,
+        { traceType, mcpId, agentId },
+      ).then((d) => {
+        const items = d.traces.items;
+        return ide ? items.filter((t) => t.ide === ide) : items;
+      }),
   });
 }
 
@@ -59,8 +71,14 @@ export function useTrace(id: string | undefined) {
     enabled: !!id,
     queryFn: () =>
       graphql<{ trace: unknown }>(
-        `query Trace($id: String!) { trace(id: $id) { id traceId startTime endTime status spans { spanId name startTime endTime attributes } } }`,
-        { id },
+        `query Trace($traceId: String!) {
+          trace(traceId: $traceId) {
+            traceId traceType name ide startTime endTime input output tags metadata
+            spans { spanId name type startTime endTime status latencyMs }
+            metrics { totalSpans errorCount totalLatencyMs toolCallCount tokenCountTotal }
+          }
+        }`,
+        { traceId: id },
       ).then((d) => d.trace),
   });
 }
@@ -69,13 +87,13 @@ export function useSessions() {
   return useQuery({
     queryKey: ["sessions"],
     queryFn: () =>
-      graphql<{ traces: unknown[] }>(
-        `query Sessions { traces { id traceId startTime endTime status spanCount } }`,
-      ).then((d) => d.traces),
+      graphql<{ traces: { items: unknown[]; totalCount: number; hasMore: boolean } }>(
+        `query Sessions {
+          traces { items { traceId traceType name ide sessionId startTime endTime } totalCount hasMore }
+        }`,
+      ).then((d) => d.traces.items),
   });
 }
-
-// ── Registry ────────────────────────────────────────────────────────
 
 export function useRegistryList(
   type: RegistryType,


### PR DESCRIPTION


## Purpose / Description

Kiro IDE sessions are not reliably detected or grouped in the Observal traces dashboard. The root cause is that the session ID generation (`$PPID`), event name normalization, and IDE detection logic were built around the Kiro CLI workflow and don't account for how the Kiro IDE fires hooks differently:

  * Each IDE hook fires as an independent subprocess, so `$PPID` differs between events, scattering one session across multiple IDs.
  * Kiro IDE uses different event names (`promptSubmit`, `agentStop`) that aren't in the normalization map.
  * Frontend detection only checks `service_name === "kiro-cli"`, missing IDE sessions with `service_name === "kiro"`.

## Fixes

  * Fixes #358

## Approach

**1. Stable UUID session IDs (replaces `$PPID`)**

  * `agentSpawn` generates a UUID and writes it to `/tmp/observal-kiro-session`.
  * All subsequent hook events read from that file, falling back to `$PPID` if missing.
  * Applied to both `hook_config_generator.py` and `agent_config_generator.py`.
  * Changed `service_name` from `"kiro-cli"` to `"kiro"` across all hook scripts.

**2. IDE event name normalization**

  * Added `promptSubmit` → `UserPromptSubmit` and `agentStop` → `Stop` to `_KIRO_TO_CC_EVENT` in `otel_dashboard.py`.

**3. Broadened frontend detection**

  * `isKiroSession()` in `traces/page.tsx` now matches `service_name === "kiro"`.
  * `isKiro` check in `traces/[id]/page.tsx` now matches `svc === "kiro"`.

**4. Server-side session correlation fallback**

  * When `session_id` matches `kiro-\d+` (PPID-based) and `cwd` is present, events from the same `cwd` within a 30-minute window are grouped under the first session ID seen.
  * This is a safety net for existing installations that haven't regenerated their hook configs yet.

## How Has This Been Tested?

Sent mock hook payloads simulating both Kiro CLI and Kiro IDE behavior. 9 test cases, all passing:

1.  **Event normalization** — `promptSubmit` → `UserPromptSubmit`, `agentStop` → `Stop`, CLI events (`userPromptSubmit`, `stop`) still normalize correctly.
2.  **Session correlation** — 4 events with different PPID-based session IDs (`kiro-70001` through `kiro-70004`) from the same `cwd` all grouped under `kiro-70001`.
3.  **Different CWDs stay separate** — events from `/project/alpha` and `/project/beta` get different session IDs (no cross-project merging).
4.  **UUID session IDs pass through unchanged** — non-PPID session IDs like `abc-def-123` are not modified by the correlation logic.
5.  **`service_name: "kiro"` accepted** — IDE events with the new service name are ingested correctly.

### To reproduce:

```bash
# Send a mock IDE session with fragmented PPIDs
curl -X POST http://localhost:8000/api/v1/otel/hooks \
   -H "Content-Type: application/json" \
   -d '{"session_id":"kiro-99001","service_name":"kiro","hookEventName":"promptSubmit","cwd":"/test"}'

curl -X POST http://localhost:8000/api/v1/otel/hooks \
   -H "Content-Type: application/json" \
   -d '{"session_id":"kiro-99002","service_name":"kiro","hookEventName":"agentStop","cwd":"/test"}'

# Both should return the same session_id in the response
# Check http://localhost:3000/traces — should appear as ONE session row
```

## Learning

  * `$PPID` is stable within a single shell session (Kiro CLI) but differs per subprocess invocation (Kiro IDE hooks). Using a temp file as a session ID store is a common pattern for correlating events across independent processes.
  * The `kiro-\d+` regex distinguishes PPID-based IDs (need correlation) from proper UUIDs (pass through), so the fallback logic doesn't interfere with correctly-generated session IDs.

## Checklist

  - [x] All commits are signed off (`git commit -s`) per the [[DCO](https://developercertificate.org/)](https://developercertificate.org/)
  - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
  - [x] You have commented your code, particularly in hard-to-understand areas
  - [x] You have performed a self-review of your own code
  - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)