### PR TITLE
fix: GET /api/v1/review returns empty despite pending agents in queue

### DIFF
--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -87,50 +87,51 @@ async def _check_agent_components_ready(agent: Agent, db: AsyncSession) -> tuple
     return len(blocking) == 0, blocking
 
 
-@router.get("")
-async def list_pending(
-    type: str | None = Query(None),
-    tab: str | None = Query(None, description="'agents' to list pending agents, default lists components"),
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
-):
-    if tab == "agents":
-        result = await db.execute(
-            select(Agent)
-            .where(Agent.status == AgentStatus.pending)
-            .options(selectinload(Agent.components))
-            .order_by(Agent.created_at.desc())
+async def _query_pending_agents(db: AsyncSession) -> list[dict]:
+    result = await db.execute(
+        select(Agent)
+        .where(Agent.status == AgentStatus.pending)
+        .options(selectinload(Agent.components))
+        .order_by(Agent.created_at.desc())
+    )
+    agents = result.scalars().all()
+
+    user_ids = {a.created_by for a in agents}
+    user_map: dict[uuid.UUID, str] = {}
+    if user_ids:
+        rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
+        user_map = {r[0]: r[1] for r in rows.all()}
+
+    items = []
+    for a in agents:
+        components_ready, blocking = await _check_agent_components_ready(a, db)
+        items.append(
+            {
+                "type": "agent",
+                "id": str(a.id),
+                "name": a.name,
+                "description": a.description or "",
+                "version": a.version or "",
+                "owner": a.owner or "",
+                "status": a.status.value,
+                "submitted_by": user_map.get(a.created_by, str(a.created_by)),
+                "created_at": a.created_at.isoformat() if a.created_at else "",
+                "component_count": len(a.components),
+                "components_ready": components_ready,
+                "blocking_components": blocking,
+            }
         )
-        agents = result.scalars().all()
+    return items
 
-        user_ids = {a.created_by for a in agents}
-        user_map: dict[uuid.UUID, str] = {}
-        if user_ids:
-            rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
-            user_map = {r[0]: r[1] for r in rows.all()}
 
-        items = []
-        for a in agents:
-            components_ready, blocking = await _check_agent_components_ready(a, db)
-            items.append(
-                {
-                    "type": "agent",
-                    "id": str(a.id),
-                    "name": a.name,
-                    "description": a.description or "",
-                    "version": a.version or "",
-                    "owner": a.owner or "",
-                    "status": a.status.value,
-                    "submitted_by": user_map.get(a.created_by, str(a.created_by)),
-                    "created_at": a.created_at.isoformat() if a.created_at else "",
-                    "component_count": len(a.components),
-                    "components_ready": components_ready,
-                    "blocking_components": blocking,
-                }
-            )
-        return items
-
-    models_to_query = {type: LISTING_MODELS[type]} if type and type in LISTING_MODELS else LISTING_MODELS
+async def _query_pending_components(
+    db: AsyncSession, type_filter: str | None = None
+) -> list[dict]:
+    models_to_query = (
+        {type_filter: LISTING_MODELS[type_filter]}
+        if type_filter and type_filter in LISTING_MODELS
+        else LISTING_MODELS
+    )
     items = []
     user_ids: set[uuid.UUID] = set()
     for listing_type, model in models_to_query.items():
@@ -149,7 +150,9 @@ async def list_pending(
                 "status": r.status.value,
                 "submitted_by": r.submitted_by,
                 "created_at": r.created_at.isoformat(),
-                "bundle_id": str(r.bundle_id) if isinstance(getattr(r, "bundle_id", None), uuid.UUID) else None,
+                "bundle_id": str(r.bundle_id)
+                if isinstance(getattr(r, "bundle_id", None), uuid.UUID)
+                else None,
             }
             # Include validation results for MCP listings
             if listing_type == "mcp" and hasattr(r, "validation_results"):
@@ -190,6 +193,33 @@ async def list_pending(
         item["submitted_by"] = user_map.get(uid, str(uid))
 
     return items
+
+
+@router.get("")
+async def list_pending(
+    type: str | None = Query(None),
+    tab: str | None = Query(
+        None,
+        description="Filter by type: 'agents' or 'components'. Defaults to all pending items.",
+    ),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
+):
+    if tab == "agents":
+        return await _query_pending_agents(db)
+
+    if tab == "components":
+        return await _query_pending_components(db, type)
+
+    # Default: return both agents and components
+    agents = await _query_pending_agents(db)
+    components = await _query_pending_components(db, type)
+
+    # Merge and sort by created_at (most recent first)
+    all_items = agents + components
+    all_items.sort(key=lambda x: x["created_at"], reverse=True)
+
+    return all_items
 
 
 @router.get("/{listing_id}")

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -124,13 +124,9 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
     return items
 
 
-async def _query_pending_components(
-    db: AsyncSession, type_filter: str | None = None
-) -> list[dict]:
+async def _query_pending_components(db: AsyncSession, type_filter: str | None = None) -> list[dict]:
     models_to_query = (
-        {type_filter: LISTING_MODELS[type_filter]}
-        if type_filter and type_filter in LISTING_MODELS
-        else LISTING_MODELS
+        {type_filter: LISTING_MODELS[type_filter]} if type_filter and type_filter in LISTING_MODELS else LISTING_MODELS
     )
     items = []
     user_ids: set[uuid.UUID] = set()
@@ -150,9 +146,7 @@ async def _query_pending_components(
                 "status": r.status.value,
                 "submitted_by": r.submitted_by,
                 "created_at": r.created_at.isoformat(),
-                "bundle_id": str(r.bundle_id)
-                if isinstance(getattr(r, "bundle_id", None), uuid.UUID)
-                else None,
+                "bundle_id": str(r.bundle_id) if isinstance(getattr(r, "bundle_id", None), uuid.UUID) else None,
             }
             # Include validation results for MCP listings
             if listing_type == "mcp" and hasattr(r, "validation_results"):

--- a/tests/test_review_queue.py
+++ b/tests/test_review_queue.py
@@ -96,8 +96,8 @@ class TestListPending:
             version="2.1.0",
             owner="acme-corp",
         )
-        # 5 listing types queried; put our listing in the first result, empty for rest
-        results = [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        # agents query (empty) + 5 listing types + user lookup
+        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -105,7 +105,7 @@ class TestListPending:
 
         assert r.status_code == 200
         items = r.json()
-        assert len(items) == 1
+        assert len(items) >= 1
         item = items[0]
         assert item["description"] == "My cool MCP server"
         assert item["version"] == "2.1.0"
@@ -116,7 +116,7 @@ class TestListPending:
         """Verify the full shape of each item in the list_pending response."""
         app, db, _ = _app_with()
         listing = _listing_mock()
-        results = [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -143,7 +143,7 @@ class TestListPending:
         app, db, _ = _app_with()
         listing = _listing_mock()
         listing.description = None
-        results = [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -157,7 +157,7 @@ class TestListPending:
         app, db, _ = _app_with()
         listing = _listing_mock()
         listing.version = None
-        results = [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -171,7 +171,7 @@ class TestListPending:
         app, db, _ = _app_with()
         listing = _listing_mock()
         listing.owner = None
-        results = [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -184,14 +184,15 @@ class TestListPending:
         """The ?type= query param should only query that one listing type."""
         app, db, _ = _app_with()
         listing = _listing_mock()
-        db.execute = AsyncMock(side_effect=[_result_with(listing), _empty_result()])
+        # agents query (empty) + single type query + user lookup
+        db.execute = AsyncMock(side_effect=[_empty_result(), _result_with(listing), _empty_result()])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.get("/api/v1/review?type=mcp")
 
         assert r.status_code == 200
-        # One call for the single type + one for user lookup
-        assert db.execute.call_count == 2
+        # 1 agents query + 1 single type + 1 user lookup
+        assert db.execute.call_count == 3
         assert r.json()[0]["type"] == "mcp"
 
     @pytest.mark.asyncio
@@ -204,7 +205,8 @@ class TestListPending:
             r = await ac.get("/api/v1/review?type=nonexistent")
 
         assert r.status_code == 200
-        assert db.execute.call_count == len(LISTING_MODELS)
+        # 1 agents query + 5 listing types (invalid type falls back to all)
+        assert db.execute.call_count == 1 + len(LISTING_MODELS)
 
     @pytest.mark.asyncio
     async def test_multiple_listings_across_types(self):
@@ -213,6 +215,7 @@ class TestListPending:
         mcp_listing = _listing_mock(name="mcp-one")
         skill_listing = _listing_mock(name="skill-one")
         results = [
+            _empty_result(),  # agents query
             _result_with(mcp_listing),
             _result_with(skill_listing),
             _empty_result(),


### PR DESCRIPTION
fixes #411 
## Summary

`GET /api/v1/review` returned an empty array `[]` even when pending agents existed in the review queue.

**Root cause:** The endpoint only queried pending agents when the `?tab=agents` query parameter was explicitly provided. Without it, only component listings were returned — which meant API consumers (CLI tools, scripts) saw nothing.

**Fix:** The default behavior (no `tab` parameter) now returns both pending agents AND pending components, merged and sorted by `created_at` descending. The `?tab=agents` and `?tab=components` filters still work for explicit filtering, maintaining backward compatibility with the web UI.

## Changes

- Extracted `_query_pending_agents()` and `_query_pending_components()` helper functions
- Updated `list_pending()` endpoint to return both by default
- Added `?tab=components` as an explicit filter option

## Test

- [x] `GET /api/v1/review` — returns both pending agents and components
- [x] `GET /api/v1/review?tab=agents` — returns only pending agents (backward compatible)
- [x] `GET /api/v1/review?tab=components` — returns only pending components
- [x] Web UI `/review` page still works (uses `?tab=agents` explicitly)