### PR TITLE
feat(web): Add MCP server config field to skill creation form

### DIFF
--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -204,13 +204,18 @@ export function SubmitComponentDialog({
         if (setupInstructions) body.setup_instructions = setupInstructions;
         return body;
       }
-      case "skills":
-        return {
+      case "skills": {
+        const skillBody: Record<string, unknown> = {
           ...base,
           task_type: taskType,
           git_url: skillGitUrl || undefined,
           skill_path: skillPath || "/",
         };
+        if (mcpServerName) {
+          skillBody.mcp_server_config = { server: mcpServerName };
+        }
+        return skillBody;
+      }
       case "hooks": {
         const body: Record<string, unknown> = {
           ...base,

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -534,6 +534,30 @@ export function SubmitComponentDialog({
                   </SelectContent>
                 </Select>
               </div>
+              <div className="space-y-1.5">
+                <Label>MCP Server</Label>
+                <Select
+                  value={mcpServerName || "none"}
+                  onValueChange={(v) => setMcpServerName(v === "none" ? "" : v)}
+                >
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None</SelectItem>
+                    {availableMcps.map((mcp) => (
+                      <SelectItem key={mcp.id} value={mcp.name}>
+                        <span className="flex items-center gap-2">
+                          {mcp.name}
+                          {mcp.status === "pending" && (
+                            <span className="text-[10px] rounded bg-yellow-500/15 text-yellow-500 px-1.5 py-0.5">
+                              pending
+                            </span>
+                          )}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1.5">
                   <Label htmlFor="skill-git-url">Git URL</Label>

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -21,6 +21,7 @@ import {
 import { Info, Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
 import type { RegistryType } from "@/lib/api";
+import { useRegistryList, useMyComponents } from "@/hooks/use-api";
 
 const MCP_CATEGORIES = [
   "browser-automation", "cloud-platforms", "code-execution", "communication",
@@ -108,6 +109,7 @@ export function SubmitComponentDialog({
   const [taskType, setTaskType] = useState("general");
   const [skillGitUrl, setSkillGitUrl] = useState("");
   const [skillPath, setSkillPath] = useState("/");
+  const [mcpServerName, setMcpServerName] = useState("");
 
   // ── Hook ────────────────────────────────────────────────
   const [event, setEvent] = useState("PreToolUse");
@@ -125,6 +127,23 @@ export function SubmitComponentDialog({
   const [image, setImage] = useState("");
   const [networkPolicy, setNetworkPolicy] = useState("none");
   const [entrypoint, setEntrypoint] = useState("");
+
+  const { data: approvedMcps } = useRegistryList("mcps");
+  const { data: myMcps } = useMyComponents("mcps");
+  const availableMcps = (() => {
+    if (type !== "skills") return [];
+    const approved = approvedMcps ?? [];
+    const pending = (myMcps ?? []).filter((m) => m.status === "pending");
+    const seen = new Set<string>();
+    const merged: typeof approved = [];
+    for (const mcp of [...approved, ...pending]) {
+      if (!seen.has(mcp.id)) {
+        seen.add(mcp.id);
+        merged.push(mcp);
+      }
+    }
+    return merged;
+  })();
 
   function reset() {
     setName("");
@@ -145,6 +164,7 @@ export function SubmitComponentDialog({
     setTaskType("general");
     setSkillGitUrl("");
     setSkillPath("/");
+    setMcpServerName("");
     setEvent("PreToolUse");
     setHandlerType("command");
     setExecutionMode("async");


### PR DESCRIPTION
## Summary

The skill creation form was missing a field to link skills to MCP servers via `mcp_server_config`. This meant users had no way to associate a skill with an MCP through the UI, which broke the bulk approve workflow introduced in PR #473.

This PR adds an **MCP Server** dropdown to the skill submission form that allows users to select which MCP server a skill is associated with.

## What's Added

- **MCP Server dropdown** in the skill form, placed between "Task Type" and "Git URL"
- Dropdown lists **approved MCPs** (from the registry) and the **current user's pending MCPs** (from `/mcps/my`), deduplicated by ID
- Pending MCPs are visually distinguished with a yellow `pending` badge
- Selecting an MCP stores `mcp_server_config: { "server": "<mcp-name>" }` in the request body
- Selecting "None" omits the field entirely (optional linking)
- State resets properly when the dialog is closed and reopened

## How It Works

1. User opens the skill submission form
2. The dropdown fetches available MCPs (approved + user's own pending)
3. User selects an MCP → stored as `{ "server": "mcp-name" }` in the submission payload
4. Backend already accepts `mcp_server_config` on `SkillSubmitRequest` and `SkillDraftRequest`
5. In the review queue, clicking an MCP now shows linked skills under "Related Pending Skills"
6. Reviewer can bulk approve the MCP and its linked skills together in one click

<img width="805" height="1264" alt="image" src="https://github.com/user-attachments/assets/e5ed1163-23b3-4960-b0e2-bb92fd17bbbd" />
<img width="1054" height="1542" alt="image" src="https://github.com/user-attachments/assets/6b1aa4af-80c9-40e3-ba56-fc357974ff4d" />



## Files Changed

- `web/src/components/registry/submit-component-dialog.tsx` — all changes are in this single file

## No Backend Changes

The backend already fully supports `mcp_server_config`:


## Test

- [x] MCP Server dropdown appears in skill form between Task Type and Git URL
- [x] Approved MCPs show in dropdown without badge
- [x] User's pending MCPs show in dropdown with yellow "pending" badge
- [x] Submitting with an MCP selected sends `mcp_server_config` in the request body
- [x] Submitting with "None" selected omits `mcp_server_config`
- [x] Review queue shows linked skill under "Related Pending Skills" when clicking the MCP
- [x] Bulk approve (Approve MCP + skills) works end-to-end
- [x] Dialog reset clears MCP selection
- [x] TypeScript typecheck passes
- [x] ESLint passes

Closes #492
