### PR TITLE
fix: prevent ClickHouse OOM crashes with configurable memory limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ DEMO_REVIEWER_PASSWORD=reviewer-changeme
 DEMO_USER_EMAIL=user@demo.example
 DEMO_USER_PASSWORD=user-changeme
 
+# Resource limits (adjust based on your server's available RAM)
+# CLICKHOUSE_MEMORY_LIMIT=2G
+# OTEL_MEMORY_LIMIT=512M
+
 # Host port mappings (change these if defaults conflict with other services)
 # API_HOST_PORT=8000
 # POSTGRES_HOST_PORT=5432

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ observal-web/dist/
 
 # Docker
 docker/data/
+docker/clickhouse/users.d/default-user.xml
 
 # Local config
 .kiro/

--- a/docker/clickhouse/config.d/memory.xml
+++ b/docker/clickhouse/config.d/memory.xml
@@ -1,13 +1,9 @@
 <clickhouse>
+    <!-- Listen on all interfaces (required for Docker networking) -->
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+
     <!-- Cap ClickHouse to 80% of container RAM; leaves headroom for OS page cache -->
     <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
-
-    <!-- Limit background merge threads to reduce memory spikes from concurrent merges -->
-    <background_pool_size>2</background_pool_size>
-    <background_merges_mutations_concurrency_ratio>1</background_merges_mutations_concurrency_ratio>
-
-    <!-- Async-insert server-side settings: flush every 200ms or 1M bytes,
-         whichever comes first.  Keeps the in-memory buffer small. -->
-    <async_insert_max_data_size>1048576</async_insert_max_data_size>
-    <async_insert_busy_timeout_ms>200</async_insert_busy_timeout_ms>
 </clickhouse>

--- a/docker/clickhouse/config.d/memory.xml
+++ b/docker/clickhouse/config.d/memory.xml
@@ -1,0 +1,13 @@
+<clickhouse>
+    <!-- Cap ClickHouse to 80% of container RAM; leaves headroom for OS page cache -->
+    <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
+
+    <!-- Limit background merge threads to reduce memory spikes from concurrent merges -->
+    <background_pool_size>2</background_pool_size>
+    <background_merges_mutations_concurrency_ratio>1</background_merges_mutations_concurrency_ratio>
+
+    <!-- Async-insert server-side settings: flush every 200ms or 1M bytes,
+         whichever comes first.  Keeps the in-memory buffer small. -->
+    <async_insert_max_data_size>1048576</async_insert_max_data_size>
+    <async_insert_busy_timeout_ms>200</async_insert_busy_timeout_ms>
+</clickhouse>

--- a/docker/clickhouse/users.d/memory.xml
+++ b/docker/clickhouse/users.d/memory.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- Per-query memory cap: 400 MB.
+                 Prevents any single SELECT/INSERT from consuming all RAM. -->
+            <max_memory_usage>400000000</max_memory_usage>
+
+            <!-- Spill GROUP BY and ORDER BY to disk instead of OOMing -->
+            <max_bytes_before_external_group_by>200000000</max_bytes_before_external_group_by>
+            <max_bytes_before_external_sort>200000000</max_bytes_before_external_sort>
+
+            <!-- Cap join memory; fall back to partial-merge on overflow -->
+            <max_bytes_in_join>100000000</max_bytes_in_join>
+            <join_algorithm>auto</join_algorithm>
+        </default>
+    </profiles>
+</clickhouse>

--- a/docker/clickhouse/users.d/memory.xml
+++ b/docker/clickhouse/users.d/memory.xml
@@ -12,6 +12,11 @@
             <!-- Cap join memory; fall back to partial-merge on overflow -->
             <max_bytes_in_join>100000000</max_bytes_in_join>
             <join_algorithm>auto</join_algorithm>
+
+            <!-- Async-insert: flush every 200ms or 1MB, whichever comes first.
+                 Keeps the in-memory buffer small. -->
+            <async_insert_max_data_size>1048576</async_insert_max_data_size>
+            <async_insert_busy_timeout_ms>200</async_insert_busy_timeout_ms>
         </default>
     </profiles>
 </clickhouse>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     volumes:
       - chdata:/var/lib/clickhouse
       - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
-      - ./clickhouse/users.d:/etc/clickhouse-server/users.d:ro
+      - ./clickhouse/users.d:/etc/clickhouse-server/users.d
     healthcheck:
       test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
       interval: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       CLICKHOUSE_DB: observal
     volumes:
       - chdata:/var/lib/clickhouse
+      - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
+      - ./clickhouse/users.d:/etc/clickhouse-server/users.d:ro
     healthcheck:
       test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
       interval: 5s
@@ -95,7 +97,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: ${CLICKHOUSE_MEMORY_LIMIT:-2G}
     networks:
       - observal-net
 
