### PR TITLE
fix(hooks): stop-hook stdin drain prevents response/thinking capture

### DIFF
--- a/docs/superpowers/specs/2026-04-19-unarchive-agent-design.md
+++ b/docs/superpowers/specs/2026-04-19-unarchive-agent-design.md
@@ -1,0 +1,117 @@
+# Design: Unarchive Action for Archived Agents
+
+**Issue:** #396
+**Date:** 2026-04-19
+**Status transition:** `archived` → `active` (direct restore, no re-review)
+
+---
+
+## Backend
+
+### Endpoint: `PATCH /api/v1/agents/{agent_id}/unarchive`
+
+**File:** `observal-server/api/routes/agent.py` (adjacent to existing `archive_agent` at line ~849)
+
+- **Auth:** `require_role(UserRole.admin)` — same as archive
+- **Org scoping:** same pattern as archive — if `current_user.org_id` is set, verify `agent.owner_org_id` matches
+- **Status guard:** only `AgentStatus.archived` agents can be unarchived. Return 400 `"Agent is not archived"` otherwise.
+- **Mutation:** `agent.status = AgentStatus.active`
+- **Telemetry:** `emit_registry_event(action="agent.unarchive", ...)`
+- **Response:** `{"id": str(agent.id), "name": agent.name, "status": agent.status.value}`
+
+Pattern: exact mirror of `archive_agent`, changing status in the opposite direction.
+
+---
+
+## Web UI
+
+### API client
+
+**File:** `web/src/lib/api.ts`
+
+Add `unarchive` method to the `registry` object, adjacent to existing `archive`:
+
+```typescript
+unarchive: (id: string) => patch(`/agents/${id}/unarchive`),
+```
+
+### React Query hook
+
+**File:** `web/src/hooks/use-api.ts`
+
+Add `useUnarchiveAgent()` mirroring `useArchiveAgent()`:
+
+- **Mutation:** calls `registry.unarchive(id)`
+- **onSuccess:** invalidates `["registry", "agents"]`, toast `"Agent restored"`
+- **onError:** toast error message
+
+### UI component
+
+**File:** `web/src/app/(registry)/agents/page.tsx`
+
+Add `UnarchiveAgentButton` component adjacent to `ArchiveAgentButton`:
+
+- **Visibility:** admin only AND `agent.status === "archived"`
+- **Icon:** `ArchiveRestore` from `lucide-react`
+- **Styling:** `hover:text-green-600` (green, vs orange for archive)
+- **Confirmation dialog:**
+  - Title: "Restore Agent"
+  - Body: "This will restore the agent to the public registry."
+  - Confirm button: green variant, text "Restore" / "Restoring..."
+  - Cancel button: outline variant
+
+Render `UnarchiveAgentButton` in the same action slot as `ArchiveAgentButton` — they are mutually exclusive (archive shows for non-archived, unarchive shows for archived).
+
+---
+
+## CLI
+
+### Command: `observal agent unarchive <agent_id>`
+
+**File:** `observal_cli/cmd_agent.py`
+
+Add new command mirroring the `agent_delete` (archive) command:
+
+- **Argument:** `agent_id` — ID, name, row number, or @alias
+- **Flag:** `--yes / -y` — skip confirmation
+- **Confirmation prompt:** `Unarchive [bold]{item['name']}[/bold] ({resolved})?`
+- **API call:** `client.patch(f"/api/v1/agents/{resolved}/unarchive")`
+- **Success message:** `[green]✓ Agent restored[/green]`
+
+---
+
+## Playwright e2e test
+
+### File: `web/e2e/unarchive-agent.spec.ts`
+
+**Setup (uses API directly):**
+1. Get admin access token via `getAccessToken()` / login API
+2. Create an agent via `POST /api/v1/agents` (status=pending)
+3. Approve it via `POST /api/v1/review/agents/{id}/approve` (status=active)
+4. Archive it via `PATCH /api/v1/agents/{id}/archive` (status=archived)
+
+**Test cases:**
+1. **Archived agent shows unarchive button** — navigate to `/agents`, verify the archived agent has an ArchiveRestore button visible
+2. **Unarchive restores agent** — click the unarchive button, confirm in dialog, verify toast "Agent restored", verify agent status returns to active
+3. **Active agent does not show unarchive button** — verify the now-active agent has the archive button (not unarchive)
+
+**Helpers:** uses existing `loginToWebUI(page)` and `waitForAPI()` from `e2e/helpers.ts`.
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `observal-server/api/routes/agent.py` | Add `unarchive_agent` endpoint |
+| `web/src/lib/api.ts` | Add `unarchive` method |
+| `web/src/hooks/use-api.ts` | Add `useUnarchiveAgent` hook |
+| `web/src/app/(registry)/agents/page.tsx` | Add `UnarchiveAgentButton` component + render |
+| `observal_cli/cmd_agent.py` | Add `agent_unarchive` command |
+| `web/e2e/unarchive-agent.spec.ts` | New e2e test file |
+
+## Not changing
+
+- No database migration needed — `active` status already exists
+- No new enum values
+- No changes to agent model

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -382,7 +382,13 @@ async def ingest_hook(request: Request, current_user: User = Depends(require_rol
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     raw_event = body.get("hook_event_name", "unknown")
     hook_event_name = _KIRO_EVENT_MAP.get(raw_event, raw_event)
-    span_type = "hook_exec" if hook_event_name == "PostToolUse" else f"hook_{hook_event_name.lower()}"
+    tool_name = body.get("tool_name", "")
+    if tool_name in ("assistant_response", "assistant_thinking"):
+        span_type = f"hook_{tool_name}"
+    elif hook_event_name == "PostToolUse":
+        span_type = "hook_exec"
+    else:
+        span_type = f"hook_{hook_event_name.lower()}"
     row = {
         "span_id": str(uuid.uuid4()),
         "trace_id": body.get("session_id", str(uuid.uuid4())),

--- a/observal_cli/hooks_spec.py
+++ b/observal_cli/hooks_spec.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 # Bump this when hook definitions change (new events, different scripts,
 # additional handlers, etc.).  Stored in ~/.observal/config.json so we
 # can detect when an upgrade is needed without re-reading all hooks.
-HOOKS_SPEC_VERSION = "3"
+HOOKS_SPEC_VERSION = "4"
 
 # Metadata key injected into every Observal matcher group.
 # Primary identification method — the reconciler checks this first.
@@ -71,8 +71,13 @@ def get_desired_hooks(
 
     # Stop event: generic hook first (always fires), then stop-specific
     # hook for transcript parsing (response + thinking capture).
+    # Each must be in its own matcher group so they receive independent
+    # copies of stdin (a single group shares one stdin pipe).
     if stop_script:
-        stop_group: list[dict] = [{**meta, "hooks": [generic, {"type": "command", "command": stop_script}]}]
+        stop_group: list[dict] = [
+            {**meta, "hooks": [generic]},
+            {**meta, "hooks": [{"type": "command", "command": stop_script}]},
+        ]
     else:
         stop_group = generic_group
 

--- a/tests/test_settings_reconciler.py
+++ b/tests/test_settings_reconciler.py
@@ -207,18 +207,18 @@ class TestReconcileHooks:
             assert event in merged
 
     def test_stop_has_two_hooks(self):
-        """Stop event should have both generic and stop-specific handlers."""
+        """Stop event should have both generic and stop-specific handlers in separate matcher groups."""
         desired = get_desired_hooks(
             "/path/observal-hook.sh", "/path/observal-stop-hook.sh", "http://localhost:8000/api/v1/otel/hooks"
         )
         stop_groups = desired["Stop"]
 
-        # One matcher group with two hook handlers
-        assert len(stop_groups) == 1
-        hooks = stop_groups[0]["hooks"]
-        assert len(hooks) == 2
-        assert "observal-hook.sh" in hooks[0]["command"]
-        assert "observal-stop-hook.sh" in hooks[1]["command"]
+        # Two separate matcher groups so each gets its own stdin
+        assert len(stop_groups) == 2
+        assert len(stop_groups[0]["hooks"]) == 1
+        assert len(stop_groups[1]["hooks"]) == 1
+        assert "observal-hook.sh" in stop_groups[0]["hooks"][0]["command"]
+        assert "observal-stop-hook.sh" in stop_groups[1]["hooks"][0]["command"]
 
 
 # ── Env reconciliation ───────────────────────────────────────

--- a/web/src/app/(admin)/traces/[id]/page.tsx
+++ b/web/src/app/(admin)/traces/[id]/page.tsx
@@ -571,9 +571,21 @@ function EventSummary({ event }: { event: RawOtelEvent }) {
   }
 
   if (isHookEvent(eName)) {
+    const hasShim = attrs._sources?.includes("shim");
     return (
       <div className="flex items-center gap-3 flex-wrap">
         <Badge>{attrs.tool_name || attrs.agent_type || eName.replace("hook_", "")}</Badge>
+        {hasShim && (
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-teal-500/15 text-teal-600 dark:text-teal-400 border border-teal-500/20">
+            shim
+          </span>
+        )}
+        {hasShim && attrs.mcp_id && (
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-medium bg-teal-500/10 text-teal-600 dark:text-teal-400">
+            <Globe className="h-3 w-3" />
+            {attrs.mcp_id}
+          </span>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Purpose / Description
Assistant Responses and Assistant Thinking events were never captured from real Claude Code sessions. The traces UI showed the filter categories but they were always empty.

## Fixes
* Fixes the stop-hook stdin drain bug causing zero `hook_assistant_response` and `hook_assistant_thinking` events in ClickHouse

## Approach
**Root cause:** The generic hook (`observal-hook.sh`) and stop-hook (`observal-stop-hook.sh`) were placed in the **same matcher group** in the Claude Code hooks config. Claude Code pipes stdin once per matcher group — so the generic hook's `cat` consumed all of stdin, and the stop-hook received empty input, silently exiting.

**Fix:** Split them into **separate matcher groups** so each gets its own independent copy of stdin. Bumped hooks spec version to v4 so the reconciler re-applies the corrected structure on next `observal setup`.

Also fixed the legacy `telemetry.py` endpoint to set `span_type` to `hook_assistant_response`/`hook_assistant_thinking` instead of always defaulting to `hook_stop` when `tool_name` indicates response/thinking data.

## How Has This Been Tested?
- Manually sent test payloads to `/api/v1/otel/hooks` and verified correct `event.name` values in ClickHouse `otel_logs`
- Confirmed the stop-hook script correctly parses transcript JSONL and extracts text/thinking blocks when given proper stdin
- Verified the settings.json structure matches the updated spec (two separate matcher groups under Stop)

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code