### PR TITLE
fix: IDE parity gaps for Codex, Gemini CLI, Copilot, and OpenCode

### DIFF
--- a/observal-server/api/routes/otlp.py
+++ b/observal-server/api/routes/otlp.py
@@ -53,6 +53,7 @@ _IDE_HINTS = {
     "amazon-kiro": "kiro",
     "aws-kiro": "kiro",
     "codex": "codex",
+    "opencode": "opencode",
     "vscode": "vscode",
 }
 
@@ -425,9 +426,6 @@ def _convert_resource_logs(body: dict, project_id: str = _DEFAULT_PROJECT) -> tu
                     log_attrs = _extract_attrs(rec.get("attributes", []))
                     all_attrs = {**res_attrs, **log_attrs}
                     event_name = all_attrs.get("event.name", "")
-                    print(
-                        f"OTLP log: event_name={event_name!r}, all_attr_keys={list(all_attrs.keys())[:15]}", flush=True
-                    )
                     time_nano = rec.get("timeUnixNano", "0")
                     dt = _nanos_to_dt(time_nano) if int(time_nano) > 0 else _now_ms()
 
@@ -599,15 +597,6 @@ def _convert_resource_logs(body: dict, project_id: str = _DEFAULT_PROJECT) -> tu
                     logger.warning("Failed to convert OTLP log record", exc_info=True)
 
     traces = list(prompt_traces.values())
-    print(
-        f"OTLP logs converted: {len(traces)} traces, {len(spans)} spans, prompt_traces_keys={list(prompt_traces.keys())[:5]}",
-        flush=True,
-    )
-    if traces:
-        print(
-            f"OTLP first trace: name={traces[0].get('name')}, input={repr(traces[0].get('input'))[:100]}, session={traces[0].get('session_id')}",
-            flush=True,
-        )
     return traces, spans
 
 
@@ -690,25 +679,7 @@ async def otlp_logs(request: Request):
         )
 
     rl_count = len(body.get("resourceLogs", []))
-    total_recs = sum(
-        len(rec)
-        for rl in body.get("resourceLogs", [])
-        for sl in rl.get("scopeLogs", [])
-        for rec in [sl.get("logRecords", [])]
-    )
-    print(f"OTLP /v1/logs: {rl_count} resourceLogs, {total_recs} total records", flush=True)
-    if rl_count > 0:
-        sample = body["resourceLogs"][0]
-        print(
-            f"OTLP /v1/logs sample resource attrs: {[a.get('key') for a in sample.get('resource', {}).get('attributes', [])][:10]}",
-            flush=True,
-        )
-        for sl in sample.get("scopeLogs", []):
-            for rec in sl.get("logRecords", [])[:3]:
-                print(
-                    f"OTLP /v1/logs sample record: body={repr(rec.get('body', {}))[:200]}, attrs={[a.get('key') for a in rec.get('attributes', [])][:15]}",
-                    flush=True,
-                )
+    logger.debug("OTLP /v1/logs: %d resourceLogs", rl_count)
 
     project_id = await _resolve_project_id(request)
 

--- a/observal-server/schemas/constants.py
+++ b/observal-server/schemas/constants.py
@@ -22,6 +22,7 @@ VALID_IDES: list[str] = [
     "vscode",
     "codex",
     "copilot",
+    "opencode",
 ]
 
 # ── IDE feature capabilities ──────────────────────────────────
@@ -46,7 +47,8 @@ IDE_FEATURE_MATRIX: dict[str, set[str]] = {
     "cursor": {"mcp_servers", "rules"},
     "gemini-cli": {"mcp_servers", "rules"},
     "codex": {"rules"},
-    "copilot": {"rules"},
+    "copilot": {"mcp_servers", "rules"},
+    "opencode": {"mcp_servers", "rules"},
     "vscode": {"mcp_servers", "rules"},
 }
 

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -8,6 +8,8 @@ Generates IDE-specific agent files from a ResolvedAgent:
 - VSCode: .vscode/rules/<name>.md + .vscode/mcp.json
 - Codex: AGENTS.md (markdown)
 - GitHub Copilot: .github/copilot-instructions.md (markdown)
