### PR TITLE
fix(hooks): skip trailing metadata in stop hook transcript parsing

### DIFF
--- a/observal_cli/hooks/observal-stop-hook.sh
+++ b/observal_cli/hooks/observal-stop-hook.sh
@@ -42,12 +42,16 @@ trap 'rm -rf "$TMPDIR_WORK"' EXIT
 
 MSG_COUNT=0
 THINK_COUNT=0
+FOUND_ASSISTANT=0
 
 # Use process substitution instead of pipe to avoid subshell variable scoping.
 # Write files from within the loop — they persist on disk regardless.
+# Transcript ends with metadata/attachment entries after the last user message,
+# so we skip user messages until we've seen at least one assistant message.
 while IFS= read -r line; do
   case "$line" in
     *'"type":"assistant"'*)
+      FOUND_ASSISTANT=1
       # Extract text blocks
       TEXT=$(echo "$line" | jq -r \
         '[.message.content[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null || true)
@@ -65,12 +69,10 @@ while IFS= read -r line; do
       fi
       ;;
     *'"type":"user"'*|*'"type":"human"'*)
-      # Hit a user message — this is the turn boundary, stop collecting
-      break
-      ;;
-    *)
-      # Skip system/tool_result/other non-assistant lines
-      continue
+      # Only break after we've collected at least one assistant message.
+      # Trailing metadata/attachments appear after the last user prompt,
+      # so we must skip past them to reach the assistant turn.
+      [ "$FOUND_ASSISTANT" = "1" ] && break
       ;;
   esac
 done < <(tac "$TRANSCRIPT_PATH" 2>/dev/null || true)


### PR DESCRIPTION
## Purpose / Description

The stop hook was never capturing assistant responses or thinking blocks from Claude Code sessions.

## Fixes
* Fixes assistant response and thinking traces never appearing in Observal

## Approach

The transcript JSONL ends with metadata/attachment entries *after* the last user prompt. Reading backwards with `tac`, the hook hit a `user` type entry before reaching any `assistant` entries, so it always broke with zero captures.

Fix: only break on user messages after we've found at least one assistant message. This skips past the trailing metadata to reach the actual assistant turn.

**Before:** `MSG=0 THINK=0` (always empty)
**After:** `MSG=1 THINK=0` (captures response; thinking when present)

## How Has This Been Tested?

Tested against a live 32MB transcript (15K lines) from a real Claude Code session. Verified the loop now correctly captures the most recent assistant text response.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code