### PR TITLE
fix: route ordering collision and CLI draft flag bugs

### DIFF
--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -75,6 +75,18 @@ async def list_hooks(
     return [HookListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
+@router.get("/my", response_model=list[HookListingSummary])
+async def my_hooks(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(HookListing).where(HookListing.submitted_by == current_user.id).order_by(HookListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [HookListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
 @router.get("/{listing_id}", response_model=HookListingResponse)
 async def get_hook(listing_id: str, db: AsyncSession = Depends(get_db)):
     listing = await resolve_listing(HookListing, listing_id, db)
@@ -103,18 +115,6 @@ async def install_hook(
 
     config = generate_hook_telemetry_config(listing, req.ide, platform=req.platform)
     return HookInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
-
-
-@router.get("/my", response_model=list[HookListingSummary])
-async def my_hooks(
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
-):
-    stmt = (
-        select(HookListing).where(HookListing.submitted_by == current_user.id).order_by(HookListing.created_at.desc())
-    )
-    result = await db.execute(stmt)
-    return [HookListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
 @router.post("/draft", response_model=HookListingResponse)

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -171,6 +171,16 @@ async def list_mcps(
     return [McpListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
+@router.get("/my", response_model=list[McpListingSummary])
+async def my_mcps(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = select(McpListing).where(McpListing.submitted_by == current_user.id).order_by(McpListing.created_at.desc())
+    result = await db.execute(stmt)
+    return [McpListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
 @router.get("/{listing_id}", response_model=McpListingResponse)
 async def get_mcp(listing_id: str, db: AsyncSession = Depends(get_db)):
     listing = await resolve_listing(McpListing, listing_id, db)
@@ -197,16 +207,6 @@ async def install_mcp(
 
     snippet = generate_config(listing, req.ide, env_values=req.env_values, header_values=req.header_values)
     return McpInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=snippet)
-
-
-@router.get("/my", response_model=list[McpListingSummary])
-async def my_mcps(
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
-):
-    stmt = select(McpListing).where(McpListing.submitted_by == current_user.id).order_by(McpListing.created_at.desc())
-    result = await db.execute(stmt)
-    return [McpListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
 @router.post("/draft", response_model=McpListingResponse)

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -70,6 +70,20 @@ async def list_prompts(
     return [PromptListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
+@router.get("/my", response_model=list[PromptListingSummary])
+async def my_prompts(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(PromptListing)
+        .where(PromptListing.submitted_by == current_user.id)
+        .order_by(PromptListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [PromptListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
 @router.get("/{listing_id}", response_model=PromptListingResponse)
 async def get_prompt(listing_id: str, db: AsyncSession = Depends(get_db)):
     listing = await resolve_listing(PromptListing, listing_id, db)
@@ -153,20 +167,6 @@ async def render_prompt(
         pass
 
     return PromptRenderResponse(listing_id=listing.id, rendered=rendered)
-
-
-@router.get("/my", response_model=list[PromptListingSummary])
-async def my_prompts(
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
-):
-    stmt = (
-        select(PromptListing)
-        .where(PromptListing.submitted_by == current_user.id)
-        .order_by(PromptListing.created_at.desc())
-    )
-    result = await db.execute(stmt)
-    return [PromptListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
 @router.post("/draft", response_model=PromptListingResponse)

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -70,6 +70,20 @@ async def list_sandboxes(
     return [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
+@router.get("/my", response_model=list[SandboxListingSummary])
+async def my_sandboxes(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(SandboxListing)
+        .where(SandboxListing.submitted_by == current_user.id)
+        .order_by(SandboxListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
 @router.get("/{listing_id}", response_model=SandboxListingResponse)
 async def get_sandbox(listing_id: str, db: AsyncSession = Depends(get_db)):
     listing = await resolve_listing(SandboxListing, listing_id, db)
@@ -98,20 +112,6 @@ async def install_sandbox(
 
     config = generate_sandbox_config(listing, req.ide)
     return SandboxInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
-
-
-@router.get("/my", response_model=list[SandboxListingSummary])
-async def my_sandboxes(
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
-):
-    stmt = (
-        select(SandboxListing)
-        .where(SandboxListing.submitted_by == current_user.id)
-        .order_by(SandboxListing.created_at.desc())
-    )
-    result = await db.execute(stmt)
-    return [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
 @router.post("/draft", response_model=SandboxListingResponse)

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -77,6 +77,20 @@ async def list_skills(
     return [SkillListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
+@router.get("/my", response_model=list[SkillListingSummary])
+async def my_skills(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    stmt = (
+        select(SkillListing)
+        .where(SkillListing.submitted_by == current_user.id)
+        .order_by(SkillListing.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [SkillListingSummary.model_validate(r) for r in result.scalars().all()]
+
+
 @router.get("/{listing_id}", response_model=SkillListingResponse)
 async def get_skill(listing_id: str, db: AsyncSession = Depends(get_db)):
     listing = await resolve_listing(SkillListing, listing_id, db)
@@ -105,20 +119,6 @@ async def install_skill(
 
     config = generate_skill_config(listing, req.ide)
     return SkillInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
-
-
-@router.get("/my", response_model=list[SkillListingSummary])
-async def my_skills(
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
-):
-    stmt = (
-        select(SkillListing)
-        .where(SkillListing.submitted_by == current_user.id)
-        .order_by(SkillListing.created_at.desc())
-    )
-    result = await db.execute(stmt)
-    return [SkillListingSummary.model_validate(r) for r in result.scalars().all()]
 
 
 @router.post("/draft", response_model=SkillListingResponse)

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -40,8 +40,17 @@ def _handle_error(e: httpx.HTTPStatusError, path: str = ""):
         rprint("[dim]  This action requires a higher role (admin or super_admin).[/dim]")
     elif code == 404:
         rprint(f"[red]Not found{path_info}.[/red]")
+        # Extract component type from API path (e.g. /api/v1/hooks/abc -> hook)
+        parts = path.strip("/").split("/")
+        type_plural = parts[2] if len(parts) > 2 else "mcps"
+        if type_plural.endswith("xes"):
+            type_singular = type_plural[:-2]  # sandboxes -> sandbox
+        elif type_plural.endswith("s"):
+            type_singular = type_plural[:-1]  # mcps -> mcp, skills -> skill
+        else:
+            type_singular = type_plural
         rprint(
-            "[dim]  Check that the resource ID is correct, or use [bold]observal registry mcp list[/bold] to browse.[/dim]"
+            f"[dim]  Check that the resource ID is correct, or use [bold]observal registry {type_singular} list[/bold] to browse.[/dim]"
         )
     elif code == 429:
         rprint(f"[red]Rate limited{path_info}.[/red]")

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -699,6 +699,11 @@ def agent_publish(
     submit: str | None = typer.Option(None, "--submit", help="Submit a draft agent for review (agent ID)"),
 ):
     """Publish the agent definition to the server."""
+    if draft and submit:
+        rprint(
+            "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
+        )
+        raise typer.Exit(code=1)
     if submit:
         resolved = config.resolve_alias(submit)
         with spinner("Submitting draft for review..."):

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -29,6 +29,11 @@ def hook_submit(
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (hook ID)"),
 ):
     """Submit a new hook for review."""
+    if draft and submit_draft:
+        rprint(
+            "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
+        )
+        raise typer.Exit(code=1)
     if submit_draft:
         resolved = config.resolve_alias(submit_draft)
         with spinner("Submitting draft for review..."):
@@ -37,8 +42,15 @@ def hook_submit(
         return
 
     if from_file:
-        with open(from_file) as f:
-            payload = _json.load(f)
+        try:
+            with open(from_file) as f:
+                payload = _json.load(f)
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON in {from_file}:[/red] {e}")
+            raise typer.Exit(code=1)
+        except FileNotFoundError:
+            rprint(f"[red]File not found:[/red] {from_file}")
+            raise typer.Exit(code=1)
     else:
         payload = {
             "name": typer.prompt("Hook name"),

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -890,6 +890,11 @@ def submit(
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (MCP ID)"),
 ):
     """Submit an MCP server for review."""
+    if draft and submit_draft:
+        rprint(
+            "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
+        )
+        raise typer.Exit(code=1)
     if submit_draft:
         from observal_cli import config as cfg
 

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -29,6 +29,11 @@ def prompt_submit(
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (prompt ID)"),
 ):
     """Submit a new prompt for review."""
+    if draft and submit_draft:
+        rprint(
+            "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
+        )
+        raise typer.Exit(code=1)
     if submit_draft:
         resolved = config.resolve_alias(submit_draft)
         with spinner("Submitting draft for review..."):

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -27,6 +27,11 @@ def sandbox_submit(
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (sandbox ID)"),
 ):
     """Submit a new sandbox for review."""
+    if draft and submit_draft:
+        rprint(
+            "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
+        )
+        raise typer.Exit(code=1)
     if submit_draft:
         resolved = config.resolve_alias(submit_draft)
         with spinner("Submitting draft for review..."):
@@ -35,8 +40,15 @@ def sandbox_submit(
         return
 
     if from_file:
-        with open(from_file) as f:
-            payload = _json.load(f)
+        try:
+            with open(from_file) as f:
+                payload = _json.load(f)
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON in {from_file}:[/red] {e}")
+            raise typer.Exit(code=1)
+        except FileNotFoundError:
+            rprint(f"[red]File not found:[/red] {from_file}")
+            raise typer.Exit(code=1)
     else:
         payload = {
             "name": typer.prompt("Sandbox name"),

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -27,6 +27,11 @@ def skill_submit(
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (skill ID)"),
 ):
     """Submit a new skill for review."""
+    if draft and submit_draft:
+        rprint(
+            "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
+        )
+        raise typer.Exit(code=1)
     if submit_draft:
         resolved = config.resolve_alias(submit_draft)
         with spinner("Submitting draft for review..."):
@@ -35,8 +40,15 @@ def skill_submit(
         return
 
     if from_file:
-        with open(from_file) as f:
-            payload = _json.load(f)
+        try:
+            with open(from_file) as f:
+                payload = _json.load(f)
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON in {from_file}:[/red] {e}")
+            raise typer.Exit(code=1)
+        except FileNotFoundError:
+            rprint(f"[red]File not found:[/red] {from_file}")
+            raise typer.Exit(code=1)
     else:
         agents_input = typer.prompt("Target agents (comma-separated)", default="")
         payload = {


### PR DESCRIPTION
## Purpose / Description

Two related bugs around the draft workflow for non-agent component types:

1. **Route collision (#400):** `GET /my` was registered _after_ `GET /{listing_id}` in all 5 listing routers (MCP, Skill, Hook, Prompt, Sandbox). FastAPI matches routes in registration order, so `/my` was captured by `/{listing_id}` — treating `"my"` as a listing ID and returning 404. The agent router already had the correct ordering.

2. **CLI bugs (#401):** Four issues in the CLI — hardcoded "mcp" in 404 hints, no mutual exclusion between `--draft` and `--submit`, and unhandled `JSONDecodeError` in `--from-file` for 3 command files.

## Fixes

* Fixes #400
* Fixes #401

## Approach

**API (5 route files):** Move the `GET /my` route definition before `GET /{listing_id}` in `mcp.py`, `skill.py`, `hook.py`, `prompt.py`, and `sandbox.py` — matching the agent router pattern.

**CLI (`client.py`):** Extract the component type from the API path (`/api/v1/{type_plural}/...`) and use it in the 404 error hint instead of hardcoding "mcp".

**CLI (6 command files):** Add `if draft and submit_draft` validation at the top of every submit function to reject conflicting flags with a clear error message.

**CLI (3 command files):** Wrap `json.load()` in try/except for `cmd_hook.py`, `cmd_sandbox.py`, and `cmd_skill.py` to show a user-friendly error on invalid JSON, matching the pattern already in `cmd_prompt.py` and `cmd_mcp.py`.

## How Has This Been Tested?

- **Route ordering:** Wrote a pytest suite spinning up each router with mocked DB/auth and hitting `GET /my` — all 5 return 200 (previously returned 404).
- **Lint:** `uvx ruff check` passes on all modified files.
- **Visual review:** Confirmed `/my` appears before `/{listing_id}` in every route file via `grep -n "@router.get"`.

## Learning

FastAPI (Starlette) matches routes in registration order. When a parameterized route like `/{listing_id}` is registered before a literal like `/my`, the parameter route wins — capturing `"my"` as a listing ID. Fixed routes must always be registered before parameterized ones at the same path depth.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)