### PR TITLE
fix: persist mcp_server_ids in agent draft and allow bodyless submit

### DIFF
--- a/observal-server/api/middleware/content_type.py
+++ b/observal-server/api/middleware/content_type.py
@@ -88,11 +88,13 @@ class ContentTypeMiddleware(BaseHTTPMiddleware):
         if path in _SKIP_PATHS or any(path.startswith(p) for p in _SKIP_PREFIXES):
             return await call_next(request)
 
-        # If there is no Content-Length or it is 0, there is no body to validate.
+        # If there is no body to validate, skip Content-Type enforcement.
         content_length = request.headers.get("content-length")
+        ct_header = request.headers.get("content-type")
         if content_length is not None and int(content_length) == 0:
             return await call_next(request)
-
+        if content_length is None and not ct_header:
+            return await call_next(request)
         ct = _content_type_base(request.headers.get("content-type"))
 
         # Determine allowed set based on path.

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -929,18 +929,34 @@ async def save_draft(
     db.add(agent)
     await db.flush()
 
-    for i, cref in enumerate(req.components):
+    # Legacy: mcp_server_ids -> AgentComponent(type=mcp)
+    order = 0
+    if not req.components and req.mcp_server_ids:
+        for mid in req.mcp_server_ids:
+            db.add(
+                AgentComponent(
+                    agent_id=agent.id,
+                    component_type="mcp",
+                    component_id=mid,
+                    version_ref="latest",
+                    order_index=order,
+                )
+            )
+            order += 1
+
+    # New: components list with all types
+    for cref in req.components:
         db.add(
             AgentComponent(
                 agent_id=agent.id,
                 component_type=cref.component_type,
                 component_id=cref.component_id,
                 version_ref="latest",
-                order_index=i,
+                order_index=order,
                 config_override=cref.config_override,
             )
         )
-
+        order += 1
     goal = AgentGoalTemplate(agent_id=agent.id, description=req.goal_template.description)
     db.add(goal)
     await db.flush()


### PR DESCRIPTION
## Purpose / Description
Two bugs in the agent API:

1. **mcp_server_ids silently dropped on draft creation** — \POST /api/v1/agents/draft\ accepts \mcp_server_ids\ without error but never persists them as \AgentComponent\ rows. The response shows \mcp_links: []\. The \create_agent\ endpoint handles this correctly, but \save_draft\ was missing the legacy field handling.

2. **Agent submit requires empty \{}\ body** — \POST /api/v1/agents/{id}/submit\ returns 415 when called without a body (e.g. \curl -X POST\ with no \-d\). The \ContentTypeMiddleware\ only skipped validation when \content-length: 0\ was explicitly set, but clients sending no body omit both \content-length\ and \content-type\ headers entirely.

## Fixes
* Fixes #410
* Fixes #405 

## Approach

**Bug 1:** Added legacy \mcp_server_ids\ → \AgentComponent(type=mcp)\ conversion in \save_draft\, matching the existing logic in \create_agent\. Only triggers when \
eq.components\ is empty (new field takes precedence).

**Bug 2:** Added a second skip condition in \ContentTypeMiddleware\: when both \content-length\ and \content-type\ headers are absent, the request has no body and should pass through without Content-Type enforcement.

## How Has This Been Tested?

- Verified \save_draft\ with \mcp_server_ids\ now returns populated \mcp_links\
- Verified \submit\ endpoint accepts requests with no body
- Existing test suite: 1217 passed (20 pre-existing failures in unrelated files)

## Checklist

- [x] All commits are signed off (\git commit -s\) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)