### PR TITLE
Chore/homebrew pyproject cleanup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Publish observal CLI to PyPI on a v* tag.
+#
+# Uses PyPI Trusted Publishing (OIDC) — no PYPI_API_TOKEN secret required.
+# Configure on PyPI: Project → Publishing → Add a trusted publisher with
+#   owner = BlazeUp-AI, repo = Observal, workflow = publish.yml,
+#   environment = pypi.
+#
+# Tag a release with `git tag -s vX.Y.Z && git push origin vX.Y.Z`.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Publish
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for PyPI Trusted Publishing
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Verify tag matches pyproject version
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          pkg=$(uv run --with tomli python -c "import tomli, pathlib; print(tomli.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag v$tag does not match pyproject version $pkg"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased] - 2026-04-12
+## [Unreleased]
+
+## [0.2.0] - 2026-04-21
 
 ### Added — Kiro CLI Setup Guide
 

--- a/docs/kiro-setup.md
+++ b/docs/kiro-setup.md
@@ -36,7 +36,7 @@ observal doctor --ide kiro
 
 Before starting, you need:
 
-- **Observal CLI installed** — `pip install observal` or `uv tool install --editable .`
+- **Observal CLI installed** — `pip install observal-cli` or `uv tool install --editable .`
 - **Authenticated with Observal** — run `observal auth login` (not the deprecated `observal login`)
 - **Observal server reachable** — either self-hosted (see [SETUP.md](../SETUP.md)) or a remote instance
 

--- a/observal_cli/README.md
+++ b/observal_cli/README.md
@@ -10,7 +10,7 @@ The CLI is packaged as a Python project. From the repo root:
 uv pip install -e .
 ```
 
-This installs five entry points:
+This installs four entry points:
 
 | Command | Purpose |
 |---------|---------|
@@ -18,7 +18,6 @@ This installs five entry points:
 | `observal-shim` | Telemetry wrapper that sits in front of MCP servers |
 | `observal-proxy` | HTTP proxy for MCP servers |
 | `observal-sandbox-run` | Sandbox execution runner |
-| `observal-graphrag-proxy` | GraphRAG integration proxy |
 
 ## Quick Start
 
@@ -147,6 +146,5 @@ observal_cli/
 ├── shim.py                  # observal-shim entrypoint
 ├── proxy.py                 # observal-proxy entrypoint
 ├── sandbox_runner.py        # observal-sandbox-run entrypoint
-├── graphrag_proxy.py        # observal-graphrag-proxy entrypoint
 └── hooks/                   # Telemetry hook scripts
 ```

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -297,7 +297,7 @@ def _check_environment(issues: list, warnings: list):
         warnings.append("Docker is not running. `observal-sandbox-run` requires Docker.")
 
     # Check entry points
-    for ep in ["observal-shim", "observal-proxy", "observal-sandbox-run", "observal-graphrag-proxy"]:
+    for ep in ["observal-shim", "observal-proxy", "observal-sandbox-run"]:
         if not shutil.which(ep):
             warnings.append(f"`{ep}` not found in PATH. Run `uv tool install --editable .` from the Observal repo.")
 

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -191,7 +191,11 @@ def _sha256_file(path: Path) -> str:
 
 async def _connect(db_url: str) -> asyncpg.Connection:
     """Establish asyncpg connection, verify alembic_version table exists."""
