### PR TITLE
fix: restart nginx LB after local `make rebuild`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ rebuild:  ## Rebuild and restart Docker stack (runs migrations automatically)
 	cd docker && docker compose up --build -d
 	@echo "Waiting for API to be healthy..."
 	@cd docker && until docker compose exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && docker compose restart observal-lb
 	@echo "API is healthy."
 
 reset:  ## Nuke all Docker volumes and rebuild from scratch (fresh app, no file changes)
@@ -66,12 +67,14 @@ reset:  ## Nuke all Docker volumes and rebuild from scratch (fresh app, no file 
 	cd docker && docker compose up --build -d
 	@echo "Waiting for API to be healthy..."
 	@cd docker && until docker compose exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && docker compose restart observal-lb
 	@echo "API is healthy — all data has been reset."
 
 rebuild-clean:  ## Rebuild from scratch (no Docker cache) and restart
 	cd docker && docker compose build --no-cache && docker compose up -d
 	@echo "Waiting for API to be healthy..."
 	@cd docker && until docker compose exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && docker compose restart observal-lb
 	@echo "API is healthy."
 
 logs:  ## Tail Docker logs


### PR DESCRIPTION
## Purpose / Description
After `make rebuild` / `make reset` / `make rebuild-clean`, the API container gets a new IP but nginx keeps routing to the old cached one, causing 502 errors locally.

PR #503 fixed this for CI deploys but the local Makefile targets were missed.

## Fixes
* Complements #503 — extends the nginx restart fix to local dev workflows

## Approach
Added `docker compose restart observal-lb` after the API health check in the `rebuild`, `reset`, and `rebuild-clean` Makefile targets, matching the same approach used in the CI deploy workflow.

## How Has This Been Tested?

- Ran `make rebuild` and verified `curl localhost:8000/health` returns 200 immediately after (previously returned 502)

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code