### PR TITLE
fix(cli): dedent shim write loop to run after per-server iteration

### DIFF
--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -1071,14 +1071,14 @@ def register_scan(app: typer.Typer):
                     servers[name] = _wrap_with_shim(servers[name], name)
                     shimmed_count += 1
 
-                for path_str, config in configs_to_update.items():
-                    config_path = Path(path_str)
-                    backup = _backup_config(config_path)
-                    config_path.write_text(json.dumps(config, indent=2) + "\n")
-                    rprint(f"  [dim]Backup: {backup.name}[/dim]")
+            for path_str, config in configs_to_update.items():
+                config_path = Path(path_str)
+                backup = _backup_config(config_path)
+                config_path.write_text(json.dumps(config, indent=2) + "\n")
+                rprint(f"  [dim]Backup: {backup.name}[/dim]")
 
-                if shimmed_count:
-                    rprint(f"[green]Shimmed {shimmed_count} MCP entries for telemetry.[/green]")
+            if shimmed_count:
+                rprint(f"[green]Shimmed {shimmed_count} MCP entries for telemetry.[/green]")
 
         # ── Auto-inject hooks into ~/.claude/settings.json ─────
         if scan_claude:


### PR DESCRIPTION
fixes #516 

## Summary

Fixes incorrect indentation in `observal scan --shim` that caused the config-write loop and success message to execute inside the per-server loop instead of after it.

## Before

With 2 MCP servers, running `observal scan --shim --yes`:

```
Backup: mcp.pre-observal.20260423_031519.bak
Shimmed 1 MCP entries for telemetry.
Backup: mcp.pre-observal.20260423_031519.bak
Shimmed 2 MCP entries for telemetry.
Backup: mcp.pre-observal.20260423_031519.bak
Shimmed 2 MCP entries for telemetry.
Backup: mcp.pre-observal.20260423_031519.bak
Shimmed 2 MCP entries for telemetry.
```

- Config file written N times instead of once
- Backup overwritten each time (original backup lost)
- Multiple confusing messages with incrementing counts

## After

```
Backup: mcp.pre-observal.20260423_033005.bak
Shimmed 2 MCP entries for telemetry.
```



- Config file written once
- One backup of the original config
- One clear message

## Change

Dedented lines 1074-1081 in `observal_cli/cmd_scan.py` by one indentation level so the config-write loop and "Shimmed N" message run after the outer `for` loop completes.