-    import asyncpg
+    try:
+        import asyncpg
+    except ImportError:
+        rprint("[red]asyncpg not found.[/red] Install the migrate extra: [bold]pip install 'observal-cli[migrate]'[/bold]")
+        raise typer.Exit(1)
 
     # Strip SQLAlchemy dialect suffixes (e.g. postgresql+asyncpg:// → postgresql://)
     clean_url = (
@@ -264,7 +268,11 @@ async def _flush_batch(
     batch: list[dict],
 ) -> tuple[int, int]:
     """Flush a batch of rows to the database. Returns (inserted, skipped)."""
-    import asyncpg
+    try:
+        import asyncpg
+    except ImportError:
+        rprint("[red]asyncpg not found.[/red] Install the migrate extra: [bold]pip install 'observal-cli[migrate]'[/bold]")
+        raise typer.Exit(1)
 
     if not batch:
         return 0, 0

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -194,7 +194,9 @@ async def _connect(db_url: str) -> asyncpg.Connection:
     try:
         import asyncpg
     except ImportError:
-        rprint("[red]asyncpg not found.[/red] Install the migrate extra: [bold]pip install 'observal-cli[migrate]'[/bold]")
+        rprint(
+            "[red]asyncpg not found.[/red] Install the migrate extra: [bold]pip install 'observal-cli[migrate]'[/bold]"
+        )
         raise typer.Exit(1)
 
     # Strip SQLAlchemy dialect suffixes (e.g. postgresql+asyncpg:// → postgresql://)
@@ -271,7 +273,9 @@ async def _flush_batch(
     try:
         import asyncpg
     except ImportError:
-        rprint("[red]asyncpg not found.[/red] Install the migrate extra: [bold]pip install 'observal-cli[migrate]'[/bold]")
+        rprint(
+            "[red]asyncpg not found.[/red] Install the migrate extra: [bold]pip install 'observal-cli[migrate]'[/bold]"
+        )
         raise typer.Exit(1)
 
     if not batch:

--- a/observal_cli/sandbox_runner.py
+++ b/observal_cli/sandbox_runner.py
@@ -45,7 +45,7 @@ def run_sandbox(sandbox_id: str, image: str, command: str | None = None, timeout
         import typer
         from rich import print as rprint
 
-        rprint("[red]Docker SDK not found.[/red] Please install via: pip install observal-cli[sandbox]")
+        rprint("[red]Docker SDK not found.[/red] Install the sandbox extra: [bold]pip install 'observal-cli[sandbox]'[/bold]")
         raise typer.Exit(1)
 
     client = docker.from_env()

--- a/observal_cli/sandbox_runner.py
+++ b/observal_cli/sandbox_runner.py
@@ -45,7 +45,9 @@ def run_sandbox(sandbox_id: str, image: str, command: str | None = None, timeout
         import typer
         from rich import print as rprint
 
-        rprint("[red]Docker SDK not found.[/red] Install the sandbox extra: [bold]pip install 'observal-cli[sandbox]'[/bold]")
+        rprint(
+            "[red]Docker SDK not found.[/red] Install the sandbox extra: [bold]pip install 'observal-cli[sandbox]'[/bold]"
+        )
         raise typer.Exit(1)
 
     client = docker.from_env()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "observal"
+name = "observal-cli"
 version = "0.2.0"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
@@ -12,10 +12,7 @@ dependencies = [
     "rich>=13.0.0",
     "pyyaml>=6.0.3",
     "questionary>=2.0.0",
-    "docker>=7.0.0",
-    "asyncpg>=0.29.0",
 ]
-
 
 keywords = ["mcp", "model-context-protocol", "registry", "cli", "agents", "observability"]
 classifiers = [
@@ -30,8 +27,14 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 
+[project.optional-dependencies]
+sandbox = ["docker>=7.0.0"]
+migrate = ["asyncpg>=0.29.0"]
+all = ["observal-cli[sandbox,migrate]"]
+
 [project.urls]
 Homepage = "https://github.com/BlazeUp-AI/Observal"
+Documentation = "https://github.com/BlazeUp-AI/Observal/blob/main/docs/cli.md"
 Repository = "https://github.com/BlazeUp-AI/Observal"
 Changelog = "https://github.com/BlazeUp-AI/Observal/blob/main/CHANGELOG.md"
 Issues = "https://github.com/BlazeUp-AI/Observal/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "observal"
-version = "0.1.0"
+version = "0.2.0"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -14,7 +14,6 @@ dependencies = [
     "questionary>=2.0.0",
     "docker>=7.0.0",
     "asyncpg>=0.29.0",
-    "hypothesis",
 ]
 
 
@@ -42,7 +41,6 @@ observal = "observal_cli.main:app"
 observal-shim = "observal_cli.shim:main"
 observal-proxy = "observal_cli.proxy:main"
 observal-sandbox-run = "observal_cli.sandbox_runner:main"
-#observal-graphrag-proxy = "observal_cli.graphrag_proxy:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -126,4 +124,5 @@ dev = [
     "ruff==0.15.11",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
+    "hypothesis",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -366,23 +366,33 @@ wheels = [
 ]
 
 [[package]]
-name = "observal"
-version = "0.1.0"
+name = "observal-cli"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "asyncpg" },
-    { name = "docker" },
     { name = "httpx" },
-    { name = "hypothesis" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "rich" },
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+all = [
+    { name = "asyncpg" },
+    { name = "docker" },
+]
+migrate = [
+    { name = "asyncpg" },
+]
+sandbox = [
+    { name = "docker" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "fastapi" },
+    { name = "hypothesis" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pytest" },
@@ -393,19 +403,21 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncpg", specifier = ">=0.29.0" },
-    { name = "docker", specifier = ">=7.0.0" },
+    { name = "asyncpg", marker = "extra == 'migrate'", specifier = ">=0.29.0" },
+    { name = "docker", marker = "extra == 'sandbox'", specifier = ">=7.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "hypothesis" },
+    { name = "observal-cli", extras = ["sandbox", "migrate"], marker = "extra == 'all'" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
+provides-extras = ["sandbox", "migrate", "all"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "hypothesis" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pytest", specifier = ">=9.0.3" },


### PR DESCRIPTION
## Purpose / Description
Prepare `observal-cli` for Homebrew distribution by cleaning up `pyproject.toml` so the project can be published under a stable, Homebrew-friendly name with a minimal default install.

Key changes:
- Rename the distribution package to `observal-cli` (the name we intend to publish on PyPI / ship via Homebrew) while keeping the import path `observal_cli` unchanged.
- Split the heavy optional dependencies (`asyncpg`, `docker` SDK) out of the base install into `[migrate]` and `[sandbox]` extras so the default CLI footprint stays small.
- Update the commands that use those extras (`cmd_migrate.py`, `sandbox_runner.py`) to fail gracefully with a clear hint pointing at the right extra (`pip install 'observal-cli[migrate]'` / `'observal-cli[sandbox]'`).
- Add a PyPI publishing workflow (`.github/workflows/publish.yml`) gated on version tags, and refresh `CHANGELOG.md`, docs, and the CLI README to use the new distribution name.
- Regenerate `uv.lock` to match the updated metadata.

## Fixes
* Fixes #465

## Approach
- **Rename only the distribution, not the import path.** `pyproject.toml` `[project].name` becomes `observal-cli`, but modules are still imported as `observal_cli`, so existing code and configs keep working.
- **Lazy-import heavy deps.** `asyncpg` and `docker` are imported inside the functions that need them; on `ImportError` the CLI prints a `rich` hint and exits with code `1` instead of crashing, so a user who never runs `migrate` or `sandbox` never needs those packages installed.
- **Extras, not base deps.** `[project.optional-dependencies]` defines `migrate = ["asyncpg>=0.29"]` and `sandbox = ["docker>=7.0"]`, keeping the default install lean for the Homebrew formula.
- **Automated publish.** The new `publish.yml` workflow builds sdist + wheel and publishes to PyPI on `v*` tags via trusted publishing, which is the prerequisite for a Homebrew formula that pulls from PyPI.
- **Docs + changelog** updated so `pip install observal-cli` and the extras are the documented install paths.

## How Has This Been Tested?
- `uv run --with ruff==0.15.10 ruff format --check .` → all 253 files formatted.
- `uv run --with ruff==0.15.10 ruff check .` → all checks passed.
- Existing CI matrix (`test (3.11)`, `test (3.12)`, `test (3.13)`, `web-lint`, `import-boundary`, `docker-build`, `security-scan`, `dependency-audit`, CodeQL) is green on this branch.
- Manually verified locally that running `observal migrate` / sandbox commands without the extras installed surfaces the friendly `[red]… not found.[/red] Install the … extra` message and exits cleanly, instead of raising an uncaught `ImportError`.

## Learning (optional, can help others)
- Homebrew-core generally prefers PyPI-backed formulas, which is why the rename + publish workflow land together — the formula in homebrew-core will pull `observal-cli` from PyPI rather than vendoring the repo.
- PEP 621 optional-dependencies let you keep a CLI's default install small while still offering opt-in feature sets, which is the cleanest pattern for tools that wrap multiple heavy backends (DB drivers, container SDKs, etc.).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings) — N/A, no UI changes

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->