### PR TITLE
fix(ci): resolve multiple release workflow issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,8 @@
 # Automated release pipeline for Observal.
 #
-# Triggered when a release PR merges to main (detected by chore(release) commit).
+# Triggered when a release PR merges to main (detected by bump(release) commit).
 # Creates the git tag, then builds: CLI binaries (6 platforms), Docker images (GHCR),
-# server tarball, PyPI package.
-#
-# Public releases (major/feature) require approval in the 'production' environment.
-# Patch releases auto-publish without approval.
+# server tarball, PyPI package. All releases require approval.
 
 name: Release
 
@@ -76,6 +73,8 @@ jobs:
       - name: Create release tag
         if: steps.version.outputs.is_release == 'true'
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           VERSION="v${{ steps.version.outputs.version }}"
           git tag -a "$VERSION" -m "Release $VERSION"
           git push origin "$VERSION"
@@ -232,11 +231,20 @@ jobs:
           name: observal-server-v${{ needs.preflight.outputs.version }}.tar.gz
           path: observal-server-v${{ needs.preflight.outputs.version }}.tar.gz
 
-  # ── Job 4: PyPI publish ────────────────────────────────────
+  # ── Approval gate (all releases) ────────────────────────────
+  approve:
+    name: Approval gate
+    needs: [preflight, cli-binaries, docker-images, server-package]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "${{ needs.preflight.outputs.bump_type }} release v${{ needs.preflight.outputs.version }} approved"
+
+  # ── Job 4: PyPI publish (after approval) ───────────────────
   pypi:
     name: Publish to PyPI
-    needs: preflight
-    if: needs.preflight.outputs.is_release == 'true'
+    needs: [preflight, approve]
+    if: needs.approve.result == 'success'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -254,20 +262,11 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-  # ── Approval gate (all releases) ────────────────────────────
-  approve:
-    name: Approval gate
-    needs: [preflight, cli-binaries, docker-images, server-package, pypi]
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - run: echo "${{ needs.preflight.outputs.bump_type }} release v${{ needs.preflight.outputs.version }} approved"
-
   # ── Final: Create GitHub Release with all artifacts ────────
   release:
     name: GitHub Release
     needs: [preflight, cli-binaries, docker-images, server-package, pypi, approve]
-    if: ${{ !cancelled() && needs.cli-binaries.result == 'success' && needs.server-package.result == 'success' }}
+    if: needs.approve.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -289,14 +288,10 @@ jobs:
           cd release
           sha256sum * > checksums.txt
 
-      - name: Generate changelog for this release
+      - name: Generate release notes
         run: |
-          if command -v git-cliff >/dev/null 2>&1; then
-            git-cliff --config cliff.toml --latest --strip header > release/RELEASE_NOTES.md
-          else
-            pip install git-cliff
-            git-cliff --config cliff.toml --latest --strip header > release/RELEASE_NOTES.md
-          fi
+          pip install git-cliff
+          git-cliff --config cliff.toml --latest --strip header > release/RELEASE_NOTES.md
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v2
@@ -313,7 +308,6 @@ jobs:
             --draft \
             --title "Observal $VERSION" \
             --notes-file release/RELEASE_NOTES.md \
-            --generate-notes \
             --latest \
             release/*
 


### PR DESCRIPTION
## Purpose / Description

Audit of the release workflow found several issues that would cause failures or incorrect behavior. This PR fixes all of them in one shot.

## Fixes

1. **Missing git identity** — `git tag -a` fails with `empty ident name not allowed` because the Actions runner has no user configured. Set to `github-actions[bot]`.
2. **Release job runs after rejected approval** — The `if` condition used `!cancelled()` checking only `cli-binaries` and `server-package`, ignoring `approve`. Changed to `needs.approve.result == 'success'`.
3. **`--generate-notes` conflicts with `--notes-file`** — `gh release create` with both flags causes `--generate-notes` to overwrite the notes file. Removed `--generate-notes`.
4. **git-cliff install** — Simplified to `pip install git-cliff` (the Python wrapper that bundles the Rust binary).
5. **Stale header comment** — Updated to say `bump(release)` and all releases require approval.

Supersedes #531 (git identity fix alone).

## How Has This Been Tested?

Manual review of each GitHub Actions step against docs. Verified `pip install git-cliff` installs correctly. Verified `gh release create` flag compatibility.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code