### PR TITLE
feat(cli): add `create-user` command to `observal admin`

### DIFF
--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -935,6 +935,14 @@ def admin_create_user(
     """Create a new user account. Requires admin privileges.
 
     If no password is provided, a secure random password will be generated.
+
+    Examples:
+
+        observal admin create-user alice@example.com "Alice Smith"
+
+        observal admin create-user bob@example.com "Bob Jones" --role admin
+
+        observal admin create-user carol@example.com "Carol Lee" -u carol -r reviewer -p s3cret
     """
     body: dict = {"email": email, "name": name, "role": role}
     if username:

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -957,7 +957,7 @@ def admin_create_user(
         output_json(data)
         return
 
-    rprint(f"\n[green]User created successfully.[/green]\n")
+    rprint("\n[green]User created successfully.[/green]\n")
     rprint(f"  [bold]Name:[/bold]     {data['name']}")
     rprint(f"  [bold]Email:[/bold]    {data['email']}")
     if data.get("username"):

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -923,6 +923,43 @@ def admin_users(output: str = typer.Option("table", "--output", "-o")):
     console.print(table)
 
 
+@admin_app.command(name="create-user")
+def admin_create_user(
+    email: str = typer.Argument(..., help="Email address for the new user"),
+    name: str = typer.Argument(..., help="Full name of the user"),
+    username: str = typer.Option(None, "--username", "-u", help="Username (optional)"),
+    role: str = typer.Option("reviewer", "--role", "-r", help="Role: admin, reviewer, or user"),
+    password: str = typer.Option(None, "--password", "-p", help="Password (auto-generated if omitted)"),
+    output: str = typer.Option("table", "--output", "-o"),
+):
+    """Create a new user account. Requires admin privileges.
+
+    If no password is provided, a secure random password will be generated.
+    """
+    body: dict = {"email": email, "name": name, "role": role}
+    if username:
+        body["username"] = username
+    if password:
+        body["password"] = password
+
+    with spinner("Creating user..."):
+        data = client.post("/api/v1/admin/users", body)
+
+    if output == "json":
+        output_json(data)
+        return
+
+    rprint(f"\n[green]User created successfully.[/green]\n")
+    rprint(f"  [bold]Name:[/bold]     {data['name']}")
+    rprint(f"  [bold]Email:[/bold]    {data['email']}")
+    if data.get("username"):
+        rprint(f"  [bold]Username:[/bold] {data['username']}")
+    rprint(f"  [bold]Role:[/bold]     {data['role']}")
+    rprint(f"  [bold]ID:[/bold]       {data['id']}")
+    rprint(f"\n[yellow]Password:[/yellow] {data['password']}")
+    rprint("[dim]Save this — it will not be shown again.[/dim]")
+
+
 @admin_app.command(name="reset-password")
 def admin_reset_password(
     email: str = typer.Argument(..., help="Email of the user to reset"),


### PR DESCRIPTION
## Purpose / Description
The `observal admin` group has commands to list, reset-password, and delete users — but no way to **create** a user from the CLI. The backend API (`POST /api/v1/admin/users`) is fully implemented, so this wires up the missing CLI command with usage examples.

## Fixes
* Fixes #509

## Approach
Added `observal admin create-user` in `observal_cli/cmd_ops.py`, following the same patterns as the existing `reset-password` and `delete-user` commands:
- Positional args for `email` and `name`
- Options for `--username`, `--role`, `--password`, and `--output`
- Auto-generates a password if none is provided (server-side)
- Includes usage examples in the help text so the command is self-documenting

## How Has This Been Tested?

- Ran `observal admin create-user --help` and verified the help output shows arguments, options, and examples
- Verified the command is now listed in `observal admin --help`

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code