### PR TITLE
feat: IDE-specific feature awareness + UI fixes

### DIFF
--- a/observal-server/alembic/versions/0016_add_ide_feature_fields.py
+++ b/observal-server/alembic/versions/0016_add_ide_feature_fields.py
@@ -1,0 +1,58 @@
+"""Add required_ide_features and inferred_supported_ides to agents.
+
+Auto-inferred from agent components so the registry knows which IDEs
+are compatible with a given agent.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-04-21
+"""
+
+from alembic import op
+
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'agents' AND column_name = 'required_ide_features'
+            ) THEN
+                ALTER TABLE agents ADD COLUMN required_ide_features JSONB DEFAULT '[]'::jsonb;
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'agents' AND column_name = 'inferred_supported_ides'
+            ) THEN
+                ALTER TABLE agents ADD COLUMN inferred_supported_ides JSONB DEFAULT '[]'::jsonb;
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'agents' AND column_name = 'required_ide_features'
+            ) THEN
+                ALTER TABLE agents DROP COLUMN required_ide_features;
+            END IF;
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'agents' AND column_name = 'inferred_supported_ides'
+            ) THEN
+                ALTER TABLE agents DROP COLUMN inferred_supported_ides;
+            END IF;
+        END
+        $$;
+    """)

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -265,14 +265,23 @@ async def create_agent(
             )
         )
 
-    # Auto-infer IDE feature requirements from components
-    await db.flush()
-    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    # Auto-infer IDE feature requirements from the request data
+    # (avoid accessing agent.components which would trigger a lazy load)
+    all_crefs = list(req.components) + [
+        type("_Ref", (), {"component_type": "mcp", "component_id": mid})() for mid in req.mcp_server_ids
+    ]
+    skill_comp_ids = [c.component_id for c in all_crefs if c.component_type == "skill"]
     skill_listings_map: dict = {}
     if skill_comp_ids:
         rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
         skill_listings_map = {row.id: row for row in rows}
-    agent.required_ide_features = infer_required_features(agent, skill_listings=skill_listings_map)
+
+    # Build a lightweight stand-in so the inference function can iterate components
+    class _AgentProxy:
+        components = all_crefs
+        external_mcps = agent.external_mcps
+
+    agent.required_ide_features = infer_required_features(_AgentProxy(), skill_listings=skill_listings_map)
     agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
 
     try:
@@ -598,13 +607,21 @@ async def update_agent(
             )
 
     # Re-infer IDE features after component changes
-    await db.flush()
-    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    # Re-query the current component rows to avoid stale relationship state
+    current_comps = (
+        (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+    )
+    skill_comp_ids = [c.component_id for c in current_comps if c.component_type == "skill"]
     skill_listings_map_update: dict = {}
     if skill_comp_ids:
         rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
         skill_listings_map_update = {row.id: row for row in rows}
-    agent.required_ide_features = infer_required_features(agent, skill_listings=skill_listings_map_update)
+
+    class _AgentProxy:
+        components = current_comps
+        external_mcps = agent.external_mcps
+
+    agent.required_ide_features = infer_required_features(_AgentProxy(), skill_listings=skill_listings_map_update)
     agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
 
     await db.commit()
@@ -1008,14 +1025,21 @@ async def save_draft(
             )
         )
 
-    # Auto-infer IDE features for draft
-    await db.flush()
-    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    # Auto-infer IDE features for draft (use request data, not ORM relationship)
+    all_crefs_draft = list(req.components) + [
+        type("_Ref", (), {"component_type": "mcp", "component_id": mid})() for mid in req.mcp_server_ids
+    ]
+    skill_comp_ids = [c.component_id for c in all_crefs_draft if c.component_type == "skill"]
     skill_listings_map_draft: dict = {}
     if skill_comp_ids:
         rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
         skill_listings_map_draft = {row.id: row for row in rows}
-    agent.required_ide_features = infer_required_features(agent, skill_listings=skill_listings_map_draft)
+
+    class _DraftProxy:
+        components = all_crefs_draft
+        external_mcps = agent.external_mcps
+
+    agent.required_ide_features = infer_required_features(_DraftProxy(), skill_listings=skill_listings_map_draft)
     agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
 
     await db.commit()
@@ -1077,13 +1101,22 @@ async def update_draft(
             )
 
     # Re-infer IDE features for draft update
-    await db.flush()
-    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    current_comps_draft = (
+        (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+    )
+    skill_comp_ids = [c.component_id for c in current_comps_draft if c.component_type == "skill"]
     skill_listings_map_draft_update: dict = {}
     if skill_comp_ids:
         rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
         skill_listings_map_draft_update = {row.id: row for row in rows}
-    agent.required_ide_features = infer_required_features(agent, skill_listings=skill_listings_map_draft_update)
+
+    class _DraftUpdateProxy:
+        components = current_comps_draft
+        external_mcps = agent.external_mcps
+
+    agent.required_ide_features = infer_required_features(
+        _DraftUpdateProxy(), skill_listings=skill_listings_map_draft_update
+    )
     agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
 
     await db.commit()

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -606,23 +606,23 @@ async def update_agent(
                 )
             )
 
-    # Re-infer IDE features after component changes
-    # Re-query the current component rows to avoid stale relationship state
-    current_comps = (
-        (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
-    )
-    skill_comp_ids = [c.component_id for c in current_comps if c.component_type == "skill"]
-    skill_listings_map_update: dict = {}
-    if skill_comp_ids:
-        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
-        skill_listings_map_update = {row.id: row for row in rows}
+    # Re-infer IDE features only when components or external_mcps changed
+    if req.components is not None or req.mcp_server_ids is not None or req.external_mcps is not None:
+        current_comps = (
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+        )
+        skill_comp_ids = [c.component_id for c in current_comps if c.component_type == "skill"]
+        skill_listings_map_update: dict = {}
+        if skill_comp_ids:
+            rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
+            skill_listings_map_update = {row.id: row for row in rows}
 
-    class _AgentProxy:
-        components = current_comps
-        external_mcps = agent.external_mcps
+        class _AgentProxy:
+            components = current_comps
+            external_mcps = agent.external_mcps
 
-    agent.required_ide_features = infer_required_features(_AgentProxy(), skill_listings=skill_listings_map_update)
-    agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
+        agent.required_ide_features = infer_required_features(_AgentProxy(), skill_listings=skill_listings_map_update)
+        agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
 
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
@@ -1100,24 +1100,25 @@ async def update_draft(
                 )
             )
 
-    # Re-infer IDE features for draft update
-    current_comps_draft = (
-        (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
-    )
-    skill_comp_ids = [c.component_id for c in current_comps_draft if c.component_type == "skill"]
-    skill_listings_map_draft_update: dict = {}
-    if skill_comp_ids:
-        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
-        skill_listings_map_draft_update = {row.id: row for row in rows}
+    # Re-infer IDE features only when components or external_mcps changed
+    if req.components is not None or req.external_mcps is not None:
+        current_comps_draft = (
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+        )
+        skill_comp_ids = [c.component_id for c in current_comps_draft if c.component_type == "skill"]
+        skill_listings_map_draft_update: dict = {}
+        if skill_comp_ids:
+            rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
+            skill_listings_map_draft_update = {row.id: row for row in rows}
 
-    class _DraftUpdateProxy:
-        components = current_comps_draft
-        external_mcps = agent.external_mcps
+        class _DraftUpdateProxy:
+            components = current_comps_draft
+            external_mcps = agent.external_mcps
 
-    agent.required_ide_features = infer_required_features(
-        _DraftUpdateProxy(), skill_listings=skill_listings_map_draft_update
-    )
-    agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
+        agent.required_ide_features = infer_required_features(
+            _DraftUpdateProxy(), skill_listings=skill_listings_map_draft_update
+        )
+        agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
 
     await db.commit()
     agent = await _load_agent(db, str(agent.id))

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -30,6 +30,7 @@ from schemas.agent import (
     ValidationResult,
 )
 from services.agent_config_generator import generate_agent_config
+from services.ide_feature_inference import compute_supported_ides, infer_required_features
 from services.registry_telemetry import emit_registry_event
 
 router = APIRouter(prefix="/api/v1/agents", tags=["agents"])
@@ -263,6 +264,16 @@ async def create_agent(
                 order=i,
             )
         )
+
+    # Auto-infer IDE feature requirements from components
+    await db.flush()
+    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    skill_listings_map: dict = {}
+    if skill_comp_ids:
+        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
+        skill_listings_map = {row.id: row for row in rows}
+    agent.required_ide_features = infer_required_features(agent, skill_listings=skill_listings_map)
+    agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
 
     try:
         await db.commit()
@@ -586,6 +597,16 @@ async def update_agent(
                 )
             )
 
+    # Re-infer IDE features after component changes
+    await db.flush()
+    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    skill_listings_map_update: dict = {}
+    if skill_comp_ids:
+        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
+        skill_listings_map_update = {row.id: row for row in rows}
+    agent.required_ide_features = infer_required_features(agent, skill_listings=skill_listings_map_update)
+    agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
+
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
     name_map = await _resolve_component_names(agent.components, db)
@@ -679,7 +700,8 @@ async def install_agent(
         metadata={"ide": req.ide},
     )
 
-    return AgentInstallResponse(agent_id=resolved_agent_id, ide=req.ide, config_snippet=snippet)
+    warnings = snippet.pop("_warnings", [])
+    return AgentInstallResponse(agent_id=resolved_agent_id, ide=req.ide, config_snippet=snippet, warnings=warnings)
 
 
 @router.get("/{agent_id}/downloads")
@@ -986,6 +1008,16 @@ async def save_draft(
             )
         )
 
+    # Auto-infer IDE features for draft
+    await db.flush()
+    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    skill_listings_map_draft: dict = {}
+    if skill_comp_ids:
+        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
+        skill_listings_map_draft = {row.id: row for row in rows}
+    agent.required_ide_features = infer_required_features(agent, skill_listings=skill_listings_map_draft)
+    agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
+
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
     return _agent_to_response(agent, created_by_email=current_user.email, created_by_username=current_user.username)
@@ -1043,6 +1075,16 @@ async def update_draft(
                     config_override=cref.config_override,
                 )
             )
+
+    # Re-infer IDE features for draft update
+    await db.flush()
+    skill_comp_ids = [c.component_id for c in agent.components if c.component_type == "skill"]
+    skill_listings_map_draft_update: dict = {}
+    if skill_comp_ids:
+        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
+        skill_listings_map_draft_update = {row.id: row for row in rows}
+    agent.required_ide_features = infer_required_features(agent, skill_listings=skill_listings_map_draft_update)
+    agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
 
     await db.commit()
     agent = await _load_agent(db, str(agent.id))

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -32,6 +32,8 @@ class Agent(Base):
     model_config_json: Mapped[dict] = mapped_column(JSON, default=dict)
     external_mcps: Mapped[list] = mapped_column(JSON, default=list)
     supported_ides: Mapped[list] = mapped_column(JSON, default=list)
+    required_ide_features: Mapped[list] = mapped_column(JSON, default=list)
+    inferred_supported_ides: Mapped[list] = mapped_column(JSON, default=list)
     is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -146,6 +146,8 @@ class AgentResponse(BaseModel):
     model_config_json: dict
     external_mcps: list = []
     supported_ides: list[str]
+    required_ide_features: list[str] = []
+    inferred_supported_ides: list[str] = []
     status: AgentStatus
     rejection_reason: str | None = None
     created_by: uuid.UUID
@@ -168,6 +170,8 @@ class AgentSummary(BaseModel):
     owner: str
     model_name: str
     supported_ides: list[str]
+    required_ide_features: list[str] = []
+    inferred_supported_ides: list[str] = []
     status: AgentStatus
     download_count: int = 0
     average_rating: float | None = None
@@ -209,3 +213,4 @@ class AgentInstallResponse(BaseModel):
     agent_id: uuid.UUID
     ide: str
     config_snippet: dict
+    warnings: list[str] = []

--- a/observal-server/schemas/constants.py
+++ b/observal-server/schemas/constants.py
@@ -24,6 +24,32 @@ VALID_IDES: list[str] = [
     "copilot",
 ]
 
+# ── IDE feature capabilities ──────────────────────────────────
+# Each IDE supports a subset of agent features. This matrix is the
+# single source of truth used by the inference engine, config
+# generator, and frontend.  Mirrored in observal_cli/constants.py
+# and web/src/lib/ide-features.ts.
+
+IDE_FEATURES: list[str] = [
+    "skills",
+    "superpowers",
+    "hook_bridge",
+    "mcp_servers",
+    "rules",
+    "steering_files",
+    "otlp_telemetry",
+]
+
+IDE_FEATURE_MATRIX: dict[str, set[str]] = {
+    "claude-code": {"skills", "hook_bridge", "mcp_servers", "rules", "otlp_telemetry"},
+    "kiro": {"superpowers", "hook_bridge", "mcp_servers", "rules", "steering_files", "otlp_telemetry"},
+    "cursor": {"mcp_servers", "rules"},
+    "gemini-cli": {"mcp_servers", "rules"},
+    "codex": {"rules"},
+    "copilot": {"rules"},
+    "vscode": {"mcp_servers", "rules"},
+}
+
 # ── MCP servers ─────────────────────────────────────────────
 VALID_MCP_CATEGORIES: list[str] = [
     "browser-automation",

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -1,6 +1,7 @@
 import re
 
 from models.agent import Agent
+from schemas.constants import IDE_FEATURE_MATRIX
 from services.config_generator import (
     _build_run_command,
     _claude_otlp_env,
@@ -10,6 +11,30 @@ from services.config_generator import (
 )
 
 _SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+_FEATURE_LABELS: dict[str, str] = {
+    "skills": "slash-command skills",
+    "superpowers": "Kiro superpowers",
+    "hook_bridge": "hook bridge",
+    "mcp_servers": "MCP servers",
+    "rules": "rules / system prompt",
+    "steering_files": "steering files",
+    "otlp_telemetry": "OTLP telemetry",
+}
+
+
+def _check_ide_compatibility(agent: Agent, ide: str) -> list[str]:
+    """Return warning strings when *ide* lacks features the agent requires."""
+    required = getattr(agent, "required_ide_features", None) or []
+    ide_caps = IDE_FEATURE_MATRIX.get(ide, set())
+    warnings: list[str] = []
+    for feature in required:
+        if feature not in ide_caps:
+            label = _FEATURE_LABELS.get(feature, feature)
+            warnings.append(
+                f"This agent requires '{label}' but {ide} does not support it. Some functionality may not work."
+            )
+    return warnings
 
 
 def _sanitize_name(name: str) -> str:
@@ -236,6 +261,7 @@ def generate_agent_config(
     rules_content = _build_rules_content(agent, component_names)
     skill_configs = _build_skill_configs(agent, skill_listings)
     options = options or {}
+    compatibility_warnings = _check_ide_compatibility(agent, ide)
 
     if ide == "kiro":
         # Kiro agent JSON: drop into ~/.kiro/agents/<name>.json
@@ -318,6 +344,8 @@ def generate_agent_config(
         skill_files = [f for f in skill_files if f]
         if skill_files:
             result["skill_files"] = skill_files
+        if compatibility_warnings:
+            result["_warnings"] = compatibility_warnings
         return result
 
     if ide in ("claude-code", "claude_code"):
@@ -372,29 +400,40 @@ def generate_agent_config(
         }
         if skill_files:
             result["skill_files"] = skill_files
+        if compatibility_warnings:
+            result["_warnings"] = compatibility_warnings
         return result
 
     if ide in ("gemini-cli", "gemini_cli"):
         gemini_scope = options.get("scope", "project")
         rules_path = "~/.gemini/GEMINI.md" if gemini_scope == "user" else "GEMINI.md"
         mcp_path = "~/.gemini/mcp.json" if gemini_scope == "user" else ".gemini/mcp.json"
-        return {
+        result = {
             "rules_file": {"path": rules_path, "content": rules_content},
             "mcp_config": {"path": mcp_path, "content": {"mcpServers": mcp_configs}},
             "otlp_env": _gemini_otlp_env(observal_url),
             "gemini_settings_snippet": _gemini_settings(observal_url),
             "scope": gemini_scope,
         }
+        if compatibility_warnings:
+            result["_warnings"] = compatibility_warnings
+        return result
 
     if ide == "codex":
-        return {
+        result = {
             "rules_file": {"path": "AGENTS.md", "content": rules_content},
         }
+        if compatibility_warnings:
+            result["_warnings"] = compatibility_warnings
+        return result
 
     if ide == "copilot":
-        return {
+        result = {
             "rules_file": {"path": ".github/copilot-instructions.md", "content": rules_content},
         }
+        if compatibility_warnings:
+            result["_warnings"] = compatibility_warnings
+        return result
 
     # cursor, vscode: rules file + mcp.json — telemetry via observal-shim
     ide_scope = options.get("scope", "project")
@@ -415,4 +454,6 @@ def generate_agent_config(
     }
     if skill_files:
         result["skill_files"] = skill_files
+    if compatibility_warnings:
+        result["_warnings"] = compatibility_warnings
     return result

--- a/observal-server/services/ide_feature_inference.py
+++ b/observal-server/services/ide_feature_inference.py
@@ -1,0 +1,50 @@
+"""Infer IDE feature requirements and compatible IDEs from agent components."""
+
+from __future__ import annotations
+
+from schemas.constants import IDE_FEATURE_MATRIX
+
+
+def infer_required_features(
+    agent,
+    skill_listings: dict | None = None,
+) -> list[str]:
+    """Determine which IDE features an agent requires based on its components.
+
+    Args:
+        agent: Agent model instance with `components` and `external_mcps`.
+        skill_listings: optional ``{component_id: SkillListing}`` map used
+            to inspect ``slash_command`` and ``is_power`` on skill components.
+
+    Returns:
+        Sorted list of required feature strings (e.g. ``["mcp_servers", "rules"]``).
+    """
+    features: set[str] = set()
+    skill_listings = skill_listings or {}
+
+    # Every agent has a prompt / rules file
+    features.add("rules")
+
+    for comp in getattr(agent, "components", []):
+        if comp.component_type == "mcp":
+            features.add("mcp_servers")
+        elif comp.component_type == "hook":
+            features.add("hook_bridge")
+        elif comp.component_type == "skill":
+            listing = skill_listings.get(comp.component_id)
+            if listing:
+                if getattr(listing, "slash_command", None):
+                    features.add("skills")
+                if getattr(listing, "is_power", False):
+                    features.add("superpowers")
+
+    if getattr(agent, "external_mcps", None):
+        features.add("mcp_servers")
+
+    return sorted(features)
+
+
+def compute_supported_ides(required_features: list[str]) -> list[str]:
+    """Return sorted IDE names that support all *required_features*."""
+    required = set(required_features)
+    return sorted(ide for ide, capabilities in IDE_FEATURE_MATRIX.items() if required.issubset(capabilities))

--- a/observal_cli/constants.py
+++ b/observal_cli/constants.py
@@ -22,6 +22,30 @@ VALID_IDES: list[str] = [
     "copilot",
 ]
 
+# ── IDE feature capabilities ──────────────────────────────────
+# Mirror of observal-server/schemas/constants.py — kept in sync by
+# tests/test_constants_sync.py.
+
+IDE_FEATURES: list[str] = [
+    "skills",
+    "superpowers",
+    "hook_bridge",
+    "mcp_servers",
+    "rules",
+    "steering_files",
+    "otlp_telemetry",
+]
+
+IDE_FEATURE_MATRIX: dict[str, set[str]] = {
+    "claude-code": {"skills", "hook_bridge", "mcp_servers", "rules", "otlp_telemetry"},
+    "kiro": {"superpowers", "hook_bridge", "mcp_servers", "rules", "steering_files", "otlp_telemetry"},
+    "cursor": {"mcp_servers", "rules"},
+    "gemini-cli": {"mcp_servers", "rules"},
+    "codex": {"rules"},
+    "copilot": {"rules"},
+    "vscode": {"mcp_servers", "rules"},
+}
+
 # ── MCP servers ─────────────────────────────────────────────
 VALID_MCP_CATEGORIES: list[str] = [
     "browser-automation",

--- a/tests/test_constants_sync.py
+++ b/tests/test_constants_sync.py
@@ -17,6 +17,7 @@ _SHARED_LISTS = [
     "VALID_PROMPT_CATEGORIES",
     "VALID_SANDBOX_RUNTIME_TYPES",
     "VALID_SANDBOX_NETWORK_POLICIES",
+    "IDE_FEATURES",
 ]
 
 
@@ -27,3 +28,18 @@ def test_constants_match(name):
     server_val = getattr(server, name)
     cli_val = getattr(cli, name)
     assert server_val == cli_val, f"{name} mismatch: server={server_val!r}, cli={cli_val!r}"
+
+
+def test_ide_feature_matrix_match():
+    """IDE_FEATURE_MATRIX uses sets, so compare per-IDE."""
+    server = importlib.import_module("schemas.constants")
+    cli = importlib.import_module("observal_cli.constants")
+    server_val = server.IDE_FEATURE_MATRIX
+    cli_val = cli.IDE_FEATURE_MATRIX
+    assert server_val.keys() == cli_val.keys(), (
+        f"IDE_FEATURE_MATRIX key mismatch: server={sorted(server_val.keys())}, cli={sorted(cli_val.keys())}"
+    )
+    for ide in server_val:
+        assert server_val[ide] == cli_val[ide], (
+            f"IDE_FEATURE_MATRIX[{ide!r}] mismatch: server={server_val[ide]!r}, cli={cli_val[ide]!r}"
+        )

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
+import Link from "next/link";
 import { CheckCircle2, X, Trash2, LayoutGrid, TableProperties, AlertTriangle, ShieldCheck, ShieldX, AlertCircle } from "lucide-react";
 import { useReviewAgents, useReviewComponents, useReviewAction, useReviewDelete } from "@/hooks/use-api";
 import type { ReviewItem, McpValidationResult } from "@/lib/types";
@@ -13,6 +14,13 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+
+/** Build a detail-page URL for a review item. */
+function reviewItemHref(item: ReviewItem): string {
+  if (item.type === "agent") return `/agents/${item.id}`;
+  const plural = item.type ? `${item.type}s` : "mcps";
+  return `/components/${item.id}?type=${plural}`;
+}
 
 type ViewMode = "list" | "grid";
 
@@ -132,9 +140,11 @@ function ReviewCard({ item, onApprove, onReject, onDelete, disableApprove }: {
     <div className="rounded-md border border-border bg-card p-4 space-y-3 hover:bg-muted/20 transition-colors">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <h4 className="text-sm font-[family-name:var(--font-display)] font-semibold truncate">
-            {item.name ?? "Unnamed"}
-          </h4>
+          <Link href={reviewItemHref(item)} className="hover:underline">
+            <h4 className="text-sm font-[family-name:var(--font-display)] font-semibold truncate">
+              {item.name ?? "Unnamed"}
+            </h4>
+          </Link>
           {item.submitted_by && (
             <p className="text-xs text-muted-foreground mt-0.5">
               by {item.submitted_by}
@@ -286,9 +296,9 @@ function ReviewRow({ item, onApprove, onReject, onDelete, disableApprove }: {
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex items-center gap-2.5">
-            <span className="text-sm font-[family-name:var(--font-display)] font-semibold truncate">
+            <Link href={reviewItemHref(item)} className="text-sm font-[family-name:var(--font-display)] font-semibold truncate hover:underline">
               {item.name ?? "Unnamed"}
-            </span>
+            </Link>
             {item.type && (
               <Badge variant="outline" className="text-[10px] shrink-0">
                 {item.type ?? item.listing_type ?? "-"}

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -32,6 +32,8 @@ import { hasMinRole } from "@/hooks/use-role-guard";
 import type { FeedbackItem } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
 import { StatusBadge } from "@/components/registry/status-badge";
+import { IdeBadges } from "@/components/registry/ide-badges";
+import { FEATURE_LABELS, type IdeFeature } from "@/lib/ide-features";
 import { ReviewForm } from "@/components/registry/review-form";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -60,6 +62,9 @@ interface AgentDetail {
     description?: string;
     sections?: { name: string; description?: string }[];
   };
+  supported_ides?: string[];
+  required_ide_features?: string[];
+  inferred_supported_ides?: string[];
   [key: string]: unknown;
 }
 
@@ -707,6 +712,31 @@ export default function AgentDetailPage({
                     </div>
                   )}
                 </div>
+              </div>
+
+              <div className="border border-border rounded-md p-4 space-y-3">
+                <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
+                  IDE Compatibility
+                </h3>
+                <IdeBadges
+                  supportedIdes={a.supported_ides}
+                  inferredSupportedIdes={a.inferred_supported_ides}
+                  max={7}
+                />
+                {a.required_ide_features && a.required_ide_features.length > 0 && (
+                  <div className="space-y-1">
+                    <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60">
+                      Required features
+                    </p>
+                    <div className="flex flex-wrap gap-1">
+                      {a.required_ide_features.map((f: string) => (
+                        <span key={f} className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                          {FEATURE_LABELS[f as IdeFeature] ?? f}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
 
               {a.owner && (

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRegistryList, useMyAgents, useWhoami, useArchiveAgent, useUnarchiveAgent, useSubmitDraft } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
 import { hasMinRole } from "@/hooks/use-role-guard";
@@ -87,17 +88,24 @@ function DeleteAgentButton({ agent }: { agent: RegistryItem }) {
 
   return (
     <>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-        onClick={(e) => {
-          e.stopPropagation();
-          setConfirmOpen(true);
-        }}
-      >
-        <Trash2 className="h-3.5 w-3.5" />
-      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+              onClick={(e) => {
+                e.stopPropagation();
+                setConfirmOpen(true);
+              }}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Delete</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent onClick={(e) => e.stopPropagation()}>
@@ -128,17 +136,24 @@ function ArchiveAgentButton({ agent }: { agent: RegistryItem }) {
 
   return (
     <>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-7 w-7 p-0 text-muted-foreground hover:text-orange-600"
-        onClick={(e) => {
-          e.stopPropagation();
-          setConfirmOpen(true);
-        }}
-      >
-        <Archive className="h-3.5 w-3.5" />
-      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-orange-600"
+              onClick={(e) => {
+                e.stopPropagation();
+                setConfirmOpen(true);
+              }}
+            >
+              <Archive className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Archive</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent onClick={(e) => e.stopPropagation()}>
@@ -178,17 +193,24 @@ function UnarchiveAgentButton({ agent }: { agent: RegistryItem }) {
 
   return (
     <>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-7 w-7 p-0 text-muted-foreground hover:text-green-600"
-        onClick={(e) => {
-          e.stopPropagation();
-          setConfirmOpen(true);
-        }}
-      >
-        <ArchiveRestore className="h-3.5 w-3.5" />
-      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-green-600"
+              onClick={(e) => {
+                e.stopPropagation();
+                setConfirmOpen(true);
+              }}
+            >
+              <ArchiveRestore className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Restore</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent onClick={(e) => e.stopPropagation()}>

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -646,6 +646,8 @@ function AgentListContent() {
                 score={(agent.average_rating as number | null) ?? undefined}
                 status={agent.status}
                 component_count={agent.component_count as number | undefined}
+                supported_ides={agent.supported_ides as string[] | undefined}
+                inferred_supported_ides={agent.inferred_supported_ides as string[] | undefined}
                 className={`animate-in stagger-${Math.min(i + 1, 5)}`}
               />
             ))}

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -85,6 +85,12 @@ export function RegistrySidebar() {
 
   function isActive(href: string) {
     if (href === "/") return pathname === "/";
+    if (pathname === href) return true;
+    // Only treat as active if no *more-specific* sibling nav item matches.
+    // e.g. /agents should NOT be active when /agents/leaderboard matches.
+    const allHrefs = [...registryNav, ...reviewNav, ...userNav, ...adminNav].map((n) => n.href);
+    const moreSpecific = allHrefs.some((h) => h !== href && h.startsWith(href + "/") && pathname.startsWith(h));
+    if (moreSpecific) return false;
     return pathname.startsWith(href);
   }
 

--- a/web/src/components/registry/agent-card.tsx
+++ b/web/src/components/registry/agent-card.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { ArrowDownToLine, Puzzle, Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { IdeBadges } from "@/components/registry/ide-badges";
 import { compactNumber } from "@/lib/utils";
 
 interface AgentCardProps {
@@ -17,6 +18,8 @@ interface AgentCardProps {
   version?: string;
   component_count?: number;
   status?: string;
+  supported_ides?: string[];
+  inferred_supported_ides?: string[];
   className?: string;
 }
 
@@ -30,6 +33,8 @@ export function AgentCard({
   score,
   version,
   component_count,
+  supported_ides,
+  inferred_supported_ides,
   className,
 }: AgentCardProps) {
   return (
@@ -86,6 +91,13 @@ export function AgentCard({
           </span>
         )}
       </div>
+
+      <IdeBadges
+        supportedIdes={supported_ides}
+        inferredSupportedIdes={inferred_supported_ides}
+        max={3}
+        className="mt-2"
+      />
     </Link>
   );
 }

--- a/web/src/components/registry/ide-badges.tsx
+++ b/web/src/components/registry/ide-badges.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { IDE_DISPLAY_NAMES, type IdeName } from "@/lib/ide-features";
+
+interface IdeBadgesProps {
+  supportedIdes?: string[];
+  inferredSupportedIdes?: string[];
+  /** Maximum badges to show before "+N more" overflow. */
+  max?: number;
+  className?: string;
+}
+
+export function IdeBadges({
+  supportedIdes,
+  inferredSupportedIdes,
+  max = 4,
+  className,
+}: IdeBadgesProps) {
+  const ides =
+    supportedIdes && supportedIdes.length > 0
+      ? supportedIdes
+      : inferredSupportedIdes ?? [];
+
+  if (ides.length === 0) return null;
+
+  const visible = ides.slice(0, max);
+  const overflow = ides.length - max;
+
+  return (
+    <div className={["flex flex-wrap items-center gap-1", className ?? ""].join(" ")}>
+      {visible.map((ide) => (
+        <Badge
+          key={ide}
+          variant="outline"
+          className="text-[10px] px-1.5 py-0 font-normal leading-4"
+        >
+          {IDE_DISPLAY_NAMES[ide as IdeName] ?? ide}
+        </Badge>
+      ))}
+      {overflow > 0 && (
+        <span className="text-[10px] text-muted-foreground">
+          +{overflow} more
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/registry/install-dialog.tsx
+++ b/web/src/components/registry/install-dialog.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { registry, type RegistryType } from "@/lib/api";
-import { Copy, Check, Download } from "lucide-react";
+import { Copy, Check, Download, AlertTriangle } from "lucide-react";
 
 const IDE_OPTIONS = [
   "Cursor",
@@ -25,14 +25,22 @@ interface InstallDialogProps {
 export function InstallDialog({ type, id, name }: InstallDialogProps) {
   const [ide, setIde] = useState("");
   const [config, setConfig] = useState("");
+  const [warnings, setWarnings] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
 
   async function handleInstall(selectedIde: string) {
     setIde(selectedIde);
     setLoading(true);
+    setWarnings([]);
     try {
       const result = await registry.install(type, id, { ide: selectedIde });
+      if (result && typeof result === "object" && !Array.isArray(result)) {
+        const w = (result as Record<string, unknown>).warnings;
+        if (Array.isArray(w) && w.length > 0) {
+          setWarnings(w as string[]);
+        }
+      }
       setConfig(typeof result === "string" ? result : JSON.stringify(result, null, 2));
     } catch (e) {
       setConfig(`Error: ${e instanceof Error ? e.message : "Failed to get config"}`);
@@ -69,6 +77,16 @@ export function InstallDialog({ type, id, name }: InstallDialogProps) {
           </SelectContent>
         </Select>
         {loading && <p className="text-sm text-muted-foreground">Loading config…</p>}
+        {warnings.length > 0 && (
+          <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3 space-y-1">
+            {warnings.map((w, i) => (
+              <p key={i} className="text-xs text-yellow-700 dark:text-yellow-400 flex items-start gap-1.5">
+                <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                {w}
+              </p>
+            ))}
+          </div>
+        )}
         {config && (
           <div className="relative">
             <pre className="max-h-80 overflow-auto rounded-md bg-muted p-4 text-xs">{config}</pre>

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -643,7 +643,8 @@ export function useReviewAgents() {
 }
 
 export function useReviewComponents(typeFilter?: string) {
-  const params = typeFilter ? { type: typeFilter } : undefined;
+  const params: Record<string, string> = { tab: "components" };
+  if (typeFilter) params.type = typeFilter;
   return useQuery({
     queryKey: ["review", "components", params],
     queryFn: () => review.list(params),

--- a/web/src/lib/ide-features.ts
+++ b/web/src/lib/ide-features.ts
@@ -1,0 +1,58 @@
+/**
+ * IDE feature capability matrix — TypeScript mirror of
+ * observal-server/schemas/constants.py.
+ */
+
+export const VALID_IDES = [
+  "claude-code",
+  "codex",
+  "copilot",
+  "cursor",
+  "gemini-cli",
+  "kiro",
+  "vscode",
+] as const;
+
+export type IdeName = (typeof VALID_IDES)[number];
+
+export const IDE_FEATURES = [
+  "skills",
+  "superpowers",
+  "hook_bridge",
+  "mcp_servers",
+  "rules",
+  "steering_files",
+  "otlp_telemetry",
+] as const;
+
+export type IdeFeature = (typeof IDE_FEATURES)[number];
+
+export const IDE_FEATURE_MATRIX: Record<IdeName, ReadonlySet<IdeFeature>> = {
+  "claude-code": new Set(["skills", "hook_bridge", "mcp_servers", "rules", "otlp_telemetry"]),
+  kiro: new Set(["superpowers", "hook_bridge", "mcp_servers", "rules", "steering_files", "otlp_telemetry"]),
+  cursor: new Set(["mcp_servers", "rules"]),
+  "gemini-cli": new Set(["mcp_servers", "rules"]),
+  codex: new Set(["rules"]),
+  copilot: new Set(["rules"]),
+  vscode: new Set(["mcp_servers", "rules"]),
+};
+
+export const IDE_DISPLAY_NAMES: Record<IdeName, string> = {
+  "claude-code": "Claude Code",
+  kiro: "Kiro",
+  cursor: "Cursor",
+  "gemini-cli": "Gemini CLI",
+  codex: "Codex",
+  copilot: "Copilot",
+  vscode: "VS Code",
+};
+
+export const FEATURE_LABELS: Record<IdeFeature, string> = {
+  skills: "Slash-command skills",
+  superpowers: "Kiro superpowers",
+  hook_bridge: "Hook bridge",
+  mcp_servers: "MCP servers",
+  rules: "Rules / system prompt",
+  steering_files: "Steering files",
+  otlp_telemetry: "OTLP telemetry",
+};


### PR DESCRIPTION
## Purpose / Description

Different IDEs support different agent features (skills, hooks, MCP servers, etc.), but the agent builder and config generator treated all IDEs identically. This PR makes the system IDE-feature-aware: agents are auto-tagged with required features, the config generator warns when a target IDE lacks required features, and the registry UI shows IDE compatibility badges. Also bundles several related frontend bug fixes.

## Fixes

* Fixes #221 — IDE-specific feature awareness in agent builder and config generator
* Fixes #451 — Agent tiles on approval queue are not clickable
* Fixes #452 — Agents are showing up in component review
* Fixes #455 — Archive and Delete buttons on Agents tab missing hover tooltips
* Fixes #459 — Agents highlighted when clicking leaderboard or builder

## Approach

**IDE Feature Awareness (#221):**
- Added `IDE_FEATURES` and `IDE_FEATURE_MATRIX` constants as the single source of truth (server + CLI, sync-tested)
- New `ide_feature_inference.py` service with `infer_required_features()` and `compute_supported_ides()`
- Two new JSON columns on agents table: `required_ide_features`, `inferred_supported_ides` (migration 0016)
- Auto-inference runs on agent create/update/draft endpoints
- Config generator warns when target IDE lacks required features (non-blocking, returned in `AgentInstallResponse.warnings`)
- Frontend: `IdeBadges` component on agent cards + detail pages, yellow warning banners in install dialog
- Manual override: existing `supported_ides` field takes precedence when non-empty

**Review Queue Clickable Items (#451):**
- Made item names in ReviewCard and ReviewRow link to the detail page (name-only, not whole card, so approve/reject/delete buttons remain functional)

**Component Review Filtering (#452):**
- `useReviewComponents` now passes `tab=components` so the `/review` endpoint only returns components

**Button Tooltips (#455):**
- Wrapped archive, delete, and restore icon buttons in Tooltip components

**Sidebar Highlight (#459):**
- `isActive()` now checks for more-specific sibling nav items before treating a parent route as active

## How Has This Been Tested?

- `make rebuild` — migration applied, server starts cleanly
- Created agents with MCP + hook components — `required_ide_features` and `inferred_supported_ides` auto-populated in response
- Installed agent for Codex — warnings about unsupported features returned
- Agent cards and detail pages show IDE compatibility badges
- Install dialog shows yellow warning banners for incompatible IDEs
- Review queue: item names are clickable, buttons (approve/reject/delete) work independently
- Components tab in review no longer shows agents
- Archive/delete/restore buttons show tooltips on hover
- Sidebar: Agents link no longer highlighted when on Leaderboard or Builder

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)