### PR TITLE
feat: add self-observability — structured logging, health probes, Prometheus metrics

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\""]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/readyz')\""]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -186,6 +186,25 @@ services:
     depends_on:
       observal-clickhouse:
         condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - observal-net
+
+  observal-prometheus:
+    image: prom/prometheus:v3.4.2
+    ports:
+      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
+    volumes:
+      - ../prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      observal-api:
+        condition: service_healthy
+    restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     deploy:

--- a/docs/self-observability.md
+++ b/docs/self-observability.md
@@ -1,0 +1,82 @@
+# Self-Observability
+
+Observal exposes health probes, structured logs, and Prometheus metrics for monitoring itself.
+
+## Health Endpoints
+
+| Endpoint | Purpose | Use Case |
+|----------|---------|----------|
+| `GET /livez` | Liveness probe | K8s/Docker: is the process alive? (no I/O) |
+| `GET /healthz` | Liveness probe (alias) | Same as `/livez` |
+| `GET /readyz` | Readiness probe | K8s/Docker: can the API serve traffic? Checks Postgres, ClickHouse, Redis |
+| `GET /health` | Readiness probe (alias) | Same as `/readyz` |
+| `GET /metrics` | Prometheus metrics | Scrape target for Prometheus |
+
+### Readiness response example
+
+```json
+{
+  "status": "ok",
+  "postgres": "ok",
+  "initialized": true,
+  "clickhouse": "ok",
+  "redis": "ok"
+}
+```
+
+When a dependency is down, `status` becomes `"degraded"` or `"unhealthy"` (HTTP 503 for Postgres failure).
+
+## Structured Logging
+
+All logs are JSON-formatted by default. Every log line includes:
+
+- `timestamp` (ISO 8601)
+- `level` (info, warning, error)
+- `logger` (module name)
+- `event` (what happened)
+- `request_id` (during HTTP requests — auto-generated or from `X-Request-ID` header)
+
+### Configuration
+
+| Env Variable | Default | Options |
+|-------------|---------|---------|
+| `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `LOG_FORMAT` | `json` | `json` (production), `console` (local dev — colored, human-readable) |
+
+### Request ID Propagation
+
+Every request gets a UUID via the `X-Request-ID` header:
+- If the client sends one, it's reused (must be a valid UUID)
+- Otherwise a new one is generated
+- It's returned in the response and bound to all log lines for that request
+
+## Prometheus Metrics
+
+Available at `GET /metrics`. Key metrics:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `http_requests_total` | counter | Total requests by method, handler, status |
+| `http_request_duration_seconds` | histogram | Latency by handler |
+| `http_request_duration_highr_seconds` | histogram | Latency with fine-grained buckets |
+| `http_response_size_bytes` | summary | Response sizes by handler |
+| `process_resident_memory_bytes` | gauge | RSS memory |
+| `process_cpu_seconds_total` | counter | CPU time |
+
+## Grafana Dashboard
+
+A pre-built dashboard is provisioned automatically at:
+
+```
+http://localhost:3001 → Dashboards → Observal → Observal API Health
+```
+
+It shows: API status, uptime, request rate by status code, latency percentiles (p50/p95/p99), top endpoints, memory, and CPU.
+
+## Docker Compose
+
+The `docker-compose.yml` includes:
+- **observal-prometheus** — scrapes `/metrics` every 15s
+- **observal-grafana** — visualizes metrics (port 3001, login: admin/admin)
+
+The API healthcheck uses `/readyz` to verify all dependencies before marking the container healthy.

--- a/grafana/dashboards/self-observability.json
+++ b/grafana/dashboards/self-observability.json
@@ -1,0 +1,235 @@
+{
+  "uid": "observal-self-observability",
+  "title": "Observal API Health",
+  "description": "Self-observability: uptime, traffic, latency, errors, and resource usage",
+  "tags": ["observal", "ops"],
+  "timezone": "browser",
+  "refresh": "15s",
+  "time": { "from": "now-30m", "to": "now" },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Overview",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "id": 1,
+      "title": "API Status",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 3, "x": 0, "y": 1 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "up{job=\"observal-api\"}", "legendFormat": "" }],
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "1": { "text": "Healthy", "color": "green" } } },
+            { "type": "value", "options": { "0": { "text": "Down", "color": "red" } } }
+          ]
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Uptime",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 3, "x": 3, "y": 1 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "time() - process_start_time_seconds{job=\"observal-api\"}", "legendFormat": "" }],
+      "options": { "colorMode": "none", "graphMode": "none", "textMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "dtdurations" } }
+    },
+    {
+      "id": 3,
+      "title": "Req/min",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 3, "x": 6, "y": 1 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "sum(rate(http_requests_total[1m])) * 60", "legendFormat": "" }],
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "decimals": 1, "color": { "mode": "fixed", "fixedColor": "blue" } } }
+    },
+    {
+      "id": 4,
+      "title": "Errors (5xx)",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 3, "x": 9, "y": 1 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "sum(rate(http_requests_total{status=\"5xx\"}[5m])) / sum(rate(http_requests_total[5m])) * 100 or vector(0)", "legendFormat": "" }],
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }, { "value": 1, "color": "yellow" }, { "value": 5, "color": "red" }] }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "p95 Latency",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 3, "x": 12, "y": 1 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "" }],
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }, { "value": 500, "color": "yellow" }, { "value": 2000, "color": "red" }] }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Memory (RSS)",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 3, "x": 15, "y": 1 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "process_resident_memory_bytes{job=\"observal-api\"}", "legendFormat": "" }],
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }, { "value": 400000000, "color": "yellow" }, { "value": 500000000, "color": "red" }] }
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "CPU",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 3, "x": 18, "y": 1 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "rate(process_cpu_seconds_total{job=\"observal-api\"}[1m]) * 100", "legendFormat": "" }],
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 1, "color": { "mode": "fixed", "fixedColor": "orange" } } }
+    },
+    {
+      "id": 15,
+      "title": "Open FDs",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 3, "x": 21, "y": 1 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "process_open_fds{job=\"observal-api\"}", "legendFormat": "" }],
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "purple" } } }
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "Traffic",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 },
+      "collapsed": false
+    },
+    {
+      "id": 7,
+      "title": "Request Rate by Status",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum(rate(http_requests_total{status=\"2xx\"}[1m]))", "legendFormat": "2xx" },
+        { "expr": "sum(rate(http_requests_total{status=\"4xx\"}[1m]))", "legendFormat": "4xx" },
+        { "expr": "sum(rate(http_requests_total{status=\"5xx\"}[1m]))", "legendFormat": "5xx" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15, "showPoints": "never", "spanNulls": true } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "2xx" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
+          { "matcher": { "id": "byName", "options": "4xx" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] },
+          { "matcher": { "id": "byName", "options": "5xx" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 8,
+      "title": "Response Time Percentiles",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "p95" },
+        { "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "p99" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 8, "showPoints": "never", "spanNulls": true } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "p50" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
+          { "matcher": { "id": "byName", "options": "p95" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }] },
+          { "matcher": { "id": "byName", "options": "p99" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 9,
+      "title": "Top Endpoints (1h)",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 13 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "topk(8, sum by (handler) (increase(http_requests_total[1h])))", "legendFormat": "{{handler}}" }],
+      "options": { "legend": { "placement": "right", "displayMode": "table", "values": ["value"] }, "pieType": "donut" }
+    },
+    {
+      "id": 10,
+      "title": "Avg Response Size",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 13 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "rate(http_response_size_bytes_sum[5m]) / rate(http_response_size_bytes_count[5m])", "legendFormat": "{{handler}}" }],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 300,
+      "type": "row",
+      "title": "Resources",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "title": "Memory",
+      "type": "timeseries",
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 22 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "process_resident_memory_bytes{job=\"observal-api\"}", "legendFormat": "RSS" },
+        { "expr": "536870912", "legendFormat": "Limit (512 MB)" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "min": 0, "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15, "showPoints": "never", "spanNulls": true } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "RSS" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }] },
+          { "matcher": { "id": "byName", "options": "Limit (512 MB)" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }, { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 10] } }, { "id": "custom.fillOpacity", "value": 0 }, { "id": "custom.lineWidth", "value": 1 }] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 12,
+      "title": "CPU",
+      "type": "timeseries",
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 22 },
+      "datasource": { "uid": "observal-prometheus", "type": "prometheus" },
+      "targets": [{ "expr": "rate(process_cpu_seconds_total{job=\"observal-api\"}[1m]) * 100", "legendFormat": "CPU %" }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 20, "showPoints": "never", "spanNulls": true },
+          "color": { "mode": "fixed", "fixedColor": "orange" }
+        }
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    }
+  ],
+  "schemaVersion": 39,
+  "version": 4
+}

--- a/grafana/provisioning/datasources/prometheus.yaml
+++ b/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: observal-prometheus
+    access: proxy
+    url: http://observal-prometheus:9090
+    isDefault: false
+    editable: true

--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -34,7 +34,7 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
         if r.status_code == 200:
             return r.json().get("data", [])
     except Exception as e:
-        logger.warning(f"ClickHouse query failed: {e}")
+        logger.warning("clickhouse_query_failed", error=str(e))
     return []
 
 

--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -1,11 +1,11 @@
 """Strawberry GraphQL schema: types, resolvers, DataLoaders, subscriptions."""
 
 import json
-import logging
 from collections.abc import AsyncGenerator
 
 import jwt
 import strawberry
+import structlog
 from starlette.requests import Request
 from strawberry.dataloader import DataLoader
 from strawberry.scalars import JSON
@@ -20,7 +20,7 @@ from services.clickhouse import (
 from services.jwt_service import decode_access_token
 from services.redis import subscribe
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _DEFAULT_PROJECT = "default"
 

--- a/observal-server/api/middleware/request_id.py
+++ b/observal-server/api/middleware/request_id.py
@@ -4,6 +4,9 @@ Assigns a unique UUID to every request and returns it via the ``X-Request-ID``
 response header.  If the client supplies a valid UUID in the ``X-Request-ID``
 request header it is reused; otherwise a new one is generated.  Invalid values
 are silently replaced to prevent header injection.
+
+The request ID is also bound to the structlog context so that every log line
+emitted during the request carries it automatically.
 """
 
 from __future__ import annotations
@@ -11,6 +14,7 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
+import structlog
 from starlette.middleware.base import BaseHTTPMiddleware
 
 if TYPE_CHECKING:
@@ -18,7 +22,7 @@ if TYPE_CHECKING:
 
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
-    """Attach an ``X-Request-ID`` header to every response."""
+    """Attach an ``X-Request-ID`` header to every response and bind it to the structlog context."""
 
     async def dispatch(self, request: Request, call_next):
         incoming = request.headers.get("x-request-id")
@@ -26,16 +30,16 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 
         if incoming:
             try:
-                # Validate that the supplied value is a well-formed UUID.
                 request_id = str(uuid.UUID(incoming))
             except (ValueError, AttributeError):
-                # Invalid — generate a fresh one instead.
                 request_id = str(uuid.uuid4())
         else:
             request_id = str(uuid.uuid4())
 
-        # Stash on request state so downstream handlers can access it.
         request.state.request_id = request_id
+
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(request_id=request_id)
 
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -1,8 +1,8 @@
-import logging
 import uuid
 from datetime import UTC, timedelta
 from datetime import datetime as dt
 
+import structlog
 from fastapi import APIRouter, Depends, Query
 from fastapi_cache.decorator import cache
 from sqlalchemy import func, select
@@ -45,7 +45,7 @@ from schemas.dashboard import (
 )
 from services.clickhouse import _query
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/api/v1", tags=["dashboard"])
 
 _RANGE_MAP = {"24h": 1, "7d": 7, "30d": 30, "90d": 90}

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -62,7 +62,7 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
         if r.status_code == 200:
             return r.json().get("data", [])
     except Exception as e:
-        logger.warning(f"ClickHouse query failed: {e}")
+        logger.warning("clickhouse_query_failed", error=str(e))
     return []
 
 

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -64,7 +64,7 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
         if r.status_code == 200:
             return r.json().get("data", [])
     except Exception as e:
-        logger.warning(f"ClickHouse query failed: {e}")
+        logger.warning("clickhouse_query_failed", error=str(e))
     return []
 
 
@@ -994,10 +994,10 @@ async def ingest_hook(request: Request):
     try:
         r = await _query(sql, data=json.dumps(row, default=str))
         if r.status_code != 200:
-            logger.warning(f"Hook insert failed: {r.status_code} {r.text[:200]}")
+            logger.warning("hook_insert_failed", status_code=r.status_code, response=r.text[:200])
             return {"ingested": 0, "error": "insert failed"}
     except Exception as e:
-        logger.warning(f"Hook insert failed: {e}")
+        logger.warning("hook_insert_failed", error=str(e))
         return {"ingested": 0, "error": str(e)}
 
     # Notify subscribers (fire-and-forget — don't block the response)

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -1,10 +1,10 @@
 import asyncio
 import json
-import logging
 import re
 import time as _time
 from datetime import UTC, datetime
 
+import structlog
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi_cache.decorator import cache
 
@@ -15,7 +15,7 @@ from services.clickhouse import _query, query_shim_spans_for_window
 from services.redis import publish
 from services.secrets_redactor import redact_secrets
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/api/v1/otel", tags=["otel-dashboard"])
 
 # Normalize legacy ServiceName values to canonical IDE names.

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -5,6 +5,10 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    # Logging
+    LOG_LEVEL: str = "INFO"
+    LOG_FORMAT: Literal["json", "console"] = "json"
+
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/observal"
     CLICKHOUSE_URL: str = "clickhouse://localhost:8123/observal"
     REDIS_URL: str = "redis://localhost:6379"

--- a/observal-server/logging_config.py
+++ b/observal-server/logging_config.py
@@ -1,0 +1,54 @@
+"""Structured logging configuration using structlog."""
+
+import logging
+import sys
+
+import structlog
+
+from config import settings
+
+
+def setup_logging() -> None:
+    """Configure structlog with JSON or console rendering based on LOG_FORMAT."""
+    shared_processors: list[structlog.types.Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+
+    if settings.LOG_FORMAT == "json":
+        renderer: structlog.types.Processor = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer()
+
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=shared_processors,
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+    )
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(settings.LOG_LEVEL.upper())
+
+    for noisy in ("uvicorn.access", "httpx", "httpcore"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from contextlib import asynccontextmanager
 
@@ -23,7 +22,6 @@ from api.graphql import get_context_dep, schema
 from api.middleware.content_type import ContentTypeMiddleware
 from api.middleware.request_id import RequestIDMiddleware
 from api.ratelimit import limiter
-from logging_config import setup_logging
 from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
 from api.routes.alert import router as alert_router
@@ -47,6 +45,7 @@ from api.routes.skill import router as skill_router
 from api.routes.telemetry import router as telemetry_router
 from config import settings
 from database import engine
+from logging_config import setup_logging
 from models import Base
 from models.user import User
 from services.cache import close_cache, init_cache

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -2,9 +2,11 @@ import logging
 import os
 from contextlib import asynccontextmanager
 
+import structlog
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from prometheus_fastapi_instrumentator import Instrumentator
 from redis.exceptions import RedisError
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -21,6 +23,7 @@ from api.graphql import get_context_dep, schema
 from api.middleware.content_type import ContentTypeMiddleware
 from api.middleware.request_id import RequestIDMiddleware
 from api.ratelimit import limiter
+from logging_config import setup_logging
 from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
 from api.routes.alert import router as alert_router
@@ -50,6 +53,8 @@ from services.cache import close_cache, init_cache
 from services.clickhouse import init_clickhouse
 from services.crypto import init_key_manager
 from services.redis import close as close_redis
+
+setup_logging()
 
 
 async def _ensure_columns(conn):
@@ -93,14 +98,14 @@ async def lifespan(app: FastAPI):
         await seed_demo_accounts(db)
 
     # Load enterprise module when in enterprise mode
-    _logger = logging.getLogger("observal")
+    _logger = structlog.get_logger("observal")
     if settings.DEPLOYMENT_MODE == "enterprise":
         try:
             from ee import register_enterprise
 
             register_enterprise(app, settings)
         except ImportError:
-            _logger.error("DEPLOYMENT_MODE=enterprise but ee/ module not found")
+            _logger.error("enterprise_module_missing", detail="DEPLOYMENT_MODE=enterprise but ee/ module not found")
             app.state.enterprise_issues = ["ee/ module not installed"]
 
     yield
@@ -130,11 +135,11 @@ async def _set_rate_limit_defaults(request: Request, call_next):
     return await call_next(request)
 
 
-logger = logging.getLogger("observal")
+logger = structlog.get_logger("observal")
 
 
 async def _redis_error_handler(request: Request, exc: RedisError):
-    logger.error("Unhandled RedisError on %s %s: %s", request.method, request.url.path, exc)
+    logger.error("redis_error", method=request.method, path=request.url.path, error=str(exc))
     return JSONResponse(status_code=503, content={"detail": "Service temporarily unavailable"})
 
 
@@ -264,26 +269,36 @@ app.include_router(component_source_router)
 app.include_router(bulk_router)
 app.include_router(config_router)
 
+# --- Prometheus metrics ---
+Instrumentator(
+    excluded_handlers=["/livez", "/healthz", "/readyz", "/metrics"],
+).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
 
+
+@app.get("/livez", include_in_schema=False)
 @app.get("/healthz", include_in_schema=False)
 async def liveness():
     """K8s liveness probe. Returns 200 if the process is alive. No I/O."""
     return {"status": "alive"}
 
 
+@app.get("/readyz", include_in_schema=False)
 @app.get("/health")
 async def readiness(db: AsyncSession = Depends(get_db)):
-    """K8s readiness probe. Checks DB connectivity, ClickHouse, and enterprise config."""
+    """K8s readiness probe. Checks Postgres, ClickHouse, and Redis connectivity."""
     checks: dict[str, object] = {"status": "ok"}
 
+    # Postgres
     try:
         count = await db.scalar(select(func.count()).select_from(User))
+        checks["postgres"] = "ok"
         checks["initialized"] = (count or 0) > 0
     except Exception:
+        checks["postgres"] = "unreachable"
         checks["status"] = "unhealthy"
         return JSONResponse(content=checks, status_code=503)
 
-    # ClickHouse health
+    # ClickHouse
     from services.clickhouse import clickhouse_health
 
     if not await clickhouse_health():
@@ -291,6 +306,15 @@ async def readiness(db: AsyncSession = Depends(get_db)):
         checks["status"] = "degraded"
     else:
         checks["clickhouse"] = "ok"
+
+    # Redis
+    from services.redis import ping as redis_ping
+
+    if not await redis_ping():
+        checks["redis"] = "unreachable"
+        checks["status"] = "degraded"
+    else:
+        checks["redis"] = "ok"
 
     if settings.DEPLOYMENT_MODE == "enterprise":
         issues = getattr(app.state, "enterprise_issues", [])

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "fastapi-cache2[redis]>=0.2.2",
     "jinja2>=3.1.0",
     "mako>=1.3.11",
+    "structlog>=24.1.0",
+    "prometheus-fastapi-instrumentator>=7.0.0",
 ]
 
 [dependency-groups]

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -1,14 +1,14 @@
 import json
-import logging
 from datetime import UTC, datetime
 from urllib.parse import urlparse
 
 import httpx
+import structlog
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from config import settings
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 async def _invalidate_cache():

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -327,7 +327,7 @@ async def init_clickhouse():
         try:
             await _query(stmt)
         except Exception as e:
-            logger.warning(f"ClickHouse init statement failed: {e}")
+            logger.warning("clickhouse_init_failed", error=str(e))
 
     # Apply data retention TTL if configured
     retention_days = settings.DATA_RETENTION_DAYS
@@ -345,7 +345,7 @@ async def init_clickhouse():
                 await _query(stmt)
                 applied += 1
             except Exception as e:
-                logger.warning(f"ClickHouse TTL configuration failed: {e}")
+                logger.warning("clickhouse_ttl_failed", error=str(e))
         if applied == len(ttl_stmts):
             logger.info("ClickHouse retention set to %d days", retention_days)
         else:
@@ -378,7 +378,7 @@ async def insert_tool_call(event: dict):
         r.raise_for_status()
         await _invalidate_cache()
     except Exception as e:
-        logger.error(f"ClickHouse insert_tool_call failed: {e}")
+        logger.error("clickhouse_insert_tool_call_failed", error=str(e))
         raise
 
 
@@ -403,7 +403,7 @@ async def insert_agent_interaction(event: dict):
         r.raise_for_status()
         await _invalidate_cache()
     except Exception as e:
-        logger.error(f"ClickHouse insert_agent_interaction failed: {e}")
+        logger.error("clickhouse_insert_agent_interaction_failed", error=str(e))
         raise
 
 
@@ -458,7 +458,7 @@ async def insert_traces(traces: list[dict]):
         r.raise_for_status()
         await _invalidate_cache()
     except Exception as e:
-        logger.error(f"ClickHouse insert_traces failed: {e}")
+        logger.error("clickhouse_insert_traces_failed", error=str(e))
         raise
 
 
@@ -543,7 +543,7 @@ async def insert_spans(spans: list[dict]):
         r.raise_for_status()
         await _invalidate_cache()
     except Exception as e:
-        logger.error(f"ClickHouse insert_spans failed: {e}")
+        logger.error("clickhouse_insert_spans_failed", error=str(e))
         raise
 
 
@@ -589,7 +589,7 @@ async def insert_scores(scores: list[dict]):
         r.raise_for_status()
         await _invalidate_cache()
     except Exception as e:
-        logger.error(f"ClickHouse insert_scores failed: {e}")
+        logger.error("clickhouse_insert_scores_failed", error=str(e))
         raise
 
 
@@ -623,7 +623,7 @@ async def insert_otel_logs(rows: list[dict]):
         r.raise_for_status()
         await _invalidate_cache()
     except Exception as e:
-        logger.error(f"ClickHouse insert_otel_logs failed: {e}")
+        logger.error("clickhouse_insert_otel_logs_failed", error=str(e))
         raise
 
 
@@ -641,7 +641,7 @@ async def query_recent_events(minutes: int = 60) -> dict:
         if r.status_code == 200:
             tool_count = int(r.json().get("data", [{}])[0].get("cnt", 0))
     except Exception as e:
-        logger.warning(f"ClickHouse query tool_calls failed: {e}")
+        logger.warning("clickhouse_query_tool_calls_failed", error=str(e))
 
     try:
         r = await _query(
@@ -651,7 +651,7 @@ async def query_recent_events(minutes: int = 60) -> dict:
         if r.status_code == 200:
             agent_count = int(r.json().get("data", [{}])[0].get("cnt", 0))
     except Exception as e:
-        logger.warning(f"ClickHouse query agent_interactions failed: {e}")
+        logger.warning("clickhouse_query_agent_interactions_failed", error=str(e))
 
     return {"tool_call_events": tool_count, "agent_interaction_events": agent_count}
 
@@ -694,7 +694,7 @@ async def query_traces(
         r.raise_for_status()
         return r.json().get("data", [])
     except Exception as e:
-        logger.error(f"ClickHouse query_traces failed: {e}")
+        logger.error("clickhouse_query_traces_failed", error=str(e))
         return []
 
 
@@ -717,7 +717,7 @@ async def query_trace_by_id(project_id: str, trace_id: str, *, user_id: str | No
         data = r.json().get("data", [])
         return data[0] if data else None
     except Exception as e:
-        logger.error(f"ClickHouse query_trace_by_id failed: {e}")
+        logger.error("clickhouse_query_trace_by_id_failed", error=str(e))
         return None
 
 
@@ -749,7 +749,7 @@ async def query_spans(
         r.raise_for_status()
         return r.json().get("data", [])
     except Exception as e:
-        logger.error(f"ClickHouse query_spans failed: {e}")
+        logger.error("clickhouse_query_spans_failed", error=str(e))
         return []
 
 
@@ -772,7 +772,7 @@ async def query_span_by_id(project_id: str, span_id: str, *, user_id: str | None
         data = r.json().get("data", [])
         return data[0] if data else None
     except Exception as e:
-        logger.error(f"ClickHouse query_span_by_id failed: {e}")
+        logger.error("clickhouse_query_span_by_id_failed", error=str(e))
         return None
 
 
@@ -821,7 +821,7 @@ async def query_shim_spans_for_window(
         r.raise_for_status()
         return r.json().get("data", [])
     except Exception as e:
-        logger.error(f"ClickHouse query_shim_spans_for_window failed: {e}")
+        logger.error("clickhouse_query_shim_spans_failed", error=str(e))
         return []
 
 
@@ -856,7 +856,7 @@ async def query_scores(
         r.raise_for_status()
         return r.json().get("data", [])
     except Exception as e:
-        logger.error(f"ClickHouse query_scores failed: {e}")
+        logger.error("clickhouse_query_scores_failed", error=str(e))
         return []
 
 
@@ -886,7 +886,7 @@ async def insert_audit_log(events: list[dict]):
         r.raise_for_status()
         await _invalidate_cache()
     except Exception as exc:
-        logger.error(f"ClickHouse insert_audit_log failed: {exc}")
+        logger.error("clickhouse_insert_audit_log_failed", error=str(exc))
 
 
 async def _insert_webhook_deliveries(records: list[dict]):
@@ -919,4 +919,4 @@ async def _insert_webhook_deliveries(records: list[dict]):
         r = await _query(sql, data=body)
         r.raise_for_status()
     except Exception as exc:
-        logger.error(f"ClickHouse _insert_webhook_deliveries failed: {exc}")
+        logger.error("clickhouse_insert_webhook_deliveries_failed", error=str(exc))

--- a/observal-server/services/eval/eval_engine.py
+++ b/observal-server/services/eval/eval_engine.py
@@ -5,17 +5,17 @@ Designed as a pluggable interface so ITJ can replace LLM-as-judge later.
 """
 
 import json
-import logging
 import uuid
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 
 import httpx
+import structlog
 
 from config import settings
 from services.clickhouse import insert_scores, query_spans, query_trace_by_id
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # --- Managed eval templates (no custom authoring) ---
 

--- a/observal-server/services/eval/eval_engine.py
+++ b/observal-server/services/eval/eval_engine.py
@@ -147,7 +147,7 @@ async def _call_bedrock(prompt: str, model_id: str) -> dict:
     try:
         return await asyncio.get_event_loop().run_in_executor(None, _sync)
     except Exception as e:
-        logger.error(f"Bedrock eval failed: {e}")
+        logger.error("bedrock_eval_failed", error=str(e))
         return {}
 
 
@@ -167,7 +167,7 @@ async def _call_openai(prompt: str, model: str) -> dict:
             r.raise_for_status()
             return _extract_json(r.json()["choices"][0]["message"]["content"])
     except Exception as e:
-        logger.error(f"OpenAI eval failed: {e}")
+        logger.error("openai_eval_failed", error=str(e))
         return {}
 
 
@@ -194,7 +194,7 @@ async def run_eval_on_trace(
     backend = get_backend()
     trace = await query_trace_by_id(project_id, trace_id)
     if not trace:
-        logger.warning(f"Trace {trace_id} not found")
+        logger.warning("trace_not_found", trace_id=trace_id)
         return []
 
     spans = await query_spans(project_id, trace_id, limit=500)
@@ -231,13 +231,13 @@ async def run_eval_on_trace(
                     }
                 )
             except Exception as e:
-                logger.error(f"Eval template {tpl_name} failed on span {span.get('span_id')}: {e}")
+                logger.error("eval_template_failed", template=tpl_name, span_id=span.get("span_id"), error=str(e))
 
     if scores_to_insert:
         try:
             await insert_scores(scores_to_insert)
         except Exception as e:
-            logger.error(f"Failed to insert eval scores: {e}")
+            logger.error("eval_insert_scores_failed", error=str(e))
 
     return scores_to_insert
 

--- a/observal-server/services/eval/eval_service.py
+++ b/observal-server/services/eval/eval_service.py
@@ -87,7 +87,7 @@ async def fetch_traces(agent_id: str, limit: int = 20, trace_id: str | None = No
         if r.status_code == 200:
             return r.json().get("data", [])
     except Exception as e:
-        logger.warning(f"Failed to fetch traces: {e}")
+        logger.warning("eval_fetch_traces_failed", error=str(e))
     return []
 
 
@@ -128,7 +128,7 @@ async def _call_bedrock(prompt: str, model_id: str) -> dict:
     try:
         return await asyncio.get_event_loop().run_in_executor(None, _sync_call)
     except Exception as e:
-        logger.error(f"Bedrock eval call failed: {e}")
+        logger.error("bedrock_eval_call_failed", error=str(e))
         return {}
 
 
@@ -157,7 +157,7 @@ async def _call_openai_compatible(prompt: str, model: str) -> dict:
             content = r.json()["choices"][0]["message"]["content"]
             return json.loads(content)
         except Exception as e:
-            logger.error(f"Eval model call failed: {e}")
+            logger.error("eval_model_call_failed", error=str(e))
             return {}
 
 
@@ -318,7 +318,7 @@ async def run_structured_eval(
             slm_penalties += await slm_scorer.score_factual_grounding(sanitized_trace, spans)
             slm_penalties += await slm_scorer.score_thought_process(spans)
         except Exception as e:
-            logger.error(f"SLM scoring failed, skipping SLM dimensions: {e}")
+            logger.error("slm_scoring_failed", error=str(e))
             slm_penalties = []
             skipped_dimensions = ["goal_completion", "factual_grounding", "thought_process"]
 
@@ -476,7 +476,7 @@ async def run_agent_scoped_eval(
             slm_penalties += await slm_scorer.score_factual_grounding(sanitized_trace, full_spans)
             slm_penalties += await slm_scorer.score_thought_process(full_spans)
         except Exception as e:
-            logger.error(f"SLM scoring failed for agent-scoped eval: {e}")
+            logger.error("slm_scoring_failed", scope="agent", error=str(e))
             slm_penalties = []
             skipped_dimensions = ["goal_completion", "factual_grounding", "thought_process"]
 

--- a/observal-server/services/eval/eval_service.py
+++ b/observal-server/services/eval/eval_service.py
@@ -1,8 +1,8 @@
 import json
-import logging
 import uuid
 
 import httpx
+import structlog
 
 from config import settings
 from models.agent import Agent
@@ -18,7 +18,7 @@ from services.eval.score_aggregator import ScoreAggregator
 from services.eval.slm_scorer import SLMScorer
 from services.eval.structural_scorer import StructuralScorer
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 DIMENSIONS = [
     "task_completion",

--- a/observal-server/services/eval/ragas_eval.py
+++ b/observal-server/services/eval/ragas_eval.py
@@ -18,14 +18,15 @@ References:
 Content was rephrased for compliance with licensing restrictions.
 """
 
-import logging
 import uuid
 from datetime import UTC, datetime
+
+import structlog
 
 from services.clickhouse import insert_scores
 from services.eval.eval_engine import _call_model
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 RAGAS_DIMENSIONS = ("faithfulness", "answer_relevancy", "context_precision", "context_recall")
 

--- a/observal-server/services/eval/ragas_eval.py
+++ b/observal-server/services/eval/ragas_eval.py
@@ -215,7 +215,7 @@ async def run_ragas_on_graphrag(
         r.raise_for_status()
         spans = r.json().get("data", [])
     except Exception as e:
-        logger.error(f"Failed to fetch retrieval spans: {e}")
+        logger.error("ragas_fetch_retrieval_spans_failed", error=str(e))
         return {"spans_evaluated": 0, "scores": [], "averages": {}}
 
     if not spans:
@@ -262,7 +262,7 @@ async def run_ragas_on_graphrag(
         try:
             await insert_scores(scores_to_insert)
         except Exception as e:
-            logger.error(f"Failed to insert RAGAS scores: {e}")
+            logger.error("ragas_insert_scores_failed", error=str(e))
 
     # Compute averages
     averages = {}

--- a/observal-server/services/eval/slm_scorer.py
+++ b/observal-server/services/eval/slm_scorer.py
@@ -286,7 +286,7 @@ class SLMScorer:
             if result:
                 return result
         except Exception as e:
-            logger.error(f"SLM scorer model call failed: {e}")
+            logger.error("slm_scorer_model_call_failed", error=str(e))
         return {}
 
 

--- a/observal-server/services/eval/slm_scorer.py
+++ b/observal-server/services/eval/slm_scorer.py
@@ -5,7 +5,8 @@ Hardened against BenchJack Pattern 4 (prompt injection in agent output).
 """
 
 import json
-import logging
+
+import structlog
 
 from models.scoring import ScoringDimension
 from schemas.judge_output import (
@@ -18,7 +19,7 @@ from schemas.judge_output import (
 )
 from services.eval.eval_engine import EvalBackend
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 # --- Hardened Prompt Templates ---

--- a/observal-server/services/hook_materializer.py
+++ b/observal-server/services/hook_materializer.py
@@ -9,14 +9,15 @@ Also provides agent-scoped annotation: given a full session, marks which
 spans belong to a target agent so the eval pipeline can focus its scoring.
 """
 
-import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 
+import structlog
+
 from services.clickhouse import _query, query_shim_spans_for_window
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _SERVICE_NAME_MAP: dict[str, str] = {
     "kiro-cli": "kiro",

--- a/observal-server/services/hook_materializer.py
+++ b/observal-server/services/hook_materializer.py
@@ -106,7 +106,7 @@ async def _fetch_session_events(session_id: str) -> list[dict]:
         r.raise_for_status()
         events = r.json().get("data", [])
     except Exception as e:
-        logger.error(f"Failed to fetch hook events for session {session_id}: {e}")
+        logger.error("hook_events_fetch_failed", session_id=session_id, error=str(e))
         return []
 
     if not events:

--- a/observal-server/services/redis.py
+++ b/observal-server/services/redis.py
@@ -42,9 +42,9 @@ async def publish(channel: str, data: dict):
         except (ConnectionError, OSError) as e:
             attempts += 1
             if attempts >= max_attempts:
-                logger.warning(f"Redis publish failed after {max_attempts} attempts: {e}")
+                logger.warning("redis_publish_failed", attempts=max_attempts, error=str(e))
                 return
-            logger.debug(f"Redis publish attempt {attempts} failed, retrying: {e}")
+            logger.debug("redis_publish_retry", attempt=attempts, error=str(e))
             await asyncio.sleep(0.5 * attempts)
 
 
@@ -68,7 +68,7 @@ async def subscribe(channel: str):
                         continue
         except (ConnectionError, OSError) as e:
             reconnect_count += 1
-            logger.warning(f"Redis subscribe reconnecting ({reconnect_count}/{max_reconnects}): {e}")
+            logger.warning("redis_subscribe_reconnecting", attempt=reconnect_count, max_attempts=max_reconnects, error=str(e))
             await asyncio.sleep(1.0 * reconnect_count)
         finally:
             try:
@@ -76,7 +76,7 @@ async def subscribe(channel: str):
                 await pubsub.close()
             except Exception:
                 pass
-    logger.error(f"Redis subscribe gave up after {max_reconnects} reconnects on channel {channel}")
+    logger.error("redis_subscribe_gave_up", max_reconnects=max_reconnects, channel=channel)
 
 
 async def enqueue_eval(agent_id: str, trace_id: str | None = None):
@@ -84,6 +84,15 @@ async def enqueue_eval(agent_id: str, trace_id: str | None = None):
     r = get_redis()
     job = json.dumps({"function": "run_eval", "agent_id": agent_id, "trace_id": trace_id})
     await r.rpush("arq:queue", job)
+
+
+async def ping() -> bool:
+    """Check Redis connectivity. Returns True if healthy."""
+    try:
+        r = get_redis()
+        return await r.ping()
+    except Exception:
+        return False
 
 
 async def close():

--- a/observal-server/services/redis.py
+++ b/observal-server/services/redis.py
@@ -68,7 +68,9 @@ async def subscribe(channel: str):
                         continue
         except (ConnectionError, OSError) as e:
             reconnect_count += 1
-            logger.warning("redis_subscribe_reconnecting", attempt=reconnect_count, max_attempts=max_reconnects, error=str(e))
+            logger.warning(
+                "redis_subscribe_reconnecting", attempt=reconnect_count, max_attempts=max_reconnects, error=str(e)
+            )
             await asyncio.sleep(1.0 * reconnect_count)
         finally:
             try:

--- a/observal-server/services/redis.py
+++ b/observal-server/services/redis.py
@@ -1,13 +1,13 @@
 """Redis client and pub/sub helpers for background jobs and subscriptions."""
 
 import json
-import logging
 
 import redis.asyncio as aioredis
+import structlog
 
 from config import settings
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _pool: aioredis.ConnectionPool | None = None
 

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -841,6 +841,7 @@ dependencies = [
     { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "mako" },
+    { name = "prometheus-fastapi-instrumentator" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -850,6 +851,7 @@ dependencies = [
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "strawberry-graphql", extra = ["fastapi"] },
+    { name = "structlog" },
     { name = "tenacity" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -881,6 +883,7 @@ requires-dist = [
     { name = "itsdangerous" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mako", specifier = ">=1.3.11" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", specifier = ">=2.8.0" },
@@ -890,6 +893,7 @@ requires-dist = [
     { name = "slowapi" },
     { name = "sqlalchemy", extras = ["asyncio"] },
     { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.314.0" },
+    { name = "structlog", specifier = ">=24.1.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "uvicorn", extras = ["standard"] },
 ]
@@ -979,6 +983,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prometheus-client" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
 ]
 
 [[package]]
@@ -1389,15 +1415,15 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]
@@ -1420,6 +1446,15 @@ wheels = [
 fastapi = [
     { name = "fastapi" },
     { name = "python-multipart" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -1,15 +1,16 @@
 """arq background worker for eval jobs and async tasks."""
 
-import logging
-
+import structlog
 from arq.connections import RedisSettings
 from arq.cron import cron
 
 from config import settings
+from logging_config import setup_logging
 from services.alert_evaluator import evaluate_alerts
 from services.redis import publish
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger(__name__)
 
 
 def _redis_settings() -> RedisSettings:
@@ -27,7 +28,7 @@ def _redis_settings() -> RedisSettings:
 
 async def run_eval(ctx: dict, agent_id: str, trace_id: str | None = None, project_id: str = "default"):
     """Background job: run eval on an agent's traces."""
-    logger.info(f"Running eval for agent={agent_id} trace={trace_id} project={project_id}")
+    logger.info("eval_started", agent_id=agent_id, trace_id=trace_id, project_id=project_id)
     try:
         from services.clickhouse import query_traces
         from services.eval.eval_engine import run_eval_on_trace
@@ -56,7 +57,7 @@ async def run_eval(ctx: dict, agent_id: str, trace_id: str | None = None, projec
                     },
                 )
     except Exception as e:
-        logger.exception(f"Eval job failed: {e}")
+        logger.exception("eval_failed", error=str(e))
 
 
 async def sync_component_sources(ctx: dict):

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "observal-api"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["observal-api:8000"]
+        labels:
+          service: "observal-api"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -39,7 +39,10 @@ class TestReadiness:
 
         app.dependency_overrides[get_db] = _mock_get_db
         try:
-            with patch("services.clickhouse.clickhouse_health", new_callable=AsyncMock, return_value=True):
+            with (
+                patch("services.clickhouse.clickhouse_health", new_callable=AsyncMock, return_value=True),
+                patch("services.redis.ping", new_callable=AsyncMock, return_value=True),
+            ):
                 async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                     r = await ac.get("/health")
             assert r.status_code == 200
@@ -65,7 +68,11 @@ class TestReadiness:
         app.dependency_overrides[get_db] = _mock_get_db
         app.state.enterprise_issues = ["SECRET_KEY is default"]
         try:
-            with patch("main.settings") as mock_settings:
+            with (
+                patch("main.settings") as mock_settings,
+                patch("services.clickhouse.clickhouse_health", new_callable=AsyncMock, return_value=True),
+                patch("services.redis.ping", new_callable=AsyncMock, return_value=True),
+            ):
                 mock_settings.DEPLOYMENT_MODE = "enterprise"
                 async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                     r = await ac.get("/health")


### PR DESCRIPTION
## Summary
- Structured JSON logging via `structlog` with request ID propagation across all services
- Health probes: `/livez` (liveness), `/readyz` (checks Postgres, ClickHouse, Redis)
- Prometheus `/metrics` endpoint with request rate, latency histograms, and resource usage
- Pre-built Grafana dashboard for API health monitoring
- Documentation for maintainers

## What changed
- **New:** `logging_config.py`, `prometheus.yml`, Grafana dashboard + datasource, `docs/self-observability.md`
- **Updated:** `main.py`, `worker.py`, `config.py`, `request_id.py`, `redis.py`, `docker-compose.yml`, `pyproject.toml`
- **Refactored:** Converted 42 f-string log calls to structured keyword args across 11 files

## How to Use

- **Health checks**: Hit `/livez` (is the server alive?) or `/readyz` (are DB, ClickHouse, Redis all connected?)
- **Metrics**: Hit `/metrics` to see Prometheus data — request rates, latency, response sizes
- **Logs**: All logs are now structured JSON with a `request_id` field. Set `LOG_FORMAT=console` for readable logs during dev.
- **Request ID**: Every request gets an `X-Request-ID` header automatically. Pass your own or let the server generate one. Shows up in all logs for that request.
- **Grafana dashboard**: Open `http://localhost:3001` → Dashboards → Observal API Health. Works out of the box, no setup.
- **Prometheus**: Runs automatically in Docker Compose at `http://localhost:9090`, scrapes the API every 15s.
- **Docker healthcheck**: Container uses `/readyz` — marks itself unhealthy if any dependency is down.

<img width="2839" height="1282" alt="image" src="https://github.com/user-attachments/assets/e3ecc7d4-c935-4d64-a6a6-c14b7c69de0b" />


--------------------------------------------------------------------------------------------------------------------------------------------
<img width="2831" height="1514" alt="image" src="https://github.com/user-attachments/assets/db8b59d8-b75f-486a-b38f-d7da9fe2dda1" />



## Test
- [x] `/livez` returns `{"status":"alive"}` (200)
- [x] `/readyz` returns status for Postgres, ClickHouse, Redis (200)
- [x] `/readyz` shows `"degraded"` when ClickHouse or Redis is stopped
- [x] `/metrics` exposes Prometheus metrics (request counts, latency, memory)
- [x] `X-Request-ID` auto-generated and propagated in response headers
- [x] Custom `X-Request-ID` echoed back, invalid UUIDs rejected
- [x] Logs output as JSON with `event`, `level`, `logger`, `timestamp`, `request_id`
- [x] Grafana dashboard loads and displays live data
- [x] Prometheus scrapes API successfully
- [x] Docker healthcheck uses `/readyz`
- [x] All 137 existing tests pass

Closes #195
