### PR TITLE
feat: detect dollar-sign input variables during MCP submit

### DIFF
--- a/observal-server/services/config_generator.py
+++ b/observal-server/services/config_generator.py
@@ -4,6 +4,7 @@ from models.mcp import McpListing
 from services.codex_config_generator import generate_codex_config
 
 _SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+_DOLLAR_VAR = re.compile(r"\$\{([A-Z][A-Z0-9_]+)\}|\$([A-Z][A-Z0-9_]+)")
 
 
 def _sanitize_name(name: str) -> str:
@@ -56,6 +57,18 @@ def _gemini_settings(observal_url: str) -> dict:
     }
 
 
+def _substitute_dollar_vars(args: list[str], env: dict[str, str] | None) -> list[str]:
+    """Replace $VAR and ${VAR} patterns in args with values from env dict."""
+    if not env:
+        return list(args)
+
+    def _replacer(m: re.Match) -> str:
+        var_name = m.group(1) or m.group(2)
+        return env.get(var_name, m.group(0))  # keep original if no value
+
+    return [_DOLLAR_VAR.sub(_replacer, arg) for arg in args]
+
+
 def _build_run_command(
     name: str,
     framework: str | None,
@@ -72,11 +85,11 @@ def _build_run_command(
     - Go: <name> (assumes binary on PATH)
     - Python / unknown: python -m <name>
     """
-    # Use stored command/args if available
+    # Use stored command/args if available, substituting $VAR placeholders
     if stored_command is not None:
         cmd = [stored_command]
         if stored_args:
-            cmd.extend(stored_args)
+            cmd.extend(_substitute_dollar_vars(stored_args, server_env))
         return cmd
 
     # Legacy path: infer from framework/docker_image

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -607,6 +607,17 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
             _framework = "python"
         _setup = ""
         _changelog = "Initial release"
+        # Detect $VAR patterns in args and merge into env vars
+        dollar_vars = _extract_dollar_vars(_args or [], {})
+        existing_names = {
+            (ev.get("name", ev) if isinstance(ev, dict) else ev) for ev in detected_env_vars
+        }
+        for var_name in dollar_vars:
+            if var_name not in existing_names:
+                detected_env_vars.append({"name": var_name, "description": "", "required": True})
+                existing_names.add(var_name)
+        if dollar_vars:
+            rprint(f"\n[dim]Auto-detected {len(dollar_vars)} input variable(s) from $VAR patterns in args.[/dim]")
         env_vars = detected_env_vars
     else:
         # Show config preview if command was detected
@@ -695,6 +706,25 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
 
         _setup = typer.prompt("Setup instructions (optional, press Enter to skip)", default="")
         _changelog = typer.prompt("Changelog", default="Initial release")
+
+        # Detect $VAR patterns in final args and merge into detected env vars
+        dollar_vars = _extract_dollar_vars(_args or [], {})
+        existing_names = {
+            (ev.get("name", ev) if isinstance(ev, dict) else ev) for ev in detected_env_vars
+        }
+        for var_name in dollar_vars:
+            if var_name not in existing_names:
+                detected_env_vars.append({"name": var_name, "description": "", "required": True})
+                existing_names.add(var_name)
+        if dollar_vars:
+            rprint("\n[bold yellow]Input variables detected in args:[/bold yellow]")
+            rprint(
+                "[dim]Dollar-sign variables will become install-time"
+                " dependencies — users will be prompted for these values.[/dim]\n"
+            )
+            for var in dollar_vars:
+                rprint(f"  [cyan]$[/cyan]{var}")
+            rprint()
 
         # Interactive env var configuration — developer reviews, edits,
         # or provides env vars instead of blindly including auto-detected ones.

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -419,9 +419,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
             # Let creator review/confirm input dependencies
             if dollar_vars:
                 rprint("\n[bold]Confirm input dependencies:[/bold]")
-                parsed["environment_variables"] = _review_env_vars(
-                    parsed.get("environment_variables", [])
-                )
+                parsed["environment_variables"] = _review_env_vars(parsed.get("environment_variables", []))
 
             _name = name or typer.prompt("Server name", default=_name)
             _desc = typer.prompt("Description (what does this server do?)", default="")
@@ -609,9 +607,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         _changelog = "Initial release"
         # Detect $VAR patterns in args and merge into env vars
         dollar_vars = _extract_dollar_vars(_args or [], {})
-        existing_names = {
-            (ev.get("name", ev) if isinstance(ev, dict) else ev) for ev in detected_env_vars
-        }
+        existing_names = {(ev.get("name", ev) if isinstance(ev, dict) else ev) for ev in detected_env_vars}
         for var_name in dollar_vars:
             if var_name not in existing_names:
                 detected_env_vars.append({"name": var_name, "description": "", "required": True})
@@ -709,9 +705,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
 
         # Detect $VAR patterns in final args and merge into detected env vars
         dollar_vars = _extract_dollar_vars(_args or [], {})
-        existing_names = {
-            (ev.get("name", ev) if isinstance(ev, dict) else ev) for ev in detected_env_vars
-        }
+        existing_names = {(ev.get("name", ev) if isinstance(ev, dict) else ev) for ev in detected_env_vars}
         for var_name in dollar_vars:
             if var_name not in existing_names:
                 detected_env_vars.append({"name": var_name, "description": "", "required": True})

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -166,6 +167,29 @@ def _enter_env_vars_manually() -> list[dict]:
     return env_vars
 
 
+# ── Dollar-sign variable detection ──────────────────────────
+
+_DOLLAR_VAR_RE = re.compile(r"\$\{?([A-Z][A-Z0-9_]+)\}?")
+
+
+def _extract_dollar_vars(args: list[str], env: dict[str, str]) -> list[str]:
+    """Extract unique $VAR / ${VAR} references from args and env values.
+
+    Returns a sorted list of uppercase variable names found in the args list
+    and the *values* (not keys) of the env dict, filtered to exclude
+    system/infrastructure vars (PATH, HOME, CI_*, etc.).
+    """
+    from observal_cli.analyzer import _is_filtered_env_var
+
+    found: set[str] = set()
+    for arg in args:
+        found.update(_DOLLAR_VAR_RE.findall(arg))
+    for value in env.values():
+        if isinstance(value, str):
+            found.update(_DOLLAR_VAR_RE.findall(value))
+    return sorted(name for name in found if not _is_filtered_env_var(name))
+
+
 # ── Direct config helpers ────────────────────────────────────
 
 
@@ -235,6 +259,18 @@ def _parse_direct_config(cfg: dict) -> dict:
         if isinstance(raw_env, dict):
             parsed["environment_variables"] = [{"name": k, "description": "", "required": True} for k in raw_env]
 
+        # Detect $VAR references in env values
+        dollar_vars = _extract_dollar_vars([], raw_env)
+        existing_names = {ev["name"] for ev in parsed.get("environment_variables", [])}
+        for var_name in dollar_vars:
+            if var_name not in existing_names:
+                parsed.setdefault("environment_variables", []).append(
+                    {"name": var_name, "description": "", "required": True}
+                )
+                existing_names.add(var_name)
+        if dollar_vars:
+            parsed["_dollar_vars_detected"] = dollar_vars
+
     elif inner.get("command"):
         # stdio transport
         parsed["transport"] = "stdio"
@@ -262,6 +298,18 @@ def _parse_direct_config(cfg: dict) -> dict:
         raw_env = inner.get("env") or {}
         if isinstance(raw_env, dict):
             parsed["environment_variables"] = [{"name": k, "description": "", "required": True} for k in raw_env]
+
+        # Detect $VAR references in args and env values
+        dollar_vars = _extract_dollar_vars(parsed["args"], raw_env)
+        existing_names = {ev["name"] for ev in parsed.get("environment_variables", [])}
+        for var_name in dollar_vars:
+            if var_name not in existing_names:
+                parsed.setdefault("environment_variables", []).append(
+                    {"name": var_name, "description": "", "required": True}
+                )
+                existing_names.add(var_name)
+        if dollar_vars:
+            parsed["_dollar_vars_detected"] = dollar_vars
 
         if inner.get("autoApprove"):
             parsed["auto_approve"] = inner["autoApprove"]
@@ -349,17 +397,39 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         parsed = _parse_direct_config(cfg)
         _name = name or parsed.pop("_server_name", None) or "my-mcp-server"
 
+        # Notify about dollar-sign input variables
+        dollar_vars = parsed.pop("_dollar_vars_detected", None)
+        if dollar_vars:
+            rprint("\n[bold yellow]Input variables detected:[/bold yellow]")
+            rprint(
+                "[dim]Dollar-sign variables in args/env will become install-time"
+                " dependencies — users will be prompted for these values.[/dim]\n"
+            )
+            for var in dollar_vars:
+                rprint(f"  [cyan]$[/cyan]{var}")
+            rprint()
+
         rprint("\n[bold]Config preview:[/bold]")
         console.print_json(json.dumps(_build_config_preview(_name, parsed), indent=2))
 
         if not yes:
             if not typer.confirm("\nSubmit this config?", default=True):
                 raise typer.Abort()
+
+            # Let creator review/confirm input dependencies
+            if dollar_vars:
+                rprint("\n[bold]Confirm input dependencies:[/bold]")
+                parsed["environment_variables"] = _review_env_vars(
+                    parsed.get("environment_variables", [])
+                )
+
             _name = name or typer.prompt("Server name", default=_name)
             _desc = typer.prompt("Description (what does this server do?)", default="")
             _owner = typer.prompt("Owner / Team (e.g. your GitHub username)", default="default")
             _category = category or select_one("Category", VALID_MCP_CATEGORIES, default="general")
         else:
+            if dollar_vars:
+                rprint(f"\n[dim]Auto-detected {len(dollar_vars)} input variable(s) from $VAR patterns.[/dim]")
             _desc = ""
             _owner = "default"
             _category = category or "general"

--- a/tests/test_env_detection_and_config.py
+++ b/tests/test_env_detection_and_config.py
@@ -833,18 +833,14 @@ class TestDollarVarDetection:
     def test_extract_from_args(self):
         from observal_cli.cmd_mcp import _extract_dollar_vars
 
-        result = _extract_dollar_vars(
-            ["-v", "$USER_VOLUME_PATH:/data", "--host", "$SERVER_HOST"], {}
-        )
+        result = _extract_dollar_vars(["-v", "$USER_VOLUME_PATH:/data", "--host", "$SERVER_HOST"], {})
         assert "USER_VOLUME_PATH" in result
         assert "SERVER_HOST" in result
 
     def test_extract_from_env_values(self):
         from observal_cli.cmd_mcp import _extract_dollar_vars
 
-        result = _extract_dollar_vars(
-            [], {"JIRA_URL": "$JIRA_BASE_URL", "TOKEN": "$JIRA_TOKEN"}
-        )
+        result = _extract_dollar_vars([], {"JIRA_URL": "$JIRA_BASE_URL", "TOKEN": "$JIRA_TOKEN"})
         assert "JIRA_BASE_URL" in result
         assert "JIRA_TOKEN" in result
 
@@ -864,9 +860,7 @@ class TestDollarVarDetection:
     def test_dedup_across_args_and_env(self):
         from observal_cli.cmd_mcp import _extract_dollar_vars
 
-        result = _extract_dollar_vars(
-            ["$JIRA_URL"], {"URL": "$JIRA_URL"}
-        )
+        result = _extract_dollar_vars(["$JIRA_URL"], {"URL": "$JIRA_URL"})
         assert result.count("JIRA_URL") == 1
 
     def test_ignores_lowercase(self):
@@ -922,9 +916,7 @@ class TestDollarVarSubstitution:
     def test_multiple_vars_in_one_arg(self):
         from services.config_generator import _substitute_dollar_vars
 
-        result = _substitute_dollar_vars(
-            ["$USER_PATH:/data/$SUBDIR"], {"USER_PATH": "/home/u", "SUBDIR": "out"}
-        )
+        result = _substitute_dollar_vars(["$USER_PATH:/data/$SUBDIR"], {"USER_PATH": "/home/u", "SUBDIR": "out"})
         assert result == ["/home/u:/data/out"]
 
 

--- a/tests/test_env_detection_and_config.py
+++ b/tests/test_env_detection_and_config.py
@@ -822,3 +822,155 @@ class TestGenerateConfigSSE:
         cfg = generate_config(listing, "cursor")
         server = cfg["mcpServers"]["my-sse-server"]
         assert "headers" not in server
+
+
+# ═══════════════════════════════════════════════════════════
+# 11. Dollar-sign variable detection (CLI)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDollarVarDetection:
+    def test_extract_from_args(self):
+        from observal_cli.cmd_mcp import _extract_dollar_vars
+
+        result = _extract_dollar_vars(
+            ["-v", "$USER_VOLUME_PATH:/data", "--host", "$SERVER_HOST"], {}
+        )
+        assert "USER_VOLUME_PATH" in result
+        assert "SERVER_HOST" in result
+
+    def test_extract_from_env_values(self):
+        from observal_cli.cmd_mcp import _extract_dollar_vars
+
+        result = _extract_dollar_vars(
+            [], {"JIRA_URL": "$JIRA_BASE_URL", "TOKEN": "$JIRA_TOKEN"}
+        )
+        assert "JIRA_BASE_URL" in result
+        assert "JIRA_TOKEN" in result
+
+    def test_extract_braces_form(self):
+        from observal_cli.cmd_mcp import _extract_dollar_vars
+
+        result = _extract_dollar_vars(["${MY_VAR}"], {})
+        assert "MY_VAR" in result
+
+    def test_filters_system_vars(self):
+        from observal_cli.cmd_mcp import _extract_dollar_vars
+
+        result = _extract_dollar_vars(["$HOME/path", "$MY_CUSTOM"], {})
+        assert "MY_CUSTOM" in result
+        assert "HOME" not in result
+
+    def test_dedup_across_args_and_env(self):
+        from observal_cli.cmd_mcp import _extract_dollar_vars
+
+        result = _extract_dollar_vars(
+            ["$JIRA_URL"], {"URL": "$JIRA_URL"}
+        )
+        assert result.count("JIRA_URL") == 1
+
+    def test_ignores_lowercase(self):
+        from observal_cli.cmd_mcp import _extract_dollar_vars
+
+        result = _extract_dollar_vars(["$lowercase_var"], {})
+        assert result == []
+
+    def test_multiple_vars_in_one_arg(self):
+        from observal_cli.cmd_mcp import _extract_dollar_vars
+
+        result = _extract_dollar_vars(["$USER_PATH:/data/$SUBDIR"], {})
+        assert "USER_PATH" in result
+        assert "SUBDIR" in result
+
+
+# ═══════════════════════════════════════════════════════════
+# 12. Dollar-sign variable substitution (server)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDollarVarSubstitution:
+    def test_substitute_in_stored_args(self):
+        from services.config_generator import _build_run_command
+
+        cmd = _build_run_command(
+            "my-mcp",
+            "docker",
+            server_env={"VOL": "/tmp/vol"},
+            stored_command="docker",
+            stored_args=["run", "-v", "$VOL:/data", "image"],
+        )
+        assert cmd == ["docker", "run", "-v", "/tmp/vol:/data", "image"]
+
+    def test_preserves_unmatched(self):
+        from services.config_generator import _substitute_dollar_vars
+
+        result = _substitute_dollar_vars(["$UNKNOWN_VAR"], {"OTHER": "val"})
+        assert result == ["$UNKNOWN_VAR"]
+
+    def test_substitute_braces_form(self):
+        from services.config_generator import _substitute_dollar_vars
+
+        result = _substitute_dollar_vars(["${MY_VAR}"], {"MY_VAR": "replaced"})
+        assert result == ["replaced"]
+
+    def test_no_substitution_without_env(self):
+        from services.config_generator import _substitute_dollar_vars
+
+        result = _substitute_dollar_vars(["$VAR"], None)
+        assert result == ["$VAR"]
+
+    def test_multiple_vars_in_one_arg(self):
+        from services.config_generator import _substitute_dollar_vars
+
+        result = _substitute_dollar_vars(
+            ["$USER_PATH:/data/$SUBDIR"], {"USER_PATH": "/home/u", "SUBDIR": "out"}
+        )
+        assert result == ["/home/u:/data/out"]
+
+
+# ═══════════════════════════════════════════════════════════
+# 13. _parse_direct_config with dollar-sign vars
+# ═══════════════════════════════════════════════════════════
+
+
+class TestParseDirectConfigDollarVars:
+    def test_detects_dollar_vars_in_args(self):
+        from observal_cli.cmd_mcp import _parse_direct_config
+
+        cfg = {
+            "command": "docker",
+            "args": ["run", "-v", "$USER_PATH:/data", "myimage"],
+        }
+        parsed = _parse_direct_config(cfg)
+        names = {ev["name"] for ev in parsed.get("environment_variables", [])}
+        assert "USER_PATH" in names
+        assert parsed.get("_dollar_vars_detected")
+        assert "USER_PATH" in parsed["_dollar_vars_detected"]
+
+    def test_merges_env_keys_and_dollar_vars(self):
+        from observal_cli.cmd_mcp import _parse_direct_config
+
+        cfg = {
+            "command": "docker",
+            "args": ["run", "myimage"],
+            "env": {"API_KEY": "sk-xxx", "URL": "$BASE_URL"},
+        }
+        parsed = _parse_direct_config(cfg)
+        names = [ev["name"] for ev in parsed.get("environment_variables", [])]
+        # API_KEY from env key, URL from env key, BASE_URL from dollar-sign in value
+        assert "API_KEY" in names
+        assert "URL" in names
+        assert "BASE_URL" in names
+        # No duplicates
+        assert len(names) == len(set(names))
+
+    def test_no_flag_when_no_dollar_vars(self):
+        from observal_cli.cmd_mcp import _parse_direct_config
+
+        cfg = {
+            "command": "python",
+            "args": ["-m", "my_server"],
+            "env": {"API_KEY": "sk-xxx"},
+        }
+        parsed = _parse_direct_config(cfg)
+        assert "_dollar_vars_detected" not in parsed


### PR DESCRIPTION
## Purpose / Description
When submitting an MCP server via `mcp submit --config` or the interactive git-URL flow, dollar-sign variables like `$USER_VOLUME_PATH_ARG` or `$JIRA_TOKEN` in args/env values represent install-time inputs that the downloading user must provide. Currently these are silently ignored — the CLI never detects them, never notifies the creator, and the server never substitutes them at install time.

## Approach
- **CLI detection**: New `_extract_dollar_vars` helper scans args and env values for `$VAR` / `${VAR}` patterns (uppercase only, filtered against system vars via existing `_is_filtered_env_var`)
- **`--config` path**: `_parse_direct_config` now merges detected dollar-sign vars into `environment_variables`; `_submit_impl` shows a notification and routes through `_review_env_vars` for confirmation
- **Git-URL path**: Same detection added before `_configure_env_vars_interactive` in both `--yes` and interactive flows
- **Server-side substitution**: New `_substitute_dollar_vars` replaces `$VAR` / `${VAR}` in stored args with user-provided values at install time in `_build_run_command`

## How Has This Been Tested?

15 new unit tests covering:
- `TestDollarVarDetection`: extraction from args, env values, `${VAR}` form, system var filtering, dedup, lowercase rejection, multiple vars in one arg
- `TestDollarVarSubstitution`: server-side substitution in stored args, unmatched var preservation, `${VAR}` form, no-env passthrough, multi-var args
- `TestParseDirectConfigDollarVars`: integration — `_parse_direct_config` with dollar vars in args produces correct `environment_variables` and detection flag

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)