+- OpenCode: AGENTS.md (markdown) + opencode.json (MCP config)
+
 """
 
 import logging
@@ -470,9 +472,20 @@ def _generate_vscode(manifest: AgentManifest) -> IdeAgentConfig:
 
 
 def _generate_gemini_cli(manifest: AgentManifest) -> IdeAgentConfig:
-    """Generate Gemini CLI agent config (GEMINI.md + MCP JSON)."""
+    """Generate Gemini CLI agent config (GEMINI.md + .gemini/settings.json)."""
     mcp_entries = _build_mcp_entries(manifest)
     rules_content = _build_rules_markdown(manifest)
+
+    settings: dict = {
+        "telemetry": {
+            "enabled": True,
+            "target": "custom",
+            "otlpEndpoint": "http://localhost:4318",
+            "logPrompts": True,
+        },
+    }
+    if mcp_entries:
+        settings["mcpServers"] = mcp_entries
 
     return IdeAgentConfig(
         ide="gemini-cli",
@@ -481,6 +494,11 @@ def _generate_gemini_cli(manifest: AgentManifest) -> IdeAgentConfig:
                 path="GEMINI.md",
                 content=rules_content,
                 format="markdown",
+            ),
+            AgentFile(
+                path=".gemini/settings.json",
+                content=settings,
+                format="json",
             ),
         ],
         mcp_servers=mcp_entries,
@@ -592,6 +610,43 @@ def _generate_copilot(manifest: AgentManifest) -> IdeAgentConfig:
     )
 
 
+def _generate_opencode(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate OpenCode agent config (AGENTS.md + opencode.json with flat command arrays)."""
+    mcp_entries = _build_mcp_entries(manifest)
+    rules_content = _build_rules_markdown(manifest)
+
+    opencode_mcp: dict = {}
+    for k, v in mcp_entries.items():
+        flat_cmd = [v["command"], *v.get("args", [])]
+        entry: dict = {"type": "local", "command": flat_cmd}
+        if v.get("env"):
+            entry["env"] = v["env"]
+        opencode_mcp[k] = entry
+
+    files = [
+        AgentFile(
+            path="AGENTS.md",
+            content=rules_content,
+            format="markdown",
+        ),
+    ]
+
+    if opencode_mcp:
+        files.append(
+            AgentFile(
+                path="opencode.json",
+                content={"mcp": opencode_mcp},
+                format="json",
+            ),
+        )
+
+    return IdeAgentConfig(
+        ide="opencode",
+        files=files,
+        mcp_servers=mcp_entries,
+    )
+
+
 _IDE_GENERATORS = {
     "claude-code": _generate_claude_code,
     "claude_code": _generate_claude_code,
@@ -602,6 +657,7 @@ _IDE_GENERATORS = {
     "kiro": _generate_kiro,
     "codex": _generate_codex,
     "copilot": _generate_copilot,
+    "opencode": _generate_opencode,
 }
 
 SUPPORTED_IDES = list(
@@ -613,6 +669,7 @@ SUPPORTED_IDES = list(
         "kiro",
         "codex",
         "copilot",
+        "opencode",
     }
 )
 

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -559,18 +559,36 @@ def _generate_codex(manifest: AgentManifest) -> IdeAgentConfig:
 
 
 def _generate_copilot(manifest: AgentManifest) -> IdeAgentConfig:
-    """Generate GitHub Copilot agent config (.github/copilot-instructions.md)."""
+    """Generate GitHub Copilot agent config (.github/copilot-instructions.md + .vscode/mcp.json)."""
+    mcp_entries = _build_mcp_entries(manifest)
     rules_content = _build_rules_markdown(manifest)
+
+    files = [
+        AgentFile(
+            path=".github/copilot-instructions.md",
+            content=rules_content,
+            format="markdown",
+        ),
+    ]
+
+    if mcp_entries:
+        copilot_mcp_entries = {}
+        for k, v in mcp_entries.items():
+            copilot_mcp_entries[k] = {"type": "stdio", "command": v["command"], "args": v.get("args", [])}
+            if v.get("env"):
+                copilot_mcp_entries[k]["env"] = v["env"]
+        files.append(
+            AgentFile(
+                path=".vscode/mcp.json",
+                content={"servers": copilot_mcp_entries},
+                format="json",
+            ),
+        )
 
     return IdeAgentConfig(
         ide="copilot",
-        files=[
-            AgentFile(
-                path=".github/copilot-instructions.md",
-                content=rules_content,
-                format="markdown",
-            ),
-        ],
+        files=files,
+        mcp_servers=mcp_entries,
     )
 
 

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -453,7 +453,7 @@ def generate_agent_config(
     if ide == "opencode":
         opencode_configs = {}
         for k, v in mcp_configs.items():
-            cmd_array = [v["command"]] + v.get("args", [])
+            cmd_array = [v["command"], *v.get("args", [])]
             opencode_configs[k] = {"type": "local", "command": cmd_array}
             if "env" in v:
                 opencode_configs[k]["env"] = v["env"]

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -407,7 +407,7 @@ def generate_agent_config(
     if ide in ("gemini-cli", "gemini_cli"):
         gemini_scope = options.get("scope", "project")
         rules_path = "~/.gemini/GEMINI.md" if gemini_scope == "user" else "GEMINI.md"
-        mcp_path = "~/.gemini/mcp.json" if gemini_scope == "user" else ".gemini/mcp.json"
+        mcp_path = "~/.gemini/settings.json" if gemini_scope == "user" else ".gemini/settings.json"
         result = {
             "rules_file": {"path": rules_path, "content": rules_content},
             "mcp_config": {"path": mcp_path, "content": {"mcpServers": mcp_configs}},
@@ -422,14 +422,45 @@ def generate_agent_config(
     if ide == "codex":
         result = {
             "rules_file": {"path": "AGENTS.md", "content": rules_content},
+            "mcp_config": {"path": "~/.codex/config.toml", "content": {"mcp.servers": mcp_configs}},
+            "scope": "user",
         }
         if compatibility_warnings:
             result["_warnings"] = compatibility_warnings
         return result
 
     if ide == "copilot":
+        copilot_configs = {}
+        for k, v in mcp_configs.items():
+            if v.get("url"):
+                transport_type = v.get("type", "sse")
+                copilot_configs[k] = {"type": transport_type, "url": v["url"]}
+                if "env" in v:
+                    copilot_configs[k]["env"] = v["env"]
+            else:
+                copilot_configs[k] = {"type": "stdio", "command": v["command"], "args": v.get("args", [])}
+                if "env" in v:
+                    copilot_configs[k]["env"] = v["env"]
         result = {
             "rules_file": {"path": ".github/copilot-instructions.md", "content": rules_content},
+            "mcp_config": {"path": ".vscode/mcp.json", "content": {"servers": copilot_configs}},
+            "scope": "project",
+        }
+        if compatibility_warnings:
+            result["_warnings"] = compatibility_warnings
+        return result
+
+    if ide == "opencode":
+        opencode_configs = {}
+        for k, v in mcp_configs.items():
+            cmd_array = [v["command"]] + v.get("args", [])
+            opencode_configs[k] = {"type": "local", "command": cmd_array}
+            if "env" in v:
+                opencode_configs[k]["env"] = v["env"]
+        result = {
+            "rules_file": {"path": "AGENTS.md", "content": rules_content},
+            "mcp_config": {"path": "~/.config/opencode/opencode.json", "content": {"mcp": opencode_configs}},
+            "scope": "user",
         }
         if compatibility_warnings:
             result["_warnings"] = compatibility_warnings

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -412,6 +412,20 @@ def _now_ms() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
 
+def _normalize_ts(value: str | None) -> str | None:
+    """Normalize a timestamp string for ClickHouse DateTime64 compatibility.
+
+    ClickHouse JSONEachRow cannot parse ISO 8601 ``T``/``Z`` separators,
+    so we convert ``2026-04-21T07:35:00Z`` -> ``2026-04-21 07:35:00.000``.
+    """
+    if value is None:
+        return None
+    v = value.replace("T", " ").rstrip("Z")
+    if "." not in v:
+        v += ".000"
+    return v
+
+
 async def insert_traces(traces: list[dict]):
     """Batch insert traces into ClickHouse using JSONEachRow."""
     if not traces:
@@ -429,8 +443,8 @@ async def insert_traces(traces: list[dict]):
             "session_id": t.get("session_id"),
             "ide": t.get("ide", ""),
             "environment": t.get("environment", "default"),
-            "start_time": t["start_time"],
-            "end_time": t.get("end_time"),
+            "start_time": _normalize_ts(t["start_time"]),
+            "end_time": _normalize_ts(t.get("end_time")),
             "trace_type": t.get("trace_type", "mcp"),
             "name": t.get("name", ""),
             "metadata": t.get("metadata", {}),
@@ -483,8 +497,8 @@ async def insert_spans(spans: list[dict]):
             "input": s.get("input"),
             "output": s.get("output"),
             "error": s.get("error"),
-            "start_time": s["start_time"],
-            "end_time": s.get("end_time"),
+            "start_time": _normalize_ts(s["start_time"]),
+            "end_time": _normalize_ts(s.get("end_time")),
             "latency_ms": s.get("latency_ms"),
             "status": s.get("status", "success"),
             "level": s.get("level", "DEFAULT"),
@@ -573,7 +587,7 @@ async def insert_scores(scores: list[dict]):
             "eval_run_id": sc.get("eval_run_id"),
             "environment": sc.get("environment", "default"),
             "metadata": sc.get("metadata", {}),
-            "timestamp": sc["timestamp"],
+            "timestamp": _normalize_ts(sc["timestamp"]),
             "event_ts": event_ts,
             "is_deleted": 0,
         }
@@ -604,7 +618,7 @@ async def insert_otel_logs(rows: list[dict]):
     lines = []
     for r in rows:
         line = {
-            "Timestamp": r["Timestamp"],
+            "Timestamp": _normalize_ts(r["Timestamp"]),
             "Body": r.get("Body", ""),
             "LogAttributes": r.get("LogAttributes", {}),
             "ServiceName": r.get("ServiceName", ""),
@@ -868,7 +882,7 @@ async def insert_audit_log(events: list[dict]):
     for e in events:
         row = {
             "event_id": e["event_id"],
-            "timestamp": e["timestamp"],
+            "timestamp": _normalize_ts(e["timestamp"]),
             "actor_id": e.get("actor_id", ""),
             "actor_email": e.get("actor_email", ""),
             "actor_role": e.get("actor_role", ""),
@@ -900,7 +914,7 @@ async def _insert_webhook_deliveries(records: list[dict]):
             "event_id": r["event_id"],
             "alert_rule_id": r["alert_rule_id"],
             "attempt_number": r["attempt_number"],
-            "timestamp": r["timestamp"],
+            "timestamp": _normalize_ts(r["timestamp"]),
             "webhook_url": r["webhook_url"],
             "status_code": r["status_code"],
             "delivery_status": r["delivery_status"],

--- a/observal-server/services/config_generator.py
+++ b/observal-server/services/config_generator.py
@@ -51,7 +51,7 @@ def _gemini_settings(observal_url: str) -> dict:
         "telemetry": {
             "enabled": True,
             "target": "custom",
-            "otlpEndpoint": "http://localhost:4318",
+            "otlpEndpoint": observal_url,
             "logPrompts": True,
         }
     }
@@ -147,6 +147,26 @@ def generate_config(
                 "claude_settings_snippet": {"env": server_env} if server_env else {},
                 "mcpServers": {name: config},
             }
+        if ide == "copilot":
+            return {"mcpServers": {name: {**config, "type": transport_type}}}
+        if ide == "opencode":
+            opencode_config: dict = {"type": "remote", "url": listing.url}
+            if header_values:
+                opencode_config["headers"] = header_values
+            if server_env:
+                opencode_config["env"] = server_env
+            return {"mcp": {name: opencode_config}}
+        if ide == "codex":
+            # Codex uses mcp.servers TOML format
+            codex_entry: dict = {"url": listing.url}
+            if header_values:
+                codex_entry["headers"] = header_values
+            if server_env:
+                codex_entry["env"] = server_env
+            return {
+                "mcp.servers": {name: codex_entry},
+                "codex_config": generate_codex_config(observal_url),
+            }
         return {"mcpServers": {name: config}}
 
     # HTTP proxy transport (existing): point IDE at the proxy URL
@@ -167,9 +187,13 @@ def generate_config(
             }
         if ide == "codex":
             return {
-                "mcpServers": {name: {"url": proxy_url, "env": server_env}},
+                "mcp.servers": {name: {"url": proxy_url, "env": server_env}},
                 "codex_config": generate_codex_config(observal_url),
             }
+        if ide == "copilot":
+            return {"mcpServers": {name: {"type": "sse", "url": proxy_url, "env": server_env}}}
+        if ide == "opencode":
+            return {"mcp": {name: {"type": "remote", "url": proxy_url, "env": server_env}}}
         return {"mcpServers": {name: {"url": proxy_url, "env": server_env}}}
 
     # Stdio transport: shim wraps the original command
@@ -208,11 +232,31 @@ def generate_config(
         }
     if ide == "codex":
         return {
-            "mcpServers": {
+            "mcp.servers": {
                 name: {"command": "observal-shim", "args": shim_args, "env": server_env, **auto_approve_fields}
             },
             "codex_config": generate_codex_config(observal_url),
         }
+
+    if ide == "copilot":
+        return {
+            "mcpServers": {
+                name: {
+                    "type": "stdio",
+                    "command": "observal-shim",
+                    "args": shim_args,
+                    "env": server_env,
+                    **auto_approve_fields,
+                }
+            },
+        }
+
+    if ide == "opencode":
+        flat_cmd = ["observal-shim", *shim_args]
+        entry: dict = {"type": "local", "command": flat_cmd}
+        if server_env:
+            entry["env"] = server_env
+        return {"mcp": {name: entry}}
 
     # cursor, vscode, kiro, kiro-cli — no native OTel; telemetry collected via observal-shim
     return {

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -442,6 +442,7 @@ def _post_auth_onboarding():
             "Cursor": (Path.home() / ".cursor", "cursor"),
             "Gemini CLI": (Path.home() / ".gemini", "gemini-cli"),
             "Codex": (Path.home() / ".codex", "codex"),
+            "Copilot": (Path.home() / ".vscode", "copilot"),
             "OpenCode": (Path.home() / ".config" / "opencode", "opencode"),
         }
 
@@ -495,14 +496,14 @@ def _post_auth_onboarding():
                     except Exception:
                         pass
             else:
-                # Cursor: just check for mcp.json
+                # Cursor / Copilot: check for mcp.json
                 mcp_file = dir_path / "mcp.json"
                 if mcp_file.exists():
                     try:
                         import json as _j
 
                         data = _j.loads(mcp_file.read_text())
-                        mcps = len(data.get("mcpServers", {}))
+                        mcps = len(data.get("mcpServers", data.get("servers", {})))
                     except Exception:
                         pass
             if agents > 0 or mcps > 0:
@@ -531,8 +532,24 @@ def _post_auth_onboarding():
 
         # Run scan for each selected IDE using the existing scan machinery
         from observal_cli import client
-        from observal_cli.cmd_scan import _scan_claude_home, _scan_gemini_home, _scan_kiro_home
+        from observal_cli.cmd_scan import (
+            _scan_claude_home,
+            _scan_codex_home,
+            _scan_copilot_home,
+            _scan_gemini_home,
+            _scan_kiro_home,
+            _scan_opencode_home,
+        )
         from observal_cli.render import spinner
+
+        _scan_fns = {
+            "claude-code": (Path.home() / ".claude", _scan_claude_home),
+            "kiro": (Path.home() / ".kiro", _scan_kiro_home),
+            "gemini-cli": (Path.home() / ".gemini", _scan_gemini_home),
+            "codex": (Path.home() / ".codex", _scan_codex_home),
+            "copilot": (Path.home() / ".vscode", _scan_copilot_home),
+            "opencode": (Path.home() / ".config" / "opencode", _scan_opencode_home),
+        }
 
         all_mcps: list = []
         all_skills: list = []
@@ -540,20 +557,10 @@ def _post_auth_onboarding():
         all_agents: list = []
 
         for _label, ide_key, _a, _m in found:
-            if ide_key == "claude-code":
-                m, s, h, a = _scan_claude_home(Path.home() / ".claude")
-                all_mcps.extend(m)
-                all_skills.extend(s)
-                all_hooks.extend(h)
-                all_agents.extend(a)
-            elif ide_key == "kiro":
-                m, s, h, a = _scan_kiro_home(Path.home() / ".kiro")
-                all_mcps.extend(m)
-                all_skills.extend(s)
-                all_hooks.extend(h)
-                all_agents.extend(a)
-            elif ide_key == "gemini-cli":
-                m, s, h, a = _scan_gemini_home(Path.home() / ".gemini")
+            entry = _scan_fns.get(ide_key)
+            if entry:
+                scan_dir, scan_fn = entry
+                m, s, h, a = scan_fn(scan_dir)
                 all_mcps.extend(m)
                 all_skills.extend(s)
                 all_hooks.extend(h)
@@ -570,6 +577,10 @@ def _post_auth_onboarding():
                 return "claude-code"
             if source.startswith("gemini:"):
                 return "gemini-cli"
+            if source.startswith("codex:"):
+                return "codex"
+            if source.startswith("copilot:"):
+                return "copilot"
             if source.startswith("opencode:"):
                 return "opencode"
             return "auto"

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -101,6 +101,9 @@ def login(
             _fetch_server_public_key(server_url)
             _configure_claude_code(server_url, data["access_token"])
             _configure_kiro(server_url)
+            _configure_gemini_cli(server_url)
+            _configure_codex(server_url)
+            _configure_opencode(server_url)
             _post_auth_onboarding()
 
         except httpx.HTTPStatusError as e:
@@ -167,6 +170,9 @@ def register(
         _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, data["access_token"])
         _configure_kiro(server_url)
+        _configure_gemini_cli(server_url)
+        _configure_codex(server_url)
+        _configure_opencode(server_url)
         _post_auth_onboarding()
 
     except httpx.HTTPStatusError as e:
@@ -330,11 +336,11 @@ def _do_password_login(server_url: str, email: str, password: str):
         _fetch_server_public_key(server_url)
         _configure_claude_code(server_url, data["access_token"])
         _configure_kiro(server_url)
+        _configure_gemini_cli(server_url)
+        _configure_codex(server_url)
+        _configure_opencode(server_url)
         _post_auth_onboarding()
 
-    except httpx.ConnectError:
-        rprint(f"[red]Connection failed.[/red] Is the server running at {server_url}?")
-        raise typer.Exit(1)
     except httpx.HTTPStatusError as e:
         detail = ""
         try:
@@ -431,6 +437,9 @@ def _post_auth_onboarding():
             "Claude Code": (Path.home() / ".claude", "claude-code"),
             "Kiro CLI": (Path.home() / ".kiro", "kiro"),
             "Cursor": (Path.home() / ".cursor", "cursor"),
+            "Gemini CLI": (Path.home() / ".gemini", "gemini-cli"),
+            "Codex": (Path.home() / ".codex", "codex"),
+            "OpenCode": (Path.home() / ".config" / "opencode", "opencode"),
         }
 
         # Quick local scan: count components per IDE (no API calls)
@@ -449,6 +458,39 @@ def _post_auth_onboarding():
 
                 m, _s, _h, a = _scan_kiro_home(dir_path)
                 agents, mcps = len(a), len(m)
+            elif ide_key == "gemini-cli":
+                from observal_cli.cmd_scan import _scan_gemini_home
+
+                m, _s, _h, _a = _scan_gemini_home(dir_path)
+                mcps = len(m)
+            elif ide_key == "codex":
+                # Codex: parse ~/.codex/config.toml for [mcp.servers]
+                toml_file = dir_path / "config.toml"
+                if toml_file.exists():
+                    try:
+                        try:
+                            import tomllib as _toml
+                        except ImportError:
+                            try:
+                                import tomli as _toml  # type: ignore[no-redef]
+                            except ImportError:
+                                import toml as _toml  # type: ignore[no-redef]
+                        content = toml_file.read_text()
+                        data = _toml.loads(content) if hasattr(_toml, "loads") else _toml.load(toml_file.open("rb"))  # type: ignore[call-arg]
+                        mcps = len(data.get("mcp", {}).get("servers", {}))
+                    except Exception:
+                        pass
+            elif ide_key == "opencode":
+                # OpenCode: parse ~/.config/opencode/opencode.json for `mcp` key
+                oc_file = dir_path / "opencode.json"
+                if oc_file.exists():
+                    try:
+                        import json as _j
+
+                        oc_data = _j.loads(oc_file.read_text())
+                        mcps = len(oc_data.get("mcp", {}))
+                    except Exception:
+                        pass
             else:
                 # Cursor: just check for mcp.json
                 mcp_file = dir_path / "mcp.json"
@@ -486,7 +528,7 @@ def _post_auth_onboarding():
 
         # Run scan for each selected IDE using the existing scan machinery
         from observal_cli import client
-        from observal_cli.cmd_scan import _scan_claude_home, _scan_kiro_home
+        from observal_cli.cmd_scan import _scan_claude_home, _scan_gemini_home, _scan_kiro_home
         from observal_cli.render import spinner
 
         all_mcps: list = []
@@ -507,6 +549,12 @@ def _post_auth_onboarding():
                 all_skills.extend(s)
                 all_hooks.extend(h)
                 all_agents.extend(a)
+            elif ide_key == "gemini-cli":
+                m, s, h, a = _scan_gemini_home(Path.home() / ".gemini")
+                all_mcps.extend(m)
+                all_skills.extend(s)
+                all_hooks.extend(h)
+                all_agents.extend(a)
 
         total = len(all_mcps) + len(all_skills) + len(all_hooks) + len(all_agents)
         if total == 0:
@@ -517,6 +565,10 @@ def _post_auth_onboarding():
                 return "kiro"
             if source.startswith("plugin:") or source.startswith("claude:"):
                 return "claude-code"
+            if source.startswith("gemini:"):
+                return "gemini-cli"
+            if source.startswith("opencode:"):
+                return "opencode"
             return "auto"
 
         scan_payload = {
@@ -754,6 +806,146 @@ def _configure_kiro(server_url: str):
     except Exception as e:
         rprint(f"\n[yellow]Could not configure Kiro automatically: {e}[/yellow]")
         rprint("Run [bold]observal scan --ide kiro --home[/bold] to set up manually.")
+
+
+def _configure_gemini_cli(server_url: str):
+    """Check for Gemini CLI and offer to configure its OTLP telemetry.
+
+    Writes the `telemetry` block in ~/.gemini/settings.json.  Non-destructive:
+    all existing keys are preserved; only the telemetry sub-block is updated.
+    A timestamped backup is created before any write.
+    """
+    gemini_dir = Path.home() / ".gemini"
+
+    try:
+        gemini_exists = gemini_dir.is_dir() or shutil.which("gemini")
+        if not gemini_exists:
+            return
+
+        if not typer.confirm(
+            "\nDetected Gemini CLI. Configure telemetry -> Observal?",
+            default=True,
+        ):
+            return
+
+        from urllib.parse import urlparse
+
+        from observal_cli.cmd_scan import inject_gemini_telemetry
+
+        # Derive the OTLP HTTP endpoint from server_url: same host, port 4318.
+
+        parsed = urlparse(server_url)
+        otlp_endpoint = f"{parsed.scheme}://{parsed.hostname}:4318"
+
+        gemini_settings = gemini_dir / "settings.json"
+        written = inject_gemini_telemetry(otlp_endpoint)
+        if written:
+            rprint(f"[green]Configured Gemini CLI telemetry in {gemini_settings}[/green]")
+            rprint(f"[dim]OTLP endpoint: {otlp_endpoint}[/dim]")
+        else:
+            rprint("[dim]Gemini CLI telemetry already configured.[/dim]")
+
+    except Exception as e:
+        rprint(f"\n[yellow]Could not configure Gemini CLI automatically: {e}[/yellow]")
+        rprint("Run [bold]observal scan --ide gemini-cli --home[/bold] to set up manually.")
+
+
+def _configure_codex(server_url: str):
+    """Check for Codex CLI and offer to configure its OTLP telemetry.
+
+    Appends [otel] / [otel.exporter.otlp-http] / [otel.trace_exporter.otlp-http]
+    blocks to ~/.codex/config.toml when they are not already present.
+    A timestamped backup is created before any write.
+    """
+    codex_dir = Path.home() / ".codex"
+
+    try:
+        codex_exists = codex_dir.is_dir() or shutil.which("codex")
+        if not codex_exists:
+            return
+
+        if not typer.confirm(
+            "\nDetected Codex CLI. Configure OTLP telemetry -> Observal?",
+            default=True,
+        ):
+            return
+
+        from urllib.parse import urlparse
+
+        parsed = urlparse(server_url)
+        otlp_base = f"{parsed.scheme}://{parsed.hostname}:4318"
+
+        codex_config = codex_dir / "config.toml"
+
+        # Load existing TOML (best-effort) to check if already configured.
+        existing_content = ""
+        already_configured = False
+        if codex_config.exists():
+            existing_content = codex_config.read_text()
+            # Consider configured if both OTLP exporter sections are present.
+            if "[otel.exporter.otlp-http]" in existing_content and "[otel.trace_exporter.otlp-http]" in existing_content:
+                already_configured = True
+
+        if already_configured:
+            rprint("[dim]Codex OTLP telemetry already configured.[/dim]")
+            return
+
+        toml_block = f"""
+[otel]
+environment = "production"
+log_user_prompt = true
+
+[otel.exporter.otlp-http]
+endpoint = "{otlp_base}/v1/logs"
+protocol = "http"
+
+[otel.trace_exporter.otlp-http]
+endpoint = "{otlp_base}/v1/traces"
+protocol = "http"
+"""
+
+        if codex_config.exists():
+            from datetime import datetime
+
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            backup = codex_config.with_suffix(f".pre-observal.{ts}.bak")
+            import shutil as _shutil
+
+            _shutil.copy2(codex_config, backup)
+
+        codex_dir.mkdir(parents=True, exist_ok=True)
+        with codex_config.open("a") as f:
+            f.write(toml_block)
+
+        rprint(f"[green]Configured Codex OTLP telemetry in {codex_config}[/green]")
+        rprint(f"[dim]OTLP endpoint: {otlp_base}[/dim]")
+
+    except Exception as e:
+        rprint(f"\n[yellow]Could not configure Codex automatically: {e}[/yellow]")
+        rprint("Add OTLP settings manually to ~/.codex/config.toml.")
+
+
+def _configure_opencode(server_url: str):
+    """Check for OpenCode and surface install instructions.
+
+    OpenCode has no global telemetry/OTLP settings block; telemetry collection
+    requires wrapping individual MCP servers with observal-shim at install time.
+    This function detects OpenCode and prints actionable guidance.
+    """
+    opencode_config = Path.home() / ".config" / "opencode" / "opencode.json"
+
+    try:
+        opencode_exists = opencode_config.exists() or shutil.which("opencode")
+        if not opencode_exists:
+            return
+
+        rprint(
+            "\n[bold]Detected OpenCode.[/bold] "
+            "Install MCPs via [bold]observal install <id> --ide opencode[/bold] to enable telemetry."
+        )
+
+    except Exception:
+        pass  # Detection is best-effort; never block login
 
 
 def _configure_claude_code(server_url: str, access_token: str):

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -103,6 +103,7 @@ def login(
             _configure_kiro(server_url)
             _configure_gemini_cli(server_url)
             _configure_codex(server_url)
+            _configure_copilot(server_url)
             _configure_opencode(server_url)
             _post_auth_onboarding()
 
@@ -172,6 +173,7 @@ def register(
         _configure_kiro(server_url)
         _configure_gemini_cli(server_url)
         _configure_codex(server_url)
+        _configure_copilot(server_url)
         _configure_opencode(server_url)
         _post_auth_onboarding()
 
@@ -338,6 +340,7 @@ def _do_password_login(server_url: str, email: str, password: str):
         _configure_kiro(server_url)
         _configure_gemini_cli(server_url)
         _configure_codex(server_url)
+        _configure_copilot(server_url)
         _configure_opencode(server_url)
         _post_auth_onboarding()
 
@@ -923,6 +926,27 @@ protocol = "http"
     except Exception as e:
         rprint(f"\n[yellow]Could not configure Codex automatically: {e}[/yellow]")
         rprint("Add OTLP settings manually to ~/.codex/config.toml.")
+
+
+def _configure_copilot(server_url: str):
+    """Check for GitHub Copilot (VS Code) and surface install instructions.
+
+    Copilot uses .vscode/mcp.json for MCP servers; telemetry collection
+    requires wrapping individual MCP servers with observal-shim at install time.
+    """
+    try:
+        vscode_mcp = Path.cwd() / ".vscode" / "mcp.json"
+        has_copilot = vscode_mcp.exists() or shutil.which("code")
+        if not has_copilot:
+            return
+
+        rprint(
+            "\n[bold]Detected VS Code / GitHub Copilot.[/bold] "
+            "Install MCPs via [bold]observal install <id> --ide copilot[/bold] to enable telemetry."
+        )
+
+    except Exception:
+        pass
 
 
 def _configure_opencode(server_url: str):

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -58,6 +58,31 @@ IDE_CONFIGS = {
         ],
         "mcp": [],
     },
+    "copilot": {
+        "user_settings": [],
+        "project_settings": [
+            Path(".vscode") / "mcp.json",
+        ],
+        "mcp": [],
+    },
+    "opencode": {
+        "user_settings": [
+            Path.home() / ".config" / "opencode" / "opencode.json",
+        ],
+        "project_settings": [
+            Path("opencode.json"),
+        ],
+        "mcp": [],
+    },
+    "codex": {
+        "user_settings": [
+            Path.home() / ".codex" / "config.toml",
+        ],
+        "project_settings": [
+            Path(".codex") / "config.toml",
+        ],
+        "mcp": [],
+    },
 }
 
 
@@ -224,6 +249,8 @@ def _check_gemini(path: Path, data: dict, issues: list, warnings: list):
     """Check Gemini CLI settings for Observal conflicts."""
     servers = data.get("mcpServers", {})
     for name, srv_cfg in servers.items():
+        if "url" in srv_cfg:
+            continue  # HTTP transport doesn't need shim
         cmd = srv_cfg.get("command", "")
         args = srv_cfg.get("args", [])
         full_cmd = f"{cmd} {' '.join(str(a) for a in args)}"
@@ -232,6 +259,168 @@ def _check_gemini(path: Path, data: dict, issues: list, warnings: list):
                 f"{path}: MCP server `{name}` is not wrapped with observal-shim. "
                 "Install via `observal install <id> --ide gemini-cli` to enable telemetry."
             )
+
+    # Check telemetry configuration — only warn if a telemetry block exists
+    # but is misconfigured. If there's no telemetry block at all, the user
+    # may not have configured Observal yet (observal scan will set it up).
+    telemetry = data.get("telemetry", {})
+    if not isinstance(telemetry, dict) or not telemetry:
+        return
+
+    if not telemetry.get("enabled", False):
+        warnings.append(
+            f"{path}: Gemini telemetry is disabled. "
+            "Set `telemetry.enabled` to `true` in .gemini/settings.json to enable Observal telemetry."
+        )
+    else:
+        target = telemetry.get("target", "")
+        otlp_endpoint = telemetry.get("otlpEndpoint", "")
+        if target != "custom" or not otlp_endpoint:
+            warnings.append(
+                f"{path}: Gemini telemetry is enabled but not configured for Observal. "
+                "Set `telemetry.target` to `custom` and `telemetry.otlpEndpoint` to your Observal OTLP endpoint "
+                "(e.g. `http://localhost:4318`)."
+            )
+
+
+def _check_gemini_installation(issues: list, warnings: list):
+    """Check Gemini CLI installation and telemetry configuration."""
+    # Check for gemini binary
+    if shutil.which("gemini"):
+        pass  # Installed
+    else:
+        warnings.append("`gemini` CLI not found in PATH. Install it to use MCP servers and telemetry with Observal.")
+
+    # Check ~/.gemini/settings.json for telemetry configuration
+    gemini_settings = Path.home() / ".gemini" / "settings.json"
+    if gemini_settings.exists():
+        data = _load_json(gemini_settings)
+        if data:
+            _check_gemini(gemini_settings, data, issues, warnings)
+    # Also check MCP servers in user settings
+    mcp_path = Path.home() / ".gemini" / "settings.json"
+    if mcp_path.exists():
+        data = _load_json(mcp_path)
+        if data:
+            servers = data.get("mcpServers", {})
+            unwrapped = [
+                n
+                for n, c in servers.items()
+                if isinstance(c, dict)
+                and "observal-shim" not in c.get("command", "")
+                and "observal-proxy" not in c.get("command", "")
+                and "url" not in c  # HTTP transport doesn't need shim
+            ]
+            if unwrapped:
+                warnings.append(
+                    f"Gemini MCP servers not wrapped with observal-shim: {', '.join(unwrapped)}. "
+                    "Run `observal scan --ide gemini-cli` to wrap them."
+                )
+
+
+def _check_copilot(path: Path, data: dict, issues: list, warnings: list):
+    """Check GitHub Copilot (VS Code) MCP config for Observal conflicts."""
+    servers = data.get("servers", data.get("mcpServers", {}))
+    for name, srv_cfg in servers.items():
+        cmd = srv_cfg.get("command", "")
+        args = srv_cfg.get("args", [])
+        full_cmd = f"{cmd} {' '.join(str(a) for a in args)}"
+        if "observal-shim" not in full_cmd and "observal-proxy" not in full_cmd:
+            warnings.append(
+                f"{path}: MCP server `{name}` is not wrapped with observal-shim. "
+                "Install via `observal install <id> --ide copilot` to enable telemetry."
+            )
+
+
+def _check_opencode(path: Path, data: dict, issues: list, warnings: list):
+    """Check OpenCode config for Observal conflicts."""
+    mcp = data.get("mcp", {})
+    for name, srv_cfg in mcp.items():
+        if not isinstance(srv_cfg, dict):
+            continue
+        cmd = srv_cfg.get("command", [])
+        cmd_str = " ".join(str(c) for c in cmd) if isinstance(cmd, list) else str(cmd)
+        if "observal-shim" not in cmd_str and "observal-proxy" not in cmd_str:
+            warnings.append(
+                f"{path}: MCP server `{name}` is not wrapped with observal-shim. "
+                "Install via `observal install <id> --ide opencode` to enable telemetry."
+            )
+
+
+def _check_codex(data: dict, issues: list, warnings: list, path: Path | None = None):
+    """Check Codex config.toml for Observal compatibility.
+
+    Codex uses TOML (not JSON), so data is a parsed dict from tomllib/toml.
+    """
+    mcp = data.get("mcp", {})
+    servers = mcp.get("servers", {})
+    for name, srv_cfg in servers.items():
+        if not isinstance(srv_cfg, dict):
+            continue
+        if "url" in srv_cfg:
+            continue
+        cmd = srv_cfg.get("command", "")
+        args = srv_cfg.get("args", [])
+        full_cmd = f"{cmd} {' '.join(str(a) for a in args)}"
+        if "observal-shim" not in full_cmd and "observal-proxy" not in full_cmd:
+            label = f"{path}: " if path else ""
+            warnings.append(
+                f"{label}MCP server `{name}` is not wrapped with observal-shim. "
+                "Install via `observal install <id> --ide codex` to enable telemetry."
+            )
+
+    otel = data.get("otel", {})
+    if otel:
+        exporter = otel.get("exporter", {}).get("otlp-http", {})
+        trace_exporter = otel.get("trace_exporter", {}).get("otlp-http", {})
+        if not exporter and not trace_exporter:
+            warnings.append(
+                f"{path}: OTel config exists but no OTLP exporters configured. "
+                "Observal needs [otel.exporter.otlp-http] and [otel.trace_exporter.otlp-http] in config.toml."
+            )
+    elif not mcp:
+        path_label = f"{path}: " if path else ""
+        warnings.append(
+            f"{path_label}No OTel or MCP configuration found. "
+            "Run `observal scan --ide codex` or `observal install <id> --ide codex` to configure."
+        )
+
+
+def _load_toml(path: Path) -> dict | None:
+    try:
+        try:
+            import tomllib
+        except ImportError:
+            try:
+                import tomli as tomllib
+            except ImportError:
+                try:
+                    import toml as tomllib
+                except ImportError:
+                    return None
+        content = path.read_text()
+        if hasattr(tomllib, "loads"):
+            return tomllib.loads(content)
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except Exception:
+        return None
+
+
+def _check_codex_installation(issues: list, warnings: list):
+    """Check Codex CLI installation and configuration."""
+    if shutil.which("codex"):
+        pass
+    else:
+        warnings.append("`codex` CLI not found in PATH. Install it to use MCP servers and telemetry with Observal.")
+
+    codex_config = Path.home() / ".codex" / "config.toml"
+    if codex_config.exists():
+        data = _load_toml(codex_config)
+        if data is None:
+            issues.append(f"{codex_config}: file exists but is not valid TOML.")
+        else:
+            _check_codex(data, issues, warnings, codex_config)
 
 
 def _check_mcp_json(path: Path, data: dict, issues: list, warnings: list):
@@ -308,7 +497,9 @@ def _check_environment(issues: list, warnings: list):
 @doctor_app.callback(invoke_without_command=True)
 def doctor(
     ctx: typer.Context,
-    ide: str = typer.Option(None, help="Check specific IDE only (claude-code, kiro, cursor, gemini-cli)"),
+    ide: str = typer.Option(
+        None, help="Check specific IDE only (claude-code, kiro, cursor, gemini-cli, copilot, opencode, codex)"
+    ),
     fix: bool = typer.Option(False, help="Show suggested fixes"),
 ):
     """Diagnose IDE and Observal settings for compatibility issues."""
@@ -332,6 +523,16 @@ def doctor(
         rprint("[cyan]Checking Kiro installation...[/cyan]")
         _check_kiro_installation(issues, warnings)
 
+    # 3b. Gemini CLI-specific installation checks
+    if not ide or ide == "gemini-cli":
+        rprint("[cyan]Checking Gemini CLI installation...[/cyan]")
+        _check_gemini_installation(issues, warnings)
+
+    # 3c. Codex-specific installation checks
+    if not ide or ide == "codex":
+        rprint("[cyan]Checking Codex installation...[/cyan]")
+        _check_codex_installation(issues, warnings)
+
     # 4. Check IDE configs
     ides_to_check = [ide] if ide else list(IDE_CONFIGS.keys())
 
@@ -348,6 +549,8 @@ def doctor(
             "kiro": _check_kiro,
             "cursor": _check_cursor,
             "gemini-cli": _check_gemini,
+            "copilot": _check_copilot,
+            "opencode": _check_opencode,
         }.get(ide_name)
 
         found_any = False
@@ -355,11 +558,19 @@ def doctor(
             for path in config[path_list_key]:
                 if path.exists():
                     found_any = True
-                    data = _load_json(path)
-                    if data is None:
-                        issues.append(f"{path}: file exists but is not valid JSON.")
-                    elif check_fn:
-                        check_fn(path, data, issues, warnings)
+                    if path.suffix == ".toml":
+                        # Codex uses TOML config — load with tomllib
+                        data = _load_toml(path)
+                        if data is None:
+                            issues.append(f"{path}: file exists but is not valid TOML.")
+                        elif ide_name == "codex":
+                            _check_codex(data, issues, warnings, path)
+                    else:
+                        data = _load_json(path)
+                        if data is None:
+                            issues.append(f"{path}: file exists but is not valid JSON.")
+                        elif check_fn:
+                            check_fn(path, data, issues, warnings)
 
         for path in config.get("mcp", []):
             if path.exists():
@@ -410,6 +621,16 @@ def doctor(
                 rprint("  Run: observal scan --ide kiro --home")
             elif "observal-shim" in issue and "Kiro" in issue:
                 rprint("  Run: observal scan --ide kiro")
+            elif "Gemini telemetry" in issue and "disabled" in issue:
+                rprint(
+                    "  Set `telemetry.enabled` to `true` and `telemetry.target` to `custom` in .gemini/settings.json"
+                )
+            elif "Gemini telemetry" in issue and "not configured" in issue:
+                rprint(
+                    '  Add telemetry config to .gemini/settings.json:\n  {"telemetry": {"enabled": true, "target": "custom", "otlpEndpoint": "http://localhost:4318", "logPrompts": true}}'
+                )
+            elif "observal-shim" in issue and "gemini-cli" in issue:
+                rprint("  Run: observal install <id> --ide gemini-cli")
 
     raise typer.Exit(1 if issues else 0)
 
@@ -608,11 +829,11 @@ def doctor_sli(
         None,
         "--ide",
         "-i",
-        help="Target IDE only (claude-code, kiro). Default: both.",
+        help="Target IDE only (claude-code, kiro, gemini-cli). Default: all.",
     ),
     dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show changes without applying"),
 ):
-    """Re-install Observal telemetry hooks into Claude Code and/or Kiro.
+    """Re-install Observal telemetry hooks into Claude Code, Kiro, and/or Gemini CLI.
 
     Repairs missing or outdated hooks non-destructively — your existing
     hooks and settings are preserved.
@@ -625,7 +846,7 @@ def doctor_sli(
         rprint("[red]Not configured. Run [bold]observal auth login[/bold] first.[/red]")
         raise typer.Exit(1)
 
-    targets = [ide] if ide else ["claude-code", "kiro"]
+    targets = [ide] if ide else ["claude-code", "kiro", "gemini-cli"]
     any_changes = False
 
     for target in targets:
@@ -665,8 +886,45 @@ def doctor_sli(
                 any_changes = True
             for c in messages:
                 rprint(f"  {c}")
+
+        elif target in ("gemini-cli", "gemini_cli"):
+            rprint("[cyan]Gemini CLI[/cyan]")
+            otlp_endpoint = cfg.get("otlp_endpoint", "http://localhost:4318")
+
+            gemini_settings = Path.home() / ".gemini" / "settings.json"
+            gemini_data: dict = {}
+            if gemini_settings.exists():
+                try:
+                    gemini_data = json.loads(gemini_settings.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+            telemetry = gemini_data.get("telemetry", {})
+            needs_update = (
+                not isinstance(telemetry, dict)
+                or not telemetry.get("enabled")
+                or telemetry.get("target") != "custom"
+                or telemetry.get("otlpEndpoint") != otlp_endpoint
+            )
+
+            if needs_update:
+                if dry_run:
+                    rprint("  [yellow]Would update telemetry config in ~/.gemini/settings.json[/yellow]")
+                else:
+                    gemini_data.setdefault("telemetry", {})
+                    gemini_data["telemetry"]["enabled"] = True
+                    gemini_data["telemetry"]["target"] = "custom"
+                    gemini_data["telemetry"]["otlpEndpoint"] = otlp_endpoint
+                    gemini_data["telemetry"]["logPrompts"] = True
+                    gemini_settings.parent.mkdir(parents=True, exist_ok=True)
+                    gemini_settings.write_text(json.dumps(gemini_data, indent=2) + "\n")
+                    rprint(f"  + Configured telemetry in {gemini_settings}")
+                    any_changes = True
+            else:
+                rprint("  [dim]Gemini telemetry already configured[/dim]")
+
         else:
-            rprint(f"[yellow]Unknown IDE: {target}. Use 'claude-code' or 'kiro'.[/yellow]")
+            rprint(f"[yellow]Unknown IDE: {target}. Use 'claude-code', 'kiro', or 'gemini-cli'.[/yellow]")
 
     if any_changes:
         rprint("\n[green]✓ Hooks installed.[/green] Restart your IDE session to pick up changes.")

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -940,6 +940,8 @@ def _install_impl(mcp_id, ide, raw):
         "claude_code": "(run the command below)",
         "gemini-cli": ".gemini/settings.json",
         "gemini_cli": ".gemini/settings.json",
+        "opencode": ".config/opencode/opencode.json",
+        "codex": "~/.codex/config.toml",
     }
 
     rprint(f"\n[bold]Config for {ide}:[/bold]\n")

--- a/observal_cli/cmd_profile.py
+++ b/observal_cli/cmd_profile.py
@@ -36,10 +36,23 @@ IDE_FILE_MAP = {
     # Gemini CLI
     ".gemini/settings.json": Path.home() / ".gemini" / "settings.json",
     ".gemini/GEMINI.md": Path.home() / ".gemini" / "GEMINI.md",
+    # GitHub Copilot (VS Code)
+    ".vscode/mcp.json": Path.home() / ".vscode" / "mcp.json",
+    ".github/copilot-instructions.md": None,  # project-level
+    # OpenCode
+    ".config/opencode/opencode.json": Path.home() / ".config" / "opencode" / "opencode.json",
+    "AGENTS.md": None,  # project-level
 }
 
 # Files that are project-level (placed in CWD, not home)
-PROJECT_FILES = {".mcp.json", ".cursor/rules", ".cursorrules", "CLAUDE.md"}
+PROJECT_FILES = {
+    ".mcp.json",
+    ".cursor/rules",
+    ".cursorrules",
+    "CLAUDE.md",
+    ".github/copilot-instructions.md",
+    "AGENTS.md",
+}
 
 
 def _load_state() -> dict:

--- a/observal_cli/cmd_profile.py
+++ b/observal_cli/cmd_profile.py
@@ -41,6 +41,8 @@ IDE_FILE_MAP = {
     ".github/copilot-instructions.md": None,  # project-level
     # OpenCode
     ".config/opencode/opencode.json": Path.home() / ".config" / "opencode" / "opencode.json",
+    # Codex
+    ".codex/config.toml": Path.home() / ".codex" / "config.toml",
     "AGENTS.md": None,  # project-level
 }
 

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -108,7 +108,7 @@ def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> 
     existed = path.exists()
 
     if isinstance(content, dict):
-        root_key = list(content.keys())[0] if content else "mcpServers"
+        root_key = next(iter(content.keys())) if content else "mcpServers"
         if path.suffix == ".toml":
             incoming_servers = content.get(root_key, {})
             toml_str = _dict_to_toml({root_key: incoming_servers})

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -73,11 +73,34 @@ def _collect_mcp_env_vars(agent_detail: dict) -> dict[str, dict[str, str]]:
     return env_values
 
 
+def _dict_to_toml(d: dict) -> str:
+    """Very basic TOML serializer for MCP configs."""
+    lines = []
+    for section, servers in d.items():
+        for name, srv in servers.items():
+            lines.append(f"[{section}.{name}]")
+            for k, v in srv.items():
+                if isinstance(v, list):
+                    arr = ", ".join(json.dumps(s) for s in v)
+                    lines.append(f"{k} = [{arr}]")
+                elif isinstance(v, dict):
+                    for subk, subv in v.items():
+                        lines.append(f"{k}.{subk} = {json.dumps(subv)}")
+                elif isinstance(v, bool):
+                    lines.append(f"{k} = {'true' if v else 'false'}")
+                elif isinstance(v, str):
+                    lines.append(f"{k} = {json.dumps(v)}")
+                else:
+                    lines.append(f"{k} = {v}")
+            lines.append("")
+    return "\n".join(lines)
+
+
 def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> str:
     """Write content to a file path, creating parent dirs as needed.
 
     If *merge_mcp* is True and the file already exists, merge the incoming
-    ``mcpServers`` dict into the existing one rather than overwriting.
+    dict into the existing one rather than overwriting.
 
     Returns a human-readable status string ("created", "updated", "merged").
     """
@@ -85,16 +108,26 @@ def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> 
     existed = path.exists()
 
     if isinstance(content, dict):
-        if merge_mcp and existed and isinstance(content, dict):
-            try:
-                existing = json.loads(path.read_text())
-            except (json.JSONDecodeError, OSError):
-                existing = {}
-            incoming_servers = content.get("mcpServers", {})
-            existing.setdefault("mcpServers", {}).update(incoming_servers)
-            path.write_text(json.dumps(existing, indent=2) + "\n")
-            return "merged"
-        path.write_text(json.dumps(content, indent=2) + "\n")
+        root_key = list(content.keys())[0] if content else "mcpServers"
+        if path.suffix == ".toml":
+            incoming_servers = content.get(root_key, {})
+            toml_str = _dict_to_toml({root_key: incoming_servers})
+            if existed and merge_mcp:
+                path.write_text(path.read_text() + "\n" + toml_str)
+                return "merged"
+            else:
+                path.write_text(toml_str)
+        else:
+            if merge_mcp and existed:
+                try:
+                    existing = json.loads(path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    existing = {}
+                incoming_servers = content.get(root_key, {})
+                existing.setdefault(root_key, {}).update(incoming_servers)
+                path.write_text(json.dumps(existing, indent=2) + "\n")
+                return "merged"
+            path.write_text(json.dumps(content, indent=2) + "\n")
     else:
         path.write_text(content)
 
@@ -132,6 +165,7 @@ _SCOPE_AWARE_IDES = {
     "kiro": ("project (.kiro/agents/)", "user (~/.kiro/agents/)"),
     "gemini-cli": ("project (GEMINI.md)", "user (~/.gemini/GEMINI.md)"),
     "cursor": ("project (.cursor/rules/)", "user (~/.cursor/rules/)"),
+    "opencode": ("project (AGENTS.md)", "user (~/.config/opencode/opencode.json)"),
 }
 
 
@@ -189,7 +223,10 @@ def register_pull(app: typer.Typer):
     def pull(
         agent_id: str = typer.Argument(..., help="Agent ID, name, row number, or @alias"),
         ide: str = typer.Option(
-            ..., "--ide", "-i", help="Target IDE (cursor, vscode, claude-code, gemini-cli, kiro, codex, copilot)"
+            ...,
+            "--ide",
+            "-i",
+            help="Target IDE (cursor, vscode, claude-code, gemini-cli, kiro, codex, copilot, opencode)",
         ),
         directory: str = typer.Option(".", "--dir", "-d", help="Target directory for written files"),
         dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Preview files without writing"),

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -430,6 +430,117 @@ def _scan_gemini_home(
     return mcps, skills, hooks, agents
 
 
+def _scan_codex_home(
+    codex_dir: Path,
+) -> tuple[list[DiscoveredMcp], list[DiscoveredSkill], list[DiscoveredHook], list[DiscoveredAgent]]:
+    """Scan ~/.codex for MCP servers from config.toml."""
+    mcps: list[DiscoveredMcp] = []
+    skills: list[DiscoveredSkill] = []
+    hooks: list[DiscoveredHook] = []
+    agents: list[DiscoveredAgent] = []
+
+    config_file = codex_dir / "config.toml"
+    if config_file.exists():
+        try:
+            try:
+                import tomllib as toml
+            except ImportError:
+                try:
+                    import tomli as toml  # type: ignore[no-redef]
+                except ImportError:
+                    import toml  # type: ignore[no-redef]
+            content = config_file.read_text()
+            data = toml.loads(content) if hasattr(toml, "loads") else toml.load(config_file.open("rb"))  # type: ignore[call-arg]
+            servers = data.get("mcp", {}).get("servers", {})
+            for srv_name, srv_config in servers.items():
+                if isinstance(srv_config, dict):
+                    mcps.append(
+                        DiscoveredMcp(
+                            name=srv_name,
+                            command=srv_config.get("command"),
+                            args=srv_config.get("args", []),
+                            url=srv_config.get("url"),
+                            description=f"Codex MCP: {srv_name}",
+                            source="codex:global",
+                        )
+                    )
+        except Exception:
+            pass
+
+    return mcps, skills, hooks, agents
+
+
+def _scan_copilot_home(
+    vscode_dir: Path,
+) -> tuple[list[DiscoveredMcp], list[DiscoveredSkill], list[DiscoveredHook], list[DiscoveredAgent]]:
+    """Scan ~/.vscode or project .vscode for Copilot MCP servers from mcp.json."""
+    mcps: list[DiscoveredMcp] = []
+    skills: list[DiscoveredSkill] = []
+    hooks: list[DiscoveredHook] = []
+    agents: list[DiscoveredAgent] = []
+
+    mcp_file = vscode_dir / "mcp.json"
+    if mcp_file.exists():
+        try:
+            data = json.loads(mcp_file.read_text())
+            servers = data.get("servers", data.get("mcpServers", {}))
+            for srv_name, srv_config in servers.items():
+                if isinstance(srv_config, dict):
+                    mcps.append(
+                        DiscoveredMcp(
+                            name=srv_name,
+                            command=srv_config.get("command"),
+                            args=srv_config.get("args", []),
+                            url=srv_config.get("url"),
+                            description=f"Copilot MCP: {srv_name}",
+                            source="copilot:global",
+                        )
+                    )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return mcps, skills, hooks, agents
+
+
+def _scan_opencode_home(
+    opencode_dir: Path,
+) -> tuple[list[DiscoveredMcp], list[DiscoveredSkill], list[DiscoveredHook], list[DiscoveredAgent]]:
+    """Scan ~/.config/opencode for MCP servers from opencode.json."""
+    mcps: list[DiscoveredMcp] = []
+    skills: list[DiscoveredSkill] = []
+    hooks: list[DiscoveredHook] = []
+    agents: list[DiscoveredAgent] = []
+
+    config_file = opencode_dir / "opencode.json"
+    if config_file.exists():
+        try:
+            data = json.loads(config_file.read_text())
+            servers = data.get("mcp", {})
+            for srv_name, srv_config in servers.items():
+                if isinstance(srv_config, dict):
+                    cmd = srv_config.get("command")
+                    if isinstance(cmd, list):
+                        command = cmd[0] if cmd else None
+                        args = cmd[1:] if len(cmd) > 1 else []
+                    else:
+                        command = cmd
+                        args = srv_config.get("args", [])
+                    mcps.append(
+                        DiscoveredMcp(
+                            name=srv_name,
+                            command=command,
+                            args=args,
+                            url=srv_config.get("url"),
+                            description=f"OpenCode MCP: {srv_name}",
+                            source="opencode:global",
+                        )
+                    )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return mcps, skills, hooks, agents
+
+
 def _extract_mcp_servers(mcp_data: dict) -> dict[str, dict]:
     """Extract server entries from .mcp.json, handling both formats.
 
@@ -631,7 +742,7 @@ def register_scan(app: typer.Typer):
         ide: str | None = typer.Option(None, "--ide", "-i", help="Target IDE (auto-detected if omitted)"),
         home: bool = typer.Option(False, "--home", help="Scan IDE home directories for plugins, agents, skills, hooks"),
         all_ides: bool = typer.Option(
-            False, "--all-ides", help="Scan home directories for ALL IDEs (Claude Code, Kiro, Gemini CLI)"
+            False, "--all-ides", help="Scan home directories for ALL supported IDEs"
         ),
         dry_run: bool = typer.Option(
             False, "--dry-run", "-n", help="Show what would be registered without making changes"
@@ -663,23 +774,37 @@ def register_scan(app: typer.Typer):
         scan_claude = False
         scan_kiro = False
         scan_gemini = False
+        scan_codex = False
+        scan_copilot = False
+        scan_opencode = False
 
         if all_ides:
             home = True  # --all-ides implies --home
             scan_claude = True
             scan_kiro = True
             scan_gemini = True
+            scan_codex = True
+            scan_copilot = True
+            scan_opencode = True
         elif home:
             if ide == "kiro":
                 scan_kiro = True
             elif ide == "gemini-cli":
                 scan_gemini = True
+            elif ide == "codex":
+                scan_codex = True
+            elif ide == "copilot":
+                scan_copilot = True
+            elif ide == "opencode":
+                scan_opencode = True
             elif ide == "claude-code" or ide is None:
                 scan_claude = True
-                # When no --ide specified, also scan kiro and gemini if they exist
                 if ide is None:
                     scan_kiro = True
                     scan_gemini = True
+                    scan_codex = True
+                    scan_copilot = True
+                    scan_opencode = True
 
         # ── Scan ~/.claude ─────────────────────────────
         if scan_claude:
@@ -722,6 +847,48 @@ def register_scan(app: typer.Typer):
                 scanned_ides.append("gemini-cli")
             elif not all_ides:
                 rprint("[yellow]~/.gemini directory not found.[/yellow]")
+
+        # ── Scan ~/.codex ────────────────────────────
+        if scan_codex:
+            codex_dir = Path.home() / ".codex"
+            if codex_dir.is_dir():
+                with spinner("Scanning ~/.codex..."):
+                    cx_mcps, cx_skills, cx_hooks, cx_agents = _scan_codex_home(codex_dir)
+                all_mcps.extend(cx_mcps)
+                all_skills.extend(cx_skills)
+                all_hooks.extend(cx_hooks)
+                all_agents.extend(cx_agents)
+                scanned_ides.append("codex")
+            elif not all_ides:
+                rprint("[yellow]~/.codex directory not found.[/yellow]")
+
+        # ── Scan ~/.vscode (Copilot) ─────────────────
+        if scan_copilot:
+            vscode_dir = Path.home() / ".vscode"
+            if vscode_dir.is_dir():
+                with spinner("Scanning ~/.vscode..."):
+                    cp_mcps, cp_skills, cp_hooks, cp_agents = _scan_copilot_home(vscode_dir)
+                all_mcps.extend(cp_mcps)
+                all_skills.extend(cp_skills)
+                all_hooks.extend(cp_hooks)
+                all_agents.extend(cp_agents)
+                scanned_ides.append("copilot")
+            elif not all_ides:
+                rprint("[yellow]~/.vscode directory not found.[/yellow]")
+
+        # ── Scan ~/.config/opencode ──────────────────
+        if scan_opencode:
+            opencode_dir = Path.home() / ".config" / "opencode"
+            if opencode_dir.is_dir():
+                with spinner("Scanning ~/.config/opencode..."):
+                    oc_mcps, oc_skills, oc_hooks, oc_agents = _scan_opencode_home(opencode_dir)
+                all_mcps.extend(oc_mcps)
+                all_skills.extend(oc_skills)
+                all_hooks.extend(oc_hooks)
+                all_agents.extend(oc_agents)
+                scanned_ides.append("opencode")
+            elif not all_ides:
+                rprint("[yellow]~/.config/opencode directory not found.[/yellow]")
 
         # ── Scan project directory (or home) ────────
         # If --home is passed, we should also scan the home directory using _IDE_PROJECT_CONFIGS

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -583,6 +583,44 @@ def _backup_config(config_path: Path) -> Path:
     return backup
 
 
+def inject_gemini_telemetry(otlp_endpoint: str) -> bool:
+    """Inject Observal OTLP telemetry settings into ~/.gemini/settings.json.
+
+    Non-destructive: preserves all existing keys, only updates the `telemetry`
+    block. Creates a timestamped backup before any write.
+
+    Returns True if a write was performed, False if already up to date.
+    """
+    gemini_settings = Path.home() / ".gemini" / "settings.json"
+    gemini_data: dict = {}
+    if gemini_settings.exists():
+        gemini_data = json.loads(gemini_settings.read_text())
+
+    telemetry = gemini_data.get("telemetry", {})
+    if not isinstance(telemetry, dict):
+        telemetry = {}
+
+    needs_update = (
+        not telemetry.get("enabled")
+        or telemetry.get("target") != "custom"
+        or telemetry.get("otlpEndpoint") != otlp_endpoint
+    )
+
+    if not needs_update:
+        return False
+
+    if gemini_settings.exists():
+        _backup_config(gemini_settings)
+    gemini_data.setdefault("telemetry", {})
+    gemini_data["telemetry"]["enabled"] = True
+    gemini_data["telemetry"]["target"] = "custom"
+    gemini_data["telemetry"]["otlpEndpoint"] = otlp_endpoint
+    gemini_data["telemetry"]["logPrompts"] = True
+    gemini_settings.parent.mkdir(parents=True, exist_ok=True)
+    gemini_settings.write_text(json.dumps(gemini_data, indent=2) + "\n")
+    return True
+
+
 # ── CLI command ─────────────────────────────────────────────
 
 
@@ -1143,34 +1181,11 @@ def register_scan(app: typer.Typer):
 
             gcfg = _load_gemini_config()
             otlp_endpoint = gcfg.get("otlp_endpoint", "http://localhost:4318")
-
             gemini_settings = Path.home() / ".gemini" / "settings.json"
+
             try:
-                gemini_data: dict = {}
-                if gemini_settings.exists():
-                    gemini_data = json.loads(gemini_settings.read_text())
-
-                telemetry = gemini_data.get("telemetry", {})
-                needs_telemetry_update = False
-
-                if not isinstance(telemetry, dict):
-                    telemetry = {}
-                if not telemetry.get("enabled"):
-                    needs_telemetry_update = True
-                if telemetry.get("target") != "custom":
-                    needs_telemetry_update = True
-                if telemetry.get("otlpEndpoint") != otlp_endpoint:
-                    needs_telemetry_update = True
-
-                if needs_telemetry_update:
-                    _backup_config(gemini_settings)
-                    gemini_data.setdefault("telemetry", {})
-                    gemini_data["telemetry"]["enabled"] = True
-                    gemini_data["telemetry"]["target"] = "custom"
-                    gemini_data["telemetry"]["otlpEndpoint"] = otlp_endpoint
-                    gemini_data["telemetry"]["logPrompts"] = True
-                    gemini_settings.parent.mkdir(parents=True, exist_ok=True)
-                    gemini_settings.write_text(json.dumps(gemini_data, indent=2) + "\n")
+                written = inject_gemini_telemetry(otlp_endpoint)
+                if written:
                     rprint(f"\n[green]Configured Gemini CLI telemetry in {gemini_settings}[/green]")
                     rprint(f"[dim]OTLP endpoint: {otlp_endpoint}[/dim]")
                     rprint("[dim]Telemetry will be sent to Observal via OTLP.[/dim]")

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -694,6 +694,49 @@ def _backup_config(config_path: Path) -> Path:
     return backup
 
 
+def _auto_shim_home_config(result: dict, config_path: Path, ide: str):
+    """Auto-wrap un-shimmed MCP servers in a home-directory config file.
+
+    For IDEs without native hook/telemetry systems (Codex, Copilot, OpenCode),
+    wrapping MCP servers with observal-shim is the primary telemetry path.
+    """
+    if not config_path.exists():
+        return
+
+    id_map = {r["name"]: r["id"] for r in result.get("registered", []) if r["type"] == "mcp"}
+    if not id_map:
+        return
+
+    try:
+        if config_path.suffix == ".toml":
+            try:
+                import tomllib as toml
+            except ImportError:
+                try:
+                    import tomli as toml  # type: ignore[no-redef]
+                except ImportError:
+                    return
+            data = toml.loads(config_path.read_text()) if hasattr(toml, "loads") else toml.load(config_path.open("rb"))  # type: ignore[call-arg]
+        else:
+            data = json.loads(config_path.read_text())
+
+        servers = _parse_project_mcp_servers(data, ide)
+        shimmed = 0
+        for name, entry in servers.items():
+            mcp_id = id_map.get(name)
+            if mcp_id and not _is_already_shimmed(entry):
+                servers[name] = _wrap_with_shim(entry, mcp_id)
+                shimmed += 1
+
+        if shimmed:
+            _backup_config(config_path)
+            config_path.write_text(json.dumps(data, indent=2) + "\n")
+            rprint(f"\n[green]Shimmed {shimmed} MCP entries in {config_path}[/green]")
+            rprint("[dim]Telemetry will be collected via observal-shim.[/dim]")
+    except Exception as e:
+        rprint(f"\n[yellow]Could not auto-shim {config_path}: {e}[/yellow]")
+
+
 def inject_gemini_telemetry(otlp_endpoint: str) -> bool:
     """Inject Observal OTLP telemetry settings into ~/.gemini/settings.json.
 
@@ -1361,3 +1404,21 @@ def register_scan(app: typer.Typer):
             except Exception as e:
                 rprint(f"\n[yellow]Could not configure Gemini CLI telemetry: {e}[/yellow]")
                 rprint("[dim]Add telemetry settings manually to ~/.gemini/settings.json.[/dim]")
+
+        # ── Auto-shim Codex home MCP servers ──
+        if scan_codex:
+            _auto_shim_home_config(
+                result, Path.home() / ".codex" / "config.toml", "codex",
+            )
+
+        # ── Auto-shim Copilot home MCP servers ──
+        if scan_copilot:
+            _auto_shim_home_config(
+                result, Path.home() / ".vscode" / "mcp.json", "copilot",
+            )
+
+        # ── Auto-shim OpenCode home MCP servers ──
+        if scan_opencode:
+            _auto_shim_home_config(
+                result, Path.home() / ".config" / "opencode" / "opencode.json", "opencode",
+            )

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -21,7 +21,10 @@ _IDE_PROJECT_CONFIGS = {
     "cursor": ".cursor/mcp.json",
     "kiro": ".kiro/settings/mcp.json",
     "vscode": ".vscode/mcp.json",
+    "copilot": ".vscode/mcp.json",
     "gemini-cli": ".gemini/settings.json",
+    "opencode": "opencode.json",
+    "codex": ".codex/config.toml",
 }
 
 
@@ -396,6 +399,37 @@ def _scan_kiro_home(
     return mcps, skills, hooks, agents
 
 
+def _scan_gemini_home(
+    gemini_dir: Path,
+) -> tuple[list[DiscoveredMcp], list[DiscoveredSkill], list[DiscoveredHook], list[DiscoveredAgent]]:
+    """Scan ~/.gemini for MCP servers from settings.json."""
+    mcps: list[DiscoveredMcp] = []
+    skills: list[DiscoveredSkill] = []
+    hooks: list[DiscoveredHook] = []
+    agents: list[DiscoveredAgent] = []
+
+    settings_file = gemini_dir / "settings.json"
+    if settings_file.exists():
+        try:
+            settings = json.loads(settings_file.read_text())
+            servers = _extract_mcp_servers(settings)
+            for srv_name, srv_config in servers.items():
+                mcps.append(
+                    DiscoveredMcp(
+                        name=srv_name,
+                        command=srv_config.get("command"),
+                        args=srv_config.get("args", []),
+                        url=srv_config.get("url"),
+                        description=f"Gemini MCP: {srv_name}",
+                        source="gemini:global",
+                    )
+                )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return mcps, skills, hooks, agents
+
+
 def _extract_mcp_servers(mcp_data: dict) -> dict[str, dict]:
     """Extract server entries from .mcp.json, handling both formats.
 
@@ -464,9 +498,24 @@ def _scan_project_dir(project_dir: Path, ide_filter: str | None) -> list[tuple[s
         config_path = project_dir / rel
         if not config_path.exists():
             continue
+
         try:
-            config = json.loads(config_path.read_text())
-        except (json.JSONDecodeError, OSError):
+            if config_path.suffix == ".toml":
+                try:
+                    import tomllib as toml
+                except ImportError:
+                    try:
+                        import tomli as toml
+                    except ImportError:
+                        try:
+                            import toml
+                        except ImportError:
+                            rprint("[yellow]Warning: no toml parser found. Skipping .toml config.[/yellow]")
+                            continue
+                config = toml.loads(config_path.read_text())
+            else:
+                config = json.loads(config_path.read_text())
+        except (Exception, OSError):
             continue
 
         servers = _parse_project_mcp_servers(config, ide)
@@ -493,8 +542,12 @@ def _scan_project_dir(project_dir: Path, ide_filter: str | None) -> list[tuple[s
 
 def _parse_project_mcp_servers(config: dict, ide: str) -> dict[str, dict]:
     """Extract MCP servers dict from project-level IDE config."""
-    if ide == "vscode":
+    if ide in ("vscode", "copilot"):
         return config.get("servers", config.get("mcpServers", {}))
+    if ide == "opencode":
+        return config.get("mcp", {})
+    if ide == "codex":
+        return config.get("mcp", {}).get("servers", {})
     # cursor, kiro, gemini-cli all use mcpServers at top level
     return config.get("mcpServers", config.get("servers", {}))
 
@@ -540,7 +593,7 @@ def register_scan(app: typer.Typer):
         ide: str | None = typer.Option(None, "--ide", "-i", help="Target IDE (auto-detected if omitted)"),
         home: bool = typer.Option(False, "--home", help="Scan IDE home directories for plugins, agents, skills, hooks"),
         all_ides: bool = typer.Option(
-            False, "--all-ides", help="Scan home directories for ALL IDEs (Claude Code, Kiro, Cursor)"
+            False, "--all-ides", help="Scan home directories for ALL IDEs (Claude Code, Kiro, Gemini CLI)"
         ),
         dry_run: bool = typer.Option(
             False, "--dry-run", "-n", help="Show what would be registered without making changes"
@@ -558,7 +611,7 @@ def register_scan(app: typer.Typer):
         With --home, scans your IDE home directory. Use --ide to target a specific
         IDE (e.g. --home --ide kiro), or --all-ides to scan all IDEs at once.
 
-        With --all-ides, scans ~/.claude, ~/.kiro, and ~/.cursor to discover
+        With --all-ides, scans ~/.claude, ~/.kiro, and ~/.gemini to discover
         all agents, MCP servers, skills, and hooks across every IDE you use.
         """
         all_mcps: list[DiscoveredMcp] = []
@@ -571,19 +624,24 @@ def register_scan(app: typer.Typer):
         # ── Determine which IDE home dirs to scan ──
         scan_claude = False
         scan_kiro = False
+        scan_gemini = False
 
         if all_ides:
             home = True  # --all-ides implies --home
             scan_claude = True
             scan_kiro = True
+            scan_gemini = True
         elif home:
             if ide == "kiro":
                 scan_kiro = True
+            elif ide == "gemini-cli":
+                scan_gemini = True
             elif ide == "claude-code" or ide is None:
                 scan_claude = True
-                # When no --ide specified, also scan kiro if it exists
+                # When no --ide specified, also scan kiro and gemini if they exist
                 if ide is None:
                     scan_kiro = True
+                    scan_gemini = True
 
         # ── Scan ~/.claude ─────────────────────────────
         if scan_claude:
@@ -613,16 +671,40 @@ def register_scan(app: typer.Typer):
             elif not all_ides:
                 rprint("[yellow]~/.kiro directory not found.[/yellow]")
 
-        # ── Scan project directory ──────────────────
+        # ── Scan ~/.gemini ────────────────────────────
+        if scan_gemini:
+            gemini_dir = Path.home() / ".gemini"
+            if gemini_dir.is_dir():
+                with spinner("Scanning ~/.gemini..."):
+                    g_mcps, g_skills, g_hooks, g_agents = _scan_gemini_home(gemini_dir)
+                all_mcps.extend(g_mcps)
+                all_skills.extend(g_skills)
+                all_hooks.extend(g_hooks)
+                all_agents.extend(g_agents)
+                scanned_ides.append("gemini-cli")
+            elif not all_ides:
+                rprint("[yellow]~/.gemini directory not found.[/yellow]")
+
+        # ── Scan project directory (or home) ────────
+        # If --home is passed, we should also scan the home directory using _IDE_PROJECT_CONFIGS
+        # (which maps to ~/.gemini, ~/.codex, etc.)
         root = Path(project_dir).resolve()
-        if root.is_dir():
-            project_mcp_entries = _scan_project_dir(root, ide)
-            # Add project MCPs to the list (dedup by name)
+
+        def _do_project_scan(target: Path):
+            if not target.is_dir():
+                return
+            entries = _scan_project_dir(target, ide)
             seen_names = {m.name for m in all_mcps}
-            for _ide, _name, mcp, _path in project_mcp_entries:
+            for _ide, _name, mcp, config_path in entries:
+                project_mcp_entries.append((_ide, _name, mcp, config_path))
                 if mcp.name not in seen_names:
                     all_mcps.append(mcp)
                     seen_names.add(mcp.name)
+
+        _do_project_scan(root)
+
+        if home and root != Path.home():
+            _do_project_scan(Path.home())
 
         total = len(all_mcps) + len(all_skills) + len(all_hooks) + len(all_agents)
         if total == 0:
@@ -1054,3 +1136,46 @@ def register_scan(app: typer.Typer):
                 rprint("[dim]These capture all Kiro sessions, including agentless chat.[/dim]")
             else:
                 rprint("[dim]Global Kiro hooks already configured.[/dim]")
+
+        # ── Auto-inject telemetry into ~/.gemini/settings.json ──
+        if scan_gemini:
+            from observal_cli.config import load as _load_gemini_config
+
+            gcfg = _load_gemini_config()
+            otlp_endpoint = gcfg.get("otlp_endpoint", "http://localhost:4318")
+
+            gemini_settings = Path.home() / ".gemini" / "settings.json"
+            try:
+                gemini_data: dict = {}
+                if gemini_settings.exists():
+                    gemini_data = json.loads(gemini_settings.read_text())
+
+                telemetry = gemini_data.get("telemetry", {})
+                needs_telemetry_update = False
+
+                if not isinstance(telemetry, dict):
+                    telemetry = {}
+                if not telemetry.get("enabled"):
+                    needs_telemetry_update = True
+                if telemetry.get("target") != "custom":
+                    needs_telemetry_update = True
+                if telemetry.get("otlpEndpoint") != otlp_endpoint:
+                    needs_telemetry_update = True
+
+                if needs_telemetry_update:
+                    _backup_config(gemini_settings)
+                    gemini_data.setdefault("telemetry", {})
+                    gemini_data["telemetry"]["enabled"] = True
+                    gemini_data["telemetry"]["target"] = "custom"
+                    gemini_data["telemetry"]["otlpEndpoint"] = otlp_endpoint
+                    gemini_data["telemetry"]["logPrompts"] = True
+                    gemini_settings.parent.mkdir(parents=True, exist_ok=True)
+                    gemini_settings.write_text(json.dumps(gemini_data, indent=2) + "\n")
+                    rprint(f"\n[green]Configured Gemini CLI telemetry in {gemini_settings}[/green]")
+                    rprint(f"[dim]OTLP endpoint: {otlp_endpoint}[/dim]")
+                    rprint("[dim]Telemetry will be sent to Observal via OTLP.[/dim]")
+                else:
+                    rprint(f"\n[dim]Gemini CLI telemetry already configured -> {otlp_endpoint}[/dim]")
+            except Exception as e:
+                rprint(f"\n[yellow]Could not configure Gemini CLI telemetry: {e}[/yellow]")
+                rprint("[dim]Add telemetry settings manually to ~/.gemini/settings.json.[/dim]")

--- a/observal_cli/constants.py
+++ b/observal_cli/constants.py
@@ -20,6 +20,7 @@ VALID_IDES: list[str] = [
     "vscode",
     "codex",
     "copilot",
+    "opencode",
 ]
 
 # ── IDE feature capabilities ──────────────────────────────────
@@ -42,7 +43,8 @@ IDE_FEATURE_MATRIX: dict[str, set[str]] = {
     "cursor": {"mcp_servers", "rules"},
     "gemini-cli": {"mcp_servers", "rules"},
     "codex": {"rules"},
-    "copilot": {"rules"},
+    "copilot": {"mcp_servers", "rules"},
+    "opencode": {"mcp_servers", "rules"},
     "vscode": {"mcp_servers", "rules"},
 }
 

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -1290,11 +1290,22 @@ class TestGenerateIdeAgentFiles:
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "copilot")
         assert config.ide == "copilot"
-        assert len(config.files) == 1
-        md = config.files[0]
-        assert md.path == ".github/copilot-instructions.md"
+        paths = [f.path for f in config.files]
+        assert ".github/copilot-instructions.md" in paths
+        md = next(f for f in config.files if f.path == ".github/copilot-instructions.md")
         assert md.format == "markdown"
         assert "You are a helpful coding assistant." in md.content
+
+    def test_copilot_generates_mcp_json(self):
+        from services.agent_builder import generate_ide_agent_files
+
+        manifest = self._make_manifest()
+        config = generate_ide_agent_files(manifest, "copilot")
+        paths = [f.path for f in config.files]
+        assert ".vscode/mcp.json" in paths
+        mcp_file = next(f for f in config.files if f.path == ".vscode/mcp.json")
+        assert mcp_file.format == "json"
+        assert "servers" in mcp_file.content
 
     # ── Rules markdown content ─────────────────────────────────
 

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -361,7 +361,7 @@ class TestGenerateGemini:
     def test_mcp_path(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "gemini-cli")
-        assert cfg["mcp_config"]["path"] == ".gemini/mcp.json"
+        assert cfg["mcp_config"]["path"] == ".gemini/settings.json"
 
     def test_gemini_underscore_alias(self):
         agent = _make_agent()
@@ -385,10 +385,17 @@ class TestGenerateCodex:
         cfg = generate_agent_config(agent, "codex")
         assert cfg["rules_file"]["path"] == "AGENTS.md"
 
-    def test_no_mcp_config(self):
+    def test_mcp_config_present(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "codex")
-        assert "mcp_config" not in cfg
+        assert "mcp_config" in cfg
+        assert cfg["mcp_config"]["path"] == "~/.codex/config.toml"
+        assert "mcp.servers" in cfg["mcp_config"]["content"]
+
+    def test_mcp_config_empty_servers(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "codex")
+        assert cfg["mcp_config"]["content"]["mcp.servers"] == {}
 
     def test_content_not_empty(self):
         agent = _make_agent()
@@ -407,15 +414,48 @@ class TestGenerateCopilot:
         cfg = generate_agent_config(agent, "copilot")
         assert cfg["rules_file"]["path"] == ".github/copilot-instructions.md"
 
-    def test_no_mcp_config(self):
+    def test_mcp_config_present(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "copilot")
-        assert "mcp_config" not in cfg
+        assert "mcp_config" in cfg
+        assert cfg["mcp_config"]["path"] == ".vscode/mcp.json"
+
+    def test_mcp_config_uses_servers_key(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot")
+        assert "servers" in cfg["mcp_config"]["content"]
 
     def test_content_not_empty(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "copilot")
         assert len(cfg["rules_file"]["content"]) > 0
+
+    def test_external_mcps_get_type_stdio(self):
+        ext = [{"name": "my-srv", "command": "npx", "args": ["-y", "my-srv"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot")
+        entry = cfg["mcp_config"]["content"]["servers"]["my-srv"]
+        assert entry["type"] == "stdio"
+        assert entry["command"] == "observal-shim"
+        assert isinstance(entry["args"], list)
+
+    def test_env_vars_preserved(self):
+        ext = [{"name": "my-srv", "command": "npx", "args": [], "env": {"API_KEY": "secret"}}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot")
+        entry = cfg["mcp_config"]["content"]["servers"]["my-srv"]
+        assert entry["env"]["API_KEY"] == "secret"
+        assert entry["env"]["OBSERVAL_AGENT_ID"] == str(agent.id)
+
+    def test_scope_is_project(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot")
+        assert cfg["scope"] == "project"
+
+    def test_no_mcpservers_key(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot")
+        assert "mcpServers" not in cfg["mcp_config"]["content"]
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -643,6 +683,40 @@ class TestBuilderCopilot:
         result = generate_ide_agent_files(manifest, "copilot")
         paths = [f.path for f in result.files]
         assert ".github/copilot-instructions.md" in paths
+
+    def test_mcp_json_path(self):
+        manifest = _make_manifest(
+            mcps=[ManifestComponent(name="my-srv", version="1.0.0", git_url="https://a.com")],
+        )
+        result = generate_ide_agent_files(manifest, "copilot")
+        paths = [f.path for f in result.files]
+        assert ".vscode/mcp.json" in paths
+
+    def test_mcp_config_uses_servers_key(self):
+        manifest = _make_manifest(
+            mcps=[ManifestComponent(name="my-srv", version="1.0.0", git_url="https://a.com")],
+        )
+        result = generate_ide_agent_files(manifest, "copilot")
+        mcp_file = next(f for f in result.files if f.path == ".vscode/mcp.json")
+        content = mcp_file.content
+        assert "servers" in content
+        assert "mcpServers" not in content
+
+    def test_mcp_entries_have_type_stdio(self):
+        manifest = _make_manifest(
+            mcps=[ManifestComponent(name="my-srv", version="1.0.0", git_url="https://a.com")],
+        )
+        result = generate_ide_agent_files(manifest, "copilot")
+        mcp_file = next(f for f in result.files if f.path == ".vscode/mcp.json")
+        entry = mcp_file.content["servers"]["my-srv"]
+        assert entry["type"] == "stdio"
+        assert entry["command"] == "observal-shim"
+
+    def test_no_mcp_file_when_no_mcp_components(self):
+        manifest = _make_manifest()
+        result = generate_ide_agent_files(manifest, "copilot")
+        paths = [f.path for f in result.files]
+        assert ".vscode/mcp.json" not in paths
 
 
 class TestBuilderUnsupportedIde:

--- a/tests/test_config_generator_utils.py
+++ b/tests/test_config_generator_utils.py
@@ -1,0 +1,37 @@
+from observal_cli.cmd_pull import _dict_to_toml, _write_file
+from observal_cli.cmd_scan import _parse_project_mcp_servers
+
+
+def test_dict_to_toml():
+    d = {"mcp.servers": {"my-server": {"command": "npx", "args": ["a", "b"], "env": {"K": "V"}}}}
+    toml = _dict_to_toml(d)
+    assert "[mcp.servers.my-server]" in toml
+    assert 'command = "npx"' in toml
+    assert 'args = ["a", "b"]' in toml
+    assert 'env.K = "V"' in toml
+
+
+def test_parse_project_mcp_servers():
+    codex_conf = {"mcp": {"servers": {"c-serv": {}}}}
+    gemini_conf = {"mcpServers": {"g-serv": {}}}
+    copilot_conf = {"servers": {"cp-serv": {}}}
+    opencode_conf = {"mcp": {"o-serv": {}}}
+
+    assert _parse_project_mcp_servers(codex_conf, "codex") == {"c-serv": {}}
+    assert _parse_project_mcp_servers(gemini_conf, "gemini-cli") == {"g-serv": {}}
+    assert _parse_project_mcp_servers(copilot_conf, "copilot") == {"cp-serv": {}}
+    assert _parse_project_mcp_servers(opencode_conf, "opencode") == {"o-serv": {}}
+
+
+def test_write_file_merge_toml(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text("[mcp.servers.old]\ncommand = 'echo'\n")
+
+    content = {"mcp.servers": {"new": {"command": "observal-shim"}}}
+    res = _write_file(p, content, merge_mcp=True)
+    assert res == "merged"
+
+    merged = p.read_text()
+    assert "[mcp.servers.old]" in merged
+    assert "[mcp.servers.new]" in merged
+    assert "observal-shim" in merged

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -1,0 +1,1699 @@
+"""Comprehensive end-to-end tests for issue #434: first-class IDE support.
+
+Covers Codex CLI, Gemini CLI, GitHub Copilot (VS Code), and OpenCode across:
+
+1. Server-side config generation (agent_config_generator)
+2. CLI scan detection (cmd_scan._parse_project_mcp_servers, _scan_project_dir)
+3. CLI pull command (cmd_pull._dict_to_toml, _write_file, full pull flow)
+4. Constants (VALID_IDES, IDE_FEATURE_MATRIX)
+5. IDE compatibility warnings
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from observal_cli.cmd_pull import _dict_to_toml, _write_file
+from observal_cli.cmd_scan import (
+    _IDE_PROJECT_CONFIGS,
+    _parse_project_mcp_servers,
+    _scan_project_dir,
+)
+from observal_cli.constants import IDE_FEATURE_MATRIX, VALID_IDES
+from observal_cli.main import app as cli_app
+from services.agent_config_generator import (
+    _check_ide_compatibility,
+    generate_agent_config,
+)
+
+# ═══════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════
+
+
+def _make_component(component_type="mcp", component_id=None):
+    comp = MagicMock()
+    comp.component_type = component_type
+    comp.component_id = component_id or uuid.uuid4()
+    return comp
+
+
+def _make_agent(
+    name="test-agent",
+    description="A test agent",
+    prompt="You are helpful.",
+    model_name="claude-sonnet-4",
+    components=None,
+    external_mcps=None,
+):
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = name
+    agent.description = description
+    agent.prompt = prompt
+    agent.model_name = model_name
+    agent.components = components or []
+    agent.external_mcps = external_mcps or []
+    agent.required_ide_features = []
+    return agent
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. CONSTANTS — VALID_IDES and IDE_FEATURE_MATRIX
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestConstants:
+    def test_codex_in_valid_ides(self):
+        assert "codex" in VALID_IDES
+
+    def test_copilot_in_valid_ides(self):
+        assert "copilot" in VALID_IDES
+
+    def test_gemini_cli_in_valid_ides(self):
+        assert "gemini-cli" in VALID_IDES
+
+    def test_opencode_in_valid_ides(self):
+        assert "opencode" in VALID_IDES
+
+    def test_codex_feature_matrix(self):
+        assert "codex" in IDE_FEATURE_MATRIX
+        assert IDE_FEATURE_MATRIX["codex"] == {"rules"}
+
+    def test_copilot_feature_matrix(self):
+        assert "copilot" in IDE_FEATURE_MATRIX
+        assert IDE_FEATURE_MATRIX["copilot"] == {"mcp_servers", "rules"}
+
+    def test_gemini_cli_feature_matrix(self):
+        assert "gemini-cli" in IDE_FEATURE_MATRIX
+        assert "mcp_servers" in IDE_FEATURE_MATRIX["gemini-cli"]
+        assert "rules" in IDE_FEATURE_MATRIX["gemini-cli"]
+
+    def test_opencode_feature_matrix(self):
+        assert "opencode" in IDE_FEATURE_MATRIX
+        assert IDE_FEATURE_MATRIX["opencode"] == {"mcp_servers", "rules"}
+
+    def test_ide_project_configs_include_all_new_ides(self):
+        assert "codex" in _IDE_PROJECT_CONFIGS
+        assert "copilot" in _IDE_PROJECT_CONFIGS
+        assert "gemini-cli" in _IDE_PROJECT_CONFIGS
+        assert "opencode" in _IDE_PROJECT_CONFIGS
+
+    def test_ide_project_config_paths(self):
+        assert _IDE_PROJECT_CONFIGS["codex"] == ".codex/config.toml"
+        assert _IDE_PROJECT_CONFIGS["copilot"] == ".vscode/mcp.json"
+        assert _IDE_PROJECT_CONFIGS["gemini-cli"] == ".gemini/settings.json"
+        assert _IDE_PROJECT_CONFIGS["opencode"] == "opencode.json"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. SERVER-SIDE CONFIG GENERATION
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestGenerateCodexConfig:
+    def test_rules_path_is_agents_md(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "codex")
+        assert cfg["rules_file"]["path"] == "AGENTS.md"
+
+    def test_mcp_config_path(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "codex")
+        assert cfg["mcp_config"]["path"] == "~/.codex/config.toml"
+
+    def test_mcp_config_root_key(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "codex")
+        assert "mcp.servers" in cfg["mcp_config"]["content"]
+        assert "my-server" in cfg["mcp_config"]["content"]["mcp.servers"]
+
+    def test_mcp_config_entry_has_command_and_args(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "codex")
+        servers = cfg["mcp_config"]["content"]["mcp.servers"]
+        assert servers["my-server"]["command"] == "observal-shim"
+        assert "--mcp-id" in servers["my-server"]["args"]
+
+    def test_mcp_config_injects_agent_id(self):
+        ext = [{"name": "srv", "command": "npx", "args": ["-y", "srv"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "codex")
+        servers = cfg["mcp_config"]["content"]["mcp.servers"]
+        assert servers["srv"]["env"]["OBSERVAL_AGENT_ID"] == str(agent.id)
+
+    def test_scope_is_user(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "codex")
+        assert cfg["scope"] == "user"
+
+    def test_rules_content_not_empty(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "codex")
+        assert len(cfg["rules_file"]["content"]) > 0
+
+    def test_empty_mcp_configs_still_produces_valid_structure(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "codex")
+        assert "mcp_config" in cfg
+        assert "mcp.servers" in cfg["mcp_config"]["content"]
+        assert cfg["mcp_config"]["content"]["mcp.servers"] == {}
+
+    def test_rules_content_uses_agent_prompt(self):
+        agent = _make_agent(prompt="Always use Python.")
+        cfg = generate_agent_config(agent, "codex")
+        assert "Always use Python." in cfg["rules_file"]["content"]
+
+
+class TestGenerateCopilotConfig:
+    def test_rules_path(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot")
+        assert cfg["rules_file"]["path"] == ".github/copilot-instructions.md"
+
+    def test_mcp_config_path(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot")
+        assert cfg["mcp_config"]["path"] == ".vscode/mcp.json"
+
+    def test_mcp_config_root_key_is_servers(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot")
+        assert "servers" in cfg["mcp_config"]["content"]
+        assert "my-server" in cfg["mcp_config"]["content"]["servers"]
+
+    def test_copilot_entries_have_type_stdio(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot")
+        entry = cfg["mcp_config"]["content"]["servers"]["my-server"]
+        assert entry["type"] == "stdio"
+        assert entry["command"] == "observal-shim"
+        assert isinstance(entry["args"], list)
+
+    def test_copilot_preserves_env_vars(self):
+        ext = [{"name": "my-server", "command": "npx", "args": [], "env": {"API_KEY": "secret"}}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot")
+        entry = cfg["mcp_config"]["content"]["servers"]["my-server"]
+        assert entry["env"]["API_KEY"] == "secret"
+        assert entry["env"]["OBSERVAL_AGENT_ID"] == str(agent.id)
+
+    def test_scope_is_project(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot")
+        assert cfg["scope"] == "project"
+
+    def test_rules_content_not_empty(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot")
+        assert len(cfg["rules_file"]["content"]) > 0
+
+    def test_empty_mcp_configs_still_produces_valid_structure(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot")
+        assert "mcp_config" in cfg
+        assert "servers" in cfg["mcp_config"]["content"]
+
+    def test_multiple_mcps_all_get_type_stdio(self):
+        ext = [
+            {"name": "srv-a", "command": "npx", "args": ["-y", "a"]},
+            {"name": "srv-b", "command": "node", "args": ["b.js"]},
+        ]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot")
+        servers = cfg["mcp_config"]["content"]["servers"]
+        assert servers["srv-a"]["type"] == "stdio"
+        assert servers["srv-b"]["type"] == "stdio"
+
+
+class TestGenerateOpenCodeConfig:
+    def test_rules_path(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "opencode")
+        assert cfg["rules_file"]["path"] == "AGENTS.md"
+
+    def test_mcp_config_path(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "opencode")
+        assert cfg["mcp_config"]["path"] == "~/.config/opencode/opencode.json"
+
+    def test_mcp_config_root_key_is_mcp(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "opencode")
+        assert "mcp" in cfg["mcp_config"]["content"]
+        assert "my-server" in cfg["mcp_config"]["content"]["mcp"]
+
+    def test_opencode_entries_have_type_local(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "opencode")
+        entry = cfg["mcp_config"]["content"]["mcp"]["my-server"]
+        assert entry["type"] == "local"
+        assert isinstance(entry["command"], list)
+        assert entry["command"][0] == "observal-shim"
+
+    def test_opencode_command_is_flat_array(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "opencode")
+        entry = cfg["mcp_config"]["content"]["mcp"]["my-server"]
+        old_cmd = "npx"
+        old_args = ["-y", "my-server"]
+        full_cmd = [entry["command"][0]] + entry["command"][1:]
+        assert "--mcp-id" in entry["command"]
+        assert "--" in entry["command"]
+        idx_dash = entry["command"].index("--")
+        assert (
+            entry["command"][idx_dash + 1] == "observal-shim"
+            or entry["command"][idx_dash + 1 : idx_dash + 1 + 1 + len(old_args)]
+        )
+
+    def test_opencode_preserves_env_vars(self):
+        ext = [{"name": "my-server", "command": "npx", "args": [], "env": {"FOO": "bar"}}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "opencode")
+        entry = cfg["mcp_config"]["content"]["mcp"]["my-server"]
+        assert entry["env"]["FOO"] == "bar"
+        assert entry["env"]["OBSERVAL_AGENT_ID"] == str(agent.id)
+
+    def test_scope_is_user(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "opencode")
+        assert cfg["scope"] == "user"
+
+    def test_rules_content_not_empty(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "opencode")
+        assert len(cfg["rules_file"]["content"]) > 0
+
+    def test_empty_mcp_configs_still_produces_valid_structure(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "opencode")
+        assert "mcp_config" in cfg
+        assert "mcp" in cfg["mcp_config"]["content"]
+
+    def test_no_separate_args_field(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "opencode")
+        entry = cfg["mcp_config"]["content"]["mcp"]["my-server"]
+        assert "args" not in entry, "OpenCode entries should not have separate 'args' key"
+        assert isinstance(entry["command"], list), "OpenCode 'command' should be a flat array"
+
+
+class TestGenerateGeminiConfig:
+    def test_rules_path_project_scope(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini-cli")
+        assert cfg["rules_file"]["path"] == "GEMINI.md"
+
+    def test_rules_path_user_scope(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini-cli", options={"scope": "user"})
+        assert cfg["rules_file"]["path"] == "~/.gemini/GEMINI.md"
+
+    def test_mcp_path_project_scope(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini-cli")
+        assert cfg["mcp_config"]["path"] == ".gemini/settings.json"
+
+    def test_mcp_path_user_scope(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini-cli", options={"scope": "user"})
+        assert cfg["mcp_config"]["path"] == "~/.gemini/settings.json"
+
+    def test_mcp_config_uses_mcpservers_key(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "gemini-cli")
+        assert "mcpServers" in cfg["mcp_config"]["content"]
+        assert "my-server" in cfg["mcp_config"]["content"]["mcpServers"]
+
+    def test_gemini_otlp_env_present(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini-cli")
+        assert "otlp_env" in cfg
+
+    def test_gemini_settings_snippet_present(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini-cli")
+        assert "gemini_settings_snippet" in cfg
+
+    def test_gemini_underscore_alias(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini_cli")
+        assert cfg["rules_file"]["path"] == "GEMINI.md"
+
+    def test_scope_defaults_to_project(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini-cli")
+        assert cfg["scope"] == "project"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 3. IDE COMPATIBILITY WARNINGS
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestIdeCompatibilityWarnings:
+    def test_codex_warns_on_mcp_requirement(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["mcp_servers"]
+        warnings = _check_ide_compatibility(agent, "codex")
+        assert len(warnings) > 0
+        assert any("mcp" in w.lower() or "MCP" in w for w in warnings)
+
+    def test_copilot_no_longer_warns_on_mcp_requirement(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["mcp_servers"]
+        warnings = _check_ide_compatibility(agent, "copilot")
+        assert len(warnings) == 0
+
+    def test_gemini_supports_mcp(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["mcp_servers", "rules"]
+        warnings = _check_ide_compatibility(agent, "gemini-cli")
+        assert len(warnings) == 0
+
+    def test_opencode_warns_on_unsupported_features(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["skills", "hook_bridge"]
+        warnings = _check_ide_compatibility(agent, "opencode")
+        assert len(warnings) == 2
+
+    def test_no_warnings_for_supported_features(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["rules"]
+        for ide in ("codex", "copilot", "gemini-cli", "opencode"):
+            if ide in IDE_FEATURE_MATRIX:
+                warnings = _check_ide_compatibility(agent, ide)
+                assert len(warnings) == 0, f"Unexpected warnings for {ide}: {warnings}"
+
+    def test_copilot_supports_mcp_servers(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["mcp_servers", "rules"]
+        warnings = _check_ide_compatibility(agent, "copilot")
+        assert len(warnings) == 0
+
+    def test_codex_warns_on_skills_requirement(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["skills"]
+        warnings = _check_ide_compatibility(agent, "codex")
+        assert len(warnings) > 0
+        assert any("skill" in w.lower() for w in warnings)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. SCAN — _parse_project_mcp_servers
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestParseProjectMcpServers:
+    def test_codex_extracts_nested_servers(self):
+        config = {"mcp": {"servers": {"srv-a": {"command": "npx"}, "srv-b": {"command": "node"}}}}
+        result = _parse_project_mcp_servers(config, "codex")
+        assert "srv-a" in result
+        assert "srv-b" in result
+        assert result["srv-a"]["command"] == "npx"
+
+    def test_codex_empty_servers(self):
+        config = {"mcp": {"servers": {}}}
+        result = _parse_project_mcp_servers(config, "codex")
+        assert result == {}
+
+    def test_codex_missing_servers_key(self):
+        config = {"mcp": {}}
+        result = _parse_project_mcp_servers(config, "codex")
+        assert result == {}
+
+    def test_gemini_extracts_mcpservers(self):
+        config = {"mcpServers": {"my-srv": {"command": "python", "args": ["serve.py"]}}}
+        result = _parse_project_mcp_servers(config, "gemini-cli")
+        assert "my-srv" in result
+
+    def test_copilot_extracts_servers_key(self):
+        config = {"servers": {"my-srv": {"type": "stdio", "command": "npx", "args": ["-y", "my-srv"]}}}
+        result = _parse_project_mcp_servers(config, "copilot")
+        assert "my-srv" in result
+
+    def test_copilot_falls_back_to_mcpservers(self):
+        config = {"mcpServers": {"my-srv": {"command": "npx"}}}
+        result = _parse_project_mcp_servers(config, "copilot")
+        assert "my-srv" in result
+
+    def test_copilot_prefers_servers_over_mcpservers(self):
+        config = {
+            "servers": {"primary": {"command": "node"}},
+            "mcpServers": {"secondary": {"command": "python"}},
+        }
+        result = _parse_project_mcp_servers(config, "copilot")
+        assert "primary" in result
+        assert "secondary" not in result
+
+    def test_opencode_extracts_mcp_key(self):
+        config = {"mcp": {"my-srv": {"type": "local", "command": ["npx", "-y", "my-srv"]}}}
+        result = _parse_project_mcp_servers(config, "opencode")
+        assert "my-srv" in result
+
+    def test_vscode_extracts_servers_key(self):
+        config = {"servers": {"my-srv": {"type": "stdio", "command": "npx"}}}
+        result = _parse_project_mcp_servers(config, "vscode")
+        assert "my-srv" in result
+
+    def test_cursor_extracts_mcpservers(self):
+        config = {"mcpServers": {"my-srv": {"command": "npx"}}}
+        result = _parse_project_mcp_servers(config, "cursor")
+        assert "my-srv" in result
+
+    def test_unknown_ide_falls_back_to_mcpservers(self):
+        config = {"mcpServers": {"my-srv": {"command": "npx"}}}
+        result = _parse_project_mcp_servers(config, "unknown-ide")
+        assert "my-srv" in result
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 5. SCAN — _scan_project_dir
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestScanProjectDir:
+    def test_detects_codex_toml(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        config_file = codex_dir / "config.toml"
+        config_file.write_text('[mcp.servers.my-toml-srv]\ncommand = "echo"\nargs = ["hello"]\n')
+        entries = _scan_project_dir(tmp_path, None)
+        ide_names = [(e[0], e[1]) for e in entries]
+        assert any(ide == "codex" for ide, _ in ide_names)
+
+    def test_detects_gemini_settings(self, tmp_path):
+        gemini_dir = tmp_path / ".gemini"
+        gemini_dir.mkdir()
+        settings = gemini_dir / "settings.json"
+        settings.write_text(json.dumps({"mcpServers": {"gemini-srv": {"command": "python"}}}))
+        entries = _scan_project_dir(tmp_path, None)
+        ide_names = [(e[0], e[1]) for e in entries]
+        assert any(ide == "gemini-cli" for ide, _ in ide_names)
+
+    def test_detects_copilot_mcp_json(self, tmp_path):
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        mcp_file = vscode_dir / "mcp.json"
+        mcp_file.write_text(json.dumps({"servers": {"vscode-srv": {"type": "stdio", "command": "npx"}}}))
+        entries = _scan_project_dir(tmp_path, None)
+        ide_names = [(e[0], e[1]) for e in entries]
+        assert any(ide == "copilot" for ide, _ in ide_names)
+
+    def test_detects_opencode_config(self, tmp_path):
+        config_file = tmp_path / "opencode.json"
+        config_file.write_text(json.dumps({"mcp": {"my-srv": {"type": "local", "command": ["npx"]}}}))
+        entries = _scan_project_dir(tmp_path, None)
+        ide_names = [(e[0], e[1]) for e in entries]
+        assert any(ide == "opencode" for ide, _ in ide_names)
+
+    def test_ide_filter(self, tmp_path):
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        mcp_file = vscode_dir / "mcp.json"
+        mcp_file.write_text(json.dumps({"servers": {"vscode-srv": {"type": "stdio", "command": "npx"}}}))
+        gemini_dir = tmp_path / ".gemini"
+        gemini_dir.mkdir()
+        settings = gemini_dir / "settings.json"
+        settings.write_text(json.dumps({"mcpServers": {"gemini-srv": {"command": "python"}}}))
+        entries = _scan_project_dir(tmp_path, "copilot")
+        ide_names = [e[0] for e in entries]
+        assert "copilot" in ide_names
+        assert "gemini-cli" not in ide_names
+
+    def test_skips_already_shimmed(self, tmp_path):
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        mcp_file = vscode_dir / "mcp.json"
+        mcp_file.write_text(
+            json.dumps(
+                {
+                    "servers": {
+                        "shimmed-srv": {
+                            "type": "stdio",
+                            "command": "observal-shim",
+                            "args": ["--mcp-id", "test"],
+                        }
+                    }
+                }
+            )
+        )
+        entries = _scan_project_dir(tmp_path, "copilot")
+        srv_names = [e[1] for e in entries]
+        assert "shimmed-srv" not in srv_names
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6. PULL — _dict_to_toml
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestDictToToml:
+    def test_basic_section(self):
+        d = {"mcp.servers": {"my-srv": {"command": "npx", "args": ["-y", "my-srv"]}}}
+        toml = _dict_to_toml(d)
+        assert "[mcp.servers.my-srv]" in toml
+        assert 'command = "npx"' in toml
+        assert 'args = ["-y", "my-srv"]' in toml
+
+    def test_env_vars(self):
+        d = {"mcp.servers": {"my-srv": {"command": "npx", "env": {"K": "V"}}}}
+        toml = _dict_to_toml(d)
+        assert "env.K" in toml or "env" in toml
+
+    def test_multiple_servers(self):
+        d = {"mcp.servers": {"srv-a": {"command": "echo"}, "srv-b": {"command": "cat"}}}
+        toml = _dict_to_toml(d)
+        assert "[mcp.servers.srv-a]" in toml
+        assert "[mcp.servers.srv-b]" in toml
+
+    def test_empty_servers(self):
+        d = {"mcp.servers": {}}
+        toml = _dict_to_toml(d)
+        assert toml.strip() == ""
+
+    def test_boolean_values(self):
+        d = {"mcp.servers": {"my-srv": {"command": "npx", "autoApprove": True}}}
+        toml = _dict_to_toml(d)
+        assert "autoApprove = true" in toml
+
+    def test_string_values_with_quotes(self):
+        d = {"mcp.servers": {"my-srv": {"command": 'echo "hello"'}}}
+        toml = _dict_to_toml(d)
+        assert "my-srv" in toml
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 7. PULL — _write_file
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestWriteFile:
+    def test_creates_json_file(self, tmp_path):
+        p = tmp_path / "config.json"
+        content = {"mcpServers": {"srv": {"command": "npx"}}}
+        status = _write_file(p, content)
+        assert status == "created"
+        data = json.loads(p.read_text())
+        assert "mcpServers" in data
+
+    def test_creates_toml_file(self, tmp_path):
+        p = tmp_path / "config.toml"
+        content = {"mcp.servers": {"srv": {"command": "npx"}}}
+        status = _write_file(p, content)
+        assert status == "created"
+        assert "[mcp.servers.srv]" in p.read_text()
+
+    def test_updates_existing_json(self, tmp_path):
+        p = tmp_path / "mcp.json"
+        p.write_text(json.dumps({"mcpServers": {"old": {"command": "old"}}}))
+        content = {"mcpServers": {"new": {"command": "new"}}}
+        status = _write_file(p, content, merge_mcp=True)
+        assert status == "merged"
+        data = json.loads(p.read_text())
+        assert "old" in data["mcpServers"]
+        assert "new" in data["mcpServers"]
+
+    def test_merges_toml(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.write_text("[mcp.servers.old]\ncommand = 'echo'\n")
+        content = {"mcp.servers": {"new": {"command": "observal-shim"}}}
+        status = _write_file(p, content, merge_mcp=True)
+        assert status == "merged"
+        merged = p.read_text()
+        assert "[mcp.servers.old]" in merged
+        assert "observal-shim" in merged
+
+    def test_creates_parent_directories(self, tmp_path):
+        p = tmp_path / ".codex" / "config.toml"
+        content = {"mcp.servers": {"srv": {"command": "npx"}}}
+        _write_file(p, content)
+        assert p.exists()
+
+    def test_non_merge_creates_new_file(self, tmp_path):
+        p = tmp_path / "new.json"
+        content = {"servers": {"srv": {"command": "npx"}}}
+        status = _write_file(p, content, merge_mcp=False)
+        assert status == "created"
+
+    def test_write_string_content(self, tmp_path):
+        p = tmp_path / "AGENTS.md"
+        status = _write_file(p, "# Rules\n\nBe helpful.")
+        assert status == "created"
+        assert "Be helpful" in p.read_text()
+
+    def test_update_status_for_existing_file(self, tmp_path):
+        p = tmp_path / "AGENTS.md"
+        p.write_text("old content")
+        status = _write_file(p, "new content")
+        assert status == "updated"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 8. PULL — Full CLI flow (E2E per IDE)
+# ═══════════════════════════════════════════════════════════════════
+
+runner = CliRunner()
+
+_FAKE_CONFIG = {"server_url": "http://localhost:8000", "api_key": "test-key"}
+
+
+def _patch_config():
+    return patch("observal_cli.config.get_or_exit", return_value=_FAKE_CONFIG)
+
+
+def _patch_post(return_value):
+    return patch("observal_cli.client.post", return_value=return_value)
+
+
+_AGENT_DETAIL_NO_ENV = {
+    "id": "abc123",
+    "name": "my-agent",
+    "mcp_links": [],
+    "component_links": [],
+}
+
+
+def _patch_get_agent(detail=None):
+    detail = detail or _AGENT_DETAIL_NO_ENV
+    return patch("observal_cli.client.get", return_value=detail)
+
+
+class TestPullCodex:
+    def test_writes_agents_md_and_mcp_toml(self, tmp_path):
+        snippet = {
+            "config_snippet": {
+                "rules_file": {
+                    "path": "AGENTS.md",
+                    "content": "# Codex Rules\n\nBe precise.\n",
+                },
+                "mcp_config": {
+                    "path": "~/.codex/config.toml",
+                    "content": {
+                        "mcp.servers": {
+                            "my-server": {
+                                "command": "observal-shim",
+                                "args": ["--mcp-id", "test", "--", "npx", "-y", "my-server"],
+                            }
+                        }
+                    },
+                },
+                "scope": "user",
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "codex", "--dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        rules = tmp_path / "AGENTS.md"
+        assert rules.exists()
+        assert "Codex Rules" in rules.read_text()
+        config = tmp_path / ".codex" / "config.toml"
+        assert config.exists()
+        content = config.read_text()
+        assert "mcp.servers" in content
+        assert "observal-shim" in content
+
+    def test_writes_only_rules_when_no_mcp(self, tmp_path):
+        snippet = {
+            "config_snippet": {
+                "rules_file": {
+                    "path": "AGENTS.md",
+                    "content": "# Simple Agent\n",
+                },
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "codex", "--dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "AGENTS.md").exists()
+
+
+class TestPullCopilot:
+    def test_writes_copilot_instructions_and_mcp(self, tmp_path):
+        snippet = {
+            "config_snippet": {
+                "rules_file": {
+                    "path": ".github/copilot-instructions.md",
+                    "content": "# Copilot Rules\n\nUse Python.\n",
+                },
+                "mcp_config": {
+                    "path": ".vscode/mcp.json",
+                    "content": {
+                        "servers": {
+                            "my-server": {
+                                "type": "stdio",
+                                "command": "observal-shim",
+                                "args": ["--mcp-id", "test", "--", "npx", "-y", "my-server"],
+                            }
+                        }
+                    },
+                },
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "copilot", "--dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        rules = tmp_path / ".github" / "copilot-instructions.md"
+        assert rules.exists()
+        assert "Copilot Rules" in rules.read_text()
+        mcp = tmp_path / ".vscode" / "mcp.json"
+        assert mcp.exists()
+        data = json.loads(mcp.read_text())
+        assert "servers" in data
+        assert data["servers"]["my-server"]["type"] == "stdio"
+
+
+class TestPullOpenCode:
+    def test_writes_agents_md_and_opencode_json(self, tmp_path):
+        snippet = {
+            "config_snippet": {
+                "rules_file": {
+                    "path": "AGENTS.md",
+                    "content": "# OpenCode Rules\n\nBe concise.\n",
+                },
+                "mcp_config": {
+                    "path": "~/.config/opencode/opencode.json",
+                    "content": {
+                        "mcp": {
+                            "my-server": {
+                                "type": "local",
+                                "command": ["observal-shim", "--mcp-id", "test", "--", "npx", "-y", "my-server"],
+                            }
+                        }
+                    },
+                },
+                "scope": "user",
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "opencode", "--dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        rules = tmp_path / "AGENTS.md"
+        assert rules.exists()
+        config = tmp_path / ".config" / "opencode" / "opencode.json"
+        assert config.exists()
+        data = json.loads(config.read_text())
+        assert "mcp" in data
+        assert "my-server" in data["mcp"]
+        assert data["mcp"]["my-server"]["type"] == "local"
+
+    def test_writes_only_rules_when_no_mcp(self, tmp_path):
+        snippet = {
+            "config_snippet": {
+                "rules_file": {
+                    "path": "AGENTS.md",
+                    "content": "# Simple Agent\n",
+                },
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "opencode", "--dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "AGENTS.md").exists()
+
+
+class TestPullGemini:
+    def test_writes_gemini_md_and_settings(self, tmp_path):
+        snippet = {
+            "config_snippet": {
+                "rules_file": {
+                    "path": "GEMINI.md",
+                    "content": "# Gemini Rules\n\nUse TypeScript.\n",
+                },
+                "mcp_config": {
+                    "path": ".gemini/settings.json",
+                    "content": {
+                        "mcpServers": {
+                            "my-server": {
+                                "command": "observal-shim",
+                                "args": ["--mcp-id", "test", "--", "npx", "-y", "my-server"],
+                            }
+                        }
+                    },
+                },
+                "otlp_env": {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"},
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(cli_app, ["pull", "abc123", "--ide", "gemini-cli", "--dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        rules = tmp_path / "GEMINI.md"
+        assert rules.exists()
+        settings = tmp_path / ".gemini" / "settings.json"
+        assert settings.exists()
+        data = json.loads(settings.read_text())
+        assert "mcpServers" in data
+
+
+class TestPullDryRunAllIdes:
+    @pytest.mark.parametrize("ide", ["codex", "copilot", "opencode"])
+    def test_dry_run_does_not_write_files(self, tmp_path, ide):
+        snippet = {
+            "config_snippet": {
+                "rules_file": {
+                    "path": "AGENTS.md",
+                    "content": "# Test\n",
+                },
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(cli_app, ["pull", "abc123", "--ide", ide, "--dir", str(tmp_path), "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert not (tmp_path / "AGENTS.md").exists()
+
+    def test_dry_run_gemini(self, tmp_path):
+        snippet = {
+            "config_snippet": {
+                "rules_file": {
+                    "path": "GEMINI.md",
+                    "content": "# Gemini\n",
+                },
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(
+                cli_app, ["pull", "abc123", "--ide", "gemini-cli", "--dir", str(tmp_path), "--dry-run"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert not (tmp_path / "GEMINI.md").exists()
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 9. CROSS-CUTTING — format correctness per IDE spec
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestCodexTomlFormat:
+    def test_toml_output_has_correct_structure(self):
+        mcp_configs = {
+            "my-server": {
+                "command": "observal-shim",
+                "args": ["--mcp-id", "abc", "--", "npx", "-y", "my-server"],
+                "env": {"OBSERVAL_AGENT_ID": "agent-123"},
+            }
+        }
+        toml = _dict_to_toml({"mcp.servers": mcp_configs})
+        assert "[mcp.servers.my-server]" in toml
+        assert 'command = "observal-shim"' in toml
+        assert "OBSERVAL_AGENT_ID" in toml
+
+    def test_toml_entry_with_no_env(self):
+        mcp_configs = {"bare-srv": {"command": "echo", "args": []}}
+        toml = _dict_to_toml({"mcp.servers": mcp_configs})
+        assert "[mcp.servers.bare-srv]" in toml
+        assert 'command = "echo"' in toml
+
+
+class TestCopilotJsonFormat:
+    def test_copilot_config_wraps_with_type_stdio(self):
+        agent = _make_agent(external_mcps=[{"name": "my-srv", "command": "npx", "args": ["-y", "my-srv"]}])
+        cfg = generate_agent_config(agent, "copilot")
+        servers = cfg["mcp_config"]["content"]["servers"]
+        entry = servers["my-srv"]
+        assert entry["type"] == "stdio"
+        assert entry["command"] == "observal-shim"
+        assert isinstance(entry["args"], list)
+        assert "--mcp-id" in entry["args"]
+
+    def test_copilot_config_has_no_mcpservers_key(self):
+        agent = _make_agent(external_mcps=[{"name": "my-srv", "command": "npx", "args": []}])
+        cfg = generate_agent_config(agent, "copilot")
+        assert "mcpServers" not in cfg["mcp_config"]["content"]
+        assert "servers" in cfg["mcp_config"]["content"]
+
+
+class TestOpenCodeJsonFormat:
+    def test_opencode_command_is_flat_array(self):
+        agent = _make_agent(external_mcps=[{"name": "my-srv", "command": "npx", "args": ["-y", "my-srv"]}])
+        cfg = generate_agent_config(agent, "opencode")
+        entry = cfg["mcp_config"]["content"]["mcp"]["my-srv"]
+        assert isinstance(entry["command"], list)
+        assert entry["command"][0] == "observal-shim"
+        assert "--" in entry["command"]
+
+    def test_opencode_has_no_args_key(self):
+        agent = _make_agent(external_mcps=[{"name": "my-srv", "command": "npx", "args": ["-y", "my-srv"]}])
+        cfg = generate_agent_config(agent, "opencode")
+        entry = cfg["mcp_config"]["content"]["mcp"]["my-srv"]
+        assert "args" not in entry
+
+    def test_opencode_type_is_local(self):
+        agent = _make_agent(external_mcps=[{"name": "my-srv", "command": "npx", "args": []}])
+        cfg = generate_agent_config(agent, "opencode")
+        entry = cfg["mcp_config"]["content"]["mcp"]["my-srv"]
+        assert entry["type"] == "local"
+
+
+class TestGeminiJsonFormat:
+    def test_gemini_mcp_uses_mcpservers_key(self):
+        agent = _make_agent(external_mcps=[{"name": "my-srv", "command": "npx", "args": ["-y", "my-srv"]}])
+        cfg = generate_agent_config(agent, "gemini-cli")
+        assert "mcpServers" in cfg["mcp_config"]["content"]
+        assert "servers" not in cfg["mcp_config"]["content"]
+        assert "mcp" not in cfg["mcp_config"]["content"]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 10. DOCTOR — Copilot IDE config checks
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestDoctorCopilot:
+    def test_copilot_in_ide_configs(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        assert "copilot" in IDE_CONFIGS
+        assert IDE_CONFIGS["copilot"]["project_settings"] != []
+
+    def test_copilot_project_settings_paths(self):
+
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        paths = IDE_CONFIGS["copilot"]["project_settings"]
+        assert any(str(p).endswith("mcp.json") for p in paths)
+
+    def test_check_copilot_fn_warns_on_unwrapped_mcp(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_copilot
+
+        data = {"servers": {"my-srv": {"type": "stdio", "command": "npx", "args": ["-y", "my-srv"]}}}
+        issues = []
+        warnings = []
+        _check_copilot(Path(".vscode/mcp.json"), data, issues, warnings)
+        assert len(warnings) > 0
+        assert any("observal-shim" in w for w in warnings)
+
+    def test_check_copilot_fn_no_warning_on_shimmed_mcp(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_copilot
+
+        data = {
+            "servers": {
+                "my-srv": {"type": "stdio", "command": "observal-shim", "args": ["--mcp-id", "test", "--", "npx"]}
+            }
+        }
+        issues = []
+        warnings = []
+        _check_copilot(Path(".vscode/mcp.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+    def test_check_copilot_fn_handles_mcpServers_fallback(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_copilot
+
+        data = {"mcpServers": {"my-srv": {"command": "npx", "args": ["-y", "my-srv"]}}}
+        issues = []
+        warnings = []
+        _check_copilot(Path(".vscode/mcp.json"), data, issues, warnings)
+        assert len(warnings) > 0
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 11. PROFILE — Copilot file map entries
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestProfileCopilot:
+    def test_copilot_mcp_json_in_file_map(self):
+        from observal_cli.cmd_profile import IDE_FILE_MAP
+
+        assert ".vscode/mcp.json" in IDE_FILE_MAP
+
+    def test_copilot_instructions_in_project_files(self):
+        from observal_cli.cmd_profile import PROJECT_FILES
+
+        assert ".github/copilot-instructions.md" in PROJECT_FILES
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 12. CONFIG GENERATOR — Copilot explicit branch
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestConfigGeneratorCopilot:
+    def _make_listing(self, name="my-mcp", listing_id="abc-123", **kw):
+        from unittest.mock import MagicMock
+
+        listing = MagicMock()
+        listing.name = name
+        listing.id = listing_id
+        listing.docker_image = kw.get("docker_image")
+        listing.framework = kw.get("framework")
+        listing.environment_variables = kw.get("environment_variables", [])
+        listing.command = kw.get("command")
+        listing.args = kw.get("args")
+        listing.url = kw.get("url")
+        listing.transport = kw.get("transport")
+        listing.auto_approve = kw.get("auto_approve")
+        return listing
+
+    def test_copilot_stdio_has_type_stdio(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "copilot")
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["type"] == "stdio"
+        assert server["command"] == "observal-shim"
+        assert "--mcp-id" in server["args"]
+
+    def test_copilot_sse_has_type_sse(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(url="http://localhost:3000/sse", transport="sse"), "copilot")
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["type"] == "sse"
+        assert server["url"] == "http://localhost:3000/sse"
+
+    def test_copilot_env_vars_preserved(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(
+            self._make_listing(environment_variables=[{"name": "API_KEY", "required": True}]),
+            "copilot",
+            env_values={"API_KEY": "secret"},
+        )
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["env"]["API_KEY"] == "secret"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 13. DOCTOR — OpenCode IDE config checks
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestDoctorOpenCode:
+    def test_opencode_in_ide_configs(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        assert "opencode" in IDE_CONFIGS
+
+    def test_opencode_user_settings_path(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        paths = IDE_CONFIGS["opencode"]["user_settings"]
+        assert any("opencode" in str(p) for p in paths)
+
+    def test_opencode_project_settings_path(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        paths = IDE_CONFIGS["opencode"]["project_settings"]
+        assert any("opencode" in str(p) for p in paths)
+
+    def test_check_opencode_fn_warns_on_unwrapped_mcp(self):
+        from observal_cli.cmd_doctor import _check_opencode
+
+        data = {"mcp": {"my-srv": {"type": "local", "command": ["npx", "-y", "my-srv"]}}}
+        issues = []
+        warnings = []
+        _check_opencode(Path(".config/opencode/opencode.json"), data, issues, warnings)
+        assert len(warnings) > 0
+        assert any("observal-shim" in w for w in warnings)
+
+    def test_check_opencode_fn_no_warning_on_shimmed_mcp(self):
+        from observal_cli.cmd_doctor import _check_opencode
+
+        data = {"mcp": {"my-srv": {"type": "local", "command": ["observal-shim", "--mcp-id", "test", "--", "npx"]}}}
+        issues = []
+        warnings = []
+        _check_opencode(Path(".config/opencode/opencode.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+    def test_check_opencode_fn_handles_empty_mcp(self):
+        from observal_cli.cmd_doctor import _check_opencode
+
+        data = {}
+        issues = []
+        warnings = []
+        _check_opencode(Path(".config/opencode/opencode.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+    def test_check_opencode_fn_ignores_non_dict_entries(self):
+        from observal_cli.cmd_doctor import _check_opencode
+
+        data = {"mcp": {"bad-srv": "not-a-dict"}}
+        issues = []
+        warnings = []
+        _check_opencode(Path(".config/opencode/opencode.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 14. PROFILE — OpenCode file map entries
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestProfileOpenCode:
+    def test_opencode_json_in_file_map(self):
+        from observal_cli.cmd_profile import IDE_FILE_MAP
+
+        assert ".config/opencode/opencode.json" in IDE_FILE_MAP
+
+    def test_agents_md_in_project_files(self):
+        from observal_cli.cmd_profile import PROJECT_FILES
+
+        assert "AGENTS.md" in PROJECT_FILES
+
+    def test_opencode_user_path_is_home_config(self):
+
+        from observal_cli.cmd_profile import IDE_FILE_MAP
+
+        dest = IDE_FILE_MAP[".config/opencode/opencode.json"]
+        assert dest is not None
+        assert str(dest).endswith("opencode.json")
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 15. CONFIG GENERATOR — OpenCode explicit branch
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestConfigGeneratorOpenCode:
+    def _make_listing(self, name="my-mcp", listing_id="abc-123", **kw):
+        from unittest.mock import MagicMock
+
+        listing = MagicMock()
+        listing.name = name
+        listing.id = listing_id
+        listing.docker_image = kw.get("docker_image")
+        listing.framework = kw.get("framework")
+        listing.environment_variables = kw.get("environment_variables", [])
+        listing.command = kw.get("command")
+        listing.args = kw.get("args")
+        listing.url = kw.get("url")
+        listing.transport = kw.get("transport")
+        listing.auto_approve = kw.get("auto_approve")
+        return listing
+
+    def test_opencode_stdio_uses_mcp_key(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "opencode")
+        assert "mcp" in cfg
+        assert "mcpServers" not in cfg
+
+    def test_opencode_stdio_type_is_local(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "opencode")
+        entry = cfg["mcp"]["my-mcp"]
+        assert entry["type"] == "local"
+
+    def test_opencode_stdio_command_is_flat_array(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "opencode")
+        entry = cfg["mcp"]["my-mcp"]
+        assert isinstance(entry["command"], list)
+        assert entry["command"][0] == "observal-shim"
+        assert "--mcp-id" in entry["command"]
+
+    def test_opencode_stdio_has_no_args_key(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "opencode")
+        entry = cfg["mcp"]["my-mcp"]
+        assert "args" not in entry
+
+    def test_opencode_sse_uses_mcp_key(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(url="http://localhost:3000/sse", transport="sse"), "opencode")
+        assert "mcp" in cfg
+        assert "mcpServers" not in cfg
+
+    def test_opencode_sse_type_is_remote(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(url="http://localhost:3000/sse", transport="sse"), "opencode")
+        entry = cfg["mcp"]["my-mcp"]
+        assert entry["type"] == "remote"
+        assert entry["url"] == "http://localhost:3000/sse"
+
+    def test_opencode_sse_has_headers(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(
+            self._make_listing(url="http://localhost:3000/sse", transport="sse"),
+            "opencode",
+            header_values={"Authorization": "Bearer test"},
+        )
+        entry = cfg["mcp"]["my-mcp"]
+        assert "headers" in entry
+
+    def test_opencode_proxy_uses_mcp_key(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "opencode", proxy_port=9999)
+        assert "mcp" in cfg
+        assert "mcpServers" not in cfg
+
+    def test_opencode_proxy_type_is_remote(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "opencode", proxy_port=9999)
+        entry = cfg["mcp"]["my-mcp"]
+        assert entry["type"] == "remote"
+        assert "localhost:9999" in entry["url"]
+
+    def test_opencode_env_vars_preserved(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(
+            self._make_listing(environment_variables=[{"name": "API_KEY", "required": True}]),
+            "opencode",
+            env_values={"API_KEY": "secret"},
+        )
+        entry = cfg["mcp"]["my-mcp"]
+        assert entry["env"]["API_KEY"] == "secret"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 16. PULL — OpenCode scope awareness
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestPullOpenCodeScope:
+    def test_opencode_in_scope_aware_ides(self):
+        from observal_cli.cmd_pull import _SCOPE_AWARE_IDES
+
+        assert "opencode" in _SCOPE_AWARE_IDES
+
+    def test_opencode_scope_labels(self):
+        from observal_cli.cmd_pull import _SCOPE_AWARE_IDES
+
+        project_label, user_label = _SCOPE_AWARE_IDES["opencode"]
+        assert "project" in project_label
+        assert "user" in user_label
+        assert "opencode" in user_label
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 17. GEMINI — config_generator uses observal_url param
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestGeminiConfigGenerator:
+    def test_gemini_settings_uses_observal_url(self):
+        from services.config_generator import _gemini_settings
+
+        settings = _gemini_settings("http://custom-host:4318")
+        assert settings["telemetry"]["otlpEndpoint"] == "http://custom-host:4318"
+
+    def test_gemini_settings_default_localhost(self):
+        from services.config_generator import _gemini_settings
+
+        settings = _gemini_settings("http://localhost:4318")
+        assert settings["telemetry"]["otlpEndpoint"] == "http://localhost:4318"
+
+    def test_gemini_otlp_env_uses_observal_url(self):
+        from services.config_generator import _gemini_otlp_env
+
+        env = _gemini_otlp_env("http://custom-host:4318")
+        assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://custom-host:4318"
+
+    def test_gemini_settings_snippet_in_agent_config(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "gemini-cli")
+        assert "gemini_settings_snippet" in cfg
+        snippet = cfg["gemini_settings_snippet"]
+        assert snippet["telemetry"]["enabled"] is True
+        assert snippet["telemetry"]["target"] == "custom"
+        assert "otlpEndpoint" in snippet["telemetry"]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 18. DOCTOR — Gemini CLI config checks
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestDoctorGemini:
+    def test_gemini_in_ide_configs(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        assert "gemini-cli" in IDE_CONFIGS
+
+    def test_gemini_user_settings_path(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        paths = IDE_CONFIGS["gemini-cli"]["user_settings"]
+        assert any("settings.json" in str(p) for p in paths)
+
+    def test_gemini_project_settings_path(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        paths = IDE_CONFIGS["gemini-cli"]["project_settings"]
+        assert any("settings.json" in str(p) for p in paths)
+
+    def test_check_gemini_warns_on_unwrapped_mcp(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {"mcpServers": {"my-srv": {"command": "npx", "args": ["-y", "my-srv"]}}}
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert len(warnings) > 0
+        assert any("observal-shim" in w for w in warnings)
+
+    def test_check_gemini_no_warning_on_shimmed_mcp(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {"mcpServers": {"my-srv": {"command": "observal-shim", "args": ["--mcp-id", "test", "--", "npx"]}}}
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+    def test_check_gemini_warns_on_disabled_telemetry(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {"telemetry": {"enabled": False}}
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert any("telemetry" in w and "disabled" in w for w in warnings)
+
+    def test_check_gemini_warns_on_missing_custom_target(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {"telemetry": {"enabled": True, "target": "default"}}
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert any("not configured" in w for w in warnings)
+
+    def test_check_gemini_warns_on_missing_otlp_endpoint(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {"telemetry": {"enabled": True, "target": "custom"}}
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert any("not configured" in w for w in warnings)
+
+    def test_check_gemini_no_warning_on_proper_telemetry(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {
+            "telemetry": {
+                "enabled": True,
+                "target": "custom",
+                "otlpEndpoint": "http://localhost:4318",
+                "logPrompts": True,
+            }
+        }
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+    def test_check_gemini_no_telemetry_block_means_no_warning(self):
+        """If there's no telemetry block at all, don't warn — user hasn't configured Observal yet."""
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {}
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+    def test_check_gemini_http_transport_skips_shim_warning(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {"mcpServers": {"my-srv": {"url": "http://localhost:3000/sse"}}}
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert not any("observal-shim" in w for w in warnings)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 19. SCAN — Gemini home directory scanning
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestScanGeminiHome:
+    def test_scan_gemini_home_finds_mcp_servers(self, tmp_path):
+        from observal_cli.cmd_scan import _scan_gemini_home
+
+        gemini_dir = tmp_path / ".gemini"
+        gemini_dir.mkdir()
+        settings = gemini_dir / "settings.json"
+        settings.write_text(json.dumps({"mcpServers": {"my-server": {"command": "python", "args": ["serve.py"]}}}))
+        mcps, skills, hooks, agents = _scan_gemini_home(gemini_dir)
+        assert len(mcps) == 1
+        assert mcps[0].name == "my-server"
+        assert mcps[0].source == "gemini:global"
+
+    def test_scan_gemini_home_empty_dir(self, tmp_path):
+        from observal_cli.cmd_scan import _scan_gemini_home
+
+        gemini_dir = tmp_path / ".gemini"
+        gemini_dir.mkdir()
+        mcps, skills, hooks, agents = _scan_gemini_home(gemini_dir)
+        assert len(mcps) == 0
+
+    def test_scan_gemini_home_handles_mcp_servers_wrapper(self, tmp_path):
+        from observal_cli.cmd_scan import _scan_gemini_home
+
+        gemini_dir = tmp_path / ".gemini"
+        gemini_dir.mkdir()
+        settings = gemini_dir / "settings.json"
+        settings.write_text(json.dumps({"mcpServers": {"wrapped": {"command": "npx"}}, "telemetry": {"enabled": True}}))
+        mcps, _, _, _ = _scan_gemini_home(gemini_dir)
+        assert len(mcps) == 1
+        assert mcps[0].name == "wrapped"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# BUG FIX REGRESSION TESTS
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestConfigGeneratorCodexFormat:
+    """Bug #4: config_generator should return mcp.servers (not mcpServers) for Codex."""
+
+    def _make_listing(self, name="my-mcp", framework="typescript", url=None, command=None, args=None):
+        from unittest.mock import MagicMock
+        import uuid
+
+        listing = MagicMock()
+        listing.id = uuid.uuid4()
+        listing.name = name
+        listing.framework = framework
+        listing.docker_image = None
+        listing.url = url
+        listing.transport = None
+        listing.auto_approve = None
+        listing.environment_variables = []
+        listing.command = command
+        listing.args = args
+        listing.headers = []
+        return listing
+
+    def test_stdio_codex_uses_mcp_servers_key(self):
+        from services.config_generator import generate_config
+
+        listing = self._make_listing(command="npx", args=["-y", "my-mcp"])
+        cfg = generate_config(listing, "codex")
+        # Must use "mcp.servers" not "mcpServers"
+        assert "mcp.servers" in cfg
+        assert "mcpServers" not in cfg
+
+    def test_stdio_codex_has_observal_shim(self):
+        from services.config_generator import generate_config
+
+        listing = self._make_listing(command="npx", args=["-y", "my-mcp"])
+        cfg = generate_config(listing, "codex")
+        servers = cfg["mcp.servers"]
+        assert len(servers) == 1
+        entry = next(iter(servers.values()))
+        assert entry["command"] == "observal-shim"
+
+    def test_stdio_codex_includes_codex_config(self):
+        from services.config_generator import generate_config
+
+        listing = self._make_listing(command="npx", args=["-y", "my-mcp"])
+        cfg = generate_config(listing, "codex")
+        assert "codex_config" in cfg
+        assert "toml_snippet" in cfg["codex_config"]
+
+    def test_proxy_codex_uses_mcp_servers_key(self):
+        from services.config_generator import generate_config
+
+        listing = self._make_listing(command="npx", args=["-y", "my-mcp"])
+        cfg = generate_config(listing, "codex", proxy_port=9000)
+        assert "mcp.servers" in cfg
+        assert "mcpServers" not in cfg
+
+    def test_sse_codex_uses_mcp_servers_key(self):
+        from services.config_generator import generate_config
+
+        listing = self._make_listing(url="https://example.com/mcp")
+        listing.transport = "sse"
+        cfg = generate_config(listing, "codex")
+        assert "mcp.servers" in cfg
+        assert "mcpServers" not in cfg
+
+    def test_sse_codex_entry_has_url(self):
+        from services.config_generator import generate_config
+
+        listing = self._make_listing(url="https://example.com/mcp")
+        listing.transport = "sse"
+        cfg = generate_config(listing, "codex")
+        entry = next(iter(cfg["mcp.servers"].values()))
+        assert entry["url"] == "https://example.com/mcp"
+
+    def test_mcp_servers_toml_renders_correctly(self):
+        """The mcp.servers dict should produce valid [mcp.servers.<name>] TOML."""
+        from observal_cli.cmd_pull import _dict_to_toml
+
+        servers = {"mcp.servers": {"my-server": {"command": "observal-shim", "args": ["--mcp-id", "abc", "--", "npx"]}}}
+        toml = _dict_to_toml(servers)
+        assert "[mcp.servers.my-server]" in toml
+        assert 'command = "observal-shim"' in toml
+
+
+class TestDoctorCodexTomlHandling:
+    """Bug #1 & #2: doctor command must use _load_toml and _check_codex for Codex configs."""
+
+    def test_doctor_check_fn_excludes_codex_from_json_dispatch(self):
+        """Codex should NOT be in the JSON check_fn dispatch — it's handled via TOML path."""
+        # The fix ensures the TOML branch is taken for codex, not the JSON branch.
+        # We test the _check_codex function is callable with parsed TOML data.
+        from observal_cli.cmd_doctor import _check_codex
+
+        issues: list = []
+        warnings: list = []
+        data = {
+            "mcp": {
+                "servers": {
+                    "my-server": {"command": "npx", "args": ["-y", "my-mcp"]}
+                }
+            }
+        }
+        _check_codex(data, issues, warnings)
+        # Should warn that server is not wrapped with observal-shim
+        assert len(warnings) > 0
+        assert any("observal-shim" in w for w in warnings)
+
+    def test_doctor_check_codex_no_warning_when_shimmed(self):
+        from observal_cli.cmd_doctor import _check_codex
+
+        issues: list = []
+        warnings: list = []
+        data = {
+            "mcp": {
+                "servers": {
+                    "shimmed": {"command": "observal-shim", "args": ["--mcp-id", "abc"]}
+                }
+            }
+        }
+        _check_codex(data, issues, warnings)
+        # Should NOT warn about observal-shim for shimmed server
+        shim_warnings = [w for w in warnings if "observal-shim" in w and "shimmed" in w]
+        assert len(shim_warnings) == 0
+
+    def test_doctor_codex_config_uses_toml_parser(self, tmp_path):
+        """When a Codex config.toml exists, doctor must load it with _load_toml."""
+        from observal_cli.cmd_doctor import _load_toml
+
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text('[mcp.servers.test]\ncommand = "npx"\n')
+        data = _load_toml(toml_file)
+        assert data is not None
+        assert "mcp" in data
+        assert "servers" in data["mcp"]
+        assert "test" in data["mcp"]["servers"]
+
+    def test_doctor_check_codex_warns_on_missing_otel_config(self):
+        from observal_cli.cmd_doctor import _check_codex
+
+        issues: list = []
+        warnings: list = []
+        # No mcp, no otel
+        _check_codex({}, issues, warnings)
+        assert len(warnings) > 0
+        assert any("OTel" in w or "MCP" in w or "otel" in w.lower() or "mcp" in w.lower() for w in warnings)
+
+
+class TestOtlpIdeDetection:
+    """Bug #5: OTLP IDE detection should recognize 'opencode' service name."""
+
+    @pytest.fixture
+    def otlp_source(self):
+        """Read _IDE_HINTS and _detect_ide directly from source to avoid heavy server deps."""
+        import pathlib
+
+        src_path = pathlib.Path(__file__).parent.parent / "observal-server" / "api" / "routes" / "otlp.py"
+        source = src_path.read_text()
+        return source
+
+    def test_opencode_in_ide_hints_source(self, otlp_source):
+        assert '"opencode": "opencode"' in otlp_source or "'opencode': 'opencode'" in otlp_source
+
+    def test_codex_in_ide_hints_source(self, otlp_source):
+        assert '"codex": "codex"' in otlp_source or "'codex': 'codex'" in otlp_source
+
+    def test_detect_ide_returns_opencode(self, otlp_source):
+        """opencode service.name should map to opencode IDE."""
+        # Verify both the hint entry exists and the _detect_ide function uses it
+        assert '"opencode"' in otlp_source or "'opencode'" in otlp_source
+        assert "_IDE_HINTS" in otlp_source
+        assert "_detect_ide" in otlp_source
+
+    def test_detect_ide_returns_codex(self, otlp_source):
+        """codex-* service.name should match codex via substring check."""
+        assert '"codex": "codex"' in otlp_source or "'codex': 'codex'" in otlp_source
+
+
+class TestCodexInstallCliPathHint:
+    """Bug #6: install command should show the correct path hint for Codex."""
+
+    def test_ide_config_paths_includes_codex(self):
+        """The MCP install command's path hint dict must include codex."""
+        import inspect
+
+        # Read the cmd_mcp.py file and verify codex is in ide_config_paths
+        import observal_cli.cmd_mcp as cmd_mcp_module
+
+        # Find the ide_config_paths dict in the install function's source
+        source = inspect.getsource(cmd_mcp_module)
+        assert '"codex": "~/.codex/config.toml"' in source or "'codex': '~/.codex/config.toml'" in source

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -270,7 +270,7 @@ class TestGenerateOpenCodeConfig:
         entry = cfg["mcp_config"]["content"]["mcp"]["my-server"]
         old_cmd = "npx"
         old_args = ["-y", "my-server"]
-        full_cmd = [entry["command"][0]] + entry["command"][1:]
+        full_cmd = [entry["command"][0], *entry["command"][1:]]
         assert "--mcp-id" in entry["command"]
         assert "--" in entry["command"]
         idx_dash = entry["command"].index("--")
@@ -1018,7 +1018,7 @@ class TestDoctorCopilot:
         _check_copilot(Path(".vscode/mcp.json"), data, issues, warnings)
         assert len(warnings) == 0
 
-    def test_check_copilot_fn_handles_mcpServers_fallback(self):
+    def test_check_copilot_fn_handles_mcp_servers_fallback(self):
         from pathlib import Path
 
         from observal_cli.cmd_doctor import _check_copilot
@@ -1511,8 +1511,8 @@ class TestConfigGeneratorCodexFormat:
     """Bug #4: config_generator should return mcp.servers (not mcpServers) for Codex."""
 
     def _make_listing(self, name="my-mcp", framework="typescript", url=None, command=None, args=None):
-        from unittest.mock import MagicMock
         import uuid
+        from unittest.mock import MagicMock
 
         listing = MagicMock()
         listing.id = uuid.uuid4()

--- a/tests/test_shim_phase3.py
+++ b/tests/test_shim_phase3.py
@@ -302,6 +302,16 @@ class TestConfigGenerator:
         server = cfg["mcpServers"]["my-mcp"]
         assert server["command"] == "observal-shim"
 
+    def test_copilot_wraps_with_shim_and_type_stdio(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "copilot")
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["type"] == "stdio"
+        assert server["command"] == "observal-shim"
+        assert "--mcp-id" in server["args"]
+        assert "abc-123" in server["args"]
+
 
 class TestAgentConfigGenerator:
     def _make_agent(self, name="test-agent", agent_id="agent-xyz"):

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -13,6 +13,7 @@ const IDE_OPTIONS = [
   { value: "gemini-cli", label: "Gemini CLI" },
   { value: "codex", label: "Codex" },
   { value: "copilot", label: "Copilot" },
+  { value: "opencode", label: "OpenCode" },
 ] as const;
 
 type Ide = (typeof IDE_OPTIONS)[number]["value"];
@@ -259,6 +260,30 @@ function generateCopilot(body: string): PreviewFile[] {
   ];
 }
 
+function generateOpenCode(
+  mcps: { id: string; name: string }[],
+  body: string,
+): PreviewFile[] {
+  const files: PreviewFile[] = [
+    { path: "AGENTS.md", content: body || "", language: "markdown" },
+  ];
+  if (mcps.length > 0) {
+    const mcp: Record<string, object> = {};
+    for (const m of mcps) {
+      mcp[m.name] = {
+        type: "local",
+        command: ["observal-shim", "--mcp-id", m.id, "--", "python", "-m", m.name],
+      };
+    }
+    files.push({
+      path: "opencode.json",
+      content: JSON.stringify({ mcp }, null, 2),
+      language: "json",
+    });
+  }
+  return files;
+}
+
 // ── Main component ────────────────────────────────────────────
 
 export function PreviewPanel({
@@ -297,6 +322,9 @@ export function PreviewPanel({
       break;
     case "copilot":
       files = generateCopilot(body);
+      break;
+    case "opencode":
+      files = generateOpenCode(mcps, body);
       break;
   }
 

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -203,6 +203,26 @@ function generateKiro(
   ];
 }
 
+function buildGeminiSettings(mcps: { id: string; name: string }[]): string {
+  const servers: Record<string, object> = {};
+  for (const mcp of mcps) {
+    servers[mcp.name] = {
+      command: "observal-shim",
+      args: ["--mcp-id", mcp.id, "--", "python", "-m", mcp.name],
+    };
+  }
+  const settings: Record<string, unknown> = {
+    telemetry: {
+      enabled: true,
+      target: "custom",
+      otlpEndpoint: "http://localhost:4318",
+      logPrompts: true,
+    },
+    mcpServers: servers,
+  };
+  return JSON.stringify(settings, null, 2);
+}
+
 function generateGemini(
   mcps: { id: string; name: string }[],
   body: string,
@@ -210,13 +230,18 @@ function generateGemini(
   const files: PreviewFile[] = [
     { path: "GEMINI.md", content: body || "", language: "markdown" },
   ];
-  if (mcps.length > 0) {
-    files.push({
-      path: ".gemini/mcp.json",
-      content: buildMcpJson(mcps),
-      language: "json",
-    });
-  }
+  files.push({
+    path: ".gemini/settings.json",
+    content: mcps.length > 0 ? buildGeminiSettings(mcps) : JSON.stringify({
+      telemetry: {
+        enabled: true,
+        target: "custom",
+        otlpEndpoint: "http://localhost:4318",
+        logPrompts: true,
+      },
+    }, null, 2),
+    language: "json",
+  });
   return files;
 }
 

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -34,7 +34,7 @@ const MCP_FRAMEWORKS = ["python", "docker", "typescript", "go"];
 const MCP_TRANSPORTS = ["stdio", "sse", "streamable-http"];
 
 const VALID_IDES = [
-  "cursor", "kiro", "claude-code", "gemini-cli", "vscode", "codex", "copilot",
+  "cursor", "kiro", "claude-code", "gemini-cli", "vscode", "codex", "copilot", "opencode",
 ];
 
 const SKILL_TASK_TYPES = [

--- a/web/src/lib/ide-features.ts
+++ b/web/src/lib/ide-features.ts
@@ -10,6 +10,7 @@ export const VALID_IDES = [
   "cursor",
   "gemini-cli",
   "kiro",
+  "opencode",
   "vscode",
 ] as const;
 
@@ -33,7 +34,8 @@ export const IDE_FEATURE_MATRIX: Record<IdeName, ReadonlySet<IdeFeature>> = {
   cursor: new Set(["mcp_servers", "rules"]),
   "gemini-cli": new Set(["mcp_servers", "rules"]),
   codex: new Set(["rules"]),
-  copilot: new Set(["rules"]),
+  copilot: new Set(["mcp_servers", "rules"]),
+  opencode: new Set(["mcp_servers", "rules"]),
   vscode: new Set(["mcp_servers", "rules"]),
 };
 
@@ -44,6 +46,7 @@ export const IDE_DISPLAY_NAMES: Record<IdeName, string> = {
   "gemini-cli": "Gemini CLI",
   codex: "Codex",
   copilot: "Copilot",
+  opencode: "OpenCode",
   vscode: "VS Code",
 };
 


### PR DESCRIPTION
## Summary

Addresses all feature parity gaps between the existing well-supported IDEs (Claude Code, Kiro) and the four new IDEs added in #472. Seven atomic commits, one per gap:

### Blockers (runtime crashes)
1. **`agent_builder.py`** — Add `_generate_opencode()` (flat command arrays, `opencode.json`) and fix `_generate_gemini_cli()` to emit `.gemini/settings.json` with telemetry + MCP config. Both were missing generators, causing `ValueError` on the builder API.
2. **`preview-panel.tsx`** — Add OpenCode to `IDE_OPTIONS`, `generateOpenCode()`, and the switch statement. Was missing entirely from the builder preview.

### Significant gaps
3. **`cmd_auth.py`** — Add `_configure_copilot()` to all three auth flows (login, register, password login). Copilot was the only new IDE missing from the configure chain.
4. **`cmd_profile.py`** — Add `~/.codex/config.toml` to `IDE_FILE_MAP`. Codex was the only new IDE missing from profile swap.
5. **`cmd_scan.py` + `cmd_auth.py`** — Add `_scan_codex_home()`, `_scan_copilot_home()`, `_scan_opencode_home()`. Wire into `--home`, `--all-ides`, and post-auth onboarding upload. Only Gemini CLI had a home scan function among the new IDEs.
6. **`cmd_scan.py`** — Add `_auto_shim_home_config()` for Codex, Copilot, and OpenCode. These IDEs lack native hook systems, so wrapping MCP servers with observal-shim during scan is their primary telemetry path — matching what hooks do for Claude Code and Kiro.

Depends on #472 — should be merged after or squashed into that PR.

## Test plan

- [x] `tests/test_ide_config_e2e.py`: 169 passed
- [x] `tests/test_agent_composition.py` builder/IDE tests: 30 passed
- [x] `tests/test_shim_phase3.py`: all passed
- [x] `tests/test_agent_config_generator.py`: all passed
- [x] `tests/test_config_generator_utils.py`: all passed
- [x] Zero new test failures (all failures are pre-existing on the PR branch)