### PR TITLE
feat: trace privacy toggle for admins

### DIFF
--- a/observal-server/alembic/versions/0017_add_org_trace_privacy.py
+++ b/observal-server/alembic/versions/0017_add_org_trace_privacy.py
@@ -1,7 +1,7 @@
 """Add trace_privacy column to organizations.
 
-When enabled, admins and super-admins can only see their own traces,
-not all traces across the organization.
+When enabled, all roles below super-admin can only see their own
+traces.  Super-admins always retain full visibility.
 
 Revision ID: 0017
 Revises: 0016

--- a/observal-server/alembic/versions/0017_add_org_trace_privacy.py
+++ b/observal-server/alembic/versions/0017_add_org_trace_privacy.py
@@ -1,0 +1,46 @@
+"""Add trace_privacy column to organizations.
+
+When enabled, admins and super-admins can only see their own traces,
+not all traces across the organization.
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-04-22
+"""
+
+from alembic import op
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'organizations' AND column_name = 'trace_privacy'
+            ) THEN
+                ALTER TABLE organizations ADD COLUMN trace_privacy BOOLEAN NOT NULL DEFAULT FALSE;
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'organizations' AND column_name = 'trace_privacy'
+            ) THEN
+                ALTER TABLE organizations DROP COLUMN trace_privacy;
+            END IF;
+        END
+        $$;
+    """)

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -25,7 +25,11 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 
 
 async def _authenticate_via_jwt(token: str, db: AsyncSession) -> User | None:
-    """Try to authenticate using a JWT access token. Returns User or None."""
+    """Try to authenticate using a JWT access token. Returns User or None.
+
+    Also resolves the org's trace_privacy flag in the same query (via JOIN)
+    so downstream code never needs a separate DB call for it.
+    """
     try:
         payload = decode_access_token(token)
     except jwt.InvalidTokenError:
@@ -40,8 +44,17 @@ async def _authenticate_via_jwt(token: str, db: AsyncSession) -> User | None:
     except ValueError:
         return None
 
