### PR TITLE
fix: allow editing and resubmitting rejected agents and components

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -1159,7 +1159,7 @@ async def update_draft(
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.created_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the agent owner")
-    if agent.status != AgentStatus.draft:
+    if agent.status not in (AgentStatus.draft, AgentStatus.rejected):
         raise HTTPException(status_code=400, detail="Agent is not a draft")
 
     for field in (
@@ -1239,7 +1239,7 @@ async def submit_draft(
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.created_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the agent owner")
-    if agent.status != AgentStatus.draft:
+    if agent.status not in (AgentStatus.draft, AgentStatus.rejected):
         raise HTTPException(status_code=400, detail="Agent is not a draft")
     if not agent.description:
         raise HTTPException(status_code=400, detail="Description is required before submitting")

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -201,7 +201,7 @@ async def update_hook_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
@@ -244,7 +244,7 @@ async def submit_hook_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     if not listing.description:

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -306,7 +306,7 @@ async def update_mcp_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
@@ -355,7 +355,7 @@ async def submit_mcp_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     if not listing.description:

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -252,7 +252,7 @@ async def update_prompt_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
@@ -294,7 +294,7 @@ async def submit_prompt_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     if not listing.description:

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -212,7 +212,7 @@ async def update_sandbox_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
@@ -257,7 +257,7 @@ async def submit_sandbox_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     if not listing.description:

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -211,7 +211,7 @@ async def update_skill_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     for field in (
@@ -260,7 +260,7 @@ async def submit_skill_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status != ListingStatus.draft:
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
 
     if not listing.description:

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -728,9 +728,16 @@ function AgentBuilderInner() {
     setPublishing(true);
     try {
       const body = buildRequestBody();
-      const created = await registry.create("agents", body);
-      toast.success("Agent submitted for review. An admin must approve it before it becomes visible.");
-      router.push(`/agents/${created.id}`);
+      if (draftId) {
+        await updateDraft.mutateAsync({ id: draftId, body });
+        await registry.submitDraft(draftId);
+        toast.success("Agent resubmitted for review.");
+        router.push(`/agents/${draftId}`);
+      } else {
+        const created = await registry.create("agents", body);
+        toast.success("Agent submitted for review. An admin must approve it before it becomes visible.");
+        router.push(`/agents/${created.id}`);
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Failed to publish agent";
       toast.error(msg);

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -427,14 +427,14 @@ function AgentListContent() {
   const qc = useQueryClient();
 
   const drafts = useMemo(() => {
-    return (myAgents ?? []).filter((a) => a.status === "draft");
+    return (myAgents ?? []).filter((a) => a.status === "draft" || a.status === "rejected");
   }, [myAgents]);
 
   const { filtered, pendingCount } = useMemo(() => {
     const active = agents ?? [];
     const activeIds = new Set(active.map((a) => a.id));
     const pending = (myAgents ?? []).filter(
-      (a) => a.status !== "active" && a.status !== "draft" && !activeIds.has(a.id),
+      (a) => a.status !== "active" && a.status !== "draft" && a.status !== "rejected" && !activeIds.has(a.id),
     );
     return { filtered: [...pending, ...active], pendingCount: pending.length };
   }, [agents, myAgents]);
@@ -529,7 +529,7 @@ function AgentListContent() {
               ) : (
                 <ChevronRight className="h-4 w-4 text-muted-foreground" />
               )}
-              My Drafts
+              My Drafts & Rejected
               <span className="ml-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
                 {drafts.length}
               </span>
@@ -539,7 +539,15 @@ function AgentListContent() {
                 {drafts.map((draft) => (
                   <div key={draft.id} className="flex items-center gap-4 px-4 py-3">
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium">{draft.name}</p>
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-sm font-medium">{draft.name}</p>
+                        {draft.status === "rejected" && <StatusBadge status="rejected" />}
+                      </div>
+                      {draft.status === "rejected" && draft.rejection_reason && (
+                        <p className="text-xs text-destructive mt-0.5">
+                          Reason: {draft.rejection_reason as string}
+                        </p>
+                      )}
                       {draft.description && (
                         <p className="truncate text-xs text-muted-foreground mt-0.5">
                           {draft.description}
@@ -569,7 +577,7 @@ function AgentListContent() {
                         onClick={() => submitDraft.mutate(draft.id)}
                       >
                         <Send className="mr-1 h-3 w-3" />
-                        Submit for Review
+                        {draft.status === "rejected" ? "Resubmit" : "Submit for Review"}
                       </Button>
                       <Button
                         variant="ghost"

--- a/web/src/app/(registry)/components/page.tsx
+++ b/web/src/app/(registry)/components/page.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   Send,
   Trash2,
+  FileEdit,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -23,6 +24,7 @@ import {
   useComponentSubmit,
   useComponentSaveDraft,
   useComponentSubmitDraft,
+  useComponentUpdateDraft,
   useComponentDelete,
 } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
@@ -157,6 +159,7 @@ export default function ComponentsPage() {
   const [view, setView] = useState<ViewMode>("table");
   const [sorting, setSorting] = useState<SortingState>([]);
   const [submitOpen, setSubmitOpen] = useState(false);
+  const [editItem, setEditItem] = useState<RegistryItem | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
@@ -182,6 +185,7 @@ export default function ComponentsPage() {
   const submitMutation = useComponentSubmit(activeType);
   const saveDraftMutation = useComponentSaveDraft(activeType);
   const submitDraftMutation = useComponentSubmitDraft(activeType);
+  const updateDraftMutation = useComponentUpdateDraft(activeType);
   const deleteMutation = useComponentDelete(activeType);
 
   const items = useMemo(() => data ?? [], [data]);
@@ -227,7 +231,7 @@ export default function ComponentsPage() {
             />
           </div>
           {authReady && role && (
-            <Button size="sm" className="h-9" onClick={() => setSubmitOpen(true)}>
+            <Button size="sm" className="h-9" onClick={() => { setEditItem(null); setSubmitOpen(true); }}>
               <Plus className="h-4 w-4 mr-1.5" />
               Create
             </Button>
@@ -393,17 +397,28 @@ export default function ComponentsPage() {
                     </div>
                   </div>
                   <div className="flex items-center gap-1.5 shrink-0">
-                    {item.status === "draft" && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-7 text-xs"
-                        onClick={() => submitDraftMutation.mutate(item.id)}
-                        disabled={submitDraftMutation.isPending}
-                      >
-                        <Send className="h-3 w-3 mr-1" />
-                        Submit
-                      </Button>
+                    {(item.status === "draft" || item.status === "rejected") && (
+                      <>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs"
+                          onClick={() => { setEditItem(item); setSubmitOpen(true); }}
+                        >
+                          <FileEdit className="h-3 w-3 mr-1" />
+                          Edit
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs"
+                          onClick={() => submitDraftMutation.mutate(item.id)}
+                          disabled={submitDraftMutation.isPending}
+                        >
+                          <Send className="h-3 w-3 mr-1" />
+                          {item.status === "rejected" ? "Resubmit" : "Submit"}
+                        </Button>
+                      </>
                     )}
                     <Button
                       variant="ghost"
@@ -423,21 +438,34 @@ export default function ComponentsPage() {
       </div>
 
       <SubmitComponentDialog
+        key={editItem?.id ?? "new"}
         open={submitOpen}
-        onOpenChange={setSubmitOpen}
+        onOpenChange={(v) => { setSubmitOpen(v); if (!v) setEditItem(null); }}
         type={activeType}
+        editItem={editItem as Record<string, unknown> | null}
         onSubmit={(body) => {
-          submitMutation.mutate(body, {
-            onSuccess: () => setSubmitOpen(false),
-          });
+          if (editItem) {
+            submitDraftMutation.mutate(editItem.id, {
+              onSuccess: () => { setSubmitOpen(false); setEditItem(null); },
+            });
+          } else {
+            submitMutation.mutate(body, {
+              onSuccess: () => setSubmitOpen(false),
+            });
+          }
         }}
         onSaveDraft={(body) => {
           saveDraftMutation.mutate(body, {
             onSuccess: () => setSubmitOpen(false),
           });
         }}
-        isSubmitting={submitMutation.isPending}
-        isSavingDraft={saveDraftMutation.isPending}
+        onUpdateDraft={(id, body) => {
+          updateDraftMutation.mutate({ id, body }, {
+            onSuccess: () => { setSubmitOpen(false); setEditItem(null); },
+          });
+        }}
+        isSubmitting={submitMutation.isPending || submitDraftMutation.isPending}
+        isSavingDraft={saveDraftMutation.isPending || updateDraftMutation.isPending}
       />
     </>
   );

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -73,8 +73,10 @@ interface SubmitComponentDialogProps {
   type: RegistryType;
   onSubmit: (body: Record<string, unknown>) => void;
   onSaveDraft: (body: Record<string, unknown>) => void;
+  onUpdateDraft?: (id: string, body: Record<string, unknown>) => void;
   isSubmitting: boolean;
   isSavingDraft: boolean;
+  editItem?: Record<string, unknown> | null;
 }
 
 export function SubmitComponentDialog({
@@ -83,50 +85,54 @@ export function SubmitComponentDialog({
   type,
   onSubmit,
   onSaveDraft,
+  onUpdateDraft,
   isSubmitting,
   isSavingDraft,
+  editItem,
 }: SubmitComponentDialogProps) {
+  const d = editItem as Record<string, unknown> | null;
+
   // ── Common ──────────────────────────────────────────────
-  const [name, setName] = useState("");
-  const [version, setVersion] = useState("0.1.0");
-  const [description, setDescription] = useState("");
-  const [owner, setOwner] = useState("");
-  const [supportedIdes, setSupportedIdes] = useState<string[]>([]);
+  const [name, setName] = useState((d?.name as string) ?? "");
+  const [version, setVersion] = useState((d?.version as string) ?? "0.1.0");
+  const [description, setDescription] = useState((d?.description as string) ?? "");
+  const [owner, setOwner] = useState((d?.owner as string) ?? "");
+  const [supportedIdes, setSupportedIdes] = useState<string[]>(Array.isArray(d?.supported_ides) ? d.supported_ides as string[] : []);
 
   // ── MCP ─────────────────────────────────────────────────
-  const [category, setCategory] = useState("general");
-  const [gitUrl, setGitUrl] = useState("");
-  const [command, setCommand] = useState("");
-  const [args, setArgs] = useState("");
-  const [mcpUrl, setMcpUrl] = useState("");
-  const [transport, setTransport] = useState("");
-  const [framework, setFramework] = useState("");
-  const [dockerImage, setDockerImage] = useState("");
-  const [envVars, setEnvVars] = useState<EnvVar[]>([]);
-  const [setupInstructions, setSetupInstructions] = useState("");
+  const [category, setCategory] = useState((d?.category as string) ?? "general");
+  const [gitUrl, setGitUrl] = useState((d?.git_url as string) ?? "");
+  const [command, setCommand] = useState((d?.command as string) ?? "");
+  const [args, setArgs] = useState(Array.isArray(d?.args) ? (d.args as string[]).join(" ") : "");
+  const [mcpUrl, setMcpUrl] = useState((d?.url as string) ?? "");
+  const [transport, setTransport] = useState((d?.transport as string) ?? "");
+  const [framework, setFramework] = useState((d?.framework as string) ?? "");
+  const [dockerImage, setDockerImage] = useState((d?.docker_image as string) ?? "");
+  const [envVars, setEnvVars] = useState<EnvVar[]>(Array.isArray(d?.environment_variables) ? d.environment_variables as EnvVar[] : []);
+  const [setupInstructions, setSetupInstructions] = useState((d?.setup_instructions as string) ?? "");
 
   // ── Skill ───────────────────────────────────────────────
-  const [taskType, setTaskType] = useState("general");
-  const [skillGitUrl, setSkillGitUrl] = useState("");
-  const [skillPath, setSkillPath] = useState("/");
-  const [mcpServerName, setMcpServerName] = useState("");
+  const [taskType, setTaskType] = useState((d?.task_type as string) ?? "general");
+  const [skillGitUrl, setSkillGitUrl] = useState((d?.git_url as string) ?? "");
+  const [skillPath, setSkillPath] = useState((d?.skill_path as string) ?? "/");
+  const [mcpServerName, setMcpServerName] = useState(((d?.mcp_server_config as Record<string, unknown>)?.server as string) ?? "");
 
   // ── Hook ────────────────────────────────────────────────
-  const [event, setEvent] = useState("PreToolUse");
-  const [handlerType, setHandlerType] = useState("command");
-  const [executionMode, setExecutionMode] = useState("async");
-  const [hookScope, setHookScope] = useState("agent");
-  const [handlerConfig, setHandlerConfig] = useState("");
+  const [event, setEvent] = useState((d?.event as string) ?? "PreToolUse");
+  const [handlerType, setHandlerType] = useState((d?.handler_type as string) ?? "command");
+  const [executionMode, setExecutionMode] = useState((d?.execution_mode as string) ?? "async");
+  const [hookScope, setHookScope] = useState((d?.scope as string) ?? "agent");
+  const [handlerConfig, setHandlerConfig] = useState(d?.handler_config && typeof d.handler_config === "object" ? JSON.stringify(d.handler_config, null, 2) : "");
 
   // ── Prompt ──────────────────────────────────────────────
-  const [promptCategory, setPromptCategory] = useState("general");
-  const [template, setTemplate] = useState("");
+  const [promptCategory, setPromptCategory] = useState(type === "prompts" ? ((d?.category as string) ?? "general") : "general");
+  const [template, setTemplate] = useState((d?.template as string) ?? "");
 
   // ── Sandbox ─────────────────────────────────────────────
-  const [runtimeType, setRuntimeType] = useState("docker");
-  const [image, setImage] = useState("");
-  const [networkPolicy, setNetworkPolicy] = useState("none");
-  const [entrypoint, setEntrypoint] = useState("");
+  const [runtimeType, setRuntimeType] = useState((d?.runtime_type as string) ?? "docker");
+  const [image, setImage] = useState((d?.image as string) ?? "");
+  const [networkPolicy, setNetworkPolicy] = useState((d?.network_policy as string) ?? "none");
+  const [entrypoint, setEntrypoint] = useState((d?.entrypoint as string) ?? "");
 
   const { data: approvedMcps } = useRegistryList("mcps");
   const { data: myMcps } = useMyComponents("mcps");
@@ -177,6 +183,8 @@ export function SubmitComponentDialog({
     setNetworkPolicy("none");
     setEntrypoint("");
   }
+
+  const isEditMode = !!editItem;
 
   function buildBody(): Record<string, unknown> {
     const base: Record<string, unknown> = {
@@ -319,7 +327,7 @@ export function SubmitComponentDialog({
     >
       <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Submit {typeLabel}</DialogTitle>
+          <DialogTitle>{isEditMode ? `Edit ${typeLabel}` : `Submit ${typeLabel}`}</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4 pt-2">
@@ -747,22 +755,53 @@ export function SubmitComponentDialog({
 
           {/* ── Actions ───────────────────────────────────── */}
           <div className="flex justify-end gap-2 pt-2">
-            <Button
-              variant="outline"
-              onClick={handleDraft}
-              disabled={busy || !name}
-            >
-              {isSavingDraft && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
-              Save Draft
-            </Button>
-            <Button
-              onClick={handleSubmit}
-              disabled={busy || !!submitError}
-              title={submitError ?? undefined}
-            >
-              {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
-              Submit for Review
-            </Button>
+            {isEditMode ? (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    if (!name) { toast.error("Name is required"); return; }
+                    onUpdateDraft?.((editItem as Record<string, unknown>).id as string, buildBody());
+                  }}
+                  disabled={busy || !name}
+                >
+                  {isSavingDraft && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+                  Save Changes
+                </Button>
+                <Button
+                  onClick={() => {
+                    const err = validateForSubmit();
+                    if (err) { toast.error(err); return; }
+                    onUpdateDraft?.((editItem as Record<string, unknown>).id as string, buildBody());
+                    onSubmit(buildBody());
+                  }}
+                  disabled={busy || !!submitError}
+                  title={submitError ?? undefined}
+                >
+                  {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+                  Save & Resubmit
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={handleDraft}
+                  disabled={busy || !name}
+                >
+                  {isSavingDraft && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+                  Save Draft
+                </Button>
+                <Button
+                  onClick={handleSubmit}
+                  disabled={busy || !!submitError}
+                  title={submitError ?? undefined}
+                >
+                  {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+                  Submit for Review
+                </Button>
+              </>
+            )}
           </div>
         </div>
       </DialogContent>


### PR DESCRIPTION
fixes #544 
## Summary

- Rejected agents and components (MCPs, Skills, Hooks, Prompts, Sandboxes) were stuck in a dead-end state with no way to edit or resubmit
- Backend: changed status checks from draft-only to accept both draft and rejected states across all 6 route files
- Frontend: rejected agents appear in "My Drafts & Rejected" with Edit + Resubmit buttons
- Agent builder updates the existing agent instead of creating a new one when editing
- Components page adds Edit button that opens submit dialog pre-filled with existing data for all component types

## Before

1. Reviewer rejects an agent/component
2. Owner gets 400 "not a draft" when trying to edit or resubmit
3. Only option: delete and recreate from scratch

## After

1. Reviewer rejects with feedback
2. Owner have access to EDIT and RESUBMIT buttons

## Test

- [x] Created agent → submitted → rejected → edited → resubmitted successfully via API
- [x] Verified UI shows rejected agents in "My Drafts & Rejected" section with Edit and Resubmit buttons
- [x] Verified agent builder updates existing agent (not creating duplicate)
- [x] Verified components page shows Edit + Resubmit for rejected items
- [x] Backend lint (ruff): all checks passed
- [x] Frontend lint (eslint): no regressions from changes
