### PR TITLE
fix: prevent kiro_default from appearing in admin approval queue

### DIFF
--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -98,6 +98,10 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
     )
     agents = result.scalars().all()
 
+    # Exclude auto-scanned agents (local IDE configs like kiro_default that
+    # were registered by the deprecated POST /api/v1/scan endpoint).
+    agents = [a for a in agents if not (a.description or "").startswith("Auto-scanned agent: ")]
+
     user_ids = {a.created_by for a in agents}
     user_map: dict[uuid.UUID, str] = {}
     if user_ids:

--- a/observal-server/api/routes/scan.py
+++ b/observal-server/api/routes/scan.py
@@ -13,7 +13,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role
-from models.agent import Agent, AgentGoalSection, AgentGoalTemplate
 from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
 from models.skill import SkillListing
@@ -184,45 +183,12 @@ async def bulk_scan(
         counts["hook"] += 1
 
     # ── Agents ──────────────────────────────────────────
+    # Scanned agents are local IDE configs (e.g. kiro_default hook files),
+    # not publishable registry entries.  Skip creation to prevent them from
+    # polluting the admin approval queue.  The current CLI no longer sends
+    # agents here; this guard protects against older CLI versions.
     for agent in req.agents:
-        result = await db.execute(select(Agent).where(Agent.name == agent.name))
-        existing = result.scalar_one_or_none()
-        if existing:
-            registered.append(RegisteredItem(name=agent.name, id=str(existing.id), type="agent", status="existing"))
-            counts["agent"] += 1
-            continue
-
-        ide_tag = agent.source_ide or req.ide
-        new_agent = Agent(
-            name=agent.name,
-            version="0.1.0",
-            description=agent.description or f"Auto-scanned agent: {agent.name}",
-            owner=owner,
-            prompt=agent.prompt or "",
-            model_name=agent.model_name or "sonnet-4-6",
-            supported_ides=[ide_tag],
-            created_by=current_user.id,
-        )
-        db.add(new_agent)
-        await db.flush()
-
-        goal_template = AgentGoalTemplate(
-            agent_id=new_agent.id,
-            description=agent.description or f"Goal for {agent.name}",
-        )
-        db.add(goal_template)
-        await db.flush()
-
-        section = AgentGoalSection(
-            goal_template_id=goal_template.id,
-            name="default",
-            description="Default goal section",
-            order=0,
-        )
-        db.add(section)
-        await db.flush()
-
-        registered.append(RegisteredItem(name=agent.name, id=str(new_agent.id), type="agent", status="created"))
+        registered.append(RegisteredItem(name=agent.name, id="", type="agent", status="skipped"))
         counts["agent"] += 1
 
     await db.commit()


### PR DESCRIPTION
fixes #453 
## Summary

- Stop the deprecated `POST /api/v1/scan` endpoint from creating Agent DB records — scanned agents are local IDE hook configs (e.g. `kiro_default`), not publishable registry entries
- Filter legacy auto-scanned agents from the review queue using the `"Auto-scanned agent:"` description prefix stamped by the server

## Why

`kiro_default` is a local Kiro CLI hook config that was being registered as a server-side agent by the old scan flow. The upload was removed in `36c28e4`, but the deprecated endpoint is still active for older CLIs, and existing records remain in the DB.

## Test plan

- [x] All review/agent/bulk/draft/scan tests pass (72/72)
- [x] Ruff lint and format checks pass
- [x] Verify `kiro_default` no longer appears in admin review queue