-    result = await db.execute(select(User).where(User.id == uid))
-    return result.scalar_one_or_none()
+    result = await db.execute(
+        select(User, Organization.trace_privacy)
+        .outerjoin(Organization, User.org_id == Organization.id)
+        .where(User.id == uid)
+    )
+    row = result.one_or_none()
+    if not row:
+        return None
+    user, trace_privacy = row
+    user._trace_privacy = bool(trace_privacy)
+    return user
 
 
 async def get_current_user(

--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -552,7 +552,7 @@ async def _resolve_user_context_from_request(request) -> dict:
     from database import async_session
     from models.user import User
 
-    default = {"project_id": _DEFAULT_PROJECT, "user_id": None, "user_role": None}
+    default = {"project_id": _DEFAULT_PROJECT, "user_id": None, "user_role": None, "trace_privacy": False}
 
     auth: str | None = None
     if request is not None:
@@ -575,16 +575,26 @@ async def _resolve_user_context_from_request(request) -> dict:
         return default
 
     try:
+        from models.organization import Organization
+
         async with async_session() as session:
             result = await session.execute(select(User.org_id, User.role).where(User.id == uid))
             row = result.one_or_none()
             if not row:
                 return default
             org_id, role = row
+
+            # Check if the org has trace privacy enabled
+            trace_privacy = False
+            if org_id:
+                tp_result = await session.execute(select(Organization.trace_privacy).where(Organization.id == org_id))
+                trace_privacy = bool(tp_result.scalar_one_or_none())
+
             return {
                 "project_id": str(org_id) if org_id else _DEFAULT_PROJECT,
                 "user_id": str(uid),
                 "user_role": role.value if role else None,
+                "trace_privacy": trace_privacy,
             }
     except Exception:
         logger.debug("Failed to resolve user context for GraphQL", exc_info=True)
@@ -595,11 +605,13 @@ def get_context(
     project_id: str = _DEFAULT_PROJECT,
     user_id: str | None = None,
     user_role: str | None = None,
+    trace_privacy: bool = False,
 ) -> dict:
     return {
         "project_id": project_id,
         "user_id": user_id,
         "user_role": user_role,
+        "trace_privacy": trace_privacy,
         "span_loader": DataLoader(load_fn=_make_span_loader(project_id)),
         "score_by_trace_loader": DataLoader(load_fn=_make_score_by_trace_loader(project_id)),
         "score_by_span_loader": DataLoader(load_fn=_make_score_by_span_loader(project_id)),
@@ -607,13 +619,15 @@ def get_context(
 
 
 def _is_admin(ctx: dict) -> bool:
+    if ctx.get("trace_privacy"):
+        return False
     return ctx.get("user_role") in ("admin", "super_admin")
 
 
 async def get_context_dep(request: Request = None) -> dict:
     """Strawberry FastAPI context getter — receives the incoming ``Request``."""
     uctx = await _resolve_user_context_from_request(request)
-    return get_context(uctx["project_id"], uctx["user_id"], uctx["user_role"])
+    return get_context(uctx["project_id"], uctx["user_id"], uctx["user_role"], uctx.get("trace_privacy", False))
 
 
 schema = strawberry.Schema(query=Query, subscription=Subscription)

--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -578,23 +578,21 @@ async def _resolve_user_context_from_request(request) -> dict:
         from models.organization import Organization
 
         async with async_session() as session:
-            result = await session.execute(select(User.org_id, User.role).where(User.id == uid))
+            result = await session.execute(
+                select(User.org_id, User.role, Organization.trace_privacy)
+                .outerjoin(Organization, User.org_id == Organization.id)
+                .where(User.id == uid)
+            )
             row = result.one_or_none()
             if not row:
                 return default
-            org_id, role = row
-
-            # Check if the org has trace privacy enabled
-            trace_privacy = False
-            if org_id:
-                tp_result = await session.execute(select(Organization.trace_privacy).where(Organization.id == org_id))
-                trace_privacy = bool(tp_result.scalar_one_or_none())
+            org_id, role, trace_privacy = row
 
             return {
                 "project_id": str(org_id) if org_id else _DEFAULT_PROJECT,
                 "user_id": str(uid),
                 "user_role": role.value if role else None,
-                "trace_privacy": trace_privacy,
+                "trace_privacy": bool(trace_privacy),
             }
     except Exception:
         logger.debug("Failed to resolve user context for GraphQL", exc_info=True)

--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -617,9 +617,12 @@ def get_context(
 
 
 def _is_admin(ctx: dict) -> bool:
+    role = ctx.get("user_role")
+    if role == "super_admin":
+        return True
     if ctx.get("trace_privacy"):
         return False
-    return ctx.get("user_role") in ("admin", "super_admin")
+    return role == "admin"
 
 
 async def get_context_dep(request: Request = None) -> dict:

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -758,8 +758,8 @@ async def set_trace_privacy(
 ):
     """Toggle trace privacy for the current user's organization.
 
-    When enabled, admins can only see their own traces instead of all
-    traces in the organization.
+    When enabled, all roles below super-admin can only see their own
+    traces.  Super-admins always retain full visibility.
     """
     enabled = bool(req.get("trace_privacy", False))
 

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.deps import get_db, get_or_create_default_org, require_role
 from config import settings
 from models.enterprise_config import EnterpriseConfig
+from models.organization import Organization
 from models.user import User, UserRole
 from schemas.admin import (
     AdminResetPasswordRequest,
@@ -729,6 +730,64 @@ async def apply_resources(
         "applied": {k: current[k] for k in applied_keys},
         "message": "ClickHouse resource settings applied",
     }
+
+
+# ── Trace Privacy ──────────────────────────────────────────
+
+
+@router.get("/org/trace-privacy")
+async def get_trace_privacy(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.super_admin)),
+):
+    """Get the trace privacy setting for the current user's organization."""
+    if not current_user.org_id:
+        return {"trace_privacy": False}
+    result = await db.execute(select(Organization).where(Organization.id == current_user.org_id))
+    org = result.scalar_one_or_none()
+    if not org:
+        return {"trace_privacy": False}
+    return {"trace_privacy": org.trace_privacy}
+
+
+@router.put("/org/trace-privacy")
+async def set_trace_privacy(
+    req: dict,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.super_admin)),
+):
+    """Toggle trace privacy for the current user's organization.
+
+    When enabled, admins can only see their own traces instead of all
+    traces in the organization.
+    """
+    enabled = bool(req.get("trace_privacy", False))
+
+    if not current_user.org_id:
+        raise HTTPException(status_code=400, detail="User has no organization")
+
+    result = await db.execute(select(Organization).where(Organization.id == current_user.org_id))
+    org = result.scalar_one_or_none()
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    org.trace_privacy = enabled
+    await db.commit()
+    await db.refresh(org)
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.SETTING_CHANGED,
+            severity=Severity.WARNING,
+            outcome="success",
+            actor_id=str(current_user.id),
+            actor_email=current_user.email,
+            actor_role=current_user.role.value,
+            target_id=str(org.id),
+            target_type="organization",
+            detail=f"Trace privacy {'enabled' if enabled else 'disabled'}",
+        )
+    )
+    return {"trace_privacy": org.trace_privacy}
 
 
 @router.post("/cache/clear")

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -13,6 +13,7 @@ from sqlalchemy import or_, select
 from api.deps import require_role
 from config import settings
 from database import async_session
