### PR TITLE
feat: add observal migrate telemetry commands for ClickHouse deep copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
             --python ${{ matrix.python-version }} \
             --with asyncpg \
             --with hypothesis \
+            --with pyarrow \
             pytest ../tests/ -q
 
 # ── Job 3: Next.js lint + typecheck ───────────────────────────────────────────

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import os
+import re
 import shutil
 import tarfile
 import tempfile
@@ -24,6 +26,8 @@ from rich import print as rprint
 
 from observal_cli import client
 from observal_cli.render import spinner
+
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 # ── Constants ────────────────────────────────────────────
 
@@ -90,6 +94,27 @@ JSONB_COLUMNS: dict[str, list[str]] = {
     "exporter_configs": ["config"],
 }
 
+# ── Phase 2: ClickHouse telemetry constants ──────────────
+
+CLICKHOUSE_TABLES: list[dict[str, str | list[str]]] = [
+    {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
+    {"name": "spans", "engine": "replacing", "time_col": "start_time", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
+    {"name": "scores", "engine": "replacing", "time_col": "timestamp", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
+    {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["actor_id"]},
+    {"name": "mcp_tool_calls", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["mcp_server_id", "user_id"]},
+    {"name": "agent_interactions", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["agent_id", "user_id"]},
+]
+
+FK_PG_TABLE_MAP: dict[str, str] = {
+    "agent_id": "agents",
+    "mcp_id": "mcp_listings",
+    "mcp_server_id": "mcp_listings",
+    "user_id": "users",
+    "actor_id": "users",
+}
+
+EPOCH_SENTINELS: set[str | None] = {None, "", "1970-01-01 00:00:00.000", "1970-01-01 00:00:00"}
+
 
 # ── PGEncoder ────────────────────────────────────────────
 
@@ -145,6 +170,34 @@ class ValidationResult:
     cross_db_results: dict[str, tuple[int, int]] | None
 
 
+@dataclass
+class TelemetryExportResult:
+    output_dir: str
+    migration_id: str
+    table_results: dict[str, dict]
+    total_rows: int
+    total_size_bytes: int
+    duration_seconds: float
+
+
+@dataclass
+class TelemetryImportResult:
+    migration_id: str
+    tables_imported: int
+    tables_skipped: list[str]
+    rows_imported: dict[str, int]
+    duration_seconds: float
+    warnings: list[str]
+
+
+@dataclass
+class TelemetryValidationResult:
+    checksums_valid: bool
+    checksum_results: dict[str, bool]
+    fk_results: dict[str, list[str]] | None
+    row_count_results: dict[str, tuple[int, int]] | None
+
+
 # ── Helper functions ─────────────────────────────────────
 
 
@@ -184,6 +237,18 @@ def _sha256_file(path: Path) -> str:
         for chunk in iter(lambda: f.read(8192), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def _parse_clickhouse_url(url: str) -> tuple[str, str, str, str]:
+    """Parse clickhouse://user:pass@host:port/db -> (http_url, db, user, password)."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url.replace("clickhouse://", "http://"))
+    http_url = f"http://{parsed.hostname}:{parsed.port or 8123}"
+    db = (parsed.path or "/").strip("/") or "default"
+    user = parsed.username or "default"
+    password = parsed.password or ""
+    return http_url, db, user, password
 
 
 # ── Async helpers ────────────────────────────────────────
@@ -340,6 +405,183 @@ async def _insert_table(
         skipped += sk
 
     return inserted, skipped
+
+
+# ── Phase 2: ClickHouse HTTP helpers ─────────────────────
+
+
+async def _ch_query(
+    http_url: str,
+    db: str,
+    user: str,
+    password: str,
+    sql: str,
+    *,
+    stream_to: Path | None = None,
+    client: object | None = None,
+) -> object:
+    """Execute a ClickHouse query via HTTP.
+
+    If stream_to is provided, streams response body to disk.
+    An optional pre-existing client avoids creating new connections per call.
+    """
+    import httpx as _httpx
+
+    params = {"database": db, "user": user, "password": password}
+    owns_client = client is None
+    if owns_client:
+        client = _httpx.AsyncClient(timeout=_httpx.Timeout(300.0, connect=10.0))
+    try:
+        if stream_to:
+            async with client.stream("POST", http_url, content=sql, params=params) as resp:
+                resp.raise_for_status()
+                with open(stream_to, "wb") as f:
+                    async for chunk in resp.aiter_bytes(chunk_size=65536):
+                        f.write(chunk)
+                return resp
+        else:
+            resp = await client.post(http_url, content=sql, params=params)
+            resp.raise_for_status()
+            return resp
+    except _httpx.HTTPStatusError as exc:
+        rprint(f"[red]ClickHouse returned HTTP {exc.response.status_code}[/red]")
+        rprint(f"[dim]{exc.response.text[:500]}[/dim]")
+        raise typer.Exit(1)
+    except _httpx.RequestError:
+        rprint("[red]ClickHouse unreachable.[/red]")
+        raise typer.Exit(1)
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+async def _ch_import(
+    http_url: str,
+    db: str,
+    user: str,
+    password: str,
+    table: str,
+    parquet_path: Path,
+) -> None:
+    """Import a Parquet file into ClickHouse via INSERT ... FORMAT Parquet."""
+    import httpx as _httpx
+
+    sql_prefix = f"INSERT INTO {table} FORMAT Parquet"
+    params = {"database": db, "user": user, "password": password, "query": sql_prefix}
+
+    async def _file_stream():
+        with open(parquet_path, "rb") as f:
+            while chunk := f.read(65536):
+                yield chunk
+
+    try:
+        async with _httpx.AsyncClient(timeout=_httpx.Timeout(600.0, connect=10.0)) as c:
+            resp = await c.post(http_url, content=_file_stream(), params=params)
+            resp.raise_for_status()
+    except _httpx.HTTPStatusError as exc:
+        rprint(f"[red]ClickHouse returned HTTP {exc.response.status_code}[/red]")
+        rprint(f"[dim]{exc.response.text[:500]}[/dim]")
+        raise typer.Exit(1)
+    except _httpx.RequestError:
+        rprint("[red]ClickHouse unreachable.[/red]")
+        raise typer.Exit(1)
+
+
+async def _ch_existing_tables(
+    http_url: str,
+    db: str,
+    user: str,
+    password: str,
+) -> set[str]:
+    """Query system.tables to discover which tables exist on target ClickHouse."""
+    sql = f"SELECT name FROM system.tables WHERE database = '{db}' FORMAT JSON"
+    resp = await _ch_query(http_url, db, user, password, sql)
+    return {r["name"] for r in resp.json().get("data", [])}
+
+
+async def _ch_partition_has_data(
+    http_url: str,
+    db: str,
+    user: str,
+    password: str,
+    table_cfg: dict,
+    yyyymm: int,
+) -> bool:
+    """Check if a MergeTree table already has data in a given month partition."""
+    name = table_cfg["name"]
+    time_col = table_cfg["time_col"]
+    sql = f"SELECT 1 AS has_data FROM {name} WHERE toYYYYMM({time_col}) = {yyyymm} LIMIT 1 FORMAT JSON"
+    resp = await _ch_query(http_url, db, user, password, sql)
+    return len(resp.json().get("data", [])) > 0
+
+
+# ── Phase 2: Query builders and utilities ────────────────
+
+
+def _build_ch_export_query(table_cfg: dict, yyyymm: int) -> str:
+    """Build a ClickHouse export query for a monthly partition."""
+    name = table_cfg["name"]
+    time_col = table_cfg["time_col"]
+    if table_cfg["engine"] == "replacing":
+        return f"SELECT * FROM {name} FINAL WHERE is_deleted = 0 AND toYYYYMM({time_col}) = {yyyymm} FORMAT Parquet"
+    return f"SELECT * FROM {name} WHERE toYYYYMM({time_col}) = {yyyymm} FORMAT Parquet"
+
+
+def _build_ch_count_query(table_cfg: dict, yyyymm: int) -> str:
+    """Build a row count query for a monthly partition."""
+    name = table_cfg["name"]
+    time_col = table_cfg["time_col"]
+    if table_cfg["engine"] == "replacing":
+        return (
+            f"SELECT count() AS cnt FROM {name} FINAL "
+            f"WHERE is_deleted = 0 AND toYYYYMM({time_col}) = {yyyymm} "
+            f"FORMAT JSON"
+        )
+    return f"SELECT count() AS cnt FROM {name} WHERE toYYYYMM({time_col}) = {yyyymm} FORMAT JSON"
+
+
+def _read_count(resp: object) -> int:
+    """Parse a count query response."""
+    return int(resp.json().get("data", [{}])[0].get("cnt", 0))
+
+
+def _build_ch_time_range_query(table_cfg: dict) -> str:
+    """Build a time range query to discover partition months."""
+    name = table_cfg["name"]
+    time_col = table_cfg["time_col"]
+    if table_cfg["engine"] == "replacing":
+        return (
+            f"SELECT min({time_col}) AS min_t, max({time_col}) AS max_t "
+            f"FROM {name} FINAL WHERE is_deleted = 0 FORMAT JSON"
+        )
+    return f"SELECT min({time_col}) AS min_t, max({time_col}) AS max_t FROM {name} FORMAT JSON"
+
+
+def _month_range(min_dt: datetime, max_dt: datetime) -> list[int]:
+    """Generate list of YYYYMM integers from min to max datetime, inclusive."""
+    months: list[int] = []
+    current = min_dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    end = max_dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    while current <= end:
+        months.append(current.year * 100 + current.month)
+        if current.month == 12:
+            current = current.replace(year=current.year + 1, month=1)
+        else:
+            current = current.replace(month=current.month + 1)
+    return months
+
+
+def _is_empty_parquet(path: Path) -> bool:
+    """Return True if the file is empty or a Parquet file with zero rows."""
+    if path.stat().st_size == 0:
+        return True
+    try:
+        import pyarrow.parquet as pq
+
+        meta = pq.read_metadata(path)
+        return meta.num_rows == 0
+    except Exception:
+        return True
 
 
 async def _import_archive(db_url: str, archive_path: Path) -> ImportResult:
@@ -606,6 +848,11 @@ async def _export_database(db_url: str, output_path: Path) -> ExportResult:
         # Ensure output parent directory exists
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
+        # Write sidecar manifest for Phase 2 consumption
+        sidecar_stem = output_path.name.removesuffix(".tar.gz").removesuffix(".tgz")
+        sidecar_path = output_path.parent / f"{sidecar_stem}.manifest.json"
+        sidecar_path.write_text(json.dumps(migration_manifest, indent=2) + "\n")
+
         # Pack archive
         with tarfile.open(output_path, "w:gz") as tar:
             tar.add(str(manifest_path), arcname="manifest.json")
@@ -628,6 +875,402 @@ async def _export_database(db_url: str, output_path: Path) -> ExportResult:
 
     finally:
         shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+# ── Phase 2: Core async functions ────────────────────────
+
+
+async def _export_telemetry(
+    clickhouse_url: str,
+    manifest_path: Path,
+    output_dir: Path,
+) -> TelemetryExportResult:
+    """Export ClickHouse telemetry tables to monthly Parquet files."""
+    import httpx as _httpx
+
+    t0 = time.monotonic()
+
+    # Phase gate: read Phase 1 manifest
+    if not manifest_path.exists():
+        rprint(f"[red]Phase 1 manifest not found:[/red] {manifest_path}")
+        raise typer.Exit(1)
+    p1_manifest = json.loads(manifest_path.read_text())
+    if not p1_manifest.get("phase1_completed_at"):
+        rprint("[red]Phase 1 has not completed.[/red]")
+        rprint("[dim]  Run 'observal migrate export' and 'observal migrate import' first.[/dim]")
+        raise typer.Exit(1)
+    migration_id = p1_manifest["migration_id"]
+
+    # Record cutoff before any queries
+    export_time_cutoff = datetime.now(UTC).isoformat()
+
+    # Parse ClickHouse URL
+    http_url, db, user, password = _parse_clickhouse_url(clickhouse_url)
+
+    # Health check
+    try:
+        await _ch_query(http_url, db, user, password, "SELECT 1")
+    except typer.Exit:
+        raise
+    except Exception:
+        rprint("[red]ClickHouse health check failed.[/red]")
+        raise typer.Exit(1)
+
+    # Create output directory
+    if output_dir.exists() and any(output_dir.iterdir()):
+        rprint(f"[red]Output directory is not empty:[/red] {output_dir}")
+        raise typer.Exit(1)
+    os.makedirs(output_dir, mode=0o700, exist_ok=True)
+
+    dir_created = True
+    try:
+        table_meta: dict[str, dict] = {}
+        total_rows = 0
+        total_size = 0
+
+        async with _httpx.AsyncClient(timeout=_httpx.Timeout(300.0, connect=10.0)) as client:
+            for table_cfg in CLICKHOUSE_TABLES:
+                table_name = table_cfg["name"]
+
+                # Query time range
+                tr_sql = _build_ch_time_range_query(table_cfg)
+                tr_resp = await _ch_query(http_url, db, user, password, tr_sql, client=client)
+                tr_data = tr_resp.json().get("data", [{}])[0]
+                min_t = tr_data.get("min_t")
+                max_t = tr_data.get("max_t")
+
+                if min_t in EPOCH_SENTINELS or max_t in EPOCH_SENTINELS:
+                    table_meta[table_name] = {"files": [], "row_count": 0, "checksum": {}, "time_range": None}
+                    rprint(f"  [dim]{table_name}: empty[/dim]")
+                    continue
+
+                # Parse time range
+                min_dt = datetime.fromisoformat(str(min_t).replace(" ", "T"))
+                max_dt = datetime.fromisoformat(str(max_t).replace(" ", "T"))
+                months = _month_range(min_dt, max_dt)
+
+                files: list[str] = []
+                checksums: dict[str, str] = {}
+                table_row_count = 0
+
+                for yyyymm in months:
+                    filename = f"{table_name}_{yyyymm // 100}-{yyyymm % 100:02d}.parquet"
+                    filepath = output_dir / filename
+
+                    # Get row count first for progress display
+                    count_sql = _build_ch_count_query(table_cfg, yyyymm)
+                    count_resp = await _ch_query(http_url, db, user, password, count_sql, client=client)
+                    partition_count = _read_count(count_resp)
+
+                    if partition_count == 0:
+                        continue
+
+                    rprint(f"  Exporting {filename} ({partition_count:,} rows)...")
+
+                    # Stream Parquet to disk
+                    export_sql = _build_ch_export_query(table_cfg, yyyymm)
+                    await _ch_query(http_url, db, user, password, export_sql, stream_to=filepath, client=client)
+
+                    # Check if file is actually empty (edge case)
+                    if _is_empty_parquet(filepath):
+                        filepath.unlink(missing_ok=True)
+                        continue
+
+                    checksum = _sha256_file(filepath)
+                    files.append(filename)
+                    checksums[filename] = checksum
+                    table_row_count += partition_count
+                    total_size += filepath.stat().st_size
+
+                total_rows += table_row_count
+                table_meta[table_name] = {
+                    "files": files,
+                    "row_count": table_row_count,
+                    "checksum": checksums,
+                    "time_range": {"min": str(min_t), "max": str(max_t)} if files else None,
+                }
+                rprint(f"  [green]✓[/green] {table_name}: {table_row_count:,} rows in {len(files)} file(s)")
+
+        # Write telemetry manifest
+        ch_url_hash = hashlib.sha256(clickhouse_url.encode()).hexdigest()
+        telemetry_manifest = {
+            "migration_id": migration_id,
+            "phase": "deep_copy",
+            "phase_status": "export_complete",
+            "export_completed_at": datetime.now(UTC).isoformat(),
+            "export_time_cutoff": export_time_cutoff,
+            "source_clickhouse_url_hash": ch_url_hash,
+            "tables": table_meta,
+            "fk_validation": {
+                "orphaned_agent_ids": [],
+                "orphaned_agent_ids_truncated": False,
+                "orphaned_mcp_ids": [],
+                "orphaned_mcp_ids_truncated": False,
+                "orphaned_user_ids": [],
+                "orphaned_user_ids_truncated": False,
+                "validated_at": None,
+            },
+        }
+        manifest_out = output_dir / "telemetry_manifest.json"
+        manifest_out.write_text(json.dumps(telemetry_manifest, indent=2) + "\n")
+
+        elapsed = time.monotonic() - t0
+        return TelemetryExportResult(
+            output_dir=str(output_dir),
+            migration_id=migration_id,
+            table_results=table_meta,
+            total_rows=total_rows,
+            total_size_bytes=total_size,
+            duration_seconds=round(elapsed, 2),
+        )
+
+    except Exception:
+        # Clean up on failure only if we created the directory
+        if dir_created and output_dir.exists():
+            shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+
+
+async def _import_telemetry(
+    clickhouse_url: str,
+    input_dir: Path,
+) -> TelemetryImportResult:
+    """Import Parquet files into target ClickHouse."""
+    t0 = time.monotonic()
+    warnings: list[str] = []
+
+    # Read telemetry manifest
+    manifest_path = input_dir / "telemetry_manifest.json"
+    if not manifest_path.exists():
+        rprint("[red]Telemetry manifest not found in input directory.[/red]")
+        raise typer.Exit(1)
+    manifest = json.loads(manifest_path.read_text())
+    migration_id = manifest["migration_id"]
+
+    # Verify checksums before any imports
+    failed: list[str] = []
+    for table_cfg in CLICKHOUSE_TABLES:
+        table_name = table_cfg["name"]
+        table_info = manifest["tables"].get(table_name, {})
+        for filename, expected_hash in table_info.get("checksum", {}).items():
+            filepath = input_dir / filename
+            if not filepath.exists():
+                failed.append(f"{filename} (missing)")
+                continue
+            actual = _sha256_file(filepath)
+            if actual != expected_hash:
+                failed.append(filename)
+
+    if failed:
+        rprint("[red]Checksum verification failed:[/red]")
+        for f in failed:
+            rprint(f"  [red]✗[/red] {f}")
+        raise typer.Exit(1)
+
+    # Connect and discover existing tables
+    http_url, db, user, password = _parse_clickhouse_url(clickhouse_url)
+    try:
+        await _ch_query(http_url, db, user, password, "SELECT 1")
+    except typer.Exit:
+        raise
+    except Exception:
+        rprint("[red]ClickHouse health check failed.[/red]")
+        raise typer.Exit(1)
+
+    existing = await _ch_existing_tables(http_url, db, user, password)
+    rows_imported: dict[str, int] = {}
+    tables_skipped: list[str] = []
+
+    for table_cfg in CLICKHOUSE_TABLES:
+        table_name = table_cfg["name"]
+        table_info = manifest["tables"].get(table_name, {})
+        files = table_info.get("files", [])
+
+        if not files:
+            rows_imported[table_name] = 0
+            continue
+
+        if table_name not in existing:
+            rprint(f"  [yellow]Skipping {table_name} (table does not exist on target)[/yellow]")
+            tables_skipped.append(table_name)
+            rows_imported[table_name] = 0
+            continue
+
+        for filename in files:
+            filepath = input_dir / filename
+
+            # MergeTree idempotency: check if partition already has data
+            if table_cfg["engine"] == "mergetree":
+                # Extract YYYYMM from filename like "traces_2025-01.parquet"
+                parts = filename.replace(".parquet", "").split("_")
+                date_part = parts[-1]  # "2025-01"
+                year, month = date_part.split("-")
+                yyyymm = int(year) * 100 + int(month)
+                if await _ch_partition_has_data(http_url, db, user, password, table_cfg, yyyymm):
+                    rprint(f"  [dim]Skipping {filename} (partition already has data)[/dim]")
+                    continue
+
+            rprint(f"  Importing {filename}...")
+            await _ch_import(http_url, db, user, password, table_name, filepath)
+
+        rows_imported[table_name] = table_info.get("row_count", 0)
+        rprint(f"  [green]✓[/green] {table_name}: {rows_imported[table_name]:,} rows")
+
+    elapsed = time.monotonic() - t0
+    return TelemetryImportResult(
+        migration_id=migration_id,
+        tables_imported=len([t for t in rows_imported if rows_imported[t] > 0]),
+        tables_skipped=tables_skipped,
+        rows_imported=rows_imported,
+        duration_seconds=round(elapsed, 2),
+        warnings=warnings,
+    )
+
+
+async def _validate_fk_references(
+    parquet_dir: Path,
+    manifest: dict,
+    db_url: str,
+) -> dict[str, list[str] | bool]:
+    """Read FK columns from Parquet files and check against PostgreSQL."""
+    import pyarrow.compute as pc
+    import pyarrow.parquet as pq
+
+    fk_values: dict[str, set[str]] = {
+        "agent_id": set(),
+        "mcp_id": set(),
+        "mcp_server_id": set(),
+        "user_id": set(),
+        "actor_id": set(),
+    }
+
+    for table_cfg in CLICKHOUSE_TABLES:
+        table_name = table_cfg["name"]
+        fk_cols = table_cfg["fk_cols"]
+        files = manifest["tables"].get(table_name, {}).get("files", [])
+        for filename in files:
+            filepath = parquet_dir / filename
+            if not filepath.exists():
+                continue
+            cols_to_read = [c for c in fk_cols if c in fk_values]
+            if not cols_to_read:
+                continue
+            table = pq.read_table(filepath, columns=cols_to_read)
+            for col in cols_to_read:
+                if col in table.column_names:
+                    unique = pc.unique(table.column(col))
+                    for val in unique.to_pylist():
+                        if val is not None and val != "":
+                            fk_values[col].add(str(val))
+
+    # Merge aliases
+    fk_values["mcp_id"] |= fk_values.pop("mcp_server_id", set())
+    fk_values["user_id"] |= fk_values.pop("actor_id", set())
+
+    # Filter to valid UUIDs only — ClickHouse stores these as String,
+    # so non-UUID values like "filesystem" or "default" can appear.
+    _uuid_re = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+    for key in list(fk_values):
+        fk_values[key] = {v for v in fk_values[key] if _uuid_re.match(v)}
+
+    # Check against PostgreSQL
+    conn = await _connect(db_url)
+    try:
+        orphaned: dict[str, list[str] | bool] = {}
+        for fk_col, pg_table in [("agent_id", "agents"), ("mcp_id", "mcp_listings"), ("user_id", "users")]:
+            ids = fk_values.get(fk_col, set())
+            if not ids:
+                orphaned[f"orphaned_{fk_col}s"] = []
+                orphaned[f"orphaned_{fk_col}s_truncated"] = False
+                continue
+            existing = set()
+            id_list = list(ids)
+            # Batch in chunks of 1000 to avoid query size limits
+            for i in range(0, len(id_list), 1000):
+                batch = id_list[i : i + 1000]
+                rows = await conn.fetch(
+                    f"SELECT id::text FROM {pg_table} WHERE id = ANY($1::uuid[])",
+                    batch,
+                )
+                existing.update(row["id"] for row in rows)
+            missing = sorted(ids - existing)
+            orphaned[f"orphaned_{fk_col}s"] = missing[:10_000]
+            orphaned[f"orphaned_{fk_col}s_truncated"] = len(missing) > 10_000
+        return orphaned
+    finally:
+        await conn.close()
+
+
+async def _validate_telemetry(
+    input_dir: Path,
+    clickhouse_url: str | None,
+    target_db_url: str | None,
+) -> TelemetryValidationResult:
+    """Validate telemetry Parquet files: checksums, row counts, FK references."""
+    manifest_path = input_dir / "telemetry_manifest.json"
+    if not manifest_path.exists():
+        rprint("[red]Telemetry manifest not found.[/red]")
+        raise typer.Exit(1)
+    manifest = json.loads(manifest_path.read_text())
+
+    # Checksum verification
+    checksum_results: dict[str, bool] = {}
+    for table_cfg in CLICKHOUSE_TABLES:
+        table_name = table_cfg["name"]
+        table_info = manifest["tables"].get(table_name, {})
+        for filename, expected in table_info.get("checksum", {}).items():
+            filepath = input_dir / filename
+            if not filepath.exists():
+                checksum_results[filename] = False
+                continue
+            actual = _sha256_file(filepath)
+            checksum_results[filename] = actual == expected
+
+    checksums_valid = all(checksum_results.values()) if checksum_results else True
+
+    # Optional row count comparison
+    row_count_results: dict[str, tuple[int, int]] | None = None
+    if clickhouse_url:
+        http_url, db, user, password = _parse_clickhouse_url(clickhouse_url)
+        try:
+            await _ch_query(http_url, db, user, password, "SELECT 1")
+        except typer.Exit:
+            raise
+        except Exception:
+            rprint("[red]ClickHouse health check failed.[/red]")
+            raise typer.Exit(1)
+
+        existing = await _ch_existing_tables(http_url, db, user, password)
+        row_count_results = {}
+        for table_cfg in CLICKHOUSE_TABLES:
+            table_name = table_cfg["name"]
+            manifest_count = manifest["tables"].get(table_name, {}).get("row_count", 0)
+            if table_name not in existing:
+                row_count_results[table_name] = (manifest_count, -1)
+                continue
+            # Use FINAL for ReplacingMergeTree
+            if table_cfg["engine"] == "replacing":
+                sql = f"SELECT count() AS cnt FROM {table_name} FINAL WHERE is_deleted = 0 FORMAT JSON"
+            else:
+                sql = f"SELECT count() AS cnt FROM {table_name} FORMAT JSON"
+            resp = await _ch_query(http_url, db, user, password, sql)
+            db_count = _read_count(resp)
+            row_count_results[table_name] = (manifest_count, db_count)
+
+    # Optional FK validation
+    fk_results: dict[str, list[str]] | None = None
+    if target_db_url:
+        fk_results = await _validate_fk_references(input_dir, manifest, target_db_url)
+        # Update manifest with FK results
+        manifest["fk_validation"] = {**fk_results, "validated_at": datetime.now(UTC).isoformat()}
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    return TelemetryValidationResult(
+        checksums_valid=checksums_valid,
+        checksum_results=checksum_results,
+        fk_results=fk_results,
+        row_count_results=row_count_results,
+    )
 
 
 # ── Typer app ────────────────────────────────────────────
@@ -762,3 +1405,123 @@ def validate_cmd(
             rprint("\n[green]✓ All row counts match[/green]")
         else:
             rprint(f"\n[yellow]⚠  {mismatches} table(s) have different row counts[/yellow]")
+
+
+# ── Phase 2: Telemetry CLI commands ─────────────────────
+
+
+@migrate_app.command("export-telemetry")
+def export_telemetry_cmd(
+    clickhouse_url: str = typer.Option(..., "--clickhouse-url", help="Source ClickHouse connection string"),
+    manifest: str = typer.Option(..., "--manifest", help="Path to Phase 1 migration_manifest.json"),
+    output_dir: str = typer.Option(..., "--output-dir", help="Directory for exported Parquet files"),
+) -> None:
+    """Export ClickHouse telemetry data to Parquet files."""
+    _require_admin()
+
+    rprint(f"[bold]Exporting telemetry to:[/bold] {output_dir}")
+    result = asyncio.run(_export_telemetry(clickhouse_url, Path(manifest), Path(output_dir)))
+
+    size_mb = result.total_size_bytes / (1024 * 1024)
+    rprint("\n[bold green]✓ Telemetry export complete[/bold green]")
+    rprint(f"  Directory:  {result.output_dir}")
+    rprint(f"  Migration:  {result.migration_id}")
+    rprint(f"  Rows:       {result.total_rows:,}")
+    rprint(f"  Size:       {size_mb:.1f} MB")
+    rprint(f"  Duration:   {result.duration_seconds:.1f}s")
+    rprint()
+    rprint("[yellow]⚠  Parquet files may contain PII in trace input/output fields.[/yellow]")
+    rprint("[yellow]   Store securely and delete after import.[/yellow]")
+
+
+@migrate_app.command("import-telemetry")
+def import_telemetry_cmd(
+    clickhouse_url: str = typer.Option(..., "--clickhouse-url", help="Target ClickHouse connection string"),
+    input_dir: str = typer.Option(..., "--input-dir", help="Directory containing Parquet files"),
+) -> None:
+    """Import Parquet telemetry files into target ClickHouse."""
+    _require_admin()
+
+    input_path = Path(input_dir)
+    if not input_path.exists():
+        rprint(f"[red]Directory not found:[/red] {input_path}")
+        raise typer.Exit(1)
+
+    rprint(f"[bold]Importing telemetry from:[/bold] {input_path}")
+    result = asyncio.run(_import_telemetry(clickhouse_url, input_path))
+
+    total = sum(result.rows_imported.values())
+    rprint("\n[bold green]✓ Telemetry import complete[/bold green]")
+    rprint(f"  Migration:  {result.migration_id}")
+    rprint(f"  Tables:     {result.tables_imported}")
+    rprint(f"  Rows:       {total:,}")
+    rprint(f"  Duration:   {result.duration_seconds:.1f}s")
+    if result.tables_skipped:
+        rprint(f"  Skipped:    {', '.join(result.tables_skipped)}")
+
+
+@migrate_app.command("validate-telemetry")
+def validate_telemetry_cmd(
+    input_dir: str = typer.Option(..., "--input-dir", help="Directory containing Parquet files"),
+    clickhouse_url: str | None = typer.Option(
+        None, "--clickhouse-url", help="Target ClickHouse for row count comparison"
+    ),
+    target_db_url: str | None = typer.Option(None, "--target-db-url", help="Target PostgreSQL for FK validation"),
+) -> None:
+    """Validate telemetry Parquet files and optionally check FK references."""
+    _require_admin()
+
+    input_path = Path(input_dir)
+    if not input_path.exists():
+        rprint(f"[red]Directory not found:[/red] {input_path}")
+        raise typer.Exit(1)
+
+    rprint(f"[bold]Validating telemetry in:[/bold] {input_path}")
+    result = asyncio.run(_validate_telemetry(input_path, clickhouse_url, target_db_url))
+
+    # Checksum results
+    rprint("\n[bold]Checksum verification:[/bold]")
+    for filename, passed in result.checksum_results.items():
+        status = "[green]✓[/green]" if passed else "[red]✗[/red]"
+        rprint(f"  {status} {filename}")
+
+    if not result.checksums_valid:
+        rprint("\n[red]Checksum validation failed.[/red]")
+        raise typer.Exit(1)
+    rprint("\n[green]✓ All checksums valid[/green]")
+
+    # Row count comparison
+    if result.row_count_results:
+        rprint("\n[bold]Row count comparison:[/bold]")
+        mismatches = 0
+        for table, (manifest_count, db_count) in result.row_count_results.items():
+            if db_count == -1:
+                rprint(f"  [dim]-[/dim] {table}: [dim]table not on target[/dim]")
+            elif manifest_count == db_count:
+                rprint(f"  [green]✓[/green] {table}: {manifest_count:,}")
+            else:
+                rprint(f"  [yellow]≠[/yellow] {table}: manifest={manifest_count:,}, db={db_count:,}")
+                mismatches += 1
+        if mismatches == 0:
+            rprint("\n[green]✓ All row counts match[/green]")
+        else:
+            rprint(f"\n[yellow]⚠  {mismatches} table(s) have different row counts[/yellow]")
+
+    # FK validation results
+    if result.fk_results:
+        rprint("\n[bold]FK validation:[/bold]")
+        has_orphans = False
+        for key, value in result.fk_results.items():
+            if key.endswith("_truncated"):
+                continue
+            if isinstance(value, list) and value:
+                has_orphans = True
+                truncated = result.fk_results.get(f"{key}_truncated", False)
+                suffix = " (truncated)" if truncated else ""
+                rprint(f"  [yellow]⚠[/yellow] {key}: {len(value)} orphaned{suffix}")
+            elif isinstance(value, list):
+                rprint(f"  [green]✓[/green] {key}: 0 orphaned")
+        if not has_orphans:
+            rprint("\n[green]✓ All FK references valid[/green]")
+        else:
+            rprint("\n[yellow]⚠  Orphaned references found (see above)[/yellow]")

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -16,18 +16,17 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, TypedDict
 
 import typer
 
 if TYPE_CHECKING:
     import asyncpg
+    import httpx
 from rich import print as rprint
 
 from observal_cli import client
 from observal_cli.render import spinner
-
-logging.getLogger("httpx").setLevel(logging.WARNING)
 
 # ── Constants ────────────────────────────────────────────
 
@@ -96,7 +95,17 @@ JSONB_COLUMNS: dict[str, list[str]] = {
 
 # ── Phase 2: ClickHouse telemetry constants ──────────────
 
-CLICKHOUSE_TABLES: list[dict[str, str | list[str]]] = [
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+
+
+class TableCfg(TypedDict):
+    name: str
+    engine: Literal["replacing", "mergetree"]
+    time_col: str
+    fk_cols: list[str]
+
+
+CLICKHOUSE_TABLES: list[TableCfg] = [
     {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
     {"name": "spans", "engine": "replacing", "time_col": "start_time", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
     {"name": "scores", "engine": "replacing", "time_col": "timestamp", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
@@ -205,10 +214,10 @@ def _require_admin() -> None:
     """Verify the current user has admin or super_admin role. Exit if not."""
     try:
         user = client.get("/api/v1/auth/whoami")
-    except SystemExit:
+    except SystemExit as exc:
         rprint("[red]Authentication required.[/red]")
         rprint("[dim]  Run [bold]observal auth login[/bold] first.[/dim]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
     role = user.get("role", "")
     if role not in ("admin", "super_admin"):
         rprint("[red]Permission denied.[/red] The migrate command requires admin or super_admin role.")
@@ -240,11 +249,24 @@ def _sha256_file(path: Path) -> str:
 
 
 def _parse_clickhouse_url(url: str) -> tuple[str, str, str, str]:
-    """Parse clickhouse://user:pass@host:port/db -> (http_url, db, user, password)."""
+    """Parse clickhouse://user:pass@host:port/db -> (http_url, db, user, password).
+
+    Supports ``clickhouses://`` for TLS (maps to https, default port 8443).
+    """
     from urllib.parse import urlparse
 
-    parsed = urlparse(url.replace("clickhouse://", "http://"))
-    http_url = f"http://{parsed.hostname}:{parsed.port or 8123}"
+    if url.startswith("clickhouses://"):
+        raw = "https://" + url[len("clickhouses://") :]
+        default_port = 8443
+    elif url.startswith("clickhouse://"):
+        raw = "http://" + url[len("clickhouse://") :]
+        default_port = 8123
+    else:
+        raw = url
+        default_port = 8123
+    parsed = urlparse(raw)
+    scheme = "https" if raw.startswith("https") else "http"
+    http_url = f"{scheme}://{parsed.hostname}:{parsed.port or default_port}"
     db = (parsed.path or "/").strip("/") or "default"
     user = parsed.username or "default"
     password = parsed.password or ""
@@ -270,9 +292,9 @@ async def _connect(db_url: str) -> asyncpg.Connection:
     )
     try:
         conn = await asyncpg.connect(clean_url)
-    except (asyncpg.InvalidCatalogNameError, asyncpg.InvalidPasswordError, OSError, Exception) as e:
-        rprint(f"[red]Database connection failed:[/red] {type(e).__name__}: {e}")
-        raise typer.Exit(1)
+    except (asyncpg.InvalidCatalogNameError, asyncpg.InvalidPasswordError, OSError, Exception) as exc:
+        rprint(f"[red]Database connection failed:[/red] {type(exc).__name__}: {exc}")
+        raise typer.Exit(1) from exc
     # Verify this is an Observal database
     result = await conn.fetchval(
         "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'alembic_version')"
@@ -418,41 +440,54 @@ async def _ch_query(
     sql: str,
     *,
     stream_to: Path | None = None,
-    client: object | None = None,
-) -> object:
+    http_client: httpx.AsyncClient | None = None,
+    extra_params: dict[str, str] | None = None,
+) -> httpx.Response:
     """Execute a ClickHouse query via HTTP.
 
-    If stream_to is provided, streams response body to disk.
-    An optional pre-existing client avoids creating new connections per call.
+    If stream_to is provided, streams response body to disk atomically via a
+    ``.tmp`` sibling file.  An optional pre-existing *http_client* avoids
+    creating new connections per call.  *extra_params* are merged into the
+    query-string (used for ClickHouse parameterized queries).
     """
     import httpx as _httpx
 
-    params = {"database": db, "user": user, "password": password}
-    owns_client = client is None
+    params: dict[str, str] = {"database": db}
+    if extra_params:
+        params.update(extra_params)
+    owns_client = http_client is None
     if owns_client:
-        client = _httpx.AsyncClient(timeout=_httpx.Timeout(300.0, connect=10.0))
+        http_client = _httpx.AsyncClient(timeout=_httpx.Timeout(300.0, connect=10.0))
     try:
         if stream_to:
-            async with client.stream("POST", http_url, content=sql, params=params) as resp:
-                resp.raise_for_status()
-                with open(stream_to, "wb") as f:
-                    async for chunk in resp.aiter_bytes(chunk_size=65536):
-                        f.write(chunk)
+            tmp = stream_to.with_suffix(stream_to.suffix + ".tmp")
+            try:
+                async with http_client.stream(
+                    "POST", http_url, content=sql, auth=(user, password), params=params
+                ) as resp:
+                    resp.raise_for_status()
+                    with open(tmp, "wb") as f:
+                        async for chunk in resp.aiter_bytes(chunk_size=65536):
+                            f.write(chunk)
+                os.replace(tmp, stream_to)
                 return resp
+            except Exception:
+                tmp.unlink(missing_ok=True)
+                raise
         else:
-            resp = await client.post(http_url, content=sql, params=params)
+            resp = await http_client.post(http_url, content=sql, auth=(user, password), params=params)
             resp.raise_for_status()
             return resp
     except _httpx.HTTPStatusError as exc:
         rprint(f"[red]ClickHouse returned HTTP {exc.response.status_code}[/red]")
         rprint(f"[dim]{exc.response.text[:500]}[/dim]")
-        raise typer.Exit(1)
-    except _httpx.RequestError:
+        raise typer.Exit(1) from exc
+    except _httpx.RequestError as exc:
         rprint("[red]ClickHouse unreachable.[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
     finally:
         if owns_client:
-            await client.aclose()
+            await http_client.aclose()
 
 
 async def _ch_import(
@@ -467,7 +502,7 @@ async def _ch_import(
     import httpx as _httpx
 
     sql_prefix = f"INSERT INTO {table} FORMAT Parquet"
-    params = {"database": db, "user": user, "password": password, "query": sql_prefix}
+    params = {"database": db, "query": sql_prefix}
 
     async def _file_stream():
         with open(parquet_path, "rb") as f:
@@ -476,15 +511,15 @@ async def _ch_import(
 
     try:
         async with _httpx.AsyncClient(timeout=_httpx.Timeout(600.0, connect=10.0)) as c:
-            resp = await c.post(http_url, content=_file_stream(), params=params)
+            resp = await c.post(http_url, content=_file_stream(), auth=(user, password), params=params)
             resp.raise_for_status()
     except _httpx.HTTPStatusError as exc:
         rprint(f"[red]ClickHouse returned HTTP {exc.response.status_code}[/red]")
         rprint(f"[dim]{exc.response.text[:500]}[/dim]")
-        raise typer.Exit(1)
-    except _httpx.RequestError:
+        raise typer.Exit(1) from exc
+    except _httpx.RequestError as exc:
         rprint("[red]ClickHouse unreachable.[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
 
 async def _ch_existing_tables(
@@ -494,8 +529,8 @@ async def _ch_existing_tables(
     password: str,
 ) -> set[str]:
     """Query system.tables to discover which tables exist on target ClickHouse."""
-    sql = f"SELECT name FROM system.tables WHERE database = '{db}' FORMAT JSON"
-    resp = await _ch_query(http_url, db, user, password, sql)
+    sql = "SELECT name FROM system.tables WHERE database = {db:String} FORMAT JSON"
+    resp = await _ch_query(http_url, db, user, password, sql, extra_params={"param_db": db})
     return {r["name"] for r in resp.json().get("data", [])}
 
 
@@ -504,13 +539,19 @@ async def _ch_partition_has_data(
     db: str,
     user: str,
     password: str,
-    table_cfg: dict,
+    table_cfg: TableCfg,
     yyyymm: int,
 ) -> bool:
-    """Check if a MergeTree table already has data in a given month partition."""
+    """Check if a table already has data in a given month partition."""
     name = table_cfg["name"]
     time_col = table_cfg["time_col"]
-    sql = f"SELECT 1 AS has_data FROM {name} WHERE toYYYYMM({time_col}) = {yyyymm} LIMIT 1 FORMAT JSON"
+    if table_cfg["engine"] == "replacing":
+        sql = (
+            f"SELECT 1 AS has_data FROM {name} FINAL "
+            f"WHERE is_deleted = 0 AND toYYYYMM({time_col}) = {yyyymm} LIMIT 1 FORMAT JSON"
+        )
+    else:
+        sql = f"SELECT 1 AS has_data FROM {name} WHERE toYYYYMM({time_col}) = {yyyymm} LIMIT 1 FORMAT JSON"
     resp = await _ch_query(http_url, db, user, password, sql)
     return len(resp.json().get("data", [])) > 0
 
@@ -518,34 +559,46 @@ async def _ch_partition_has_data(
 # ── Phase 2: Query builders and utilities ────────────────
 
 
-def _build_ch_export_query(table_cfg: dict, yyyymm: int) -> str:
+def _build_ch_export_query(table_cfg: TableCfg, yyyymm: int, *, cutoff: str | None = None) -> str:
     """Build a ClickHouse export query for a monthly partition."""
     name = table_cfg["name"]
     time_col = table_cfg["time_col"]
+    where_parts: list[str] = []
     if table_cfg["engine"] == "replacing":
-        return f"SELECT * FROM {name} FINAL WHERE is_deleted = 0 AND toYYYYMM({time_col}) = {yyyymm} FORMAT Parquet"
-    return f"SELECT * FROM {name} WHERE toYYYYMM({time_col}) = {yyyymm} FORMAT Parquet"
+        final = " FINAL"
+        where_parts.append("is_deleted = 0")
+    else:
+        final = ""
+    where_parts.append(f"toYYYYMM({time_col}) = {yyyymm}")
+    if cutoff:
+        where_parts.append(f"{time_col} < {{cutoff:String}}")
+    where = " AND ".join(where_parts)
+    return f"SELECT * FROM {name}{final} WHERE {where} FORMAT Parquet"
 
 
-def _build_ch_count_query(table_cfg: dict, yyyymm: int) -> str:
+def _build_ch_count_query(table_cfg: TableCfg, yyyymm: int, *, cutoff: str | None = None) -> str:
     """Build a row count query for a monthly partition."""
     name = table_cfg["name"]
     time_col = table_cfg["time_col"]
+    where_parts: list[str] = []
     if table_cfg["engine"] == "replacing":
-        return (
-            f"SELECT count() AS cnt FROM {name} FINAL "
-            f"WHERE is_deleted = 0 AND toYYYYMM({time_col}) = {yyyymm} "
-            f"FORMAT JSON"
-        )
-    return f"SELECT count() AS cnt FROM {name} WHERE toYYYYMM({time_col}) = {yyyymm} FORMAT JSON"
+        final = " FINAL"
+        where_parts.append("is_deleted = 0")
+    else:
+        final = ""
+    where_parts.append(f"toYYYYMM({time_col}) = {yyyymm}")
+    if cutoff:
+        where_parts.append(f"{time_col} < {{cutoff:String}}")
+    where = " AND ".join(where_parts)
+    return f"SELECT count() AS cnt FROM {name}{final} WHERE {where} FORMAT JSON"
 
 
-def _read_count(resp: object) -> int:
+def _read_count(resp: httpx.Response) -> int:
     """Parse a count query response."""
     return int(resp.json().get("data", [{}])[0].get("cnt", 0))
 
 
-def _build_ch_time_range_query(table_cfg: dict) -> str:
+def _build_ch_time_range_query(table_cfg: TableCfg) -> str:
     """Build a time range query to discover partition months."""
     name = table_cfg["name"]
     time_col = table_cfg["time_col"]
@@ -576,11 +629,12 @@ def _is_empty_parquet(path: Path) -> bool:
     if path.stat().st_size == 0:
         return True
     try:
+        import pyarrow as pa
         import pyarrow.parquet as pq
 
         meta = pq.read_metadata(path)
         return meta.num_rows == 0
-    except Exception:
+    except (pa.lib.ArrowInvalid, pa.lib.ArrowIOError):
         return True
 
 
@@ -601,7 +655,7 @@ async def _import_archive(db_url: str, archive_path: Path) -> ImportResult:
         if not manifest_path.exists():
             rprint("[red]Archive does not contain manifest.json[/red]")
             raise typer.Exit(1)
-        manifest = json.loads(manifest_path.read_text())
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         migration_id = manifest["migration_id"]
 
         # Verify checksums BEFORE any DB operations
@@ -692,7 +746,7 @@ async def _validate_archive(archive_path: Path, db_url: str | None) -> Validatio
         if not manifest_path.exists():
             rprint("[red]Archive does not contain manifest.json[/red]")
             raise typer.Exit(1)
-        manifest = json.loads(manifest_path.read_text())
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
         # Verify checksums
         checksum_results: list[ChecksumResult] = []
@@ -779,7 +833,7 @@ async def _export_database(db_url: str, output_path: Path) -> ExportResult:
                     if table not in existing_tables:
                         rprint(f"[dim]  Skipping {table} (table does not exist)[/dim]")
                         # Write empty JSONL file so archive structure is consistent
-                        dest.write_text("")
+                        dest.write_text("", encoding="utf-8")
                         table_counts[table] = 0
                         file_hashes[table] = _sha256_file(dest)
                         continue
@@ -831,7 +885,7 @@ async def _export_database(db_url: str, output_path: Path) -> ExportResult:
             },
         }
         manifest_path = staging_dir / "manifest.json"
-        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
         # Write migration_manifest.json
         db_url_hash = hashlib.sha256(db_url.encode()).hexdigest()
@@ -843,7 +897,7 @@ async def _export_database(db_url: str, output_path: Path) -> ExportResult:
             "uuid_ranges": uuid_ranges,
         }
         migration_manifest_path = staging_dir / "migration_manifest.json"
-        migration_manifest_path.write_text(json.dumps(migration_manifest, indent=2) + "\n")
+        migration_manifest_path.write_text(json.dumps(migration_manifest, indent=2) + "\n", encoding="utf-8")
 
         # Ensure output parent directory exists
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -851,7 +905,6 @@ async def _export_database(db_url: str, output_path: Path) -> ExportResult:
         # Write sidecar manifest for Phase 2 consumption
         sidecar_stem = output_path.name.removesuffix(".tar.gz").removesuffix(".tgz")
         sidecar_path = output_path.parent / f"{sidecar_stem}.manifest.json"
-        sidecar_path.write_text(json.dumps(migration_manifest, indent=2) + "\n")
 
         # Pack archive
         with tarfile.open(output_path, "w:gz") as tar:
@@ -860,6 +913,11 @@ async def _export_database(db_url: str, output_path: Path) -> ExportResult:
             for table in INSERT_ORDER:
                 jsonl_file = pg_dir / f"{table}.jsonl"
                 tar.add(str(jsonl_file), arcname=f"pg/{table}.jsonl")
+
+        # Compute archive hash and write sidecar
+        archive_hash = _sha256_file(output_path)
+        migration_manifest["archive_sha256"] = archive_hash
+        sidecar_path.write_text(json.dumps(migration_manifest, indent=2) + "\n", encoding="utf-8")
 
         elapsed = time.monotonic() - t0
         total_rows = sum(table_counts.values())
@@ -894,15 +952,15 @@ async def _export_telemetry(
     if not manifest_path.exists():
         rprint(f"[red]Phase 1 manifest not found:[/red] {manifest_path}")
         raise typer.Exit(1)
-    p1_manifest = json.loads(manifest_path.read_text())
+    p1_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     if not p1_manifest.get("phase1_completed_at"):
         rprint("[red]Phase 1 has not completed.[/red]")
         rprint("[dim]  Run 'observal migrate export' and 'observal migrate import' first.[/dim]")
         raise typer.Exit(1)
     migration_id = p1_manifest["migration_id"]
 
-    # Record cutoff before any queries
-    export_time_cutoff = datetime.now(UTC).isoformat()
+    # Record cutoff before any queries — use ClickHouse-compatible DateTime64 format
+    export_time_cutoff = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
     # Parse ClickHouse URL
     http_url, db, user, password = _parse_clickhouse_url(clickhouse_url)
@@ -912,29 +970,30 @@ async def _export_telemetry(
         await _ch_query(http_url, db, user, password, "SELECT 1")
     except typer.Exit:
         raise
-    except Exception:
+    except Exception as exc:
         rprint("[red]ClickHouse health check failed.[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
     # Create output directory
     if output_dir.exists() and any(output_dir.iterdir()):
         rprint(f"[red]Output directory is not empty:[/red] {output_dir}")
         raise typer.Exit(1)
+    dir_existed = output_dir.exists()
     os.makedirs(output_dir, mode=0o700, exist_ok=True)
+    os.chmod(output_dir, 0o700)
 
-    dir_created = True
     try:
         table_meta: dict[str, dict] = {}
         total_rows = 0
         total_size = 0
 
-        async with _httpx.AsyncClient(timeout=_httpx.Timeout(300.0, connect=10.0)) as client:
+        async with _httpx.AsyncClient(timeout=_httpx.Timeout(300.0, connect=10.0)) as http_client:
             for table_cfg in CLICKHOUSE_TABLES:
                 table_name = table_cfg["name"]
 
                 # Query time range
                 tr_sql = _build_ch_time_range_query(table_cfg)
-                tr_resp = await _ch_query(http_url, db, user, password, tr_sql, client=client)
+                tr_resp = await _ch_query(http_url, db, user, password, tr_sql, http_client=http_client)
                 tr_data = tr_resp.json().get("data", [{}])[0]
                 min_t = tr_data.get("min_t")
                 max_t = tr_data.get("max_t")
@@ -953,13 +1012,25 @@ async def _export_telemetry(
                 checksums: dict[str, str] = {}
                 table_row_count = 0
 
+                cutoff_params: dict[str, str] | None = (
+                    {"param_cutoff": export_time_cutoff} if export_time_cutoff else None
+                )
+
                 for yyyymm in months:
                     filename = f"{table_name}_{yyyymm // 100}-{yyyymm % 100:02d}.parquet"
                     filepath = output_dir / filename
 
                     # Get row count first for progress display
-                    count_sql = _build_ch_count_query(table_cfg, yyyymm)
-                    count_resp = await _ch_query(http_url, db, user, password, count_sql, client=client)
+                    count_sql = _build_ch_count_query(table_cfg, yyyymm, cutoff=export_time_cutoff)
+                    count_resp = await _ch_query(
+                        http_url,
+                        db,
+                        user,
+                        password,
+                        count_sql,
+                        http_client=http_client,
+                        extra_params=cutoff_params,
+                    )
                     partition_count = _read_count(count_resp)
 
                     if partition_count == 0:
@@ -968,8 +1039,17 @@ async def _export_telemetry(
                     rprint(f"  Exporting {filename} ({partition_count:,} rows)...")
 
                     # Stream Parquet to disk
-                    export_sql = _build_ch_export_query(table_cfg, yyyymm)
-                    await _ch_query(http_url, db, user, password, export_sql, stream_to=filepath, client=client)
+                    export_sql = _build_ch_export_query(table_cfg, yyyymm, cutoff=export_time_cutoff)
+                    await _ch_query(
+                        http_url,
+                        db,
+                        user,
+                        password,
+                        export_sql,
+                        stream_to=filepath,
+                        http_client=http_client,
+                        extra_params=cutoff_params,
+                    )
 
                     # Check if file is actually empty (edge case)
                     if _is_empty_parquet(filepath):
@@ -1012,7 +1092,7 @@ async def _export_telemetry(
             },
         }
         manifest_out = output_dir / "telemetry_manifest.json"
-        manifest_out.write_text(json.dumps(telemetry_manifest, indent=2) + "\n")
+        manifest_out.write_text(json.dumps(telemetry_manifest, indent=2) + "\n", encoding="utf-8")
 
         elapsed = time.monotonic() - t0
         return TelemetryExportResult(
@@ -1026,7 +1106,7 @@ async def _export_telemetry(
 
     except Exception:
         # Clean up on failure only if we created the directory
-        if dir_created and output_dir.exists():
+        if not dir_existed and output_dir.exists():
             shutil.rmtree(output_dir, ignore_errors=True)
         raise
 
@@ -1044,7 +1124,7 @@ async def _import_telemetry(
     if not manifest_path.exists():
         rprint("[red]Telemetry manifest not found in input directory.[/red]")
         raise typer.Exit(1)
-    manifest = json.loads(manifest_path.read_text())
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     migration_id = manifest["migration_id"]
 
     # Verify checksums before any imports
@@ -1073,13 +1153,21 @@ async def _import_telemetry(
         await _ch_query(http_url, db, user, password, "SELECT 1")
     except typer.Exit:
         raise
-    except Exception:
+    except Exception as exc:
         rprint("[red]ClickHouse health check failed.[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
     existing = await _ch_existing_tables(http_url, db, user, password)
     rows_imported: dict[str, int] = {}
     tables_skipped: list[str] = []
+
+    # Resume state
+    state_path = input_dir / ".import_state.json"
+    if state_path.exists():
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        completed_tables: set[str] = set(state.get("completed", []))
+    else:
+        completed_tables = set()
 
     for table_cfg in CLICKHOUSE_TABLES:
         table_name = table_cfg["name"]
@@ -1093,22 +1181,28 @@ async def _import_telemetry(
         if table_name not in existing:
             rprint(f"  [yellow]Skipping {table_name} (table does not exist on target)[/yellow]")
             tables_skipped.append(table_name)
+            warnings.append(f"{table_name}: table does not exist on target")
             rows_imported[table_name] = 0
+            continue
+
+        if table_name in completed_tables:
+            rprint(f"  [dim]Skipping {table_name} (already imported)[/dim]")
+            rows_imported[table_name] = table_info.get("row_count", 0)
             continue
 
         for filename in files:
             filepath = input_dir / filename
 
-            # MergeTree idempotency: check if partition already has data
-            if table_cfg["engine"] == "mergetree":
-                # Extract YYYYMM from filename like "traces_2025-01.parquet"
-                parts = filename.replace(".parquet", "").split("_")
-                date_part = parts[-1]  # "2025-01"
-                year, month = date_part.split("-")
-                yyyymm = int(year) * 100 + int(month)
-                if await _ch_partition_has_data(http_url, db, user, password, table_cfg, yyyymm):
-                    rprint(f"  [dim]Skipping {filename} (partition already has data)[/dim]")
-                    continue
+            # Idempotency: check if partition already has data
+            # Extract YYYYMM from filename like "traces_2025-01.parquet"
+            parts = filename.replace(".parquet", "").split("_")
+            date_part = parts[-1]  # "2025-01"
+            year, month = date_part.split("-")
+            yyyymm = int(year) * 100 + int(month)
+            if await _ch_partition_has_data(http_url, db, user, password, table_cfg, yyyymm):
+                rprint(f"  [dim]Skipping {filename} (partition already has data)[/dim]")
+                warnings.append(f"{filename}: partition already has data")
+                continue
 
             rprint(f"  Importing {filename}...")
             await _ch_import(http_url, db, user, password, table_name, filepath)
@@ -1116,10 +1210,17 @@ async def _import_telemetry(
         rows_imported[table_name] = table_info.get("row_count", 0)
         rprint(f"  [green]✓[/green] {table_name}: {rows_imported[table_name]:,} rows")
 
+        # Persist resume state after each successful table
+        completed_tables.add(table_name)
+        state_path.write_text(
+            json.dumps({"completed": sorted(completed_tables)}, indent=2),
+            encoding="utf-8",
+        )
+
     elapsed = time.monotonic() - t0
     return TelemetryImportResult(
         migration_id=migration_id,
-        tables_imported=len([t for t in rows_imported if rows_imported[t] > 0]),
+        tables_imported=sum(1 for v in rows_imported.values() if v > 0),
         tables_skipped=tables_skipped,
         rows_imported=rows_imported,
         duration_seconds=round(elapsed, 2),
@@ -1169,9 +1270,9 @@ async def _validate_fk_references(
 
     # Filter to valid UUIDs only — ClickHouse stores these as String,
     # so non-UUID values like "filesystem" or "default" can appear.
-    _uuid_re = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+    # Normalize to lowercase to match PostgreSQL's canonical form.
     for key in list(fk_values):
-        fk_values[key] = {v for v in fk_values[key] if _uuid_re.match(v)}
+        fk_values[key] = {v.lower() for v in fk_values[key] if _UUID_RE.match(v)}
 
     # Check against PostgreSQL
     conn = await _connect(db_url)
@@ -1211,7 +1312,7 @@ async def _validate_telemetry(
     if not manifest_path.exists():
         rprint("[red]Telemetry manifest not found.[/red]")
         raise typer.Exit(1)
-    manifest = json.loads(manifest_path.read_text())
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     # Checksum verification
     checksum_results: dict[str, bool] = {}
@@ -1236,9 +1337,9 @@ async def _validate_telemetry(
             await _ch_query(http_url, db, user, password, "SELECT 1")
         except typer.Exit:
             raise
-        except Exception:
+        except Exception as exc:
             rprint("[red]ClickHouse health check failed.[/red]")
-            raise typer.Exit(1)
+            raise typer.Exit(1) from exc
 
         existing = await _ch_existing_tables(http_url, db, user, password)
         row_count_results = {}
@@ -1263,7 +1364,7 @@ async def _validate_telemetry(
         fk_results = await _validate_fk_references(input_dir, manifest, target_db_url)
         # Update manifest with FK results
         manifest["fk_validation"] = {**fk_results, "validated_at": datetime.now(UTC).isoformat()}
-        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
     return TelemetryValidationResult(
         checksums_valid=checksums_valid,
@@ -1418,6 +1519,7 @@ def export_telemetry_cmd(
 ) -> None:
     """Export ClickHouse telemetry data to Parquet files."""
     _require_admin()
+    logging.getLogger("httpx").setLevel(logging.WARNING)
 
     rprint(f"[bold]Exporting telemetry to:[/bold] {output_dir}")
     result = asyncio.run(_export_telemetry(clickhouse_url, Path(manifest), Path(output_dir)))
@@ -1441,6 +1543,7 @@ def import_telemetry_cmd(
 ) -> None:
     """Import Parquet telemetry files into target ClickHouse."""
     _require_admin()
+    logging.getLogger("httpx").setLevel(logging.WARNING)
 
     input_path = Path(input_dir)
     if not input_path.exists():
@@ -1458,6 +1561,10 @@ def import_telemetry_cmd(
     rprint(f"  Duration:   {result.duration_seconds:.1f}s")
     if result.tables_skipped:
         rprint(f"  Skipped:    {', '.join(result.tables_skipped)}")
+    if result.warnings:
+        rprint("\n[yellow]Warnings:[/yellow]")
+        for w in result.warnings:
+            rprint(f"  [yellow]⚠[/yellow]  {w}")
 
 
 @migrate_app.command("validate-telemetry")
@@ -1470,6 +1577,7 @@ def validate_telemetry_cmd(
 ) -> None:
     """Validate telemetry Parquet files and optionally check FK references."""
     _require_admin()
+    logging.getLogger("httpx").setLevel(logging.WARNING)
 
     input_path = Path(input_dir)
     if not input_path.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "observal-cli"
-version = "0.2.0"
+name = "observal"
+version = "0.1.0"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -12,7 +12,12 @@ dependencies = [
     "rich>=13.0.0",
     "pyyaml>=6.0.3",
     "questionary>=2.0.0",
+    "docker>=7.0.0",
+    "asyncpg>=0.29.0",
+    "hypothesis",
+    "pyarrow",
 ]
+
 
 keywords = ["mcp", "model-context-protocol", "registry", "cli", "agents", "observability"]
 classifiers = [
@@ -27,14 +32,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 
-[project.optional-dependencies]
-sandbox = ["docker>=7.0.0"]
-migrate = ["asyncpg>=0.29.0"]
-all = ["observal-cli[sandbox,migrate]"]
-
 [project.urls]
 Homepage = "https://github.com/BlazeUp-AI/Observal"
-Documentation = "https://github.com/BlazeUp-AI/Observal/blob/main/docs/cli.md"
 Repository = "https://github.com/BlazeUp-AI/Observal"
 Changelog = "https://github.com/BlazeUp-AI/Observal/blob/main/CHANGELOG.md"
 Issues = "https://github.com/BlazeUp-AI/Observal/issues"
@@ -44,6 +43,7 @@ observal = "observal_cli.main:app"
 observal-shim = "observal_cli.shim:main"
 observal-proxy = "observal_cli.proxy:main"
 observal-sandbox-run = "observal_cli.sandbox_runner:main"
+#observal-graphrag-proxy = "observal_cli.graphrag_proxy:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -127,5 +127,4 @@ dev = [
     "ruff==0.15.11",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
-    "hypothesis",
 ]

--- a/tests/test_migrate_telemetry.py
+++ b/tests/test_migrate_telemetry.py
@@ -1,0 +1,974 @@
+"""Unit and property-based tests for ch-deep-copy: ClickHouse telemetry migration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import click.exceptions
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from hypothesis import given
+from hypothesis import settings as hsettings
+from hypothesis import strategies as st
+from typer.testing import CliRunner
+
+from observal_cli.cmd_migrate import (
+    CLICKHOUSE_TABLES,
+    EPOCH_SENTINELS,
+    FK_PG_TABLE_MAP,
+    TelemetryExportResult,
+    TelemetryImportResult,
+    TelemetryValidationResult,
+    _build_ch_count_query,
+    _build_ch_export_query,
+    _build_ch_time_range_query,
+    _is_empty_parquet,
+    _month_range,
+    _parse_clickhouse_url,
+    _read_count,
+    _require_admin,
+    _sha256_file,
+)
+from observal_cli.main import app as cli_app
+
+runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+# ── Mock helpers ─────────────────────────────────────────
+
+
+class MockResponse:
+    """Mock httpx response for _read_count tests."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def json(self) -> dict:
+        return self._data
+
+
+# ══════════════════════════════════════════════════════════
+# Unit Tests (Example-Based)
+# ══════════════════════════════════════════════════════════
+
+
+# ── CLI Registration Tests ───────────────────────────────
+
+
+class TestCLIRegistration:
+    """Verify Phase 2 telemetry subcommands appear in migrate --help."""
+
+    def test_export_telemetry_in_help(self):
+        result = runner.invoke(cli_app, ["migrate", "--help"])
+        assert result.exit_code == 0
+        assert "export-telemetry" in _plain(result.output)
+
+    def test_import_telemetry_in_help(self):
+        result = runner.invoke(cli_app, ["migrate", "--help"])
+        assert result.exit_code == 0
+        assert "import-telemetry" in _plain(result.output)
+
+    def test_validate_telemetry_in_help(self):
+        result = runner.invoke(cli_app, ["migrate", "--help"])
+        assert result.exit_code == 0
+        assert "validate-telemetry" in _plain(result.output)
+
+    def test_export_telemetry_help_shows_options(self):
+        result = runner.invoke(cli_app, ["migrate", "export-telemetry", "--help"])
+        assert result.exit_code == 0
+        out = _plain(result.output)
+        assert "--clickhouse-url" in out
+        assert "--manifest" in out
+        assert "--output-dir" in out
+
+    def test_import_telemetry_help_shows_options(self):
+        result = runner.invoke(cli_app, ["migrate", "import-telemetry", "--help"])
+        assert result.exit_code == 0
+        out = _plain(result.output)
+        assert "--clickhouse-url" in out
+        assert "--input-dir" in out
+
+    def test_validate_telemetry_help_shows_options(self):
+        result = runner.invoke(cli_app, ["migrate", "validate-telemetry", "--help"])
+        assert result.exit_code == 0
+        out = _plain(result.output)
+        assert "--input-dir" in out
+        assert "--clickhouse-url" in out
+        assert "--target-db-url" in out
+
+
+# ── ClickHouse URL Parsing Tests ─────────────────────────
+
+
+class TestParseClickhouseUrl:
+    """Test _parse_clickhouse_url with various URL formats."""
+
+    def test_full_url_with_all_components(self):
+        url = "clickhouse://myuser:mypass@ch-host:9000/mydb"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert http_url == "http://ch-host:9000"
+        assert db == "mydb"
+        assert user == "myuser"
+        assert password == "mypass"
+
+    def test_url_with_default_port(self):
+        url = "clickhouse://user:pass@host/db"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert http_url == "http://host:8123"
+        assert db == "db"
+
+    def test_url_with_default_database(self):
+        url = "clickhouse://user:pass@host:9000"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert db == "default"
+
+    def test_url_with_default_user_and_password(self):
+        url = "clickhouse://host:9000/db"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert user == "default"
+        assert password == ""
+
+    def test_url_with_slash_only_path(self):
+        url = "clickhouse://user:pass@host:8123/"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert db == "default"
+
+
+# ── Export Query Builder Tests ───────────────────────────
+
+
+class TestBuildChExportQuery:
+    """Test _build_ch_export_query for ReplacingMergeTree vs MergeTree."""
+
+    def test_replacing_engine_has_final_and_is_deleted(self):
+        cfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501)
+        assert "FINAL" in query
+        assert "is_deleted = 0" in query
+
+    def test_mergetree_engine_plain_select(self):
+        cfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501)
+        assert "FINAL" not in query
+        assert "is_deleted" not in query
+
+    def test_correct_time_column_used(self):
+        cfg = {"name": "spans", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202503)
+        assert "toYYYYMM(start_time) = 202503" in query
+
+    def test_ends_with_format_parquet(self):
+        cfg = {"name": "scores", "engine": "replacing", "time_col": "timestamp", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501)
+        assert query.rstrip().endswith("FORMAT Parquet")
+
+    def test_mergetree_ends_with_format_parquet(self):
+        cfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501)
+        assert query.rstrip().endswith("FORMAT Parquet")
+
+
+# ── Count Query Builder Tests ────────────────────────────
+
+
+class TestBuildChCountQuery:
+    """Test _build_ch_count_query for count() AS cnt and FORMAT JSON."""
+
+    def test_has_count_alias(self):
+        cfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_count_query(cfg, 202501)
+        assert "count() AS cnt" in query
+
+    def test_has_format_json(self):
+        cfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_count_query(cfg, 202501)
+        assert "FORMAT JSON" in query
+
+    def test_replacing_has_final(self):
+        cfg = {"name": "spans", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_count_query(cfg, 202501)
+        assert "FINAL" in query
+        assert "is_deleted = 0" in query
+
+    def test_mergetree_no_final(self):
+        cfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        query = _build_ch_count_query(cfg, 202501)
+        assert "FINAL" not in query
+        assert "is_deleted" not in query
+
+
+# ── Time Range Query Builder Tests ───────────────────────
+
+
+class TestBuildChTimeRangeQuery:
+    """Test _build_ch_time_range_query for min/max with aliases."""
+
+    def test_has_min_max_aliases(self):
+        cfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_time_range_query(cfg)
+        assert "AS min_t" in query
+        assert "AS max_t" in query
+
+    def test_replacing_has_final(self):
+        cfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_time_range_query(cfg)
+        assert "FINAL" in query
+        assert "is_deleted = 0" in query
+
+    def test_mergetree_no_final(self):
+        cfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        query = _build_ch_time_range_query(cfg)
+        assert "FINAL" not in query
+
+
+# ── Month Range Tests ────────────────────────────────────
+
+
+class TestMonthRange:
+    """Test _month_range generation."""
+
+    def test_same_month_single_entry(self):
+        result = _month_range(datetime(2025, 3, 10), datetime(2025, 3, 20))
+        assert result == [202503]
+
+    def test_cross_year_boundary(self):
+        result = _month_range(datetime(2024, 11, 1), datetime(2025, 2, 1))
+        assert result == [202411, 202412, 202501, 202502]
+
+    def test_multi_year_range(self):
+        result = _month_range(datetime(2023, 12, 1), datetime(2025, 1, 1))
+        assert result[0] == 202312
+        assert result[-1] == 202501
+        assert len(result) == 14  # Dec 2023 through Jan 2025
+
+    def test_ascending_order_no_gaps(self):
+        result = _month_range(datetime(2025, 1, 1), datetime(2025, 6, 30))
+        assert result == [202501, 202502, 202503, 202504, 202505, 202506]
+        # Verify ascending
+        for i in range(len(result) - 1):
+            assert result[i] < result[i + 1]
+
+
+# ── _is_empty_parquet Tests ──────────────────────────────
+
+
+class TestIsEmptyParquet:
+    """Test _is_empty_parquet with real Parquet files."""
+
+    def test_zero_byte_file_is_empty(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".parquet") as f:
+            path = Path(f.name)
+        try:
+            assert _is_empty_parquet(path) is True
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_non_empty_parquet_file(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".parquet") as f:
+            path = Path(f.name)
+        try:
+            table = pa.table({"id": [1, 2, 3]})
+            pq.write_table(table, path)
+            assert _is_empty_parquet(path) is False
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_empty_rows_parquet_file(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".parquet") as f:
+            path = Path(f.name)
+        try:
+            table = pa.table({"id": pa.array([], type=pa.int64())})
+            pq.write_table(table, path)
+            assert _is_empty_parquet(path) is True
+        finally:
+            path.unlink(missing_ok=True)
+
+
+# ── _read_count Tests ────────────────────────────────────
+
+
+class TestReadCount:
+    """Test _read_count parsing of ClickHouse JSON responses."""
+
+    def test_normal_response(self):
+        resp = MockResponse({"data": [{"cnt": "42"}]})
+        assert _read_count(resp) == 42
+
+    def test_empty_data(self):
+        resp = MockResponse({"data": [{}]})
+        assert _read_count(resp) == 0
+
+    def test_missing_cnt_key(self):
+        resp = MockResponse({"data": [{"other": "value"}]})
+        assert _read_count(resp) == 0
+
+    def test_zero_count(self):
+        resp = MockResponse({"data": [{"cnt": "0"}]})
+        assert _read_count(resp) == 0
+
+
+# ── Constants Tests ──────────────────────────────────────
+
+
+class TestConstants:
+    """Verify CLICKHOUSE_TABLES, FK_PG_TABLE_MAP, and EPOCH_SENTINELS."""
+
+    def test_clickhouse_tables_has_6_entries(self):
+        assert len(CLICKHOUSE_TABLES) == 6
+
+    def test_each_table_has_required_keys(self):
+        for table_cfg in CLICKHOUSE_TABLES:
+            assert "name" in table_cfg
+            assert "engine" in table_cfg
+            assert "time_col" in table_cfg
+            assert "fk_cols" in table_cfg
+
+    def test_table_names(self):
+        names = {t["name"] for t in CLICKHOUSE_TABLES}
+        expected = {"traces", "spans", "scores", "audit_log", "mcp_tool_calls", "agent_interactions"}
+        assert names == expected
+
+    def test_engine_types(self):
+        for t in CLICKHOUSE_TABLES:
+            assert t["engine"] in ("replacing", "mergetree")
+
+    def test_replacing_tables(self):
+        replacing = [t["name"] for t in CLICKHOUSE_TABLES if t["engine"] == "replacing"]
+        assert set(replacing) == {"traces", "spans", "scores"}
+
+    def test_mergetree_tables(self):
+        mergetree = [t["name"] for t in CLICKHOUSE_TABLES if t["engine"] == "mergetree"]
+        assert set(mergetree) == {"audit_log", "mcp_tool_calls", "agent_interactions"}
+
+    def test_fk_pg_table_map_has_5_entries(self):
+        assert len(FK_PG_TABLE_MAP) == 5
+
+    def test_fk_pg_table_map_keys(self):
+        expected_keys = {"agent_id", "mcp_id", "mcp_server_id", "user_id", "actor_id"}
+        assert set(FK_PG_TABLE_MAP.keys()) == expected_keys
+
+    def test_epoch_sentinels_contains_expected(self):
+        assert None in EPOCH_SENTINELS
+        assert "" in EPOCH_SENTINELS
+        assert "1970-01-01 00:00:00.000" in EPOCH_SENTINELS
+        assert "1970-01-01 00:00:00" in EPOCH_SENTINELS
+
+
+# ── Dataclass Tests ──────────────────────────────────────
+
+
+class TestDataclasses:
+    """Verify Phase 2 dataclass fields."""
+
+    def test_telemetry_export_result_fields(self):
+        result = TelemetryExportResult(
+            output_dir="/tmp/out",
+            migration_id="abc-123",
+            table_results={"traces": {"files": [], "row_count": 0}},
+            total_rows=100,
+            total_size_bytes=1024,
+            duration_seconds=5.0,
+        )
+        assert result.output_dir == "/tmp/out"
+        assert result.migration_id == "abc-123"
+        assert result.total_rows == 100
+        assert result.total_size_bytes == 1024
+        assert result.duration_seconds == 5.0
+
+    def test_telemetry_import_result_fields(self):
+        result = TelemetryImportResult(
+            migration_id="abc-123",
+            tables_imported=4,
+            tables_skipped=["scores"],
+            rows_imported={"traces": 500},
+            duration_seconds=10.0,
+            warnings=["some warning"],
+        )
+        assert result.tables_imported == 4
+        assert result.tables_skipped == ["scores"]
+        assert result.rows_imported["traces"] == 500
+        assert result.warnings == ["some warning"]
+
+    def test_telemetry_validation_result_fields(self):
+        result = TelemetryValidationResult(
+            checksums_valid=True,
+            checksum_results={"traces_2025-01.parquet": True},
+            fk_results=None,
+            row_count_results=None,
+        )
+        assert result.checksums_valid is True
+        assert result.fk_results is None
+        assert result.row_count_results is None
+
+
+# ── Error Path Tests (CLI) ───────────────────────────────
+
+
+class TestErrorPaths:
+    """Test CLI error handling for missing arguments and files."""
+
+    def test_export_telemetry_missing_options(self):
+        """export-telemetry without required options should fail."""
+        result = runner.invoke(cli_app, ["migrate", "export-telemetry"])
+        assert result.exit_code != 0
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_export_telemetry_missing_manifest(self, mock_admin):
+        """export-telemetry with non-existent manifest should fail."""
+        result = runner.invoke(
+            cli_app,
+            [
+                "migrate",
+                "export-telemetry",
+                "--clickhouse-url",
+                "clickhouse://localhost:8123/db",
+                "--manifest",
+                "/nonexistent/manifest.json",
+                "--output-dir",
+                "/tmp/test-out",
+            ],
+        )
+        assert result.exit_code != 0
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_import_telemetry_missing_input_dir(self, mock_admin):
+        """import-telemetry with non-existent input dir should fail."""
+        result = runner.invoke(
+            cli_app,
+            [
+                "migrate",
+                "import-telemetry",
+                "--clickhouse-url",
+                "clickhouse://localhost:8123/db",
+                "--input-dir",
+                "/nonexistent/dir",
+            ],
+        )
+        assert result.exit_code != 0
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_validate_telemetry_missing_input_dir(self, mock_admin):
+        """validate-telemetry with non-existent input dir should fail."""
+        result = runner.invoke(
+            cli_app,
+            [
+                "migrate",
+                "validate-telemetry",
+                "--input-dir",
+                "/nonexistent/dir",
+            ],
+        )
+        assert result.exit_code != 0
+
+
+# ── Security Tests ───────────────────────────────────────
+
+
+class TestSecurity:
+    """Verify connection strings never appear in CLI output."""
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    @patch("observal_cli.cmd_migrate.asyncio")
+    def test_clickhouse_url_not_in_export_output(self, mock_asyncio, mock_admin):
+        secret_url = "clickhouse://secret_user:secret_pass@secret-host:9000/secret_db"
+        mock_asyncio.run.side_effect = SystemExit(1)
+        result = runner.invoke(
+            cli_app,
+            [
+                "migrate",
+                "export-telemetry",
+                "--clickhouse-url",
+                secret_url,
+                "--manifest",
+                "/nonexistent/manifest.json",
+                "--output-dir",
+                "/tmp/test-out",
+            ],
+        )
+        assert secret_url not in result.output
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_clickhouse_url_not_in_import_output(self, mock_admin):
+        secret_url = "clickhouse://secret_user:secret_pass@secret-host:9000/secret_db"
+        result = runner.invoke(
+            cli_app,
+            [
+                "migrate",
+                "import-telemetry",
+                "--clickhouse-url",
+                secret_url,
+                "--input-dir",
+                "/nonexistent/dir",
+            ],
+        )
+        assert secret_url not in result.output
+
+    @patch("observal_cli.cmd_migrate._require_admin")
+    def test_clickhouse_url_not_in_validate_output(self, mock_admin):
+        secret_url = "clickhouse://secret_user:secret_pass@secret-host:9000/secret_db"
+        result = runner.invoke(
+            cli_app,
+            [
+                "migrate",
+                "validate-telemetry",
+                "--input-dir",
+                "/nonexistent/dir",
+                "--clickhouse-url",
+                secret_url,
+            ],
+        )
+        assert secret_url not in result.output
+
+
+# ══════════════════════════════════════════════════════════
+# Property-Based Tests (Hypothesis)
+# ══════════════════════════════════════════════════════════
+
+
+# ── Property 1: Admin role authorization gate ────────────
+
+
+class TestAdminRoleGateProperty:
+    """Property 1: Only admin and super_admin roles pass the gate.
+
+    **Validates: Requirements 1.5**
+    """
+
+    ALLOWED_ROLES = {"admin", "super_admin"}
+
+    @given(
+        role=st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N", "P")),
+            min_size=0,
+            max_size=20,
+        )
+    )
+    @hsettings(max_examples=100)
+    def test_role_gate(self, role):
+        with patch("observal_cli.cmd_migrate.client") as mock_client:
+            mock_client.get.return_value = {"role": role}
+            if role in self.ALLOWED_ROLES:
+                _require_admin()  # Should not raise
+            else:
+                with pytest.raises((SystemExit, click.exceptions.Exit)):
+                    _require_admin()
+
+
+# ── Property 2: ClickHouse URL parsing correctness ──────
+
+
+class TestClickhouseUrlParsingProperty:
+    """Property 2: ClickHouse URL parsing extracts correct components.
+
+    **Validates: Requirements 3.1**
+    """
+
+    @given(
+        host=st.from_regex(r"[a-z][a-z0-9-]{0,20}", fullmatch=True),
+        port=st.integers(min_value=1, max_value=65535),
+        db=st.from_regex(r"[a-z][a-z0-9_]{0,20}", fullmatch=True),
+        user=st.from_regex(r"[a-z][a-z0-9]{0,10}", fullmatch=True),
+        password=st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N")),
+            min_size=1,
+            max_size=20,
+        ),
+    )
+    @hsettings(max_examples=100)
+    def test_url_components_extracted(self, host, port, db, user, password):
+        url = f"clickhouse://{user}:{password}@{host}:{port}/{db}"
+        http_url, parsed_db, parsed_user, parsed_password = _parse_clickhouse_url(url)
+        assert http_url == f"http://{host}:{port}"
+        assert parsed_db == db
+        assert parsed_user == user
+        assert parsed_password == password
+
+    @given(
+        host=st.from_regex(r"[a-z][a-z0-9-]{0,20}", fullmatch=True),
+    )
+    @hsettings(max_examples=100)
+    def test_defaults_applied_for_missing_components(self, host):
+        url = f"clickhouse://{host}"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert http_url == f"http://{host}:8123"
+        assert db == "default"
+        assert user == "default"
+        assert password == ""
+
+
+# ── Property 3: Export query builder correctness ─────────
+
+
+class TestExportQueryBuilderProperty:
+    """Property 3: Export query builder correctness.
+
+    **Validates: Requirements 4.2, 4.3, 4.4, 5.4, 12.1, 12.2, 12.3**
+    """
+
+    @given(
+        table_cfg=st.sampled_from(CLICKHOUSE_TABLES),
+        yyyymm=st.integers(min_value=200001, max_value=209912).filter(lambda x: 1 <= x % 100 <= 12),
+    )
+    @hsettings(max_examples=100)
+    def test_export_query_properties(self, table_cfg, yyyymm):
+        query = _build_ch_export_query(table_cfg, yyyymm)
+
+        # FINAL iff replacing
+        if table_cfg["engine"] == "replacing":
+            assert "FINAL" in query
+            assert "is_deleted = 0" in query
+        else:
+            assert "FINAL" not in query
+            assert "is_deleted" not in query
+
+        # Correct time column
+        assert f"toYYYYMM({table_cfg['time_col']}) = {yyyymm}" in query
+
+        # Ends with FORMAT Parquet
+        assert query.rstrip().endswith("FORMAT Parquet")
+
+    @given(
+        table_cfg=st.sampled_from(CLICKHOUSE_TABLES),
+        yyyymm=st.integers(min_value=200001, max_value=209912).filter(lambda x: 1 <= x % 100 <= 12),
+    )
+    @hsettings(max_examples=100)
+    def test_count_query_properties(self, table_cfg, yyyymm):
+        query = _build_ch_count_query(table_cfg, yyyymm)
+
+        assert "count() AS cnt" in query
+        assert "FORMAT JSON" in query
+
+        if table_cfg["engine"] == "replacing":
+            assert "FINAL" in query
+            assert "is_deleted = 0" in query
+        else:
+            assert "FINAL" not in query
+            assert "is_deleted" not in query
+
+
+# ── Property 4: Month range completeness and ordering ────
+
+
+class TestMonthRangeProperty:
+    """Property 4: Month range generation completeness and ordering.
+
+    **Validates: Requirements 5.2, 5.5**
+    """
+
+    @given(
+        min_dt=st.datetimes(min_value=datetime(2000, 1, 1), max_value=datetime(2099, 12, 31)),
+        max_dt=st.datetimes(min_value=datetime(2000, 1, 1), max_value=datetime(2099, 12, 31)),
+    )
+    @hsettings(max_examples=100)
+    def test_month_range_properties(self, min_dt, max_dt):
+        if min_dt > max_dt:
+            min_dt, max_dt = max_dt, min_dt
+
+        result = _month_range(min_dt, max_dt)
+
+        # No duplicates
+        assert len(result) == len(set(result))
+
+        # Ascending order
+        for i in range(len(result) - 1):
+            assert result[i] < result[i + 1]
+
+        # First and last months correct
+        assert result[0] == min_dt.year * 100 + min_dt.month
+        assert result[-1] == max_dt.year * 100 + max_dt.month
+
+        # No gaps: consecutive months differ by 1 month or year rollover
+        for i in range(len(result) - 1):
+            y1, m1 = divmod(result[i], 100)
+            y2, m2 = divmod(result[i + 1], 100)
+            if m1 == 12:
+                assert y2 == y1 + 1 and m2 == 1
+            else:
+                assert y2 == y1 and m2 == m1 + 1
+
+        # Correct length
+        min_months = min_dt.year * 12 + min_dt.month
+        max_months = max_dt.year * 12 + max_dt.month
+        expected_len = max_months - min_months + 1
+        assert len(result) == expected_len
+
+
+# ── Property 5: SHA-256 checksum integrity ───────────────
+
+
+class TestSha256IntegrityProperty:
+    """Property 5: SHA-256 checksum integrity.
+
+    **Validates: Requirements 6.1, 6.5**
+    """
+
+    @given(data=st.binary(min_size=0, max_size=10000))
+    @hsettings(max_examples=100)
+    def test_sha256_deterministic(self, data):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".bin") as f:
+            f.write(data)
+            f.flush()
+            path = Path(f.name)
+        try:
+            hash1 = _sha256_file(path)
+            hash2 = _sha256_file(path)
+            assert hash1 == hash2
+            # Also matches stdlib
+            assert hash1 == hashlib.sha256(data).hexdigest()
+        finally:
+            path.unlink(missing_ok=True)
+
+
+# ── Property 6: Telemetry manifest JSON round-trip ───────
+
+
+class TestTelemetryManifestRoundTripProperty:
+    """Property 6: Telemetry manifest JSON round-trip.
+
+    **Validates: Requirements 10.4**
+    """
+
+    @given(
+        migration_id=st.uuids(),
+        row_counts=st.dictionaries(
+            keys=st.sampled_from(["traces", "spans", "scores", "audit_log", "mcp_tool_calls"]),
+            values=st.integers(min_value=0, max_value=1_000_000),
+            min_size=1,
+            max_size=5,
+        ),
+        checksums_valid=st.booleans(),
+    )
+    @hsettings(max_examples=100)
+    def test_telemetry_manifest_round_trip(self, migration_id, row_counts, checksums_valid):
+        manifest = {
+            "migration_id": str(migration_id),
+            "phase": "deep_copy",
+            "phase_status": "export_complete",
+            "export_completed_at": datetime.now(UTC).isoformat(),
+            "export_time_cutoff": datetime.now(UTC).isoformat(),
+            "source_clickhouse_url_hash": hashlib.sha256(b"clickhouse://test").hexdigest(),
+            "tables": {
+                table: {
+                    "files": [f"{table}_2025-01.parquet"],
+                    "row_count": count,
+                    "checksum": {f"{table}_2025-01.parquet": hashlib.sha256(f"{table}".encode()).hexdigest()},
+                    "time_range": {"min": "2025-01-01T00:00:00", "max": "2025-01-31T23:59:59"},
+                }
+                for table, count in row_counts.items()
+            },
+            "fk_validation": {
+                "orphaned_agent_ids": [],
+                "orphaned_agent_ids_truncated": False,
+                "orphaned_mcp_ids": [],
+                "orphaned_mcp_ids_truncated": False,
+                "orphaned_user_ids": [],
+                "orphaned_user_ids_truncated": False,
+                "validated_at": None,
+            },
+        }
+        serialized = json.dumps(manifest)
+        deserialized = json.loads(serialized)
+        assert deserialized == manifest
+
+
+# ── Property 7: migration_id consistency ─────────────────
+
+
+class TestMigrationIdConsistencyProperty:
+    """Property 7: migration_id consistency across phases.
+
+    **Validates: Requirements 2.4, 16.3**
+    """
+
+    @given(migration_id=st.uuids())
+    @hsettings(max_examples=100)
+    def test_migration_id_carried_forward(self, migration_id):
+        mid = str(migration_id)
+
+        # Phase 1 manifest
+        p1_manifest = {
+            "migration_id": mid,
+            "phase1_completed_at": datetime.now(UTC).isoformat(),
+            "source_db_url_hash": hashlib.sha256(b"pg://test").hexdigest(),
+            "table_row_counts": {},
+            "uuid_ranges": {},
+        }
+
+        # Simulate Phase 2 reading Phase 1 manifest and carrying forward
+        p2_manifest = {
+            "migration_id": p1_manifest["migration_id"],
+            "phase": "deep_copy",
+            "phase_status": "export_complete",
+            "export_completed_at": datetime.now(UTC).isoformat(),
+            "tables": {},
+        }
+
+        # Serialize and deserialize both
+        p1 = json.loads(json.dumps(p1_manifest))
+        p2 = json.loads(json.dumps(p2_manifest))
+        assert p1["migration_id"] == p2["migration_id"]
+        assert p2["migration_id"] == mid
+
+
+# ── Property 8: FK validation completeness ───────────────
+
+
+class TestFKValidationCompletenessProperty:
+    """Property 8: FK validation completeness.
+
+    **Validates: Requirements 9.2, 9.3, 9.4**
+    """
+
+    @given(
+        agent_ids=st.frozensets(st.uuids().map(str), min_size=0, max_size=20),
+        mcp_ids=st.frozensets(st.uuids().map(str), min_size=0, max_size=20),
+        user_ids=st.frozensets(st.uuids().map(str), min_size=0, max_size=20),
+        actor_ids=st.frozensets(st.uuids().map(str), min_size=0, max_size=20),
+        mcp_server_ids=st.frozensets(st.uuids().map(str), min_size=0, max_size=20),
+    )
+    @hsettings(max_examples=100)
+    def test_fk_collection_is_complete(self, agent_ids, mcp_ids, user_ids, actor_ids, mcp_server_ids):
+        """Verify the set logic for FK collection matches the union of all unique non-null values."""
+        # Simulate the FK collection logic from _validate_fk_references
+        fk_values = {
+            "agent_id": set(agent_ids),
+            "mcp_id": set(mcp_ids),
+            "mcp_server_id": set(mcp_server_ids),
+            "user_id": set(user_ids),
+            "actor_id": set(actor_ids),
+        }
+
+        # Merge aliases (same logic as _validate_fk_references)
+        fk_values["mcp_id"] |= fk_values.pop("mcp_server_id", set())
+        fk_values["user_id"] |= fk_values.pop("actor_id", set())
+
+        # Verify merged sets
+        assert fk_values["mcp_id"] == set(mcp_ids) | set(mcp_server_ids)
+        assert fk_values["user_id"] == set(user_ids) | set(actor_ids)
+        assert fk_values["agent_id"] == set(agent_ids)
+
+
+# ── Property 9: Orphaned reference detection ─────────────
+
+
+class TestOrphanedReferenceDetectionProperty:
+    """Property 9: Orphaned reference detection correctness.
+
+    **Validates: Requirements 9.7**
+    """
+
+    @given(
+        collected=st.frozensets(st.uuids().map(str), min_size=0, max_size=50),
+        existing=st.frozensets(st.uuids().map(str), min_size=0, max_size=50),
+    )
+    @hsettings(max_examples=100)
+    def test_orphaned_is_set_difference(self, collected, existing):
+        """orphaned = collected - existing, exactly."""
+        orphaned = sorted(collected - existing)
+        assert set(orphaned) == collected - existing
+        # No false positives: every orphaned ID is in collected but not existing
+        for oid in orphaned:
+            assert oid in collected
+            assert oid not in existing
+        # No false negatives: every collected ID not in existing is orphaned
+        for cid in collected:
+            if cid not in existing:
+                assert cid in orphaned
+
+
+# ── Property 10: Connection string never leaked ──────────
+
+
+class TestConnectionStringNeverLeakedProperty:
+    """Property 10: Connection string never leaked.
+
+    **Validates: Requirements 1.6, 13.1, 13.4**
+    """
+
+    @given(
+        host=st.from_regex(r"[a-z][a-z0-9]{2,10}", fullmatch=True),
+        port=st.integers(min_value=1000, max_value=65535),
+        user=st.from_regex(r"[a-z]{3,10}", fullmatch=True),
+        password=st.from_regex(r"[a-z0-9]{5,15}", fullmatch=True),
+    )
+    @hsettings(max_examples=100)
+    def test_clickhouse_url_never_in_output(self, host, port, user, password):
+        secret_url = f"clickhouse://{user}:{password}@{host}:{port}/testdb"
+
+        # Test export-telemetry path
+        with patch("observal_cli.cmd_migrate._require_admin"):
+            result = runner.invoke(
+                cli_app,
+                [
+                    "migrate",
+                    "export-telemetry",
+                    "--clickhouse-url",
+                    secret_url,
+                    "--manifest",
+                    "/nonexistent/manifest.json",
+                    "--output-dir",
+                    "/tmp/test-out",
+                ],
+            )
+            assert secret_url not in result.output
+
+    @given(
+        host=st.from_regex(r"[a-z][a-z0-9]{2,10}", fullmatch=True),
+        port=st.integers(min_value=1000, max_value=65535),
+        user=st.from_regex(r"[a-z]{3,10}", fullmatch=True),
+        password=st.from_regex(r"[a-z0-9]{5,15}", fullmatch=True),
+    )
+    @hsettings(max_examples=100)
+    def test_clickhouse_url_never_in_import_output(self, host, port, user, password):
+        secret_url = f"clickhouse://{user}:{password}@{host}:{port}/testdb"
+
+        with patch("observal_cli.cmd_migrate._require_admin"):
+            result = runner.invoke(
+                cli_app,
+                [
+                    "migrate",
+                    "import-telemetry",
+                    "--clickhouse-url",
+                    secret_url,
+                    "--input-dir",
+                    "/nonexistent/dir",
+                ],
+            )
+            assert secret_url not in result.output
+
+    @given(
+        host=st.from_regex(r"[a-z][a-z0-9]{2,10}", fullmatch=True),
+        port=st.integers(min_value=1000, max_value=65535),
+        user=st.from_regex(r"[a-z]{3,10}", fullmatch=True),
+        password=st.from_regex(r"[a-z0-9]{5,15}", fullmatch=True),
+    )
+    @hsettings(max_examples=100)
+    def test_clickhouse_url_never_in_validate_output(self, host, port, user, password):
+        secret_url = f"clickhouse://{user}:{password}@{host}:{port}/testdb"
+
+        with patch("observal_cli.cmd_migrate._require_admin"):
+            result = runner.invoke(
+                cli_app,
+                [
+                    "migrate",
+                    "validate-telemetry",
+                    "--input-dir",
+                    "/nonexistent/dir",
+                    "--clickhouse-url",
+                    secret_url,
+                ],
+            )
+            assert secret_url not in result.output

--- a/tests/test_migrate_telemetry.py
+++ b/tests/test_migrate_telemetry.py
@@ -20,9 +20,11 @@ from hypothesis import strategies as st
 from typer.testing import CliRunner
 
 from observal_cli.cmd_migrate import (
+    _UUID_RE,
     CLICKHOUSE_TABLES,
     EPOCH_SENTINELS,
     FK_PG_TABLE_MAP,
+    TableCfg,
     TelemetryExportResult,
     TelemetryImportResult,
     TelemetryValidationResult,
@@ -146,6 +148,28 @@ class TestParseClickhouseUrl:
         http_url, db, user, password = _parse_clickhouse_url(url)
         assert db == "default"
 
+    def test_clickhouses_tls_url(self):
+        url = "clickhouses://myuser:mypass@ch-host:9440/mydb"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert http_url == "https://ch-host:9440"
+        assert db == "mydb"
+        assert user == "myuser"
+        assert password == "mypass"
+
+    def test_clickhouses_default_port_is_8443(self):
+        url = "clickhouses://user:pass@host/db"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert http_url == "https://host:8443"
+        assert db == "db"
+
+    def test_anchored_prefix_password_containing_clickhouse(self):
+        """Password containing 'clickhouse://' should not corrupt parsing."""
+        url = "clickhouse://admin:clickhouse%3A%2F%2Ffoo@host:8123/db"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert http_url == "http://host:8123"
+        assert user == "admin"
+        assert db == "db"
+
 
 # ── Export Query Builder Tests ───────────────────────────
 
@@ -180,6 +204,22 @@ class TestBuildChExportQuery:
         query = _build_ch_export_query(cfg, 202501)
         assert query.rstrip().endswith("FORMAT Parquet")
 
+    def test_cutoff_in_replacing_query(self):
+        cfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501, cutoff="2025-01-15T00:00:00")
+        assert "start_time < {cutoff:String}" in query
+        assert "FINAL" in query
+
+    def test_cutoff_in_mergetree_query(self):
+        cfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501, cutoff="2025-01-15T00:00:00")
+        assert "timestamp < {cutoff:String}" in query
+
+    def test_no_cutoff_when_none(self):
+        cfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501)
+        assert "cutoff" not in query
+
 
 # ── Count Query Builder Tests ────────────────────────────
 
@@ -208,6 +248,12 @@ class TestBuildChCountQuery:
         query = _build_ch_count_query(cfg, 202501)
         assert "FINAL" not in query
         assert "is_deleted" not in query
+
+    def test_cutoff_in_count_query(self):
+        cfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        query = _build_ch_count_query(cfg, 202501, cutoff="2025-01-15T00:00:00")
+        assert "timestamp < {cutoff:String}" in query
+        assert "FORMAT JSON" in query
 
 
 # ── Time Range Query Builder Tests ───────────────────────
@@ -296,6 +342,16 @@ class TestIsEmptyParquet:
         finally:
             path.unlink(missing_ok=True)
 
+    def test_invalid_parquet_returns_true(self):
+        """ArrowInvalid from corrupt data should return True (narrow exception)."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".parquet") as f:
+            f.write(b"not a parquet file at all")
+            path = Path(f.name)
+        try:
+            assert _is_empty_parquet(path) is True
+        finally:
+            path.unlink(missing_ok=True)
+
 
 # ── _read_count Tests ────────────────────────────────────
 
@@ -352,6 +408,23 @@ class TestConstants:
     def test_mergetree_tables(self):
         mergetree = [t["name"] for t in CLICKHOUSE_TABLES if t["engine"] == "mergetree"]
         assert set(mergetree) == {"audit_log", "mcp_tool_calls", "agent_interactions"}
+
+    def test_typed_dict_structure(self):
+        """Verify CLICKHOUSE_TABLES entries conform to TableCfg TypedDict."""
+        required_keys = {"name", "engine", "time_col", "fk_cols"}
+        for table_cfg in CLICKHOUSE_TABLES:
+            assert set(table_cfg.keys()) == required_keys
+            assert isinstance(table_cfg["name"], str)
+            assert table_cfg["engine"] in ("replacing", "mergetree")
+            assert isinstance(table_cfg["time_col"], str)
+            assert isinstance(table_cfg["fk_cols"], list)
+            assert all(isinstance(c, str) for c in table_cfg["fk_cols"])
+
+    def test_tablecfg_type_exists(self):
+        """Verify TableCfg is importable and is a TypedDict."""
+        assert hasattr(TableCfg, "__annotations__")
+        assert "name" in TableCfg.__annotations__
+        assert "engine" in TableCfg.__annotations__
 
     def test_fk_pg_table_map_has_5_entries(self):
         assert len(FK_PG_TABLE_MAP) == 5
@@ -607,6 +680,36 @@ class TestClickhouseUrlParsingProperty:
         assert db == "default"
         assert user == "default"
         assert password == ""
+
+    @given(
+        host=st.from_regex(r"[a-z][a-z0-9-]{0,20}", fullmatch=True),
+        port=st.integers(min_value=1, max_value=65535),
+        db=st.from_regex(r"[a-z][a-z0-9_]{0,20}", fullmatch=True),
+        user=st.from_regex(r"[a-z][a-z0-9]{0,10}", fullmatch=True),
+        password=st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N")),
+            min_size=1,
+            max_size=20,
+        ),
+    )
+    @hsettings(max_examples=100)
+    def test_tls_url_components_extracted(self, host, port, db, user, password):
+        url = f"clickhouses://{user}:{password}@{host}:{port}/{db}"
+        http_url, parsed_db, parsed_user, parsed_password = _parse_clickhouse_url(url)
+        assert http_url == f"https://{host}:{port}"
+        assert parsed_db == db
+        assert parsed_user == user
+        assert parsed_password == password
+
+    @given(
+        host=st.from_regex(r"[a-z][a-z0-9-]{0,20}", fullmatch=True),
+    )
+    @hsettings(max_examples=100)
+    def test_tls_defaults_applied(self, host):
+        url = f"clickhouses://{host}"
+        http_url, db, user, password = _parse_clickhouse_url(url)
+        assert http_url == f"https://{host}:8443"
+        assert db == "default"
 
 
 # ── Property 3: Export query builder correctness ─────────
@@ -972,3 +1075,205 @@ class TestConnectionStringNeverLeakedProperty:
                 ],
             )
             assert secret_url not in result.output
+
+
+# ══════════════════════════════════════════════════════════
+# New Tests for Fix Tasks
+# ══════════════════════════════════════════════════════════
+
+
+# ── UUID Lowercase Normalization ─────────────────────────
+
+
+class TestUUIDLowercaseNormalization:
+    """Verify UUID values are normalized to lowercase for FK comparison."""
+
+    def test_uuid_re_matches_lowercase(self):
+        assert _UUID_RE.match("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+    def test_uuid_re_matches_uppercase(self):
+        assert _UUID_RE.match("A1B2C3D4-E5F6-7890-ABCD-EF1234567890")
+
+    def test_uuid_re_matches_mixed_case(self):
+        assert _UUID_RE.match("A1b2C3d4-E5f6-7890-AbCd-Ef1234567890")
+
+    def test_uuid_re_rejects_non_uuid(self):
+        assert not _UUID_RE.match("not-a-uuid")
+        assert not _UUID_RE.match("filesystem")
+        assert not _UUID_RE.match("")
+
+    def test_uuid_re_is_module_level_constant(self):
+        """Verify _UUID_RE is compiled once at module level, not per call."""
+        import observal_cli.cmd_migrate as mod
+
+        assert hasattr(mod, "_UUID_RE")
+        assert mod._UUID_RE is _UUID_RE
+
+
+# ── Partition Check for All Engines ──────────────────────
+
+
+class TestPartitionCheckAllEngines:
+    """Verify partition-has-data check applies to both replacing and mergetree."""
+
+    def test_replacing_partition_query_uses_final(self):
+        """For replacing engines, the partition check should use FINAL WHERE is_deleted = 0."""
+        # We test this indirectly by checking _ch_partition_has_data builds the right query.
+        # The function is async, so we verify the query pattern via _build_ch_export_query.
+        cfg: TableCfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501)
+        assert "FINAL" in query
+        assert "is_deleted = 0" in query
+
+    def test_mergetree_partition_query_no_final(self):
+        cfg: TableCfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        query = _build_ch_export_query(cfg, 202501)
+        assert "FINAL" not in query
+
+
+# ── Import Resume State ──────────────────────────────────
+
+
+class TestImportResumeState:
+    """Verify .import_state.json is written and read for resume."""
+
+    def test_state_file_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / ".import_state.json"
+            completed = {"traces", "spans"}
+            state_path.write_text(
+                json.dumps({"completed": sorted(completed)}, indent=2),
+                encoding="utf-8",
+            )
+            loaded = json.loads(state_path.read_text(encoding="utf-8"))
+            assert set(loaded["completed"]) == completed
+
+    def test_state_file_empty_initially(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / ".import_state.json"
+            assert not state_path.exists()
+
+
+# ── Atomic Write Pattern ─────────────────────────────────
+
+
+class TestAtomicWritePattern:
+    """Verify the .tmp file pattern for atomic writes."""
+
+    def test_tmp_suffix_construction(self):
+        """Verify the tmp path is constructed correctly."""
+        original = Path("/tmp/traces_2025-01.parquet")
+        tmp = original.with_suffix(original.suffix + ".tmp")
+        assert str(tmp).endswith(".parquet.tmp")
+        assert tmp.name == "traces_2025-01.parquet.tmp"
+
+
+# ── Exception Chaining ───────────────────────────────────
+
+
+class TestExceptionChaining:
+    """Verify raise typer.Exit(1) from exc preserves __cause__."""
+
+    def test_require_admin_chains_exception(self):
+        with patch("observal_cli.cmd_migrate.client") as mock_client:
+            mock_client.get.side_effect = SystemExit(1)
+            with pytest.raises((SystemExit, click.exceptions.Exit)) as exc_info:
+                _require_admin()
+            # The raised exception should have a __cause__
+            if hasattr(exc_info.value, "__cause__"):
+                assert exc_info.value.__cause__ is not None
+
+
+# ── UTF-8 Encoding ───────────────────────────────────────
+
+
+class TestUTF8Encoding:
+    """Verify encoding='utf-8' is used on all text I/O."""
+
+    def test_utf8_write_and_read(self):
+        """Verify UTF-8 encoding works for non-ASCII content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.json"
+            content = json.dumps({"name": "tëst-dàtà-日本語"}, indent=2)
+            path.write_text(content, encoding="utf-8")
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            assert loaded["name"] == "tëst-dàtà-日本語"
+
+
+# ── Sidecar Archive Hash ─────────────────────────────────
+
+
+class TestSidecarArchiveHash:
+    """Verify archive_sha256 field in sidecar manifest."""
+
+    def test_sha256_file_deterministic(self):
+        """Verify _sha256_file produces consistent results."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".tar.gz") as f:
+            f.write(b"test archive content")
+            path = Path(f.name)
+        try:
+            h1 = _sha256_file(path)
+            h2 = _sha256_file(path)
+            assert h1 == h2
+            assert len(h1) == 64  # SHA-256 hex digest length
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_archive_hash_field_in_manifest(self):
+        """Verify the archive_sha256 field can be added to a manifest dict."""
+        manifest = {"migration_id": "test-123"}
+        archive_hash = hashlib.sha256(b"test").hexdigest()
+        manifest["archive_sha256"] = archive_hash
+        serialized = json.dumps(manifest)
+        deserialized = json.loads(serialized)
+        assert deserialized["archive_sha256"] == archive_hash
+
+
+# ── Parameterized Query ──────────────────────────────────
+
+
+class TestParameterizedQuery:
+    """Verify _ch_existing_tables uses parameterized query, not f-string."""
+
+    def test_existing_tables_query_uses_parameterized_syntax(self):
+        """The SQL should use {db:String} placeholder, not f-string interpolation."""
+        # We can't easily call the async function, but we can verify the pattern
+        # by checking the source code uses the right SQL string.
+        import inspect
+
+        from observal_cli.cmd_migrate import _ch_existing_tables
+
+        source = inspect.getsource(_ch_existing_tables)
+        assert "{db:String}" in source
+        assert "extra_params" in source
+        # Should NOT have f-string with db variable in SQL
+        assert 'f"SELECT' not in source or "f'SELECT" not in source
+
+
+# ── Cutoff in WHERE Clause ───────────────────────────────
+
+
+class TestCutoffInWhereClause:
+    """Verify export_time_cutoff appears in WHERE clause."""
+
+    def test_export_query_with_cutoff(self):
+        cfg: TableCfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        cutoff = "2025-06-15T12:00:00+00:00"
+        query = _build_ch_export_query(cfg, 202506, cutoff=cutoff)
+        assert "timestamp < {cutoff:String}" in query
+        assert "toYYYYMM(timestamp) = 202506" in query
+
+    def test_count_query_with_cutoff(self):
+        cfg: TableCfg = {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []}
+        cutoff = "2025-06-15T12:00:00+00:00"
+        query = _build_ch_count_query(cfg, 202506, cutoff=cutoff)
+        assert "timestamp < {cutoff:String}" in query
+        assert "count() AS cnt" in query
+
+    def test_replacing_query_with_cutoff(self):
+        cfg: TableCfg = {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": []}
+        cutoff = "2025-06-15T12:00:00+00:00"
+        query = _build_ch_export_query(cfg, 202506, cutoff=cutoff)
+        assert "start_time < {cutoff:String}" in query
+        assert "FINAL" in query
+        assert "is_deleted = 0" in query

--- a/uv.lock
+++ b/uv.lock
@@ -366,33 +366,24 @@ wheels = [
 ]
 
 [[package]]
-name = "observal-cli"
-version = "0.2.0"
+name = "observal"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "asyncpg" },
+    { name = "docker" },
     { name = "httpx" },
+    { name = "hypothesis" },
+    { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "rich" },
     { name = "typer" },
 ]
 
-[package.optional-dependencies]
-all = [
-    { name = "asyncpg" },
-    { name = "docker" },
-]
-migrate = [
-    { name = "asyncpg" },
-]
-sandbox = [
-    { name = "docker" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "fastapi" },
-    { name = "hypothesis" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pytest" },
@@ -403,21 +394,20 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncpg", marker = "extra == 'migrate'", specifier = ">=0.29.0" },
-    { name = "docker", marker = "extra == 'sandbox'", specifier = ">=7.0.0" },
+    { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "docker", specifier = ">=7.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "observal-cli", extras = ["sandbox", "migrate"], marker = "extra == 'all'" },
+    { name = "hypothesis" },
+    { name = "pyarrow" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
-provides-extras = ["sandbox", "migrate", "all"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "fastapi", specifier = ">=0.135.3" },
-    { name = "hypothesis" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pytest", specifier = ">=9.0.3" },
@@ -454,6 +444,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/41/8e6b6ef7e225d4ceead8459427a52afdc23379768f54dd3566014d7618c1/pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb", size = 34302230, upload-time = "2026-02-16T10:09:03.859Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4a/1472c00392f521fea03ae93408bf445cc7bfa1ab81683faf9bc188e36629/pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350", size = 35850050, upload-time = "2026-02-16T10:09:11.877Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b2/bd1f2f05ded56af7f54d702c8364c9c43cd6abb91b0e9933f3d77b4f4132/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd", size = 44491918, upload-time = "2026-02-16T10:09:18.144Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9", size = 47562811, upload-time = "2026-02-16T10:09:25.792Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/94/1170e235add1f5f45a954e26cd0e906e7e74e23392dcb560de471f7366ec/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c30143b17161310f151f4a2bcfe41b5ff744238c1039338779424e38579d701", size = 48183766, upload-time = "2026-02-16T10:09:34.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/39a42af4570377b99774cdb47f63ee6c7da7616bd55b3d5001aa18edfe4f/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db2190fa79c80a23fdd29fef4b8992893f024ae7c17d2f5f4db7171fa30c2c78", size = 50607669, upload-time = "2026-02-16T10:09:44.153Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/db94101c187f3df742133ac837e93b1f269ebdac49427f8310ee40b6a58f/pyarrow-23.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919", size = 27527698, upload-time = "2026-02-16T10:09:50.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
+    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds deep copy for the cloud migration: three new CLI commands that export, import, and validate ClickHouse telemetry data using Apache Parquet. Requires PostgreSQL shallow copy to be completed first. Also adds a sidecar manifest to shallow copy exports for it's coordination.

**Commands Added:**
1. `observal migrate export-telemetry` : Export all 6 ClickHouse telemetry tables to Parquet files
2. `observal migrate import-telemetry` : Import Parquet files into a target ClickHouse instance
3. `observal migrate validate-telemetry` : Verify checksums, compare row counts, and validate FK references against PostgreSQL

**Execution Example:**
```
uv tool install --editable . --force

# Phase 1 prerequisite (creates sidecar manifest for Phase 2)
observal migrate export --db-url "postgresql://..." --output test-export.tar.gz

# Export telemetry
observal migrate export-telemetry \
  --clickhouse-url "clickhouse://..." \
  --manifest test-export.manifest.json \
  --output-dir telemetry-export

# Validate checksums 
observal migrate validate-telemetry --input-dir telemetry-export

# FK validation against PostgreSQL 
observal migrate validate-telemetry --input-dir telemetry-export --target-db-url "postgresql://..."

# Row count comparison against ClickHouse 
observal migrate validate-telemetry --input-dir telemetry-export --clickhouse-url "clickhouse://..."

# Import into ClickHouse 
observal migrate import-telemetry --clickhouse-url "clickhouse://..." --input-dir telemetry-export

# Idempotent re-import 
observal migrate import-telemetry --clickhouse-url "clickhouse://..." --input-dir telemetry-export

# Post-import validation 
observal migrate validate-telemetry --input-dir telemetry-export --clickhouse-url "clickhouse://..."
```

