### PR TITLE
feat(skills): generate IDE-specific skill files on agent install (#431)

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -12,6 +12,7 @@ from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus
 from models.agent_component import AgentComponent
 from models.download import AgentDownloadRecord
 from models.mcp import ListingStatus, McpListing
+from models.skill import SkillListing
 from models.user import User, UserRole
 from schemas.agent import (
     AgentCreateRequest,
@@ -631,6 +632,13 @@ async def install_agent(
         mcp_rows = (await db.execute(select(McpListing).where(McpListing.id.in_(mcp_comp_ids)))).scalars().all()
         mcp_listings_map = {row.id: row for row in mcp_rows}
 
+    # Pre-load skill listings for skill file generation
+    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    skill_listings_map = {}
+    if skill_comp_ids:
+        skill_rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
+        skill_listings_map = {row.id: row for row in skill_rows}
+
     # Resolve all component names for rules file content
     name_map = await _resolve_component_names(agent.components, db)
 
@@ -642,6 +650,7 @@ async def install_agent(
         env_values=req.env_values,
         options=req.options,
         platform=req.platform,
+        skill_listings=skill_listings_map,
     )
 
     # Capture agent.id before any DB operations that might expire the ORM

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -119,7 +119,7 @@ async def install_skill(
 
     from services.skill_config_generator import generate_skill_config
 
-    config = generate_skill_config(listing, req.ide)
+    config = generate_skill_config(listing, req.ide, scope=req.scope)
     return SkillInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
 
 

--- a/observal-server/schemas/skill.py
+++ b/observal-server/schemas/skill.py
@@ -106,6 +106,7 @@ class SkillListingSummary(BaseModel):
 
 class SkillInstallRequest(BaseModel):
     ide: str
+    scope: str = "project"
 
 
 class SkillInstallResponse(BaseModel):

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -295,6 +295,40 @@ def _build_mcp_entries(manifest: AgentManifest) -> dict:
     return entries
 
 
+def _build_skill_files(manifest: AgentManifest, ide: str) -> list[AgentFile]:
+    """Generate IDE-specific skill files from manifest skills."""
+    files: list[AgentFile] = []
+    for skill in manifest.components.skills:
+        name = _sanitize_name(skill.name)
+        desc = skill.description or ""
+
+        if ide in ("claude-code", "claude_code"):
+            content = f"---\nname: {name}\n"
+            if desc:
+                content += f'description: "{desc}"\n'
+            if skill.slash_command:
+                content += f"command: /{skill.slash_command}\n"
+            content += f"---\n\n{desc}\n"
+            files.append(AgentFile(path=f".claude/skills/{name}/SKILL.md", content=content, format="markdown"))
+
+        elif ide == "kiro":
+            content = f"---\nname: {name}\n"
+            if desc:
+                content += f'description: "{desc}"\n'
+            content += f"---\n\n{desc}\n"
+            files.append(AgentFile(path=f".kiro/skills/{name}/SKILL.md", content=content, format="markdown"))
+
+        elif ide == "cursor":
+            content = f"---\ndescription: {desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+            files.append(AgentFile(path=f".cursor/rules/{name}.md", content=content, format="markdown"))
+
+        elif ide == "vscode":
+            content = f"---\ndescription: {desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+            files.append(AgentFile(path=f".vscode/rules/{name}.md", content=content, format="markdown"))
+
+    return files
+
+
 def _build_rules_markdown(manifest: AgentManifest) -> str:
     """Build markdown rules content from the agent manifest."""
     sections = []
@@ -314,7 +348,8 @@ def _build_rules_markdown(manifest: AgentManifest) -> str:
         lines = ["## Skills", ""]
         for skill in manifest.components.skills:
             cmd = f" (`/{skill.slash_command}`)" if skill.slash_command else ""
-            lines.append(f"- **{skill.name}** v{skill.version}{cmd}")
+            desc = f" — {skill.description}" if skill.description else ""
+            lines.append(f"- **{skill.name}** v{skill.version}{cmd}{desc}")
         sections.append("\n".join(lines))
 
     if manifest.components.hooks:
@@ -358,6 +393,8 @@ def _generate_claude_code(manifest: AgentManifest) -> IdeAgentConfig:
     frontmatter_lines.append("---")
     agent_content = "\n".join(frontmatter_lines) + "\n\n" + rules_content
 
+    skill_files = _build_skill_files(manifest, "claude-code")
+
     return IdeAgentConfig(
         ide="claude-code",
         files=[
@@ -366,6 +403,7 @@ def _generate_claude_code(manifest: AgentManifest) -> IdeAgentConfig:
                 content=agent_content,
                 format="markdown",
             ),
+            *skill_files,
         ],
         mcp_servers=mcp_entries,
         env={
@@ -383,6 +421,8 @@ def _generate_cursor(manifest: AgentManifest) -> IdeAgentConfig:
     mcp_entries = _build_mcp_entries(manifest)
     rules_content = _build_rules_markdown(manifest)
 
+    skill_files = _build_skill_files(manifest, "cursor")
+
     return IdeAgentConfig(
         ide="cursor",
         files=[
@@ -396,6 +436,7 @@ def _generate_cursor(manifest: AgentManifest) -> IdeAgentConfig:
                 content={"mcpServers": mcp_entries},
                 format="json",
             ),
+            *skill_files,
         ],
         mcp_servers=mcp_entries,
     )
@@ -406,6 +447,8 @@ def _generate_vscode(manifest: AgentManifest) -> IdeAgentConfig:
     safe_name = _sanitize_name(manifest.name)
     mcp_entries = _build_mcp_entries(manifest)
     rules_content = _build_rules_markdown(manifest)
+
+    skill_files = _build_skill_files(manifest, "vscode")
 
     return IdeAgentConfig(
         ide="vscode",
@@ -420,6 +463,7 @@ def _generate_vscode(manifest: AgentManifest) -> IdeAgentConfig:
                 content={"mcpServers": mcp_entries},
                 format="json",
             ),
+            *skill_files,
         ],
         mcp_servers=mcp_entries,
     )
@@ -463,6 +507,8 @@ def _generate_kiro(manifest: AgentManifest) -> IdeAgentConfig:
         "model": manifest.model_name or "default",
     }
 
+    skill_files = _build_skill_files(manifest, "kiro")
+
     return IdeAgentConfig(
         ide="kiro",
         files=[
@@ -471,6 +517,7 @@ def _generate_kiro(manifest: AgentManifest) -> IdeAgentConfig:
                 content=kiro_agent,
                 format="json",
             ),
+            *skill_files,
         ],
         mcp_servers=mcp_entries,
     )

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -118,13 +118,15 @@ def _build_skill_configs(
         listing = skill_listings.get(comp.component_id)
         if not listing:
             continue
-        skills.append({
-            "name": _sanitize_name(listing.name),
-            "description": getattr(listing, "description", "") or "",
-            "slash_command": getattr(listing, "slash_command", None),
-            "task_type": getattr(listing, "task_type", ""),
-            "activation_keywords": getattr(listing, "activation_keywords", None),
-        })
+        skills.append(
+            {
+                "name": _sanitize_name(listing.name),
+                "description": getattr(listing, "description", "") or "",
+                "slash_command": getattr(listing, "slash_command", None),
+                "task_type": getattr(listing, "task_type", ""),
+                "activation_keywords": getattr(listing, "activation_keywords", None),
+            }
+        )
 
     return skills
 

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -100,6 +100,75 @@ def _build_mcp_configs(
     return mcp_configs
 
 
+def _build_skill_configs(
+    agent: Agent,
+    skill_listings: dict | None = None,
+) -> list[dict]:
+    """Build skill metadata from registry skill components.
+
+    Returns a list of dicts with skill metadata (name, description, etc.)
+    that IDE-specific generators turn into skill files.
+    """
+    skill_listings = skill_listings or {}
+    skills: list[dict] = []
+
+    for comp in agent.components:
+        if comp.component_type != "skill":
+            continue
+        listing = skill_listings.get(comp.component_id)
+        if not listing:
+            continue
+        skills.append({
+            "name": _sanitize_name(listing.name),
+            "description": getattr(listing, "description", "") or "",
+            "slash_command": getattr(listing, "slash_command", None),
+            "task_type": getattr(listing, "task_type", ""),
+            "activation_keywords": getattr(listing, "activation_keywords", None),
+        })
+
+    return skills
+
+
+def _generate_skill_file(skill: dict, ide: str, scope: str = "project") -> dict:
+    """Generate an IDE-specific skill file entry.
+
+    Returns a dict with 'path' and 'content' keys, or None for
+    monolithic IDEs (Gemini, Codex, Copilot) that inline skills into rules.
+    """
+    name = skill["name"]
+    desc = skill.get("description", "")
+    slash_cmd = skill.get("slash_command")
+
+    if ide in ("claude-code", "claude_code"):
+        content = f"---\nname: {name}\n"
+        if desc:
+            content += f'description: "{desc}"\n'
+        if slash_cmd:
+            content += f"command: /{slash_cmd}\n"
+        content += f"---\n\n{desc}\n"
+        prefix = "~/.claude" if scope == "user" else ".claude"
+        return {"path": f"{prefix}/skills/{name}/SKILL.md", "content": content}
+
+    if ide == "kiro":
+        content = f"---\nname: {name}\n"
+        if desc:
+            content += f'description: "{desc}"\n'
+        content += f"---\n\n{desc}\n"
+        return {"path": f".kiro/skills/{name}/SKILL.md", "content": content}
+
+    if ide == "cursor":
+        prefix = "~/.cursor" if scope == "user" else ".cursor"
+        content = f"---\ndescription: {desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+        return {"path": f"{prefix}/rules/{name}.md", "content": content}
+
+    if ide == "vscode":
+        content = f"---\ndescription: {desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+        return {"path": f".vscode/rules/{name}.md", "content": content}
+
+    # Monolithic IDEs (gemini, codex, copilot) — no separate file
+    return None
+
+
 def _build_rules_content(agent: Agent, component_names: dict | None = None) -> str:
     """Build markdown rules content from the agent and its components.
 
@@ -149,6 +218,7 @@ def generate_agent_config(
     env_values: dict | None = None,
     options: dict | None = None,
     platform: str = "",
+    skill_listings: dict | None = None,
 ) -> dict:
     """Generate IDE-specific config for an agent.
 
@@ -157,10 +227,12 @@ def generate_agent_config(
         component_names: optional {component_id_str: name} map for all component types.
         env_values: optional {mcp_listing_id_str: {VAR: value}} map of user-supplied env var values.
         platform: client platform string (e.g. "win32", "darwin", "linux"). Empty = Unix default.
+        skill_listings: optional {component_id: SkillListing} map pre-loaded by caller.
     """
     safe_name = _sanitize_name(agent.name)
     mcp_configs = _build_mcp_configs(agent, ide, observal_url, mcp_listings=mcp_listings, env_values=env_values)
     rules_content = _build_rules_content(agent, component_names)
+    skill_configs = _build_skill_configs(agent, skill_listings)
     options = options or {}
 
     if ide == "kiro":
@@ -240,6 +312,10 @@ def generate_agent_config(
                     f"{agent.prompt}"
                 ),
             }
+        skill_files = [_generate_skill_file(s, "kiro") for s in skill_configs]
+        skill_files = [f for f in skill_files if f]
+        if skill_files:
+            result["skill_files"] = skill_files
         return result
 
     if ide in ("claude-code", "claude_code"):
@@ -281,7 +357,10 @@ def generate_agent_config(
         # Path: project-level (.claude/agents/) or user-level (~/.claude/agents/)
         agent_path = f"~/.claude/agents/{safe_name}.md" if scope == "user" else f".claude/agents/{safe_name}.md"
 
-        return {
+        skill_files = [_generate_skill_file(s, ide, scope) for s in skill_configs]
+        skill_files = [f for f in skill_files if f]
+
+        result = {
             "rules_file": {"path": agent_path, "content": agent_content},
             "mcp_config": claude_mcps,
             "mcp_setup_commands": setup_commands,
@@ -289,6 +368,9 @@ def generate_agent_config(
             "claude_settings_snippet": {"env": otlp},
             "scope": scope,
         }
+        if skill_files:
+            result["skill_files"] = skill_files
+        return result
 
     if ide in ("gemini-cli", "gemini_cli"):
         gemini_scope = options.get("scope", "project")
@@ -322,8 +404,13 @@ def generate_agent_config(
         "vscode": (".vscode/rules/{name}.md", ".vscode/mcp.json"),
     }
     rules_path, mcp_path = ide_paths.get(ide, (f".rules/{safe_name}.md", ".mcp.json"))
-    return {
+    skill_files = [_generate_skill_file(s, ide, ide_scope) for s in skill_configs]
+    skill_files = [f for f in skill_files if f]
+    result = {
         "rules_file": {"path": rules_path.format(name=safe_name), "content": rules_content},
         "mcp_config": {"path": mcp_path, "content": {"mcpServers": mcp_configs}},
         "scope": ide_scope,
     }
+    if skill_files:
+        result["skill_files"] = skill_files
+    return result

--- a/observal-server/services/skill_config_generator.py
+++ b/observal-server/services/skill_config_generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 _SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")

--- a/observal-server/services/skill_config_generator.py
+++ b/observal-server/services/skill_config_generator.py
@@ -1,5 +1,60 @@
-def generate_skill_config(skill_listing, ide: str, server_url: str = "http://localhost:8000") -> dict:
-    """Generate config snippet for skill telemetry via SessionStart/End hooks."""
+import re
+
+_SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _sanitize_name(name: str) -> str:
+    if _SAFE_NAME.match(name):
+        return name
+    return re.sub(r"[^a-zA-Z0-9_-]", "-", name)
+
+
+def _generate_skill_file(skill_listing, ide: str, scope: str = "project") -> dict | None:
+    """Generate an IDE-specific skill file dict with path and content.
+
+    Returns None for monolithic IDEs (gemini, codex, copilot) that inline
+    skills into their rules markdown.
+    """
+    name = _sanitize_name(skill_listing.name)
+    desc = getattr(skill_listing, "description", "") or ""
+    slash_cmd = getattr(skill_listing, "slash_command", None)
+
+    if ide in ("claude-code", "claude_code"):
+        content = f"---\nname: {name}\n"
+        if desc:
+            content += f'description: "{desc}"\n'
+        if slash_cmd:
+            content += f"command: /{slash_cmd}\n"
+        content += f"---\n\n{desc}\n"
+        prefix = "~/.claude" if scope == "user" else ".claude"
+        return {"path": f"{prefix}/skills/{name}/SKILL.md", "content": content}
+
+    if ide == "kiro":
+        content = f"---\nname: {name}\n"
+        if desc:
+            content += f'description: "{desc}"\n'
+        content += f"---\n\n{desc}\n"
+        return {"path": f".kiro/skills/{name}/SKILL.md", "content": content}
+
+    if ide == "cursor":
+        prefix = "~/.cursor" if scope == "user" else ".cursor"
+        content = f"---\ndescription: {desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+        return {"path": f"{prefix}/rules/{name}.md", "content": content}
+
+    if ide == "vscode":
+        content = f"---\ndescription: {desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+        return {"path": f".vscode/rules/{name}.md", "content": content}
+
+    return None
+
+
+def generate_skill_config(
+    skill_listing,
+    ide: str,
+    server_url: str = "http://localhost:8000",
+    scope: str = "project",
+) -> dict:
+    """Generate config snippet for skill install: telemetry hooks + skill file."""
     skill_id = str(skill_listing.id)
     skill_name = str(skill_listing.name)
 
@@ -32,5 +87,10 @@ def generate_skill_config(skill_listing, ide: str, server_url: str = "http://loc
     skill_path = getattr(skill_listing, "skill_path", None)
     if skill_path:
         config["skill"]["skill_path"] = skill_path
+
+    # Generate IDE-specific skill file
+    skill_file = _generate_skill_file(skill_listing, ide, scope)
+    if skill_file:
+        config["skill_file"] = skill_file
 
     return config

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -509,6 +509,14 @@ def agent_install(
         content = rules.get("content", "")
         rprint(f"[dim]{content[:200]}{'...' if len(content) > 200 else ''}[/dim]\n")
 
+    # Skill files
+    skill_files = snippet.get("skill_files", [])
+    if skill_files:
+        rprint(f"[bold]Skill files ({len(skill_files)}):[/bold]")
+        for sf in skill_files:
+            rprint(f"  [green]{sf['path']}[/green]")
+        rprint()
+
     # MCP config
     mcp_cfg = snippet.get("mcp_config")
     if mcp_cfg:

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -153,15 +153,35 @@ def skill_install(
     skill_id: str = typer.Argument(..., help="Skill ID, name, row number, or @alias"),
     ide: str = typer.Option(..., "--ide", "-i", help="Target IDE"),
     raw: bool = typer.Option(False, "--raw", help="Output raw JSON only"),
+    no_write: bool = typer.Option(False, "--no-write", help="Print config without writing files"),
 ):
-    """Get install config for a skill."""
+    """Install a skill — writes the skill file to disk and shows config."""
     resolved = config.resolve_alias(skill_id)
     with spinner(f"Generating {ide} config..."):
         result = client.post(f"/api/v1/skills/{resolved}/install", {"ide": ide})
     snippet = result.get("config_snippet", result)
+
     if raw:
         print(_json.dumps(snippet, indent=2))
         return
+
+    # Write the skill file to disk unless --no-write
+    skill_file = snippet.get("skill_file")
+    if skill_file and not no_write:
+        import os
+        from pathlib import Path
+
+        file_path = skill_file["path"]
+        if file_path.startswith("~/"):
+            file_path = str(Path.home() / file_path[2:])
+
+        dest = Path(file_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(skill_file["content"], encoding="utf-8")
+        rprint(f"[green]✓ Wrote skill file:[/green] {dest}")
+    elif skill_file:
+        rprint(f"[dim]Skill file (not written):[/dim] {skill_file['path']}")
+
     rprint(f"\n[bold]Config for {ide}:[/bold]\n")
     console.print_json(_json.dumps(snippet, indent=2))
 

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -168,7 +168,6 @@ def skill_install(
     # Write the skill file to disk unless --no-write
     skill_file = snippet.get("skill_file")
     if skill_file and not no_write:
-        import os
         from pathlib import Path
 
         file_path = skill_file["path"]

--- a/scripts/seed_test_skill.py
+++ b/scripts/seed_test_skill.py
@@ -6,7 +6,6 @@ Usage:
 Requires the server to be running at localhost:8000 with demo accounts enabled.
 """
 
-import json
 import sys
 
 import requests
@@ -23,7 +22,7 @@ if r.status_code != 200:
     print(f"   FAILED to login: {r.status_code} {r.text}")
     sys.exit(1)
 admin_token = r.json()["access_token"]
-print(f"   OK — got token")
+print("   OK — got token")
 
 # Use admin token for everything (user account may not exist)
 user_token = admin_token
@@ -76,9 +75,9 @@ r = requests.post(
     headers={"Authorization": f"Bearer {admin_token}"},
 )
 if r.status_code == 200:
-    print(f"   OK — approved!")
+    print("   OK — approved!")
 elif "already" in r.text.lower() or r.status_code == 400:
-    print(f"   Already approved (or status doesn't allow re-approve)")
+    print("   Already approved (or status doesn't allow re-approve)")
 else:
     print(f"   Warning: {r.status_code} {r.text}")
 

--- a/scripts/seed_test_skill.py
+++ b/scripts/seed_test_skill.py
@@ -1,0 +1,198 @@
+"""Seed a test skill into the local Observal instance for testing skill installs.
+
+Usage:
+    python scripts/seed_test_skill.py
+
+Requires the server to be running at localhost:8000 with demo accounts enabled.
+"""
+
+import json
+import sys
+
+import requests
+
+BASE = "http://localhost:8000"
+
+# Login as admin (can approve skills)
+print("1. Logging in as admin...")
+r = requests.post(f"{BASE}/api/v1/auth/login", json={
+    "email": "admin@demo.example",
+    "password": "admin-changeme",
+})
+if r.status_code != 200:
+    print(f"   FAILED to login: {r.status_code} {r.text}")
+    sys.exit(1)
+admin_token = r.json()["access_token"]
+print(f"   OK — got token")
+
+# Use admin token for everything (user account may not exist)
+user_token = admin_token
+print("2. Using admin token for skill submission too")
+
+# Submit a skill as user
+print("3. Submitting test skill...")
+skill_payload = {
+    "name": "code-review-ai",
+    "version": "1.0.0",
+    "description": "AI-powered code review that checks for bugs, security issues, and style violations. Provides inline suggestions and generates review summaries.",
+    "owner": "demo-user",
+    "git_url": "https://github.com/observal/skills-library.git",
+    "skill_path": "skills/code-review-ai",
+    "task_type": "code-review",
+    "slash_command": "review",
+    "target_agents": ["claude-code", "cursor", "kiro"],
+    "activation_keywords": ["review", "check code", "audit"],
+    "supported_ides": ["claude-code", "cursor", "vscode", "kiro"],
+}
+r = requests.post(
+    f"{BASE}/api/v1/skills/submit",
+    json=skill_payload,
+    headers={"Authorization": f"Bearer {user_token}"},
+)
+if r.status_code == 409:
+    print("   Skill already exists — looking it up...")
+    r2 = requests.get(
+        f"{BASE}/api/v1/skills/my",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    skills = r2.json()
+    skill = next((s for s in skills if s["name"] == "code-review-ai"), None)
+    if not skill:
+        print("   FAILED to find existing skill")
+        sys.exit(1)
+    skill_id = skill["id"]
+    print(f"   Using existing skill: {skill_id}")
+elif r.status_code != 200:
+    print(f"   FAILED: {r.status_code} {r.text}")
+    sys.exit(1)
+else:
+    skill_id = r.json()["id"]
+    print(f"   OK — skill ID: {skill_id}")
+
+# Approve as admin
+print("4. Approving skill as admin...")
+r = requests.post(
+    f"{BASE}/api/v1/review/{skill_id}/approve",
+    headers={"Authorization": f"Bearer {admin_token}"},
+)
+if r.status_code == 200:
+    print(f"   OK — approved!")
+elif "already" in r.text.lower() or r.status_code == 400:
+    print(f"   Already approved (or status doesn't allow re-approve)")
+else:
+    print(f"   Warning: {r.status_code} {r.text}")
+
+# Verify it shows up in the public list
+print("5. Verifying skill appears in list...")
+r = requests.get(f"{BASE}/api/v1/skills")
+skills = r.json()
+found = next((s for s in skills if s["name"] == "code-review-ai"), None)
+if found:
+    print(f"   OK — visible in list! Status: {found.get('status')}")
+else:
+    print("   WARNING: not visible in public list (may need approval)")
+
+# Test install endpoint
+print("6. Testing install endpoint...")
+r = requests.post(
+    f"{BASE}/api/v1/skills/{skill_id}/install",
+    json={"ide": "claude-code", "scope": "project"},
+    headers={"Authorization": f"Bearer {user_token}"},
+)
+if r.status_code == 200:
+    config = r.json()["config_snippet"]
+    print(f"   OK — install response has skill_file: {'skill_file' in config}")
+    if "skill_file" in config:
+        print(f"   Path: {config['skill_file']['path']}")
+        print(f"   Content preview: {config['skill_file']['content'][:100]}...")
+else:
+    print(f"   FAILED: {r.status_code} {r.text}")
+
+
+# ── Part 2: Create an agent that bundles the skill ──
+
+print("\n7. Creating agent with skill bundled...")
+agent_payload = {
+    "name": "test-skill-agent",
+    "version": "1.0.0",
+    "description": "Test agent to verify skill file generation on install",
+    "prompt": "You are a helpful coding assistant with code review capabilities.",
+    "owner": "demo-admin",
+    "model_name": "claude-sonnet-4",
+    "supported_ides": ["claude-code", "cursor", "vscode", "kiro"],
+    "components": [
+        {"component_type": "skill", "component_id": skill_id}
+    ],
+    "external_mcps": [],
+    "goal_template": {
+        "description": "Code review and assistance",
+        "sections": [
+            {"name": "default", "description": "Default goal section"}
+        ],
+    },
+}
+r = requests.post(
+    f"{BASE}/api/v1/agents",
+    json=agent_payload,
+    headers={"Authorization": f"Bearer {admin_token}"},
+)
+if r.status_code == 409:
+    print("   Agent already exists — looking it up...")
+    r2 = requests.get(
+        f"{BASE}/api/v1/agents",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    agents = r2.json()
+    agent = next((a for a in agents if a["name"] == "test-skill-agent"), None)
+    if not agent:
+        print("   FAILED to find existing agent")
+        sys.exit(1)
+    agent_id = agent["id"]
+    print(f"   Using existing agent: {agent_id}")
+elif r.status_code not in (200, 201):
+    print(f"   FAILED: {r.status_code} {r.text}")
+    sys.exit(1)
+else:
+    agent_id = r.json()["id"]
+    print(f"   OK — agent ID: {agent_id}")
+
+# Approve the agent
+print("8. Approving agent...")
+r = requests.post(
+    f"{BASE}/api/v1/review/{agent_id}/approve",
+    headers={"Authorization": f"Bearer {admin_token}"},
+)
+if r.status_code == 200:
+    print("   OK — approved!")
+else:
+    print(f"   Status: {r.status_code} {r.text}")
+
+# Test agent install
+print("9. Testing agent install (claude-code)...")
+r = requests.post(
+    f"{BASE}/api/v1/agents/{agent_id}/install",
+    json={"ide": "claude-code"},
+    headers={"Authorization": f"Bearer {admin_token}"},
+)
+if r.status_code == 200:
+    result = r.json()
+    has_skills = "skill_files" in result
+    print(f"   OK — response has skill_files: {has_skills}")
+    if has_skills:
+        for sf in result["skill_files"]:
+            print(f"   → {sf['path']}")
+    else:
+        print(f"   Keys in response: {list(result.keys())}")
+else:
+    print(f"   FAILED: {r.status_code} {r.text}")
+
+print("\n--- DONE ---")
+print(f"Skill ID: {skill_id}")
+print(f"Agent ID: {agent_id}")
+print("\nTest from frontend:")
+print("  1. Go to http://localhost:3000")
+print("  2. Login: admin@demo.example / admin-changeme")
+print("  3. Find 'test-skill-agent' → Install → pick IDE")
+print("  4. Response should include skill_files with SKILL.md")
+print("\nTest from CLI:")
+print(f"  observal agent install {agent_id} --ide claude-code")

--- a/scripts/seed_test_skill.py
+++ b/scripts/seed_test_skill.py
@@ -14,10 +14,13 @@ BASE = "http://localhost:8000"
 
 # Login as admin (can approve skills)
 print("1. Logging in as admin...")
-r = requests.post(f"{BASE}/api/v1/auth/login", json={
-    "email": "admin@demo.example",
-    "password": "admin-changeme",
-})
+r = requests.post(
+    f"{BASE}/api/v1/auth/login",
+    json={
+        "email": "admin@demo.example",
+        "password": "admin-changeme",
+    },
+)
 if r.status_code != 200:
     print(f"   FAILED to login: {r.status_code} {r.text}")
     sys.exit(1)
@@ -119,15 +122,11 @@ agent_payload = {
     "owner": "demo-admin",
     "model_name": "claude-sonnet-4",
     "supported_ides": ["claude-code", "cursor", "vscode", "kiro"],
-    "components": [
-        {"component_type": "skill", "component_id": skill_id}
-    ],
+    "components": [{"component_type": "skill", "component_id": skill_id}],
     "external_mcps": [],
     "goal_template": {
         "description": "Code review and assistance",
-        "sections": [
-            {"name": "default", "description": "Default goal section"}
-        ],
+        "sections": [{"name": "default", "description": "Default goal section"}],
     },
 }
 r = requests.post(

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -1166,10 +1166,9 @@ class TestGenerateIdeAgentFiles:
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "claude-code")
         assert config.ide == "claude-code"
-        rules_files = [f for f in config.files if f.format == "markdown"]
-        assert len(rules_files) == 1
-        assert rules_files[0].path == ".claude/agents/test-agent.md"
-        assert "You are a helpful coding assistant." in rules_files[0].content
+        agent_file = next(f for f in config.files if f.path == ".claude/agents/test-agent.md")
+        assert agent_file.format == "markdown"
+        assert "You are a helpful coding assistant." in agent_file.content
 
     def test_claude_code_mcp_setup_commands(self):
         from services.agent_builder import generate_ide_agent_files
@@ -1203,10 +1202,9 @@ class TestGenerateIdeAgentFiles:
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "cursor")
         assert config.ide == "cursor"
-        assert len(config.files) == 2
-        rules = next(f for f in config.files if f.format == "markdown")
+        rules = next(f for f in config.files if f.path == ".cursor/rules/test-agent.md")
         mcp_json = next(f for f in config.files if f.format == "json")
-        assert rules.path == ".cursor/rules/test-agent.md"
+        assert rules.format == "markdown"
         assert mcp_json.path == ".cursor/mcp.json"
         assert "mcpServers" in mcp_json.content
         assert "github-mcp" in mcp_json.content["mcpServers"]
@@ -1259,9 +1257,7 @@ class TestGenerateIdeAgentFiles:
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "kiro")
         assert config.ide == "kiro"
-        assert len(config.files) == 1
-        agent_file = config.files[0]
-        assert agent_file.path == "~/.kiro/agents/test-agent.json"
+        agent_file = next(f for f in config.files if f.path == "~/.kiro/agents/test-agent.json")
         assert agent_file.format == "json"
         content = agent_file.content
         assert content["name"] == "test-agent"

--- a/tests/test_skill_config_generator.py
+++ b/tests/test_skill_config_generator.py
@@ -15,7 +15,7 @@ from services.skill_config_generator import (
 def _make_skill_listing(
     name: str = "code-review",
     description: str = "Automated code review skill",
-    slash_command: str | None = "/review",
+    slash_command: str | None = "review",
     git_url: str = "https://github.com/org/skills.git",
     skill_path: str = "skills/code-review",
 ) -> MagicMock:
@@ -48,7 +48,7 @@ class TestGenerateSkillFile:
         assert result["path"] == ".claude/skills/code-review/SKILL.md"
         assert "name: code-review" in result["content"]
         assert 'description: "Automated code review skill"' in result["content"]
-        assert "command: //review" in result["content"]
+        assert "command: /review" in result["content"]
 
     def test_claude_code_user_scope(self):
         listing = _make_skill_listing()

--- a/tests/test_skill_config_generator.py
+++ b/tests/test_skill_config_generator.py
@@ -1,0 +1,144 @@
+"""Tests for skill_config_generator — IDE-specific skill file generation."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+from services.skill_config_generator import (
+    _generate_skill_file,
+    _sanitize_name,
+    generate_skill_config,
+)
+
+
+def _make_skill_listing(
+    name: str = "code-review",
+    description: str = "Automated code review skill",
+    slash_command: str | None = "/review",
+    git_url: str = "https://github.com/org/skills.git",
+    skill_path: str = "skills/code-review",
+) -> MagicMock:
+    listing = MagicMock()
+    listing.id = uuid.uuid4()
+    listing.name = name
+    listing.description = description
+    listing.slash_command = slash_command
+    listing.git_url = git_url
+    listing.skill_path = skill_path
+    return listing
+
+
+class TestSanitizeName:
+    def test_safe_name_passthrough(self):
+        assert _sanitize_name("my-skill_v2") == "my-skill_v2"
+
+    def test_unsafe_chars_replaced(self):
+        assert _sanitize_name("my skill!") == "my-skill-"
+
+    def test_dots_replaced(self):
+        assert _sanitize_name("v1.2.3") == "v1-2-3"
+
+
+class TestGenerateSkillFile:
+    def test_claude_code_project_scope(self):
+        listing = _make_skill_listing()
+        result = _generate_skill_file(listing, "claude-code", scope="project")
+        assert result is not None
+        assert result["path"] == ".claude/skills/code-review/SKILL.md"
+        assert "name: code-review" in result["content"]
+        assert 'description: "Automated code review skill"' in result["content"]
+        assert "command: //review" in result["content"]
+
+    def test_claude_code_user_scope(self):
+        listing = _make_skill_listing()
+        result = _generate_skill_file(listing, "claude-code", scope="user")
+        assert result["path"] == "~/.claude/skills/code-review/SKILL.md"
+
+    def test_kiro(self):
+        listing = _make_skill_listing()
+        result = _generate_skill_file(listing, "kiro")
+        assert result is not None
+        assert result["path"] == ".kiro/skills/code-review/SKILL.md"
+        assert "name: code-review" in result["content"]
+
+    def test_cursor_project_scope(self):
+        listing = _make_skill_listing()
+        result = _generate_skill_file(listing, "cursor", scope="project")
+        assert result["path"] == ".cursor/rules/code-review.md"
+        assert "alwaysApply: false" in result["content"]
+        assert "# code-review" in result["content"]
+
+    def test_cursor_user_scope(self):
+        listing = _make_skill_listing()
+        result = _generate_skill_file(listing, "cursor", scope="user")
+        assert result["path"] == "~/.cursor/rules/code-review.md"
+
+    def test_vscode(self):
+        listing = _make_skill_listing()
+        result = _generate_skill_file(listing, "vscode")
+        assert result["path"] == ".vscode/rules/code-review.md"
+        assert "alwaysApply: false" in result["content"]
+
+    def test_monolithic_ide_returns_none(self):
+        listing = _make_skill_listing()
+        assert _generate_skill_file(listing, "gemini-cli") is None
+        assert _generate_skill_file(listing, "codex") is None
+        assert _generate_skill_file(listing, "copilot") is None
+
+    def test_no_slash_command(self):
+        listing = _make_skill_listing(slash_command=None)
+        result = _generate_skill_file(listing, "claude-code")
+        assert "command:" not in result["content"]
+
+    def test_no_description(self):
+        listing = _make_skill_listing(description="")
+        result = _generate_skill_file(listing, "claude-code")
+        assert "description:" not in result["content"]
+
+
+class TestGenerateSkillConfig:
+    def test_includes_hooks(self):
+        listing = _make_skill_listing()
+        config = generate_skill_config(listing, "claude-code")
+        assert "hooks" in config
+        assert "SessionStart" in config["hooks"]
+        assert "SessionEnd" in config["hooks"]
+
+    def test_includes_skill_file_for_claude_code(self):
+        listing = _make_skill_listing()
+        config = generate_skill_config(listing, "claude-code")
+        assert "skill_file" in config
+        assert config["skill_file"]["path"] == ".claude/skills/code-review/SKILL.md"
+
+    def test_includes_skill_file_for_kiro(self):
+        listing = _make_skill_listing()
+        config = generate_skill_config(listing, "kiro")
+        assert "skill_file" in config
+        assert config["skill_file"]["path"] == ".kiro/skills/code-review/SKILL.md"
+
+    def test_no_skill_file_for_codex(self):
+        listing = _make_skill_listing()
+        config = generate_skill_config(listing, "codex")
+        assert "skill_file" not in config
+
+    def test_scope_user(self):
+        listing = _make_skill_listing()
+        config = generate_skill_config(listing, "claude-code", scope="user")
+        assert config["skill_file"]["path"].startswith("~/.claude/")
+
+    def test_git_url_included(self):
+        listing = _make_skill_listing()
+        config = generate_skill_config(listing, "claude-code")
+        assert config["skill"]["git_url"] == "https://github.com/org/skills.git"
+
+    def test_skill_path_included(self):
+        listing = _make_skill_listing()
+        config = generate_skill_config(listing, "cursor")
+        assert config["skill"]["skill_path"] == "skills/code-review"
+
+    def test_claude_code_allows_env_vars(self):
+        listing = _make_skill_listing()
+        config = generate_skill_config(listing, "claude-code")
+        hook = config["hooks"]["SessionStart"][0]["hooks"][0]
+        assert "allowedEnvVars" in hook


### PR DESCRIPTION
When agents bundle skills as components, installing the agent now produces the correct skill files for each IDE (SKILL.md for Claude Code/Kiro, rule files for Cursor/VS Code). Previously skill components were silently skipped.

## Purpose / Description

When an agent bundles skills as components, the install endpoint only generated MCP configs and rules files. Skill components were silently skipped, meaning IDEs never received the skill files needed to activate slash commands, task-type routing, or skill descriptions. This PR adds full skill file generation across all supported IDEs.

## Fixes

* Fixes generate IDE-specific skill files on agent install 

## Approach

1. **Server - agent_config_generator.py**: Added `_build_skill_configs()` to extract skill metadata from registry listings, and `_generate_skill_file()` to produce IDE-specific file dicts. Wired into `generate_agent_config()` for Claude Code, Kiro, Cursor, and VS Code. Monolithic IDEs (Gemini, Codex, Copilot) inline skill info into their rules markdown instead.

2. **Server - skill_config_generator.py**: Added `_generate_skill_file()` so standalone skill installs also return the skill file alongside telemetry hooks config.

3. **Server - agent_builder.py**: Added `_build_skill_files()` to the manifest-based builder pipeline, wired into all per-IDE generators.

4. **Server - api/routes/agent.py**: Pre-loads skill listings in the install endpoint to avoid N+1 queries.

5. **Server - schemas/skill.py**: Added `scope` field to `SkillInstallRequest` (defaults to "project").

6. **CLI - cmd_agent.py**: Agent install output now displays skill files.

7. **CLI - cmd_skill.py**: Skill install now writes the skill file to disk (with `--no-write` flag to skip).

## How Has This Been Tested?

- 20 unit tests added in `tests/test_skill_config_generator.py` covering all IDEs, scopes, edge cases (no description, no slash command, monolithic IDE returns None)
- All 88 existing `test_agent_config_generator.py` tests still pass
- End-to-end tested locally: seeded a skill ("code-review-ai"), created an agent bundling it, installed via API for claude-code and kiro, verified `skill_files` array in response with correct paths and YAML frontmatter content
- Tested CLI install command output shows skill files

Test commands:
```bash
python -m pytest tests/test_skill_config_generator.py -v
python -m pytest tests/test_agent_config_generator.py -v
python scripts/seed_test_skill.py  # seeds skill + agent, tests install endpoint
