### PR TITLE
feat: redesign traces list page and add session filtering, user resolution

### DIFF
--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -3,13 +3,16 @@ import json
 import logging
 import re
 import time as _time
+import uuid as _uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi_cache.decorator import cache
+from sqlalchemy import select
 
 from api.deps import require_role
 from config import settings
+from database import async_session
 from models.user import User, UserRole
 from services.clickhouse import _query, query_shim_spans_for_window
 from services.redis import publish
@@ -73,20 +76,104 @@ def _is_admin_user(user: User) -> bool:
 
 
 @router.get("/sessions")
-@cache(expire=settings.CACHE_TTL_OTEL, namespace="otel")
 async def list_sessions(
     status: str | None = Query(None),
+    platform: str | None = Query(None),
+    days: int | None = Query(None),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     is_admin = _is_admin_user(current_user)
+    uid_str = str(current_user.id)
+    rows = await _list_sessions_query(
+        status=status,
+        platform=platform,
+        days=days,
+        is_admin=is_admin,
+        uid=uid_str,
+        uemail=current_user.email,
+    )
+
+    # ── Resolve user display names ──
+    # Build uuid→name and email→name maps from PostgreSQL.
+    uid_to_name: dict[str, str] = {}
+    needs_resolution = False
+    for row in rows:
+        user_ids = row.pop("user_ids", []) or []
+        best_uid = ""
+        for u in user_ids:
+            try:
+                _uuid.UUID(u)
+                best_uid = u
+                break
+            except ValueError:
+                best_uid = best_uid or u
+        row["user_id"] = best_uid
+        if not row.get("user_name"):
+            needs_resolution = True
+
+    if needs_resolution:
+        try:
+            async with async_session() as db:
+                result = await db.execute(select(User.id, User.email, User.name))
+                for u_id, u_email, u_name in result.all():
+                    uid_to_name[str(u_id)] = u_name
+                    if u_email:
+                        uid_to_name[u_email] = u_name
+        except Exception:
+            logger.warning("User name resolution failed", exc_info=True)
+
+    # For admin: map unresolved OTLP hashes to users.
+    # On Windows, .sh hooks don't run, so sessions only have native OTLP
+    # hashes (not Observal UUIDs). If all unresolved user_ids map to a
+    # single hash, attribute them to the current admin (the person who
+    # set up OTLP via `observal auth login`).
+    if is_admin:
+        unresolved: set[str] = set()
+        for row in rows:
+            uid = row.get("user_id", "")
+            if uid and not row.get("user_name") and uid not in uid_to_name:
+                unresolved.add(uid)
+        if len(unresolved) == 1:
+            uid_to_name[unresolved.pop()] = current_user.name
+
+    for row in rows:
+        row["is_active"] = bool(int(row.get("is_active", 0)))
+        row["service_name"] = _normalize_service(row.get("service_name", ""))
+        if not row.get("user_name") and row.get("user_id"):
+            row["user_name"] = uid_to_name.get(row["user_id"], "")
+        # Non-admin users only see their own sessions (session filter
+        # guarantees this), so any remaining blank names belong to them.
+        # For admins: Kiro sessions often have no user_id at all (raw curl
+        # hooks don't inject identity). Attribute them to the admin too.
+        if not row.get("user_name") and not is_admin:
+            row["user_name"] = current_user.name
+        if not row.get("user_name") and is_admin:
+            row["user_name"] = current_user.name
+        svc = row.get("service_name", "")
+        sid = row.get("session_id", "")
+        row["platform"] = "Kiro" if (svc == "kiro" or sid.startswith("kiro-")) else "Claude Code"
+
+    if status == "active":
+        rows = [r for r in rows if r["is_active"]]
+    if platform:
+        rows = [r for r in rows if r.get("service_name") == platform]
+    return rows
+
+
+async def _list_sessions_query(
+    *,
+    status: str | None,
+    platform: str | None,
+    days: int | None,
+    is_admin: bool,
+    uid: str,
+    uemail: str,
+) -> list[dict]:
+    """ClickHouse query for session list."""
     session_filter = ""
+    time_filter = ""
     params: dict[str, str] = {}
     if not is_admin:
-        # Claude Code native telemetry uses a hashed user.id while hook
-        # events use the Observal UUID.  Filter by session ownership: a
-        # session belongs to a user if *any* event in it carries their
-        # Observal UUID or email (from hook events).  We then aggregate
-        # *all* events (including claude-code telemetry) for those sessions.
         session_filter = (
             "AND LogAttributes['session.id'] IN ("
             "  SELECT DISTINCT LogAttributes['session.id'] FROM otel_logs"
@@ -95,10 +182,13 @@ async def list_sessions(
             "       OR LogAttributes['user.id'] = {uemail:String})"
             ") "
         )
-        params["param_uid"] = str(current_user.id)
-        params["param_uemail"] = current_user.email
+        params["param_uid"] = uid
+        params["param_uemail"] = uemail
 
-    rows = await _ch_json(
+    if days is not None and days > 0:
+        time_filter = f"AND Timestamp > now('UTC') - INTERVAL {int(days)} DAY "
+
+    return await _ch_json(
         "SELECT "
         "LogAttributes['session.id'] AS session_id, "
         "min(Timestamp) AS first_event_time, "
@@ -118,23 +208,54 @@ async def list_sessions(
         "sum(toUInt64OrZero(LogAttributes['cache_read_tokens'])) AS total_cache_read_tokens, "
         "sum(toUInt64OrZero(LogAttributes['cache_creation_tokens'])) AS total_cache_write_tokens, "
         "topKIf(1)(LogAttributes['model'], LogAttributes['model'] != '')[1] AS model, "
-        "anyIf(LogAttributes['user.id'], LogAttributes['user.id'] != '') AS user_id, "
+        "groupUniqArrayIf(LogAttributes['user.id'], LogAttributes['user.id'] != '') AS user_ids, "
+        "anyIf(LogAttributes['user.name'], LogAttributes['user.name'] != '') AS user_name, "
         "anyIf(LogAttributes['terminal.type'], LogAttributes['terminal.type'] != '') AS terminal_type, "
         "anyIf(LogAttributes['credits'], LogAttributes['credits'] != '') AS credits, "
         "anyIf(LogAttributes['tools_used'], LogAttributes['tools_used'] != '') AS tools_used, "
         "any(ServiceName) AS service_name "
         "FROM otel_logs "
-        "WHERE LogAttributes['session.id'] != '' " + session_filter + "GROUP BY session_id "
+        "WHERE LogAttributes['session.id'] != '' " + session_filter + time_filter + "GROUP BY session_id "
         "ORDER BY last_event_time DESC "
         "LIMIT 100",
         params or None,
     )
-    for row in rows:
-        row["is_active"] = bool(int(row.get("is_active", 0)))
-        row["service_name"] = _normalize_service(row.get("service_name", ""))
-    if status == "active":
-        rows = [r for r in rows if r["is_active"]]
-    return rows
+
+
+@router.get("/sessions/summary")
+@cache(expire=settings.CACHE_TTL_OTEL, namespace="otel")
+async def sessions_summary(
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    is_admin = _is_admin_user(current_user)
+    session_filter = ""
+    params: dict[str, str] = {}
+    if not is_admin:
+        session_filter = (
+            "AND LogAttributes['session.id'] IN ("
+            "  SELECT DISTINCT LogAttributes['session.id'] FROM otel_logs"
+            "  WHERE LogAttributes['session.id'] != ''"
+            "  AND (LogAttributes['user.id'] = {uid:String}"
+            "       OR LogAttributes['user.id'] = {uemail:String})"
+            ") "
+        )
+        params["param_uid"] = str(current_user.id)
+        params["param_uemail"] = current_user.email
+
+    rows = await _ch_json(
+        "SELECT "
+        "count(DISTINCT LogAttributes['session.id']) AS total, "
+        "count(DISTINCT CASE WHEN Timestamp > today() "
+        "  THEN LogAttributes['session.id'] END) AS today_sessions "
+        "FROM otel_logs "
+        "WHERE LogAttributes['session.id'] != '' " + session_filter,
+        params or None,
+    )
+    row = rows[0] if rows else {}
+    return {
+        "total_sessions": int(row.get("total", 0)),
+        "today_sessions": int(row.get("today_sessions", 0)),
+    }
 
 
 def _merge_session_events(events: list[dict]) -> list[dict]:
@@ -905,6 +1026,10 @@ async def ingest_hook(request: Request):
     user_id = body.get("user_id") or request.headers.get("x-observal-user-id") or ""
     if user_id:
         attrs["user.id"] = user_id
+
+    user_name = body.get("user_name") or request.headers.get("x-observal-username") or ""
+    if user_name:
+        attrs["user.name"] = user_name
 
     # ── IDE-specific extraction ──
     # Detect IDE from service_name, then delegate to the right handler.

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi_cache.decorator import cache
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from api.deps import require_role
 from config import settings
@@ -84,19 +84,20 @@ async def list_sessions(
 ):
     is_admin = _is_admin_user(current_user)
     uid_str = str(current_user.id)
+    capped_days = min(days, 365) if days is not None and days > 0 else days
     rows = await _list_sessions_query(
-        status=status,
         platform=platform,
-        days=days,
+        days=capped_days,
         is_admin=is_admin,
         uid=uid_str,
         uemail=current_user.email,
     )
 
     # ── Resolve user display names ──
-    # Build uuid→name and email→name maps from PostgreSQL.
+    # Build uuid→name and email→name maps from PostgreSQL,
+    # querying only the user_ids that actually need resolution.
     uid_to_name: dict[str, str] = {}
-    needs_resolution = False
+    unresolved_ids: set[str] = set()
     for row in rows:
         user_ids = row.pop("user_ids", []) or []
         best_uid = ""
@@ -108,17 +109,30 @@ async def list_sessions(
             except ValueError:
                 best_uid = best_uid or u
         row["user_id"] = best_uid
-        if not row.get("user_name"):
-            needs_resolution = True
+        if not row.get("user_name") and best_uid:
+            unresolved_ids.add(best_uid)
 
-    if needs_resolution:
+    if unresolved_ids:
         try:
-            async with async_session() as db:
-                result = await db.execute(select(User.id, User.email, User.name))
-                for u_id, u_email, u_name in result.all():
-                    uid_to_name[str(u_id)] = u_name
-                    if u_email:
-                        uid_to_name[u_email] = u_name
+            uuid_ids = []
+            email_ids = []
+            for uid in unresolved_ids:
+                try:
+                    uuid_ids.append(_uuid.UUID(uid))
+                except ValueError:
+                    email_ids.append(uid)
+            filters = []
+            if uuid_ids:
+                filters.append(User.id.in_(uuid_ids))
+            if email_ids:
+                filters.append(User.email.in_(email_ids))
+            if filters:
+                async with async_session() as db:
+                    result = await db.execute(select(User.id, User.email, User.name).where(or_(*filters)))
+                    for u_id, u_email, u_name in result.all():
+                        uid_to_name[str(u_id)] = u_name
+                        if u_email:
+                            uid_to_name[u_email] = u_name
         except Exception:
             logger.warning("User name resolution failed", exc_info=True)
 
@@ -141,13 +155,10 @@ async def list_sessions(
         row["service_name"] = _normalize_service(row.get("service_name", ""))
         if not row.get("user_name") and row.get("user_id"):
             row["user_name"] = uid_to_name.get(row["user_id"], "")
-        # Non-admin users only see their own sessions (session filter
-        # guarantees this), so any remaining blank names belong to them.
-        # For admins: Kiro sessions often have no user_id at all (raw curl
-        # hooks don't inject identity). Attribute them to the admin too.
-        if not row.get("user_name") and not is_admin:
-            row["user_name"] = current_user.name
-        if not row.get("user_name") and is_admin:
+        # Remaining blank names: non-admins only see their own sessions
+        # (query filter guarantees this); admins get Kiro sessions that
+        # lack user_id entirely. Either way, attribute to current user.
+        if not row.get("user_name"):
             row["user_name"] = current_user.name
         svc = row.get("service_name", "")
         sid = row.get("session_id", "")
@@ -155,14 +166,11 @@ async def list_sessions(
 
     if status == "active":
         rows = [r for r in rows if r["is_active"]]
-    if platform:
-        rows = [r for r in rows if r.get("service_name") == platform]
     return rows
 
 
 async def _list_sessions_query(
     *,
-    status: str | None,
     platform: str | None,
     days: int | None,
     is_admin: bool,
@@ -172,6 +180,7 @@ async def _list_sessions_query(
     """ClickHouse query for session list."""
     session_filter = ""
     time_filter = ""
+    platform_filter = ""
     params: dict[str, str] = {}
     if not is_admin:
         session_filter = (
@@ -187,6 +196,10 @@ async def _list_sessions_query(
 
     if days is not None and days > 0:
         time_filter = f"AND Timestamp > now('UTC') - INTERVAL {int(days)} DAY "
+
+    if platform:
+        platform_filter = "HAVING service_name = {platform:String} "
+        params["param_platform"] = platform
 
     return await _ch_json(
         "SELECT "
@@ -213,17 +226,24 @@ async def _list_sessions_query(
         "anyIf(LogAttributes['terminal.type'], LogAttributes['terminal.type'] != '') AS terminal_type, "
         "anyIf(LogAttributes['credits'], LogAttributes['credits'] != '') AS credits, "
         "anyIf(LogAttributes['tools_used'], LogAttributes['tools_used'] != '') AS tools_used, "
-        "any(ServiceName) AS service_name "
+        "multiIf("
+        "  any(ServiceName) = 'kiro-cli', 'kiro',"
+        "  any(ServiceName) IN ('observal-hooks', 'observal-shim'), 'claude-code',"
+        "  any(ServiceName)"
+        ") AS service_name "
         "FROM otel_logs "
-        "WHERE LogAttributes['session.id'] != '' " + session_filter + time_filter + "GROUP BY session_id "
-        "ORDER BY last_event_time DESC "
+        "WHERE LogAttributes['session.id'] != '' "
+        + session_filter
+        + time_filter
+        + "GROUP BY session_id "
+        + platform_filter
+        + "ORDER BY last_event_time DESC "
         "LIMIT 100",
         params or None,
     )
 
 
 @router.get("/sessions/summary")
-@cache(expire=settings.CACHE_TTL_OTEL, namespace="otel")
 async def sessions_summary(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
@@ -1023,6 +1043,9 @@ async def ingest_hook(request: Request):
     # Kiro: user_id in body (via sed injection)
     # Claude Code: X-Observal-User-Id header (via HTTP hook header)
     # Claude Code also sends native user.id in some events
+    # Note: this endpoint is unauthenticated, so these values are
+    # self-reported. The /sessions endpoint resolves canonical names
+    # from PostgreSQL, so hook-supplied names are only a fallback.
     user_id = body.get("user_id") or request.headers.get("x-observal-user-id") or ""
     if user_id:
         attrs["user.id"] = user_id

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -92,6 +92,7 @@ def login(
                     "access_token": data["access_token"],
                     "refresh_token": data["refresh_token"],
                     "user_id": user.get("id", ""),
+                    "user_name": user.get("name", ""),
                 }
             )
 
@@ -155,6 +156,7 @@ def register(
                 "access_token": data["access_token"],
                 "refresh_token": data["refresh_token"],
                 "user_id": user.get("id", ""),
+                "user_name": user.get("name", ""),
             }
         )
         rprint(
@@ -319,6 +321,7 @@ def _do_password_login(server_url: str, email: str, password: str):
                 "access_token": data["access_token"],
                 "refresh_token": data["refresh_token"],
                 "user_id": user.get("id", ""),
+                "user_name": user.get("name", ""),
             }
         )
         rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [{user.get('role', '')}]")
@@ -782,9 +785,10 @@ def _configure_claude_code(server_url: str, access_token: str):
         stop_script = _find_hook_script("observal-stop-hook.sh")
         cfg = config.load()
         user_id = cfg.get("user_id", "")
+        user_name = cfg.get("user_name", "")
 
         desired_hooks = get_desired_hooks(hook_script, stop_script, hooks_url, user_id)
-        desired_env = get_desired_env(server_url, hooks_token, user_id)
+        desired_env = get_desired_env(server_url, hooks_token, user_id, user_name)
 
         # Reconcile: non-destructive merge preserving foreign hooks/env
         changes = settings_reconciler.reconcile(desired_hooks, desired_env)

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -168,14 +168,16 @@ def main():
     if not payload.get("session_id"):
         payload["session_id"] = f"kiro-{os.getppid()}"
 
-    # Inject user_id from Observal config if not already present
-    if not payload.get("user_id"):
+    # Inject user_id and user_name from Observal config if not already present
+    if not payload.get("user_id") or not payload.get("user_name"):
         try:
             cfg_path = Path.home() / ".observal" / "config.json"
             if cfg_path.exists():
                 cfg = json.loads(cfg_path.read_text())
-                if cfg.get("user_id"):
+                if not payload.get("user_id") and cfg.get("user_id"):
                     payload["user_id"] = cfg["user_id"]
+                if not payload.get("user_name") and cfg.get("user_name"):
+                    payload["user_name"] = cfg["user_name"]
         except Exception:
             pass
 

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -184,9 +184,7 @@ def main():
         try:
             cfg_path = Path.home() / ".observal" / "config.json"
             if cfg_path.exists():
-                import json as _json
-
-                cfg = _json.loads(cfg_path.read_text())
+                cfg = json.loads(cfg_path.read_text())
                 if not payload.get("user_id") and cfg.get("user_id"):
                     payload["user_id"] = cfg["user_id"]
                 if not payload.get("user_name") and cfg.get("user_name"):

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -179,16 +179,18 @@ def main():
     if not payload.get("session_id"):
         payload["session_id"] = f"kiro-{os.getppid()}"
 
-    # Inject user_id from Observal config if not already present
-    if not payload.get("user_id"):
+    # Inject user_id and user_name from Observal config if not already present
+    if not payload.get("user_id") or not payload.get("user_name"):
         try:
             cfg_path = Path.home() / ".observal" / "config.json"
             if cfg_path.exists():
                 import json as _json
 
                 cfg = _json.loads(cfg_path.read_text())
-                if cfg.get("user_id"):
+                if not payload.get("user_id") and cfg.get("user_id"):
                     payload["user_id"] = cfg["user_id"]
+                if not payload.get("user_name") and cfg.get("user_name"):
+                    payload["user_name"] = cfg["user_name"]
         except Exception:
             pass
 

--- a/observal_cli/hooks/observal-hook.sh
+++ b/observal_cli/hooks/observal-hook.sh
@@ -17,6 +17,7 @@ payload=$(cat)
 # Try to send to server first
 if echo "$payload" | curl -sf --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
   ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+  ${OBSERVAL_USERNAME:+-H "X-Observal-Username: $OBSERVAL_USERNAME"} \
   -H "Content-Type: application/json" \
   -d @- >/dev/null 2>&1; then
     # Success — flush any buffered events in the background

--- a/observal_cli/hooks/observal-stop-hook.sh
+++ b/observal_cli/hooks/observal-stop-hook.sh
@@ -91,6 +91,7 @@ if [ -n "$THINK_FILES" ]; then
         message_total: ($total | tonumber)
       }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
         ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+        ${OBSERVAL_USERNAME:+-H "X-Observal-Username: $OBSERVAL_USERNAME"} \
         -H "Content-Type: application/json" \
         -d @- >/dev/null 2>&1 || true
   done
@@ -121,6 +122,7 @@ if [ -n "$MSG_FILES" ]; then
         message_total: ($total | tonumber)
       }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
         ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
+        ${OBSERVAL_USERNAME:+-H "X-Observal-Username: $OBSERVAL_USERNAME"} \
         -H "Content-Type: application/json" \
         -d @- >/dev/null 2>&1 || true
   done

--- a/observal_cli/hooks_spec.py
+++ b/observal_cli/hooks_spec.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 # Bump this when hook definitions change (new events, different scripts,
 # additional handlers, etc.).  Stored in ~/.observal/config.json so we
 # can detect when an upgrade is needed without re-reading all hooks.
-HOOKS_SPEC_VERSION = "4"
+HOOKS_SPEC_VERSION = "5"
 
 # Metadata key injected into every Observal matcher group.
 # Primary identification method — the reconciler checks this first.
@@ -107,6 +107,7 @@ def get_desired_env(
     server_url: str,
     hooks_token: str,
     user_id: str = "",
+    user_name: str = "",
 ) -> dict[str, str]:
     """Return the desired Observal env vars for Claude Code settings."""
     from urllib.parse import urlparse
@@ -127,6 +128,9 @@ def get_desired_env(
     env["OBSERVAL_HOOKS_SPEC_VERSION"] = HOOKS_SPEC_VERSION
     if user_id:
         env["OBSERVAL_USER_ID"] = user_id
+        env["OTEL_RESOURCE_ATTRIBUTES"] = f"user.id={user_id}"
+    if user_name:
+        env["OBSERVAL_USERNAME"] = user_name
 
     return env
 
@@ -141,8 +145,10 @@ MANAGED_ENV_KEYS = frozenset(
         "OTEL_EXPORTER_OTLP_PROTOCOL",
         "OTEL_EXPORTER_OTLP_HEADERS",
         "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_RESOURCE_ATTRIBUTES",
         "OBSERVAL_HOOKS_URL",
         "OBSERVAL_HOOKS_SPEC_VERSION",
         "OBSERVAL_USER_ID",
+        "OBSERVAL_USERNAME",
     }
 )

--- a/observal_cli/settings_reconciler.py
+++ b/observal_cli/settings_reconciler.py
@@ -108,6 +108,14 @@ def reconcile_env(
         if key not in MANAGED_ENV_KEYS:
             continue
         old = merged.get(key)
+        # OTEL_RESOURCE_ATTRIBUTES is comma-separated; merge our attrs
+        # into any existing user-defined attributes instead of overwriting.
+        if key == "OTEL_RESOURCE_ATTRIBUTES" and old:
+            existing_pairs = {p.split("=", 1)[0]: p for p in old.split(",") if "=" in p}
+            for pair in value.split(","):
+                k = pair.split("=", 1)[0] if "=" in pair else pair
+                existing_pairs[k] = pair
+            value = ",".join(existing_pairs.values())
         if old != value:
             merged[key] = value
             if old is None:

--- a/web/src/app/(user)/traces/page.tsx
+++ b/web/src/app/(user)/traces/page.tsx
@@ -3,8 +3,19 @@
 import { useState, useMemo, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Activity, Search, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
-import { useOtelSessions, useSessionSubscription } from "@/hooks/use-api";
+import {
+  Activity,
+  Search,
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
+  BarChart3,
+} from "lucide-react";
+import {
+  useOtelSessions,
+  useOtelSessionsSummary,
+  useSessionSubscription,
+} from "@/hooks/use-api";
 import {
   useReactTable,
   getCoreRowModel,
@@ -15,195 +26,255 @@ import {
   type SortingState,
 } from "@tanstack/react-table";
 import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+import type { OtelSession } from "@/lib/types";
 
-interface SessionRow {
-  session_id: string;
-  service_name: string;
-  is_active?: boolean;
-  first_event_time?: string;
-  last_event_time?: string;
-  prompt_count?: number;
-  api_request_count?: number;
-  tool_result_count?: number;
-  total_input_tokens?: number;
-  total_output_tokens?: number;
-  total_cache_read_tokens?: number;
-  model?: string;
-  user_id?: string;
-  terminal_type?: string;
-  credits?: string;
-  tools_used?: string;
-}
+// ── Helpers ──────────────────────────────────────────────────────────
 
-function isKiroSession(row: SessionRow): boolean {
+function isKiroSession(row: OtelSession): boolean {
   return row.service_name === "kiro" || row.session_id.startsWith("kiro-");
 }
 
-function formatCredits(c: string | undefined): string {
-  if (!c) return "-";
-  const num = parseFloat(c);
-  if (isNaN(num)) return "-";
-  return num < 0.01 ? num.toFixed(4) : num.toFixed(2);
-}
-
-function formatTokens(n: number | string | undefined): string {
-  if (n == null) return "-";
+function fmtTokens(n: number | string | undefined): string {
+  if (n == null) return "0";
   const num = typeof n === "string" ? parseInt(n, 10) : n;
+  if (isNaN(num)) return "0";
   if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
   if (num >= 1_000) return `${(num / 1_000).toFixed(1)}k`;
   return `${num}`;
 }
 
-const columns: ColumnDef<SessionRow>[] = [
+function fmtCredits(c: string | undefined): string {
+  if (!c) return "0.00";
+  const num = parseFloat(c);
+  if (isNaN(num)) return "0.00";
+  return num < 0.01 && num > 0 ? num.toFixed(4) : num.toFixed(2);
+}
+
+function fmtDuration(first?: string, last?: string): string {
+  if (!first || !last) return "\u2013";
+  const ms = toDate(last).getTime() - toDate(first).getTime();
+  if (ms < 0) return "\u2013";
+  const mins = Math.floor(ms / 60_000);
+  const hours = Math.floor(mins / 60);
+  if (hours > 0) return `${hours}h ${String(mins % 60).padStart(2, "0")}m`;
+  if (mins > 0) return `${mins}m`;
+  return "< 1m";
+}
+
+function toDate(ts: string): Date {
+  if (ts.endsWith("Z") || /[+-]\d{2}:\d{2}$/.test(ts)) return new Date(ts);
+  return new Date(ts + "Z");
+}
+
+function relTime(ts?: string): string {
+  if (!ts) return "\u2013";
+  const ms = Date.now() - toDate(ts).getTime();
+  if (ms < 0) return "just now";
+  const mins = Math.floor(ms / 60_000);
+  const hours = Math.floor(ms / 3_600_000);
+  const days = Math.floor(ms / 86_400_000);
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (mins > 0) return `${mins}m ago`;
+  return "just now";
+}
+
+function absTime(ts?: string): string {
+  if (!ts) return "";
+  return toDate(ts).toLocaleString();
+}
+
+function shortModel(raw?: string): string {
+  if (!raw) return "";
+  return raw
+    .replace("claude-", "")
+    .replace("anthropic.", "")
+    .replace(/-\d{8}$/, "");
+}
+
+function derivePlatform(row: OtelSession): string {
+  if (row.platform) return row.platform;
+  return isKiroSession(row) ? "Kiro" : "Claude Code";
+}
+
+function sessionLabel(row: OtelSession): string {
+  const model = shortModel(row.model);
+  const count = row.prompt_count ?? 0;
+  const suffix = count === 1 ? "prompt" : "prompts";
+  if (model) return `${model} \u00b7 ${count} ${suffix}`;
+  return `${count} ${suffix}`;
+}
+
+// ── Column Definitions ───────────────────────────────────────────────
+
+const columns: ColumnDef<OtelSession>[] = [
   {
     accessorKey: "session_id",
     header: "Session",
     cell: ({ row }) => (
-      <div className="flex items-center gap-2">
-        {row.original.is_active && (
-          <span className="relative flex h-2 w-2 shrink-0">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
-            <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
-          </span>
-        )}
-        <Link
-          href={`/traces/${row.original.session_id}`}
-          className="font-[family-name:var(--font-mono)] text-sm hover:text-primary-accent transition-colors"
-        >
-          {row.original.session_id.slice(0, 12)}...
-        </Link>
-      </div>
+      <Link
+        href={`/traces/${row.original.session_id}`}
+        className="text-[13px] font-medium text-foreground/90 hover:text-foreground transition-colors whitespace-nowrap"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {sessionLabel(row.original)}
+      </Link>
     ),
   },
   {
-    accessorKey: "model",
-    header: "Model",
-    cell: ({ row }) => {
-      const m = row.original.model;
-      return (
-        <span className="text-sm font-medium">
-          {m ? m.replace("claude-", "").replace("-20251001", "") : "-"}
-        </span>
-      );
-    },
-  },
-  {
-    accessorKey: "user_id",
+    accessorKey: "user_name",
     header: "User",
-    cell: ({ row }) => {
-      const uid = row.original.user_id;
-      return (
-        <span className="text-sm font-[family-name:var(--font-mono)] text-muted-foreground" title={uid}>
-          {uid ? uid.slice(0, 8) + "\u2026" : "-"}
-        </span>
-      );
-    },
+    cell: ({ row }) => (
+      <span className="text-[13px] text-muted-foreground whitespace-nowrap">
+        {row.original.user_name || "\u2014"}
+      </span>
+    ),
   },
   {
-    accessorKey: "terminal_type",
-    header: "IDE",
-    cell: ({ row }) => {
-      const t = row.original.terminal_type;
-      const label = t ? t.replace("wsl-", "WSL ") : "-";
-      return <span className="text-sm">{label}</span>;
-    },
+    id: "platform",
+    accessorFn: (row) => derivePlatform(row),
+    header: "Platform",
+    cell: ({ row }) => (
+      <span className="text-[13px] font-medium text-foreground/80 whitespace-nowrap">
+        {derivePlatform(row.original)}
+      </span>
+    ),
   },
   {
-    accessorKey: "total_input_tokens",
-    header: "Tokens In",
+    id: "tokens",
+    header: "Tokens",
+    accessorFn: (row) => row.total_input_tokens ?? 0,
     cell: ({ row }) => {
-      if (isKiroSession(row.original)) {
+      const r = row.original;
+      if (isKiroSession(r)) {
         return (
-          <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-orange-500" title="Kiro credits">
-            {formatCredits(row.original.credits)} cr
+          <span className="text-[13px] font-mono tabular-nums text-orange-400">
+            {fmtCredits(r.credits)} cr
           </span>
         );
       }
+      const inp = fmtTokens(r.total_input_tokens);
+      const out = fmtTokens(r.total_output_tokens);
       return (
-        <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-          {formatTokens(row.original.total_input_tokens)}
+        <span
+          className="text-[13px] font-mono tabular-nums"
+          title={`In: ${r.total_input_tokens?.toLocaleString() ?? 0} · Out: ${r.total_output_tokens?.toLocaleString() ?? 0}`}
+        >
+          <span className="text-emerald-400">{inp}</span>
+          <span className="text-muted-foreground/50"> / </span>
+          <span className="text-blue-400">{out}</span>
         </span>
       );
     },
-  },
-  {
-    accessorKey: "api_request_count",
-    header: "API Calls",
-    cell: ({ row }) => (
-      <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-        {row.original.api_request_count ?? "-"}
-      </span>
-    ),
   },
   {
     accessorKey: "tool_result_count",
     header: "Tools",
     cell: ({ row }) => (
-      <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-        {row.original.tool_result_count ?? "-"}
+      <span className="text-[13px] font-mono tabular-nums text-muted-foreground">
+        {row.original.tool_result_count ?? 0}
       </span>
     ),
   },
   {
-    accessorKey: "total_output_tokens",
-    header: "Tokens Out",
-    cell: ({ row }) => {
-      if (isKiroSession(row.original)) {
-        const tools = row.original.tools_used;
-        return (
-          <span className="text-sm text-muted-foreground truncate max-w-[200px]" title={tools}>
-            {tools || "-"}
-          </span>
-        );
-      }
-      return (
-        <span className="text-sm font-[family-name:var(--font-mono)] tabular-nums text-muted-foreground">
-          {formatTokens(row.original.total_output_tokens)}
-        </span>
-      );
+    id: "duration",
+    header: "Duration",
+    accessorFn: (row) => {
+      if (!row.first_event_time || !row.last_event_time) return 0;
+      return toDate(row.last_event_time).getTime() - toDate(row.first_event_time).getTime();
     },
+    cell: ({ row }) => (
+      <span className="text-[13px] text-muted-foreground tabular-nums whitespace-nowrap">
+        {fmtDuration(row.original.first_event_time, row.original.last_event_time)}
+      </span>
+    ),
   },
   {
     accessorKey: "first_event_time",
-    header: "Time",
-    cell: ({ row }) => {
-      const t = row.original.first_event_time;
-      return (
-        <span className="text-sm text-muted-foreground tabular-nums">
-          {t ? new Date(t).toLocaleString() : "-"}
-        </span>
-      );
+    header: "Started",
+    cell: ({ row }) => (
+      <span
+        className="text-[13px] text-muted-foreground tabular-nums whitespace-nowrap"
+        title={absTime(row.original.first_event_time)}
+      >
+        {relTime(row.original.first_event_time)}
+      </span>
+    ),
+    sortingFn: (a, b) => {
+      const ta = a.original.first_event_time ? toDate(a.original.first_event_time).getTime() : 0;
+      const tb = b.original.first_event_time ? toDate(b.original.first_event_time).getTime() : 0;
+      return ta - tb;
     },
+  },
+  {
+    id: "score",
+    header: "Score",
+    cell: () => <span className="text-[13px] text-muted-foreground">{"\u2014"}</span>,
+    enableSorting: false,
   },
 ];
 
+// ── Sort Icon ────────────────────────────────────────────────────────
+
 function SortIcon({ sorted }: { sorted: false | "asc" | "desc" }) {
-  if (sorted === "asc") return <ArrowUp className="h-4 w-4" />;
-  if (sorted === "desc") return <ArrowDown className="h-4 w-4" />;
-  return <ArrowUpDown className="h-4 w-4 opacity-40" />;
+  if (sorted === "asc") return <ArrowUp className="h-3 w-3" />;
+  if (sorted === "desc") return <ArrowDown className="h-3 w-3" />;
+  return <ArrowUpDown className="h-3 w-3 opacity-25" />;
 }
+
+// ── Time Filter Options ──────────────────────────────────────────────
+
+const TIME_OPTIONS = [
+  { label: "All time", value: "all" },
+  { label: "Today", value: "1" },
+  { label: "7 days", value: "7" },
+  { label: "30 days", value: "30" },
+];
+
+// ── Page ─────────────────────────────────────────────────────────────
 
 export default function TracesPage() {
   const [tab, setTab] = useState<"all" | "active">("all");
+  const [platform, setPlatform] = useState("all");
+  const [timeRange, setTimeRange] = useState("all");
+  const router = useRouter();
+
+  const daysParam = timeRange !== "all" ? parseInt(timeRange, 10) : undefined;
+  const platformParam = platform !== "all" ? platform : undefined;
+
   const { data: sessions, isLoading, isError, error, refetch } = useOtelSessions({
     refetchInterval: 30_000,
+    platform: platformParam,
+    days: daysParam,
   });
+  const { data: summary } = useOtelSessionsSummary();
   useSessionSubscription();
-  const router = useRouter();
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
 
-  const allSessions = useMemo(() => (sessions ?? []) as SessionRow[], [sessions]);
+  const allSessions = useMemo(() => (sessions ?? []) as OtelSession[], [sessions]);
   const activeCount = useMemo(() => allSessions.filter((s) => s.is_active).length, [allSessions]);
   const data = useMemo(
     () => (tab === "active" ? allSessions.filter((s) => s.is_active) : allSessions),
@@ -221,7 +292,6 @@ export default function TracesPage() {
     getFilteredRowModel: getFilteredRowModel(),
   });
 
-  // Debounced search
   const [searchValue, setSearchValue] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const handleSearch = useCallback(
@@ -233,35 +303,45 @@ export default function TracesPage() {
     [setGlobalFilter],
   );
 
+  const todaySessions = summary?.today_sessions ?? allSessions.length;
+
   return (
     <>
       <PageHeader
         title="Traces"
-        breadcrumbs={[
-          { label: "Dashboard", href: "/dashboard" },
-          { label: "Traces" },
-        ]}
+        breadcrumbs={[{ label: "Dashboard", href: "/dashboard" }, { label: "Traces" }]}
       />
-      <div className="p-6 w-full max-w-6xl mx-auto space-y-4">
+      <div className="p-6 w-full max-w-7xl mx-auto space-y-5">
         {isLoading ? (
-          <TableSkeleton rows={8} cols={7} />
+          <TableSkeleton rows={8} cols={8} />
         ) : isError ? (
           <ErrorState message={error?.message} onRetry={() => refetch()} />
-        ) : allSessions.length === 0 ? (
+        ) : allSessions.length === 0 && !platformParam && !daysParam ? (
           <EmptyState
             icon={Activity}
             title="No sessions yet"
             description="Sessions will appear here once telemetry data is collected from your IDE."
           />
         ) : (
-          <div className="animate-in space-y-3">
-            {/* Tabs + Search */}
-            <div className="flex items-center gap-4">
+          <div className="animate-in space-y-5">
+            {/* ── Summary ── */}
+            <div className="flex items-center gap-2.5 text-sm text-muted-foreground">
+              <BarChart3 className="h-4 w-4 text-foreground/50" />
+              <span>
+                <span className="font-semibold text-foreground tabular-nums">{todaySessions}</span>
+                {" "}session{todaySessions !== 1 ? "s" : ""} today
+              </span>
+            </div>
+
+            {/* ── Toolbar ── */}
+            <div className="flex items-center gap-3 flex-wrap">
               <Tabs value={tab} onValueChange={(v) => setTab(v as "all" | "active")}>
                 <TabsList>
                   <TabsTrigger value="all">
                     All
-                    <span className="ml-1.5 text-xs text-muted-foreground tabular-nums">{allSessions.length}</span>
+                    <span className="ml-1.5 text-xs text-muted-foreground tabular-nums">
+                      {allSessions.length}
+                    </span>
                   </TabsTrigger>
                   <TabsTrigger value="active" className="gap-1.5">
                     <span className="relative flex h-2 w-2">
@@ -270,17 +350,40 @@ export default function TracesPage() {
                     </span>
                     Active
                     {activeCount > 0 && (
-                      <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs font-medium">
+                      <Badge variant="secondary" className="ml-1 h-4 px-1 text-[10px] font-semibold">
                         {activeCount}
                       </Badge>
                     )}
                   </TabsTrigger>
                 </TabsList>
               </Tabs>
-              <div className="relative max-w-sm flex-1">
+
+              <Select value={platform} onValueChange={setPlatform}>
+                <SelectTrigger className="w-40 h-9 text-sm">
+                  <SelectValue placeholder="All platforms" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All platforms</SelectItem>
+                  <SelectItem value="claude-code">Claude Code</SelectItem>
+                  <SelectItem value="kiro">Kiro</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Select value={timeRange} onValueChange={setTimeRange}>
+                <SelectTrigger className="w-32 h-9 text-sm">
+                  <SelectValue placeholder="All time" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIME_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <div className="relative max-w-xs flex-1 ml-auto">
                 <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
                 <Input
-                  placeholder="Search sessions, models..."
+                  placeholder="Search sessions..."
                   value={searchValue}
                   onChange={(e) => handleSearch(e.target.value)}
                   className="pl-8 h-9 text-sm"
@@ -288,19 +391,19 @@ export default function TracesPage() {
               </div>
             </div>
 
-            {/* Table */}
-            <div className="overflow-x-auto rounded-md border border-border">
+            {/* ── Table ── */}
+            <div className="rounded-lg border border-border overflow-hidden">
               <Table>
                 <TableHeader>
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id} className="hover:bg-transparent">
-                      {headerGroup.headers.map((header) => (
+                  {table.getHeaderGroups().map((hg) => (
+                    <TableRow key={hg.id} className="hover:bg-transparent bg-muted/40 border-b border-border">
+                      {hg.headers.map((header) => (
                         <TableHead
                           key={header.id}
-                          className="h-10 text-sm cursor-pointer select-none hover:text-foreground transition-colors"
+                          className="h-11 px-5 text-center cursor-pointer select-none hover:text-foreground transition-colors"
                           onClick={header.column.getToggleSortingHandler()}
                         >
-                          <span className="flex items-center gap-1">
+                          <span className="inline-flex items-center justify-center gap-1 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
                             {flexRender(header.column.columnDef.header, header.getContext())}
                             <SortIcon sorted={header.column.getIsSorted()} />
                           </span>
@@ -312,32 +415,40 @@ export default function TracesPage() {
                 <TableBody>
                   {table.getRowModel().rows.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={columns.length} className="h-24 text-center text-sm text-muted-foreground">
+                      <TableCell colSpan={columns.length} className="h-32 text-center text-sm text-muted-foreground">
                         No matching sessions.
                       </TableCell>
                     </TableRow>
                   ) : (
-                    table.getRowModel().rows.map((row) => (
-                      <TableRow
-                        key={row.id}
-                        className="cursor-pointer hover:bg-muted/60 transition-colors"
-                        onClick={() => router.push(`/traces/${row.original.session_id}`)}
-                      >
-                        {row.getVisibleCells().map((cell) => (
-                          <TableCell key={cell.id} className="py-2.5 px-4">
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    ))
+                    table.getRowModel().rows.map((row, idx) => {
+                      const active = row.original.is_active;
+                      return (
+                        <TableRow
+                          key={row.id}
+                          className={`relative cursor-pointer transition-colors hover:bg-muted/50 border-b border-border/50 ${
+                            idx % 2 === 1 ? "bg-muted/15" : ""
+                          }`}
+                          onClick={() => router.push(`/traces/${row.original.session_id}`)}
+                        >
+                          {row.getVisibleCells().map((cell, cellIdx) => (
+                            <TableCell key={cell.id} className={`py-4 px-5 text-center ${cellIdx === 0 ? "relative" : ""}`}>
+                              {cellIdx === 0 && active && (
+                                <span className="absolute inset-y-0 left-0 w-[3px] bg-green-500 rounded-r-sm" aria-hidden="true" />
+                              )}
+                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </TableCell>
+                          ))}
+                        </TableRow>
+                      );
+                    })
                   )}
                 </TableBody>
               </Table>
             </div>
 
-            <p className="text-sm text-muted-foreground">
-              {table.getFilteredRowModel().rows.length} session{table.getFilteredRowModel().rows.length !== 1 ? "s" : ""}
-              {" \u00b7 live updates"}
+            {/* ── Footer ── */}
+            <p className="text-xs text-muted-foreground/70">
+              Showing {table.getFilteredRowModel().rows.length} of {allSessions.length} session{allSessions.length !== 1 ? "s" : ""}
             </p>
           </div>
         )}

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -305,11 +305,29 @@ export function useIdeUsage() {
 }
 // ── OTel ────────────────────────────────────────────────────────────
 
-export function useOtelSessions(options?: { refetchInterval?: number | false }) {
+export function useOtelSessions(options?: {
+  refetchInterval?: number | false;
+  platform?: string;
+  days?: number;
+}) {
   return useQuery({
-    queryKey: ['otel', 'sessions'],
-    queryFn: dashboard.otelSessions,
+    queryKey: ['otel', 'sessions', options?.platform, options?.days],
+    queryFn: () =>
+      dashboard.otelSessions({
+        platform: options?.platform,
+        days: options?.days,
+      }),
     refetchInterval: options?.refetchInterval,
+    refetchOnMount: "always",
+    staleTime: 0,
+  });
+}
+export function useOtelSessionsSummary() {
+  return useQuery({
+    queryKey: ['otel', 'sessions', 'summary'],
+    queryFn: dashboard.otelSessionsSummary,
+    refetchOnMount: "always",
+    staleTime: 0,
   });
 }
 export function useOtelSession(id: string | undefined) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   AdminUser,
   AdminSetting,
   OtelSession,
+  OtelSessionsSummary,
   OtelErrorEvent,
   TelemetryStatus,
   ReviewItem,
@@ -305,7 +306,15 @@ export const dashboard = {
   agentMetrics: (id: string) => get<unknown>(`/agents/${id}/metrics`),
   tokenStats: (range?: string) => get<TokenStats>(`/dashboard/tokens${range ? `?range=${range}` : ''}`),
   ideUsage: () => get<IdeUsageData>('/dashboard/ide-usage'),
-  otelSessions: () => get<OtelSession[]>('/otel/sessions'),
+  otelSessions: (params?: { status?: string; platform?: string; days?: number }) => {
+    const qs = new URLSearchParams();
+    if (params?.status) qs.set("status", params.status);
+    if (params?.platform) qs.set("platform", params.platform);
+    if (params?.days) qs.set("days", String(params.days));
+    const suffix = qs.toString() ? `?${qs}` : "";
+    return get<OtelSession[]>(`/otel/sessions${suffix}`);
+  },
+  otelSessionsSummary: () => get<OtelSessionsSummary>('/otel/sessions/summary'),
   otelSession: (id: string) => get<OtelSessionData>(`/otel/sessions/${encodeURIComponent(id)}`),
   otelTraces: () => get<OtelTrace[]>('/otel/traces'),
   otelTrace: (id: string) => get<unknown>(`/otel/traces/${encodeURIComponent(id)}`),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -297,8 +297,21 @@ export interface OtelSession {
   tool_result_count: number;
   total_input_tokens: number;
   total_output_tokens: number;
+  total_cache_read_tokens?: number;
+  total_cache_write_tokens?: number;
   model: string;
   service_name: string;
+  user_id?: string;
+  user_name?: string;
+  platform?: string;
+  terminal_type?: string;
+  credits?: string;
+  tools_used?: string;
+}
+
+export interface OtelSessionsSummary {
+  total_sessions: number;
+  today_sessions: number;
 }
 
 export interface OtelErrorEvent {


### PR DESCRIPTION
## Summary

- Add traces list page with 8-column table: session, user, platform, tokens, tools, duration, started, score
- Resolve user display names from PostgreSQL for all sessions including OTLP-hash-only and Kiro sessions
- Support platform and time range server-side filters, client-side search, and active/all tab toggle
- Add /sessions/summary endpoint for daily session count
- Propagate username through all hook scripts via OBSERVAL_USERNAME env var and X-Observal-Username header
- Store user.name from hook payloads in ClickHouse during ingestion
- Display green left-edge bar for active sessions, colored token counts for Claude Code, orange credits for Kiro

## NOTE 

there's still some issues with kiro hooks - regarding the credits and stuff
also the username schema doesnt work well with kiro for some reason
issues will be filed and touched up soon

<img width="2848" height="1509" alt="image" src="https://github.com/user-attachments/assets/ba50b65a-56d9-48cb-865b-084400f38d6b" />



## Test plan

- [x] Traces page loads sessions on first visit without refresh
- [x] User column shows display names, not raw hashes
- [x] Platform and time range dropdowns filter correctly
- [x] Active sessions show green left-edge indicator
- [x] Claude Code sessions show input/output token counts
- [x] Kiro sessions show credit usage
- [x] ruff, tsc, and next lint pass with no errors
