### PR TITLE
fix: Windows hook paths and Kiro python3 compatibility

### DIFF
--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 import shutil
+import sys
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -1151,6 +1152,8 @@ def register_scan(app: typer.Typer):
                 args = f"--url {kiro_hooks_url} --agent-name {agent_name}"
                 if model:
                     args += f" --model {model}"
+                if sys.platform == "win32" and hook_script.is_file():
+                    return f"python {hook_script.resolve().as_posix()} {args}"
                 if hook_script.is_file():
                     return f"cat | python3 {hook_script.resolve().as_posix()} {args}"
                 return f'cat | curl -sf -X POST {kiro_hooks_url} -H "Content-Type: application/json" -d @-'
@@ -1160,6 +1163,8 @@ def register_scan(app: typer.Typer):
                 args = f"--url {kiro_hooks_url} --agent-name {agent_name}"
                 if model:
                     args += f" --model {model}"
+                if sys.platform == "win32" and stop_script.is_file():
+                    return f"python {stop_script.resolve().as_posix()} {args}"
                 if stop_script.is_file():
                     return f"cat | python3 {stop_script.resolve().as_posix()} {args}"
                 return f'cat | curl -sf -X POST {kiro_hooks_url} -H "Content-Type: application/json" -d @-'


### PR DESCRIPTION
Three Windows-specific bugs that break hook execution:

1. Path.resolve() returns backslash paths (C:\Users\...) which bash cannot interpret. Use .as_posix() for forward slashes everywhere hook paths are written to settings.json or agent configs.

2. Kiro hook commands use "cat | python3 ..." but on Windows python3 is a broken Microsoft Store alias. Use "python" directly on win32.

3. "cat |" pipe syntax doesn't work for Kiro hooks on Windows. On win32, pipe stdin directly: "python path/to/hook.py --url ..." matching the pattern already used in kiro_hook.py auto-inject.

<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #<!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->