### PR TITLE
feat(cli): display $VAR as <VAR> placeholders in config preview

### DIFF
--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -172,6 +172,17 @@ def _enter_env_vars_manually() -> list[dict]:
 _DOLLAR_VAR_RE = re.compile(r"\$\{?([A-Z][A-Z0-9_]+)\}?")
 
 
+def _dollar_to_placeholder(value: str) -> str:
+    """Replace $VAR / ${VAR} references with <VAR> placeholders.
+
+    Examples:
+        "Bearer $TOKEN"           → "Bearer <TOKEN>"
+        "Bearer $TOKEN1 $TOKEN2"  → "Bearer <TOKEN1> <TOKEN2>"
+        "$API_KEY"                → "<API_KEY>"
+    """
+    return _DOLLAR_VAR_RE.sub(lambda m: f"<{m.group(1)}>", value)
+
+
 def _extract_dollar_vars(args: list[str], env: dict[str, str]) -> list[str]:
     """Extract unique $VAR / ${VAR} references from args and env values.
 
@@ -328,7 +339,12 @@ def _build_config_preview(server_name: str, parsed: dict) -> dict:
         preview["type"] = parsed.get("transport", "sse")
         preview["url"] = parsed["url"]
         if parsed.get("headers"):
-            preview["headers"] = {h["name"]: h.get("value", f"<{h['name']}>") for h in parsed["headers"]}
+            preview["headers"] = {
+                h["name"]: _dollar_to_placeholder(h["value"])
+                if _DOLLAR_VAR_RE.search(h.get("value", ""))
+                else h.get("value", f"<{h['name']}>")
+                for h in parsed["headers"]
+            }
         env_vars = parsed.get("environment_variables") or []
         if env_vars:
             preview["env"] = {ev["name"]: f"<{ev['name']}>" for ev in env_vars}
@@ -338,7 +354,7 @@ def _build_config_preview(server_name: str, parsed: dict) -> dict:
     else:
         # stdio preview
         command = parsed.get("command", "")
-        args = list(parsed.get("args") or [])
+        args = [_dollar_to_placeholder(a) if _DOLLAR_VAR_RE.search(a) else a for a in (parsed.get("args") or [])]
 
         # Inject -e flags for docker env vars
         env_vars = parsed.get("environment_variables") or []
@@ -399,20 +415,19 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         parsed = _parse_direct_config(cfg)
         _name = name or parsed.pop("_server_name", None) or "my-mcp-server"
 
-        # Notify about dollar-sign input variables
+        # Extract dollar-sign input variables before preview
         dollar_vars = parsed.pop("_dollar_vars_detected", None)
-        if dollar_vars:
-            rprint("\n[bold yellow]Input variables detected:[/bold yellow]")
-            rprint(
-                "[dim]Dollar-sign variables in args/env will become install-time"
-                " dependencies — users will be prompted for these values.[/dim]\n"
-            )
-            for var in dollar_vars:
-                rprint(f"  [cyan]$[/cyan]{var}")
-            rprint()
 
         rprint("\n[bold]Config preview:[/bold]")
         console.print_json(json.dumps(_build_config_preview(_name, parsed), indent=2))
+
+        if dollar_vars:
+            placeholders = " ".join(f"<{v}>" for v in dollar_vars)
+            rprint(f"\n[bold]The user variables are:[/bold] [cyan]{placeholders}[/cyan]")
+            rprint(
+                "[dim]These will become install-time prompts — users must supply"
+                " values before the server can run.[/dim]"
+            )
 
         if not yes:
             if not typer.confirm("\nSubmit this config?", default=True):

--- a/tests/test_env_detection_and_config.py
+++ b/tests/test_env_detection_and_config.py
@@ -966,3 +966,133 @@ class TestParseDirectConfigDollarVars:
         }
         parsed = _parse_direct_config(cfg)
         assert "_dollar_vars_detected" not in parsed
+
+
+# ═══════════════════════════════════════════════════════════
+# 14. _dollar_to_placeholder
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDollarToPlaceholder:
+    def test_bearer_single_token(self):
+        from observal_cli.cmd_mcp import _dollar_to_placeholder
+
+        assert _dollar_to_placeholder("Bearer $TOKEN") == "Bearer <TOKEN>"
+
+    def test_bearer_braces_form(self):
+        from observal_cli.cmd_mcp import _dollar_to_placeholder
+
+        assert _dollar_to_placeholder("Bearer ${TOKEN}") == "Bearer <TOKEN>"
+
+    def test_bearer_multiple_tokens(self):
+        from observal_cli.cmd_mcp import _dollar_to_placeholder
+
+        assert _dollar_to_placeholder("Bearer $TOKEN1 $TOKEN2") == "Bearer <TOKEN1> <TOKEN2>"
+
+    def test_bearer_mixed_literal(self):
+        from observal_cli.cmd_mcp import _dollar_to_placeholder
+
+        result = _dollar_to_placeholder("Bearer $TOKEN1, token2")
+        assert result == "Bearer <TOKEN1>, token2"
+
+    def test_bare_variable(self):
+        from observal_cli.cmd_mcp import _dollar_to_placeholder
+
+        assert _dollar_to_placeholder("$API_KEY") == "<API_KEY>"
+
+    def test_no_variables(self):
+        from observal_cli.cmd_mcp import _dollar_to_placeholder
+
+        assert _dollar_to_placeholder("static-value") == "static-value"
+
+    def test_empty_string(self):
+        from observal_cli.cmd_mcp import _dollar_to_placeholder
+
+        assert _dollar_to_placeholder("") == ""
+
+    def test_multiple_vars_in_path(self):
+        from observal_cli.cmd_mcp import _dollar_to_placeholder
+
+        assert _dollar_to_placeholder("$HOST:$PORT/api") == "<HOST>:<PORT>/api"
+
+
+# ═══════════════════════════════════════════════════════════
+# 15. _build_config_preview dollar-var placeholders
+# ═══════════════════════════════════════════════════════════
+
+
+class TestBuildConfigPreviewPlaceholders:
+    def test_sse_header_bearer_token_placeholder(self):
+        from observal_cli.cmd_mcp import _build_config_preview
+
+        parsed = {
+            "transport": "sse",
+            "url": "https://example.com/sse",
+            "headers": [
+                {"name": "Authorization", "value": "Bearer $TOKEN", "description": "", "required": True},
+            ],
+            "environment_variables": [{"name": "TOKEN", "description": "", "required": True}],
+        }
+        result = _build_config_preview("test-server", parsed)
+        headers = result["test-server"]["headers"]
+        assert headers["Authorization"] == "Bearer <TOKEN>"
+
+    def test_sse_header_multiple_dollar_vars(self):
+        from observal_cli.cmd_mcp import _build_config_preview
+
+        parsed = {
+            "transport": "sse",
+            "url": "https://example.com/sse",
+            "headers": [
+                {"name": "Authorization", "value": "Bearer $TOKEN1 $TOKEN2", "description": "", "required": True},
+            ],
+            "environment_variables": [],
+        }
+        result = _build_config_preview("test-server", parsed)
+        headers = result["test-server"]["headers"]
+        assert headers["Authorization"] == "Bearer <TOKEN1> <TOKEN2>"
+
+    def test_sse_header_no_dollar_uses_name_fallback(self):
+        from observal_cli.cmd_mcp import _build_config_preview
+
+        parsed = {
+            "transport": "sse",
+            "url": "https://example.com/sse",
+            "headers": [
+                {"name": "X-Custom", "description": "", "required": True},
+            ],
+            "environment_variables": [],
+        }
+        result = _build_config_preview("test-server", parsed)
+        headers = result["test-server"]["headers"]
+        assert headers["X-Custom"] == "<X-Custom>"
+
+    def test_stdio_args_dollar_vars_replaced(self):
+        from observal_cli.cmd_mcp import _build_config_preview
+
+        parsed = {
+            "transport": "stdio",
+            "command": "node",
+            "args": ["server.js", "--token=$API_KEY", "--host", "$HOST"],
+            "environment_variables": [
+                {"name": "API_KEY", "description": "", "required": True},
+                {"name": "HOST", "description": "", "required": True},
+            ],
+        }
+        result = _build_config_preview("test-server", parsed)
+        args = result["test-server"]["args"]
+        assert "--token=<API_KEY>" in args
+        assert "<HOST>" in args
+
+    def test_stdio_args_no_dollar_unchanged(self):
+        from observal_cli.cmd_mcp import _build_config_preview
+
+        parsed = {
+            "transport": "stdio",
+            "command": "python",
+            "args": ["-m", "my_server"],
+            "environment_variables": [],
+        }
+        result = _build_config_preview("test-server", parsed)
+        args = result["test-server"]["args"]
+        assert args == ["-m", "my_server"]


### PR DESCRIPTION
## Purpose / Description
When users paste MCP server configs containing dollar-sign variable references (e.g. `"Authorization": "Bearer $TOKEN"`), the config preview now shows them as readable angle-bracket placeholders (`Bearer <TOKEN>`) instead of raw `$TOKEN` syntax. A summary line after the preview lists all user variables that need to be filled in at install time.

## Fixes
* Improves clarity of the config preview for configs with environment variable references in header values and args

## Approach
- Add `_dollar_to_placeholder()` helper that converts `$VAR`/`${VAR}` → `<VAR>` in any string, preserving surrounding text (e.g. `Bearer $TOKEN` → `Bearer <TOKEN>`)
- Update `_build_config_preview()` to apply placeholder substitution on:
  - SSE/HTTP header values containing `$VAR` references
  - stdio args containing `$VAR` references
- Replace the "Input variables detected" block with a concise "user variables" summary line shown after the config preview

**Examples handled:**
| Input | Output |
|---|---|
| `Bearer $TOKEN` | `Bearer <TOKEN>` |
| `Bearer ${TOKEN}` | `Bearer <TOKEN>` |
| `Bearer $TOKEN1 $TOKEN2` | `Bearer <TOKEN1> <TOKEN2>` |
| `Bearer $TOKEN1, token2` | `Bearer <TOKEN1>, token2` |
| `$API_KEY` | `<API_KEY>` |

## How Has This Been Tested?

- 13 new unit tests covering:
  - `TestDollarToPlaceholder` (8 tests): bearer single/braces/multiple/mixed, bare variable, no variables, empty string, path with multiple vars
  - `TestBuildConfigPreviewPlaceholders` (5 tests): SSE header bearer token, multiple dollar vars, no-dollar fallback, stdio args replacement, unchanged args
- Full existing test suite (78 tests) passes with no regressions

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens — N/A (CLI only)