### PR TITLE
fix(api): rename mislabeled _today stats fields to match actual query range

### DIFF
--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -194,8 +194,8 @@ async def overview_stats(
         total_mcps=total_mcps,
         total_agents=total_agents,
         total_users=total_users,
-        total_tool_calls_today=int(tool_rows[0].get("cnt", 0)) if tool_rows else 0,
-        total_agent_interactions_today=int(agent_rows[0].get("cnt", 0)) if agent_rows else 0,
+        total_tool_calls=int(tool_rows[0].get("cnt", 0)) if tool_rows else 0,
+        total_agent_interactions=int(agent_rows[0].get("cnt", 0)) if agent_rows else 0,
     )
 
 

--- a/observal-server/schemas/dashboard.py
+++ b/observal-server/schemas/dashboard.py
@@ -37,8 +37,8 @@ class OverviewStats(BaseModel):
     total_mcps: int
     total_agents: int
     total_users: int
-    total_tool_calls_today: int
-    total_agent_interactions_today: int
+    total_tool_calls: int
+    total_agent_interactions: int
 
 
 class TopItem(BaseModel):

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -355,8 +355,8 @@ def _overview(output: str = typer.Option("table", "--output", "-o")):
     rprint(f"  [bold cyan]MCP Servers[/bold cyan]     {data.get('total_mcps', 0)}")
     rprint(f"  [bold magenta]Agents[/bold magenta]          {data.get('total_agents', 0)}")
     rprint(f"  [bold]Users[/bold]           {data.get('total_users', 0)}")
-    rprint(f"  [bold green]Tool calls[/bold green]      {data.get('total_tool_calls_today', 0)} today")
-    rprint(f"  [bold yellow]Interactions[/bold yellow]    {data.get('total_agent_interactions_today', 0)} today")
+    rprint(f"  [bold green]Tool calls[/bold green]      {data.get('total_tool_calls', 0)}")
+    rprint(f"  [bold yellow]Interactions[/bold yellow]    {data.get('total_agent_interactions', 0)}")
     rprint()
 
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -4,8 +4,8 @@ export interface OverviewStats {
   total_mcps: number;
   total_agents: number;
   total_users: number;
-  total_tool_calls_today: number;
-  total_agent_interactions_today: number;
+  total_tool_calls: number;
+  total_agent_interactions: number;
 }
 
 export interface TopItem {


### PR DESCRIPTION
## Issue 
`GET /api/v1/overview/stats?range=30d` returns fields named `total_tool_calls_today` and `total_agent_interactions_today`, but the query uses the full range (1-90 days). CLI `observal ops overview` also prints "today" for non-today data.



## Fix

- Renamed `total_tool_calls_today` → `total_tool_calls` and `total_agent_interactions_today` → `total_agent_interactions`
- Updated across 4 files: backend schema, backend route, CLI display, frontend types
- The endpoint already correctly computes data for the selected range via `?range=` param — the field names were the only thing wrong

## Before

`GET /api/v1/overview/stats?range=30d` returns `total_tool_calls_today: 300` — misleading.

## After

Returns `total_tool_calls: 300` — matches any range.

## Test Plan

- [x] Verified API response with default and `?range=30d` — fields correctly renamed
- [x] No frontend breakage (dashboard doesn't display these fields yet)
