### PR TITLE
docs: use install.sh as primary CLI installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,36 @@ See [CHANGELOG.md](CHANGELOG.md) for recent updates.
 
 ## Quick start
 
+**Install the CLI** (standalone binary, no Python required):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+```
+
+Or install via Python: `uv tool install observal-cli` / `pipx install observal-cli` / `pip install --user observal-cli`. See [Installation](docs/getting-started/installation.md) for details.
+
+**Start the server:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install-server.sh | bash
+```
+
+Or manually:
+
 ```bash
 git clone https://github.com/BlazeUp-AI/Observal.git
 cd Observal
 cp .env.example .env
-
 docker compose -f docker/docker-compose.yml up --build -d
-uv tool install --editable .
+```
+
+**Log in:**
+
+```bash
 observal auth login            # auto-creates admin on fresh server
 ```
 
-Eight services start (API, web UI, Postgres, ClickHouse, Redis, worker, OTEL collector, Grafana). Full walkthrough in [Quickstart](docs/getting-started/quickstart.md); operator guide in [Self-Hosting → Docker Compose setup](docs/self-hosting/docker-compose.md).
+Eight services start (API, web UI, Postgres, ClickHouse, Redis, worker, OTEL collector, Grafana). Full walkthrough in [Quickstart](docs/getting-started/quickstart.md); operator guide in [Self-Hosting](docs/self-hosting/docker-compose.md).
 
 Already have MCP servers in your IDE? Instrument them in one command:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,21 +1,18 @@
 # Installation
 
-Install the Observal CLI — `observal` — on your machine. The CLI is what you use to log in, instrument IDE configs, pull agents, and query traces.
+Install the Observal CLI on your machine. The CLI is what you use to log in, instrument IDE configs, pull agents, and query traces.
 
-If you also want to **self-host** the Observal server (API + web UI + databases), see [Self-Hosting → Docker Compose setup](../self-hosting/docker-compose.md). You can install the CLI first and point it at any Observal server later.
+If you also want to **self-host** the Observal server (API + web UI + databases), see [Self-Hosting](../self-hosting/docker-compose.md).
 
-## Requirements
+## Install (standalone binary)
 
