### PR TITLE
feat: add Redis-backed caching and gzip compression

### DIFF
--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -695,3 +695,12 @@ async def get_audit_log(
     except Exception as e:
         logger.warning("Audit log query failed: %s", e)
         return {"events": [], "total": 0}
+
+
+@router.post("/admin/cache/clear")
+async def clear_cache(current_user: User = Depends(require_role(UserRole.admin))):
+    """Clear all cached dashboard and OTEL responses."""
+    from services.cache import invalidate_all
+
+    deleted = await invalidate_all()
+    return {"cleared": deleted}

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -697,7 +697,7 @@ async def get_audit_log(
         return {"events": [], "total": 0}
 
 
-@router.post("/admin/cache/clear")
+@router.post("/cache/clear")
 async def clear_cache(current_user: User = Depends(require_role(UserRole.admin))):
     """Clear all cached dashboard and OTEL responses."""
     from services.cache import invalidate_all

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -4,11 +4,13 @@ from datetime import UTC, timedelta
 from datetime import datetime as dt
 
 from fastapi import APIRouter, Depends, Query
+from fastapi_cache.decorator import cache
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role
 from api.sanitize import escape_like
+from config import settings
 from models.agent import Agent, AgentStatus
 from models.download import AgentDownloadRecord
 from models.mcp import ListingStatus, McpDownload, McpListing
@@ -65,6 +67,7 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
 
 
 @router.get("/mcps/{listing_id}/metrics", response_model=McpMetrics)
+@cache(expire=settings.CACHE_TTL_DEFAULT, namespace="dashboard")
 async def mcp_metrics(
     listing_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -101,6 +104,7 @@ async def mcp_metrics(
 
 
 @router.get("/agents/{agent_id}/metrics", response_model=AgentMetrics)
+@cache(expire=settings.CACHE_TTL_DEFAULT, namespace="dashboard")
 async def agent_metrics(
     agent_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -162,6 +166,7 @@ async def agent_metrics(
 
 
 @router.get("/overview/stats", response_model=OverviewStats)
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def overview_stats(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
@@ -192,6 +197,7 @@ async def overview_stats(
 
 
 @router.get("/overview/top-mcps", response_model=list[TopItem])
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def top_mcps(db: AsyncSession = Depends(get_db)):
     result = await db.execute(
         select(McpDownload.listing_id, func.count(McpDownload.id).label("cnt"), McpListing.name)
@@ -204,6 +210,7 @@ async def top_mcps(db: AsyncSession = Depends(get_db)):
 
 
 @router.get("/overview/top-agents", response_model=list[TopAgentItem])
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def top_agents(
     limit: int = Query(6, le=50),
     db: AsyncSession = Depends(get_db),
@@ -253,6 +260,7 @@ async def top_agents(
 
 
 @router.get("/overview/leaderboard", response_model=list[LeaderboardItem])
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def agent_leaderboard(
     window: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
     limit: int = Query(20, le=50),
@@ -363,6 +371,7 @@ async def agent_leaderboard(
 
 
 @router.get("/overview/component-leaderboard", response_model=list[ComponentLeaderboardItem])
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def component_leaderboard(
     window: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
     limit: int = Query(20, le=50),
@@ -414,6 +423,7 @@ async def component_leaderboard(
 
 
 @router.get("/overview/trends", response_model=list[TrendPoint])
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def trends(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
@@ -452,6 +462,7 @@ async def trends(
 
 
 @router.get("/dashboard/tokens", response_model=TokenStats)
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def token_stats(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
@@ -585,6 +596,7 @@ async def token_stats(
 
 
 @router.get("/dashboard/ide-usage", response_model=IdeUsage)
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def ide_usage(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),
@@ -619,6 +631,7 @@ async def ide_usage(
 
 
 @router.get("/dashboard/sandbox-metrics", response_model=SandboxStats)
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def sandbox_metrics(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),
@@ -688,6 +701,7 @@ async def sandbox_metrics(
 
 
 @router.get("/dashboard/graphrag-metrics", response_model=GraphRagStats)
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def graphrag_metrics(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),
@@ -781,6 +795,7 @@ async def run_graphrag_ragas_eval(
 
 
 @router.get("/dashboard/graphrag-ragas-scores", response_model=RagasScores)
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def graphrag_ragas_scores(
     graphrag_id: str | None = None,
     db: AsyncSession = Depends(get_db),
@@ -810,6 +825,7 @@ async def graphrag_ragas_scores(
 
 
 @router.get("/dashboard/latency-heatmap", response_model=list[LatencyCell])
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def latency_heatmap(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),
@@ -844,6 +860,7 @@ async def latency_heatmap(
 
 
 @router.get("/dashboard/unannotated-traces", response_model=list[UnannotatedTrace])
+@cache(expire=settings.CACHE_TTL_DASHBOARD, namespace="dashboard")
 async def unannotated_traces(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -6,8 +6,10 @@ import time as _time
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query, Request
+from fastapi_cache.decorator import cache
 
 from api.deps import require_role
+from config import settings
 from models.user import User, UserRole
 from services.clickhouse import _query, query_shim_spans_for_window
 from services.redis import publish
@@ -71,6 +73,7 @@ def _is_admin_user(user: User) -> bool:
 
 
 @router.get("/sessions")
+@cache(expire=settings.CACHE_TTL_OTEL, namespace="otel")
 async def list_sessions(
     status: str | None = Query(None),
     current_user: User = Depends(require_role(UserRole.user)),
@@ -467,6 +470,7 @@ async def get_session(session_id: str, current_user: User = Depends(require_role
 
 
 @router.get("/traces")
+@cache(expire=settings.CACHE_TTL_OTEL, namespace="otel")
 async def list_traces(current_user: User = Depends(require_role(UserRole.admin))):
     rows = await _ch_json(
         "SELECT "
@@ -532,6 +536,7 @@ async def get_trace(trace_id: str, current_user: User = Depends(require_role(Use
 
 
 @router.get("/errors")
+@cache(expire=settings.CACHE_TTL_OTEL, namespace="otel")
 async def list_errors(current_user: User = Depends(require_role(UserRole.admin))):
     """List recent error events (tool failures, stop failures, API errors)."""
     rows = await _ch_json(
@@ -558,6 +563,7 @@ async def list_errors(current_user: User = Depends(require_role(UserRole.admin))
 
 
 @router.get("/stats")
+@cache(expire=settings.CACHE_TTL_DEFAULT, namespace="otel")
 async def otel_stats(current_user: User = Depends(require_role(UserRole.admin))):
     log_rows = await _ch_json(
         "SELECT "

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -41,6 +41,11 @@ class Settings(BaseSettings):
     # ClickHouse data retention
     DATA_RETENTION_DAYS: int = 90
 
+    # Cache TTL defaults (seconds)
+    CACHE_TTL_DEFAULT: int = 30
+    CACHE_TTL_DASHBOARD: int = 60
+    CACHE_TTL_OTEL: int = 15
+
     @field_validator("DATA_RETENTION_DAYS")
     @classmethod
     def validate_retention_days(cls, v: int) -> int:

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -11,6 +11,7 @@ from slowapi.errors import RateLimitExceeded
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.requests import Request
 from strawberry.fastapi import GraphQLRouter
@@ -45,6 +46,7 @@ from config import settings
 from database import engine
 from models import Base
 from models.user import User
+from services.cache import close_cache, init_cache
 from services.clickhouse import init_clickhouse
 from services.crypto import init_key_manager
 from services.redis import close as close_redis
@@ -76,6 +78,7 @@ async def lifespan(app: FastAPI):
         await conn.run_sync(Base.metadata.create_all)
         await _ensure_columns(conn)
     await init_clickhouse()
+    await init_cache()
     # Initialize asymmetric key manager for JWT signing
     init_key_manager(
         key_dir=settings.JWT_KEY_DIR,
@@ -101,6 +104,7 @@ async def lifespan(app: FastAPI):
             app.state.enterprise_issues = ["ee/ module not installed"]
 
     yield
+    await close_cache()
     await close_redis()
 
 
@@ -213,6 +217,23 @@ app.add_middleware(ContentTypeMiddleware)
 
 # --- Request ID ---
 app.add_middleware(RequestIDMiddleware)
+
+# --- GZip compression for responses >= 500 bytes ---
+app.add_middleware(GZipMiddleware, minimum_size=500)
+
+
+class CacheControlMiddleware(BaseHTTPMiddleware):
+    """Set Cache-Control headers on responses served from cache."""
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        cache_header = response.headers.get("X-FastAPI-Cache")
+        if cache_header == "HIT" or (request.method == "GET" and cache_header == "MISS"):
+            response.headers["Cache-Control"] = f"public, max-age={settings.CACHE_TTL_DEFAULT}"
+        return response
+
+
+app.add_middleware(CacheControlMiddleware)
 
 # GraphQL (replaces REST dashboard endpoints)
 graphql_app = GraphQLRouter(schema, context_getter=get_context_dep)

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "aiosqlite>=0.22.1",
     "tenacity>=8.0.0",
     "python-multipart>=0.0.26",
+    "fastapi-cache2[redis]>=0.2.2",
+    "jinja2>=3.1.0",
     "mako>=1.3.11",
 ]
 

--- a/observal-server/services/cache.py
+++ b/observal-server/services/cache.py
@@ -1,8 +1,10 @@
 """Redis-backed response cache for dashboard and OTEL endpoints."""
 
+import hashlib
 import logging
 
 from redis import asyncio as aioredis
+from starlette.requests import Request
 
 from config import settings
 
@@ -11,6 +13,15 @@ logger = logging.getLogger(__name__)
 CACHE_PREFIX = "observal-cache"
 
 _redis: aioredis.Redis | None = None
+
+
+def _request_key_builder(func, namespace="", *, request: Request | None = None, **kwargs):
+    """Build cache key from path + query string only, ignoring Depends params."""
+    prefix = f"{CACHE_PREFIX}:{namespace}" if namespace else CACHE_PREFIX
+    url = request.url.path if request else func.__name__
+    qs = str(request.query_params) if request and request.query_params else ""
+    raw = f"{url}?{qs}" if qs else url
+    return f"{prefix}:{hashlib.md5(raw.encode(), usedforsecurity=False).hexdigest()}"
 
 
 async def init_cache() -> None:
@@ -30,7 +41,7 @@ async def init_cache() -> None:
         socket_connect_timeout=settings.REDIS_SOCKET_TIMEOUT,
         socket_timeout=settings.REDIS_SOCKET_TIMEOUT,
     )
-    FastAPICache.init(RedisBackend(_redis), prefix=CACHE_PREFIX)
+    FastAPICache.init(RedisBackend(_redis), prefix=CACHE_PREFIX, key_builder=_request_key_builder)
     logger.info("FastAPICache initialized (Redis backend, prefix=%s)", CACHE_PREFIX)
 
 

--- a/observal-server/services/cache.py
+++ b/observal-server/services/cache.py
@@ -1,0 +1,74 @@
+"""Redis-backed response cache for dashboard and OTEL endpoints."""
+
+import logging
+
+from redis import asyncio as aioredis
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+CACHE_PREFIX = "observal-cache"
+
+_redis: aioredis.Redis | None = None
+
+
+async def init_cache() -> None:
+    """Initialize FastAPICache with a Redis backend.
+
+    Uses a separate Redis connection with ``decode_responses=False``
+    because fastapi-cache2 stores binary (bytes) values.
+    """
+    global _redis
+    from fastapi_cache import FastAPICache
+    from fastapi_cache.backends.redis import RedisBackend
+
+    _redis = aioredis.from_url(
+        settings.REDIS_URL,
+        encoding="utf-8",
+        decode_responses=False,
+        socket_connect_timeout=settings.REDIS_SOCKET_TIMEOUT,
+        socket_timeout=settings.REDIS_SOCKET_TIMEOUT,
+    )
+    FastAPICache.init(RedisBackend(_redis), prefix=CACHE_PREFIX)
+    logger.info("FastAPICache initialized (Redis backend, prefix=%s)", CACHE_PREFIX)
+
+
+async def close_cache() -> None:
+    global _redis
+    if _redis:
+        await _redis.aclose()
+        _redis = None
+
+
+async def invalidate_all() -> int:
+    """Delete every key under the cache prefix. Returns count deleted."""
+    if not _redis:
+        return 0
+    cursor, keys = 0, []
+    pattern = f"{CACHE_PREFIX}:*"
+    while True:
+        cursor, batch = await _redis.scan(cursor=cursor, match=pattern, count=500)
+        keys.extend(batch)
+        if cursor == 0:
+            break
+    if keys:
+        await _redis.delete(*keys)
+    logger.info("Cache invalidated: %d keys deleted", len(keys))
+    return len(keys)
+
+
+async def invalidate_namespace(namespace: str) -> int:
+    """Delete keys matching a specific namespace."""
+    if not _redis:
+        return 0
+    pattern = f"{CACHE_PREFIX}:{namespace}:*"
+    cursor, keys = 0, []
+    while True:
+        cursor, batch = await _redis.scan(cursor=cursor, match=pattern, count=500)
+        keys.extend(batch)
+        if cursor == 0:
+            break
+    if keys:
+        await _redis.delete(*keys)
+    return len(keys)

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -10,6 +10,17 @@ from config import settings
 
 logger = logging.getLogger(__name__)
 
+
+async def _invalidate_cache():
+    """Best-effort cache invalidation after ClickHouse writes."""
+    try:
+        from services.cache import invalidate_all
+
+        await invalidate_all()
+    except Exception:
+        pass
+
+
 _parsed = urlparse(settings.CLICKHOUSE_URL.replace("clickhouse://", "http://"))
 CLICKHOUSE_HTTP = f"http://{_parsed.hostname}:{_parsed.port or 8123}"
 CLICKHOUSE_DB = _parsed.path.strip("/") or "default"
@@ -349,6 +360,7 @@ async def insert_tool_call(event: dict):
     try:
         r = await _query(sql, params)
         r.raise_for_status()
+        await _invalidate_cache()
     except Exception as e:
         logger.error(f"ClickHouse insert_tool_call failed: {e}")
         raise
@@ -373,6 +385,7 @@ async def insert_agent_interaction(event: dict):
     try:
         r = await _query(sql, params)
         r.raise_for_status()
+        await _invalidate_cache()
     except Exception as e:
         logger.error(f"ClickHouse insert_agent_interaction failed: {e}")
         raise
@@ -427,6 +440,7 @@ async def insert_traces(traces: list[dict]):
     try:
         r = await _query(sql, data="\n".join(lines))
         r.raise_for_status()
+        await _invalidate_cache()
     except Exception as e:
         logger.error(f"ClickHouse insert_traces failed: {e}")
         raise
@@ -511,6 +525,7 @@ async def insert_spans(spans: list[dict]):
     try:
         r = await _query(sql, data="\n".join(lines))
         r.raise_for_status()
+        await _invalidate_cache()
     except Exception as e:
         logger.error(f"ClickHouse insert_spans failed: {e}")
         raise
@@ -556,6 +571,7 @@ async def insert_scores(scores: list[dict]):
     try:
         r = await _query(sql, data="\n".join(lines))
         r.raise_for_status()
+        await _invalidate_cache()
     except Exception as e:
         logger.error(f"ClickHouse insert_scores failed: {e}")
         raise
@@ -589,6 +605,7 @@ async def insert_otel_logs(rows: list[dict]):
     try:
         r = await _query(sql, data="\n".join(lines))
         r.raise_for_status()
+        await _invalidate_cache()
     except Exception as e:
         logger.error(f"ClickHouse insert_otel_logs failed: {e}")
         raise
@@ -851,5 +868,6 @@ async def insert_audit_log(events: list[dict]):
     try:
         r = await _query(sql, data=body)
         r.raise_for_status()
+        await _invalidate_cache()
     except Exception as exc:
         logger.error(f"ClickHouse insert_audit_log failed: {exc}")

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -389,6 +389,26 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi-cache2"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "pendulum" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/6f/7c2078bf097634276a266fe225d9d6a1f882fe505a662bd1835fb2cf6891/fastapi_cache2-0.2.2.tar.gz", hash = "sha256:71bf4450117dc24224ec120be489dbe09e331143c9f74e75eb6f576b78926026", size = 17950, upload-time = "2024-07-24T15:47:21.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/b3/ce7c5d9f5e75257a3039ee1e38feb77bee29da3a1792c57d6ea1acb55d17/fastapi_cache2-0.2.2-py3-none-any.whl", hash = "sha256:e1fae86d8eaaa6c8501dfe08407f71d69e87cc6748042d59d51994000532846c", size = 25411, upload-time = "2024-07-24T15:47:19.065Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -647,6 +667,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -803,9 +835,11 @@ dependencies = [
     { name = "cryptography" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "fastapi-cache2", extra = ["redis"] },
     { name = "gitpython" },
     { name = "httpx" },
     { name = "itsdangerous" },
+    { name = "jinja2" },
     { name = "mako" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -841,9 +875,11 @@ requires-dist = [
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "fastapi-cache2", extras = ["redis"], specifier = ">=0.2.2" },
     { name = "gitpython" },
     { name = "httpx" },
     { name = "itsdangerous" },
+    { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mako", specifier = ">=1.3.11" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -874,6 +910,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pendulum"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/72/9a51afa0a822b09e286c4cb827ed7b00bc818dac7bd11a5f161e493a217d/pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce", size = 86912, upload-time = "2026-01-30T11:22:24.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/27/a4be6ec12161b503dd036f8d7cc57f8626170ae31bb298038be9af0001ce/pendulum-3.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5d775cc608c909ad415c8e789c84a9f120bb6a794c4215b2d8d910893cf0ec6a", size = 337923, upload-time = "2026-01-30T11:20:51.61Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/2a214e18355ec2a6ce3f683a97eecdb6050866ff3a6cf165d411450aeb1b/pendulum-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8de794a7f665aebc8c1ba4dd4b05ab8fe1a36ce9c0498366adf1d1edd79b2686", size = 327379, upload-time = "2026-01-30T11:20:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/01/7392e58ebc1d9e70b987dc8bb0c89710b47ac8125067efe7aa4c420b616f/pendulum-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bac7df7696e1c942e17c0556b3a7bcdd1d7aa5b24faee7620cb071e754a0622", size = 340115, upload-time = "2026-01-30T11:20:54.635Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/80de84c5ca1a3e4f7f3b75090c9b61b6dbb6d095e302ee592cebbaf0bbfb/pendulum-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db0f6a8a04475d9cba26ce701e7d66d266fd97227f2f5f499270eba04be1c7e9", size = 373969, upload-time = "2026-01-30T11:20:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/f7b4c1818927ab394a2a0a9b7011f360a0a75839a22678833c5bc0a84183/pendulum-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c352c63c1ff05f2198409b28498d7158547a8be23e1fbd4aa2cf5402fb239b55", size = 379058, upload-time = "2026-01-30T11:20:57.618Z" },
+    { url = "https://files.pythonhosted.org/packages/36/94/9947cf710620afcc68751683f2f8de88d902505e7c13c0349d7e9d362f97/pendulum-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de8c1ad1d1aa7d4ceae341528bab35a0f8c88a5aa63f2f5d84e16b517d1b32c2", size = 348403, upload-time = "2026-01-30T11:20:59.56Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/12/0e6ba0bb00fa57907af2a3fca8643bded5dba1e87072d50673776a0d6ed2/pendulum-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1ba955511c12fec2252038b0c866c25c0c30b720bf74d3023710f121e42b1498", size = 517457, upload-time = "2026-01-30T11:21:01.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/fe/dae5fbfe67bd41d943def0ad8f1e7f6988aa8e527255e433cd7c494f9ad5/pendulum-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4115bf364a2ec6d5ddc476751ceaa4164a04f2c15589f0d29aa210ddb784b15d", size = 561103, upload-time = "2026-01-30T11:21:03.924Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a0/8f646160b98abfc19152505af19bd643a4279ec2bdbe0959f16b7025fc6b/pendulum-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:4151a903356413fdd9549de0997b708fb95a214ed97803ffb479ffd834088378", size = 260595, upload-time = "2026-01-30T11:21:05.495Z" },
+    { url = "https://files.pythonhosted.org/packages/79/01/feead7af9ded7a13f2d798fb6573e70f469113eafcd8cc8f59671584ca3e/pendulum-3.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:acfdee9ddc56053cb7c8c075afbfde0857322d09e56a56195b9cd127fae87e4c", size = 255382, upload-time = "2026-01-30T11:21:06.847Z" },
+    { url = "https://files.pythonhosted.org/packages/41/56/dd0ea9f97d25a0763cda09e2217563b45714786118d8c68b0b745395d6eb/pendulum-3.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bf0b489def51202a39a2a665dcc4162d5e46934a740fe4c4fe3068979610156c", size = 337830, upload-time = "2026-01-30T11:21:08.298Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/98/83d62899bf7226fc12396de4bc1fb2b5da27e451c7c60790043aaf8b4731/pendulum-3.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:937a529aa302efa18dcf25e53834964a87ffb2df8f80e3669ab7757a6126beaf", size = 327574, upload-time = "2026-01-30T11:21:09.715Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fa/ff2aa992b23f0543c709b1a3f3f9ed760ec71fd02c8bb01f93bf008b52e4/pendulum-3.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85c7689defc65c4dc29bf257f7cca55d210fabb455de9476e1748d2ab2ae80d7", size = 339891, upload-time = "2026-01-30T11:21:11.089Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4e/25b4fa11d19503d50d7b52d7ef943c0f20fd54422aaeb9e38f588c815c50/pendulum-3.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d5e216e5a412563ea2ecf5de467dcf3d02717947fcdabe6811d5ee360726b02b", size = 373726, upload-time = "2026-01-30T11:21:12.493Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/30/0acad6396c4e74e5c689aa4f0b0c49e2ecdcfce368e7b5bf35ca1c0fc61a/pendulum-3.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a2af22eeec438fbaac72bb7fba783e0950a514fba980d9a32db394b51afccec", size = 379827, upload-time = "2026-01-30T11:21:14.08Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f7/e6a2fdf2a23d59b4b48b8fa89e8d4bf2dd371aea2c6ba8fcecec20a4acb9/pendulum-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3159cceb54f5aa8b85b141c7f0ce3fac8bdd1ffdc7c79e67dca9133eac7c4d11", size = 348921, upload-time = "2026-01-30T11:21:15.816Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f2/c15fa7f9ad4e181aa469b6040b574988bd108ccdf4ae509ad224f9e4db44/pendulum-3.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c39ea5e9ffa20ea8bae986d00e0908bd537c8468b71d6b6503ab0b4c3d76e0ea", size = 517188, upload-time = "2026-01-30T11:21:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c7/5f80b12ee88ec26e930c3a5a602608a63c29cf60c81a0eb066d583772550/pendulum-3.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e5afc753e570cce1f44197676371f68953f7d4f022303d141bb09f804d5fe6d7", size = 561833, upload-time = "2026-01-30T11:21:19.232Z" },
+    { url = "https://files.pythonhosted.org/packages/90/15/1ac481626cb63db751f6281e294661947c1f0321ebe5d1c532a3b51a8006/pendulum-3.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:fd55c12560816d9122ca2142d9e428f32c0c083bf77719320b1767539c7a3a3b", size = 258725, upload-time = "2026-01-30T11:21:20.558Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/50b0398d7d027eb70a3e1e336de7b6e599c6b74431cb7d3863287e1292bb/pendulum-3.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:faef52a7ed99729f0838353b956f3fabf6c550c062db247e9e2fc2b48fcb9457", size = 253089, upload-time = "2026-01-30T11:21:22.497Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8c/400c8b8dbd7524424f3d9902ded64741e82e5e321d1aabbd68ade89e71cf/pendulum-3.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:addb0512f919fe5b70c8ee534ee71c775630d3efe567ea5763d92acff857cfc3", size = 337820, upload-time = "2026-01-30T11:21:24.305Z" },
+    { url = "https://files.pythonhosted.org/packages/59/38/7c16f26cc55d9206d71da294ce6857d0da381e26bc9e0c2a069424c2b173/pendulum-3.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3aaa50342dc174acebdc21089315012e63789353957b39ac83cac9f9fc8d1075", size = 327551, upload-time = "2026-01-30T11:21:25.747Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cd/f36ec5d56d55104232380fdbf84ff53cc05607574af3cbdc8a43991ac8a7/pendulum-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:927e9c9ab52ff68e71b76dd410e5f1cd78f5ea6e7f0a9f5eb549aea16a4d5354", size = 339894, upload-time = "2026-01-30T11:21:27.229Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/b9a1e546519c3a92d5bc17787cea925e06a20def2ae344fa136d2fc40338/pendulum-3.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:249d18f5543c9f43aba3bd77b34864ec8cf6f64edbead405f442e23c94fce63d", size = 373766, upload-time = "2026-01-30T11:21:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a6/6471ab87ae2260594501f071586a765fc894817043b7d2d4b04e2eff4f31/pendulum-3.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c644cc15eec5fb02291f0f193195156780fd5a0affd7a349592403826d1a35e", size = 379837, upload-time = "2026-01-30T11:21:30.637Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/79/0ba0c14e862388f7b822626e6e989163c23bebe7f96de5ec4b207cbe7c3d/pendulum-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:063ab61af953bb56ad5bc8e131fd0431c915ed766d90ccecd7549c8090b51004", size = 348904, upload-time = "2026-01-30T11:21:32.436Z" },
+    { url = "https://files.pythonhosted.org/packages/17/34/df922c7c0b12719589d4954bfa5bdca9e02bcde220f5c5c1838a87118960/pendulum-3.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:26a3ae26c9dd70a4256f1c2f51addc43641813574c0db6ce5664f9861cd93621", size = 517173, upload-time = "2026-01-30T11:21:34.428Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/3b9e061eeee97b72a47c1434ee03f6d85f0284d9285d92b12b0fff2d19ac/pendulum-3.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:2b10d91dc00f424444a42f47c69e6b3bfd79376f330179dc06bc342184b35f9a", size = 561744, upload-time = "2026-01-30T11:21:35.861Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7e/f12fdb6070b7975c1fcfa5685dbe4ab73c788878a71f4d1d7e3c87979e37/pendulum-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:63070ff03e30a57b16c8e793ee27da8dac4123c1d6e0cf74c460ce9ee8a64aa4", size = 258746, upload-time = "2026-01-30T11:21:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/5abd872056357f069ae34a9b24a75ac58e79092d16201d779a8dd31386bb/pendulum-3.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:c8dde63e2796b62070a49ce813ce200aba9186130307f04ec78affcf6c2e8122", size = 253028, upload-time = "2026-01-30T11:21:39.381Z" },
+    { url = "https://files.pythonhosted.org/packages/82/99/5b9cc823862450910bcb2c7cdc6884c0939b268639146d30e4a4f55eb1f1/pendulum-3.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c17ac069e88c5a1e930a5ae0ef17357a14b9cc5a28abadda74eaa8106d241c8e", size = 338281, upload-time = "2026-01-30T11:21:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/3a/64a35260f6ac36c0ad50eeb5f1a465b98b0d7603f79a5c2077c41326d639/pendulum-3.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e1fbb540edecb21f8244aebfb05a1f2333ddc6c7819378c099d4a61cc91ae93c", size = 328030, upload-time = "2026-01-30T11:21:42.778Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6b/1140e09310035a2afb05bb90a2b8fbda9d3222e03b92de9533123afe6b65/pendulum-3.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8c67fb9a1fe8fc1adae2cc01b0c292b268c12475b4609ff4aed71c9dd367b4d", size = 340206, upload-time = "2026-01-30T11:21:44.148Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4a/a493de56cbc24a64b21ac6ba98513a9ec5c67daa3dba325e39a8e53f30d8/pendulum-3.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:baa9a66c980defda6cfe1275103a94b22e90d83ebd7a84cc961cee6cbd25a244", size = 373976, upload-time = "2026-01-30T11:21:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/f083c4fd1a161d4ab218680cc906338c541497b3098373f2241f58c429cb/pendulum-3.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef8f783fa7a14973b0596d8af2a5b2d90858a55030e9b4c6885eb4284b88314f", size = 380075, upload-time = "2026-01-30T11:21:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b6/333a0fcb33bf15eb879a46a11ce6300c1698a141e689665fe430783ff8d6/pendulum-3.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7d2e9bfb065727d8676e7ada3793b47a24349500a5e9637404355e482c822be", size = 349026, upload-time = "2026-01-30T11:21:48.271Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1a/dfb526ec0cba1e7cd6a5e4f4dd64a6ada7428d1449c54b15f7b295f6e122/pendulum-3.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:55d7ba6bb74171c3ee409bf30076ee3a259a3c2bb147ac87ebb76aaa3cf5d3a2", size = 517395, upload-time = "2026-01-30T11:21:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/37/b4f2b5f1200351c4869b8b46ad5c21019e3dbe0417f5867ae969fad7b5fe/pendulum-3.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:a50d8cf42f06d3d8c3f8bb2a7ac47fa93b5145e69de6a7209be6a47afdd9cf76", size = 561926, upload-time = "2026-01-30T11:21:51.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9e/567376582da58f5fe8e4f579db2bcfbf243cf619a5825bdf1023ad1436b3/pendulum-3.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e5bbb92b155cd5018b3cf70ee49ed3b9c94398caaaa7ed97fe41e5bb5a968418", size = 258817, upload-time = "2026-01-30T11:21:53.074Z" },
+    { url = "https://files.pythonhosted.org/packages/95/67/dfffd7eb50d67fa821cd4d92cf71575ead6162930202bc40dfcedf78c38c/pendulum-3.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:d53134418e04335c3029a32e9341cccc9b085a28744fb5ee4e6a8f5039363b1a", size = 253292, upload-time = "2026-01-30T11:21:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0d/d5ac8468a1b40f09a62d6e91654088de432367907579dd161c0fb1bdf222/pendulum-3.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9585594d32faa71efa5a78f576f1ee4f79e9c5340d7c6f0cd6c5dfe725effaaa", size = 338760, upload-time = "2026-01-30T11:22:12.225Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/7fa8c8be6caac8e0be78fbe7668df571f44820ed779cb3736fab645fcba8/pendulum-3.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:26401e2de77c437e8f3b6160c08c6c5d45518d906f8f9b48fd7cb5aa0f4e2aff", size = 328333, upload-time = "2026-01-30T11:22:13.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/78/73a1031b7d1bf7986e8e655cea3f018164b3470aecfea25a4074e77dda73/pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:637e65af042f383a2764a886aa28ccc6f853bf7a142df18e41c720542934c13b", size = 340841, upload-time = "2026-01-30T11:22:15.278Z" },
+    { url = "https://files.pythonhosted.org/packages/49/40/4e36e9074e92b0164c088b9ada3c02bfea386d83e24fa98b30fe9b6e61a8/pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6e46c28f4d067233c4a4c42748f4ffa641d9289c09e0e81488beb6d4b3fab51", size = 348959, upload-time = "2026-01-30T11:22:16.718Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/8bf7fcb91b526e1efe17d047faa845709b88800fff915ff848ff26054293/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:71d46bcc86269f97bfd8c5f1475d55e717696a0a010b1871023605ca94624031", size = 518102, upload-time = "2026-01-30T11:22:18.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b0/a36c468d2d0dec62ddea7c5e4177e93abb12f48ac90f09f24d0581c5189f/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5cd956d4176afc7bfe8a91bf3f771b46ff8d326f6c5bf778eb5010eb742ebba6", size = 561884, upload-time = "2026-01-30T11:22:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4d/dad105261898907bf806cabca53d3878529a9fa2c0d5d7f95f2035246fc2/pendulum-3.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:39ef129d7b90aab49708645867abdd207b714ba7bff12dae549975b0aca09716", size = 261236, upload-time = "2026-01-30T11:22:21.059Z" },
+    { url = "https://files.pythonhosted.org/packages/02/fb/d65db067a67df7252f18b0cb7420dda84078b9e8bfb375215469c14a50be/pendulum-3.2.0-py3-none-any.whl", hash = "sha256:f3a9c18a89b4d9ef39c5fa6a78722aaff8d5be2597c129a3b16b9f40a561acf3", size = 114111, upload-time = "2026-01-30T11:22:22.361Z" },
 ]
 
 [[package]]
@@ -1154,15 +1250,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "5.3.1"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
-    { name = "pyjwt" },
+    { name = "async-timeout", marker = "python_full_version <= '3.11.2'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/88/63d802c2b18dd9eaa5b846cbf18917c6b2882f20efda398cc16a7500b02c/redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d", size = 4561721, upload-time = "2023-06-25T13:13:57.139Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2e/409703d645363352a20c944f5d119bdae3eb3034051a53724a7c5fee12b8/redis-4.6.0-py3-none-any.whl", hash = "sha256:e2b03db868160ee4591de3cb90d40ebb50a90dd302138775937f6a42b7ed183c", size = 241149, upload-time = "2023-06-25T13:13:54.563Z" },
 ]
 
 [package.optional-dependencies]
@@ -1370,6 +1465,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds Redis-backed response caching and gzip compression to reduce ClickHouse query load and improve response times. The existing Redis connection is used exclusively for pub/sub and arq; this adds a separate cache layer using `fastapi-cache2`.

## Changes

### New: `services/cache.py`
- `init_cache()` / `close_cache()` — lifecycle tied to app lifespan
- `invalidate_all()` — flush all cached keys (used by write paths and admin endpoint)
- `invalidate_namespace()` — flush keys by namespace (dashboard vs otel)
- Uses a separate Redis connection with `decode_responses=False` (required by fastapi-cache2)

### Caching (19 endpoints)
**dashboard.py** (15 endpoints, 30-60s TTL):
- Overview stats, top MCPs, top agents, leaderboard, component leaderboard, trends
- Token stats, IDE usage, sandbox metrics, GraphRAG metrics/scores, latency heatmap, unannotated traces
- Per-entity metrics (MCP/agent) at 30s TTL

**otel_dashboard.py** (4 endpoints, 15-30s TTL):
- `/sessions`, `/traces`, `/errors` at 15s (near-realtime)
- `/stats` at 30s
- Individual session/trace lookups and `/hooks` POST are NOT cached

### Cache Invalidation
- All ClickHouse insert functions (`insert_tool_call`, `insert_agent_interaction`, `insert_traces`, `insert_spans`, `insert_scores`) call `_invalidate_cache()` after successful writes
- Best-effort: failures are silently ignored to not block writes

### GZip Compression
- `GZipMiddleware(minimum_size=500)` compresses responses >= 500 bytes

### Cache-Control Headers
- `CacheControlMiddleware` sets `Cache-Control: public, max-age=N` on cached GET responses based on `X-FastAPI-Cache` header

### Admin Endpoint
- `POST /api/v1/admin/cache/clear` — manually flush all cached responses (admin only)

### Configuration
- `CACHE_TTL_DEFAULT` (30s) — per-entity metrics, otel stats
- `CACHE_TTL_DASHBOARD` (60s) — overview/dashboard endpoints
- `CACHE_TTL_OTEL` (15s) — session/trace list endpoints

## Files Changed
- `observal-server/pyproject.toml` — added `fastapi-cache2[redis]`, `jinja2`
- `observal-server/config.py` — added cache TTL settings
- `observal-server/main.py` — cache lifecycle, GZipMiddleware, CacheControlMiddleware
- `observal-server/services/cache.py` — new file
- `observal-server/services/clickhouse.py` — cache invalidation on writes
- `observal-server/api/routes/dashboard.py` — @cache decorators
- `observal-server/api/routes/otel_dashboard.py` — @cache decorators
- `observal-server/api/routes/admin.py` — /cache/clear endpoint

## Testing
- 1230 tests pass (20 failures are pre-existing Windows-specific issues)
- Zero regressions from this change
