### PR TITLE
fix(cli): scan standalone skills from ~/.claude/skills/

### DIFF
--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -215,6 +215,30 @@ def _scan_claude_home(
             except (json.JSONDecodeError, OSError):
                 pass
 
+    # ── Discover standalone skills from ~/.claude/skills/ ──
+    skills_dir = claude_dir / "skills"
+    if skills_dir.is_dir():
+        for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+            skill_name = skill_md.parent.name
+            desc = ""
+            task_type = "general"
+            try:
+                content = skill_md.read_text()
+                desc = _parse_frontmatter_field(content, "description") or ""
+                task_type = _parse_frontmatter_field(content, "task_type") or "general"
+                if not desc:
+                    desc = _first_content_line(content)
+            except OSError:
+                pass
+            skills.append(
+                DiscoveredSkill(
+                    name=skill_name,
+                    description=desc or f"Skill: {skill_name}",
+                    source="claude:skills",
+                    task_type=task_type,
+                )
+            )
+
     # ── Discover Agents from ~/.claude/agents/ ──────
     agents_dir = claude_dir / "agents"
     if agents_dir.is_dir():


### PR DESCRIPTION
\`_scan_claude_home()\` only discovered skills inside plugin directories (\`plugin_dir.rglob("SKILL.md")\`) but never scanned \`~/.claude/skills/\` for standalone user-created skills. This caused skills like \`prod-diff\` to be invisible to \`observal scan --home\`.

The Kiro scanner already handled this correctly via \`~/.kiro/skills/\` (lines 331-361), and agents were already scanned from \`~/.claude/agents/\` (lines 218-238) — standalone Claude skills were simply overlooked.

**Change:** Added a \`~/.claude/skills/\` scan block mirroring the existing Kiro pattern, right before the agents discovery block in \`_scan_claude_home()\`.

**Verified:** \`prod-diff\` now shows up as a standalone skill with source \`claude:skills\`. All 25 scan tests pass, ruff clean.