### PR TITLE
fix(ci): allow PR number suffix in release commit detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: version
         run: |
           COMMIT_MSG=$(git log -1 --pretty=%s)
-          if [[ "$COMMIT_MSG" =~ ^bump\(release\):\ v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+          if [[ "$COMMIT_MSG" =~ ^bump\(release\):\ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             VERSION="${BASH_REMATCH[1]}"
             echo "is_release=true" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Purpose / Description

The release workflow regex uses a strict `$` anchor that rejects GitHub's auto-appended PR number suffix (e.g. `bump(release): v0.3.0 (#525)`). This is why the v0.3.0 release didn't trigger.

## Fixes
* Fixes the release pipeline not triggering after merging a release PR

## Approach

Remove the `$` anchor from the bash regex so `bump(release): v1.2.3 (#456)` matches correctly.

## How Has This Been Tested?

```bash
[[ "bump(release): v0.3.0 (#525)" =~ ^bump\(release\):\ v([0-9]+\.[0-9]+\.[0-9]+) ]] && echo "${BASH_REMATCH[1]}"
# Output: 0.3.0
```

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code