### PR TITLE
feat: interactive component registration during post-auth onboarding

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -465,7 +465,8 @@ def _post_auth_onboarding():
             return
 
         rprint()
-        rprint("[bold]Detected local IDE components:[/bold]")
+        rprint("[bold]\N{ELECTRIC LIGHT BULB} You have local agent configs that aren't in Observal.[/bold]")
+        rprint("[dim]Register them to track usage, share with your team, and enable telemetry.[/dim]")
         rprint()
         for label, _key, agents, mcps in found:
             parts = []
@@ -475,15 +476,120 @@ def _post_auth_onboarding():
                 parts.append(f"{mcps} MCP{'s' if mcps != 1 else ''}")
             rprint(f"  [bold]{label}[/bold] — {', '.join(parts)} found")
         rprint()
-        rprint("[dim]Telemetry hooks are now configured. Your IDE sessions will be tracked.[/dim]")
-        rprint("[dim]Tip: Run 'observal scan --shim' in a project dir to wrap MCP configs with telemetry shims.[/dim]")
-        rprint(
-            "[dim]Tip: Run 'observal registry <type> submit <git_url>' to publish a component."
-            " Only submit if you are the creator or point-of-contact.[/dim]"
-        )
+
+        if not typer.confirm("Register these in Observal?", default=True):
+            rprint()
+            rprint("[dim]You can register these anytime by running:[/dim]")
+            rprint("  [bold]observal scan --home --all-ides[/bold]")
+            return
+
+        # Run scan for each selected IDE using the existing scan machinery
+        from observal_cli import client
+        from observal_cli.cmd_scan import _scan_claude_home, _scan_kiro_home
+        from observal_cli.render import spinner
+
+        all_mcps: list = []
+        all_skills: list = []
+        all_hooks: list = []
+        all_agents: list = []
+
+        for _label, ide_key, _a, _m in found:
+            if ide_key == "claude-code":
+                m, s, h, a = _scan_claude_home(Path.home() / ".claude")
+                all_mcps.extend(m)
+                all_skills.extend(s)
+                all_hooks.extend(h)
+                all_agents.extend(a)
+            elif ide_key == "kiro":
+                m, s, h, a = _scan_kiro_home(Path.home() / ".kiro")
+                all_mcps.extend(m)
+                all_skills.extend(s)
+                all_hooks.extend(h)
+                all_agents.extend(a)
+
+        total = len(all_mcps) + len(all_skills) + len(all_hooks) + len(all_agents)
+        if total == 0:
+            return
+
+        def _ide_from_source(source: str) -> str:
+            if source.startswith("kiro:"):
+                return "kiro"
+            if source.startswith("plugin:") or source.startswith("claude:"):
+                return "claude-code"
+            return "auto"
+
+        scan_payload = {
+            "ide": "multi",
+            "mcps": [
+                {
+                    "name": m.name,
+                    "command": m.command,
+                    "args": m.args,
+                    "url": m.url,
+                    "description": m.description,
+                    "source_plugin": m.source,
+                    "source_ide": _ide_from_source(m.source),
+                }
+                for m in all_mcps
+            ],
+            "skills": [
+                {
+                    "name": s.name,
+                    "description": s.description,
+                    "source_plugin": s.source,
+                    "task_type": getattr(s, "task_type", "general"),
+                    "source_ide": _ide_from_source(s.source),
+                }
+                for s in all_skills
+            ],
+            "hooks": [
+                {
+                    "name": h.name,
+                    "event": h.event,
+                    "handler_type": h.handler_type,
+                    "handler_config": h.handler_config,
+                    "description": h.description,
+                    "source_plugin": h.source,
+                    "source_ide": _ide_from_source(h.source),
+                }
+                for h in all_hooks
+            ],
+            "agents": [
+                {
+                    "name": a.name,
+                    "description": a.description,
+                    "model_name": a.model_name or "",
+                    "prompt": a.prompt,
+                    "source_file": a.source_file,
+                    "source_ide": _ide_from_source(
+                        f"kiro:{a.source_file}" if a.source_file and ".kiro" in a.source_file else a.source_file or ""
+                    ),
+                }
+                for a in all_agents
+            ],
+        }
+
+        with spinner(f"Registering {total} components..."):
+            try:
+                result = client.post("/api/v1/scan", scan_payload)
+            except Exception as e:
+                rprint(f"[yellow]Registration failed: {e}[/yellow]")
+                rprint("[dim]You can retry by running:[/dim] [bold]observal scan --home --all-ides[/bold]")
+                return
+
+        summary = result.get("summary", {})
+        parts = [f"{v} {k}" for k, v in summary.items() if v]
+        if parts:
+            rprint(f"[green]Registered: {', '.join(parts)}[/green]")
+            rprint(
+                "[dim]View them with[/dim] [bold]observal agent list[/bold] [dim]or in the Observal dashboard.[/dim]"
+            )
+        else:
+            rprint("[dim]All components already registered.[/dim]")
 
     except Exception as e:
         rprint(f"[yellow]Onboarding skipped: {e}[/yellow]")
+        rprint("[dim]You can register these anytime by running:[/dim] [bold]observal scan --home --all-ides[/bold]")
 
 
 def _configure_kiro(server_url: str):


### PR DESCRIPTION
## Summary

Replaces the passive post-auth tips with an interactive registration flow. After `observal auth login`, users are shown their detected local IDE components and prompted to register them on the spot — no need to manually run scan commands.

## Changes

- **Discovery prompt**: Shows detected components per IDE with counts, explains what registration does (track usage, share with team, enable telemetry)
- **Interactive registration**: On confirm, runs scan machinery for Claude Code and Kiro home dirs, builds a multi-IDE payload, and POSTs to `/api/v1/scan`
- **Decline path**: Shows the exact command to register later (`observal scan --home --all-ides`) on its own line for visibility
- **Success path**: Shows registered counts and points to `observal agent list` / dashboard
- **Error path**: Shows clear retry command
- **Terminology**: "Upload" → "Register" throughout for accuracy

## Before / After

**Before:** Static tips about `observal scan --shim` and `observal registry submit` — no action taken.

**After:** Interactive prompt → immediate registration → summary of what was registered.

## Files Changed
- `observal_cli/cmd_auth.py`

## Test Plan
- [ ] Run `observal auth login` with local Claude Code / Kiro configs present → confirm registration → verify components appear in dashboard
- [ ] Decline registration → verify tip message shows correct command
- [ ] Simulate API failure → verify error message and retry command shown
- [ ] Run with no IDE configs detected → verify flow exits cleanly