+from models.organization import Organization
 from models.user import User, UserRole
 from services.clickhouse import _query, query_shim_spans_for_window
 from services.redis import publish
@@ -75,6 +76,22 @@ def _is_admin_user(user: User) -> bool:
     return user.role in (UserRole.admin, UserRole.super_admin)
 
 
+async def _is_admin_with_trace_access(user: User) -> bool:
+    """Check if user is admin AND their org has not enabled trace privacy.
+
+    When trace privacy is on, admins are treated like regular users for
+    trace visibility — they can only see their own traces.
+    """
+    if not _is_admin_user(user):
+        return False
+    if not user.org_id:
+        return True
+    async with async_session() as db:
+        result = await db.execute(select(Organization.trace_privacy).where(Organization.id == user.org_id))
+        trace_privacy = result.scalar_one_or_none()
+        return not trace_privacy
+
+
 @router.get("/sessions")
 async def list_sessions(
     status: str | None = Query(None),
@@ -82,7 +99,7 @@ async def list_sessions(
     days: int | None = Query(None),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    is_admin = _is_admin_user(current_user)
+    is_admin = await _is_admin_with_trace_access(current_user)
     uid_str = str(current_user.id)
     capped_days = min(days, 365) if days is not None and days > 0 else days
     rows = await _list_sessions_query(
@@ -247,7 +264,7 @@ async def _list_sessions_query(
 async def sessions_summary(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    is_admin = _is_admin_user(current_user)
+    is_admin = await _is_admin_with_trace_access(current_user)
     session_filter = ""
     params: dict[str, str] = {}
     if not is_admin:
@@ -556,7 +573,7 @@ async def _sideload_shim_spans(events: list[dict]) -> list[dict]:
 
 @router.get("/sessions/{session_id}")
 async def get_session(session_id: str, current_user: User = Depends(require_role(UserRole.user))):
-    is_admin = _is_admin_user(current_user)
+    is_admin = await _is_admin_with_trace_access(current_user)
     params: dict[str, str] = {"param_sid": session_id}
 
     if not is_admin:

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -76,10 +76,11 @@ def _is_admin_user(user: User) -> bool:
 
 
 def _has_admin_trace_access(user: User) -> bool:
-    """Check if user is admin AND their org has not enabled trace privacy.
+    """Check if user has admin-level trace access.
 
-    When trace privacy is on, admins are treated like regular users for
-    trace visibility — they can only see their own traces.
+    Super-admins always have full trace visibility regardless of the
+    trace_privacy setting.  When trace privacy is on, regular admins are
+    treated like normal users — they can only see their own traces.
 
     The trace_privacy flag is resolved once at authentication time (see
     deps._authenticate_via_jwt) and attached to the user object, so this
@@ -87,6 +88,8 @@ def _has_admin_trace_access(user: User) -> bool:
     """
     if not _is_admin_user(user):
         return False
+    if user.role == UserRole.super_admin:
+        return True
     return not getattr(user, "_trace_privacy", False)
 
 

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -13,7 +13,6 @@ from sqlalchemy import or_, select
 from api.deps import require_role
 from config import settings
 from database import async_session
-from models.organization import Organization
 from models.user import User, UserRole
 from services.clickhouse import _query, query_shim_spans_for_window
 from services.redis import publish
@@ -76,20 +75,19 @@ def _is_admin_user(user: User) -> bool:
     return user.role in (UserRole.admin, UserRole.super_admin)
 
 
-async def _is_admin_with_trace_access(user: User) -> bool:
+def _has_admin_trace_access(user: User) -> bool:
     """Check if user is admin AND their org has not enabled trace privacy.
 
     When trace privacy is on, admins are treated like regular users for
     trace visibility — they can only see their own traces.
+
+    The trace_privacy flag is resolved once at authentication time (see
+    deps._authenticate_via_jwt) and attached to the user object, so this
+    check never makes an extra DB call.
     """
     if not _is_admin_user(user):
         return False
-    if not user.org_id:
-        return True
-    async with async_session() as db:
-        result = await db.execute(select(Organization.trace_privacy).where(Organization.id == user.org_id))
-        trace_privacy = result.scalar_one_or_none()
-        return not trace_privacy
+    return not getattr(user, "_trace_privacy", False)
 
 
 @router.get("/sessions")
@@ -99,7 +97,7 @@ async def list_sessions(
     days: int | None = Query(None),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    is_admin = await _is_admin_with_trace_access(current_user)
+    is_admin = _has_admin_trace_access(current_user)
     uid_str = str(current_user.id)
     capped_days = min(days, 365) if days is not None and days > 0 else days
     rows = await _list_sessions_query(
@@ -264,7 +262,7 @@ async def _list_sessions_query(
 async def sessions_summary(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    is_admin = await _is_admin_with_trace_access(current_user)
+    is_admin = _has_admin_trace_access(current_user)
     session_filter = ""
     params: dict[str, str] = {}
     if not is_admin:
@@ -573,7 +571,7 @@ async def _sideload_shim_spans(events: list[dict]) -> list[dict]:
 
 @router.get("/sessions/{session_id}")
 async def get_session(session_id: str, current_user: User = Depends(require_role(UserRole.user))):
-    is_admin = await _is_admin_with_trace_access(current_user)
+    is_admin = _has_admin_trace_access(current_user)
     params: dict[str, str] = {"param_sid": session_id}
 
     if not is_admin:

--- a/observal-server/models/organization.py
+++ b/observal-server/models/organization.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, String
+from sqlalchemy import Boolean, DateTime, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,6 +14,7 @@ class Organization(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    trace_privacy: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/observal-server/tests/test_jwt.py
+++ b/observal-server/tests/test_jwt.py
@@ -172,7 +172,7 @@ class TestAuthDependency:
         token, _ = create_access_token(user.id, user.role)
 
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = user
+        mock_result.one_or_none.return_value = (user, False)
         mock_db = AsyncMock()
         mock_db.execute.return_value = mock_result
 

--- a/observal-server/tests/test_multi_tenancy.py
+++ b/observal-server/tests/test_multi_tenancy.py
@@ -128,7 +128,7 @@ class TestOptionalCurrentUser:
         token, _ = create_access_token(user.id, user.role)
 
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = user
+        mock_result.one_or_none.return_value = (user, False)
         mock_db = AsyncMock()
         mock_db.execute.return_value = mock_result
 

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { Settings, Plus, Pencil, Trash2, Save, X, Loader2, Info, Database, Activity, BookOpen, Shield, HelpCircle } from "lucide-react";
+import { useState, useCallback, useEffect } from "react";
+import { Settings, Plus, Pencil, Trash2, Save, X, Loader2, Info, Database, Activity, BookOpen, Shield, HelpCircle, Eye } from "lucide-react";
 import { toast } from "sonner";
 import { useAdminSettings } from "@/hooks/use-api";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
@@ -10,6 +10,7 @@ import type { AdminSetting } from "@/lib/types";
 import { admin } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -190,6 +191,29 @@ export default function SettingsPage() {
   const [showAdd, setShowAdd] = useState(false);
   const [saving, setSaving] = useState(false);
   const [applyingResources, setApplyingResources] = useState(false);
+  const [tracePrivacy, setTracePrivacy] = useState(false);
+  const [tracePrivacyLoading, setTracePrivacyLoading] = useState(true);
+  const [tracePrivacyToggling, setTracePrivacyToggling] = useState(false);
+
+  useEffect(() => {
+    admin.getTracePrivacy()
+      .then((res) => setTracePrivacy(res.trace_privacy))
+      .catch(() => {})
+      .finally(() => setTracePrivacyLoading(false));
+  }, []);
+
+  const handleTracePrivacyToggle = useCallback(async (checked: boolean) => {
+    setTracePrivacyToggling(true);
+    try {
+      const res = await admin.setTracePrivacy(checked);
+      setTracePrivacy(res.trace_privacy);
+      toast.success(`Trace privacy ${res.trace_privacy ? "enabled" : "disabled"}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update trace privacy");
+    } finally {
+      setTracePrivacyToggling(false);
+    }
+  }, []);
 
   const entries: { key: string; value: string }[] = Array.isArray(settings)
     ? settings.map((s: AdminSetting) => ({ key: s.key, value: s.value }))
@@ -288,6 +312,30 @@ export default function SettingsPage() {
               <span>Enterprise mode is active. Self-registration and password login are disabled.</span>
             </div>
           )}
+        </section>
+
+        {/* Trace Privacy */}
+        <section className="animate-in">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-1.5">
+            <Eye className="h-3.5 w-3.5" />
+            Trace Privacy
+          </h3>
+          <div className="rounded-md border border-border bg-card px-4 py-3">
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <p className="text-sm font-medium">Hide user traces from admins</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  When enabled, admins and super-admins can only see their own traces.
+                  Users&apos; traces remain private and are not visible to other roles.
+                </p>
+              </div>
+              <Switch
+                checked={tracePrivacy}
+                onCheckedChange={handleTracePrivacyToggle}
+                disabled={tracePrivacyLoading || tracePrivacyToggling}
+              />
+            </div>
+          </div>
         </section>
 
         {isLoading ? (

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -323,10 +323,10 @@ export default function SettingsPage() {
           <div className="rounded-md border border-border bg-card px-4 py-3">
             <div className="flex items-center justify-between">
               <div className="flex-1">
-                <p className="text-sm font-medium">Hide user traces from admins</p>
+                <p className="text-sm font-medium">Restrict trace visibility</p>
                 <p className="text-xs text-muted-foreground mt-0.5">
-                  When enabled, admins and super-admins can only see their own traces.
-                  Users&apos; traces remain private and are not visible to other roles.
+                  When enabled, all users (including admins) can only see their own traces.
+                  Super-admins always retain full visibility across all traces.
                 </p>
               </div>
               <Switch

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -376,6 +376,10 @@ export const admin = {
   deleteUser: (id: string) => del(`/admin/users/${id}`),
   applyResources: () =>
     post<{ applied: Record<string, string>; message: string }>("/admin/resources/apply", {}),
+  getTracePrivacy: () =>
+    get<{ trace_privacy: boolean }>("/admin/org/trace-privacy"),
+  setTracePrivacy: (enabled: boolean) =>
+    put<{ trace_privacy: boolean }>("/admin/org/trace-privacy", { trace_privacy: enabled }),
 };
 
 // ── Config ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Purpose / Description
Adds an organization-level toggle that hides user traces from admins and super-admins. When trace privacy is enabled, admins can only see their own traces instead of all traces across the organization.

## Fixes
* Fixes #486

## Approach
**Database layer**: Added a `trace_privacy` boolean column to the `organizations` table (default `false`) with an Alembic migration (`0017`).

**Backend enforcement**: Created `_is_admin_with_trace_access()` helper in the OTel dashboard routes that checks both the user's role and the org's `trace_privacy` flag. When privacy is on, all admin users are treated like regular users for trace visibility — sessions, session detail, and summary endpoints filter to only the requesting user's data. The same logic is applied in the GraphQL layer by passing `trace_privacy` through the resolver context and short-circuiting `_is_admin()` when the flag is set.

**Admin API**: Added `GET/PUT /api/v1/admin/org/trace-privacy` endpoints (super-admin only) to read and toggle the setting, with audit logging via security events.

**Frontend**: Added a "Trace Privacy" section with a Switch toggle in the super-admin settings page, wired to the new API endpoints.

## How Has This Been Tested?
- TypeScript compiles cleanly (`tsc --noEmit`)
- Ruff lint and format pass on all changed Python files
- Existing backend tests pass (those that can run in the local environment)
- Manual verification of the toggle UI rendering in the settings page

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)