### PR TITLE
fix(auth): handle Redis unavailability gracefully in auth endpoints

### DIFF
--- a/observal-server/api/ratelimit.py
+++ b/observal-server/api/ratelimit.py
@@ -6,5 +6,9 @@ from config import settings
 limiter = Limiter(
     key_func=get_remote_address,
     storage_uri=settings.REDIS_URL or "memory://",
+    storage_options={
+        "socket_connect_timeout": settings.REDIS_SOCKET_TIMEOUT,
+        "socket_timeout": settings.REDIS_SOCKET_TIMEOUT,
+    },
     swallow_errors=True,
 )

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/observal"
     CLICKHOUSE_URL: str = "clickhouse://localhost:8123/observal"
     REDIS_URL: str = "redis://localhost:6379"
+    REDIS_SOCKET_TIMEOUT: float = 2.0
     SECRET_KEY: str = "change-me-to-a-random-string"
     EVAL_MODEL_URL: str = ""  # OpenAI-compatible endpoint (e.g., https://bedrock-runtime.us-east-1.amazonaws.com)
     EVAL_MODEL_API_KEY: str = ""  # API key or empty for AWS credential chain

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from redis.exceptions import RedisError
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import func, select
@@ -114,6 +115,26 @@ app = FastAPI(
 # Rate limiting
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+
+@app.middleware("http")
+async def _set_rate_limit_defaults(request: Request, call_next):
+    """Workaround for slowapi 0.1.9 bug: when swallow_errors swallows a Redis
+    failure, request.state.view_rate_limit is never set, causing an
+    AttributeError in the post-response header injection."""
+    request.state.view_rate_limit = None
+    return await call_next(request)
+
+
+logger = logging.getLogger("observal")
+
+
+async def _redis_error_handler(request: Request, exc: RedisError):
+    logger.error("Unhandled RedisError on %s %s: %s", request.method, request.url.path, exc)
+    return JSONResponse(status_code=503, content={"detail": "Service temporarily unavailable"})
+
+
+app.add_exception_handler(RedisError, _redis_error_handler)
 
 # Add SessionMiddleware for Authlib (OAuth state)
 app.add_middleware(

--- a/observal-server/services/redis.py
+++ b/observal-server/services/redis.py
@@ -15,7 +15,12 @@ _pool: aioredis.ConnectionPool | None = None
 def get_pool() -> aioredis.ConnectionPool:
     global _pool
     if _pool is None:
-        _pool = aioredis.ConnectionPool.from_url(settings.REDIS_URL, decode_responses=True)
+        _pool = aioredis.ConnectionPool.from_url(
+            settings.REDIS_URL,
+            decode_responses=True,
+            socket_connect_timeout=settings.REDIS_SOCKET_TIMEOUT,
+            socket_timeout=settings.REDIS_SOCKET_TIMEOUT,
+        )
     return _pool
 
 

--- a/tests/test_auth_redis_down.py
+++ b/tests/test_auth_redis_down.py
@@ -1,0 +1,154 @@
+"""Tests for auth endpoint resilience when Redis is unavailable (issue #398).
+
+Validates that:
+- Login fails open (returns tokens) when Redis is down
+- Token refresh returns 503 when Redis is down
+- Token revoke returns 503 when Redis is down
+- The global RedisError handler catches unhandled errors as 503
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+
+def _make_mock_user():
+    from models.user import UserRole
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "test@example.com"
+    user.username = "testuser"
+    user.name = "Test User"
+    user.role = UserRole.user
+    user.verify_password = MagicMock(return_value=True)
+    return user
+
+
+def _make_broken_redis():
+    r = MagicMock()
+    r.setex = AsyncMock(side_effect=RedisConnectionError("Connection refused"))
+    r.get = AsyncMock(side_effect=RedisConnectionError("Connection refused"))
+    r.delete = AsyncMock(side_effect=RedisConnectionError("Connection refused"))
+    return r
+
+
+class TestLoginRedisDown:
+    """POST /api/v1/auth/login should fail-open when Redis is unreachable."""
+
+    @pytest.mark.asyncio
+    async def test_login_succeeds_when_redis_down(self):
+        from api.deps import get_db
+        from main import app
+
+        mock_user = _make_mock_user()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_user
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        async def _mock_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _mock_get_db
+        try:
+            with patch("api.routes.auth.get_redis", return_value=_make_broken_redis()):
+                from httpx import ASGITransport, AsyncClient
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app, raise_app_exceptions=False),
+                    base_url="http://test",
+                ) as client:
+                    resp = await client.post(
+                        "/api/v1/auth/login",
+                        json={"email": "test@example.com", "password": "password"},
+                    )
+
+            assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            assert "access_token" in body
+            assert "refresh_token" in body
+        finally:
+            app.dependency_overrides.clear()
+
+
+class TestRefreshRedisDown:
+    """POST /api/v1/auth/token/refresh should return 503 when Redis is unreachable."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_returns_503_when_redis_down(self):
+        from services.jwt_service import create_refresh_token
+
+        mock_user = _make_mock_user()
+        refresh_tok, _ = create_refresh_token(mock_user.id, mock_user.role)
+
+        from httpx import ASGITransport, AsyncClient
+
+        from main import app
+
+        with patch("api.routes.auth.get_redis", return_value=_make_broken_redis()):
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/auth/token/refresh",
+                    json={"refresh_token": refresh_tok},
+                )
+
+        assert resp.status_code == 503, f"Expected 503, got {resp.status_code}: {resp.text}"
+        assert resp.json()["detail"] == "Service temporarily unavailable"
+
+
+class TestRevokeRedisDown:
+    """POST /api/v1/auth/token/revoke should return 503 when Redis is unreachable."""
+
+    @pytest.mark.asyncio
+    async def test_revoke_returns_503_when_redis_down(self):
+        from services.jwt_service import create_refresh_token
+
+        mock_user = _make_mock_user()
+        refresh_tok, _ = create_refresh_token(mock_user.id, mock_user.role)
+
+        from httpx import ASGITransport, AsyncClient
+
+        from main import app
+
+        with patch("api.routes.auth.get_redis", return_value=_make_broken_redis()):
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/auth/token/revoke",
+                    json={"refresh_token": refresh_tok},
+                )
+
+        assert resp.status_code == 503, f"Expected 503, got {resp.status_code}: {resp.text}"
+        assert resp.json()["detail"] == "Service temporarily unavailable"
+
+
+class TestGlobalRedisErrorHandler:
+    """Any unhandled RedisError should be caught by the global handler and return 503."""
+
+    @pytest.mark.asyncio
+    async def test_unhandled_redis_error_returns_503(self):
+        from main import app
+
+        @app.get("/_test_redis_error")
+        async def _trigger():
+            raise RedisConnectionError("simulated")
+
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/_test_redis_error")
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Service temporarily unavailable"


