### PR TITLE
fix: resolve intermittent 500 errors through Next.js proxy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -159,7 +159,8 @@ services:
     environment:
       - NEXT_PUBLIC_API_URL=http://observal-api:8000
     depends_on:
-      - observal-api
+      observal-api:
+        condition: service_healthy
     restart: unless-stopped
     read_only: true
     tmpfs:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -115,15 +115,22 @@ async function request<T = unknown>(
   const token = getAccessToken();
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
-  const res = await fetch(`${API}${path}`, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  let res: Response | undefined;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    res = await fetch(`${API}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    if (res.status < 500) break;
+    // Brief pause before retry on 5xx
+    if (attempt === 0) await new Promise((r) => setTimeout(r, 500));
+  }
+  const response = res!;
 
-  if (!res.ok) {
+  if (!response.ok) {
     // Auto-refresh on 401 (except for auth endpoints where 401 means bad credentials)
-    if (res.status === 401 && !path.startsWith("/auth/")) {
+    if (response.status === 401 && !path.startsWith("/auth/")) {
       // Deduplicate concurrent refresh attempts
       if (!_refreshPromise) {
         _refreshPromise = _tryRefreshToken().finally(() => {
@@ -155,12 +162,12 @@ async function request<T = unknown>(
       throw new Error("Session expired");
     }
 
-    const text = await res.text().catch(() => res.statusText);
-    throw new Error(`${res.status}: ${text}`);
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`${response.status}: ${text}`);
   }
 
-  if (res.status === 204) return undefined as T;
-  return res.json() as Promise<T>;
+  if (response.status === 204) return undefined as T;
+  return response.json() as Promise<T>;
 }
 
 function get<T = unknown>(path: string) {


### PR DESCRIPTION
## Purpose / Description
API calls through the Next.js proxy at \localhost:3000/api/v1/...\ intermittently return 500 Internal Server Error, while the same requests to the direct API at \localhost:8000/api/v1/...\ always succeed. This affects web UI reliability — users see intermittent login failures and draft creation errors.

## Fixes
* Fixes issue #404 

## Approach
Two complementary fixes:

1. **Docker startup race condition** — The \observal-web\ service had \depends_on: observal-api\ without a health condition, so Next.js could start proxying before the API was ready. Changed to \condition: service_healthy\ so the web container waits for the API healthcheck to pass.

2. **Transient 5xx retry** — Added a single retry with 500ms delay in the frontend \
equest()\ wrapper for 5xx responses. If the first attempt gets a 500/502/503/504, it waits briefly and retries once. This handles transient proxy failures (API restart, brief connection reset) without masking persistent errors.

## How Has This Been Tested?

- Verified Docker compose validates with the updated depends_on syntax
- Verified TypeScript compiles cleanly with the retry logic
- The retry is bounded (max 1 retry, 500ms delay) so it won't cause cascading issues

## Checklist

- [x] All commits are signed off (\git commit -s\) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)