### PR TITLE
Fix/deploy nginx stale ip

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,29 +29,34 @@ jobs:
             cd docker
             docker compose up -d --build --remove-orphans
 
-            # Wait for the API process to be alive (no dependency checks).
-            # /livez returns 200 as soon as uvicorn is serving; /health
-            # checks Postgres+ClickHouse+Redis and returns 503 while they
-            # warm up, which caused false negatives on slow cold-starts.
+            # Phase 1: Wait for API container to be alive (bypasses nginx).
+            # Uses direct container exec because curl through nginx fails
+            # when nginx caches a stale upstream IP from the old container.
+            echo "Waiting for API container to start..."
             for i in $(seq 1 60); do
-              if curl -sf http://localhost:8000/livez > /dev/null 2>&1; then
-                echo "API is alive (livez ok)"
+              if docker compose exec -T observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/livez')" 2>/dev/null; then
+                echo "API process is alive"
                 break
               fi
               echo "Waiting for API process... ($i/60)"
               sleep 5
             done
 
-            # Now wait for full readiness (dependencies healthy)
+            # Nginx caches upstream container IPs — after rebuild the API
+            # gets a new IP but nginx still routes to the old one.
+            docker compose restart observal-lb
+            sleep 3
+
+            # Phase 2: Verify health through nginx (the path clients use)
             for i in $(seq 1 30); do
               if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
-                echo "API is healthy (all dependencies up)"
+                echo "API is healthy (full stack verified)"
                 exit 0
               fi
-              echo "Waiting for dependencies... ($i/30)"
+              echo "Waiting for health check... ($i/30)"
               sleep 5
             done
 
             echo "API failed health check"
-            docker compose logs observal-api observal-init observal-db observal-clickhouse --tail 20
+            docker compose logs observal-api observal-init observal-lb observal-db observal-clickhouse --tail 20
             exit 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -150,7 +150,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.api
-    command: ["/app/.venv/bin/python", "-m", "arq", "worker.WorkerSettings"]
+    command: ["/app/.venv/bin/python", "-c", "import asyncio; asyncio.set_event_loop(asyncio.new_event_loop()); from arq import run_worker; from worker import WorkerSettings; run_worker(WorkerSettings)"]
     env_file:
       - ../.env
     environment:


### PR DESCRIPTION
## Purpose / Description
Deploy health check fails every time because nginx caches the old API container IP after a rebuild. The worker has also been crash-looping on Python 3.14 since the image upgrade.

## Fixes
* Fixes deploy health check false failures (all deploys since nginx LB was added)
* Fixes worker crash-loop on Python 3.14

## Approach

**Nginx stale IP:** After `docker compose up --build`, the API container gets a new IP but nginx keeps routing to the old cached one. `curl localhost:8000` goes through nginx → dead IP → timeout for the entire 7.5-minute retry window. Fix: check API health directly inside the container (bypassing nginx), then `docker compose restart observal-lb` to force DNS re-resolution, then verify through the full stack.

**Worker crash:** Python 3.14 removed auto-creation of event loops in `asyncio.get_event_loop()`. arq's CLI calls this internally at import time, so the worker crashes on every startup. Fix: explicitly create an event loop before importing arq.

Also removes invalid `script_stop` option from ssh-action and adds `set -e`.

## How Has This Been Tested?

1. SSHed into EC2 and confirmed the issue live:
   - `docker compose ps` showed worker `Restarting (1) 57 seconds ago` (crash-loop)
   - `curl localhost:8000/health` failed, but `docker compose exec -T observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/livez')"` returned 200 (proving API was alive but nginx was broken)
2. Ran `docker compose restart observal-lb` → health check immediately passed
3. Patched worker command on EC2 → worker started successfully, running 7 functions, no more crash-loop
4. All 10 containers confirmed healthy after both fixes

## Learning

- Nginx with `proxy_pass` to a Docker Compose service name resolves the IP once at startup. If the upstream container is recreated, nginx keeps routing to the old IP until restarted. This is a known Docker + nginx issue.
- Python 3.14 changelog: `asyncio.get_event_loop()` now raises `RuntimeError` if there is no running event loop instead of creating one. Libraries that call it at module level (like arq) break silently.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens — N/A (CI + infra only)