@@ -191,7 +193,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: ${OTEL_MEMORY_LIMIT:-512M}
     networks:
       - observal-net
 

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -705,9 +705,7 @@ async def apply_resources(
     """Re-apply resource tuning settings to ClickHouse without restart."""
     from services.clickhouse import RESOURCE_SETTINGS_MAP, apply_resource_settings
 
-    result = await db.execute(
-        select(EnterpriseConfig).where(EnterpriseConfig.key.like("resource.%"))
-    )
+    result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key.like("resource.%")))
     current = {cfg.key: cfg.value for cfg in result.scalars().all()}
 
     await apply_resource_settings(overrides=current)

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -697,6 +697,42 @@ async def get_audit_log(
         return {"events": [], "total": 0}
 
 
+@router.post("/resources/apply")
+async def apply_resources(
+    current_user: User = Depends(require_role(UserRole.admin)),
+    db: AsyncSession = Depends(get_db),
+):
+    """Re-apply resource tuning settings to ClickHouse without restart."""
+    from services.clickhouse import RESOURCE_SETTINGS_MAP, apply_resource_settings
+
+    result = await db.execute(
+        select(EnterpriseConfig).where(EnterpriseConfig.key.like("resource.%"))
+    )
+    current = {cfg.key: cfg.value for cfg in result.scalars().all()}
+
+    await apply_resource_settings(overrides=current)
+
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.SETTING_CHANGED,
+            severity=Severity.WARNING,
+            outcome="success",
+            actor_id=str(current_user.id),
+            actor_email=current_user.email,
+            actor_role=current_user.role.value,
+            target_id="resource_settings",
+            target_type="setting",
+            detail=f"Applied resource settings: {list(current.keys())}",
+        )
+    )
+
+    applied_keys = [k for k in current if k in RESOURCE_SETTINGS_MAP]
+    return {
+        "applied": {k: current[k] for k in applied_keys},
+        "message": "ClickHouse resource settings applied",
+    }
+
+
 @router.post("/cache/clear")
 async def clear_cache(current_user: User = Depends(require_role(UserRole.admin))):
     """Clear all cached dashboard and OTEL responses."""

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -314,6 +314,72 @@ INIT_SQL = [
 ]
 
 
+# ── Resource tuning ───────────────────────────────────────
+# Maps enterprise_config keys to ClickHouse SET-able settings.
+# Only whitelisted settings are accepted to avoid SQL injection.
+RESOURCE_SETTINGS_MAP: dict[str, tuple[str, type]] = {
+    "resource.max_query_memory_mb": ("max_memory_usage", int),
+    "resource.group_by_spill_mb": ("max_bytes_before_external_group_by", int),
+    "resource.sort_spill_mb": ("max_bytes_before_external_sort", int),
+    "resource.join_memory_mb": ("max_bytes_in_join", int),
+}
+
+
+async def apply_resource_settings(overrides: dict[str, str] | None = None):
+    """Apply resource tuning settings to ClickHouse.
+
+    Reads from enterprise_config (Postgres) unless *overrides* is supplied.
+    Values are in megabytes and converted to bytes for ClickHouse.
+    """
+    resource_values: dict[str, str] = {}
+
+    if overrides is not None:
+        resource_values = overrides
+    else:
+        try:
+            from database import async_session
+            from models.enterprise_config import EnterpriseConfig
+
+            from sqlalchemy import select
+
+            async with async_session() as db:
+                result = await db.execute(
+                    select(EnterpriseConfig).where(
+                        EnterpriseConfig.key.like("resource.%")
+                    )
+                )
+                for cfg in result.scalars().all():
+                    resource_values[cfg.key] = cfg.value
+        except Exception as e:
+            logger.debug("Could not read resource settings from DB: %s", e)
+
+    if not resource_values:
+        return
+
+    parts = []
+    for config_key, (ch_setting, cast) in RESOURCE_SETTINGS_MAP.items():
+        raw = resource_values.get(config_key)
+        if raw is None:
+            continue
+        try:
+            mb = cast(raw)
+            if mb <= 0:
+                continue
+            parts.append(f"{ch_setting} = {mb * 1_000_000}")
+        except (ValueError, TypeError):
+            logger.warning("Invalid resource setting %s=%s, skipping", config_key, raw)
+
+    if not parts:
+        return
+
+    sql = f"ALTER USER {CLICKHOUSE_USER} SETTINGS {', '.join(parts)}"
+    try:
+        await _query(sql)
+        logger.info("ClickHouse resource settings applied: %s", ", ".join(parts))
+    except Exception as e:
+        logger.warning("Failed to apply ClickHouse resource settings: %s", e)
+
+
 async def init_clickhouse():
     """Create ClickHouse tables if they don't exist and configure retention.
 
@@ -328,6 +394,9 @@ async def init_clickhouse():
             await _query(stmt)
         except Exception as e:
             logger.warning(f"ClickHouse init statement failed: {e}")
+
+    # Apply admin-configured resource tuning from enterprise_config
+    await apply_resource_settings()
 
     # Apply data retention TTL if configured
     retention_days = settings.DATA_RETENTION_DAYS

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -61,6 +61,9 @@ async def _query(sql: str, params: dict | None = None, *, data: str | None = Non
         "user": CLICKHOUSE_USER,
         "password": CLICKHOUSE_PASSWORD,
     }
+    # Inject admin-configured resource overrides (e.g. max_memory_usage)
+    if _resource_overrides:
+        query_params.update(_resource_overrides)
     if params:
         query_params.update(params)
     body = f"{sql}\n{data}" if data else sql
@@ -324,23 +327,31 @@ RESOURCE_SETTINGS_MAP: dict[str, tuple[str, type]] = {
     "resource.join_memory_mb": ("max_bytes_in_join", int),
 }
 
+# Per-query overrides injected into every HTTP request.
+# Populated from enterprise_config on startup and when admin clicks "Apply".
+_resource_overrides: dict[str, str] = {}
+
 
 async def apply_resource_settings(overrides: dict[str, str] | None = None):
-    """Apply resource tuning settings to ClickHouse.
+    """Load resource tuning settings and inject them into every ClickHouse query.
+
+    ClickHouse's HTTP API accepts settings as query parameters (e.g.
+    ``?max_memory_usage=300000000``).  This sidesteps the XML-user
+    readonly limitation: no ALTER USER needed, settings apply per-request.
 
     Reads from enterprise_config (Postgres) unless *overrides* is supplied.
-    Values are in megabytes and converted to bytes for ClickHouse.
     """
+    global _resource_overrides
     resource_values: dict[str, str] = {}
 
     if overrides is not None:
         resource_values = overrides
     else:
         try:
