### PR TITLE
feat(auth): add SSO_ONLY mode to make SSO optional in enterprise

### DIFF
--- a/ee/observal_server/services/config_validator.py
+++ b/ee/observal_server/services/config_validator.py
@@ -19,14 +19,13 @@ def validate_enterprise_config(settings: Settings) -> list[str]:
     if settings.SECRET_KEY == "change-me-to-a-random-string":
         issues.append("SECRET_KEY is using default value")
 
-    if not settings.OAUTH_CLIENT_ID:
-        issues.append("OAUTH_CLIENT_ID is not set")
-
-    if not settings.OAUTH_CLIENT_SECRET:
-        issues.append("OAUTH_CLIENT_SECRET is not set")
-
-    if not settings.OAUTH_SERVER_METADATA_URL:
-        issues.append("OAUTH_SERVER_METADATA_URL is not set")
+    if settings.SSO_ONLY:
+        if not settings.OAUTH_CLIENT_ID:
+            issues.append("OAUTH_CLIENT_ID is not set (required when SSO_ONLY=true)")
+        if not settings.OAUTH_CLIENT_SECRET:
+            issues.append("OAUTH_CLIENT_SECRET is not set (required when SSO_ONLY=true)")
+        if not settings.OAUTH_SERVER_METADATA_URL:
+            issues.append("OAUTH_SERVER_METADATA_URL is not set (required when SSO_ONLY=true)")
 
     if settings.FRONTEND_URL in ("http://localhost:3000", ""):
         issues.append("FRONTEND_URL is localhost or empty")

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -170,6 +170,12 @@ async def require_local_mode() -> None:
         raise HTTPException(status_code=403, detail="Disabled in enterprise mode")
 
 
+async def require_password_auth() -> None:
+    """FastAPI dependency that blocks the endpoint when SSO_ONLY is enabled."""
+    if settings.SSO_ONLY:
+        raise HTTPException(status_code=403, detail="Password authentication is disabled (SSO-only mode)")
+
+
 async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_status=None):
     """Resolve a listing by UUID or name. Returns most recent if duplicates exist."""
 

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -9,7 +9,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import ROLE_HIERARCHY, get_db, get_or_create_default_org, require_role
+from api.deps import ROLE_HIERARCHY, get_db, get_or_create_default_org, require_password_auth, require_role
 from config import settings
 from models.enterprise_config import EnterpriseConfig
 from models.organization import Organization
