### PR TITLE
feat(web): redesign traces list page

### DIFF
--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -1,11 +1,14 @@
 import asyncio
 import json
 import logging
+import uuid as _uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import require_role
+from api.deps import get_db, require_role
 from models.user import User, UserRole
 from services.clickhouse import _query, query_shim_spans_for_window
 from services.redis import publish
@@ -42,11 +45,73 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
     return []
 
 
+_PLATFORM_MAP: dict[str, str] = {
+    "claude-code": "Claude Code",
+    "observal-hooks": "Claude Code",
+    "observal-shim": "Claude Code",
+    "kiro-cli": "Kiro",
+}
+
+_IDE_LABEL_MAP: dict[str, str] = {
+    "vscode": "VS Code",
+    "cursor": "Cursor",
+    "windsurf": "Windsurf",
+    "antigravity": "Antigravity",
+}
+
+
+def _derive_platform(service_name: str) -> str:
+    sn = (service_name or "").strip().lower()
+    return _PLATFORM_MAP.get(sn, sn.replace("-", " ").title() if sn else "Unknown")
+
+
+_IGNORE_TERMINAL_TYPES = {"terminal", "non-interactive", "cli", "unknown", ""}
+
+
+def _derive_ide(terminal_type: str, service_name: str) -> str:
+    t = (terminal_type or "").strip().lower()
+    sn = (service_name or "").strip().lower()
+    if t and t not in _IGNORE_TERMINAL_TYPES:
+        if t in _IDE_LABEL_MAP:
+            return _IDE_LABEL_MAP[t]
+        prefix = ""
+        raw = t
+        if t.startswith("wsl-"):
+            prefix = "WSL "
+            raw = t[4:]
+        if raw in _IDE_LABEL_MAP:
+            return f"{prefix}{_IDE_LABEL_MAP[raw]}"
+        for key, label in _IDE_LABEL_MAP.items():
+            if key in raw:
+                return f"{prefix}{label}"
+        if raw not in _IGNORE_TERMINAL_TYPES:
+            return f"{prefix}{raw.title()}"
+    if "kiro" in sn:
+        return "Kiro"
+    return ""
+
+
 @router.get("/sessions")
 async def list_sessions(
     status: str | None = Query(None),
+    platform: str | None = Query(None),
+    days: int | None = Query(None),
     current_user: User = Depends(require_role(UserRole.admin)),
+    db: AsyncSession = Depends(get_db),
 ):
