### PR TITLE
fix(web): clipboard copy works on plain HTTP self-hosted deployments

### DIFF
--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -5,6 +5,7 @@ import { Users, Plus, Copy, Check, Loader2, Key, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { useAdminUsers, useCreateUser, useUpdateUserRole, useDeleteUser } from "@/hooks/use-api";
 import type { AdminUser } from "@/lib/types";
+import { copyToClipboard } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -78,7 +79,7 @@ export default function UsersPage() {
 
   const handleCopyPassword = useCallback(() => {
     if (!createdPassword) return;
-    navigator.clipboard.writeText(createdPassword);
+    copyToClipboard(createdPassword);
     setCopied(true);
     toast.success("Password copied");
     setTimeout(() => setCopied(false), 2000);

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -44,7 +44,7 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
-import { compactNumber } from "@/lib/utils";
+import { compactNumber, copyToClipboard } from "@/lib/utils";
 
 interface AgentDetail {
   name: string;
@@ -774,7 +774,7 @@ function ConfigSnippet({
   );
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(snippet);
+    copyToClipboard(snippet);
     setCopied(true);
     toast.success("Copied to clipboard");
     setTimeout(() => setCopied(false), 2000);

--- a/web/src/app/(registry)/components/[id]/page.tsx
+++ b/web/src/app/(registry)/components/[id]/page.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { useRegistryItem, useFeedback, useFeedbackSummary, useRegistryMetrics } from "@/hooks/use-api";
 import type { RegistryType } from "@/lib/api";
 import type { FeedbackItem, RegistryItem } from "@/lib/types";
+import { copyToClipboard } from "@/lib/utils";
 import Link from "next/link";
 import { ReviewForm } from "@/components/registry/review-form";
 import { Badge } from "@/components/ui/badge";
@@ -284,7 +285,7 @@ function InstallSnippet({ type, name }: { type: string; name: string }) {
   const cmd = `observal agent add ${type} ${name}`;
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(cmd);
+    copyToClipboard(cmd);
     setCopied(true);
     toast.success("Copied to clipboard");
     setTimeout(() => setCopied(false), 2000);

--- a/web/src/app/(registry)/page.tsx
+++ b/web/src/app/(registry)/page.tsx
@@ -27,6 +27,7 @@ import {
   useLeaderboard,
 } from "@/hooks/use-api";
 import { useRouter } from "next/navigation";
+import { copyToClipboard } from "@/lib/utils";
 import { PageHeader } from "@/components/layouts/page-header";
 import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -60,7 +61,7 @@ export default function RegistryHome() {
   }
 
   const handleHeroCopy = useCallback(() => {
-    navigator.clipboard.writeText("observal pull my-agent --ide cursor");
+    copyToClipboard("observal pull my-agent --ide cursor");
     setHeroCopied(true);
     toast.success("Copied to clipboard");
     setTimeout(() => setHeroCopied(false), 2000);

--- a/web/src/components/registry/install-dialog.tsx
+++ b/web/src/components/registry/install-dialog.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Button } from "@/components/ui/button";
 import { registry, type RegistryType } from "@/lib/api";
 import { Copy, Check, Download, AlertTriangle } from "lucide-react";
+import { copyToClipboard } from "@/lib/utils";
 
 const IDE_OPTIONS = [
   "Cursor",
@@ -50,7 +51,7 @@ export function InstallDialog({ type, id, name }: InstallDialogProps) {
   }
 
   function handleCopy() {
-    navigator.clipboard.writeText(config);
+    copyToClipboard(config);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }

--- a/web/src/components/registry/pull-command.tsx
+++ b/web/src/components/registry/pull-command.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Check, Copy, Terminal } from "lucide-react";
 import { toast } from "sonner";
+import { copyToClipboard } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -29,7 +30,7 @@ export function PullCommand({ agentName }: { agentName: string }) {
   const command = `observal pull ${agentName} --ide ${ide}`;
 
   function handleCopy() {
-    navigator.clipboard.writeText(command);
+    copyToClipboard(command);
     setCopied(true);
     toast.success("Copied to clipboard");
     setTimeout(() => setCopied(false), 2000);

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -14,3 +14,33 @@ export function compactNumber(n: number): string {
 export function formatNumber(n: number, decimals = 0): string {
   return n.toLocaleString("en-US", { maximumFractionDigits: decimals });
 }
+
+/**
+ * Copy text to the clipboard.
+ *
+ * Uses the modern Clipboard API when available (secure contexts — HTTPS or
+ * localhost). Falls back to a hidden textarea + execCommand("copy") so that
+ * copy works on plain HTTP self-hosted deployments too.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Clipboard API can throw even when present (e.g. permissions denied
+      // in non-secure contexts). Fall through to legacy path.
+    }
+  }
+
+  // Legacy fallback for non-secure contexts (plain HTTP)
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
+}


### PR DESCRIPTION
## Purpose / Description
All copy-to-clipboard buttons (quick install, config snippets, passwords) silently fail on self-hosted deployments running over plain HTTP. The browser's `navigator.clipboard` API requires a secure context (HTTPS or localhost) and throws or is undefined on `http://` origins, which is the default for internal company deployments.

## Fixes
* Fixes copy-to-clipboard failing silently on plain HTTP self-hosted servers

## Approach
- Add a `copyToClipboard()` utility in `web/src/lib/utils.ts` that:
  1. Tries `navigator.clipboard.writeText()` first (works on HTTPS/localhost)
  2. Falls back to creating a hidden textarea + `document.execCommand("copy")` when the modern API is unavailable or throws
- Replace all 6 direct `navigator.clipboard.writeText()` calls across the frontend:
  - `pull-command.tsx` — quick install CLI command copy
  - `install-dialog.tsx` — IDE config copy
  - `(registry)/page.tsx` — hero section example command
  - `(registry)/components/[id]/page.tsx` — component install snippet
  - `(admin)/users/page.tsx` — created password copy
  - `(registry)/agents/[id]/page.tsx` — manual config snippet copy

## How Has This Been Tested?

- ESLint: 0 errors (3 pre-existing unrelated warnings)
- TypeScript: clean, no errors
- Verified no remaining `navigator.clipboard` calls outside the utility function

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens — N/A (behavior fix, no visual changes)