### PR TITLE
fix(ci): set git identity for release tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,8 @@ jobs:
       - name: Create release tag
         if: steps.version.outputs.is_release == 'true'
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           VERSION="v${{ steps.version.outputs.version }}"
           git tag -a "$VERSION" -m "Release $VERSION"
           git push origin "$VERSION"


### PR DESCRIPTION
## Purpose / Description

The release workflow fails when creating the annotated tag because the GitHub Actions runner has no git identity configured.

## Fixes
* Fixes `fatal: empty ident name not allowed` when creating release tags

## Approach

Set `user.name` and `user.email` to the standard `github-actions[bot]` identity before `git tag -a`.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code