### PR TITLE
fix: enable delete/withdraw action in review queue for super_admin users (#408)

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from api.deps import get_db, optional_current_user, require_role, resolve_prefix_id
+from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_prefix_id
 from api.sanitize import escape_like
 from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus
 from models.agent_component import AgentComponent
@@ -808,7 +808,7 @@ async def delete_agent(
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
-    is_admin = current_user.role.value == "admin"
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if agent.created_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
     if agent.status == AgentStatus.active and not is_admin:

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role, resolve_listing
+from api.deps import ROLE_HIERARCHY, get_db, require_role, resolve_listing
 from api.sanitize import escape_like
 from models.hook import HookDownload, HookListing
 from models.mcp import ListingStatus
@@ -224,7 +224,7 @@ async def delete_hook(
     listing = await resolve_listing(HookListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    is_admin = current_user.role.value == "admin"
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
     if listing.status == ListingStatus.approved and not is_admin:

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role, resolve_listing
+from api.deps import ROLE_HIERARCHY, get_db, require_role, resolve_listing
 from api.sanitize import escape_like
 from database import async_session
 from models.mcp import ListingStatus, McpDownload, McpListing, McpValidationResult
@@ -329,7 +329,7 @@ async def delete_mcp(
     listing = await resolve_listing(McpListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    is_admin = current_user.role.value == "admin"
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
     if listing.status == ListingStatus.approved and not is_admin:

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role, resolve_listing
+from api.deps import ROLE_HIERARCHY, get_db, require_role, resolve_listing
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.prompt import PromptDownload, PromptListing
@@ -268,7 +268,7 @@ async def delete_prompt(
     listing = await resolve_listing(PromptListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    is_admin = current_user.role.value == "admin"
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
     if listing.status == ListingStatus.approved and not is_admin:

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role, resolve_listing
+from api.deps import ROLE_HIERARCHY, get_db, require_role, resolve_listing
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.sandbox import SandboxDownload, SandboxListing
@@ -219,7 +219,7 @@ async def delete_sandbox(
     listing = await resolve_listing(SandboxListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    is_admin = current_user.role.value == "admin"
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
     if listing.status == ListingStatus.approved and not is_admin:

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role, resolve_listing
+from api.deps import ROLE_HIERARCHY, get_db, require_role, resolve_listing
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.skill import SkillDownload, SkillListing
@@ -232,7 +232,7 @@ async def delete_skill(
     listing = await resolve_listing(SkillListing, listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    is_admin = current_user.role.value == "admin"
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if listing.submitted_by != current_user.id and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
     if listing.status == ListingStatus.approved and not is_admin:

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -236,6 +236,7 @@ function ReviewCard({ item, onApprove, onReject, onDelete, disableApprove }: {
                 size="sm"
                 className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
                 onClick={() => setConfirmDelete(true)}
+                aria-label="Delete submission"
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>
@@ -392,6 +393,7 @@ function ReviewRow({ item, onApprove, onReject, onDelete, disableApprove }: {
                     size="sm"
                     className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
                     onClick={() => setConfirmDelete(true)}
+                    aria-label="Delete submission"
                   >
                     <Trash2 className="h-3.5 w-3.5" />
                   </Button>


### PR DESCRIPTION
## Summary

Fixes #408 — the delete/withdraw trash icon in the review queue was visible but non-functional. Clicking it returned `403: Not authorized` because the backend rejected `super_admin` delete requests.

## Root Cause

All 6 registry DELETE endpoints checked `current_user.role.value == "admin"` — an exact string match that only allowed the `admin` role and excluded `super_admin` (the highest-privilege role). This meant `super_admin` users could see the trash icon but could never use it on items submitted by others.

## Changes

- **6 backend route files** (`agent.py`, `mcp.py`, `skill.py`, `hook.py`, `prompt.py`, `sandbox.py`): Replaced broken string comparison with `ROLE_HIERARCHY` check so both `admin` and `super_admin` are authorized to delete
- **1 frontend file** (`review/page.tsx`): Added `aria-label="Delete submission"` to trash icon buttons for accessibility

## Test Plan

- [x] Trash icon visible in both grid and list views across Agents and Components tabs
- [x] Clicking trash icon shows "Permanently delete this submission?" confirmation
- [x] Confirming shows "Submission withdrawn" toast and removes item from queue
- [x] Works for `super_admin` deleting items submitted by other users