### PR DESCRIPTION

Closes #398

## Summary
- Login now fails open (returns tokens) when Redis is down instead of 500
- Refresh/Revoke return 503 with `{"detail": "Service temporarily unavailable"}` instead of 500
- Responses return within ~2s instead of hanging indefinitely

## Root Causes Fixed
- Redis connection pool had no socket timeouts — connections hung until OS TCP timeout (75-120s)
- slowapi rate limiter's internal Redis client also had no timeouts, blocking the event loop
- slowapi 0.1.9 bug: `swallow_errors=True` swallows Redis error but never sets `request.state.view_rate_limit`, causing AttributeError → 500

## Changes
- `config.py` — Added `REDIS_SOCKET_TIMEOUT` setting (default 2s)
- `services/redis.py` — Added `socket_connect_timeout` and `socket_timeout` to connection pool
- `api/ratelimit.py` — Added `storage_options` with timeouts to slowapi Limiter
- `main.py` — Added middleware to pre-set `view_rate_limit` (slowapi workaround) + global `RedisError` → 503 handler
- `tests/test_auth_redis_down.py` — 4 new tests covering all scenarios

## Test Plan
- [x] `pytest tests/test_auth_redis_down.py` — 4 pass
- [x] `pytest tests/test_resilience.py tests/test_health.py` — 21 pass, no regressions
- [x] `ruff check` — clean
- [x] Manual: `docker stop redis` → login returns 200, refresh/revoke return 503