+            from sqlalchemy import select
+
             from database import async_session
             from models.enterprise_config import EnterpriseConfig
-
-            from sqlalchemy import select
 
             async with async_session() as db:
                 result = await db.execute(
@@ -356,7 +367,7 @@ async def apply_resource_settings(overrides: dict[str, str] | None = None):
     if not resource_values:
         return
 
-    parts = []
+    new_overrides: dict[str, str] = {}
     for config_key, (ch_setting, cast) in RESOURCE_SETTINGS_MAP.items():
         raw = resource_values.get(config_key)
         if raw is None:
@@ -365,19 +376,12 @@ async def apply_resource_settings(overrides: dict[str, str] | None = None):
             mb = cast(raw)
             if mb <= 0:
                 continue
-            parts.append(f"{ch_setting} = {mb * 1_000_000}")
+            new_overrides[ch_setting] = str(mb * 1_000_000)
         except (ValueError, TypeError):
             logger.warning("Invalid resource setting %s=%s, skipping", config_key, raw)
 
-    if not parts:
-        return
-
-    sql = f"ALTER USER {CLICKHOUSE_USER} SETTINGS {', '.join(parts)}"
-    try:
-        await _query(sql)
-        logger.info("ClickHouse resource settings applied: %s", ", ".join(parts))
-    except Exception as e:
-        logger.warning("Failed to apply ClickHouse resource settings: %s", e)
+    _resource_overrides = new_overrides
+    logger.info("ClickHouse resource overrides loaded: %s", new_overrides)
 
 
 async def init_clickhouse():

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -354,11 +354,7 @@ async def apply_resource_settings(overrides: dict[str, str] | None = None):
             from models.enterprise_config import EnterpriseConfig
 
             async with async_session() as db:
-                result = await db.execute(
-                    select(EnterpriseConfig).where(
-                        EnterpriseConfig.key.like("resource.%")
-                    )
-                )
+                result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key.like("resource.%")))
                 for cfg in result.scalars().all():
                     resource_values[cfg.key] = cfg.value
         except Exception as e:

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -101,6 +101,43 @@ async def sync_component_sources(ctx: dict):
             )
 
 
+async def maintain_clickhouse(ctx: dict):
+    """Periodic ClickHouse maintenance: compact parts to prevent OOM on long-running agents.
+
+    OPTIMIZE TABLE (without FINAL) merges small parts into larger ones.
+    This is lightweight and safe to run frequently.  Without it, a
+    month-long agent session accumulates thousands of tiny parts that
+    bloat memory during merges and FINAL queries.
+    """
+    from services.clickhouse import _query
+
+    tables = ["traces", "spans", "scores", "mcp_tool_calls", "agent_interactions"]
+    for table in tables:
+        try:
+            await _query(f"OPTIMIZE TABLE {table}")
+        except Exception as e:
+            logger.warning("ClickHouse OPTIMIZE %s failed: %s", table, e)
+
+    # Check part health — warn before things get critical
+    try:
+        resp = await _query(
+            "SELECT table, count() as parts, sum(rows) as total_rows "
+            "FROM system.parts WHERE database = currentDatabase() AND active "
+            "GROUP BY table FORMAT JSON"
+        )
+        if resp.status_code == 200:
+            for row in resp.json().get("data", []):
+                parts = int(row.get("parts", 0))
+                if parts > 300:
+                    logger.warning(
+                        "ClickHouse table %s has %s active parts — merges may be falling behind",
+                        row["table"],
+                        parts,
+                    )
+    except Exception as e:
+        logger.debug("Part health check failed: %s", e)
+
+
 async def startup(ctx: dict):
     logger.info("arq worker started")
 
@@ -112,10 +149,11 @@ async def shutdown(ctx: dict):
 class WorkerSettings:
     """arq worker configuration."""
 
