### PR TITLE
feat: Kimi eval provider + dashboard scores + ClickHouse init hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ EVAL_MODEL_API_KEY=
 EVAL_MODEL_NAME=
 EVAL_MODEL_PROVIDER=
 
+# Moonshot / Kimi example (OpenAI-compatible). URL and Thinking-Mode toggle
+# are handled automatically when PROVIDER=moonshot.
+# EVAL_MODEL_PROVIDER=moonshot
+# EVAL_MODEL_API_KEY=sk-...
+# EVAL_MODEL_NAME=kimi-k2.5-preview
+
 # Optional: AWS credentials for Bedrock eval engine
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
       - ./clickhouse/users.d:/etc/clickhouse-server/users.d
     healthcheck:
-      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
+      test: ["CMD-SHELL", "clickhouse-client --password ${CLICKHOUSE_PASSWORD:-clickhouse} --query 'SELECT 1'"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 echo "Ensuring base schema exists..."
@@ -19,43 +19,39 @@ echo "Running database migrations..."
 /app/.venv/bin/python -m alembic upgrade head
 
 echo "Ensuring ClickHouse database exists..."
-# Parse credentials from CLICKHOUSE_URL (clickhouse://user:pass@host:port/db)
-CH_URL="${CLICKHOUSE_URL:-clickhouse://default:clickhouse@observal-clickhouse:8123/observal}"
-CH_HOST=$(echo "$CH_URL" | sed 's|clickhouse://[^@]*@||' | sed 's|/.*||')
-CH_USER=$(echo "$CH_URL" | sed 's|clickhouse://||' | sed 's|:.*||')
-CH_PASS=$(echo "$CH_URL" | sed 's|clickhouse://[^:]*:||' | sed 's|@.*||')
-CH_DB=$(echo "$CH_URL" | sed 's|.*/||')
+# Parse credentials from CLICKHOUSE_URL using Python to handle special chars
+eval "$(/app/.venv/bin/python -c "
+from urllib.parse import urlparse, unquote
+import os
+url = urlparse(os.environ.get('CLICKHOUSE_URL', 'clickhouse://default:clickhouse@observal-clickhouse:8123/observal'))
+print(f'CH_HOST={url.hostname}:{url.port or 8123}')
+print(f'CH_USER={unquote(url.username or \"default\")}')
+print(f'CH_PASS={unquote(url.password or \"clickhouse\")}')
+print(f'CH_DB={url.path.lstrip(\"/\") or \"observal\"}')
+")"
 CH_PROTO_HOST="http://${CH_HOST}"
 
 CH_CREATE_RETRIES=15
 CH_CREATE_COUNT=0
 while [ $CH_CREATE_COUNT -lt $CH_CREATE_RETRIES ]; do
-  HTTP_CODE=$(/app/.venv/bin/python -c "
-import urllib.request, sys
-try:
-    req = urllib.request.Request('${CH_PROTO_HOST}/?user=${CH_USER}&password=${CH_PASS}',
-                                data=b'CREATE DATABASE IF NOT EXISTS ${CH_DB}')
-    urllib.request.urlopen(req, timeout=5)
-    print('ok')
-except Exception:
-    print('fail')
-")
+  HTTP_CODE=$(wget -q -O- --user="$CH_USER" --password="$CH_PASS" \
+    --post-data="CREATE DATABASE IF NOT EXISTS ${CH_DB}" \
+    "${CH_PROTO_HOST}/" 2>/dev/null && echo "ok" || echo "fail")
   if [ "$HTTP_CODE" = "ok" ]; then
     echo "ClickHouse database '${CH_DB}' ready"
     break
   fi
   CH_CREATE_COUNT=$((CH_CREATE_COUNT + 1))
-  WAIT=$((2 ** CH_CREATE_COUNT > 30 ? 30 : 2 ** CH_CREATE_COUNT))
-  echo "Waiting for ClickHouse to accept connections (attempt $CH_CREATE_COUNT/$CH_CREATE_RETRIES, retry in ${WAIT}s)..."
-  sleep "$WAIT"
   if [ $CH_CREATE_COUNT -ge $CH_CREATE_RETRIES ]; then
     echo "ClickHouse not reachable after $CH_CREATE_RETRIES attempts, aborting."
     exit 1
   fi
+  WAIT=$(( 2 ** CH_CREATE_COUNT > 30 ? 30 : 2 ** CH_CREATE_COUNT ))
+  echo "Waiting for ClickHouse to accept connections (attempt $CH_CREATE_COUNT/$CH_CREATE_RETRIES, retry in ${WAIT}s)..."
+  sleep "$WAIT"
 done
 
 echo "Initializing ClickHouse tables..."
-# Retry logic for ClickHouse initialization
 MAX_RETRIES=10
 RETRY_COUNT=0
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
@@ -70,9 +66,9 @@ asyncio.run(init_clickhouse())
   else
     RETRY_COUNT=$((RETRY_COUNT + 1))
     if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-      WAIT_TIME=$((2 ** RETRY_COUNT))
+      WAIT_TIME=$(( 2 ** RETRY_COUNT > 30 ? 30 : 2 ** RETRY_COUNT ))
       echo "ClickHouse initialization failed. Retrying in ${WAIT_TIME}s (attempt $RETRY_COUNT/$MAX_RETRIES)..."
-      sleep $WAIT_TIME
+      sleep "$WAIT_TIME"
     else
       echo "ClickHouse initialization failed after $MAX_RETRIES attempts"
       exit 1

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -30,8 +30,16 @@ CH_PROTO_HOST="http://${CH_HOST}"
 CH_CREATE_RETRIES=15
 CH_CREATE_COUNT=0
 while [ $CH_CREATE_COUNT -lt $CH_CREATE_RETRIES ]; do
-  HTTP_CODE=$(wget -q -O- "${CH_PROTO_HOST}/?user=${CH_USER}&password=${CH_PASS}" \
-    --post-data="CREATE DATABASE IF NOT EXISTS ${CH_DB}" 2>/dev/null && echo "ok" || echo "fail")
+  HTTP_CODE=$(/app/.venv/bin/python -c "
+import urllib.request, sys
+try:
+    req = urllib.request.Request('${CH_PROTO_HOST}/?user=${CH_USER}&password=${CH_PASS}',
+                                data=b'CREATE DATABASE IF NOT EXISTS ${CH_DB}')
+    urllib.request.urlopen(req, timeout=5)
+    print('ok')
+except Exception:
+    print('fail')
+")
   if [ "$HTTP_CODE" = "ok" ]; then
     echo "ClickHouse database '${CH_DB}' ready"
     break

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,12 +18,58 @@ asyncio.run(init())
 echo "Running database migrations..."
 /app/.venv/bin/python -m alembic upgrade head
 
+echo "Ensuring ClickHouse database exists..."
+# Parse credentials from CLICKHOUSE_URL (clickhouse://user:pass@host:port/db)
+CH_URL="${CLICKHOUSE_URL:-clickhouse://default:clickhouse@observal-clickhouse:8123/observal}"
+CH_HOST=$(echo "$CH_URL" | sed 's|clickhouse://[^@]*@||' | sed 's|/.*||')
+CH_USER=$(echo "$CH_URL" | sed 's|clickhouse://||' | sed 's|:.*||')
+CH_PASS=$(echo "$CH_URL" | sed 's|clickhouse://[^:]*:||' | sed 's|@.*||')
+CH_DB=$(echo "$CH_URL" | sed 's|.*/||')
+CH_PROTO_HOST="http://${CH_HOST}"
+
+CH_CREATE_RETRIES=15
+CH_CREATE_COUNT=0
+while [ $CH_CREATE_COUNT -lt $CH_CREATE_RETRIES ]; do
+  HTTP_CODE=$(wget -q -O- "${CH_PROTO_HOST}/?user=${CH_USER}&password=${CH_PASS}" \
+    --post-data="CREATE DATABASE IF NOT EXISTS ${CH_DB}" 2>/dev/null && echo "ok" || echo "fail")
+  if [ "$HTTP_CODE" = "ok" ]; then
+    echo "ClickHouse database '${CH_DB}' ready"
+    break
+  fi
+  CH_CREATE_COUNT=$((CH_CREATE_COUNT + 1))
+  WAIT=$((2 ** CH_CREATE_COUNT > 30 ? 30 : 2 ** CH_CREATE_COUNT))
+  echo "Waiting for ClickHouse to accept connections (attempt $CH_CREATE_COUNT/$CH_CREATE_RETRIES, retry in ${WAIT}s)..."
+  sleep "$WAIT"
+  if [ $CH_CREATE_COUNT -ge $CH_CREATE_RETRIES ]; then
+    echo "ClickHouse not reachable after $CH_CREATE_RETRIES attempts, aborting."
+    exit 1
+  fi
+done
+
 echo "Initializing ClickHouse tables..."
-/app/.venv/bin/python -c "
+# Retry logic for ClickHouse initialization
+MAX_RETRIES=10
+RETRY_COUNT=0
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+  if /app/.venv/bin/python -c "
 import asyncio
 from services.clickhouse import init_clickhouse
 
 asyncio.run(init_clickhouse())
-"
+"; then
+    echo "ClickHouse initialization successful"
+    break
+  else
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+      WAIT_TIME=$((2 ** RETRY_COUNT))
+      echo "ClickHouse initialization failed. Retrying in ${WAIT_TIME}s (attempt $RETRY_COUNT/$MAX_RETRIES)..."
+      sleep $WAIT_TIME
+    else
+      echo "ClickHouse initialization failed after $MAX_RETRIES attempts"
+      exit 1
+    fi
+  fi
+done
 
 echo "Initialization complete."

--- a/docs/self-hosting/evaluation-engine.md
+++ b/docs/self-hosting/evaluation-engine.md
@@ -44,9 +44,21 @@ EVAL_MODEL_NAME=llama3
 EVAL_MODEL_PROVIDER=openai
 ```
 
+### Moonshot / Kimi
+
+Kimi K2.5 (and K2) are accessible through Moonshot's OpenAI-compatible API. Set `EVAL_MODEL_PROVIDER=moonshot` and the base URL defaults to `https://api.moonshot.ai/v1`; the server also injects `{"thinking": {"type": "disabled"}}` into the request so the model returns a single deterministic JSON response instead of streaming reasoning tokens.
+
+```
+EVAL_MODEL_PROVIDER=moonshot
+EVAL_MODEL_API_KEY=sk-...
+EVAL_MODEL_NAME=kimi-k2.5-preview
+```
+
+Override `EVAL_MODEL_URL` only if you're using a third-party Moonshot-compatible gateway.
+
 ### Auto-detect
 
-If `EVAL_MODEL_PROVIDER` is empty and `EVAL_MODEL_NAME` contains `anthropic`, Bedrock is used. Otherwise the OpenAI-compatible path is used.
+If `EVAL_MODEL_PROVIDER` is empty: model names containing `anthropic` route to Bedrock, names containing `kimi` route to Moonshot, everything else uses the generic OpenAI-compatible path.
 
 ## Choosing the judge model
 

--- a/observal-server/services/eval/eval_engine.py
+++ b/observal-server/services/eval/eval_engine.py
@@ -126,6 +126,8 @@ async def _call_model(prompt: str) -> dict:
         return {}
     if provider == "bedrock" or (not provider and "anthropic" in model):
         return await _call_bedrock(prompt, model)
+    if provider == "moonshot" or (not provider and "kimi" in model.lower()):
+        return await _call_openai(prompt, model, provider="moonshot")
     return await _call_openai(prompt, model)
 
 
@@ -151,19 +153,22 @@ async def _call_bedrock(prompt: str, model_id: str) -> dict:
         return {}
 
 
-async def _call_openai(prompt: str, model: str) -> dict:
-    url = getattr(settings, "EVAL_MODEL_URL", "") or "http://localhost:11434/v1"
+async def _call_openai(prompt: str, model: str, provider: str = "") -> dict:
+    default_url = "https://api.moonshot.ai/v1" if provider == "moonshot" else "http://localhost:11434/v1"
+    url = getattr(settings, "EVAL_MODEL_URL", "") or default_url
     key = getattr(settings, "EVAL_MODEL_API_KEY", "") or ""
     headers = {"Content-Type": "application/json"}
     if key:
         headers["Authorization"] = f"Bearer {key}"
+    body: dict = {"model": model, "messages": [{"role": "user", "content": prompt}], "temperature": 0.1}
+    if provider == "moonshot":
+        # Kimi defaults to Thinking Mode; disable it for deterministic JSON scoring.
+        # Moonshot Instant Mode requires temperature=0.6 — API rejects anything else.
+        body["thinking"] = {"type": "disabled"}
+        body["temperature"] = 0.6
     try:
         async with httpx.AsyncClient(timeout=60) as client:
-            r = await client.post(
-                f"{url}/chat/completions",
-                headers=headers,
-                json={"model": model, "messages": [{"role": "user", "content": prompt}], "temperature": 0.1},
-            )
+            r = await client.post(f"{url}/chat/completions", headers=headers, json=body)
             r.raise_for_status()
             return _extract_json(r.json()["choices"][0]["message"]["content"])
     except Exception as e:

--- a/observal-server/services/eval/eval_engine.py
+++ b/observal-server/services/eval/eval_engine.py
@@ -153,19 +153,29 @@ async def _call_bedrock(prompt: str, model_id: str) -> dict:
         return {}
 
 
-async def _call_openai(prompt: str, model: str, provider: str = "") -> dict:
+def _build_openai_body(model: str, prompt: str, provider: str = "", extra: dict | None = None) -> dict:
+    body: dict = {"model": model, "messages": [{"role": "user", "content": prompt}], "temperature": 0.1}
+    if provider == "moonshot":
+        body["thinking"] = {"type": "disabled"}
+        body["temperature"] = 0.6
+    if extra:
+        body.update(extra)
+    return body
+
+
+def _openai_url_and_headers(provider: str = "") -> tuple[str, dict]:
     default_url = "https://api.moonshot.ai/v1" if provider == "moonshot" else "http://localhost:11434/v1"
     url = getattr(settings, "EVAL_MODEL_URL", "") or default_url
     key = getattr(settings, "EVAL_MODEL_API_KEY", "") or ""
     headers = {"Content-Type": "application/json"}
     if key:
         headers["Authorization"] = f"Bearer {key}"
-    body: dict = {"model": model, "messages": [{"role": "user", "content": prompt}], "temperature": 0.1}
-    if provider == "moonshot":
-        # Kimi defaults to Thinking Mode; disable it for deterministic JSON scoring.
-        # Moonshot Instant Mode requires temperature=0.6 — API rejects anything else.
-        body["thinking"] = {"type": "disabled"}
-        body["temperature"] = 0.6
+    return url, headers
+
+
+async def _call_openai(prompt: str, model: str, provider: str = "") -> dict:
+    url, headers = _openai_url_and_headers(provider)
+    body = _build_openai_body(model, prompt, provider)
     try:
         async with httpx.AsyncClient(timeout=60) as client:
             r = await client.post(f"{url}/chat/completions", headers=headers, json=body)

--- a/observal-server/services/eval/eval_service.py
+++ b/observal-server/services/eval/eval_service.py
@@ -11,7 +11,7 @@ from models.scoring import DEFAULT_PENALTIES
 from services.clickhouse import _query
 from services.eval.adversarial_scorer import AdversarialScorer
 from services.eval.canary import CanaryConfig, CanaryDetector
-from services.eval.eval_engine import FallbackBackend, get_backend
+from services.eval.eval_engine import FallbackBackend, _build_openai_body, _openai_url_and_headers, get_backend
 from services.eval.eval_watchdog import EvalWatchdog
 from services.eval.sanitizer import TraceSanitizer
 from services.eval.score_aggregator import ScoreAggregator
@@ -136,25 +136,8 @@ async def _call_bedrock(prompt: str, model_id: str) -> dict:
 
 async def _call_openai_compatible(prompt: str, model: str, provider: str = "") -> dict:
     """Call an OpenAI-compatible API."""
-    default_url = "https://api.moonshot.ai/v1" if provider == "moonshot" else "http://localhost:11434/v1"
-    eval_url = getattr(settings, "EVAL_MODEL_URL", "") or default_url
-    eval_key = getattr(settings, "EVAL_MODEL_API_KEY", "") or ""
-
-    headers = {"Content-Type": "application/json"}
-    if eval_key:
-        headers["Authorization"] = f"Bearer {eval_key}"
-
-    body: dict = {
-        "model": model,
-        "messages": [{"role": "user", "content": prompt}],
-        "temperature": 0.1,
-        "response_format": {"type": "json_object"},
-    }
-    if provider == "moonshot":
-        # Kimi defaults to Thinking Mode; disable for deterministic JSON scoring.
-        # Moonshot Instant Mode requires temperature=0.6 — API rejects anything else.
-        body["thinking"] = {"type": "disabled"}
-        body["temperature"] = 0.6
+    eval_url, headers = _openai_url_and_headers(provider)
+    body = _build_openai_body(model, prompt, provider, extra={"response_format": {"type": "json_object"}})
 
     async with httpx.AsyncClient(timeout=120) as client:
         try:

--- a/observal-server/services/eval/eval_service.py
+++ b/observal-server/services/eval/eval_service.py
@@ -92,7 +92,7 @@ async def fetch_traces(agent_id: str, limit: int = 20, trace_id: str | None = No
 
 
 async def call_eval_model(prompt: str) -> dict:
-    """Call the evaluation model. Supports Bedrock and OpenAI-compatible APIs."""
+    """Call the evaluation model. Supports Bedrock, Moonshot, and OpenAI-compatible APIs."""
     provider = getattr(settings, "EVAL_MODEL_PROVIDER", "") or ""
     eval_model = getattr(settings, "EVAL_MODEL_NAME", "") or ""
 
@@ -101,6 +101,8 @@ async def call_eval_model(prompt: str) -> dict:
 
     if provider == "bedrock" or (not provider and "anthropic" in eval_model):
         return await _call_bedrock(prompt, eval_model)
+    if provider == "moonshot" or (not provider and "kimi" in eval_model.lower()):
+        return await _call_openai_compatible(prompt, eval_model, provider="moonshot")
     return await _call_openai_compatible(prompt, eval_model)
 
 
@@ -132,27 +134,31 @@ async def _call_bedrock(prompt: str, model_id: str) -> dict:
         return {}
 
 
-async def _call_openai_compatible(prompt: str, model: str) -> dict:
+async def _call_openai_compatible(prompt: str, model: str, provider: str = "") -> dict:
     """Call an OpenAI-compatible API."""
-    eval_url = getattr(settings, "EVAL_MODEL_URL", "") or "http://localhost:11434/v1"
+    default_url = "https://api.moonshot.ai/v1" if provider == "moonshot" else "http://localhost:11434/v1"
+    eval_url = getattr(settings, "EVAL_MODEL_URL", "") or default_url
     eval_key = getattr(settings, "EVAL_MODEL_API_KEY", "") or ""
 
     headers = {"Content-Type": "application/json"}
     if eval_key:
         headers["Authorization"] = f"Bearer {eval_key}"
 
+    body: dict = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.1,
+        "response_format": {"type": "json_object"},
+    }
+    if provider == "moonshot":
+        # Kimi defaults to Thinking Mode; disable for deterministic JSON scoring.
+        # Moonshot Instant Mode requires temperature=0.6 — API rejects anything else.
+        body["thinking"] = {"type": "disabled"}
+        body["temperature"] = 0.6
+
     async with httpx.AsyncClient(timeout=120) as client:
         try:
-            r = await client.post(
-                f"{eval_url}/chat/completions",
-                headers=headers,
-                json={
-                    "model": model,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "temperature": 0.1,
-                    "response_format": {"type": "json_object"},
-                },
-            )
+            r = await client.post(f"{eval_url}/chat/completions", headers=headers, json=body)
             r.raise_for_status()
             content = r.json()["choices"][0]["message"]["content"]
             return json.loads(content)

--- a/tests/eval/test_eval_phase8.py
+++ b/tests/eval/test_eval_phase8.py
@@ -8,6 +8,7 @@ from services.eval.eval_engine import (
     EVAL_TEMPLATES,
     FallbackBackend,
     LLMJudgeBackend,
+    _call_model,
     _extract_json,
     get_backend,
     list_templates,
@@ -170,3 +171,94 @@ class TestRunEvalOnTrace:
 
             result = await run_eval_on_trace("agent-1", "t1")
             assert result == []  # errors caught, no scores
+
+
+class TestMoonshotProvider:
+    """Kimi/Moonshot routes through the OpenAI-compatible path with Moonshot defaults."""
+
+    @pytest.mark.asyncio
+    async def test_moonshot_provider_sets_defaults_and_disables_thinking(self):
+        captured: dict = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": '{"score": 0.75, "reason": "ok"}'}}]}
+
+        class _Client:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, url, headers=None, json=None):
+                captured["url"] = url
+                captured["headers"] = headers
+                captured["body"] = json
+                return _Resp()
+
+        with (
+            patch("services.eval.eval_engine.settings") as mock_settings,
+            patch("services.eval.eval_engine.httpx.AsyncClient", _Client),
+        ):
+            mock_settings.EVAL_MODEL_PROVIDER = "moonshot"
+            mock_settings.EVAL_MODEL_NAME = "kimi-k2.5-preview"
+            mock_settings.EVAL_MODEL_URL = ""
+            mock_settings.EVAL_MODEL_API_KEY = "sk-test"
+
+            result = await _call_model("score this")
+
+        assert result == {"score": 0.75, "reason": "ok"}
+        assert captured["url"].startswith("https://api.moonshot.ai/v1")
+        assert captured["headers"]["Authorization"] == "Bearer sk-test"
+        assert captured["body"]["model"] == "kimi-k2.5-preview"
+        assert captured["body"]["thinking"] == {"type": "disabled"}
+        assert captured["body"]["temperature"] == 0.6
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_by_model_name(self):
+        """Model name containing 'kimi' routes to moonshot even without explicit provider."""
+        captured: dict = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": "{}"}}]}
+
+        class _Client:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, url, headers=None, json=None):
+                captured["url"] = url
+                captured["body"] = json
+                return _Resp()
+
+        with (
+            patch("services.eval.eval_engine.settings") as mock_settings,
+            patch("services.eval.eval_engine.httpx.AsyncClient", _Client),
+        ):
+            mock_settings.EVAL_MODEL_PROVIDER = ""
+            mock_settings.EVAL_MODEL_NAME = "Kimi-K2.5"
+            mock_settings.EVAL_MODEL_URL = ""
+            mock_settings.EVAL_MODEL_API_KEY = ""
+
+            await _call_model("hi")
+
+        assert captured["url"].startswith("https://api.moonshot.ai/v1")
+        assert captured["body"]["thinking"] == {"type": "disabled"}
+        assert captured["body"]["temperature"] == 0.6

--- a/tests/eval/test_eval_phase8.py
+++ b/tests/eval/test_eval_phase8.py
@@ -14,6 +14,7 @@ from services.eval.eval_engine import (
     list_templates,
     run_eval_on_trace,
 )
+from services.eval.eval_service import call_eval_model
 
 
 class TestEvalTemplates:
@@ -262,3 +263,52 @@ class TestMoonshotProvider:
         assert captured["url"].startswith("https://api.moonshot.ai/v1")
         assert captured["body"]["thinking"] == {"type": "disabled"}
         assert captured["body"]["temperature"] == 0.6
+
+
+class TestMoonshotEvalService:
+    """call_eval_model in eval_service.py shares body-building with eval_engine."""
+
+    @pytest.mark.asyncio
+    async def test_moonshot_via_eval_service(self):
+        captured: dict = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": '{"score": 0.9}'}}]}
+
+        class _Client:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, url, headers=None, json=None):
+                captured["url"] = url
+                captured["body"] = json
+                return _Resp()
+
+        with (
+            patch("services.eval.eval_service.settings") as svc_settings,
+            patch("services.eval.eval_engine.settings") as eng_settings,
+            patch("services.eval.eval_service.httpx.AsyncClient", _Client),
+        ):
+            for s in (svc_settings, eng_settings):
+                s.EVAL_MODEL_PROVIDER = "moonshot"
+                s.EVAL_MODEL_NAME = "kimi-k2.5"
+                s.EVAL_MODEL_URL = ""
+                s.EVAL_MODEL_API_KEY = "sk-svc"
+
+            result = await call_eval_model("test prompt")
+
+        assert result == {"score": 0.9}
+        assert captured["url"].startswith("https://api.moonshot.ai/v1")
+        assert captured["body"]["thinking"] == {"type": "disabled"}
+        assert captured["body"]["temperature"] == 0.6
+        assert captured["body"]["response_format"] == {"type": "json_object"}

--- a/web/src/app/(admin)/dashboard/page.tsx
+++ b/web/src/app/(admin)/dashboard/page.tsx
@@ -66,7 +66,7 @@ function AgentScoreCard({ agent }: { agent: RegistryItem }) {
   const { data: scorecards } = useEvalScorecards(agent.id);
   const latest = (scorecards ?? [])[0] as Scorecard | undefined;
 
-  if (!latest?.dimension_scores || !latest?.grade) return null;
+  if (!latest?.dimension_scores || !latest?.grade || latest.display_score == null) return null;
 
   return (
     <Link href={`/eval/${agent.id}`} className="block">
@@ -80,8 +80,8 @@ function AgentScoreCard({ agent }: { agent: RegistryItem }) {
           )}
         </div>
         <ScoreOverview
-          displayScore={latest.display_score ?? latest.overall_score ?? 0}
-          grade={latest.grade ?? latest.overall_grade ?? "-"}
+          displayScore={latest.display_score}
+          grade={latest.grade}
           dimensionScores={latest.dimension_scores ?? {}}
           penaltyCount={latest.penalty_count}
           compact

--- a/web/src/app/(admin)/dashboard/page.tsx
+++ b/web/src/app/(admin)/dashboard/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { Bot, Activity, TrendingUp, TrendingDown, Minus, Download } from "lucide-react";
-import { useOverviewStats, useRegistryList, useTopAgents, useOtelSessions } from "@/hooks/use-api";
-import type { RegistryItem, OtelSession, TopAgentItem } from "@/lib/types";
+import { Bot, Activity, TrendingUp, TrendingDown, Minus, Download, FlaskConical } from "lucide-react";
+import { useOverviewStats, useRegistryList, useTopAgents, useOtelSessions, useEvalScorecards } from "@/hooks/use-api";
+import type { RegistryItem, OtelSession, TopAgentItem, Scorecard } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
@@ -12,6 +12,7 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+import { ScoreOverview } from "@/components/dashboard/score-overview";
 
 function TrendIcon({ value }: { value: number }) {
   if (value > 0) return <TrendingUp className="h-3 w-3 text-success" />;
@@ -58,6 +59,35 @@ function TopDownloadsBar({ items }: { items: { name: string; value: number }[] }
         </div>
       ))}
     </div>
+  );
+}
+
+function AgentScoreCard({ agent }: { agent: RegistryItem }) {
+  const { data: scorecards } = useEvalScorecards(agent.id);
+  const latest = (scorecards ?? [])[0] as Scorecard | undefined;
+
+  if (!latest?.dimension_scores || !latest?.grade) return null;
+
+  return (
+    <Link href={`/eval/${agent.id}`} className="block">
+      <div className="rounded-md border border-border p-4 hover:bg-muted/30 transition-colors space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="font-[family-name:var(--font-display)] text-sm font-semibold truncate">
+            {agent.name}
+          </span>
+          {latest.version && (
+            <Badge variant="secondary" className="text-[10px]">v{latest.version}</Badge>
+          )}
+        </div>
+        <ScoreOverview
+          displayScore={latest.display_score ?? latest.overall_score ?? 0}
+          grade={latest.grade ?? latest.overall_grade ?? "-"}
+          dimensionScores={latest.dimension_scores ?? {}}
+          penaltyCount={latest.penalty_count}
+          compact
+        />
+      </div>
+    </Link>
   );
 }
 