+    where_clauses = ["LogAttributes['session.id'] != ''"]
+
+    if platform:
+        sn_values = [k for k, v in _PLATFORM_MAP.items() if v.lower() == platform.lower()]
+        if sn_values:
+            placeholders = ", ".join(f"'{s}'" for s in sn_values)
+            where_clauses.append(f"ServiceName IN ({placeholders})")
+
+    if days and days > 0:
+        where_clauses.append(f"Timestamp >= now('UTC') - INTERVAL {int(days)} DAY")
+
+    where_sql = " AND ".join(where_clauses)
+
     rows = await _ch_json(
         "SELECT "
         "LogAttributes['session.id'] AS session_id, "
@@ -67,21 +132,108 @@ async def list_sessions(
         "sum(toUInt64OrZero(LogAttributes['cache_read_tokens'])) AS total_cache_read_tokens, "
         "anyIf(LogAttributes['model'], LogAttributes['model'] != '') AS model, "
         "anyIf(LogAttributes['user.id'], LogAttributes['user.id'] != '') AS user_id, "
+        "anyIf(LogAttributes['user.uuid'], LogAttributes['user.uuid'] != '') AS user_uuid, "
+        "anyIf(LogAttributes['user.username'], LogAttributes['user.username'] != '') AS user_username, "
         "anyIf(LogAttributes['terminal.type'], LogAttributes['terminal.type'] != '') AS terminal_type, "
         "anyIf(LogAttributes['credits'], LogAttributes['credits'] != '') AS credits, "
         "anyIf(LogAttributes['tools_used'], LogAttributes['tools_used'] != '') AS tools_used, "
-        "any(ServiceName) AS service_name "
-        "FROM otel_logs "
-        "WHERE LogAttributes['session.id'] != '' "
+        "any(ServiceName) AS service_name, "
+        "groupUniqArrayIf(LogAttributes['model'], LogAttributes['model'] != '') AS models_used "
+        f"FROM otel_logs "
+        f"WHERE {where_sql} "
         "GROUP BY session_id "
         "ORDER BY last_event_time DESC "
         "LIMIT 100"
     )
+
+    # Build user display map from PostgreSQL
+    all_uuids: list[_uuid.UUID] = []
+    uuid_str_set: set[str] = set()
+    hash_to_uuid: dict[str, str] = {}
+    for r in rows:
+        # Collect UUIDs from both user.uuid and user.id fields
+        for field in ("user_uuid", "user_id"):
+            val = r.get(field, "")
+            if val and val not in uuid_str_set:
+                try:
+                    all_uuids.append(_uuid.UUID(val))
+                    uuid_str_set.add(val)
+                except ValueError:
+                    pass
+        # Map non-UUID user.id → user.uuid for fallback
+        u = r.get("user_uuid", "")
+        h = r.get("user_id", "")
+        if u and h and h != u:
+            hash_to_uuid[h] = u
+
+    # Load all users for small teams, or filter by collected UUIDs
+    user_display_map: dict[str, str] = {}
+    if all_uuids:
+        result = await db.execute(select(User).where(User.id.in_(all_uuids)))
+        for u in result.scalars().all():
+            user_display_map[str(u.id)] = u.name or u.username or u.email or ""
+    if not user_display_map and any(r.get("user_id") for r in rows):
+        result = await db.execute(select(User))
+        all_users = result.scalars().all()
+        for u in all_users:
+            user_display_map[str(u.id)] = u.name or u.username or u.email or ""
+        if len(all_users) == 1:
+            u = all_users[0]
+            user_display_map["_single"] = u.name or u.username or u.email or ""
+    # Fallback: map unresolvable hash user IDs to the requesting user when
+    # there is only one distinct hash (typical single-developer setup).
+    unresolved_hashes = set()
+    for r in rows:
+        uid = r.get("user_id", "")
+        if uid and uid not in user_display_map and uid not in uuid_str_set:
+            unresolved_hashes.add(uid)
+    if unresolved_hashes and len(unresolved_hashes) == 1:
+        h = next(iter(unresolved_hashes))
+        display = current_user.name or current_user.username or current_user.email or ""
+        if display:
+            user_display_map[h] = display
+
     for row in rows:
         row["is_active"] = bool(int(row.get("is_active", 0)))
+        row["platform"] = _derive_platform(row.get("service_name", ""))
+        row["ide"] = _derive_ide(row.get("terminal_type", ""), row.get("service_name", ""))
+        uid = row.get("user_id", "")
+        row["user_display"] = (
+            row.get("user_username", "")
+            or user_display_map.get(row.get("user_uuid", ""), "")
+            or user_display_map.get(uid, "")
+            or user_display_map.get(hash_to_uuid.get(uid, ""), "")
+            or (user_display_map.get("_single", "") if uid else "")
+        )
+        mu = row.get("models_used")
+        if isinstance(mu, str):
+            row["models_used"] = [m.strip().strip("'\"") for m in mu.strip("[]").split(",") if m.strip()]
+        elif not isinstance(mu, list):
+            row["models_used"] = []
     if status == "active":
         rows = [r for r in rows if r["is_active"]]
     return rows
+
+
+@router.get("/sessions/summary")
+async def sessions_summary(
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    rows = await _ch_json(
+        "SELECT "
+        "uniqExact(LogAttributes['session.id']) AS sessions_today, "
+        "sum(toUInt64OrZero(LogAttributes['input_tokens'])) "
+        "+ sum(toUInt64OrZero(LogAttributes['output_tokens'])) AS tokens_today "
+        "FROM otel_logs "
+        "WHERE Timestamp >= today() "
+        "AND LogAttributes['session.id'] != ''"
+    )
+    if rows:
+        return {
+            "sessions_today": int(rows[0].get("sessions_today", 0)),
+            "tokens_today": int(rows[0].get("tokens_today", 0)),
+        }
+    return {"sessions_today": 0, "tokens_today": 0}
 
 
 def _merge_session_events(events: list[dict]) -> list[dict]:
@@ -789,6 +941,13 @@ async def ingest_hook(request: Request):
     user_id = body.get("user_id") or request.headers.get("x-observal-user-id") or ""
     if user_id:
         attrs["user.id"] = user_id
+    # Also store the Observal UUID separately so the session query can resolve it
+    observal_uuid = request.headers.get("x-observal-user-id") or ""
+    if observal_uuid:
+        attrs["user.uuid"] = observal_uuid
+    username = request.headers.get("x-observal-username") or ""
+    if username:
+        attrs["user.username"] = username
 
     # ── IDE-specific extraction ──
     # Detect IDE from service_name, then delegate to the right handler.

--- a/observal_cli/hooks/observal-hook.sh
+++ b/observal_cli/hooks/observal-hook.sh
@@ -14,9 +14,20 @@ HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Read payload from stdin into a variable so we can reuse it
 payload=$(cat)
 
+# Get user_id from env var first, then fall back to config file
+if [ -z "$OBSERVAL_USER_ID" ] && [ -f "$HOME/.observal/config.json" ]; then
+  OBSERVAL_USER_ID=$(sed -n 's/.*"user_id":\s*"\([^"]*\)".*/\1/p' "$HOME/.observal/config.json" | head -1)
+fi
+
+# Get username from env var first, then fall back to config file
+if [ -z "$OBSERVAL_USERNAME" ] && [ -f "$HOME/.observal/config.json" ]; then
+  OBSERVAL_USERNAME=$(sed -n 's/.*"username":\s*"\([^"]*\)".*/\1/p' "$HOME/.observal/config.json" | head -1)
+fi
+
 # Try to send to server first
 if echo "$payload" | curl -sf --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
   ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+  ${OBSERVAL_USERNAME:+-H "X-Observal-Username: $OBSERVAL_USERNAME"} \
   -H "Content-Type: application/json" \
   -d @- >/dev/null 2>&1; then
     # Success — flush any buffered events in the background

--- a/observal_cli/hooks/observal-stop-hook.sh
+++ b/observal_cli/hooks/observal-stop-hook.sh
@@ -25,6 +25,16 @@ if [ -z "$SESSION_ID" ] || [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH
   exit 0
 fi
 
+# Get user_id from env var first, then fall back to config file
+if [ -z "$OBSERVAL_USER_ID" ] && [ -f "$HOME/.observal/config.json" ]; then
+  OBSERVAL_USER_ID=$(sed -n 's/.*"user_id":\s*"\([^"]*\)".*/\1/p' "$HOME/.observal/config.json" | head -1)
+fi
+
+# Get username from env var first, then fall back to config file
+if [ -z "$OBSERVAL_USERNAME" ] && [ -f "$HOME/.observal/config.json" ]; then
+  OBSERVAL_USERNAME=$(sed -n 's/.*"username":\s*"\([^"]*\)".*/\1/p' "$HOME/.observal/config.json" | head -1)
+fi
+
 # Collect assistant messages from the current turn (bottom-up until user msg).
 # Each assistant message becomes a separate event with a sequence number.
 # We also capture thinking blocks separately.
@@ -91,6 +101,7 @@ if [ -n "$THINK_FILES" ]; then
         message_total: ($total | tonumber)
       }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
         ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+        ${OBSERVAL_USERNAME:+-H "X-Observal-Username: $OBSERVAL_USERNAME"} \
         -H "Content-Type: application/json" \
         -d @- >/dev/null 2>&1 || true
   done
@@ -121,6 +132,7 @@ if [ -n "$MSG_FILES" ]; then
         message_total: ($total | tonumber)
       }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
         ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+        ${OBSERVAL_USERNAME:+-H "X-Observal-Username: $OBSERVAL_USERNAME"} \
         -H "Content-Type: application/json" \
         -d @- >/dev/null 2>&1 || true
   done

--- a/observal_cli/hooks_spec.py
+++ b/observal_cli/hooks_spec.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 # Bump this when hook definitions change (new events, different scripts,
 # additional handlers, etc.).  Stored in ~/.observal/config.json so we
 # can detect when an upgrade is needed without re-reading all hooks.
-HOOKS_SPEC_VERSION = "3"
+HOOKS_SPEC_VERSION = "4"
 
 # Metadata key injected into every Observal matcher group.
 # Primary identification method — the reconciler checks this first.
@@ -123,6 +123,12 @@ def get_desired_env(
     if user_id:
         env["OBSERVAL_USER_ID"] = user_id
 
+    from observal_cli import config as _cfg
+    _loaded = _cfg.load()
+    _username = _loaded.get("username", "")
+    if _username:
+        env["OBSERVAL_USERNAME"] = _username
+
     return env
 
 
@@ -139,5 +145,6 @@ MANAGED_ENV_KEYS = frozenset(
         "OBSERVAL_HOOKS_URL",
         "OBSERVAL_HOOKS_SPEC_VERSION",
         "OBSERVAL_USER_ID",
+        "OBSERVAL_USERNAME",
     }
 )

--- a/observal_cli/hooks_spec.py
+++ b/observal_cli/hooks_spec.py
@@ -124,6 +124,7 @@ def get_desired_env(
         env["OBSERVAL_USER_ID"] = user_id
 
     from observal_cli import config as _cfg
+
     _loaded = _cfg.load()
     _username = _loaded.get("username", "")
     if _username:

--- a/web/src/app/(admin)/traces/page.tsx
+++ b/web/src/app/(admin)/traces/page.tsx
@@ -3,8 +3,19 @@
 import { useState, useMemo, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Activity, Search, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
-import { useOtelSessions, useSessionSubscription } from "@/hooks/use-api";
+import {
+  Search,
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
+  Activity,
+  Zap,
+} from "lucide-react";
+import {
+  useOtelSessions,
+  useSessionSubscription,
+  useSessionsSummary,
+} from "@/hooks/use-api";
 import {
   useReactTable,
   getCoreRowModel,
@@ -15,204 +26,307 @@ import {
   type SortingState,
 } from "@tanstack/react-table";
 import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+import type { OtelSession } from "@/lib/types";
 
-interface SessionRow {
-  session_id: string;
-  service_name: string;
-  is_active?: boolean;
-  first_event_time?: string;
-  last_event_time?: string;
-  prompt_count?: number;
-  api_request_count?: number;
-  tool_result_count?: number;
-  total_input_tokens?: number;
-  total_output_tokens?: number;
-  total_cache_read_tokens?: number;
-  model?: string;
-  user_id?: string;
-  terminal_type?: string;
-  credits?: string;
-  tools_used?: string;
+/* ── Helpers ──────────────────────────────────────────────────────── */
+
+function fmtTokens(n: number | string | undefined): string {
+  if (n == null) return "0";
+  const v = typeof n === "string" ? parseInt(n, 10) : n;
+  if (isNaN(v) || v === 0) return "0";
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return `${v}`;
 }
 
-function isKiroSession(row: SessionRow): boolean {
-  return row.service_name === "kiro-cli" || row.session_id.startsWith("kiro-");
+function relTime(dateStr: string | undefined): string {
+  if (!dateStr) return "\u2014";
+  const d = new Date(dateStr.includes("T") || dateStr.includes("Z") ? dateStr : dateStr.replace(" ", "T") + "Z");
+  const ms = Date.now() - d.getTime();
+  const m = Math.floor(ms / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(ms / 3_600_000);
+  if (h < 24) return `${h}h ago`;
+  const y = new Date();
+  y.setDate(y.getDate() - 1);
+  const t = d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  if (d.toDateString() === y.toDateString()) return `Yesterday ${t}`;
+  return d.toLocaleDateString([], { month: "short", day: "numeric" }) + ` ${t}`;
 }
 
-function formatCredits(c: string | undefined): string {
-  if (!c) return "-";
-  const num = parseFloat(c);
-  if (isNaN(num)) return "-";
-  return num < 0.01 ? num.toFixed(4) : num.toFixed(2);
+function absTime(dateStr: string | undefined): string {
+  if (!dateStr) return "";
+  const d = new Date(dateStr.includes("T") || dateStr.includes("Z") ? dateStr : dateStr.replace(" ", "T") + "Z");
+  return d.toLocaleString([], { weekday: "short", year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit", second: "2-digit" });
 }
 
-function formatTokens(n: number | string | undefined): string {
-  if (n == null) return "-";
-  const num = typeof n === "string" ? parseInt(n, 10) : n;
-  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
-  if (num >= 1_000) return `${(num / 1_000).toFixed(1)}k`;
-  return `${num}`;
+function fmtDuration(s?: string, e?: string): string {
+  if (!s || !e) return "\u2014";
+  const p = (v: string) => new Date(v.includes("T") || v.includes("Z") ? v : v.replace(" ", "T") + "Z");
+  const ms = p(e).getTime() - p(s).getTime();
+  if (ms < 0) return "\u2014";
+  const totalMin = Math.floor(ms / 60_000);
+  if (totalMin < 1) return "< 1m";
+  const hr = Math.floor(totalMin / 60), mn = totalMin % 60;
+  if (hr >= 24) { const d = Math.floor(hr / 24), r = hr % 24; return r > 0 ? `${d}d ${r}h` : `${d}d`; }
+  if (hr > 0) return `${hr}h ${mn}m`;
+  return `${mn}m`;
 }
 
-const columns: ColumnDef<SessionRow>[] = [
-  {
-    accessorKey: "session_id",
-    header: "Session",
-    cell: ({ row }) => (
-      <div className="flex items-center gap-2">
-        {row.original.is_active && (
-          <span className="relative flex h-2 w-2 shrink-0">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
-            <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
-          </span>
-        )}
-        <Link
-          href={`/traces/${row.original.session_id}`}
-          className="font-[family-name:var(--font-mono)] text-sm hover:text-primary-accent transition-colors"
-        >
-          {row.original.session_id.slice(0, 12)}...
-        </Link>
-      </div>
-    ),
-  },
-  {
-    accessorKey: "model",
-    header: "Model",
-    cell: ({ row }) => {
-      const m = row.original.model;
-      return (
-        <span className="text-sm font-medium">
-          {m ? m.replace("claude-", "").replace("-20251001", "") : "-"}
-        </span>
-      );
-    },
-  },
-  {
-    accessorKey: "user_id",
-    header: "User",
-    cell: ({ row }) => {
-      const uid = row.original.user_id;
-      return (
-        <span className="text-sm font-[family-name:var(--font-mono)] text-muted-foreground" title={uid}>
-          {uid ? uid.slice(0, 8) + "\u2026" : "-"}
-        </span>
-      );
-    },
-  },
-  {
-    accessorKey: "terminal_type",
-    header: "IDE",
-    cell: ({ row }) => {
-      const t = row.original.terminal_type;
-      const label = t ? t.replace("wsl-", "WSL ") : "-";
-      return <span className="text-sm">{label}</span>;
-    },
-  },
-  {
-    accessorKey: "total_input_tokens",
-    header: "Tokens In",
-    cell: ({ row }) => {
-      if (isKiroSession(row.original)) {
-        return (
-          <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-orange-500" title="Kiro credits">
-            {formatCredits(row.original.credits)} cr
-          </span>
-        );
-      }
-      return (
-        <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-          {formatTokens(row.original.total_input_tokens)}
-        </span>
-      );
-    },
-  },
-  {
-    accessorKey: "api_request_count",
-    header: "API Calls",
-    cell: ({ row }) => (
-      <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-        {row.original.api_request_count ?? "-"}
-      </span>
-    ),
-  },
-  {
-    accessorKey: "tool_result_count",
-    header: "Tools",
-    cell: ({ row }) => (
-      <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-        {row.original.tool_result_count ?? "-"}
-      </span>
-    ),
-  },
-  {
-    accessorKey: "total_output_tokens",
-    header: "Tokens Out",
-    cell: ({ row }) => {
-      if (isKiroSession(row.original)) {
-        const tools = row.original.tools_used;
-        return (
-          <span className="text-sm text-muted-foreground truncate max-w-[200px]" title={tools}>
-            {tools || "-"}
-          </span>
-        );
-      }
-      return (
-        <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-          {formatTokens(row.original.total_output_tokens)}
-        </span>
-      );
-    },
-  },
-  {
-    accessorKey: "first_event_time",
-    header: "Time",
-    cell: ({ row }) => {
-      const t = row.original.first_event_time;
-      return (
-        <span className="text-sm text-muted-foreground tabular-nums">
-          {t ? new Date(t).toLocaleString() : "-"}
-        </span>
-      );
-    },
-  },
-];
-
-function SortIcon({ sorted }: { sorted: false | "asc" | "desc" }) {
-  if (sorted === "asc") return <ArrowUp className="h-4 w-4" />;
-  if (sorted === "desc") return <ArrowDown className="h-4 w-4" />;
-  return <ArrowUpDown className="h-4 w-4 opacity-40" />;
+function fmtCredits(c: string | undefined): string {
+  if (!c) return "\u2014";
+  const v = parseFloat(c);
+  if (isNaN(v)) return "\u2014";
+  return v < 0.01 ? v.toFixed(4) : v.toFixed(2);
 }
+
+function shortModel(raw: string | undefined): string {
+  if (!raw) return "";
+  return raw
+    .replace(/^us\.anthropic\./, "")
+    .replace(/^eu\.anthropic\./, "")
+    .replace(/^claude-/, "")
+    .replace(/-\d{8}$/, "")
+    .replace(/-v\d+:\d+$/, "");
+}
+
+function sessionLabel(row: OtelSession): { title: string; sub: string } {
+  const parts: string[] = [];
+  const m = shortModel(row.model);
+  if (m) parts.push(m);
+  const pc = Number(row.prompt_count || 0);
+  if (pc > 0) parts.push(`${pc} prompt${pc !== 1 ? "s" : ""}`);
+
+  return { title: parts.join(" \u00b7 "), sub: "" };
+}
+
+function userName(row: OtelSession): string {
+  return row.user_display || (row.user_id ? row.user_id.slice(0, 8) + "\u2026" : "\u2014");
+}
+
+function SortIcon({ s }: { s: false | "asc" | "desc" }) {
+  if (s === "asc") return <ArrowUp className="h-3 w-3" />;
+  if (s === "desc") return <ArrowDown className="h-3 w-3" />;
+  return <ArrowUpDown className="h-3 w-3 opacity-20" />;
+}
+
+/* ── Page ─────────────────────────────────────────────────────────── */
 
 export default function TracesPage() {
   const [tab, setTab] = useState<"all" | "active">("all");
-  const { data: sessions, isLoading, isError, error, refetch } = useOtelSessions({
-    refetchInterval: 30_000,
-  });
+  const [platformFilter, setPlatformFilter] = useState("all");
+  const [daysFilter, setDaysFilter] = useState("all");
+
+  const filters = useMemo(() => {
+    const f: { platform?: string; days?: number } = {};
+    if (platformFilter !== "all") f.platform = platformFilter;
+    if (daysFilter !== "all") f.days = parseInt(daysFilter, 10);
+    return Object.keys(f).length > 0 ? f : undefined;
+  }, [platformFilter, daysFilter]);
+
+  const { data: sessions, isLoading, isError, error, refetch } =
+    useOtelSessions({ refetchInterval: 30_000, filters });
+  const { data: summary } = useSessionsSummary();
   useSessionSubscription();
   const router = useRouter();
 
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([{ id: "first_event_time", desc: true }]);
   const [globalFilter, setGlobalFilter] = useState("");
 
-  const allSessions = useMemo(() => (sessions ?? []) as SessionRow[], [sessions]);
-  const activeCount = useMemo(() => allSessions.filter((s) => s.is_active).length, [allSessions]);
-  const data = useMemo(
-    () => (tab === "active" ? allSessions.filter((s) => s.is_active) : allSessions),
-    [allSessions, tab],
-  );
+  const all = useMemo(() => (sessions ?? []) as OtelSession[], [sessions]);
+  const activeCount = useMemo(() => all.filter((s) => s.is_active).length, [all]);
+  const data = useMemo(() => (tab === "active" ? all.filter((s) => s.is_active) : all), [all, tab]);
+
+  /* ── Columns ────────────────────────────────────────── */
+
+  const columns = useMemo<ColumnDef<OtelSession>[]>(() => [
+    {
+      id: "session",
+      header: "Session",
+      size: 400,
+      cell: ({ row }) => {
+        const { title, sub } = sessionLabel(row.original);
+        const display = title || sub || "Session";
+        return (
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="shrink-0 w-2.5 flex justify-center">
+              {row.original.is_active ? (
+                <span className="relative flex h-2 w-2">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+                </span>
+              ) : (
+                <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/20" />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <Link
+                href={`/traces/${row.original.session_id}`}
+                className={`text-[13px] leading-snug block truncate transition-colors ${
+                  title ? "font-medium text-foreground hover:text-primary" : "text-muted-foreground hover:text-foreground"
+                }`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {display}
+              </Link>
+              {title && sub && (
+                <p className="text-[11px] text-muted-foreground/40 truncate mt-0.5">{sub}</p>
+              )}
+            </div>
+          </div>
+        );
+      },
+      sortingFn: (a, b) => {
+        const at = a.original.first_event_time ?? "";
+        const bt = b.original.first_event_time ?? "";
+        return at < bt ? -1 : at > bt ? 1 : 0;
+      },
+    },
+    {
+      accessorKey: "user_id",
+      header: "User",
+      size: 160,
+      cell: ({ row }) => {
+        const name = userName(row.original);
+        const hasName = !!row.original.user_display;
+        return (
+          <span className={`text-[13px] truncate block max-w-[150px] ${hasName ? "text-foreground" : "text-muted-foreground font-mono text-xs"}`}>
+            {name}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: "platform",
+      header: "Platform",
+      size: 120,
+      cell: ({ row }) => {
+        const platform = row.original.platform || "Unknown";
+        const ide = row.original.ide;
+        return (
+          <span className="text-[13px] text-muted-foreground">
+            {platform}{ide ? ` \u00b7 ${ide}` : ""}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: "total_input_tokens",
+      header: "Tokens",
+      size: 120,
+      meta: { align: "center" },
+      cell: ({ row }) => {
+        const r = row.original;
+        if (r.service_name === "kiro-cli" || r.session_id.startsWith("kiro-")) {
+          return <span className="text-[13px] font-mono tabular-nums text-orange-500">{fmtCredits(r.credits)} cr</span>;
+        }
+        const inp = Number(r.total_input_tokens || 0) + Number(r.total_cache_read_tokens || 0);
+        const out = Number(r.total_output_tokens || 0);
+        return (
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-[13px] font-mono tabular-nums cursor-default">
+                  <span className="text-emerald-600 dark:text-emerald-400">{fmtTokens(inp)}</span>
+                  <span className="text-muted-foreground/20 mx-px">/</span>
+                  <span className="text-blue-600 dark:text-blue-400">{fmtTokens(out)}</span>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <div className="text-xs space-y-1 py-0.5">
+                  <div className="flex justify-between gap-6"><span className="text-muted-foreground">Input</span><span className="font-mono">{Number(r.total_input_tokens || 0).toLocaleString()}</span></div>
+                  {Number(r.total_cache_read_tokens || 0) > 0 && (
+                    <div className="flex justify-between gap-6"><span className="text-muted-foreground">Cache</span><span className="font-mono">{Number(r.total_cache_read_tokens || 0).toLocaleString()}</span></div>
+                  )}
+                  <div className="flex justify-between gap-6"><span className="text-muted-foreground">Output</span><span className="font-mono">{Number(r.total_output_tokens || 0).toLocaleString()}</span></div>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        );
+      },
+    },
+    {
+      accessorKey: "tool_result_count",
+      header: "Tools",
+      size: 64,
+      meta: { align: "center" },
+      cell: ({ row }) => {
+        const c = Number(row.original.tool_result_count || 0);
+        return <span className="text-[13px] font-mono tabular-nums text-muted-foreground">{c || "\u2013"}</span>;
+      },
+    },
+    {
+      id: "duration",
+      header: "Duration",
+      size: 90,
+      meta: { align: "center" },
+      accessorFn: (row) => {
+        if (!row.first_event_time || !row.last_event_time) return 0;
+        const p = (v: string) => new Date(v.includes("T") || v.includes("Z") ? v : v.replace(" ", "T") + "Z");
+        return p(row.last_event_time).getTime() - p(row.first_event_time).getTime();
+      },
+      cell: ({ row }) => (
+        <span className="text-[13px] font-mono tabular-nums text-muted-foreground">
+          {fmtDuration(row.original.first_event_time, row.original.last_event_time)}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "first_event_time",
+      header: "Started",
+      size: 110,
+      meta: { align: "center" },
+      cell: ({ row }) => (
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-[13px] text-muted-foreground tabular-nums cursor-default">{relTime(row.original.first_event_time)}</span>
+            </TooltipTrigger>
+            <TooltipContent side="left"><span className="text-xs">{absTime(row.original.first_event_time)}</span></TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ),
+    },
+    {
+      id: "score",
+      header: "Score",
+      size: 56,
+      meta: { align: "center" },
+      cell: () => <span className="text-[13px] text-muted-foreground/20">{"\u2014"}</span>,
+      enableSorting: false,
+    },
+  ], []);
 
   const table = useReactTable({
-    data,
-    columns,
+    data, columns,
     state: { sorting, globalFilter },
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
@@ -221,110 +335,144 @@ export default function TracesPage() {
     getFilteredRowModel: getFilteredRowModel(),
   });
 
-  // Debounced search
-  const [searchValue, setSearchValue] = useState("");
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const handleSearch = useCallback(
-    (value: string) => {
-      setSearchValue(value);
-      clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => setGlobalFilter(value), 300);
-    },
-    [setGlobalFilter],
-  );
+  const [searchVal, setSearchVal] = useState("");
+  const debounce = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const onSearch = useCallback((v: string) => {
+    setSearchVal(v);
+    clearTimeout(debounce.current);
+    debounce.current = setTimeout(() => setGlobalFilter(v), 200);
+  }, [setGlobalFilter]);
 
   return (
     <>
       <PageHeader
         title="Traces"
-        breadcrumbs={[
-          { label: "Dashboard", href: "/dashboard" },
-          { label: "Traces" },
-        ]}
+        breadcrumbs={[{ label: "Dashboard", href: "/dashboard" }, { label: "Traces" }]}
       />
-      <div className="p-6 w-full max-w-6xl mx-auto space-y-4">
+
+      <div className="p-6 w-full max-w-[1440px] mx-auto space-y-5">
         {isLoading ? (
-          <TableSkeleton rows={8} cols={7} />
+          <TableSkeleton rows={8} cols={8} />
         ) : isError ? (
           <ErrorState message={error?.message} onRetry={() => refetch()} />
-        ) : allSessions.length === 0 ? (
-          <EmptyState
-            icon={Activity}
-            title="No sessions yet"
-            description="Sessions will appear here once telemetry data is collected from your IDE."
-          />
+        ) : all.length === 0 && !filters ? (
+          <EmptyState icon={Zap} title="No sessions yet" description="Sessions appear here once telemetry data is collected from your IDE." />
         ) : (
-          <div className="animate-in space-y-3">
-            {/* Tabs + Search */}
-            <div className="flex items-center gap-4">
+          <>
+            {/* Summary */}
+            <div className="flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <Activity className="h-3.5 w-3.5" />
+                <span className="font-semibold text-foreground tabular-nums">{summary?.sessions_today ?? all.length}</span>
+                <span>sessions today</span>
+              </span>
+            </div>
+
+            {/* Toolbar */}
+            <div className="flex items-center gap-3">
               <Tabs value={tab} onValueChange={(v) => setTab(v as "all" | "active")}>
-                <TabsList>
-                  <TabsTrigger value="all">
+                <TabsList className="h-9 p-1">
+                  <TabsTrigger value="all" className="text-xs px-3 h-7 gap-1.5 data-[state=active]:shadow-sm">
                     All
-                    <span className="ml-1.5 text-xs text-muted-foreground tabular-nums">{allSessions.length}</span>
+                    <span className="tabular-nums text-[10px] text-muted-foreground ml-0.5">{all.length}</span>
                   </TabsTrigger>
-                  <TabsTrigger value="active" className="gap-1.5">
-                    <span className="relative flex h-2 w-2">
-                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
-                      <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+                  <TabsTrigger value="active" className="text-xs px-3 h-7 gap-1.5 data-[state=active]:shadow-sm">
+                    <span className="relative flex h-1.5 w-1.5">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
                     </span>
                     Active
-                    {activeCount > 0 && (
-                      <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs font-medium">
-                        {activeCount}
-                      </Badge>
-                    )}
+                    {activeCount > 0 && <span className="tabular-nums text-[10px] text-emerald-600 dark:text-emerald-400 ml-0.5">{activeCount}</span>}
                   </TabsTrigger>
                 </TabsList>
               </Tabs>
-              <div className="relative max-w-sm flex-1">
-                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                <Input
-                  placeholder="Search sessions, models..."
-                  value={searchValue}
-                  onChange={(e) => handleSearch(e.target.value)}
-                  className="pl-8 h-9 text-sm"
-                />
+
+              <Select value={platformFilter} onValueChange={setPlatformFilter}>
+                <SelectTrigger className="w-[140px] h-9 text-xs border-dashed">
+                  <SelectValue placeholder="Platform" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All platforms</SelectItem>
+                  <SelectItem value="Claude Code">Claude Code</SelectItem>
+                  <SelectItem value="Kiro">Kiro</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Select value={daysFilter} onValueChange={setDaysFilter}>
+                <SelectTrigger className="w-[120px] h-9 text-xs border-dashed">
+                  <SelectValue placeholder="Time" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All time</SelectItem>
+                  <SelectItem value="1">Today</SelectItem>
+                  <SelectItem value="7">Last 7 days</SelectItem>
+                  <SelectItem value="30">Last 30 days</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <div className="flex-1" />
+
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/40" />
+                <Input value={searchVal} onChange={(e) => onSearch(e.target.value)} placeholder="Search sessions\u2026" className="pl-9 h-9 w-64 text-xs" />
               </div>
             </div>
 
             {/* Table */}
-            <div className="overflow-x-auto rounded-md border border-border">
+            <div className="rounded-lg border border-border/60 overflow-hidden">
               <Table>
                 <TableHeader>
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id} className="hover:bg-transparent">
-                      {headerGroup.headers.map((header) => (
-                        <TableHead
-                          key={header.id}
-                          className="h-10 text-sm cursor-pointer select-none hover:text-foreground transition-colors"
-                          onClick={header.column.getToggleSortingHandler()}
-                        >
-                          <span className="flex items-center gap-1">
-                            {flexRender(header.column.columnDef.header, header.getContext())}
-                            <SortIcon sorted={header.column.getIsSorted()} />
-                          </span>
-                        </TableHead>
-                      ))}
+                  {table.getHeaderGroups().map((hg) => (
+                    <TableRow key={hg.id} className="hover:bg-transparent border-b border-border/60 bg-muted/30">
+                      {hg.headers.map((h) => {
+                        const centered = (h.column.columnDef.meta as { align?: string })?.align === "center";
+                        return (
+                          <TableHead
+                            key={h.id}
+                            className={`h-10 px-4 first:pl-5 last:pr-5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/60 select-none ${
+                              centered ? "text-center" : ""
+                            } ${h.column.getCanSort() ? "cursor-pointer hover:text-muted-foreground transition-colors" : ""}`}
+                            onClick={h.column.getToggleSortingHandler()}
+                          >
+                            {centered ? (
+                              <span className="relative inline-flex items-center">
+                                {flexRender(h.column.columnDef.header, h.getContext())}
+                                {h.column.getCanSort() && (
+                                  <span className="absolute -right-4 top-1/2 -translate-y-1/2">
+                                    <SortIcon s={h.column.getIsSorted()} />
+                                  </span>
+                                )}
+                              </span>
+                            ) : (
+                              <span className="inline-flex items-center gap-1">
+                                {flexRender(h.column.columnDef.header, h.getContext())}
+                                {h.column.getCanSort() && <SortIcon s={h.column.getIsSorted()} />}
+                              </span>
+                            )}
+                          </TableHead>
+                        );
+                      })}
                     </TableRow>
                   ))}
                 </TableHeader>
                 <TableBody>
                   {table.getRowModel().rows.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={columns.length} className="h-24 text-center text-sm text-muted-foreground">
+                      <TableCell colSpan={columns.length} className="h-32 text-center text-sm text-muted-foreground/50">
                         No matching sessions.
                       </TableCell>
                     </TableRow>
                   ) : (
-                    table.getRowModel().rows.map((row) => (
+                    table.getRowModel().rows.map((row, idx) => (
                       <TableRow
                         key={row.id}
-                        className="cursor-pointer hover:bg-muted/60 transition-colors"
+                        className={`group/row cursor-pointer transition-colors border-b border-border/30 last:border-0 hover:bg-muted/30 ${
+                          idx % 2 === 1 ? "bg-muted/8" : ""
+                        }`}
                         onClick={() => router.push(`/traces/${row.original.session_id}`)}
                       >
                         {row.getVisibleCells().map((cell) => (
-                          <TableCell key={cell.id} className="py-2.5 px-4">
+                          <TableCell key={cell.id} className={`py-3.5 px-4 first:pl-5 last:pr-5 ${(cell.column.columnDef.meta as { align?: string })?.align === "center" ? "text-center" : ""}`}>
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}
                           </TableCell>
                         ))}
@@ -335,11 +483,11 @@ export default function TracesPage() {
               </Table>
             </div>
 
-            <p className="text-sm text-muted-foreground">
-              {table.getFilteredRowModel().rows.length} session{table.getFilteredRowModel().rows.length !== 1 ? "s" : ""}
-              {" \u00b7 live updates"}
+            {/* Footer */}
+            <p className="text-[11px] text-muted-foreground/40 tabular-nums">
+              Showing {table.getFilteredRowModel().rows.length} of {all.length} sessions
             </p>
-          </div>
+          </>
         )}
       </div>
     </>

--- a/web/src/components/traces/platform-badge.tsx
+++ b/web/src/components/traces/platform-badge.tsx
@@ -1,0 +1,31 @@
+import { Badge } from "@/components/ui/badge";
+
+const PLATFORM_STYLES: Record<string, { bg: string; text: string; dot: string }> = {
+  "Claude Code": {
+    bg: "bg-blue-500/8 dark:bg-blue-500/15",
+    text: "text-blue-700 dark:text-blue-300",
+    dot: "bg-blue-500",
+  },
+  Kiro: {
+    bg: "bg-orange-500/8 dark:bg-orange-500/15",
+    text: "text-orange-700 dark:text-orange-300",
+    dot: "bg-orange-500",
+  },
+};
+
+const DEFAULT_STYLE = {
+  bg: "bg-muted/50",
+  text: "text-muted-foreground",
+  dot: "bg-muted-foreground/40",
+};
+
+export function PlatformBadge({ platform }: { platform?: string }) {
+  const label = platform || "Unknown";
+  const style = PLATFORM_STYLES[label] ?? DEFAULT_STYLE;
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11px] font-medium ${style.bg} ${style.text}`}>
+      <span className={`h-1.5 w-1.5 rounded-full ${style.dot}`} />
+      {label}
+    </span>
+  );
+}

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -287,11 +287,19 @@ export function useIdeUsage() {
 }
 // ── OTel ────────────────────────────────────────────────────────────
 
-export function useOtelSessions(options?: { refetchInterval?: number | false }) {
+export function useOtelSessions(options?: { refetchInterval?: number | false; filters?: { platform?: string; days?: number } }) {
   return useQuery({
-    queryKey: ['otel', 'sessions'],
-    queryFn: dashboard.otelSessions,
+    queryKey: ['otel', 'sessions', options?.filters],
+    queryFn: () => dashboard.otelSessions(options?.filters),
     refetchInterval: options?.refetchInterval,
+  });
+}
+
+export function useSessionsSummary() {
+  return useQuery({
+    queryKey: ['otel', 'sessions', 'summary'],
+    queryFn: dashboard.otelSessionsSummary,
+    refetchInterval: 60_000,
   });
 }
 export function useOtelSession(id: string | undefined) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   AdminUser,
   AdminSetting,
   OtelSession,
+  SessionsSummary,
   OtelErrorEvent,
   TelemetryStatus,
   ReviewItem,
@@ -292,7 +293,14 @@ export const dashboard = {
   agentMetrics: (id: string) => get<unknown>(`/agents/${id}/metrics`),
   tokenStats: (range?: string) => get<TokenStats>(`/dashboard/tokens${range ? `?range=${range}` : ''}`),
   ideUsage: () => get<IdeUsageData>('/dashboard/ide-usage'),
-  otelSessions: () => get<OtelSession[]>('/otel/sessions'),
+  otelSessions: (filters?: { platform?: string; days?: number }) => {
+    const params = new URLSearchParams();
+    if (filters?.platform) params.set('platform', filters.platform);
+    if (filters?.days) params.set('days', String(filters.days));
+    const qs = params.toString();
+    return get<OtelSession[]>(`/otel/sessions${qs ? `?${qs}` : ''}`);
+  },
+  otelSessionsSummary: () => get<SessionsSummary>('/otel/sessions/summary'),
   otelSession: (id: string) => get<OtelSessionData>(`/otel/sessions/${encodeURIComponent(id)}`),
   otelTraces: () => get<OtelTrace[]>('/otel/traces'),
   otelTrace: (id: string) => get<unknown>(`/otel/traces/${encodeURIComponent(id)}`),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -296,8 +296,22 @@ export interface OtelSession {
   tool_result_count: number;
   total_input_tokens: number;
   total_output_tokens: number;
+  total_cache_read_tokens?: number;
   model: string;
   service_name: string;
+  platform?: string;
+  ide?: string;
+  models_used?: string[];
+  user_id?: string;
+  user_display?: string;
+  terminal_type?: string;
+  credits?: string;
+  tools_used?: string;
+}
+
+export interface SessionsSummary {
+  sessions_today: number;
+  tokens_today: number;
 }
 
 export interface OtelErrorEvent {


### PR DESCRIPTION
## Purpose / Description
The traces list page needed a cleaner design and proper user attribution. Sessions were showing truncated UUIDs instead of usernames because `OBSERVAL_USERNAME` was not propagated through hooks, and the backend lacked a fallback resolution chain.


## Approach
**CLI:** Add `OBSERVAL_USERNAME` to `MANAGED_ENV_KEYS` and config.json fallback in hook scripts so the username header reaches ClickHouse. Bump hooks spec version to trigger re-reconciliation.

**Backend:** Add multi-level user display resolution (ClickHouse `user.username` → PostgreSQL lookup by UUID → hash mapping → single-user fallback). Add platform/IDE derivation, session filters (platform, days), and sessions summary endpoint.

**Frontend:** Rewrite traces page with minimal table layout — centered numeric columns, plain text platform, alternating row shading, all/active tabs, platform and time range filters, and search.

<img width="1436" height="761" alt="image" src="https://github.com/user-attachments/assets/f8a7fc9d-3b5f-4bd9-af91-471825f837e2" />

## How Has This Been Tested?
- Verified traces page loads and displays session data correctly
- Tested platform and time range filters
- Tested all/active tab switching and column sorting
- Confirmed `OBSERVAL_USERNAME` is written to `~/.claude/settings.json` after `observal auth login`

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)



