### PR TITLE
feat: add post-auth onboarding with IDE detection and component upload

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -98,6 +98,7 @@ def login(
             _fetch_server_public_key(server_url)
             _configure_claude_code(server_url, data["access_token"])
             _configure_kiro(server_url)
+            _post_auth_onboarding()
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 400 and "already initialized" in e.response.text.lower():
@@ -162,6 +163,7 @@ def register(
         _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, data["access_token"])
         _configure_kiro(server_url)
+        _post_auth_onboarding()
 
     except httpx.HTTPStatusError as e:
         detail = ""
@@ -323,6 +325,7 @@ def _do_password_login(server_url: str, email: str, password: str):
         _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, data["access_token"])
         _configure_kiro(server_url)
+        _post_auth_onboarding()
 
     except httpx.ConnectError:
         rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
@@ -414,6 +417,172 @@ def _find_hook_script(name: str) -> str | None:
         if p.is_file():
             return str(p.resolve())
     return None
+
+
+def _post_auth_onboarding():
+    """Detect local IDE configs and offer to scan+register components."""
+    try:
+        _ide_dirs = {
+            "Claude Code": (Path.home() / ".claude", "claude-code"),
+            "Kiro CLI": (Path.home() / ".kiro", "kiro"),
+            "Cursor": (Path.home() / ".cursor", "cursor"),
+        }
+
+        # Quick local scan: count components per IDE (no API calls)
+        found: list[tuple[str, str, int, int]] = []  # (label, ide_key, agents, mcps)
+        for label, (dir_path, ide_key) in _ide_dirs.items():
+            if not dir_path.is_dir():
+                continue
+            agents = mcps = 0
+            if ide_key == "claude-code":
+                from observal_cli.cmd_scan import _scan_claude_home
+
+                m, _s, _h, a = _scan_claude_home(dir_path)
+                agents, mcps = len(a), len(m)
+            elif ide_key == "kiro":
+                from observal_cli.cmd_scan import _scan_kiro_home
+
+                m, _s, _h, a = _scan_kiro_home(dir_path)
+                agents, mcps = len(a), len(m)
+            else:
+                # Cursor: just check for mcp.json
+                mcp_file = dir_path / "mcp.json"
+                if mcp_file.exists():
+                    try:
+                        import json as _j
+
+                        data = _j.loads(mcp_file.read_text())
+                        mcps = len(data.get("mcpServers", {}))
+                    except Exception:
+                        pass
+            if agents > 0 or mcps > 0:
+                found.append((label, ide_key, agents, mcps))
+
+        if not found:
+            return
+
+        # Show what we found
+        rprint()
+        rprint("[bold]\N{ELECTRIC LIGHT BULB} You have local agent configs that aren't in Observal.[/bold]")
+        rprint("[dim]Upload them to track usage, share with your team, and enable telemetry.[/dim]")
+        rprint()
+        for label, _key, agents, mcps in found:
+            parts = []
+            if agents:
+                parts.append(f"{agents} agent{'s' if agents != 1 else ''}")
+            if mcps:
+                parts.append(f"{mcps} MCP{'s' if mcps != 1 else ''}")
+            rprint(f"  [bold]{label}[/bold] — {', '.join(parts)} found")
+        rprint()
+
+        if not typer.confirm("Upload these to Observal?", default=True):
+            rprint("[dim]Tip: run `observal scan --home --all-ides` anytime to upload agents from your IDEs.[/dim]")
+            return
+
+        # Run scan for each selected IDE using the existing scan machinery
+        from observal_cli import client
+        from observal_cli.cmd_scan import _scan_claude_home, _scan_kiro_home
+        from observal_cli.render import spinner
+
+        all_mcps: list = []
+        all_skills: list = []
+        all_hooks: list = []
+        all_agents: list = []
+
+        for _label, ide_key, _a, _m in found:
+            if ide_key == "claude-code":
+                m, s, h, a = _scan_claude_home(Path.home() / ".claude")
+                all_mcps.extend(m)
+                all_skills.extend(s)
+                all_hooks.extend(h)
+                all_agents.extend(a)
+            elif ide_key == "kiro":
+                m, s, h, a = _scan_kiro_home(Path.home() / ".kiro")
+                all_mcps.extend(m)
+                all_skills.extend(s)
+                all_hooks.extend(h)
+                all_agents.extend(a)
+
+        total = len(all_mcps) + len(all_skills) + len(all_hooks) + len(all_agents)
+        if total == 0:
+            return
+
+        def _ide_from_source(source: str) -> str:
+            if source.startswith("kiro:"):
+                return "kiro"
+            if source.startswith("plugin:") or source.startswith("claude:"):
+                return "claude-code"
+            return "auto"
+
+        scan_payload = {
+            "ide": "multi",
+            "mcps": [
+                {
+                    "name": m.name,
+                    "command": m.command,
+                    "args": m.args,
+                    "url": m.url,
+                    "description": m.description,
+                    "source_plugin": m.source,
+                    "source_ide": _ide_from_source(m.source),
+                }
+                for m in all_mcps
+            ],
+            "skills": [
+                {
+                    "name": s.name,
+                    "description": s.description,
+                    "source_plugin": s.source,
+                    "task_type": getattr(s, "task_type", "general"),
+                    "source_ide": _ide_from_source(s.source),
+                }
+                for s in all_skills
+            ],
+            "hooks": [
+                {
+                    "name": h.name,
+                    "event": h.event,
+                    "handler_type": h.handler_type,
+                    "handler_config": h.handler_config,
+                    "description": h.description,
+                    "source_plugin": h.source,
+                    "source_ide": _ide_from_source(h.source),
+                }
+                for h in all_hooks
+            ],
+            "agents": [
+                {
+                    "name": a.name,
+                    "description": a.description,
+                    "model_name": a.model_name or "",
+                    "prompt": a.prompt,
+                    "source_file": a.source_file,
+                    "source_ide": _ide_from_source(
+                        f"kiro:{a.source_file}" if a.source_file and ".kiro" in a.source_file else a.source_file or ""
+                    ),
+                }
+                for a in all_agents
+            ],
+        }
+
+        with spinner(f"Registering {total} components..."):
+            try:
+                result = client.post("/api/v1/scan", scan_payload)
+            except Exception as e:
+                rprint(f"[yellow]Registration failed: {e}[/yellow]")
+                rprint("[dim]Tip: run `observal scan --home --all-ides` to retry.[/dim]")
+                return
+
+        summary = result.get("summary", {})
+        parts = [f"{v} {k}" for k, v in summary.items() if v]
+        if parts:
+            rprint(f"[green]Registered: {', '.join(parts)}[/green]")
+        else:
+            rprint("[dim]All components already registered.[/dim]")
+
+    except Exception as e:
+        rprint(f"[yellow]Onboarding skipped: {e}[/yellow]")
+        rprint("[dim]Tip: run `observal scan --home --all-ides` anytime to upload agents from your IDEs.[/dim]")
 
 
 def _configure_kiro(server_url: str):


