### PR TITLE
fix(ci): inline python version check to avoid indentation error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,7 @@ jobs:
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
             # Validate version matches pyproject.toml
-            PKG_VERSION=$(python3 -c "
-            import re, pathlib
-            m = re.search(r'^version\s*=\s*\"([^\"]+)\"', pathlib.Path('pyproject.toml').read_text(), re.M)
-            print(m.group(1))
-            ")
+            PKG_VERSION=$(python3 -c "import re, pathlib; m = re.search(r'^version\s*=\s*\"([^\"]+)\"', pathlib.Path('pyproject.toml').read_text(), re.M); print(m.group(1))")
             if [ "$VERSION" != "$PKG_VERSION" ]; then
               echo "::error::Commit says v$VERSION but pyproject.toml says $PKG_VERSION"
               exit 1


### PR DESCRIPTION
## Purpose / Description

The multi-line Python snippet in the release workflow's `run:` block inherits YAML indentation, causing `IndentationError: unexpected indent` in CI.

## Fixes
* Fixes release workflow failing at preflight with Python IndentationError

## Approach

Inline the Python version extraction to a single line, avoiding the indentation issue entirely.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code