-* Python **3.11 or newer** (3.11, 3.12, 3.13 are tested)
-* One of: `uv` (recommended), `pipx`, or `pip`
-
-## Install with uv (recommended)
-
-[`uv`](https://docs.astral.sh/uv/) is the fastest way to install Python CLIs. It keeps Observal isolated in its own virtualenv without polluting your system Python.
+The standalone binary is the simplest way to install. No Python required.
 
 ```bash
-uv tool install observal-cli
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
 ```
+
+This downloads the latest release binary for your platform and places it on your `PATH`.
 
 Verify it worked:
 
@@ -23,39 +20,45 @@ Verify it worked:
 observal --version
 ```
 
-## Install with pipx
+## Alternative: install with Python
+
+If you prefer to install via Python, use one of these methods. Requires Python 3.11 or newer.
+
+**uv (recommended):**
+
+```bash
+uv tool install observal-cli
+```
+
+**pipx:**
 
 ```bash
 pipx install observal-cli
 ```
 
-## Install with pip
+**pip:**
 
 ```bash
 pip install --user observal-cli
 ```
 
-## Optional extras
+### Optional extras
 
-Observal ships with two opt-in extras:
+Observal ships with two opt-in extras for the Python install:
 
 | Extra | What it adds | When to install |
 | --- | --- | --- |
-| `sandbox` | Docker SDK (for sandbox execution) | If you'll run agents inside Observal sandboxes |
+| `sandbox` | Docker SDK (for sandbox execution) | If you run agents inside Observal sandboxes |
 | `migrate` | `asyncpg` (for the `observal migrate` command) | If you operate the server and run DB migrations from the CLI |
-| `all` | Both of the above | If you're an operator doing everything |
+| `all` | Both of the above | If you do both |
 
 Install an extra:
 
 ```bash
 uv tool install 'observal-cli[sandbox]'
-uv tool install 'observal-cli[migrate]'
-uv tool install 'observal-cli[all]'
 ```
 
-## Install from source (editable)
-
-If you're contributing or testing an unreleased build:
+## Install from source (for contributors)
 
 ```bash
 git clone https://github.com/BlazeUp-AI/Observal.git
@@ -65,24 +68,32 @@ uv tool install --editable .
 
 ## What gets installed
 
-Three entry points land on your `PATH`:
+Four entry points land on your `PATH`:
 
 | Command | Purpose |
 | --- | --- |
 | `observal` | The main CLI |
-| `observal-shim` | stdio shim — sits between your IDE and stdio MCP servers |
-| `observal-proxy` | HTTP proxy — sits between your IDE and HTTP/SSE MCP servers |
+| `observal-shim` | stdio shim between your IDE and stdio MCP servers |
+| `observal-proxy` | HTTP proxy between your IDE and HTTP/SSE MCP servers |
 | `observal-sandbox-run` | Sandbox runner invoked by Observal sandboxes |
 
-You will almost never call the shim, proxy, or sandbox runner directly — the CLI wires them into your IDE config for you.
+You will almost never call the shim, proxy, or sandbox runner directly. The CLI wires them into your IDE config for you.
 
-## Upgrade later
+## Upgrade
 
 ```bash
 observal self upgrade
 ```
 
 ## Uninstall
+
+Standalone binary:
+
+```bash
+rm "$(which observal)"
+```
+
+Python install:
 
 ```bash
 uv tool uninstall observal-cli
@@ -98,4 +109,4 @@ rm -rf ~/.observal
 
 ## Next
 
-→ [Quickstart](quickstart.md)
+-> [Quickstart](quickstart.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,15 +1,24 @@
 # Quickstart
 
-Go from zero to "my first trace in the Observal dashboard" in about five minutes. This assumes you've [installed the CLI](installation.md) and have Docker running.
+Go from zero to "my first trace in the Observal dashboard" in about five minutes. This assumes you have Docker running.
 
 By the end of this guide you will have:
 
+* The Observal CLI installed
 * An Observal server running locally
 * The CLI logged in as an admin
 * At least one MCP server instrumented
 * A live trace visible in the web UI
 
-## 1. Start the server
+## 1. Install the CLI
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+```
+
+No Python required. For alternative install methods, see [Installation](installation.md).
+
+## 2. Start the server
 
 ```bash
 git clone https://github.com/BlazeUp-AI/Observal.git
@@ -41,7 +50,7 @@ curl http://localhost:8000/health
 
 Hitting a port conflict? See [Self-Hosting → Ports and volumes](../self-hosting/ports-and-volumes.md).
 
-## 2. Log in
+## 3. Log in
 
 ```bash
 observal auth login
@@ -69,7 +78,7 @@ observal auth whoami
 # → super@demo.example (super_admin)
 ```
 
-## 3. Instrument your IDE
+## 4. Instrument your IDE
 
 If you already have MCP servers configured in Claude Code, Kiro, Cursor, VS Code, or Gemini CLI, one command wires them all up:
 
@@ -102,7 +111,7 @@ Nothing broke. Your agents still work exactly as before. The only difference: ev
 
 Restart your IDE to pick up the new config. The next MCP call will produce a trace.
 
-## 4. See your first trace
+## 5. See your first trace
 
 Open `http://localhost:3000/traces` in your browser. Trigger anything in your IDE that uses an MCP tool (ask Claude to list files, read a GitHub issue, whatever). Refresh — you'll see the trace appear.
 
@@ -118,7 +127,7 @@ Drill in:
 observal ops spans <trace-id>
 ```
 
-## 5. (Optional) Pull an agent
+## 6. (Optional) Pull an agent
 
 Browse what the community has published:
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -14,7 +14,7 @@ Claude Code is the most complete integration. Native OpenTelemetry traces and lo
 
 ```bash
 # 1. Install and log in to the Observal CLI
-uv tool install observal-cli
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
 observal auth login
 
 # 2. Instrument any MCP servers you already have

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -17,7 +17,7 @@ If these matter, use Claude Code or Kiro instead.
 ## Setup
 
 ```bash
-uv tool install observal-cli
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
 observal auth login
 
 observal scan --ide cursor

--- a/docs/integrations/gemini-cli.md
+++ b/docs/integrations/gemini-cli.md
@@ -15,7 +15,7 @@ Gemini CLI is supported at the MCP and rules level. Mostly the same shape as [Cu
 ## Setup
 
 ```bash
-uv tool install observal-cli
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
 observal auth login
 
 observal scan --ide gemini-cli

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -43,7 +43,7 @@ kiro login
 ### 2. Install the Observal CLI
 
 ```bash
-uv tool install observal-cli
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
 observal auth login
 ```
 
@@ -171,8 +171,10 @@ Add at least one MCP server to Kiro first, then re-run `scan`.
 
 ### `observal-shim` not found
 
+Reinstall:
+
 ```bash
-uv tool install --force observal-cli
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
 which observal-shim
 ```
 

--- a/docs/integrations/vscode.md
+++ b/docs/integrations/vscode.md
@@ -14,7 +14,7 @@ VS Code (with MCP-aware extensions) is supported at the MCP and rules level.
 ## Setup
 
 ```bash
-uv tool install observal-cli
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
 observal auth login
 
 observal scan --ide vscode

--- a/docs/self-hosting/docker-compose.md
+++ b/docs/self-hosting/docker-compose.md
@@ -55,7 +55,7 @@ For local dev, `http://localhost:3000` and `http://localhost:8000` are fine. For
 Log in with the CLI:
 
 ```bash
-uv tool install observal-cli     # if you haven't already
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash   # if you haven't already
 observal auth login              # Email: super@demo.example, Password: super-changeme
 ```
 

--- a/docs/self-hosting/requirements.md
+++ b/docs/self-hosting/requirements.md
@@ -47,8 +47,8 @@ Postgres stays under 500 MB for most deployments — it holds only registry meta
 
 For the **CLI** (developer machines, not the server):
 
-* Python **3.11, 3.12, or 3.13**
-* Any of `uv` (recommended), `pipx`, or `pip`
+* **Standalone binary** (recommended) -- no dependencies, just `curl | bash`
+* Or Python **3.11, 3.12, or 3.13** with `uv`, `pipx`, or `pip`
 
 ## Network
 

--- a/docs/use-cases/team-registry.md
+++ b/docs/use-cases/team-registry.md
@@ -60,8 +60,8 @@ Two commands to get them productive:
 
 ```bash
 # The new engineer runs:
-uv tool install observal-cli
-observal auth register --server https://observal.your-company.internal
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+observal auth login --server https://observal.your-company.internal
 ```
 
 Self-registration is enabled in `DEPLOYMENT_MODE=local`. For enterprise mode (SSO / SCIM), users provision via your IdP — see [Authentication and SSO](../self-hosting/authentication.md).


### PR DESCRIPTION
## Purpose / Description

The automated release pipeline (#521) now produces standalone binaries with a `curl | bash` installer. The README and setup documentation still instruct users to install the CLI via `uv tool install observal-cli`, which requires Python. This PR updates all installation docs to use `install.sh` as the primary method and keeps the Python install as an alternative.

## Fixes

* Fixes #522

## Approach

- **README.md**: Quick start now leads with `curl | bash` for both CLI (`install.sh`) and server (`install-server.sh`). The manual `git clone` + `docker compose` path is kept as a fallback.
- **docs/getting-started/installation.md**: Restructured with standalone binary as the primary install method (no Python required). Python install (uv/pipx/pip) moved to an "Alternative" section. Uninstall section covers both methods. Removed em-dashes for cleaner prose.
- **docs/getting-started/quickstart.md**: Added "Step 1: Install the CLI" with `curl | bash`, renumbered subsequent steps.
- **Integration docs** (claude-code, kiro, cursor, gemini-cli, vscode): Replaced `uv tool install observal-cli` with `curl | bash` in all setup blocks. Fixed Kiro troubleshooting for `observal-shim` reinstall.
- **docs/self-hosting/docker-compose.md**: Updated CLI install line in the demo accounts section.
- **docs/self-hosting/requirements.md**: CLI requirements now list standalone binary as recommended, Python as alternative.
- **docs/use-cases/team-registry.md**: Updated install command and replaced deprecated `observal auth register` with `observal auth login`.

## How Has This Been Tested?

- Verified all edited markdown renders correctly
- Ran `make lint` -- all checks passed
- Grep confirmed no remaining `uv tool install observal-cli` in docs that should reference the standalone installer
- Checked that no em-dashes or en-dashes were introduced in the rewritten installation.md

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)