### PR TITLE
fix: prevent non-admin deletion of approved/active registry items

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -809,8 +809,11 @@ async def delete_agent(
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
-    if agent.created_by != current_user.id and current_user.role.value != "admin":
+    is_admin = current_user.role.value == "admin"
+    if agent.created_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
+    if agent.status == AgentStatus.active and not is_admin:
+        raise HTTPException(status_code=400, detail="Cannot delete an approved listing. Contact an admin.")
 
     # Delete related records with correct type filters
     for r in (

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -222,8 +222,11 @@ async def delete_hook(
     listing = await resolve_listing(HookListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    if listing.submitted_by != current_user.id and current_user.role.value != "admin":
+    is_admin = current_user.role.value == "admin"
+    if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
+    if listing.status == ListingStatus.approved and not is_admin:
+        raise HTTPException(status_code=400, detail="Cannot delete an approved listing. Contact an admin.")
 
     for r in (await db.execute(select(HookDownload).where(HookDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -327,8 +327,11 @@ async def delete_mcp(
     listing = await resolve_listing(McpListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    if listing.submitted_by != current_user.id and current_user.role.value != "admin":
+    is_admin = current_user.role.value == "admin"
+    if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
+    if listing.status == ListingStatus.approved and not is_admin:
+        raise HTTPException(status_code=400, detail="Cannot delete an approved listing. Contact an admin.")
 
     for r in (
         (await db.execute(select(Feedback).where(Feedback.listing_id == listing.id, Feedback.listing_type == "mcp")))

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -266,8 +266,11 @@ async def delete_prompt(
     listing = await resolve_listing(PromptListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    if listing.submitted_by != current_user.id and current_user.role.value != "admin":
+    is_admin = current_user.role.value == "admin"
+    if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
+    if listing.status == ListingStatus.approved and not is_admin:
+        raise HTTPException(status_code=400, detail="Cannot delete an approved listing. Contact an admin.")
 
     for r in (await db.execute(select(PromptDownload).where(PromptDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -217,8 +217,11 @@ async def delete_sandbox(
     listing = await resolve_listing(SandboxListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    if listing.submitted_by != current_user.id and current_user.role.value != "admin":
+    is_admin = current_user.role.value == "admin"
+    if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
+    if listing.status == ListingStatus.approved and not is_admin:
+        raise HTTPException(status_code=400, detail="Cannot delete an approved listing. Contact an admin.")
 
     for r in (
         (await db.execute(select(SandboxDownload).where(SandboxDownload.listing_id == listing.id))).scalars().all()

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -230,8 +230,11 @@ async def delete_skill(
     listing = await resolve_listing(SkillListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    if listing.submitted_by != current_user.id and current_user.role.value != "admin":
+    is_admin = current_user.role.value == "admin"
+    if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
+    if listing.status == ListingStatus.approved and not is_admin:
+        raise HTTPException(status_code=400, detail="Cannot delete an approved listing. Contact an admin.")
 
     for r in (await db.execute(select(SkillDownload).where(SkillDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)


### PR DESCRIPTION
## Purpose / Description
After an item is approved by a reviewer (status transitions to active/approved), the original submitting user could still delete it via the DELETE endpoint. This bypasses the review process and could cause data loss for approved registry items. Additionally, super_admin users got 'Not authorized' when trying to delete items submitted by other users.

## Fixes
* Fixes #409 

## Approach
Added a status check to all 6 registry delete endpoints (agents, MCPs, skills, hooks, prompts, sandboxes):

- If the item is approved/active and the user is **not** an admin, return \400 Cannot delete an approved listing. Contact an admin.\
- Admins can delete any item regardless of status (fixes the super_admin authorization issue)
- Non-admin users can still delete their own draft/pending/rejected items

The \is_admin\ check is extracted into a local variable to avoid repeating \current_user.role.value == 'admin'\ and to make the logic clearer.

## How Has This Been Tested?

- All 55 registry type tests pass (\	est_registry_types.py\)
- Full test suite: 1217 passed (20 pre-existing failures in unrelated \	est_git_mirror.py\ and \	est_uninstall.py\)

## Checklist

- [x] All commits are signed off (\git commit -s\) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)