### PR TITLE
fix(sec): escape LIKE wildcards to prevent SQL injection (SOC 2)

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from api.deps import get_db, optional_current_user, require_role, resolve_prefix_id
+from api.sanitize import escape_like
 from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus
 from models.agent_component import AgentComponent
 from models.download import AgentDownloadRecord
@@ -308,7 +309,8 @@ async def list_agents(
     base_filter = Agent.status == AgentStatus.active
     search_filter = None
     if search:
-        search_filter = Agent.name.ilike(f"%{search}%") | Agent.description.ilike(f"%{search}%")
+        safe = escape_like(search)
+        search_filter = Agent.name.ilike(f"%{safe}%") | Agent.description.ilike(f"%{safe}%")
 
     # Org-scoping: when the caller belongs to an org, only show agents owned by that org
     org_filter = None

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -8,6 +8,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role
+from api.sanitize import escape_like
 from models.agent import Agent, AgentStatus
 from models.download import AgentDownloadRecord
 from models.mcp import ListingStatus, McpDownload, McpListing
@@ -275,7 +276,7 @@ async def agent_leaderboard(
         .where(Agent.status == AgentStatus.active)
     )
     if user:
-        stmt = stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{user}%"))
+        stmt = stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{escape_like(user)}%"))
     if window != "all":
         days = _RANGE_MAP.get(window, 7)
         stmt = stmt.where(AgentDownloadRecord.installed_at >= dt.now(UTC) - timedelta(days=days))
@@ -315,7 +316,9 @@ async def agent_leaderboard(
         existing_ids = {r.agent_id for r in rows}
         extra_stmt = select(Agent).where(Agent.status == AgentStatus.active, Agent.id.notin_(existing_ids))
         if user:
-            extra_stmt = extra_stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{user}%"))
+            extra_stmt = extra_stmt.join(User, Agent.created_by == User.id).where(
+                User.email.ilike(f"%{escape_like(user)}%")
+            )
         extra_stmt = extra_stmt.order_by(Agent.created_at.desc()).limit(limit - len(rows))
         extra = (await db.execute(extra_stmt)).scalars().all()
         missing_ids = {a.created_by for a in extra} - set(email_map.keys())
@@ -379,7 +382,7 @@ async def component_leaderboard(
         .where(McpListing.status == ListingStatus.approved)
     )
     if user:
-        stmt = stmt.join(User, McpListing.submitted_by == User.id).where(User.email.ilike(f"%{user}%"))
+        stmt = stmt.join(User, McpListing.submitted_by == User.id).where(User.email.ilike(f"%{escape_like(user)}%"))
     if window != "all":
         days = _RANGE_MAP.get(window, 7)
         stmt = stmt.where(McpDownload.downloaded_at >= dt.now(UTC) - timedelta(days=days))

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -3,6 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role, resolve_listing
+from api.sanitize import escape_like
 from models.hook import HookDownload, HookListing
 from models.mcp import ListingStatus
 from models.user import User, UserRole
@@ -70,7 +71,8 @@ async def list_hooks(
     if scope:
         stmt = stmt.where(HookListing.scope == scope)
     if search:
-        stmt = stmt.where(HookListing.name.ilike(f"%{search}%") | HookListing.description.ilike(f"%{search}%"))
+        safe = escape_like(search)
+        stmt = stmt.where(HookListing.name.ilike(f"%{safe}%") | HookListing.description.ilike(f"%{safe}%"))
     result = await db.execute(stmt.order_by(HookListing.created_at.desc()))
     return [HookListingSummary.model_validate(r) for r in result.scalars().all()]
 

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role, resolve_listing
+from api.sanitize import escape_like
 from database import async_session
 from models.mcp import ListingStatus, McpDownload, McpListing, McpValidationResult
 from models.user import User, UserRole
@@ -166,7 +167,8 @@ async def list_mcps(
     if category:
         stmt = stmt.where(McpListing.category == category)
     if search:
-        stmt = stmt.where(McpListing.name.ilike(f"%{search}%") | McpListing.description.ilike(f"%{search}%"))
+        safe = escape_like(search)
+        stmt = stmt.where(McpListing.name.ilike(f"%{safe}%") | McpListing.description.ilike(f"%{safe}%"))
     result = await db.execute(stmt.order_by(McpListing.created_at.desc()))
     return [McpListingSummary.model_validate(r) for r in result.scalars().all()]
 

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role, resolve_listing
+from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.prompt import PromptDownload, PromptListing
 from models.user import User, UserRole
@@ -65,7 +66,8 @@ async def list_prompts(
     if category:
         stmt = stmt.where(PromptListing.category == category)
     if search:
-        stmt = stmt.where(PromptListing.name.ilike(f"%{search}%") | PromptListing.description.ilike(f"%{search}%"))
+        safe = escape_like(search)
+        stmt = stmt.where(PromptListing.name.ilike(f"%{safe}%") | PromptListing.description.ilike(f"%{safe}%"))
     result = await db.execute(stmt.order_by(PromptListing.created_at.desc()))
     return [PromptListingSummary.model_validate(r) for r in result.scalars().all()]
 

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -3,6 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role, resolve_listing
+from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.sandbox import SandboxDownload, SandboxListing
 from models.user import User, UserRole
@@ -65,7 +66,8 @@ async def list_sandboxes(
     if runtime_type:
         stmt = stmt.where(SandboxListing.runtime_type == runtime_type)
     if search:
-        stmt = stmt.where(SandboxListing.name.ilike(f"%{search}%") | SandboxListing.description.ilike(f"%{search}%"))
+        safe = escape_like(search)
+        stmt = stmt.where(SandboxListing.name.ilike(f"%{safe}%") | SandboxListing.description.ilike(f"%{safe}%"))
     result = await db.execute(stmt.order_by(SandboxListing.created_at.desc()))
     return [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
 

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -3,6 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role, resolve_listing
+from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.skill import SkillDownload, SkillListing
 from models.user import User, UserRole
@@ -70,9 +71,10 @@ async def list_skills(
     if task_type:
         stmt = stmt.where(SkillListing.task_type == task_type)
     if target_agent:
-        stmt = stmt.where(SkillListing.target_agents.cast(str).ilike(f"%{target_agent}%"))
+        stmt = stmt.where(SkillListing.target_agents.cast(str).ilike(f"%{escape_like(target_agent)}%"))
     if search:
-        stmt = stmt.where(SkillListing.name.ilike(f"%{search}%") | SkillListing.description.ilike(f"%{search}%"))
+        safe = escape_like(search)
+        stmt = stmt.where(SkillListing.name.ilike(f"%{safe}%") | SkillListing.description.ilike(f"%{safe}%"))
     result = await db.execute(stmt.order_by(SkillListing.created_at.desc()))
     return [SkillListingSummary.model_validate(r) for r in result.scalars().all()]
 

--- a/observal-server/api/sanitize.py
+++ b/observal-server/api/sanitize.py
@@ -1,0 +1,10 @@
+"""Input sanitization utilities for SQL-safe query construction."""
+
+
+def escape_like(value: str) -> str:
+    """Escape SQL LIKE/ILIKE wildcard characters in user input.
+
+    Prevents LIKE injection by escaping %, _, and \\ so user-supplied
+    strings are treated as literals inside LIKE patterns.
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,35 @@
+"""Tests for SQL LIKE wildcard escaping (SOC 2 compliance)."""
+
+from api.sanitize import escape_like
+
+
+class TestEscapeLike:
+    def test_plain_string_unchanged(self):
+        assert escape_like("hello") == "hello"
+
+    def test_percent_escaped(self):
+        assert escape_like("100%") == "100\\%"
+
+    def test_underscore_escaped(self):
+        assert escape_like("my_table") == "my\\_table"
+
+    def test_backslash_escaped(self):
+        assert escape_like("path\\file") == "path\\\\file"
+
+    def test_all_wildcards_escaped(self):
+        assert escape_like("%_\\") == "\\%\\_\\\\"
+
+    def test_sqli_payload_neutralized(self):
+        payload = "'; DROP TABLE users; --"
+        result = escape_like(payload)
+        assert "%" not in result
+        assert "_" not in result.replace("\\_", "")
+
+    def test_wildcard_flood(self):
+        assert escape_like("%%%") == "\\%\\%\\%"
+
+    def test_empty_string(self):
+        assert escape_like("") == ""
+
+    def test_unicode_preserved(self):
+        assert escape_like("café_résumé") == "café\\_résumé"


### PR DESCRIPTION
## Purpose / Description
All `.ilike(f"%{user_input}%")` patterns across the codebase were vulnerable to LIKE wildcard injection. Attacker-supplied `%` and `_` characters in search/filter query params could manipulate SQL LIKE patterns for information disclosure or filter bypass.

## Fixes
* Fixes #412

## Approach
- Added `escape_like()` utility in `api/sanitize.py` that escapes `%`, `_`, and `\` (the three SQL LIKE special characters) in user input before it reaches `.ilike()` calls
- Applied across all 7 route files, covering all 10 vulnerable query patterns:
  - `agents` — name/description search
  - `mcps` — name/description search
  - `hooks` — name/description search
  - `prompts` — name/description search
  - `sandboxes` — name/description search
  - `skills` — name/description search + target_agent filter
  - `dashboard` — user email filter (3 leaderboard queries)

**ClickHouse queries were audited and found safe** — they already use parameterized `{param:Type}` syntax. No changes needed there.

## How Has This Been Tested?
- 9-case unit test suite (`tests/test_sanitize.py`): plain strings, individual wildcards, combined wildcards, SQLi payloads, wildcard floods, empty strings, unicode
- Ruff lint passes on all modified files
- All existing tests pass

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code