### PR TITLE
fix(hooks): resolve server URL from auth config instead of hardcoding localhost

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -709,9 +709,11 @@ async def install_agent(
     # Resolve all component names for rules file content
     name_map = await _resolve_component_names(agent.components, db)
 
+    server_url = str(request.base_url).rstrip("/")
     snippet = generate_agent_config(
         agent,
         req.ide,
+        observal_url=server_url,
         mcp_listings=mcp_listings_map,
         component_names=name_map,
         env_values=req.env_values,

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -101,6 +101,7 @@ async def get_hook(listing_id: str, db: AsyncSession = Depends(get_db)):
 async def install_hook(
     listing_id: str,
     req: HookInstallRequest,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
@@ -115,7 +116,8 @@ async def install_hook(
 
     from services.hook_config_generator import generate_hook_telemetry_config
 
-    config = generate_hook_telemetry_config(listing, req.ide, platform=req.platform)
+    server_url = str(request.base_url).rstrip("/")
+    config = generate_hook_telemetry_config(listing, req.ide, server_url=server_url, platform=req.platform)
     return HookInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
 
 

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -98,6 +98,7 @@ async def get_sandbox(listing_id: str, db: AsyncSession = Depends(get_db)):
 async def install_sandbox(
     listing_id: str,
     req: SandboxInstallRequest,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
@@ -112,7 +113,8 @@ async def install_sandbox(
 
     from services.sandbox_config_generator import generate_sandbox_config
 
-    config = generate_sandbox_config(listing, req.ide)
+    server_url = str(request.base_url).rstrip("/")
+    config = generate_sandbox_config(listing, req.ide, server_url=server_url)
     return SandboxInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
 
 

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -105,6 +105,7 @@ async def get_skill(listing_id: str, db: AsyncSession = Depends(get_db)):
 async def install_skill(
     listing_id: str,
     req: SkillInstallRequest,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
@@ -119,7 +120,8 @@ async def install_skill(
 
     from services.skill_config_generator import generate_skill_config
 
-    config = generate_skill_config(listing, req.ide, scope=req.scope)
+    server_url = str(request.base_url).rstrip("/")
+    config = generate_skill_config(listing, req.ide, server_url=server_url, scope=req.scope)
     return SkillInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
 
 

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -105,11 +105,13 @@ def _check_claude_code(path: Path, data: dict, issues: list, warnings: list):
     # allowedHttpHookUrls blocks our endpoint
     allowed_urls = data.get("allowedHttpHookUrls")
     if isinstance(allowed_urls, list) and len(allowed_urls) > 0:
-        has_observal = any("localhost:8000" in u or "observal" in u.lower() for u in allowed_urls)
+        cfg = config.load()
+        cfg_server = cfg.get("server_url", "localhost:8000")
+        has_observal = any(cfg_server in u or "observal" in u.lower() for u in allowed_urls)
         if not has_observal:
             issues.append(
                 f"{path}: `allowedHttpHookUrls` is set but does not include Observal's URL. "
-                "Add `http://localhost:8000/*` to allow hook telemetry."
+                f"Add `{cfg_server.rstrip('/')}/*` to allow hook telemetry."
             )
 
     # httpHookAllowedEnvVars blocks OBSERVAL_API_KEY
@@ -142,11 +144,16 @@ def _check_claude_code(path: Path, data: dict, issues: list, warnings: list):
     network = sandbox.get("network", {})
     allowed_domains = network.get("allowedDomains", [])
     if isinstance(allowed_domains, list) and len(allowed_domains) > 0:
-        has_localhost = any("localhost" in d for d in allowed_domains)
-        if not has_localhost:
+        cfg = config.load()
+        cfg_server = cfg.get("server_url", "http://localhost:8000")
+        from urllib.parse import urlparse
+
+        cfg_host = urlparse(cfg_server).hostname or "localhost"
+        has_server_host = any(cfg_host in d for d in allowed_domains)
+        if not has_server_host:
             warnings.append(
-                f"{path}: sandbox `network.allowedDomains` does not include `localhost`. "
-                "Observal telemetry POSTs to localhost:8000."
+                f"{path}: sandbox `network.allowedDomains` does not include `{cfg_host}`. "
+                f"Observal telemetry POSTs to {cfg_server}."
             )
 
     # env vars that override Observal
@@ -604,7 +611,9 @@ def doctor(
             if "disableAllHooks" in issue:
                 rprint("  Set `disableAllHooks: false` in your Claude Code settings.json")
             elif "allowedHttpHookUrls" in issue:
-                rprint('  Add `"http://localhost:8000/*"` to `allowedHttpHookUrls`')
+                cfg = config.load()
+                cfg_server = cfg.get("server_url", "http://localhost:8000").rstrip("/")
+                rprint(f'  Add `"{cfg_server}/*"` to `allowedHttpHookUrls`')
             elif "OBSERVAL_API_KEY" in issue and "httpHookAllowedEnvVars" in issue:
                 rprint('  Add `"OBSERVAL_API_KEY"` to `httpHookAllowedEnvVars`')
             elif "allowManagedHooksOnly" in issue:

--- a/observal_cli/hooks/flush_buffer.py
+++ b/observal_cli/hooks/flush_buffer.py
@@ -20,8 +20,27 @@ FLUSH_LIMIT = 20
 MAX_RETRIES = 3
 
 
+def _resolve_hooks_url() -> str:
+    """Resolve the hooks URL from env var or config file."""
+    env_url = os.environ.get("OBSERVAL_HOOKS_URL")
+    if env_url:
+        return env_url
+    try:
+        import json
+
+        cfg_path = Path.home() / ".observal" / "config.json"
+        if cfg_path.exists():
+            cfg = json.loads(cfg_path.read_text())
+            server_url = cfg.get("server_url", "")
+            if server_url:
+                return server_url.rstrip("/") + "/api/v1/otel/hooks"
+    except Exception:
+        pass
+    return "http://localhost:8000/api/v1/otel/hooks"
+
+
 def main() -> None:
-    hooks_url = os.environ.get("OBSERVAL_HOOKS_URL", "http://localhost:8000/api/v1/otel/hooks")
+    hooks_url = _resolve_hooks_url()
     user_id = os.environ.get("OBSERVAL_USER_ID", "")
 
     if not DB_PATH.exists():

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -7,8 +7,10 @@ the full enrichment in ``kiro_stop_hook.py`` — it only reads the
 conversation_id column, not the multi-MB conversation JSON.
 
 Usage (in a Kiro agent hook):
-    Unix:    cat | python3 /path/to/kiro_hook.py --url http://localhost:8000/api/v1/otel/hooks
-    Windows: python -m observal_cli.hooks.kiro_hook --url http://localhost:8000/api/v1/otel/hooks --agent-name my-agent
+    Unix:    cat | python3 /path/to/kiro_hook.py --url https://your-server/api/v1/otel/hooks
+    Windows: python -m observal_cli.hooks.kiro_hook --url https://your-server/api/v1/otel/hooks --agent-name my-agent
+
+URL resolution order: --url flag > OBSERVAL_HOOKS_URL env var > ~/.observal/config.json server_url > localhost:8000
 """
 
 from __future__ import annotations
@@ -137,10 +139,27 @@ def _auto_inject_hooks(url: str):
             pass
 
 
+def _resolve_hooks_url() -> str:
+    """Resolve the hooks URL from env var or config file."""
+    env_url = os.environ.get("OBSERVAL_HOOKS_URL")
+    if env_url:
+        return env_url
+    try:
+        cfg_path = Path.home() / ".observal" / "config.json"
+        if cfg_path.exists():
+            cfg = json.loads(cfg_path.read_text())
+            server_url = cfg.get("server_url", "")
+            if server_url:
+                return server_url.rstrip("/") + "/api/v1/otel/hooks"
+    except Exception:
+        pass
+    return "http://localhost:8000/api/v1/otel/hooks"
+
+
 def main():
     import urllib.request
 
-    url = "http://localhost:8000/api/v1/otel/hooks"
+    url = ""
     agent_name = ""
     model = ""
     args = sys.argv[1:]
@@ -151,6 +170,9 @@ def main():
             agent_name = args[i + 1]
         elif arg == "--model" and i + 1 < len(args):
             model = args[i + 1]
+
+    if not url:
+        url = _resolve_hooks_url()
 
     try:
         raw = sys.stdin.read()

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -10,8 +10,10 @@ When a Kiro agent's ``stop`` hook fires, this script:
 4. Merges the enriched fields into the payload and POSTs to Observal.
 
 Usage (in a Kiro agent hook):
-    Unix:    cat | python3 /path/to/kiro_stop_hook.py --url http://localhost:8000/api/v1/otel/hooks
-    Windows: python -m observal_cli.hooks.kiro_stop_hook --url http://localhost:8000/api/v1/otel/hooks --agent-name my-agent
+    Unix:    cat | python3 /path/to/kiro_stop_hook.py --url https://your-server/api/v1/otel/hooks
+    Windows: python -m observal_cli.hooks.kiro_stop_hook --url https://your-server/api/v1/otel/hooks --agent-name my-agent
+
+URL resolution order: --url flag > OBSERVAL_HOOKS_URL env var > ~/.observal/config.json server_url > localhost:8000
 """
 
 from __future__ import annotations
@@ -148,11 +150,28 @@ def _enrich(payload: dict) -> dict:
     return payload
 
 
+def _resolve_hooks_url() -> str:
+    """Resolve the hooks URL from env var or config file."""
+    env_url = os.environ.get("OBSERVAL_HOOKS_URL")
+    if env_url:
+        return env_url
+    try:
+        cfg_path = Path.home() / ".observal" / "config.json"
+        if cfg_path.exists():
+            cfg = json.loads(cfg_path.read_text())
+            server_url = cfg.get("server_url", "")
+            if server_url:
+                return server_url.rstrip("/") + "/api/v1/otel/hooks"
+    except Exception:
+        pass
+    return "http://localhost:8000/api/v1/otel/hooks"
+
+
 def main():
     import urllib.request
 
     # Parse --url and --agent-name arguments
-    url = "http://localhost:8000/api/v1/otel/hooks"
+    url = ""
     agent_name = ""
     model = ""
     args = sys.argv[1:]
@@ -163,6 +182,9 @@ def main():
             agent_name = args[i + 1]
         elif arg == "--model" and i + 1 < len(args):
             model = args[i + 1]
+
+    if not url:
+        url = _resolve_hooks_url()
 
     # Read hook payload from stdin
     try:

--- a/observal_cli/hooks/observal-hook.sh
+++ b/observal_cli/hooks/observal-hook.sh
@@ -8,7 +8,20 @@
 #
 # Claude Code sessions are never disrupted regardless of server state.
 
-OBSERVAL_HOOKS_URL="${OBSERVAL_HOOKS_URL:-http://localhost:8000/api/v1/otel/hooks}"
+if [ -z "$OBSERVAL_HOOKS_URL" ]; then
+  _cfg="$HOME/.observal/config.json"
+  if [ -f "$_cfg" ] && command -v python3 >/dev/null 2>&1; then
+    OBSERVAL_HOOKS_URL=$(python3 -c "
+import json, sys
+try:
+    c = json.load(open('$_cfg'))
+    u = c.get('server_url','')
+    if u: print(u.rstrip('/') + '/api/v1/otel/hooks')
+except Exception: pass
+" 2>/dev/null)
+  fi
+  OBSERVAL_HOOKS_URL="${OBSERVAL_HOOKS_URL:-http://localhost:8000/api/v1/otel/hooks}"
+fi
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Read payload from stdin into a variable so we can reuse it

--- a/observal_cli/hooks/observal-stop-hook.sh
+++ b/observal_cli/hooks/observal-stop-hook.sh
@@ -12,7 +12,20 @@
 # IMPORTANT: No `set -eu` — we must never exit early and always reach
 # the final exit 0 so Claude Code doesn't see a hook failure.
 
-OBSERVAL_HOOKS_URL="${OBSERVAL_HOOKS_URL:-http://localhost:8000/api/v1/otel/hooks}"
+if [ -z "$OBSERVAL_HOOKS_URL" ]; then
+  _cfg="$HOME/.observal/config.json"
+  if [ -f "$_cfg" ] && command -v python3 >/dev/null 2>&1; then
+    OBSERVAL_HOOKS_URL=$(python3 -c "
+import json, sys
+try:
+    c = json.load(open('$_cfg'))
+    u = c.get('server_url','')
+    if u: print(u.rstrip('/') + '/api/v1/otel/hooks')
+except Exception: pass
+" 2>/dev/null)
+  fi
+  OBSERVAL_HOOKS_URL="${OBSERVAL_HOOKS_URL:-http://localhost:8000/api/v1/otel/hooks}"
+fi
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Read hook payload from stdin


### PR DESCRIPTION
## Purpose / Description
Hook scripts were hardcoded to fall back to `http://localhost:8000` when no `--url` flag or `OBSERVAL_HOOKS_URL` env var was set. This meant hooks silently pointed to localhost regardless of what server the user authenticated against during `observal auth login`.

## Fixes
* Hooks now resolve the server URL from `~/.observal/config.json` (the `server_url` saved during `observal auth login`) before falling back to localhost.

## Approach
Added a unified URL resolution order across all 5 hook scripts and the server-side install endpoint:

1. `--url` CLI flag (Kiro Python hooks only)
2. `OBSERVAL_HOOKS_URL` env var
3. `~/.observal/config.json` → `server_url` field
4. `http://localhost:8000` as last resort

**Files changed:**
- **`kiro_hook.py`** / **`kiro_stop_hook.py`** — Added `_resolve_hooks_url()` that checks env var and config file before falling back. `--url` flag still takes priority.
- **`flush_buffer.py`** — Same `_resolve_hooks_url()` instead of bare `os.environ.get(..., "localhost:8000")`.
- **`observal-hook.sh`** / **`observal-stop-hook.sh`** — Added config file lookup via inline Python when `OBSERVAL_HOOKS_URL` isn't set.
- **`hook.py` (server-side)** — `install_hook` route now derives `server_url` from the incoming `Request` object instead of using the hardcoded default in `generate_hook_telemetry_config`.

## How Has This Been Tested?
- `make test` — 98 tests in `test_agent_config_generator.py` pass
- Verified URL resolution order: `--url` > env var > config file > localhost fallback

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code