### PR TITLE
fix: use POSIX paths for hook scripts on Windows

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -456,7 +456,7 @@ def _find_hook_script(name: str) -> str | None:
     ]
     for p in candidates:
         if p.is_file():
-            return str(p.resolve())
+            return p.resolve().as_posix()
     return None
 
 

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -1062,7 +1062,7 @@ def register_scan(app: typer.Typer):
             # Stop uses a command hook to read transcript for Claude's response
             stop_script = Path(__file__).parent / "hooks" / "observal-stop-hook.sh"
             stop_hook = (
-                [{"hooks": [{"type": "command", "command": str(stop_script.resolve())}]}]
+                [{"hooks": [{"type": "command", "command": stop_script.resolve().as_posix()}]}]
                 if stop_script.is_file()
                 else http_hook
             )
@@ -1152,7 +1152,7 @@ def register_scan(app: typer.Typer):
                 if model:
                     args += f" --model {model}"
                 if hook_script.is_file():
-                    return f"cat | python3 {hook_script.resolve()} {args}"
+                    return f"cat | python3 {hook_script.resolve().as_posix()} {args}"
                 return f'cat | curl -sf -X POST {kiro_hooks_url} -H "Content-Type: application/json" -d @-'
 
             def _kiro_stop_cmd(agent_name: str, model: str) -> str:
@@ -1161,7 +1161,7 @@ def register_scan(app: typer.Typer):
                 if model:
                     args += f" --model {model}"
                 if stop_script.is_file():
-                    return f"cat | python3 {stop_script.resolve()} {args}"
+                    return f"cat | python3 {stop_script.resolve().as_posix()} {args}"
                 return f'cat | curl -sf -X POST {kiro_hooks_url} -H "Content-Type: application/json" -d @-'
 
             def _kiro_hooks_block(agent_name: str, model: str) -> dict:


### PR DESCRIPTION

This breaks all trace collection on Windows.

## Fixes

* Fixes Windows hook path resolution , all Claude Code and Kiro hook events now fire correctly on Windows.

## Approach

Replaced `str(p.resolve())` with `p.resolve().as_posix()` in all 4 locations where hook script paths are generated:

- `cmd_auth.py` : `_find_stop_hook_script()` (Claude Code stop hook)
- `cmd_scan.py` :stop hook injection into `~/.claude/settings.json`
- `cmd_scan.py` :`_kiro_hook_cmd()` (Kiro hook command)
- `cmd_scan.py` :`_kiro_stop_cmd()` (Kiro stop hook command)

`Path.as_posix()` returns forward-slash paths (`C:/Users/lokes/...`) which bash resolves correctly. On Linux/macOS this is a no-op since paths are already forward-slash, so there is zero regression risk.

## How Has This Been Tested?

1. Reproduced the bug on Windows 11 by running `claude --agent precise-builder --model opus` — confirmed `SessionStart: startup hook error` with mangled path
2. Applied the fix and relaunched Claude Code :hook error gone, session starts cleanly
3. Verified the generated path format: `C:/Users/lokes/OneDrive/Desktop/BlazeUp/Observal/observal_cli/hooks/observal-hook.sh` (forward slashes)

**Test configuration:** Windows 11 Home 10.0.26200, Claude Code v2.1.117, Git Bash

## Learning

- On Windows, Python's `Path.resolve()` returns `WindowsPath` with backslash separators. `str()` preserves those backslashes, but bash (used by Claude Code for hook execution) cannot interpret them as path separators.
- `Path.as_posix()` is the idiomatic cross-platform solution — it converts to forward slashes which both bash and Windows APIs accept.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
