### PR TITLE
fix: ensure default org at startup to prevent trace privacy 400

### DIFF
--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -95,9 +95,7 @@ async def lifespan(app: FastAPI):
     # Ensure default org exists and backfill any users missing one
     async with _session_factory() as db:
         default_org = await get_or_create_default_org(db)
-        await db.execute(
-            update(User).where(User.org_id.is_(None)).values(org_id=default_org.id)
-        )
+        await db.execute(update(User).where(User.org_id.is_(None)).values(org_id=default_org.id))
         await db.commit()
 
     # Seed demo accounts when no real users exist and DEMO_* env vars are set

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -9,7 +9,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from redis.exceptions import RedisError
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.gzip import GZipMiddleware
@@ -17,7 +17,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from starlette.requests import Request
 from strawberry.fastapi import GraphQLRouter
 
-from api.deps import get_db
+from api.deps import get_db, get_or_create_default_org
 from api.graphql import get_context_dep, schema
 from api.middleware.content_type import ContentTypeMiddleware
 from api.middleware.request_id import RequestIDMiddleware
@@ -90,8 +90,17 @@ async def lifespan(app: FastAPI):
         key_password=settings.JWT_KEY_PASSWORD,
     )
 
-    # Seed demo accounts when no real users exist and DEMO_* env vars are set
     from database import async_session as _session_factory
+
+    # Ensure default org exists and backfill any users missing one
+    async with _session_factory() as db:
+        default_org = await get_or_create_default_org(db)
+        await db.execute(
+            update(User).where(User.org_id.is_(None)).values(org_id=default_org.id)
+        )
+        await db.commit()
+
+    # Seed demo accounts when no real users exist and DEMO_* env vars are set
     from services.demo_accounts import seed_demo_accounts
 
     async with _session_factory() as db:

--- a/observal-server/services/demo_accounts.py
+++ b/observal-server/services/demo_accounts.py
@@ -16,6 +16,7 @@ from config import settings
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
+from models.organization import Organization
 from models.user import User, UserRole
 from services.events import UserCreated, bus
 
@@ -41,6 +42,11 @@ async def seed_demo_accounts(db: AsyncSession) -> int:
     if real_count and real_count > 0:
         return 0
 
+    result = await db.execute(select(Organization).where(Organization.slug == "default"))
+    default_org = result.scalar_one_or_none()
+    if not default_org:
+        return 0
+
     created = 0
     for prefix, role in DEMO_TIERS:
         email = getattr(settings, f"{prefix}_EMAIL", None)
@@ -59,6 +65,7 @@ async def seed_demo_accounts(db: AsyncSession) -> int:
             name=f"Demo {role.value.replace('_', ' ').title()}",
             role=role,
             is_demo=True,
+            org_id=default_org.id,
         )
         user.set_password(password)
         db.add(user)

--- a/tests/test_demo_accounts.py
+++ b/tests/test_demo_accounts.py
@@ -19,6 +19,20 @@ def _make_user(role=UserRole.user, is_demo=False, email="test@test.com"):
     return user
 
 
+def _mock_org():
+    org = MagicMock()
+    org.id = uuid.uuid4()
+    org.slug = "default"
+    return org
+
+
+def _patch_db_execute(db, org):
+    """Make db.execute return a result whose scalar_one_or_none returns org."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = org
+    db.execute = AsyncMock(return_value=result)
+
+
 class TestSeedDemoAccounts:
     @pytest.mark.asyncio
     async def test_seeds_when_no_real_users(self):
@@ -28,6 +42,7 @@ class TestSeedDemoAccounts:
         # First call: real_count=0, then per-tier exists checks return 0
         db.scalar = AsyncMock(side_effect=[0, 0, 0, 0, 0])
         db.commit = AsyncMock()
+        _patch_db_execute(db, _mock_org())
 
         with patch("services.demo_accounts.settings") as mock_settings:
             mock_settings.DEMO_SUPER_ADMIN_EMAIL = "super@demo.example"
@@ -67,6 +82,7 @@ class TestSeedDemoAccounts:
 
         db = AsyncMock()
         db.scalar = AsyncMock(return_value=0)  # no real users
+        _patch_db_execute(db, _mock_org())
 
         with patch("services.demo_accounts.settings") as mock_settings:
             mock_settings.DEMO_SUPER_ADMIN_EMAIL = None
@@ -90,6 +106,7 @@ class TestSeedDemoAccounts:
         # real_count=0, super_admin exists=1 (skip), admin exists=0 (create)
         db.scalar = AsyncMock(side_effect=[0, 1, 0])
         db.commit = AsyncMock()
+        _patch_db_execute(db, _mock_org())
 
         with patch("services.demo_accounts.settings") as mock_settings:
             mock_settings.DEMO_SUPER_ADMIN_EMAIL = "super@demo.example"


### PR DESCRIPTION
## Purpose / Description
Users without an `org_id` (created before the org system or via demo seeding) hit a `400: "User has no organization"` when toggling trace privacy. In local mode there should always be a single default org with all users assigned to it.

## Fixes
* Fixes trace privacy 400 error for org-less users

## Approach
- Create the default org at server startup (in lifespan) and backfill any users with `NULL` org_id
- Assign demo accounts to the default org when seeded
- Update demo seed tests to mock the org lookup

## How Has This Been Tested?

- Rebuilt Docker, toggled trace privacy — no more 400 error
- Existing test suite updated to cover new org lookup in demo seeding

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code