@@ -83,15 +83,16 @@ async def diagnostics(
     # Enterprise config
     if settings.DEPLOYMENT_MODE == "enterprise":
         issues: list[str] = []
-        # Check for common misconfigurations
         if settings.SECRET_KEY == "change-me-to-a-random-string":
             issues.append("SECRET_KEY is using default value")
-        if not settings.OAUTH_CLIENT_ID:
-            issues.append("OAUTH_CLIENT_ID is not set")
+        if settings.SSO_ONLY and not settings.OAUTH_CLIENT_ID:
+            issues.append("OAUTH_CLIENT_ID is not set (required for SSO-only mode)")
         if settings.FRONTEND_URL in ("http://localhost:3000", ""):
             issues.append("FRONTEND_URL is localhost")
         diag["checks"]["enterprise"] = {
             "status": "ok" if not issues else "misconfigured",
+            "sso_only": settings.SSO_ONLY,
+            "sso_configured": bool(settings.OAUTH_CLIENT_ID),
             "issues": issues,
         }
         if issues:
@@ -194,7 +195,7 @@ async def list_users(
     return users
 
 
-@router.post("/users", response_model=UserCreateResponse)
+@router.post("/users", response_model=UserCreateResponse, dependencies=[Depends(require_password_auth)])
 async def create_user(
     req: UserCreateRequest,
     db: AsyncSession = Depends(get_db),
@@ -316,7 +317,7 @@ async def update_user_role(
     return UserAdminResponse.model_validate(user)
 
 
-@router.put("/users/{user_id}/password")
+@router.put("/users/{user_id}/password", dependencies=[Depends(require_password_auth)])
 async def reset_user_password(
     user_id: uuid.UUID,
     req: AdminResetPasswordRequest,

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -11,7 +11,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_current_user, get_db, get_or_create_default_org, require_local_mode
+from api.deps import get_current_user, get_db, get_or_create_default_org, require_local_mode, require_password_auth
 from api.ratelimit import limiter
 from config import settings
 from models.user import User, UserRole
@@ -200,7 +200,7 @@ async def register(request: Request, req: RegisterRequest, db: AsyncSession = De
     )
 
 
-@router.post("/login", response_model=InitResponse)
+@router.post("/login", response_model=InitResponse, dependencies=[Depends(require_password_auth)])
 @limiter.limit("5/minute")
 async def login(request: Request, req: LoginRequest, db: AsyncSession = Depends(get_db)):
     """Login with email + password. Returns user info and JWT tokens."""
@@ -427,7 +427,7 @@ async def whoami(current_user: User = Depends(get_current_user)):
 # ── JWT Token Endpoints ────────────────────────────────────
 
 
-@router.post("/token", response_model=TokenResponse)
+@router.post("/token", response_model=TokenResponse, dependencies=[Depends(require_password_auth)])
 @limiter.limit(settings.RATE_LIMIT_AUTH)
 async def issue_token(request: Request, req: TokenRequest, db: AsyncSession = Depends(get_db)):
     """Exchange email+password for JWT access + refresh tokens."""

--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -43,6 +43,7 @@ async def get_public_config():
     return {
         "deployment_mode": settings.DEPLOYMENT_MODE,
         "sso_enabled": bool(settings.OAUTH_CLIENT_ID),
+        "sso_only": settings.SSO_ONLY,
         "saml_enabled": False,  # placeholder for future ee/ SAML
         "eval_configured": bool(settings.EVAL_MODEL_NAME),
     }

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -83,6 +83,11 @@ class Settings(BaseSettings):
     # Deployment mode
     DEPLOYMENT_MODE: Literal["local", "enterprise"] = "local"
 
+    # When True, password-based auth is disabled entirely.
+    # Users can only authenticate via SSO (OAuth/OIDC).
+    # Blocks: login, token, register, admin user create, admin password reset.
+    SSO_ONLY: bool = False
+
     # Demo accounts (seeded on first startup if set and no real users exist)
     DEMO_SUPER_ADMIN_EMAIL: str | None = None
     DEMO_SUPER_ADMIN_PASSWORD: str | None = None

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -12,22 +12,21 @@ class TestConfigValidator:
 
         settings = MagicMock()
         settings.SECRET_KEY = "change-me-to-a-random-string"
-        settings.OAUTH_CLIENT_ID = "some-id"
-        settings.OAUTH_CLIENT_SECRET = "some-secret"
-        settings.OAUTH_SERVER_METADATA_URL = "https://example.com/.well-known"
+        settings.SSO_ONLY = False
         settings.FRONTEND_URL = "https://app.example.com"
 
         issues = validate_enterprise_config(settings)
         assert any("SECRET_KEY" in i for i in issues)
         assert len(issues) == 1
 
-    def test_detects_missing_oauth(self):
+    def test_detects_missing_oauth_when_sso_only(self):
         from unittest.mock import MagicMock
 
         from ee.observal_server.services.config_validator import validate_enterprise_config
 
         settings = MagicMock()
         settings.SECRET_KEY = "proper-random-secret-key"
+        settings.SSO_ONLY = True
         settings.OAUTH_CLIENT_ID = None
         settings.OAUTH_CLIENT_SECRET = None
         settings.OAUTH_SERVER_METADATA_URL = None
@@ -39,6 +38,22 @@ class TestConfigValidator:
         assert any("OAUTH_CLIENT_SECRET" in i for i in issues)
         assert any("OAUTH_SERVER_METADATA_URL" in i for i in issues)
 
+    def test_no_oauth_issues_when_sso_not_required(self):
+        from unittest.mock import MagicMock
+
+        from ee.observal_server.services.config_validator import validate_enterprise_config
+
+        settings = MagicMock()
+        settings.SECRET_KEY = "proper-random-secret-key"
+        settings.SSO_ONLY = False
+        settings.OAUTH_CLIENT_ID = None
+        settings.OAUTH_CLIENT_SECRET = None
+        settings.OAUTH_SERVER_METADATA_URL = None
+        settings.FRONTEND_URL = "https://app.example.com"
+
+        issues = validate_enterprise_config(settings)
+        assert len(issues) == 0
+
     def test_detects_localhost_frontend(self):
         from unittest.mock import MagicMock
 
@@ -46,9 +61,7 @@ class TestConfigValidator:
 
         settings = MagicMock()
         settings.SECRET_KEY = "proper-random-secret-key"
-        settings.OAUTH_CLIENT_ID = "id"
-        settings.OAUTH_CLIENT_SECRET = "secret"
-        settings.OAUTH_SERVER_METADATA_URL = "https://example.com/.well-known"
+        settings.SSO_ONLY = False
         settings.FRONTEND_URL = "http://localhost:3000"
 
         issues = validate_enterprise_config(settings)
@@ -61,9 +74,7 @@ class TestConfigValidator:
 
         settings = MagicMock()
         settings.SECRET_KEY = "proper-random-secret-key"
-        settings.OAUTH_CLIENT_ID = "id"
-        settings.OAUTH_CLIENT_SECRET = "secret"
-        settings.OAUTH_SERVER_METADATA_URL = "https://login.microsoftonline.com/..."
+        settings.SSO_ONLY = False
         settings.FRONTEND_URL = "https://app.example.com"
 
         issues = validate_enterprise_config(settings)
@@ -187,9 +198,7 @@ class TestRegisterEnterprise:
 
         settings = MagicMock()
         settings.SECRET_KEY = "change-me-to-a-random-string"
-        settings.OAUTH_CLIENT_ID = None
-        settings.OAUTH_CLIENT_SECRET = None
-        settings.OAUTH_SERVER_METADATA_URL = None
+        settings.SSO_ONLY = False
         settings.FRONTEND_URL = "http://localhost:3000"
 
         from services.events import bus

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -23,6 +23,7 @@ import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { ROLE_LABELS, hasMinRole, type Role } from "@/hooks/use-role-guard";
 import { getUserRole } from "@/lib/api";
+import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 
 const ALL_ROLES: Role[] = ["super_admin", "admin", "reviewer", "user"];
 
@@ -62,6 +63,7 @@ export default function UsersPage() {
   const createUser = useCreateUser();
   const deleteUser = useDeleteUser();
   const assignableRoles = useAssignableRoles();
+  const { ssoOnly } = useDeploymentConfig();
   const [showCreate, setShowCreate] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
   const [name, setName] = useState("");
@@ -112,9 +114,11 @@ export default function UsersPage() {
           { label: "Users" },
         ]}
         actionButtonsRight={
-          <Button size="sm" variant="outline" onClick={() => setShowCreate(true)} className="h-8">
-            <Plus className="mr-1 h-3.5 w-3.5" /> Add User
-          </Button>
+          !ssoOnly ? (
+            <Button size="sm" variant="outline" onClick={() => setShowCreate(true)} className="h-8">
+              <Plus className="mr-1 h-3.5 w-3.5" /> Add User
+            </Button>
+          ) : undefined
         }
       />
       <div className="p-6 w-full mx-auto space-y-4">

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -15,8 +15,7 @@ type Mode = "login" | "register";
 function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { deploymentMode, ssoEnabled } = useDeploymentConfig();
-  const isEnterprise = deploymentMode === "enterprise";
+  const { ssoEnabled, ssoOnly } = useDeploymentConfig();
   const [mode, setMode] = useState<Mode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -85,10 +84,10 @@ function LoginContent() {
 
   // In enterprise mode, force login mode (SSO only)
   useEffect(() => {
-    if (isEnterprise && mode !== "login") {
+    if (ssoOnly && mode !== "login") {
       setMode("login");
     }
-  }, [isEnterprise, mode]);
+  }, [ssoOnly, mode]);
 
   function switchMode(next: Mode) {
     setMode(next);
@@ -169,7 +168,7 @@ function LoginContent() {
               className="space-y-4"
             >
               {/* Email + Password mode (login & register) — hidden in enterprise mode */}
-              {(mode === "login" || mode === "register") && !isEnterprise && (
+              {(mode === "login" || mode === "register") && !ssoOnly && (
                 <>
                   <div className="space-y-2 animate-in">
                     <Label htmlFor="email">Email</Label>
@@ -231,7 +230,7 @@ function LoginContent() {
               {/* Submit */}
               <div className="animate-in stagger-2 space-y-3">
                 {/* In enterprise mode, hide all non-SSO submit buttons */}
-                {!isEnterprise && (
+                {!ssoOnly && (
                   <Button type="submit" disabled={loading || ssoLoading} className="w-full">
                     {loading && !ssoLoading ? (
                       <Loader2 className="h-4 w-4 animate-spin" />
@@ -244,7 +243,7 @@ function LoginContent() {
                   </Button>
                 )}
 
-                {mode === "login" && !isEnterprise && (
+                {mode === "login" && !ssoOnly && (
                   <div className="relative py-2">
                     <div className="absolute inset-0 flex items-center">
                       <span className="w-full border-t" />
@@ -255,10 +254,10 @@ function LoginContent() {
                   </div>
                 )}
 
-                {mode === "login" && (isEnterprise || ssoEnabled) && (
+                {mode === "login" && (ssoOnly || ssoEnabled) && (
                   <Button
                     type="button"
-                    variant={isEnterprise ? "default" : "outline"}
+                    variant={ssoOnly ? "default" : "outline"}
                     className="w-full"
                     onClick={handleSsoLogin}
                     disabled={loading || ssoLoading}
@@ -275,7 +274,7 @@ function LoginContent() {
 
               {/* Mode switches */}
               <div className="animate-in stagger-3 space-y-2 text-center">
-                {mode === "login" && !isEnterprise && (
+                {mode === "login" && !ssoOnly && (
                   <>
                     <p className="text-sm text-muted-foreground/60">
                       Forgot password? Contact your admin.
@@ -289,7 +288,7 @@ function LoginContent() {
                     </button>
                   </>
                 )}
-                {mode === "register" && !isEnterprise && (
+                {mode === "register" && !ssoOnly && (
                   <button
                     type="button"
                     className="block w-full text-sm text-muted-foreground transition-colors hover:text-foreground"

--- a/web/src/hooks/use-deployment-config.ts
+++ b/web/src/hooks/use-deployment-config.ts
@@ -14,6 +14,7 @@ export function useDeploymentConfig() {
   return {
     deploymentMode: data?.deployment_mode ?? "local",
     ssoEnabled: data?.sso_enabled ?? false,
+    ssoOnly: data?.sso_only ?? false,
     samlEnabled: data?.saml_enabled ?? false,
     evalConfigured: data?.eval_configured ?? false,
     loading: isLoading,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -407,6 +407,7 @@ export const admin = {
 export type PublicConfig = {
   deployment_mode: "local" | "enterprise";
   sso_enabled: boolean;
+  sso_only: boolean;
   saml_enabled: boolean;
   eval_configured: boolean;
 };


### PR DESCRIPTION
## Summary

- Add `SSO_ONLY` env var (default `false`) that controls whether password-based auth is available
- When `SSO_ONLY=true`: blocks password login, token exchange, self-registration, admin user creation, and admin password reset with 403
- Config validator only requires `OAUTH_*` vars when `SSO_ONLY=true` — enterprise mode no longer forces SSO
- Frontend login page gates password form on `sso_only` (not `deployment_mode`), so enterprise + password auth works
- Admin users page hides "Add User" button in SSO-only mode
- Diagnostics endpoint reports `sso_only` and `sso_configured` status
- Public config endpoint exposes `sso_only` flag

## Test plan

- [ ] Verify `SSO_ONLY=false` (default): enterprise mode works with password login, admin can create users
- [ ] Verify `SSO_ONLY=true` + no `OAUTH_*` vars: config validator reports issues, ee/ routes return 503
- [ ] Verify `SSO_ONLY=true` + valid `OAUTH_*` vars: password endpoints return 403, SSO login works
- [ ] Verify frontend login page shows password form when `sso_only=false`, hides it when `true`
- [ ] Verify admin users page hides "Add User" when `sso_only=true`
- [ ] Run `make test` — 1821 tests pass