### PR TITLE
chore: add pre-commit secrets guard and pre-push DCO check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,15 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
 
+  # ── Secrets / .env guard ───────────────────────────────
+  - repo: local
+    hooks:
+      - id: check-secrets
+        name: check for secrets and .env files
+        entry: scripts/check_secrets.sh
+        language: script
+        pass_filenames: false
+
   # ── Alembic migrations ─────────────────────────────────
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,17 @@ repos:
         files: ^observal-server/alembic/versions/.*\.py$
         pass_filenames: false
 
+  # ── DCO sign-off (pre-push) ────────────────────────────
+  - repo: local
+    hooks:
+      - id: check-dco
+        name: check DCO sign-off on all commits
+        entry: scripts/check_dco.sh
+        language: script
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]
+
   # ── Docker ─────────────────────────────────────────────
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,19 +153,23 @@ Keep the subject line under 72 characters, use the imperative mood ("add", not "
 
 All commits must include a `Signed-off-by` line to certify the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). The DCO is a lightweight agreement that confirms you wrote (or have the right to submit) your contribution and that it is licensed under the project's open-source Apache 2.0 license (for all code outside `ee/`).
 
-Add the sign-off automatically with the `-s` flag:
+You can add the sign-off manually to your commit message:
+
+```
+feat(cli): add skill submit command
+
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Or use the `-s` flag to have Git append it for you:
 
 ```bash
 git commit -s -m "feat(cli): add skill submit command"
 ```
 
-This appends a line like:
+> **Note:** The project does not configure or encourage automatic sign-off (e.g. via Git hooks or aliases). The DCO sign-off is a conscious attestation that you have the right to submit your contribution. If you choose to automate it, that is your responsibility — you are still bound by its terms.
 
-```
-Signed-off-by: Your Name <your.email@example.com>
-```
-
-Make sure your `user.name` and `user.email` in git config match the identity you want to use. A CI check will block PRs that have unsigned commits.
+Make sure your `user.name` and `user.email` in git config match the identity you want to use. A CI check and a pre-push hook will block PRs that have unsigned commits.
 
 ### Changelog
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ hooks:  ## Install pre-commit hooks
 	pip install pre-commit
 	pre-commit install
 	pre-commit install --hook-type commit-msg
+	pre-commit install --hook-type pre-push
 	@echo "✓ Hooks installed"
 
 # ── Docker ───────────────────────────────────────────────

--- a/scripts/check_dco.sh
+++ b/scripts/check_dco.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# check_dco.sh — pre-push guard ensuring every commit has a DCO sign-off
+set -euo pipefail
+
+RED='\033[0;31m'
+NC='\033[0m'
+
+remote="$1"
+url="$2"
+
+EXIT_CODE=0
+
+while read -r local_ref local_oid remote_ref remote_oid; do
+    # Skip delete pushes
+    if [ "$local_oid" = "0000000000000000000000000000000000000000" ]; then
+        continue
+    fi
+
+    # Determine range: new branch vs update
+    if [ "$remote_oid" = "0000000000000000000000000000000000000000" ]; then
+        # New branch — check commits not on any remote branch
+        range="$local_oid --not --remotes"
+    else
+        range="$remote_oid..$local_oid"
+    fi
+
+    # shellcheck disable=SC2086
+    for commit in $(git rev-list $range 2>/dev/null); do
+        if ! git log -1 --format='%B' "$commit" | grep -qE '^Signed-off-by: .+ <.+>'; then
+            echo -e "${RED}ERROR: Commit $(git rev-parse --short "$commit") is missing a DCO sign-off:${NC}"
+            git log -1 --format='  %h %s' "$commit"
+            EXIT_CODE=1
+        fi
+    done
+done
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo ""
+    echo "All commits must include: Signed-off-by: Name <email>"
+    echo "To fix, amend with: git commit --amend  (and add the sign-off line)"
+    echo "Or to skip this check: git push --no-verify"
+fi
+
+exit $EXIT_CODE

--- a/scripts/check_secrets.sh
+++ b/scripts/check_secrets.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check_secrets.sh — pre-commit guard against .env files and hardcoded secrets
+set -euo pipefail
+
+RED='\033[0;31m'
+NC='\033[0m'
+EXIT_CODE=0
+
+# 1. Block .env files (allow .env.example)
+env_files=$(git diff --cached --name-only --diff-filter=ACR | grep -E '(^|/)\.env$' || true)
+if [ -n "$env_files" ]; then
+    echo -e "${RED}ERROR: .env file(s) staged for commit:${NC}"
+    echo "$env_files"
+    echo "These files contain secrets and must not be committed."
+    EXIT_CODE=1
+fi
+
+# 2. Scan staged file contents for common secret patterns
+patterns=(
+    'AKIA[0-9A-Z]{16}'                          # AWS access key ID
+    'aws_secret_access_key\s*=\s*[A-Za-z0-9/+=]{40}'  # AWS secret key
+    'sk-[A-Za-z0-9]{20,}'                       # OpenAI / Anthropic style API keys
+    'ghp_[A-Za-z0-9]{36}'                       # GitHub personal access token
+    'gho_[A-Za-z0-9]{36}'                       # GitHub OAuth token
+    'github_pat_[A-Za-z0-9_]{82}'               # GitHub fine-grained PAT
+    'xox[bporas]-[A-Za-z0-9-]+'                 # Slack tokens
+)
+
+combined_pattern=$(IFS='|'; echo "${patterns[*]}")
+
+# Only check text files that are staged (added/copied/modified), skip binary
+staged_files=$(git diff --cached --name-only --diff-filter=ACRM | grep -v '\.env\.example$' || true)
+
+if [ -n "$staged_files" ]; then
+    # Check staged content (not working tree) via git show
+    for file in $staged_files; do
+        matches=$(git show ":${file}" 2>/dev/null | grep -nEo "$combined_pattern" || true)
+        if [ -n "$matches" ]; then
+            echo -e "${RED}ERROR: Possible secret found in ${file}:${NC}"
+            echo "$matches"
+            EXIT_CODE=1
+        fi
+    done
+fi
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo ""
+    echo "If this is a false positive, use: git commit --no-verify"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Purpose / Description
Adds git hooks to prevent accidental secret leaks and enforce DCO sign-off on all pushes.

`.env` is already in `.gitignore`, but these hooks act as an extra safety net — catching secrets even if someone stages a file with hardcoded keys, and blocking pushes where any commit is missing a `Signed-off-by` trailer.

## Approach
- **`scripts/check_secrets.sh`** (pre-commit): blocks `.env` files from being staged and scans staged file contents for common secret patterns (AWS access keys, `sk-` style API keys, GitHub PATs, Slack tokens).
- **`scripts/check_dco.sh`** (pre-push): iterates every commit in the push range and verifies each has a `Signed-off-by: Name <email>` line.
- Both hooks are wired into `.pre-commit-config.yaml` so they run automatically via the `pre-commit` framework.
- `Makefile` `hooks` target updated to also install the `pre-push` hook type.

## How Has This Been Tested?

Tested both hooks locally:

| Hook | Test | Result |
|---|---|---|
| `check_secrets` | Staged file with `sk-` API key | Blocked |
| `check_secrets` | `.env` file staged | Blocked |
| `check_secrets` | Clean staging area | Passed |
| `check_dco` | Commits with `Signed-off-by` | Passed |
| `check_dco` | Commit missing sign-off | Blocked |

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)