### PR TITLE
fix(review): validation badge shows 'failed' for validated MCPs 

### DIFF
--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -1,7 +1,7 @@
 import logging
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, require_role, resolve_listing
@@ -39,6 +39,8 @@ async def analyze_mcp(
 
 async def _store_client_analysis(listing: McpListing, analysis: ClientAnalysis, db: AsyncSession) -> None:
     """Store validation results from client-side (CLI) analysis."""
+    await db.execute(delete(McpValidationResult).where(McpValidationResult.listing_id == listing.id))
+
     has_entry = bool(analysis.entry_point or analysis.framework)
     tool_count = len(analysis.tools)
     issue_count = len(analysis.issues)

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -156,6 +156,7 @@ async def _query_pending_components(db: AsyncSession, type_filter: str | None = 
                         "stage": vr.stage,
                         "passed": vr.passed,
                         "details": vr.details,
+                        "run_at": vr.run_at.isoformat() if vr.run_at else None,
                     }
                     for vr in r.validation_results
                 ]

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from git import Repo
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.mcp import McpListing, McpValidationResult
@@ -448,6 +449,9 @@ def _extract_repo_name(git_url: str, tmp_dir: str) -> str:
 
 
 async def run_validation(listing: McpListing, db: AsyncSession):
+    await db.execute(delete(McpValidationResult).where(McpValidationResult.listing_id == listing.id))
+    await db.commit()
+
     tmp_dir = tempfile.mkdtemp(prefix="observal_")
     try:
         # Stage 1: Clone & Inspect

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -20,7 +20,24 @@ function ValidationBadge({ item }: { item: ReviewItem }) {
   if (item.type !== "mcp" || !item.validation_results?.length) return null;
 
   const failed = item.validation_results.filter((v: McpValidationResult) => !v.passed);
-  const hasIssues = failed.some((v: McpValidationResult) => v.details?.includes("Issues:"));
+  const hasWarnings = item.validation_results.some(
+    (v: McpValidationResult) => v.details?.includes("Issues:"),
+  );
+
+  if (item.mcp_validated) {
+    if (hasWarnings) {
+      return (
+        <span className="inline-flex items-center gap-1 text-[10px] text-amber-500 bg-amber-500/10 border border-amber-500/25 rounded px-1.5 py-0.5">
+          <AlertTriangle className="h-3 w-3" /> Has warnings
+        </span>
+      );
+    }
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] text-success bg-success/10 border border-success/25 rounded px-1.5 py-0.5">
+        <ShieldCheck className="h-3 w-3" /> Validated
+      </span>
+    );
+  }
 
   if (failed.length > 0) {
     return (
@@ -29,20 +46,7 @@ function ValidationBadge({ item }: { item: ReviewItem }) {
       </span>
     );
   }
-  if (hasIssues) {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] text-amber-500 bg-amber-500/10 border border-amber-500/25 rounded px-1.5 py-0.5">
-        <AlertTriangle className="h-3 w-3" /> Has warnings
-      </span>
-    );
-  }
-  if (item.mcp_validated) {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] text-success bg-success/10 border border-success/25 rounded px-1.5 py-0.5">
-        <ShieldCheck className="h-3 w-3" /> Validated
-      </span>
-    );
-  }
+
   return null;
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -160,6 +160,7 @@ export interface McpValidationResult {
   stage: string;
   passed: boolean;
   details?: string;
+  run_at?: string;
 }
 
 export interface ReviewItem {


### PR DESCRIPTION
## Summary
- Badge now trusts `mcp_validated` as the authoritative signal instead of being overridden by stale `passed=false` results
- Stale `McpValidationResult` rows are deleted before each re-validation run
- Fixed unreachable "Has warnings" branch by scanning all results for warnings, not just failed ones
- Added `run_at` timestamp to review API response

## Test plan
- [x] Submit MCP via CLI with quality warnings → badge shows "Has warnings" (amber)
- [x] Inject stale failed result with `mcp_validated=true` → badge shows "Has warnings" (amber), not "Validation failed" (red)
- [x] 137/138 backend tests pass (1 pre-existing Windows-only failure)


Closes #353