### PR TITLE
fix(ci): two-phase deploy health check to prevent false failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
-          script_stop: true
           script: |
+            set -e
             cd ~/Observal
             git fetch origin main
             git reset --hard origin/main
@@ -29,16 +29,29 @@ jobs:
             cd docker
             docker compose up -d --build --remove-orphans
 
-            # Wait for API health check
+            # Wait for the API process to be alive (no dependency checks).
+            # /livez returns 200 as soon as uvicorn is serving; /health
+            # checks Postgres+ClickHouse+Redis and returns 503 while they
+            # warm up, which caused false negatives on slow cold-starts.
+            for i in $(seq 1 60); do
+              if curl -sf http://localhost:8000/livez > /dev/null 2>&1; then
+                echo "API is alive (livez ok)"
+                break
+              fi
+              echo "Waiting for API process... ($i/60)"
+              sleep 5
+            done
+
+            # Now wait for full readiness (dependencies healthy)
             for i in $(seq 1 30); do
               if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
-                echo "API is healthy"
+                echo "API is healthy (all dependencies up)"
                 exit 0
               fi
-              echo "Waiting for API... ($i/30)"
+              echo "Waiting for dependencies... ($i/30)"
               sleep 5
             done
 
             echo "API failed health check"
-            docker compose logs observal-api --tail 30
+            docker compose logs observal-api observal-init observal-db observal-clickhouse --tail 20
             exit 1


### PR DESCRIPTION
## Purpose / Description

The GitHub Actions deploy workflow was reporting failures even though the API started successfully. The `/health` endpoint checks Postgres, ClickHouse, and Redis connectivity and returns 503 while dependencies are still warming up. On cold starts or slow rebuilds, the health check loop exhausted its 30 retries before all dependencies were ready, causing every deploy to show as failed.

## Fixes

* Fixes deploy workflow false-negative health check failures

## Approach

Split the single health check loop into two phases:

1. **Phase 1 -- Process liveness** (`/livez`, 60 retries x 5s): Waits for the uvicorn process to be serving. This endpoint returns 200 immediately with no dependency checks, so it passes as soon as the API container is up.

2. **Phase 2 -- Full readiness** (`/health`, 30 retries x 5s): Waits for Postgres, ClickHouse, and Redis to all report healthy. By this point the process is already alive, so this phase only waits on dependency warmup.

Additional fixes:
- Removed `script_stop: true` input (not a valid parameter for `appleboy/ssh-action@v1`, was throwing a warning on every run)
- Added `set -e` for proper error propagation
- On failure, now dumps logs from `observal-init`, `observal-db`, and `observal-clickhouse` in addition to `observal-api` for easier debugging

## How Has This Been Tested?

- Validated YAML syntax with `yaml.safe_load()`
- Verified `/livez` endpoint exists and returns `{"status": "alive"}` with zero dependency checks (`main.py:278-282`)
- Verified `/health` endpoint returns 503 when dependencies are unreachable, 200 when all healthy (`main.py:285-324`)
- Ran existing test suite (18/18 passed)
- The two-phase approach matches the pattern already used by the Docker Compose internal healthcheck which uses `/readyz` (same handler as `/health`)

## Learning

- `appleboy/ssh-action@v1` does not support `script_stop` -- valid inputs are listed in the action warning output
- Kubernetes-style probe separation (`/livez` vs `/readyz` vs `/healthz`) is useful beyond K8s -- it lets deploy scripts distinguish "process crashed" from "dependencies still starting"
- When a health endpoint checks multiple services, cold-start timing can cause false 503s even when the app itself is fine

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