### PR DESCRIPTION
## Summary

After `observal auth login` (or register), users land in a dead-end with no agents registered. This adds a post-auth onboarding step that detects local IDE configs and offers to bulk-register components with Observal.

Implements issue #433 

## What it does

After successful authentication, the new `_post_auth_onboarding()` function:

1. **Detects installed IDEs** by checking for `~/.claude/`, `~/.kiro/`, `~/.cursor/`
2. **Counts components** per IDE using the existing scan functions (local fs only, no API calls)
3. **Shows a summary**:
   ```
   You have local agent configs that aren't in Observal.
   Upload them to track usage, share with your team, and enable telemetry.

     Claude Code - 4 agents, 12 MCPs found
     Kiro CLI - 2 agents, 5 MCPs found
   ```
4. **Prompts to upload** via `typer.confirm()` (opt-in, not automatic)
5. **Registers via `POST /api/v1/scan`** using the same payload format as `observal scan`
6. **Skips gracefully** if declined or no IDE dirs found, with a tip about `observal scan`

## Where it hooks in

Called after `_configure_kiro()` in all 3 login paths:
- Admin init (fresh server bootstrap)
- `observal auth register`
- `observal auth login` (email+password)

## Design decisions

- **Reuses existing scan machinery** (`_scan_claude_home`, `_scan_kiro_home`, `/api/v1/scan` endpoint) instead of duplicating discovery logic
- **Opt-in only** via `typer.confirm()` - never auto-uploads
- **Best-effort** - failures are caught and show a tip to retry manually
- **No new dependencies** - uses typer.confirm() instead of a multi-select library to keep it simple

## Files Changed
- `observal_cli/cmd_auth.py` - added `_post_auth_onboarding()` and wired into all login paths

## Testing
- 1230 tests pass (20 failures are pre-existing Windows-specific issues)
- Zero regressions
<img width="863" height="430" alt="image" src="https://github.com/user-attachments/assets/62913096-2831-4548-9c1f-2a67ce96d98c" />

