### PR TITLE
fix: preserve header values in MCP config preview

### DIFF
--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -244,10 +244,12 @@ def _parse_direct_config(cfg: dict) -> dict:
         parsed["transport"] = transport
         parsed["url"] = inner["url"]
 
-        # Convert headers dict {name: value} → list of {name, description, required}
+        # Convert headers dict {name: value} → list of {name, value, description, required}
         raw_headers = inner.get("headers") or {}
         if isinstance(raw_headers, dict):
-            parsed["headers"] = [{"name": k, "description": "", "required": True} for k in raw_headers]
+            parsed["headers"] = [
+                {"name": k, "value": v, "description": "", "required": True} for k, v in raw_headers.items()
+            ]
         elif isinstance(raw_headers, list):
             parsed["headers"] = raw_headers
 
@@ -259,8 +261,8 @@ def _parse_direct_config(cfg: dict) -> dict:
         if isinstance(raw_env, dict):
             parsed["environment_variables"] = [{"name": k, "description": "", "required": True} for k in raw_env]
 
-        # Detect $VAR references in env values
-        dollar_vars = _extract_dollar_vars([], raw_env)
+        # Detect $VAR references in header values and env values
+        dollar_vars = _extract_dollar_vars([], {**raw_headers, **raw_env})
         existing_names = {ev["name"] for ev in parsed.get("environment_variables", [])}
         for var_name in dollar_vars:
             if var_name not in existing_names:
@@ -326,7 +328,7 @@ def _build_config_preview(server_name: str, parsed: dict) -> dict:
         preview["type"] = parsed.get("transport", "sse")
         preview["url"] = parsed["url"]
         if parsed.get("headers"):
-            preview["headers"] = {h["name"]: f"<{h['name']}>" for h in parsed["headers"]}
+            preview["headers"] = {h["name"]: h.get("value", f"<{h['name']}>") for h in parsed["headers"]}
         env_vars = parsed.get("environment_variables") or []
         if env_vars:
             preview["env"] = {ev["name"]: f"<{ev['name']}>" for ev in env_vars}


### PR DESCRIPTION
## Purpose / Description
When submitting an MCP server config with header values containing `$` env var references (e.g. `"Authorization": "Bearer $APPIAN_TOKEN"`), the Config Preview displayed `<Authorization>` instead of the actual value. The header values were being discarded during parsing, and the preview substituted placeholder text.

## Fixes
* Fixes header values being lost during third-party MCP config submission

## Approach
Three changes in `observal_cli/cmd_mcp.py`:

1. **Preserve header values during parsing** (`_parse_direct_config`): The dict-to-list conversion now stores the original value (`"value": v`) instead of only the key name.
2. **Extend `$VAR` detection to headers** (`_parse_direct_config`): `_extract_dollar_vars` now scans both `raw_headers` and `raw_env` values, so `$APPIAN_TOKEN` in a header is properly detected as an environment variable reference.
3. **Show actual values in preview** (`_build_config_preview`): Uses `h.get("value", ...)` to display the real header value, falling back to the `<name>` placeholder only when no value is stored.

## How Has This Been Tested?

- Manually verified that pasting an SSE MCP config with `"Authorization": "Bearer $APPIAN_TOKEN"` now shows the correct value in the Config Preview instead of `<Authorization>`
- Verified that `$VAR` references in header values are detected and surfaced as environment variables
- Confirmed existing configs without header values still fall back to the `<name>` placeholder

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)