### PR TITLE
fix(ci): use git reset --hard instead of pull to avoid divergent bran…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,8 @@ jobs:
           script_stop: true
           script: |
             cd ~/Observal
-            git pull origin main
+            git fetch origin main
+            git reset --hard origin/main
 
             cd docker
             docker compose up -d --build --remove-orphans


### PR DESCRIPTION

The deploy script was failing when the server repo diverged from origin/main, causing git pull to error out without updating code.
This is a fix for only the deploy script, to make sure it redeploys whenever a new merge or commit to main happens.