### PR TITLE
fix: correct agent name resolution and 404 error hint

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -75,6 +75,14 @@ async def _load_agent(
             if mine:
                 return mine
 
+        # Fall back to global name lookup (any creator)
+        stmt = select(Agent).where(Agent.name == agent_id).options(*_agent_load_options)
+        if extra_conditions:
+            stmt = stmt.where(*extra_conditions)
+        results = (await db.execute(stmt)).scalars().all()
+        if len(results) == 1:
+            return results[0]
+
         return None
 
 

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -47,12 +47,14 @@ async def _load_agent(
     extra_conditions=None,
     *,
     prefer_user_id: uuid.UUID | None = None,
+    org_id: uuid.UUID | None = None,
 ) -> Agent | None:
     """Load an agent by UUID, prefix, or name with eager loading.
 
     When *prefer_user_id* is provided and resolution is by name, prefer the
     caller's own agent over agents created by other users with the same name.
-    Returns None if no match is found for the current user.
+    The global name fallback is restricted to active agents and, when *org_id*
+    is set, to agents within the same organisation.
     """
     try:
         return await resolve_prefix_id(
@@ -75,10 +77,16 @@ async def _load_agent(
             if mine:
                 return mine
 
-        # Fall back to global name lookup (any creator)
-        stmt = select(Agent).where(Agent.name == agent_id).options(*_agent_load_options)
+        # Fall back to global name lookup — only active, org-scoped agents
+        stmt = (
+            select(Agent)
+            .where(Agent.name == agent_id, Agent.status == AgentStatus.active)
+            .options(*_agent_load_options)
+        )
         if extra_conditions:
             stmt = stmt.where(*extra_conditions)
+        if org_id is not None:
+            stmt = stmt.where(Agent.owner_org_id == org_id)
         results = (await db.execute(stmt)).scalars().all()
         if len(results) == 1:
             return results[0]
@@ -436,7 +444,12 @@ async def get_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User | None = Depends(optional_current_user),
 ):
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id if current_user else None)
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id if current_user else None,
+        org_id=current_user.org_id if current_user else None,
+    )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user is not None and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -457,7 +470,12 @@ async def version_suggestions(
     db: AsyncSession = Depends(get_db),
     current_user: User | None = Depends(optional_current_user),
 ):
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id if current_user else None)
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id if current_user else None,
+        org_id=current_user.org_id if current_user else None,
+    )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user is not None and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -474,7 +492,7 @@ async def update_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -625,9 +643,10 @@ async def install_agent(
         agent_id,
         extra_conditions=[Agent.status == AgentStatus.active],
         prefer_user_id=current_user.id,
+        org_id=current_user.org_id,
     )
     if not agent:
-        agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+        agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
         if not agent or agent.created_by != current_user.id:
             raise HTTPException(status_code=404, detail="Agent not found or not active")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -696,7 +715,12 @@ async def agent_download_stats(
     db: AsyncSession = Depends(get_db),
     current_user: User | None = Depends(optional_current_user),
 ):
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id if current_user else None)
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id if current_user else None,
+        org_id=current_user.org_id if current_user else None,
+    )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user is not None and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -716,7 +740,12 @@ async def get_agent_traces(
     current_user: User | None = Depends(optional_current_user),
 ):
     """Return all traces where this agent participated."""
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id if current_user else None)
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id if current_user else None,
+        org_id=current_user.org_id if current_user else None,
+    )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user is not None and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -743,7 +772,7 @@ async def resolve_agent_components(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Resolve all components for an agent — validates they exist and are approved."""
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -763,7 +792,7 @@ async def get_agent_manifest(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Generate a portable agent manifest with all resolved components."""
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -824,7 +853,7 @@ async def delete_agent(
     from models.eval import EvalRun, Scorecard
     from models.feedback import Feedback
 
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -875,7 +904,7 @@ async def archive_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -901,7 +930,7 @@ async def unarchive_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -1007,7 +1036,7 @@ async def update_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Update a draft agent."""
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
@@ -1064,7 +1093,7 @@ async def submit_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Submit a draft agent for review (transitions draft -> pending)."""
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -49,8 +49,13 @@ def _handle_error(e: httpx.HTTPStatusError, path: str = ""):
             type_singular = type_plural[:-1]  # mcps -> mcp, skills -> skill
         else:
             type_singular = type_plural
+        # 'agent' is a top-level subcommand, not nested under 'registry'
+        if type_singular == "agent":
+            browse_cmd = f"observal agent list"
+        else:
+            browse_cmd = f"observal registry {type_singular} list"
         rprint(
-            f"[dim]  Check that the resource ID is correct, or use [bold]observal registry {type_singular} list[/bold] to browse.[/dim]"
+            f"[dim]  Check that the resource ID is correct, or use [bold]{browse_cmd}[/bold] to browse.[/dim]"
         )
     elif code == 429:
         rprint(f"[red]Rate limited{path_info}.[/red]")

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -50,13 +50,8 @@ def _handle_error(e: httpx.HTTPStatusError, path: str = ""):
         else:
             type_singular = type_plural
         # 'agent' is a top-level subcommand, not nested under 'registry'
-        if type_singular == "agent":
-            browse_cmd = f"observal agent list"
-        else:
-            browse_cmd = f"observal registry {type_singular} list"
-        rprint(
-            f"[dim]  Check that the resource ID is correct, or use [bold]{browse_cmd}[/bold] to browse.[/dim]"
-        )
+        browse_cmd = "observal agent list" if type_singular == "agent" else f"observal registry {type_singular} list"
+        rprint(f"[dim]  Check that the resource ID is correct, or use [bold]{browse_cmd}[/bold] to browse.[/dim]")
     elif code == 429:
         rprint(f"[red]Rate limited{path_info}.[/red]")
         retry_after = e.response.headers.get("Retry-After", "a few seconds")


### PR DESCRIPTION
## Purpose / Description
Two related bugs around agent name handling in the CLI and server:

1. **Wrong CLI hint on 404**: The 404 error handler in `client.py` always suggested `observal registry agent list`, but `agent` is a top-level subcommand — the correct command is `observal agent list`.
2. **`observal pull` fails on first run by name** (#458): `_load_agent` only tried name-based lookup for agents created by the current user. When referencing another user's agent by name (e.g. `observal pull appian_docs_v1 --ide kiro`), the name fallback missed it and returned 404. Running `observal agent list` first worked around this by populating the local name→UUID cache.

## Fixes
* Fixes #458
* Fixes #457 

## Approach
- **`observal_cli/client.py`**: In the 404 handler, check if the resource type is `agent` and suggest `observal agent list` instead of `observal registry agent list`.
- **`observal-server/api/routes/agent.py`**: Add a global name fallback in `_load_agent` after the user-specific lookup. When exactly one agent matches the name, return it regardless of creator. When multiple agents share the same name, return `None` to avoid ambiguity.

## How Has This Been Tested?

- Verified the 404 error path produces the correct hint for both agent and registry resource types
- Confirmed `_load_agent` resolves agent names globally when the user-specific lookup misses

## Learning (optional, can help others)
The `resolve_alias` function in the CLI resolves names via a local cache populated by `list` commands. When the cache is empty (first run), the raw name is passed to the server. The server's `_load_agent` was only doing a user-scoped name fallback, which silently failed for agents created by other users.

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)