-    functions = [run_eval, sync_component_sources, evaluate_alerts]
+    functions = [run_eval, sync_component_sources, evaluate_alerts, maintain_clickhouse]
     cron_jobs = [
         cron(sync_component_sources, hour={0, 6, 12, 18}),  # Every 6 hours
         cron(evaluate_alerts, second={0}, timeout=55),  # Every minute
+        cron(maintain_clickhouse, hour={0, 4, 8, 12, 16, 20}, timeout=120),  # Every 4 hours
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -19,7 +19,7 @@ receivers:
 processors:
   batch:
     timeout: 5s
-    send_batch_size: 10000
+    send_batch_size: 2000
   memory_limiter:
     check_interval: 1s
     limit_mib: 512
@@ -36,7 +36,7 @@ processors:
 
 exporters:
   clickhouse:
-    endpoint: tcp://default:clickhouse@observal-clickhouse:9000?dial_timeout=10s&compress=lz4&async_insert=1
+    endpoint: tcp://default:clickhouse@observal-clickhouse:9000?dial_timeout=10s&compress=lz4&async_insert=1&wait_for_async_insert=1
     database: observal
     logs_table_name: otel_logs
     traces_table_name: otel_traces

--- a/tests/test_clickhouse_resource_tuning.py
+++ b/tests/test_clickhouse_resource_tuning.py
@@ -1,0 +1,427 @@
+"""Tests for ClickHouse resource tuning — edge cases around admin-configured
+memory limits, concurrent override swaps, invalid inputs, and query-level
+injection via the HTTP API.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+def _mock_response(status_code=200, data=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    if data is not None:
+        resp.json.return_value = {"data": data}
+    return resp
+
+
+def _make_admin():
+    from models.user import User, UserRole
+
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.email = "admin@test.example"
+    user.role = UserRole.super_admin
+    user.org_id = None
+    return user
+
+
+def _enterprise_rows(rows: dict[str, str]):
+    """Create mock EnterpriseConfig scalar results."""
+    items = []
+    for key, value in rows.items():
+        item = MagicMock()
+        item.key = key
+        item.value = value
+        items.append(item)
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = items
+    return result
+
+
+# ── apply_resource_settings unit tests ───────────────────
+
+
+class TestApplyResourceSettings:
+    """Unit tests for services.clickhouse.apply_resource_settings."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_overrides(self):
+        """Clear overrides before/after each test."""
+        import services.clickhouse as ch
+
+        ch._resource_overrides = {}
+        yield
+        ch._resource_overrides = {}
+
+    async def test_valid_override_sets_bytes(self):
+        """Setting max_query_memory_mb=300 produces max_memory_usage=300000000."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "300"})
+        assert ch._resource_overrides == {"max_memory_usage": "300000000"}
+
+    async def test_multiple_overrides(self):
+        """All four resource keys map to the correct ClickHouse settings."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(
+            overrides={
+                "resource.max_query_memory_mb": "500",
+                "resource.group_by_spill_mb": "250",
+                "resource.sort_spill_mb": "250",
+                "resource.join_memory_mb": "150",
+            }
+        )
+        assert ch._resource_overrides == {
+            "max_memory_usage": "500000000",
+            "max_bytes_before_external_group_by": "250000000",
+            "max_bytes_before_external_sort": "250000000",
+            "max_bytes_in_join": "150000000",
+        }
+
+    async def test_zero_value_ignored(self):
+        """A value of 0 MB is silently skipped (means 'use default')."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "0"})
+        assert ch._resource_overrides == {}
+
+    async def test_negative_value_ignored(self):
+        """Negative values are silently skipped."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "-100"})
+        assert ch._resource_overrides == {}
+
+    async def test_non_numeric_value_ignored(self):
+        """Non-numeric strings are skipped with a warning, not crash."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "not-a-number"})
+        assert ch._resource_overrides == {}
+
+    async def test_empty_string_ignored(self):
+        """Empty string values are skipped."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": ""})
+        assert ch._resource_overrides == {}
+
+    async def test_unknown_key_ignored(self):
+        """Keys not in RESOURCE_SETTINGS_MAP are silently ignored."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.unknown_setting": "100"})
+        assert ch._resource_overrides == {}
+
+    async def test_empty_overrides_no_change(self):
+        """Empty overrides dict leaves _resource_overrides unchanged."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={})
+        assert ch._resource_overrides == {}
+
+    async def test_swap_replaces_previous(self):
+        """Calling apply twice replaces the old overrides entirely."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "400"})
+        assert ch._resource_overrides["max_memory_usage"] == "400000000"
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "200"})
+        assert ch._resource_overrides["max_memory_usage"] == "200000000"
+
+    async def test_swap_removes_dropped_keys(self):
+        """If the second apply has fewer keys, removed ones disappear."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(
+            overrides={
+                "resource.max_query_memory_mb": "400",
+                "resource.join_memory_mb": "100",
+            }
+        )
+        assert len(ch._resource_overrides) == 2
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "400"})
+        assert len(ch._resource_overrides) == 1
+        assert "max_bytes_in_join" not in ch._resource_overrides
+
+    async def test_extremely_large_value(self):
+        """Absurdly large values are accepted — ClickHouse will reject at query time."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "999999999"})
+        # 999999999 MB = ~1 exabyte — obviously can't allocate, but the
+        # override is stored; ClickHouse will clamp or error at query time.
+        assert ch._resource_overrides["max_memory_usage"] == "999999999000000"
+
+    async def test_fractional_value_truncated(self):
+        """Fractional MB values fail int() cast and are skipped."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "300.5"})
+        # int("300.5") raises ValueError → skipped
+        assert ch._resource_overrides == {}
+
+    async def test_reads_from_enterprise_config(self):
+        """When overrides passed directly, they are applied correctly."""
+        import services.clickhouse as ch
+
+        await ch.apply_resource_settings(overrides={"resource.max_query_memory_mb": "350"})
+
+        assert ch._resource_overrides["max_memory_usage"] == "350000000"
+
+    async def test_db_failure_gracefully_handled(self):
+        """If enterprise_config DB read fails, no overrides are applied."""
+        import services.clickhouse as ch
+
+        with patch.dict(
+            "sys.modules",
+            {"database": MagicMock(async_session=MagicMock(side_effect=Exception("DB down")))},
+        ):
+            await ch.apply_resource_settings()  # no overrides, triggers DB read
+
+        assert ch._resource_overrides == {}
+
+
+# ── _query injection tests ───────────────────────────────
+
+
+class TestQueryInjection:
+    """Verify that _resource_overrides are injected into _query HTTP params."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_overrides(self):
+        import services.clickhouse as ch
+
+        ch._resource_overrides = {}
+        yield
+        ch._resource_overrides = {}
+
+    async def test_overrides_injected_into_query_params(self):
+        """When overrides are set, they appear in the HTTP query parameters."""
+        import services.clickhouse as ch
+
+        ch._resource_overrides = {"max_memory_usage": "300000000"}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _mock_response()
+
+        with patch.object(ch, "_get_client", return_value=mock_client):
+            await ch._query("SELECT 1")
+
+        _, kwargs = mock_client.post.call_args
+        params = kwargs.get("params", {})
+        assert params["max_memory_usage"] == "300000000"
+
+    async def test_no_overrides_no_extra_params(self):
+        """When no overrides are set, only standard params are sent."""
+        import services.clickhouse as ch
+
+        ch._resource_overrides = {}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _mock_response()
+
+        with patch.object(ch, "_get_client", return_value=mock_client):
+            await ch._query("SELECT 1")
+
+        _, kwargs = mock_client.post.call_args
+        params = kwargs.get("params", {})
+        assert "max_memory_usage" not in params
+
+    async def test_query_params_override_resource_params(self):
+        """Explicit query params (e.g. param_x) take precedence over overrides."""
+        import services.clickhouse as ch
+
+        ch._resource_overrides = {"max_memory_usage": "300000000"}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _mock_response()
+
+        with patch.object(ch, "_get_client", return_value=mock_client):
+            # Simulate a query with explicit max_memory_usage param
+            await ch._query("SELECT 1", params={"max_memory_usage": "999"})
+
+        _, kwargs = mock_client.post.call_args
+        params = kwargs.get("params", {})
+        # Explicit param should win because params.update() runs after overrides
+        assert params["max_memory_usage"] == "999"
+
+    async def test_overrides_dont_corrupt_param_prefix_keys(self):
+        """Resource overrides don't collide with param_* ClickHouse parameters."""
+        import services.clickhouse as ch
+
+        ch._resource_overrides = {"max_memory_usage": "300000000"}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _mock_response()
+
+        with patch.object(ch, "_get_client", return_value=mock_client):
+            await ch._query(
+                "SELECT * FROM t WHERE id = {id:String}",
+                params={"param_id": "abc"},
+            )
+
+        _, kwargs = mock_client.post.call_args
+        params = kwargs.get("params", {})
+        assert params["param_id"] == "abc"
+        assert params["max_memory_usage"] == "300000000"
+
+
+# ── Admin API endpoint tests ─────────────────────────────
+
+
+class TestResourceApplyEndpoint:
+    """Tests for POST /api/v1/admin/resources/apply."""
+
+    async def test_apply_returns_applied_settings(self):
+        """Endpoint returns the settings that were applied."""
+        from api.deps import get_current_user, get_db
+        from main import app
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=_enterprise_rows({"resource.max_query_memory_mb": "300"}))
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        app.dependency_overrides[get_current_user] = _make_admin
+
+        try:
+            from httpx import ASGITransport, AsyncClient
+
+            with patch("services.clickhouse.apply_resource_settings", new_callable=AsyncMock):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                    r = await ac.post("/api/v1/admin/resources/apply")
+
+            assert r.status_code == 200
+            body = r.json()
+            assert "applied" in body
+            assert "resource.max_query_memory_mb" in body["applied"]
+        finally:
+            app.dependency_overrides.clear()
+
+    async def test_apply_with_no_settings_returns_empty(self):
+        """When no resource.* settings exist, endpoint returns empty applied dict."""
+        from api.deps import get_current_user, get_db
+        from main import app
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=_enterprise_rows({}))
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        app.dependency_overrides[get_current_user] = _make_admin
+
+        try:
+            from httpx import ASGITransport, AsyncClient
+
+            with patch("services.clickhouse.apply_resource_settings", new_callable=AsyncMock):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                    r = await ac.post("/api/v1/admin/resources/apply")
+
+            assert r.status_code == 200
+            assert r.json()["applied"] == {}
+        finally:
+            app.dependency_overrides.clear()
+
+    async def test_apply_requires_admin_role(self):
+        """Non-admin users get 403."""
+        from api.deps import get_current_user, get_db
+        from main import app
+        from models.user import User, UserRole
+
+        regular_user = MagicMock(spec=User)
+        regular_user.id = uuid.uuid4()
+        regular_user.email = "user@test.example"
+        regular_user.role = UserRole.user
+        regular_user.org_id = None
+
+        mock_db = AsyncMock()
+        app.dependency_overrides[get_db] = lambda: mock_db
+        app.dependency_overrides[get_current_user] = lambda: regular_user
+
+        try:
+            from httpx import ASGITransport, AsyncClient
+
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.post("/api/v1/admin/resources/apply")
+
+            assert r.status_code == 403
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── Maintenance cron job tests ───────────────────────────
+
+
+class TestMaintainClickhouse:
+    """Tests for the maintain_clickhouse worker cron job."""
+
+    async def test_optimizes_all_tables(self):
+        """Cron job runs OPTIMIZE TABLE on all five tables."""
+        with patch("services.clickhouse._query", new_callable=AsyncMock) as mock_q:
+            mock_q.return_value = _mock_response()
+
+            from worker import maintain_clickhouse
+
+            await maintain_clickhouse({})
+
+        optimize_calls = [c for c in mock_q.call_args_list if "OPTIMIZE TABLE" in str(c)]
+        tables = {c.args[0].replace("OPTIMIZE TABLE ", "") for c in optimize_calls}
+        assert tables == {
+            "traces",
+            "spans",
+            "scores",
+            "mcp_tool_calls",
+            "agent_interactions",
+        }
+
+    async def test_optimize_failure_doesnt_stop_other_tables(self):
+        """If OPTIMIZE fails on one table, the others still run."""
+        call_count = 0
+
+        async def _flaky_query(sql, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "traces" in sql and "OPTIMIZE" in sql:
+                raise Exception("Simulated merge failure")
+            resp = _mock_response()
+            # For the system.parts health check query
+            if "system.parts" in sql:
+                resp.json.return_value = {"data": []}
+            return resp
+
+        with patch("services.clickhouse._query", side_effect=_flaky_query):
+            from worker import maintain_clickhouse
+
+            await maintain_clickhouse({})
+
+        # Should have attempted all 5 OPTIMIZE + 1 health check = 6 calls minimum
+        assert call_count >= 5
+
+    async def test_high_part_count_logged_as_warning(self):
+        """Part counts > 300 produce a warning log."""
+
+        async def _parts_query(sql, *args, **kwargs):
+            resp = _mock_response()
+            if "system.parts" in sql:
+                resp.json.return_value = {"data": [{"table": "traces", "parts": "500", "total_rows": "1000000"}]}
+            return resp
+
+        with (
+            patch("services.clickhouse._query", side_effect=_parts_query),
+            patch("worker.logger") as mock_logger,
+        ):
+            from worker import maintain_clickhouse
+
+            await maintain_clickhouse({})
+
+        # Check that a warning was logged about high part count
+        warning_calls = [c for c in mock_logger.warning.call_args_list if "500" in str(c) and "parts" in str(c).lower()]
+        assert len(warning_calls) > 0

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Settings, Plus, Pencil, Trash2, Save, X, Loader2, Info } from "lucide-react";
+import { Settings, Plus, Pencil, Trash2, Save, X, Loader2, Info, Database } from "lucide-react";
 import { toast } from "sonner";
 import { useAdminSettings } from "@/hooks/use-api";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
