### PR TITLE
fix(cli): handle HTTP 204 No Content in client.delete()

### DIFF
--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -240,6 +240,8 @@ def delete(path: str) -> dict:
     base, headers = _client()
     try:
         r = _request_with_retry("delete", f"{base}{path}", headers)
+        if r.status_code == 204 or not r.content:
+            return {}
         return r.json()
     except httpx.HTTPStatusError as e:
         _handle_error(e, path)


### PR DESCRIPTION
fixes #538 
## Summary

- `client.delete()` crashed with `JSONDecodeError` on HTTP 204 responses (empty body)
- Affects `observal admin delete-user` and `observal alerts delete`
- Returns empty dict on 204 or empty body before calling `.json()`

## Before

```
observal admin delete-user "[test@example.com](mailto:test@example.com)"

→ JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## After

```
observal admin delete-user "[test@example.com](mailto:test@example.com)"

→ Deleted user [test@example.com](mailto:test@example.com)
```