### PR TITLE
feat: add make reset target for fresh Docker rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration
+.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset
 
 # ── Linting ──────────────────────────────────────────────
 
@@ -59,6 +59,13 @@ rebuild:  ## Rebuild and restart Docker stack (runs migrations automatically)
 	@echo "Waiting for API to be healthy..."
 	@cd docker && until docker compose exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
 	@echo "API is healthy."
+
+reset:  ## Nuke all Docker volumes and rebuild from scratch (fresh app, no file changes)
+	cd docker && docker compose down -v
+	cd docker && docker compose up --build -d
+	@echo "Waiting for API to be healthy..."
+	@cd docker && until docker compose exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	@echo "API is healthy — all data has been reset."
 
 rebuild-clean:  ## Rebuild from scratch (no Docker cache) and restart
 	cd docker && docker compose build --no-cache && docker compose up -d


### PR DESCRIPTION
## Purpose / Description
Adds a `make reset` Makefile target that tears down all Docker containers, **deletes all volumes** (pgdata, chdata, redisdata, grafanadata, apidata), and rebuilds the entire stack from scratch. This gives a completely fresh app state without touching any local files.

## Fixes
* N/A — quality-of-life improvement

## Approach
- `docker compose down -v` removes containers **and** named volumes
- Then runs the same build + health-check flow as `make rebuild`

## How Has This Been Tested?
- Verified `make reset` tears down containers, removes volumes, rebuilds, and waits for the API health check

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code