### PR TITLE
fix(web): allow reviewer role to access /review page

### DIFF
--- a/web/src/app/(admin)/layout.tsx
+++ b/web/src/app/(admin)/layout.tsx
@@ -12,7 +12,7 @@ export default function AdminLayout({
 }) {
   return (
     <AuthGuard>
-      <RoleGuard minRole="admin">
+      <RoleGuard minRole="reviewer">
         <SidebarProvider>
           <RegistrySidebar />
           <SidebarInset>{children}</SidebarInset>


### PR DESCRIPTION
## Purpose / Description
Users with `reviewer` role can see the "Review" link in the sidebar but get redirected when clicking it. The sidebar config uses `minRole: "reviewer"` while the `(admin)/layout.tsx` RoleGuard requires `"admin"`, creating a mismatch.

## Fixes
* Fixes #485

## Approach
Changed `RoleGuard minRole` in `web/src/app/(admin)/layout.tsx` from `"admin"` to `"reviewer"` so the page guard matches the sidebar visibility. The backend API already permits reviewer access, so this is purely a frontend guard fix.

## How Has This Been Tested?

- Verified that the sidebar link (`minRole: "reviewer"`) and the layout guard (`minRole: "reviewer"`) are now consistent
- Backend `/api/v1/review` already supports reviewer role — no backend changes needed
- Admin and super_admin access is unaffected since `reviewer` is a lower role threshold

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)