@@ -102,6 +102,10 @@ const DEFAULT_SETTINGS = [
   { key: "registry.max_agents_per_user", description: "Maximum agents per user" },
   { key: "eval.default_window_size", description: "Default eval window size" },
   { key: "hooks.auth_required", description: "Require auth for hook endpoints" },
+  { key: "resource.max_query_memory_mb", description: "Per-query memory limit in MB (default: 400)" },
+  { key: "resource.group_by_spill_mb", description: "GROUP BY spill-to-disk threshold in MB (default: 200)" },
+  { key: "resource.sort_spill_mb", description: "ORDER BY spill-to-disk threshold in MB (default: 200)" },
+  { key: "resource.join_memory_mb", description: "JOIN memory limit in MB (default: 100)" },
 ];
 
 export default function SettingsPage() {
@@ -112,6 +116,7 @@ export default function SettingsPage() {
   const [addingValue, setAddingValue] = useState("");
   const [showAdd, setShowAdd] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [applyingResources, setApplyingResources] = useState(false);
 
   const entries: { key: string; value: string }[] = Array.isArray(settings)
     ? settings.map((s: AdminSetting) => ({ key: s.key, value: s.value }))
@@ -136,6 +141,25 @@ export default function SettingsPage() {
       setSaving(false);
     }
   }, [addingKey, addingValue, refetch]);
