### PR TITLE
fix(docs): correct e2e checklist setup commands

### DIFF
--- a/docs/e2e-test-checklist.md
+++ b/docs/e2e-test-checklist.md
@@ -15,8 +15,8 @@
 ---
 
 ## 1. Environment Setup
-- [ ] `make up`
-- [ ] `uv install`
+- [ ] `make rebuild-clean`
+- [ ] `uv sync`
 
 ## 2. Super Admin — User Management
 - [ ] Log in as super admin


### PR DESCRIPTION
## Purpose / Description
The e2e test checklist had incorrect setup commands — `make up` should be `make rebuild-clean` and `uv install` should be `uv sync`.

## Fixes
* N/A — minor docs fix

## Approach
Updated the two commands in the Environment Setup section of `docs/e2e-test-checklist.md`.

## How Has This Been Tested?
Verified the commands match actual CLI usage (`make rebuild-clean` is a valid Makefile target, `uv sync` is the correct uv subcommand).

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code