@@ -211,7 +241,35 @@ export default function DashboardPage() {
 
           {/* Right column: 1/3 */}
           <div className="space-y-6">
+            {/* Agent Scores */}
             <section className="animate-in stagger-3">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Agent Scores
+                </h3>
+                <Link href="/eval" className="text-[10px] text-primary hover:underline">
+                  View all
+                </Link>
+              </div>
+              {agentsLoading ? (
+                <CardSkeleton count={2} />
+              ) : (agents ?? []).length === 0 ? (
+                <EmptyState
+                  icon={FlaskConical}
+                  title="No agents scored"
+                  description="Run evaluations to see scores here."
+                />
+              ) : (
+                <div className="space-y-3">
+                  {(agents ?? []).slice(0, 4).map((a: RegistryItem) => (
+                    <AgentScoreCard key={a.id} agent={a} />
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {/* Top Downloads */}
+            <section className="animate-in stagger-4">
               <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
                 Top Downloads
               </h3>

--- a/web/src/app/(admin)/eval/[agentId]/page.tsx
+++ b/web/src/app/(admin)/eval/[agentId]/page.tsx
@@ -17,6 +17,7 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton, ChartSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+import { ScoreOverview } from "@/components/dashboard/score-overview";
 
 function gradeColor(grade: string | undefined): string {
   if (!grade) return "text-muted-foreground";
@@ -149,30 +150,24 @@ export default function EvalDetailPage({ params }: { params: Promise<{ agentId: 
 
           {/* Right: 1/3 — Score Summary */}
           <div className="space-y-6">
-            {/* Current Grade */}
+            {/* Score Overview with Dimension Breakdown */}
             {latest && (
               <section className="animate-in stagger-1">
                 <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
                   Current Score
                 </h3>
-                <div className="rounded-md border border-border p-4 space-y-3">
-                  <div className="flex items-center gap-4">
-                    <div className={`flex items-center justify-center w-14 h-14 rounded-md ${gradeBg(latest.grade)}`}>
-                      <span className={`text-2xl font-bold font-[family-name:var(--font-display)] ${gradeColor(latest.grade)}`}>
-                        {latest.grade ?? "-"}
-                      </span>
-                    </div>
-                    <div>
-                      {latest.display_score != null && (
-                        <p className="text-lg font-semibold font-[family-name:var(--font-mono)] tabular-nums">
-                          {latest.display_score.toFixed(1)}<span className="text-xs text-muted-foreground">/10</span>
-                        </p>
-                      )}
-                      {latest.version && (
-                        <p className="text-xs text-muted-foreground">v{latest.version}</p>
-                      )}
-                    </div>
-                  </div>
+                <div className="rounded-md border border-border p-5">
+                  <ScoreOverview
+                    displayScore={latest.display_score ?? latest.overall_score ?? 0}
+                    grade={latest.grade ?? latest.overall_grade ?? "-"}
+                    dimensionScores={latest.dimension_scores ?? {}}
+                    penaltyCount={latest.penalty_count}
+                  />
+                  {latest.version && (
+                    <p className="text-xs text-muted-foreground mt-3 pt-3 border-t border-border">
+                      Version: <span className="font-[family-name:var(--font-mono)]">v{latest.version}</span>
+                    </p>
+                  )}
                 </div>
               </section>
             )}
@@ -181,7 +176,7 @@ export default function EvalDetailPage({ params }: { params: Promise<{ agentId: 
             {latest?.dimension_scores && (
               <section className="animate-in stagger-2">
                 <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-                  Dimensions
+                  Dimension Radar
                 </h3>
                 <div className="rounded-md border border-border p-2">
                   <DimensionRadar dimensionScores={latest.dimension_scores} />

--- a/web/src/app/(admin)/eval/[agentId]/page.tsx
+++ b/web/src/app/(admin)/eval/[agentId]/page.tsx
@@ -158,8 +158,8 @@ export default function EvalDetailPage({ params }: { params: Promise<{ agentId: 
                 </h3>
                 <div className="rounded-md border border-border p-5">
                   <ScoreOverview
-                    displayScore={latest.display_score ?? latest.overall_score ?? 0}
-                    grade={latest.grade ?? latest.overall_grade ?? "-"}
+                    displayScore={latest.display_score ?? 0}
+                    grade={latest.grade ?? "-"}
                     dimensionScores={latest.dimension_scores ?? {}}
                     penaltyCount={latest.penalty_count}
                   />

--- a/web/src/app/(admin)/eval/page.tsx
+++ b/web/src/app/(admin)/eval/page.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { CardSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
+import { ScoreOverview } from "@/components/dashboard/score-overview";
 
 function gradeColor(grade: string | undefined): string {
   if (!grade) return "bg-muted text-muted-foreground";
@@ -43,19 +44,29 @@ function AgentEvalCard({ agent }: { agent: RegistryItem }) {
         )}
       </div>
 
-      <div className="flex items-center gap-3 text-xs text-muted-foreground">
-        {latest?.display_score != null && (
-          <span className="font-[family-name:var(--font-mono)] tabular-nums">
-            {latest.display_score.toFixed(1)}/10
-          </span>
-        )}
-        {evalCount > 0 && (
-          <span>{evalCount} eval{evalCount !== 1 ? "s" : ""}</span>
-        )}
-        {!latest && (
-          <span>No evaluations yet</span>
-        )}
-      </div>
+      {latest?.dimension_scores ? (
+        <ScoreOverview
+          displayScore={latest.display_score ?? latest.overall_score ?? 0}
+          grade={latest.grade ?? latest.overall_grade ?? "-"}
+          dimensionScores={latest.dimension_scores}
+          penaltyCount={latest.penalty_count}
+          compact
+        />
+      ) : (
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {latest?.display_score != null && (
+            <span className="font-[family-name:var(--font-mono)] tabular-nums">
+              {latest.display_score.toFixed(1)}/10
+            </span>
+          )}
+          {evalCount > 0 && (
+            <span>{evalCount} eval{evalCount !== 1 ? "s" : ""}</span>
+          )}
+          {!latest && (
+            <span>No evaluations yet</span>
+          )}
+        </div>
+      )}
 
       <div className="flex items-center gap-2 mt-auto pt-1">
         <Link href={`/eval/${agent.id}`} className="flex-1">

--- a/web/src/app/(admin)/eval/page.tsx
+++ b/web/src/app/(admin)/eval/page.tsx
@@ -46,8 +46,8 @@ function AgentEvalCard({ agent }: { agent: RegistryItem }) {
 
       {latest?.dimension_scores ? (
         <ScoreOverview
-          displayScore={latest.display_score ?? latest.overall_score ?? 0}
-          grade={latest.grade ?? latest.overall_grade ?? "-"}
+          displayScore={latest.display_score ?? 0}
+          grade={latest.grade ?? "-"}
           dimensionScores={latest.dimension_scores}
           penaltyCount={latest.penalty_count}
           compact

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -211,22 +211,41 @@ function AnalyticsTab({ agentId }: { agentId: string }) {
       {Object.keys(dims).length > 0 && (
         <div className="space-y-3">
           <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Dimension Averages</h4>
-          <div className="space-y-2">
-            {Object.entries(dims).map(([dim, score]) => (
-              <div key={dim} className="flex items-center gap-3">
-                <span className="text-xs text-muted-foreground w-32 shrink-0 truncate">{dim}</span>
-                <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
-                  <div
-                    className="h-full bg-primary rounded-full transition-all"
-                    style={{ width: `${Math.min(Number(score) * 10, 100)}%` }}
-                  />
+          <div className="space-y-2.5">
+            {Object.entries(dims).map(([dim, score]) => {
+              const dimLabels: Record<string, string> = {
+                goal_completion: "Goal Completion",
+                tool_efficiency: "Tool Efficiency",
+                tool_failures: "Tool Failures",
+                factual_grounding: "Factual Grounding",
+                thought_process: "Thought Process",
+              };
+              const dimColors: Record<string, string> = {
+                goal_completion: "bg-emerald-500",
+                tool_efficiency: "bg-blue-500",
+                tool_failures: "bg-amber-500",
+                factual_grounding: "bg-violet-500",
+                thought_process: "bg-cyan-500",
+              };
+              const clampedScore = Math.max(0, Math.min(100, Number(score)));
+              return (
+                <div key={dim} className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">{dimLabels[dim] ?? dim}</span>
+                    <span className="text-xs font-mono tabular-nums">{Math.round(clampedScore)}<span className="text-muted-foreground">/100</span></span>
+                  </div>
+                  <div className="h-2 bg-muted rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${dimColors[dim] ?? "bg-primary"}`}
+                      style={{ width: `${clampedScore}%` }}
+                    />
+                  </div>
                 </div>
-                <span className="text-xs font-mono w-10 text-right">{Number(score).toFixed(1)}</span>
-              </div>
-            ))}
+              );
+            })}
           </div>
           {aggregate.weakest_dimension && (
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-muted-foreground mt-2">
               Weakest: <span className="text-foreground font-medium">{aggregate.weakest_dimension}</span>
             </p>
           )}

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -45,6 +45,7 @@ import { DetailSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { compactNumber, copyToClipboard } from "@/lib/utils";
+import { DIMENSION_META } from "@/components/dashboard/score-overview";
 
 interface AgentDetail {
   name: string;
@@ -213,30 +214,17 @@ function AnalyticsTab({ agentId }: { agentId: string }) {
           <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Dimension Averages</h4>
           <div className="space-y-2.5">
             {Object.entries(dims).map(([dim, score]) => {
-              const dimLabels: Record<string, string> = {
-                goal_completion: "Goal Completion",
-                tool_efficiency: "Tool Efficiency",
-                tool_failures: "Tool Failures",
-                factual_grounding: "Factual Grounding",
-                thought_process: "Thought Process",
-              };
-              const dimColors: Record<string, string> = {
-                goal_completion: "bg-emerald-500",
-                tool_efficiency: "bg-blue-500",
-                tool_failures: "bg-amber-500",
-                factual_grounding: "bg-violet-500",
-                thought_process: "bg-cyan-500",
-              };
+              const meta = DIMENSION_META[dim];
               const clampedScore = Math.max(0, Math.min(100, Number(score)));
               return (
                 <div key={dim} className="space-y-1">
                   <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">{dimLabels[dim] ?? dim}</span>
+                    <span className="text-xs text-muted-foreground">{meta?.label ?? dim}</span>
                     <span className="text-xs font-mono tabular-nums">{Math.round(clampedScore)}<span className="text-muted-foreground">/100</span></span>
                   </div>
                   <div className="h-2 bg-muted rounded-full overflow-hidden">
                     <div
-                      className={`h-full rounded-full transition-all ${dimColors[dim] ?? "bg-primary"}`}
+                      className={`h-full rounded-full transition-all ${meta?.color ?? "bg-primary"}`}
                       style={{ width: `${clampedScore}%` }}
                     />
                   </div>

--- a/web/src/components/dashboard/score-overview.tsx
+++ b/web/src/components/dashboard/score-overview.tsx
@@ -10,13 +10,13 @@ interface ScoreOverviewProps {
   compact?: boolean;
 }
 
-const DIMENSION_META: Record<string, { label: string; color: string }> = {
+export const DIMENSION_META: Record<string, { label: string; color: string; hidden?: boolean }> = {
   goal_completion: { label: "Goal Completion", color: "bg-emerald-500" },
   tool_efficiency: { label: "Tool Efficiency", color: "bg-blue-500" },
   tool_failures: { label: "Tool Failures", color: "bg-amber-500" },
   factual_grounding: { label: "Factual Grounding", color: "bg-violet-500" },
   thought_process: { label: "Thought Process", color: "bg-cyan-500" },
-  adversarial_robustness: { label: "Adversarial", color: "bg-rose-500" },
+  adversarial_robustness: { label: "Adversarial", color: "bg-rose-500", hidden: true },
 };
 
 function gradeColor(grade: string): string {
@@ -50,7 +50,7 @@ export function ScoreOverview({
   compact = false,
 }: ScoreOverviewProps) {
   const dims = Object.entries(dimensionScores).filter(
-    ([key, value]) => value !== null && key !== "adversarial_robustness"
+    ([key, value]) => value !== null && !DIMENSION_META[key]?.hidden
   );
 
   if (compact) {

--- a/web/src/components/dashboard/score-overview.tsx
+++ b/web/src/components/dashboard/score-overview.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+
+interface ScoreOverviewProps {
+  displayScore: number;
+  grade: string;
+  dimensionScores: Record<string, number>;
+  penaltyCount?: number;
+  compact?: boolean;
+}
+
+const DIMENSION_META: Record<string, { label: string; color: string }> = {
+  goal_completion: { label: "Goal Completion", color: "bg-emerald-500" },
+  tool_efficiency: { label: "Tool Efficiency", color: "bg-blue-500" },
+  tool_failures: { label: "Tool Failures", color: "bg-amber-500" },
+  factual_grounding: { label: "Factual Grounding", color: "bg-violet-500" },
+  thought_process: { label: "Thought Process", color: "bg-cyan-500" },
+  adversarial_robustness: { label: "Adversarial", color: "bg-rose-500" },
+};
+
+function gradeColor(grade: string): string {
+  const g = grade.toUpperCase();
+  if (g.startsWith("A")) return "text-success";
+  if (g.startsWith("B")) return "text-info";
+  if (g.startsWith("C")) return "text-warning";
+  return "text-destructive";
+}
+
+function gradeBg(grade: string): string {
+  const g = grade.toUpperCase();
+  if (g.startsWith("A")) return "bg-success/10 border-success/20";
+  if (g.startsWith("B")) return "bg-info/10 border-info/20";
+  if (g.startsWith("C")) return "bg-warning/10 border-warning/20";
+  return "bg-destructive/10 border-destructive/20";
+}
+
+function scoreBarColor(score: number): string {
+  if (score >= 85) return "bg-emerald-500";
+  if (score >= 70) return "bg-blue-500";
+  if (score >= 55) return "bg-amber-500";
+  return "bg-red-500";
+}
+
+export function ScoreOverview({
+  displayScore,
+  grade,
+  dimensionScores,
+  penaltyCount,
+  compact = false,
+}: ScoreOverviewProps) {
+  const dims = Object.entries(dimensionScores).filter(
+    ([key, value]) => value !== null && key !== "adversarial_robustness"
+  );
+
+  if (compact) {
+    return (
+      <div className="space-y-3">
+        {/* Compact: score + grade inline */}
+        <div className="flex items-center gap-3">
+          <div className={`flex items-center justify-center w-10 h-10 rounded-md border ${gradeBg(grade)}`}>
+            <span className={`text-lg font-bold font-[family-name:var(--font-display)] ${gradeColor(grade)}`}>
+              {grade}
+            </span>
+          </div>
+          <div>
+            <p className="text-base font-semibold font-[family-name:var(--font-mono)] tabular-nums">
+              {displayScore.toFixed(1)}<span className="text-xs text-muted-foreground">/10</span>
+            </p>
+            {penaltyCount != null && (
+              <p className="text-[10px] text-muted-foreground">{penaltyCount} penalties</p>
+            )}
+          </div>
+        </div>
+        {/* Compact dimension bars */}
+        <div className="space-y-1.5">
+          {dims.map(([key, score]) => {
+            const meta = DIMENSION_META[key];
+            const clampedScore = Math.max(0, Math.min(100, score));
+            return (
+              <div key={key} className="flex items-center gap-2">
+                <span className="text-[10px] text-muted-foreground w-20 truncate">
+                  {meta?.label ?? key}
+                </span>
+                <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className={`h-full rounded-full transition-all ${scoreBarColor(clampedScore)}`}
+                    style={{ width: `${clampedScore}%` }}
+                  />
+                </div>
+                <span className="text-[10px] font-[family-name:var(--font-mono)] text-muted-foreground w-7 text-right tabular-nums">
+                  {Math.round(clampedScore)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Hero score */}
+      <div className="flex items-center gap-5">
+        <div className={`flex items-center justify-center w-16 h-16 rounded-lg border ${gradeBg(grade)}`}>
+          <span className={`text-3xl font-bold font-[family-name:var(--font-display)] ${gradeColor(grade)}`}>
+            {grade}
+          </span>
+        </div>
+        <div>
+          <p className="text-2xl font-bold font-[family-name:var(--font-mono)] tabular-nums">
+            {displayScore.toFixed(1)}<span className="text-sm text-muted-foreground font-normal">/10</span>
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Display Score
+            {penaltyCount != null && (
+              <span className="ml-2">
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                  {penaltyCount} penalties
+                </Badge>
+              </span>
+            )}
+          </p>
+        </div>
+      </div>
+
+      {/* Dimension breakdown */}
+      <div className="space-y-3">
+        <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Dimension Scores
+        </h4>
+        <div className="space-y-2.5">
+          {dims.map(([key, score]) => {
+            const meta = DIMENSION_META[key];
+            const clampedScore = Math.max(0, Math.min(100, score));
+            return (
+              <div key={key} className="space-y-1">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground">
+                    {meta?.label ?? key}
+                  </span>
+                  <span className="text-xs font-[family-name:var(--font-mono)] tabular-nums">
+                    {Math.round(clampedScore)}<span className="text-muted-foreground">/100</span>
+                  </span>
+                </div>
+                <div className="h-2 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className={`h-full rounded-full transition-all ${meta?.color ?? scoreBarColor(clampedScore)}`}
+                    style={{ width: `${clampedScore}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Eval:** adds a Moonshot/Kimi judge provider. Setting `EVAL_MODEL_PROVIDER=moonshot` (or a model name containing `kimi`) routes through the OpenAI-compatible path with Moonshot's base URL and `thinking: {type: disabled}` so Kimi returns a single deterministic JSON score instead of streaming reasoning tokens. Moonshot's Instant Mode requires `temperature=0.6`, which is set automatically.
- **Dashboard:** displays per-dimension and overall agent display scores.
- **Docker:** hardens first-boot ClickHouse init — the healthcheck now passes `CLICKHOUSE_PASSWORD`, and `entrypoint.sh` creates the target DB over HTTP with exponential-backoff retries before running `init_clickhouse()`, so races against the clickhouse container no longer wedge startup.

## Verification
- `pytest tests/eval/test_eval_phase8.py` — 19/19 pass, incl. two new `TestMoonshotProvider` tests covering both explicit-provider and auto-detect-by-model-name paths.
- Live smoke-test against `kimi-k2.5`: all 8 `EVAL_TEMPLATES` returned well-formed `{score, reason}` payloads with coherent scoring (e.g. `tool_selection_accuracy=1.0`, `graph_context_precision=0.5` when 1 of 2 retrieved chunks was off-topic, `recall_accuracy=0.3` for tangentially relevant memory).

## Test plan
- [ ] `pytest tests/eval/test_eval_phase8.py`
- [ ] Set `EVAL_MODEL_PROVIDER=moonshot`, `EVAL_MODEL_NAME=kimi-k2.5`, `EVAL_MODEL_API_KEY=...` and run an eval on a recent trace; confirm scores land in ClickHouse and render on the dashboard.
- [ ] Fresh `docker compose up` on a machine without prior ClickHouse state; confirm server comes up without manual intervention and healthcheck passes with a non-default `CLICKHOUSE_PASSWORD`.