+
+  const handleApplyResources = useCallback(async () => {
+    setApplyingResources(true);
+    try {
+      const res = await admin.applyResources();
+      const count = Object.keys(res.applied).length;
+      if (count > 0) {
+        toast.success(`Applied ${count} resource setting${count > 1 ? "s" : ""} to ClickHouse`);
+      } else {
+        toast.info("No resource settings configured yet. Add resource.* settings first.");
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to apply resource settings");
+    } finally {
+      setApplyingResources(false);
+    }
+  }, []);
+
+  const hasResourceSettings = entries.some((e) => e.key.startsWith("resource."));
 
   if (!ready) return null;
 
@@ -232,6 +256,37 @@ export default function SettingsPage() {
                   {entries.map((s) => (
                     <SettingRow key={s.key} setting={s} onSaved={() => refetch()} onDeleted={() => refetch()} />
                   ))}
+                </div>
+              </section>
+            )}
+
+            {/* Resource Tuning */}
+            {hasResourceSettings && (
+              <section>
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+                  Resource Tuning
+                </h3>
+                <div className="rounded-md border border-border bg-card px-4 py-3">
+                  <div className="flex items-start gap-3">
+                    <Database className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+                    <div className="flex-1">
+                      <p className="text-xs text-muted-foreground">
+                        Resource settings control ClickHouse memory limits for queries, aggregations, and joins.
+                        After changing any <span className="font-[family-name:var(--font-mono)]">resource.*</span> setting above,
+                        click apply to push the changes to ClickHouse without restarting.
+                      </p>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="mt-3 h-8"
+                        onClick={handleApplyResources}
+                        disabled={applyingResources}
+                      >
+                        {applyingResources ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Database className="mr-1.5 h-3.5 w-3.5" />}
+                        Apply Resource Settings
+                      </Button>
+                    </div>
+                  </div>
                 </div>
               </section>
             )}

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Settings, Plus, Pencil, Trash2, Save, X, Loader2, Info, Database } from "lucide-react";
+import { Settings, Plus, Pencil, Trash2, Save, X, Loader2, Info, Database, Activity, BookOpen, Shield, HelpCircle } from "lucide-react";
 import { toast } from "sonner";
 import { useAdminSettings } from "@/hooks/use-api";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
@@ -13,15 +13,18 @@ import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 function SettingRow({
   setting,
   onSaved,
   onDeleted,
+  tooltip,
 }: {
   setting: { key: string; value: string };
   onSaved: () => void;
   onDeleted: () => void;
+  tooltip?: string;
 }) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(setting.value);
