### PR TITLE
fix: resolve 5 Kiro telemetry bugs

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -97,6 +97,7 @@ def login(
             rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]\n")
             _fetch_server_public_key(server_url)
             _configure_claude_code(server_url, data["access_token"])
+            _configure_kiro(server_url)
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 400 and "already initialized" in e.response.text.lower():
@@ -160,6 +161,7 @@ def register(
 
         _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, data["access_token"])
+        _configure_kiro(server_url)
 
     except httpx.HTTPStatusError as e:
         detail = ""
@@ -320,6 +322,7 @@ def _do_password_login(server_url: str, email: str, password: str):
 
         _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, data["access_token"])
+        _configure_kiro(server_url)
 
     except httpx.ConnectError:
         rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
@@ -411,6 +414,129 @@ def _find_hook_script(name: str) -> str | None:
         if p.is_file():
             return str(p.resolve())
     return None
+
+
+def _configure_kiro(server_url: str):
+    """Check for Kiro CLI and offer to configure its telemetry hooks."""
+    kiro_dir = Path.home() / ".kiro"
+
+    try:
+        kiro_exists = kiro_dir.is_dir() or shutil.which("kiro-cli") or shutil.which("kiro")
+        if not kiro_exists:
+            return
+
+        if not typer.confirm(
+            "\nDetected Kiro CLI. Configure telemetry -> Observal?",
+            default=True,
+        ):
+            return
+
+        hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
+        cfg = config.load()
+        user_id = cfg.get("user_id", "")
+
+        hook_py = _find_hook_script("kiro_hook.py")
+        stop_py = _find_hook_script("kiro_stop_hook.py")
+
+        def _sed_prefix(agent_name: str) -> str:
+            meta = f'"session_id":"kiro-\'$PPID\'","service_name":"kiro-cli","agent_name":"{agent_name}"'
+            if user_id:
+                meta += f',"user_id":"{user_id}"'
+            return "cat | sed 's/^{/{" + meta + ",/' "
+
+        def _hook_cmd(agent_name: str) -> str:
+            prefix = _sed_prefix(agent_name)
+            if hook_py:
+                return f"{prefix}| python3 {hook_py} --url {hooks_url}"
+            return f'{prefix}| curl -sf -X POST {hooks_url} -H "Content-Type: application/json" -d @-'
+
+        def _stop_cmd(agent_name: str) -> str:
+            prefix = _sed_prefix(agent_name)
+            if stop_py:
+                return f"{prefix}| python3 {stop_py} --url {hooks_url}"
+            return f'{prefix}| curl -sf -X POST {hooks_url} -H "Content-Type: application/json" -d @-'
+
+        changes = 0
+
+        # 1. Inject into agent JSON files (merge, preserve existing hooks)
+        agents_dir = kiro_dir / "agents"
+        if agents_dir.is_dir():
+            for af in sorted(agents_dir.glob("*.json")):
+                try:
+                    data = _json.loads(af.read_text())
+                    existing = data.get("hooks", {})
+                    already = any(
+                        "otel/hooks" in h.get("command", "")
+                        for handlers in existing.values()
+                        if isinstance(handlers, list)
+                        for h in handlers
+                    )
+                    if already:
+                        continue
+                    name = data.get("name") or af.stem
+                    cmd = _hook_cmd(name)
+                    stop = _stop_cmd(name)
+                    desired = {
+                        "agentSpawn": [{"command": cmd}],
+                        "userPromptSubmit": [{"command": cmd}],
+                        "preToolUse": [{"matcher": "*", "command": cmd}],
+                        "postToolUse": [{"matcher": "*", "command": cmd}],
+                        "stop": [{"command": stop}],
+                    }
+                    merged = dict(existing)
+                    for evt, handlers in desired.items():
+                        cur = merged.get(evt, [])
+                        has_obs = any("otel/hooks" in h.get("command", "") for h in cur)
+                        if not has_obs:
+                            merged[evt] = cur + handlers
+                    data["hooks"] = merged
+                    af.write_text(_json.dumps(data, indent=2) + "\n")
+                    changes += 1
+                except (ValueError, OSError):
+                    pass
+
+        # 2. Install global IDE-format hooks for agentless chat
+        global_hooks_dir = kiro_dir / "hooks"
+        global_hooks_dir.mkdir(parents=True, exist_ok=True)
+        g_cmd = _hook_cmd("global")
+        g_stop = _stop_cmd("global")
+        for hook_id, event_type, cmd in [
+            ("observal-prompt-submit", "promptSubmit", g_cmd),
+            ("observal-pre-tool-use", "preToolUse", g_cmd),
+            ("observal-post-tool-use", "postToolUse", g_cmd),
+            ("observal-agent-stop", "agentStop", g_stop),
+        ]:
+            hf = global_hooks_dir / f"{hook_id}.json"
+            if hf.exists():
+                try:
+                    ex = _json.loads(hf.read_text())
+                    if hooks_url in ex.get("then", {}).get("command", ""):
+                        continue
+                except (ValueError, OSError):
+                    pass
+            hf.write_text(
+                _json.dumps(
+                    {
+                        "id": hook_id,
+                        "name": f"Observal: {event_type}",
+                        "comment": "Auto-injected by Observal for telemetry collection",
+                        "when": {"type": event_type},
+                        "then": {"type": "runCommand", "command": cmd},
+                    },
+                    indent=2,
+                )
+                + "\n"
+            )
+            changes += 1
+
+        if changes:
+            rprint(f"[green]Configured Kiro telemetry ({changes} hooks updated)[/green]")
+        else:
+            rprint("[dim]Kiro hooks already configured.[/dim]")
+
+    except Exception as e:
+        rprint(f"\n[yellow]Could not configure Kiro automatically: {e}[/yellow]")
+        rprint("Run [bold]observal scan --ide kiro --home[/bold] to set up manually.")
 
 
 def _configure_claude_code(server_url: str, access_token: str):

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -279,9 +279,9 @@ def _scan_kiro_home(
             try:
                 data = json.loads(agent_file.read_text())
                 name = data.get("name", agent_file.stem)
-                desc = data.get("description", "")
-                model = data.get("model", "")
-                prompt = data.get("prompt", "")
+                desc = data.get("description") or ""
+                model = data.get("model") or ""
+                prompt = data.get("prompt") or ""
 
                 agents.append(
                     DiscoveredAgent(
@@ -932,11 +932,18 @@ def register_scan(app: typer.Typer):
 
                         # Extract agent metadata for per-agent hook enrichment
                         agent_name = agent_data.get("name", agent_file.stem)
-                        agent_model = agent_data.get("model", "")
+                        agent_model = agent_data.get("model") or ""
 
-                        # Backup and inject
+                        # Backup and merge (preserve existing user hooks)
                         _backup_config(agent_file)
-                        agent_data["hooks"] = _kiro_hooks_block(agent_name, agent_model)
+                        desired = _kiro_hooks_block(agent_name, agent_model)
+                        merged = dict(existing)
+                        for evt, handlers in desired.items():
+                            cur = merged.get(evt, [])
+                            has_obs = any("otel/hooks" in h.get("command", "") for h in cur)
+                            if not has_obs:
+                                merged[evt] = cur + handlers
+                        agent_data["hooks"] = merged
                         agent_file.write_text(json.dumps(agent_data, indent=2) + "\n")
                         injected_count += 1
                     except (json.JSONDecodeError, OSError) as e:
@@ -947,3 +954,46 @@ def register_scan(app: typer.Typer):
                     rprint(f"[dim]Hooks endpoint: {kiro_hooks_url}[/dim]")
                 else:
                     rprint(f"\n[dim]Kiro agent hooks already configured -> {kiro_hooks_url}[/dim]")
+
+            # ── Global IDE-format hooks in ~/.kiro/hooks/ ─────────
+            # These fire for ALL Kiro sessions (including agentless chat)
+            kiro_global_hooks_dir = Path.home() / ".kiro" / "hooks"
+            kiro_global_hooks_dir.mkdir(parents=True, exist_ok=True)
+
+            global_hook_cmd = _kiro_hook_cmd("global", "")
+            global_stop_cmd = _kiro_stop_cmd("global", "")
+
+            _ide_hook_defs = [
+                ("observal-prompt-submit", "promptSubmit", global_hook_cmd),
+                ("observal-pre-tool-use", "preToolUse", global_hook_cmd),
+                ("observal-post-tool-use", "postToolUse", global_hook_cmd),
+                ("observal-agent-stop", "agentStop", global_stop_cmd),
+            ]
+
+            global_injected = 0
+            for hook_id, event_type, cmd in _ide_hook_defs:
+                hook_file = kiro_global_hooks_dir / f"{hook_id}.json"
+                hook_json = {
+                    "id": hook_id,
+                    "name": f"Observal: {event_type}",
+                    "comment": "Auto-injected by Observal for telemetry collection",
+                    "when": {"type": event_type},
+                    "then": {"type": "runCommand", "command": cmd},
+                }
+                # Only write if missing or stale (different URL)
+                if hook_file.exists():
+                    try:
+                        existing_hook = json.loads(hook_file.read_text())
+                        if kiro_hooks_url in existing_hook.get("then", {}).get("command", ""):
+                            continue
+                    except (json.JSONDecodeError, OSError):
+                        pass
+                    _backup_config(hook_file)
+                hook_file.write_text(json.dumps(hook_json, indent=2) + "\n")
+                global_injected += 1
+
+            if global_injected:
+                rprint(f"[green]Installed {global_injected} global Kiro hooks in ~/.kiro/hooks/[/green]")
+                rprint("[dim]These capture all Kiro sessions, including agentless chat.[/dim]")
+            else:
+                rprint("[dim]Global Kiro hooks already configured.[/dim]")

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -81,6 +81,17 @@ def main():
     # native fields due to JSON duplicate-key semantics — last key wins).
     payload.setdefault("service_name", "kiro")
 
+    # Inject user_id from Observal config if not already present
+    if not payload.get("user_id"):
+        try:
+            cfg_path = Path.home() / ".observal" / "config.json"
+            if cfg_path.exists():
+                cfg = json.loads(cfg_path.read_text())
+                if cfg.get("user_id"):
+                    payload["user_id"] = cfg["user_id"]
+        except Exception:
+            pass
+
     # Inject metadata from CLI args (used on Windows where sed is unavailable)
     if agent_name:
         payload.setdefault("agent_name", agent_name)

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -161,6 +161,19 @@ def main():
 
     payload.setdefault("service_name", "kiro")
 
+    # Inject user_id from Observal config if not already present
+    if not payload.get("user_id"):
+        try:
+            cfg_path = Path.home() / ".observal" / "config.json"
+            if cfg_path.exists():
+                import json as _json
+
+                cfg = _json.loads(cfg_path.read_text())
+                if cfg.get("user_id"):
+                    payload["user_id"] = cfg["user_id"]
+        except Exception:
+            pass
+
     # Inject metadata from CLI args (used on Windows where sed is unavailable)
     if agent_name:
         payload.setdefault("agent_name", agent_name)

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,54 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159, upload-time = "2025-11-24T23:25:36.443Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157, upload-time = "2025-11-24T23:25:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051, upload-time = "2025-11-24T23:25:39.461Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640, upload-time = "2025-11-24T23:25:41.512Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050, upload-time = "2025-11-24T23:25:43.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574, upload-time = "2025-11-24T23:25:44.942Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076, upload-time = "2025-11-24T23:25:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980, upload-time = "2025-11-24T23:25:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -267,6 +315,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.152.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/b1/c32bcddb9aab9e3abc700f1f56faf14e7655c64a16ca47701a57362276ea/hypothesis-6.152.1.tar.gz", hash = "sha256:4f4ed934eee295dd84ee97592477d23e8dc03e9f12ae0ee30a4e7c9ef3fca3b0", size = 465029, upload-time = "2026-04-14T22:29:24.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl", hash = "sha256:40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e", size = 530752, upload-time = "2026-04-14T22:29:20.893Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -310,8 +370,10 @@ name = "observal"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "asyncpg" },
     { name = "docker" },
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "rich" },
@@ -331,8 +393,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "docker", specifier = ">=7.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "hypothesis" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
@@ -699,6 +763,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes 5 Kiro CLI telemetry bugs that prevented traces from showing up in the Observal dashboard.

## Bugs Fixed

### Bug #1: No traces for agentless Kiro chat
**Problem:** `kiro-cli chat` without an agent produced zero telemetry because hooks only existed in per-agent JSON files.
**Fix:** `observal scan` now writes 4 global IDE-format hook JSON files to `~/.kiro/hooks/` (promptSubmit, preToolUse, postToolUse, agentStop). These fire for ALL Kiro sessions.

### Bug #2: Pre-existing agent hooks wiped on scan
**Problem:** `agent_data["hooks"] = _kiro_hooks_block(...)` replaced all existing hooks, destroying user-configured hooks.
**Fix:** Changed to merge-based injection — iterates each event, checks if Observal hook already present, appends only if missing.

### Bug #3: `observal scan` crashes on null model_name
**Problem:** `data.get("model", "")` returns `None` when Kiro agent JSON has `"model": null` (key exists, value is null). This caused a Pydantic validation error on the server.
**Fix:** Changed to `data.get("model") or ""` pattern in both the agent discovery and hook injection paths.

### Bug #4: Missing session metadata (user, model) in traces UI
**Problem:** Hook scripts didn't inject `user_id`, so the User column in the traces dashboard was always empty.
**Fix:** Both `kiro_hook.py` and `kiro_stop_hook.py` now read `user_id` from `~/.observal/config.json` and inject it into the payload if not already present via sed prefix.

### Bug #5: No Kiro auto-detection during `observal auth login`
**Problem:** Claude Code was auto-configured on login via `_configure_claude_code()`, but Kiro had no equivalent — users had to manually run `observal scan`.
**Fix:** Added `_configure_kiro()` function called after every login/register path. Detects `~/.kiro` or `kiro-cli` binary, prompts user, injects both per-agent hooks and global IDE hooks.

## Files Changed
- `observal_cli/cmd_scan.py` — Bugs #1, #2, #3
- `observal_cli/cmd_auth.py` — Bug #5
- `observal_cli/hooks/kiro_hook.py` — Bug #4
- `observal_cli/hooks/kiro_stop_hook.py` — Bug #4

## Testing
- All 25 Kiro scan tests pass
- 1217/1237 tests pass (20 failures are pre-existing Windows-specific issues unrelated to this PR)
- Docker stack rebuilt and verified
