### PR TITLE
fix(cli): decouple scan from registry registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ docker/data/
 CLAUDE.md
 graphify-out/
 observal-web/tsconfig.tsbuildinfo
+.worktrees/

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -547,12 +547,17 @@ async def token_stats(
     mcp_ids = [r["mcp_id"] for r in by_mcp_rows if r.get("mcp_id")]
     mcp_names: dict[str, str] = {}
     if mcp_ids:
-        rows = (
-            await db.execute(
-                select(McpListing.id, McpListing.name).where(McpListing.id.in_([uuid.UUID(m) for m in mcp_ids]))
-            )
-        ).all()
-        mcp_names = {str(r.id): r.name for r in rows}
+        valid_uuids = []
+        for m in mcp_ids:
+            try:
+                valid_uuids.append(uuid.UUID(m))
+            except (ValueError, AttributeError):
+                pass
+        if valid_uuids:
+            rows = (
+                await db.execute(select(McpListing.id, McpListing.name).where(McpListing.id.in_(valid_uuids)))
+            ).all()
+            mcp_names = {str(r.id): r.name for r in rows}
     by_mcp = [
         TokenByEntity(
             id=r["mcp_id"],

--- a/observal-server/api/routes/scan.py
+++ b/observal-server/api/routes/scan.py
@@ -1,6 +1,13 @@
-"""Bulk scan endpoint: register multiple component types in one call."""
+"""Bulk scan endpoint: register multiple component types in one call.
 
-from fastapi import APIRouter, Depends
+DEPRECATED: The CLI no longer calls this endpoint as of the scan redesign.
+Kept for backwards compatibility with older CLI versions. Use
+'observal registry <type> submit' for explicit component publishing.
+"""
+
+import warnings
+
+from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -83,12 +90,15 @@ class ScanResponse(BaseModel):
 # ── Endpoint ────────────────────────────────────────────────
 
 
-@router.post("", response_model=ScanResponse)
+@router.post("", response_model=ScanResponse, deprecated=True)
 async def bulk_scan(
     req: ScanRequest,
+    response: Response,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
+    response.headers["X-Deprecated"] = "Use 'observal registry <type> submit' instead"
+    warnings.warn("POST /api/v1/scan is deprecated; use explicit submit endpoints", DeprecationWarning, stacklevel=1)
     registered = []
     counts: dict[str, int] = {"mcp": 0, "skill": 0, "hook": 0, "agent": 0}
 

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -425,7 +425,7 @@ def _find_hook_script(name: str) -> str | None:
 
 
 def _post_auth_onboarding():
-    """Detect local IDE configs and offer to scan+register components."""
+    """Detect local IDE configs and show what was found."""
     try:
         _ide_dirs = {
             "Claude Code": (Path.home() / ".claude", "claude-code"),
@@ -433,7 +433,6 @@ def _post_auth_onboarding():
             "Cursor": (Path.home() / ".cursor", "cursor"),
         }
 
-        # Quick local scan: count components per IDE (no API calls)
         found: list[tuple[str, str, int, int]] = []  # (label, ide_key, agents, mcps)
         for label, (dir_path, ide_key) in _ide_dirs.items():
             if not dir_path.is_dir():
@@ -450,7 +449,6 @@ def _post_auth_onboarding():
                 m, _s, _h, a = _scan_kiro_home(dir_path)
                 agents, mcps = len(a), len(m)
             else:
-                # Cursor: just check for mcp.json
                 mcp_file = dir_path / "mcp.json"
                 if mcp_file.exists():
                     try:
@@ -466,10 +464,8 @@ def _post_auth_onboarding():
         if not found:
             return
 
-        # Show what we found
         rprint()
-        rprint("[bold]\N{ELECTRIC LIGHT BULB} You have local agent configs that aren't in Observal.[/bold]")
-        rprint("[dim]Upload them to track usage, share with your team, and enable telemetry.[/dim]")
+        rprint("[bold]Detected local IDE components:[/bold]")
         rprint()
         for label, _key, agents, mcps in found:
             parts = []
@@ -479,115 +475,15 @@ def _post_auth_onboarding():
                 parts.append(f"{mcps} MCP{'s' if mcps != 1 else ''}")
             rprint(f"  [bold]{label}[/bold] — {', '.join(parts)} found")
         rprint()
-
-        if not typer.confirm("Upload these to Observal?", default=True):
-            rprint("[dim]Tip: run `observal scan --home --all-ides` anytime to upload agents from your IDEs.[/dim]")
-            return
-
-        # Run scan for each selected IDE using the existing scan machinery
-        from observal_cli import client
-        from observal_cli.cmd_scan import _scan_claude_home, _scan_kiro_home
-        from observal_cli.render import spinner
-
-        all_mcps: list = []
-        all_skills: list = []
-        all_hooks: list = []
-        all_agents: list = []
-
-        for _label, ide_key, _a, _m in found:
-            if ide_key == "claude-code":
-                m, s, h, a = _scan_claude_home(Path.home() / ".claude")
-                all_mcps.extend(m)
-                all_skills.extend(s)
-                all_hooks.extend(h)
-                all_agents.extend(a)
-            elif ide_key == "kiro":
-                m, s, h, a = _scan_kiro_home(Path.home() / ".kiro")
-                all_mcps.extend(m)
-                all_skills.extend(s)
-                all_hooks.extend(h)
-                all_agents.extend(a)
-
-        total = len(all_mcps) + len(all_skills) + len(all_hooks) + len(all_agents)
-        if total == 0:
-            return
-
-        def _ide_from_source(source: str) -> str:
-            if source.startswith("kiro:"):
-                return "kiro"
-            if source.startswith("plugin:") or source.startswith("claude:"):
-                return "claude-code"
-            return "auto"
-
-        scan_payload = {
-            "ide": "multi",
-            "mcps": [
-                {
-                    "name": m.name,
-                    "command": m.command,
-                    "args": m.args,
-                    "url": m.url,
-                    "description": m.description,
-                    "source_plugin": m.source,
-                    "source_ide": _ide_from_source(m.source),
-                }
-                for m in all_mcps
-            ],
-            "skills": [
-                {
-                    "name": s.name,
-                    "description": s.description,
-                    "source_plugin": s.source,
-                    "task_type": getattr(s, "task_type", "general"),
-                    "source_ide": _ide_from_source(s.source),
-                }
-                for s in all_skills
-            ],
-            "hooks": [
-                {
-                    "name": h.name,
-                    "event": h.event,
-                    "handler_type": h.handler_type,
-                    "handler_config": h.handler_config,
-                    "description": h.description,
-                    "source_plugin": h.source,
-                    "source_ide": _ide_from_source(h.source),
-                }
-                for h in all_hooks
-            ],
-            "agents": [
-                {
-                    "name": a.name,
-                    "description": a.description,
-                    "model_name": a.model_name or "",
-                    "prompt": a.prompt,
-                    "source_file": a.source_file,
-                    "source_ide": _ide_from_source(
-                        f"kiro:{a.source_file}" if a.source_file and ".kiro" in a.source_file else a.source_file or ""
-                    ),
-                }
-                for a in all_agents
-            ],
-        }
-
-        with spinner(f"Registering {total} components..."):
-            try:
-                result = client.post("/api/v1/scan", scan_payload)
-            except Exception as e:
-                rprint(f"[yellow]Registration failed: {e}[/yellow]")
-                rprint("[dim]Tip: run `observal scan --home --all-ides` to retry.[/dim]")
-                return
-
-        summary = result.get("summary", {})
-        parts = [f"{v} {k}" for k, v in summary.items() if v]
-        if parts:
-            rprint(f"[green]Registered: {', '.join(parts)}[/green]")
-        else:
-            rprint("[dim]All components already registered.[/dim]")
+        rprint("[dim]Telemetry hooks are now configured. Your IDE sessions will be tracked.[/dim]")
+        rprint("[dim]Tip: Run 'observal scan --shim' in a project dir to wrap MCP configs with telemetry shims.[/dim]")
+        rprint(
+            "[dim]Tip: Run 'observal registry <type> submit <git_url>' to publish a component."
+            " Only submit if you are the creator or point-of-contact.[/dim]"
+        )
 
     except Exception as e:
         rprint(f"[yellow]Onboarding skipped: {e}[/yellow]")
-        rprint("[dim]Tip: run `observal scan --home --all-ides` anytime to upload agents from your IDEs.[/dim]")
 
 
 def _configure_kiro(server_url: str):

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -28,7 +28,11 @@ def hook_submit(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (hook ID)"),
 ):
-    """Submit a new hook for review."""
+    """Submit a new hook for review.
+
+    Only submit hooks you created or are the point-of-contact for.
+    """
+    rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
     if draft and submit_draft:
         rprint(
             "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -983,7 +983,10 @@ def submit(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (MCP ID)"),
 ):
-    """Submit an MCP server for review."""
+    """Submit an MCP server for review.
+
+    Only submit servers you created or are the point-of-contact for.
+    """
     if draft and submit_draft:
         rprint(
             "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
@@ -1000,6 +1003,7 @@ def submit(
     if not git_url and not config:
         rprint("[red]Provide a git URL or use --config[/red]")
         raise typer.Exit(1)
+    rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
     _submit_impl(git_url, name, category, yes, config, draft=draft)
 
 

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -28,7 +28,11 @@ def prompt_submit(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (prompt ID)"),
 ):
-    """Submit a new prompt for review."""
+    """Submit a new prompt for review.
+
+    Only submit prompts you created or are the point-of-contact for.
+    """
+    rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
     if draft and submit_draft:
         rprint(
             "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -26,7 +26,11 @@ def sandbox_submit(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (sandbox ID)"),
 ):
-    """Submit a new sandbox for review."""
+    """Submit a new sandbox for review.
+
+    Only submit sandboxes you created or are the point-of-contact for.
+    """
+    rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
     if draft and submit_draft:
         rprint(
             "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -22,6 +22,7 @@ def _deterministic_mcp_id(name: str) -> str:
     """Generate a stable UUID for an MCP based on its name."""
     return str(uuid.uuid5(_OBSERVAL_NS, name))
 
+
 # ── IDE config file locations (relative to project root) ────
 
 _IDE_PROJECT_CONFIGS = {
@@ -549,9 +550,7 @@ def register_scan(app: typer.Typer):
         all_ides: bool = typer.Option(
             False, "--all-ides", help="Scan home directories for ALL IDEs (Claude Code, Kiro, Cursor)"
         ),
-        dry_run: bool = typer.Option(
-            False, "--dry-run", "-n", help="Show discovered components without instrumenting"
-        ),
+        dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show discovered components without instrumenting"),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
         shim: bool = typer.Option(
             False, "--shim", help="Rewrite project IDE configs to route MCPs through observal-shim"

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -1,10 +1,11 @@
-"""observal scan: auto-detect IDE configs, register items, wrap with telemetry shims."""
+"""observal scan: auto-detect IDE configs, discover components, and instrument for telemetry."""
 
 from __future__ import annotations
 
 import json
 import re
 import shutil
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -12,8 +13,14 @@ import typer
 from rich import print as rprint
 from rich.table import Table
 
-from observal_cli import client
 from observal_cli.render import console, spinner
+
+_OBSERVAL_NS = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+
+def _deterministic_mcp_id(name: str) -> str:
+    """Generate a stable UUID for an MCP based on its name."""
+    return str(uuid.uuid5(_OBSERVAL_NS, name))
 
 # ── IDE config file locations (relative to project root) ────
 
@@ -543,14 +550,14 @@ def register_scan(app: typer.Typer):
             False, "--all-ides", help="Scan home directories for ALL IDEs (Claude Code, Kiro, Cursor)"
         ),
         dry_run: bool = typer.Option(
-            False, "--dry-run", "-n", help="Show what would be registered without making changes"
+            False, "--dry-run", "-n", help="Show discovered components without instrumenting"
         ),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
         shim: bool = typer.Option(
             False, "--shim", help="Rewrite project IDE configs to route MCPs through observal-shim"
         ),
     ):
-        """Scan IDE configs and register discovered components with Observal.
+        """Discover IDE components and instrument for telemetry.
 
         By default, scans the current project directory for Cursor, VS Code, Kiro,
         and Gemini CLI MCP configs.
@@ -560,6 +567,9 @@ def register_scan(app: typer.Typer):
 
         With --all-ides, scans ~/.claude, ~/.kiro, and ~/.cursor to discover
         all agents, MCP servers, skills, and hooks across every IDE you use.
+
+        Components are NOT published to the registry. Use 'observal registry <type>
+        submit' to explicitly publish when ready.
         """
         all_mcps: list[DiscoveredMcp] = []
         all_skills: list[DiscoveredSkill] = []
@@ -679,119 +689,40 @@ def register_scan(app: typer.Typer):
 
         if dry_run:
             rprint("[yellow]Dry run — no changes made.[/yellow]")
+            rprint(
+                "[dim]Tip: Use 'observal registry <type> submit <git_url>' to publish components."
+                " Only submit if you are the creator or point-of-contact.[/dim]"
+            )
             return
-
-        if not yes and not typer.confirm("Register these components with Observal?"):
-            raise typer.Abort()
-
-        # ── Register via bulk scan API ──────────────
-        def _ide_from_source(source: str) -> str:
-            """Infer source IDE from component source string."""
-            if source.startswith("kiro:"):
-                return "kiro"
-            if source.startswith("plugin:") or source.startswith("claude:"):
-                return "claude-code"
-            return ide or "auto"
-
-        scan_payload = {
-            "ide": ide or ("multi" if all_ides else ("claude-code" if home else "auto")),
-            "mcps": [
-                {
-                    "name": m.name,
-                    "command": m.command,
-                    "args": m.args,
-                    "url": m.url,
-                    "description": m.description,
-                    "source_plugin": m.source,
-                    "source_ide": _ide_from_source(m.source),
-                }
-                for m in all_mcps
-            ],
-            "skills": [
-                {
-                    "name": s.name,
-                    "description": s.description,
-                    "source_plugin": s.source,
-                    "task_type": s.task_type,
-                    "source_ide": _ide_from_source(s.source),
-                }
-                for s in all_skills
-            ],
-            "hooks": [
-                {
-                    "name": h.name,
-                    "event": h.event,
-                    "handler_type": h.handler_type,
-                    "handler_config": h.handler_config,
-                    "description": h.description,
-                    "source_plugin": h.source,
-                    "source_ide": _ide_from_source(h.source),
-                }
-                for h in all_hooks
-            ],
-            "agents": [
-                {
-                    "name": a.name,
-                    "description": a.description,
-                    "model_name": a.model_name,
-                    "prompt": a.prompt,
-                    "source_file": a.source_file,
-                    "source_ide": _ide_from_source(
-                        f"kiro:{a.source_file}" if a.source_file and ".kiro" in a.source_file else a.source_file or ""
-                    ),
-                }
-                for a in all_agents
-            ],
-        }
-
-        with spinner(f"Registering {total} components..."):
-            try:
-                result = client.post("/api/v1/scan", scan_payload)
-            except (Exception, SystemExit) as e:
-                rprint(f"[red]Failed to register: {e}[/red]")
-                raise typer.Exit(1) from None
-
-        # Show registration results
-        new_count = 0
-        existing_count = 0
-        for reg in result.get("registered", []):
-            if reg["status"] == "created":
-                rprint(f"  [green]+ new[/green] [{reg['type']}] {reg['name']} -> {reg['id'][:8]}...")
-                new_count += 1
-            else:
-                rprint(f"  [dim]= existing[/dim] [{reg['type']}] {reg['name']}")
-                existing_count += 1
-
-        rprint(f"\n[green]Done![/green] {new_count} new, {existing_count} existing.")
 
         # ── Optionally shim project MCP configs ─────
         if shim and project_mcp_entries:
-            id_map = {r["name"]: r["id"] for r in result.get("registered", []) if r["type"] == "mcp"}
-            shimmed_count = 0
-            configs_to_update: dict[str, dict] = {}
+            if not yes and not typer.confirm("Rewrite project MCP configs to add telemetry shims?"):
+                rprint("[dim]Skipped shimming.[/dim]")
+            else:
+                shimmed_count = 0
+                configs_to_update: dict[str, dict] = {}
 
-            for ide_name, name, _mcp, config_path in project_mcp_entries:
-                mcp_id = id_map.get(name)
-                if not mcp_id:
-                    continue
-                path_str = str(config_path)
-                if path_str not in configs_to_update:
-                    configs_to_update[path_str] = json.loads(config_path.read_text())
+                for ide_name, name, _mcp, config_path in project_mcp_entries:
+                    mcp_id = _deterministic_mcp_id(name)
+                    path_str = str(config_path)
+                    if path_str not in configs_to_update:
+                        configs_to_update[path_str] = json.loads(config_path.read_text())
 
-                config = configs_to_update[path_str]
-                servers = _parse_project_mcp_servers(config, ide_name)
-                if name in servers and not _is_already_shimmed(servers[name]):
-                    servers[name] = _wrap_with_shim(servers[name], mcp_id)
-                    shimmed_count += 1
+                    config = configs_to_update[path_str]
+                    servers = _parse_project_mcp_servers(config, ide_name)
+                    if name in servers and not _is_already_shimmed(servers[name]):
+                        servers[name] = _wrap_with_shim(servers[name], mcp_id)
+                        shimmed_count += 1
 
-            for path_str, config in configs_to_update.items():
-                config_path = Path(path_str)
-                backup = _backup_config(config_path)
-                config_path.write_text(json.dumps(config, indent=2) + "\n")
-                rprint(f"  [dim]Backup: {backup.name}[/dim]")
+                for path_str, config in configs_to_update.items():
+                    config_path = Path(path_str)
+                    backup = _backup_config(config_path)
+                    config_path.write_text(json.dumps(config, indent=2) + "\n")
+                    rprint(f"  [dim]Backup: {backup.name}[/dim]")
 
-            if shimmed_count:
-                rprint(f"[green]Shimmed {shimmed_count} MCP entries for telemetry.[/green]")
+                if shimmed_count:
+                    rprint(f"[green]Shimmed {shimmed_count} MCP entries for telemetry.[/green]")
 
         # ── Auto-inject hooks into ~/.claude/settings.json ─────
         if scan_claude:
@@ -1054,3 +985,9 @@ def register_scan(app: typer.Typer):
                 rprint("[dim]These capture all Kiro sessions, including agentless chat.[/dim]")
             else:
                 rprint("[dim]Global Kiro hooks already configured.[/dim]")
+
+        rprint()
+        rprint(
+            "[dim]Tip: Use 'observal registry <type> submit <git_url>' to publish components to the shared registry."
+            " Only submit if you are the creator or point-of-contact.[/dim]"
+        )

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -26,7 +26,11 @@ def skill_submit(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (skill ID)"),
 ):
-    """Submit a new skill for review."""
+    """Submit a new skill for review.
+
+    Only submit skills you created or are the point-of-contact for.
+    """
+    rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
     if draft and submit_draft:
         rprint(
             "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -10,6 +10,7 @@ import {
   ArrowRight,
   Save,
   FileText,
+  Info,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
@@ -1081,6 +1082,10 @@ function AgentBuilderInner() {
             <Separator />
 
             {/* Publish */}
+            <div className="flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+              <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span>Only submit agents you created or are the point-of-contact for.</span>
+            </div>
             <div className="flex items-center gap-3 animate-in stagger-3">
               {!isEditMode && (
                 <Button

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -18,7 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Loader2, Plus, X } from "lucide-react";
+import { Info, Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
 import type { RegistryType } from "@/lib/api";
 
@@ -298,6 +298,11 @@ export function SubmitComponentDialog({
         </DialogHeader>
 
         <div className="space-y-4 pt-2">
+          <div className="flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>Only submit components you created (private) or are the point-of-contact for (external).</span>
+          </div>
+
           {/* ── Common fields ──────────────────────────────── */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">


### PR DESCRIPTION
## Summary

- **Scan no longer registers components in the registry.** It discovers IDE components and instruments them for telemetry (shims + hooks) — nothing more. Publishing is now always explicit via `observal registry <type> submit`.
- **Post-login onboarding is informational only.** No more "Upload these to Observal?" prompt that auto-registers everything.
- **Ownership tooltips added to all submit commands** (mcp, skill, hook, prompt, sandbox) — guides users to only submit components they created or are POC for.
- **Server `/api/v1/scan` endpoint deprecated** but kept for backwards compatibility with older CLI versions.
- **Dashboard UUID parsing hardened** to gracefully handle deterministic UUIDs from shimmed MCPs.

### Why

The scan command conflated discovery with publishing, causing:
1. First-scanner-wins ownership — whoever scans "github-mcp-server" first becomes the owner
2. Wrong attribution in teams — users who aren't creators could claim components
3. Junk `pending` entries flooding admin review with no `git_url`
4. Post-login onboarding auto-registering everything on confirmation

### Technical details

- Shim now uses deterministic `uuid5(OBSERVAL_NS, mcp_name)` instead of server-assigned UUIDs — same MCP name always gets the same telemetry ID, no server round-trip needed
- Net -132 lines (107 added, 239 removed)

## Test plan

- [x] `make test` — 1415 tests pass
- [x] `make lint` — clean
- [x] Grep confirms zero `client.post.*scan` calls remain in `cmd_scan.py` and `cmd_auth.py`
- [x] Manual: `observal scan --home --dry-run` discovers without server call
- [x] Manual: `observal auth login` shows components informationally, no upload prompt
- [x] Manual: `observal registry mcp submit` shows ownership tooltip