@@ -56,8 +59,18 @@ function SettingRow({
 
   return (
     <div className="flex items-start gap-4 py-3 border-b border-border last:border-b-0 group">
-      <span className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground shrink-0 min-w-[220px] pt-1.5 select-all">
+      <span className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground shrink-0 min-w-[220px] pt-1.5 select-all inline-flex items-center gap-1.5">
         {setting.key}
+        {tooltip && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <HelpCircle className="h-3 w-3 text-muted-foreground/50 hover:text-muted-foreground transition-colors shrink-0 cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-[280px] text-xs leading-relaxed">
+              {tooltip}
+            </TooltipContent>
+          </Tooltip>
+        )}
       </span>
       {editing ? (
         <div className="flex items-center gap-2 flex-1">
@@ -95,18 +108,78 @@ function SettingRow({
   );
 }
 
-const DEFAULT_SETTINGS = [
-  { key: "telemetry.otlp_endpoint", description: "OpenTelemetry collector endpoint" },
-  { key: "telemetry.enabled", description: "Enable/disable telemetry collection" },
-  { key: "registry.auto_approve", description: "Auto-approve new submissions" },
-  { key: "registry.max_agents_per_user", description: "Maximum agents per user" },
-  { key: "eval.default_window_size", description: "Default eval window size" },
-  { key: "hooks.auth_required", description: "Require auth for hook endpoints" },
-  { key: "resource.max_query_memory_mb", description: "Per-query memory limit in MB (default: 400)" },
-  { key: "resource.group_by_spill_mb", description: "GROUP BY spill-to-disk threshold in MB (default: 200)" },
-  { key: "resource.sort_spill_mb", description: "ORDER BY spill-to-disk threshold in MB (default: 200)" },
-  { key: "resource.join_memory_mb", description: "JOIN memory limit in MB (default: 100)" },
+interface SettingDef {
+  key: string;
+  description: string;
+  tooltip?: string;
+}
+
+interface SettingSection {
+  title: string;
+  icon: React.ReactNode;
+  settings: SettingDef[];
+}
+
+const SETTING_SECTIONS: SettingSection[] = [
+  {
+    title: "Telemetry",
+    icon: <Activity className="h-3.5 w-3.5" />,
+    settings: [
+      { key: "telemetry.otlp_endpoint", description: "OpenTelemetry collector endpoint" },
+      { key: "telemetry.enabled", description: "Enable/disable telemetry collection" },
+    ],
+  },
+  {
+    title: "Registry",
+    icon: <BookOpen className="h-3.5 w-3.5" />,
+    settings: [
+      { key: "registry.auto_approve", description: "Auto-approve new submissions" },
+      { key: "registry.max_agents_per_user", description: "Maximum agents per user" },
+    ],
+  },
+  {
+    title: "Evaluation",
+    icon: <Settings className="h-3.5 w-3.5" />,
+    settings: [
+      { key: "eval.default_window_size", description: "Default eval window size" },
+    ],
+  },
+  {
+    title: "Security",
+    icon: <Shield className="h-3.5 w-3.5" />,
+    settings: [
+      { key: "hooks.auth_required", description: "Require auth for hook endpoints" },
+    ],
+  },
+  {
+    title: "Resource Tuning",
+    icon: <Database className="h-3.5 w-3.5" />,
+    settings: [
+      {
+        key: "resource.max_query_memory_mb",
+        description: "Per-query memory limit in MB (default: 400)",
+        tooltip: "Maximum memory a single ClickHouse query can use before it is killed. Set this below your container memory limit to prevent OOM crashes. Applied live via HTTP query parameters — no restart required.",
+      },
+      {
+        key: "resource.group_by_spill_mb",
+        description: "GROUP BY spill threshold in MB (default: 200)",
+        tooltip: "When a GROUP BY aggregation exceeds this memory threshold, ClickHouse spills intermediate data to disk instead of consuming more RAM. Lower values reduce peak memory usage but may slow down large aggregation queries.",
+      },
+      {
+        key: "resource.sort_spill_mb",
+        description: "ORDER BY spill threshold in MB (default: 200)",
+        tooltip: "When an ORDER BY sort exceeds this memory threshold, ClickHouse spills to disk. Prevents large result set sorting from consuming all available memory. Lower values trade query speed for memory safety.",
+      },
+      {
+        key: "resource.join_memory_mb",
+        description: "JOIN memory limit in MB (default: 100)",
+        tooltip: "Maximum memory for hash JOIN operations. When exceeded, ClickHouse falls back to a partial-merge join algorithm which uses less memory but is slower. Critical for queries joining large tables.",
+      },
+    ],
+  },
 ];
+
+const ALL_DEFAULT_SETTINGS = SETTING_SECTIONS.flatMap((s) => s.settings);
 
 export default function SettingsPage() {
   const { ready } = useRoleGuard("super_admin");
@@ -123,7 +196,13 @@ export default function SettingsPage() {
     : Object.entries(settings ?? {}).map(([k, v]) => ({ key: k, value: String(v) }));
 
   const existingKeys = new Set(entries.map((e) => e.key));
-  const missingDefaults = DEFAULT_SETTINGS.filter((d) => !existingKeys.has(d.key));
+  const missingSections = SETTING_SECTIONS
+    .map((section) => ({
+      ...section,
+      settings: section.settings.filter((d) => !existingKeys.has(d.key)),
+    }))
+    .filter((section) => section.settings.length > 0);
+  const hasMissingDefaults = missingSections.length > 0;
 
   const handleAdd = useCallback(async () => {
     if (!addingKey.trim()) return;
@@ -252,11 +331,19 @@ export default function SettingsPage() {
                 <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
                   Active Settings
                 </h3>
-                <div className="rounded-md border border-border bg-card px-4">
-                  {entries.map((s) => (
-                    <SettingRow key={s.key} setting={s} onSaved={() => refetch()} onDeleted={() => refetch()} />
-                  ))}
-                </div>
+                <TooltipProvider delayDuration={300}>
+                  <div className="rounded-md border border-border bg-card px-4">
+                    {entries.map((s) => (
+                      <SettingRow
+                        key={s.key}
+                        setting={s}
+                        onSaved={() => refetch()}
+                        onDeleted={() => refetch()}
+                        tooltip={ALL_DEFAULT_SETTINGS.find((d) => d.key === s.key)?.tooltip}
+                      />
+                    ))}
+                  </div>
+                </TooltipProvider>
               </section>
             )}
 
@@ -291,26 +378,43 @@ export default function SettingsPage() {
               </section>
             )}
 
-            {/* Suggested defaults */}
-            {missingDefaults.length > 0 && (
-              <section>
-                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-                  Suggested Settings
-                </h3>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  {missingDefaults.map((d) => (
-                    <button
-                      key={d.key}
-                      type="button"
-                      onClick={() => { setAddingKey(d.key); setAddingValue(""); setShowAdd(true); }}
-                      className="text-left rounded-md border border-dashed border-border p-3 hover:bg-muted/30 transition-colors"
-                    >
-                      <span className="block text-xs font-[family-name:var(--font-mono)] text-foreground">{d.key}</span>
-                      <span className="block text-[11px] text-muted-foreground mt-0.5">{d.description}</span>
-                    </button>
-                  ))}
-                </div>
-              </section>
+            {/* Suggested defaults — grouped by section */}
+            {hasMissingDefaults && (
+              <TooltipProvider delayDuration={300}>
+                {missingSections.map((section) => (
+                  <section key={section.title}>
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-1.5">
+                      {section.icon}
+                      {section.title}
+                    </h3>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      {section.settings.map((d) => (
+                        <button
+                          key={d.key}
+                          type="button"
+                          onClick={() => { setAddingKey(d.key); setAddingValue(""); setShowAdd(true); }}
+                          className="text-left rounded-md border border-dashed border-border p-3 hover:bg-muted/30 transition-colors group/card"
+                        >
+                          <span className="flex items-center gap-1.5">
+                            <span className="text-xs font-[family-name:var(--font-mono)] text-foreground">{d.key}</span>
+                            {d.tooltip && (
+                              <Tooltip>
+                                <TooltipTrigger asChild onClick={(e) => e.stopPropagation()}>
+                                  <HelpCircle className="h-3 w-3 text-muted-foreground/50 hover:text-muted-foreground transition-colors shrink-0" />
+                                </TooltipTrigger>
+                                <TooltipContent side="top" className="max-w-[280px] text-xs leading-relaxed">
+                                  {d.tooltip}
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+                          </span>
+                          <span className="block text-[11px] text-muted-foreground mt-0.5">{d.description}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </TooltipProvider>
             )}
 
             {entries.length === 0 && !showAdd && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -370,6 +370,8 @@ export const admin = {
   resetPassword: (id: string, body: { new_password: string }) =>
     put<{ message: string }>(`/admin/users/${id}/password`, body),
   deleteUser: (id: string) => del(`/admin/users/${id}`),
+  applyResources: () =>
+    post<{ applied: Record<string, string>; message: string }>("/admin/resources/apply", {}),
 };
 
 // ── Config ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Purpose / Description
ClickHouse was crashing with `MEMORY_LIMIT_EXCEEDED` on low-RAM hosts, causing traces to silently disappear. The root cause was no per-query memory caps, unbounded async insert buffers, and no spill-to-disk configuration. This PR adds comprehensive memory guardrails, makes limits configurable (both via env vars and admin UI), and adds long-running stability features.

## Fixes
* Fixes ClickHouse OOM crashes on machines with limited RAM
* Fixes disappearing traces caused by unflushed async inserts during OOM

## Approach

**Docker / Infrastructure:**
- Add ClickHouse memory config (`config.d/memory.xml` for server-level, `users.d/memory.xml` for per-query profile settings)
- Cap server memory to 80% of container RAM, set per-query limit to 400 MB, enable spill-to-disk for GROUP BY, ORDER BY, and JOINs
- Make container memory limits configurable via env vars (`CLICKHOUSE_MEMORY_LIMIT`, `OTEL_MEMORY_LIMIT`) with sensible defaults
- Reduce OTEL batch size (10000 → 2000) and add `wait_for_async_insert=1` for durability

**Runtime Resource Tuning:**
- Add `apply_resource_settings()` in `services/clickhouse.py` that injects memory limits as HTTP query parameters per request
- Reads from `enterprise_config` table on startup, can be re-applied live via admin API
- Add `POST /admin/resources/apply` endpoint (admin-only)
- Add admin UI section in Settings page with categorized sections (Telemetry, Registry, Evaluation, Security, Resource Tuning) and detailed tooltips on each resource setting

**Long-running Stability:**
- Add `maintain_clickhouse` cron job (every 4h) that runs `OPTIMIZE TABLE` on all tables and checks `system.parts` health
- Logs warnings when part counts exceed 300 (merges falling behind)

## How Has This Been Tested?

- 24 unit tests in `tests/test_clickhouse_resource_tuning.py` covering:
  - Valid overrides, zero/negative/non-numeric/empty/fractional value handling
  - Extremely large values (hardware-exceeding), unknown keys
  - Concurrent swap scenarios (apply replaces previous, dropped keys disappear)
  - HTTP query param injection correctness and precedence
  - Admin endpoint authorization (403 for non-admin)
  - Maintenance cron resilience (single table failure doesn't stop others)
  - High part count warning logging
- Manual testing with `docker compose up` — verified ClickHouse starts healthy, API connects, OTEL collector delivers traces

## Learning (optional, can help others)

- ClickHouse Docker image creates the `default` user via XML, making it **readonly from SQL** — `ALTER USER` and `ALTER SETTINGS PROFILE` both fail. The workaround is injecting settings as HTTP query parameters on every request.
- Mounting `config.d/` replaces the Docker image's built-in `docker_related_config.xml` which contains `listen_host`. Without it, ClickHouse only listens on localhost and other containers can't connect.
- `users.d/` must **not** be mounted as `:ro` — the ClickHouse entrypoint writes `default-user.xml` there at startup.
- Profile-level settings (`max_memory_usage`, etc.) must go in `users.d/`, not `config.d/` — they silently don't apply in `config.d/`.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)