### PR TITLE
fix(rbac): downgrade settings + trace privacy from super_admin to admin

### DIFF
--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -738,7 +738,7 @@ async def apply_resources(
 @router.get("/org/trace-privacy")
 async def get_trace_privacy(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.super_admin)),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Get the trace privacy setting for the current user's organization."""
     if not current_user.org_id:
@@ -754,7 +754,7 @@ async def get_trace_privacy(
 async def set_trace_privacy(
     req: dict,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.super_admin)),
+    current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Toggle trace privacy for the current user's organization.
 

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -8,7 +8,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, get_or_create_default_org, require_role
+from api.deps import ROLE_HIERARCHY, get_db, get_or_create_default_org, require_role
 from config import settings
 from models.enterprise_config import EnterpriseConfig
 from models.organization import Organization
@@ -200,6 +200,9 @@ async def create_user(
     except ValueError:
         raise HTTPException(status_code=422, detail=f"Invalid role. Must be one of: {[r.value for r in UserRole]}")
 
+    if ROLE_HIERARCHY.get(role, 999) < ROLE_HIERARCHY[current_user.role]:
+        raise HTTPException(status_code=403, detail="Cannot assign a role higher than your own")
+
     password = req.password or await _generate_unique_password(db)
 
     org_id = current_user.org_id
@@ -252,8 +255,13 @@ async def update_user_role(
     except ValueError:
         raise HTTPException(status_code=422, detail=f"Invalid role. Must be one of: {[r.value for r in UserRole]}")
 
-    if user_id == current_user.id and new_role != UserRole.admin:
-        raise HTTPException(status_code=400, detail="Cannot demote yourself")
+    from api.deps import ROLE_HIERARCHY
+
+    if ROLE_HIERARCHY.get(new_role, 999) < ROLE_HIERARCHY[current_user.role]:
+        raise HTTPException(status_code=403, detail="Cannot assign a role higher than your own")
+
+    if user_id == current_user.id and new_role != current_user.role:
+        raise HTTPException(status_code=400, detail="Cannot change your own role")
 
     stmt = select(User).where(User.id == user_id)
     if current_user.org_id is not None:

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -183,7 +183,7 @@ const SETTING_SECTIONS: SettingSection[] = [
 const ALL_DEFAULT_SETTINGS = SETTING_SECTIONS.flatMap((s) => s.settings);
 
 export default function SettingsPage() {
-  const { ready } = useRoleGuard("super_admin");
+  const { ready } = useRoleGuard("admin");
   const { data: settings, isLoading, isError, error, refetch } = useAdminSettings();
   const { deploymentMode, ssoEnabled, evalConfigured } = useDeploymentConfig();
   const [addingKey, setAddingKey] = useState("");

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -21,12 +21,19 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
-import { ROLE_LABELS, type Role } from "@/hooks/use-role-guard";
+import { ROLE_LABELS, hasMinRole, type Role } from "@/hooks/use-role-guard";
+import { getUserRole } from "@/lib/api";
 
-const ROLES: Role[] = ["super_admin", "admin", "reviewer", "user"];
+const ALL_ROLES: Role[] = ["super_admin", "admin", "reviewer", "user"];
+
+function useAssignableRoles(): Role[] {
+  const myRole = getUserRole();
+  return ALL_ROLES.filter((r) => hasMinRole(myRole, r));
+}
 
 function RoleSelect({ userId, currentRole }: { userId: string; currentRole: string }) {
   const mutation = useUpdateUserRole();
+  const assignable = useAssignableRoles();
 
   return (
     <Select
@@ -40,7 +47,7 @@ function RoleSelect({ userId, currentRole }: { userId: string; currentRole: stri
         </SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {ROLES.map((r) => (
+        {assignable.map((r) => (
           <SelectItem key={r} value={r} className="text-xs">
             {ROLE_LABELS[r]}
           </SelectItem>
@@ -54,6 +61,7 @@ export default function UsersPage() {
   const { data: users, isLoading, isError, error, refetch } = useAdminUsers();
   const createUser = useCreateUser();
   const deleteUser = useDeleteUser();
+  const assignableRoles = useAssignableRoles();
   const [showCreate, setShowCreate] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
   const [name, setName] = useState("");
@@ -236,7 +244,7 @@ export default function UsersPage() {
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    {ROLES.map((r) => (
+                    {assignableRoles.map((r) => (
                       <SelectItem key={r} value={r}>{ROLE_LABELS[r]}</SelectItem>
                     ))}
                   </SelectContent>

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -59,7 +59,7 @@ const adminNav: NavItem[] = [
   { title: "Errors", href: "/errors", icon: AlertTriangle, minRole: "admin" },
   { title: "Evals", href: "/eval", icon: FlaskConical, minRole: "admin" },
   { title: "Users", href: "/users", icon: Users, minRole: "admin" },
-  { title: "Settings", href: "/settings", icon: Settings, minRole: "super_admin" },
+  { title: "Settings", href: "/settings", icon: Settings, minRole: "admin" },
 ];
 
 export const allNavItems = [


### PR DESCRIPTION
## Purpose / Description

`super_admin` should behave like root in AWS/cloud providers — used only for initial project setup and emergencies. `admin` should handle day-to-day operations including user management, settings, and configuration.

Currently, the Settings page and trace privacy endpoints are gated to `super_admin`, and there's no privilege escalation guard preventing admins from creating `super_admin` accounts.

Ref: https://github.com/BlazeUp-AI/Observal/discussions/500

## Fixes
* Fixes #512

## Approach

**Downgrade super_admin gates to admin:**
- `GET/PUT /api/v1/admin/org/trace-privacy` — `require_role(UserRole.super_admin)` → `require_role(UserRole.admin)`
- Settings page guard — `useRoleGuard("super_admin")` → `useRoleGuard("admin")`
- Sidebar Settings nav item — `minRole: "super_admin"` → `minRole: "admin"`

**Privilege escalation guard (new):**
- Backend: `create_user` and `update_user_role` now check that the target role is not higher than the caller's role (e.g., admin cannot create/promote to super_admin)
- Backend: self-role-change blocked for all roles (was previously only a partial check)
- Frontend: role dropdown in both user creation dialog and inline role editor now filters to only show assignable roles based on the current user's role

`super_admin` retains full access via the existing role hierarchy.

## How Has This Been Tested?

- Verified remaining `super_admin` references are correct (role definitions, hierarchy, demo seeding, inclusive OR checks)
- Confirmed `require_super_admin` alias in `deps.py` has no consumers
- Manual: admin can see Settings page, toggle trace privacy, create/promote users up to admin
- Manual: admin cannot see or assign super_admin role
- Manual: reviewer/user cannot access Settings

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)