### PR TITLE
fix(gemini): hook bridge for telemetry capture

### DIFF
--- a/docs/integrations/gemini-cli.md
+++ b/docs/integrations/gemini-cli.md
@@ -1,16 +1,13 @@
 # Gemini CLI
 
-Gemini CLI is supported at the MCP and rules level. Mostly the same shape as [Cursor](cursor.md).
+Gemini CLI is supported at the MCP, rules, hook bridge, and OTLP telemetry level.
 
 ## What you get
 
 * **MCP server instrumentation** — `observal scan --ide gemini-cli`
 * **Rules files** — `AGENTS.md` or `GEMINI.md`
-
-## What you don't get
-
-* No hook bridge
-* No native OTLP
+* **OTLP telemetry** — `observal scan` configures `~/.gemini/settings.json` to export traces via OTLP
+* **Hook bridge** — `observal scan` injects hooks into `~/.gemini/settings.json` to capture prompts, tool I/O, agent responses, and session lifecycle events
 
 ## Setup
 
@@ -34,7 +31,7 @@ Restart Gemini CLI.
 observal pull <agent-id> --ide gemini-cli
 ```
 
-Writes MCP config + rules files. No session lifecycle hooks — telemetry is MCP-traffic-only.
+Writes MCP config + rules files. OTLP telemetry and hooks are configured automatically by `observal scan`.
 
 ## Known issues
 

--- a/observal-server/api/routes/otel_dashboard.py
+++ b/observal-server/api/routes/otel_dashboard.py
@@ -1244,6 +1244,11 @@ def _extract_gemini(body: dict, hook_event: str, attrs: dict[str, str]) -> None:
     if body.get("model"):
         attrs["model"] = str(body["model"])
 
+    # Token usage from gemini_hook.py AfterModel extraction
+    for enriched_field in ("input_tokens", "output_tokens", "total_tokens"):
+        if body.get(enriched_field):
+            attrs[enriched_field] = str(body[enriched_field])
+
 
 def _extract_cursor(body: dict, hook_event: str, attrs: dict[str, str]) -> None:
     """Extract Cursor-specific fields into *attrs*.

--- a/observal-server/schemas/constants.py
+++ b/observal-server/schemas/constants.py
@@ -45,7 +45,7 @@ IDE_FEATURE_MATRIX: dict[str, set[str]] = {
     "claude-code": {"skills", "hook_bridge", "mcp_servers", "rules", "otlp_telemetry"},
     "kiro": {"superpowers", "hook_bridge", "mcp_servers", "rules", "steering_files", "otlp_telemetry"},
     "cursor": {"mcp_servers", "rules"},
-    "gemini-cli": {"mcp_servers", "rules"},
+    "gemini-cli": {"hook_bridge", "mcp_servers", "rules", "otlp_telemetry"},
     "codex": {"rules"},
     "copilot": {"mcp_servers", "rules"},
     "opencode": {"mcp_servers", "rules"},

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -479,9 +479,7 @@ def _generate_gemini_cli(manifest: AgentManifest) -> IdeAgentConfig:
 
     settings: dict = {
         "telemetry": {
-            "enabled": True,
-            "target": "custom",
-            "otlpEndpoint": otlp_url,
+            "enabled": False,
             "logPrompts": True,
         },
     }

--- a/observal-server/services/config_generator.py
+++ b/observal-server/services/config_generator.py
@@ -46,12 +46,15 @@ def _gemini_otlp_env(observal_url: str) -> dict:
 
 
 def _gemini_settings(observal_url: str) -> dict:
-    """Gemini CLI .gemini/settings.json telemetry block."""
+    """Gemini CLI .gemini/settings.json telemetry block.
+
+    Native OTLP is disabled because Gemini CLI hardcodes gRPC export
+    which is incompatible with Observal's HTTP/JSON endpoint.
+    Telemetry is captured via the hook bridge instead.
+    """
     return {
         "telemetry": {
-            "enabled": True,
-            "target": "custom",
-            "otlpEndpoint": observal_url,
+            "enabled": False,
             "logPrompts": True,
         }
     }

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -891,12 +891,14 @@ def _configure_kiro(server_url: str):
 
 
 def _configure_gemini_cli(server_url: str):
-    """Check for Gemini CLI and offer to configure its OTLP telemetry.
+    """Check for Gemini CLI and configure hooks + disable native OTLP.
 
-    Writes the `telemetry` block in ~/.gemini/settings.json.  Non-destructive:
-    all existing keys are preserved; only the telemetry sub-block is updated.
-    A timestamped backup is created before any write.
+    Gemini CLI hardcodes gRPC for OTLP export (incompatible with Observal's
+    HTTP/JSON endpoint). We disable native OTLP and inject command-type hooks
+    into ~/.gemini/settings.json for telemetry capture.
     """
+    import sys
+
     gemini_dir = Path.home() / ".gemini"
 
     try:
@@ -913,21 +915,81 @@ def _configure_gemini_cli(server_url: str):
         from observal_cli.cmd_scan import inject_gemini_telemetry
 
         cfg = config.load()
-        otlp_endpoint = cfg.get("otlp_http_url", "")
-        if not otlp_endpoint:
-            from urllib.parse import urlparse
-
-            parsed = urlparse(server_url)
-            scheme = "http" if parsed.hostname in ("localhost", "127.0.0.1") else "https"
-            otlp_endpoint = f"{scheme}://{parsed.hostname}:4318"
-
         gemini_settings = gemini_dir / "settings.json"
-        written = inject_gemini_telemetry(otlp_endpoint)
+        changes = 0
+
+        # 1. Disable native OTLP (gRPC-only, incompatible with Observal)
+        written = inject_gemini_telemetry("")
         if written:
-            rprint(f"[green]Configured Gemini CLI telemetry in {gemini_settings}[/green]")
-            rprint(f"[dim]OTLP endpoint: {otlp_endpoint}[/dim]")
-        else:
-            rprint("[dim]Gemini CLI telemetry already configured.[/dim]")
+            rprint(f"[green]Disabled native OTLP in {gemini_settings} (gRPC incompatible)[/green]")
+            changes += 1
+
+        # 2. Inject hooks for telemetry capture
+        hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
+        hooks_dir = Path(__file__).parent / "hooks"
+        hook_script = hooks_dir / "gemini_hook.py"
+        stop_script = hooks_dir / "gemini_stop_hook.py"
+
+        def _hook_cmd(script: Path) -> str:
+            if sys.platform == "win32":
+                return f"python {script.resolve().as_posix()}"
+            return f"python3 {script.resolve().as_posix()}"
+
+        def _hook_entry(script: Path) -> list:
+            return [{"hooks": [{"type": "command", "command": _hook_cmd(script)}]}]
+
+        cmd_hook = _hook_entry(hook_script)
+        stop_hook = _hook_entry(stop_script)
+
+        gemini_hooks_block = {
+            "SessionStart": cmd_hook,
+            "BeforeAgent": cmd_hook,
+            "AfterAgent": stop_hook,
+            "AfterModel": cmd_hook,
+            "BeforeTool": cmd_hook,
+            "AfterTool": cmd_hook,
+            "SessionEnd": stop_hook,
+            "Notification": cmd_hook,
+        }
+
+        gdata: dict = {}
+        if gemini_settings.exists():
+            gdata = _json.loads(gemini_settings.read_text())
+
+        existing_hooks = gdata.get("hooks", {})
+        hooks_need_update = False
+
+        for event_name, entry in gemini_hooks_block.items():
+            if event_name not in existing_hooks:
+                hooks_need_update = True
+                break
+            existing_cmd = ""
+            try:
+                existing_cmd = existing_hooks[event_name][0]["hooks"][0].get("command", "")
+            except (KeyError, IndexError, TypeError):
+                pass
+            expected_cmd = entry[0]["hooks"][0].get("command", "")
+            if existing_cmd != expected_cmd:
+                hooks_need_update = True
+                break
+
+        if hooks_need_update:
+            gdata["hooks"] = {**existing_hooks, **gemini_hooks_block}
+            if "env" not in gdata:
+                gdata["env"] = {}
+            gdata["env"]["OBSERVAL_HOOKS_URL"] = hooks_url
+            if cfg.get("user_id"):
+                gdata["env"]["OBSERVAL_USER_ID"] = cfg["user_id"]
+            if cfg.get("user_name"):
+                gdata["env"]["OBSERVAL_USERNAME"] = cfg["user_name"]
+            gemini_settings.parent.mkdir(parents=True, exist_ok=True)
+            gemini_settings.write_text(_json.dumps(gdata, indent=2) + "\n")
+            rprint(f"[green]Injected hooks into {gemini_settings}[/green]")
+            rprint(f"[dim]Hooks endpoint: {hooks_url}[/dim]")
+            changes += 1
+
+        if changes == 0:
+            rprint("[dim]Gemini CLI already configured for Observal.[/dim]")
 
     except Exception as e:
         rprint(f"\n[yellow]Could not configure Gemini CLI automatically: {e}[/yellow]")

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -291,7 +291,7 @@ def _check_gemini(path: Path, data: dict, issues: list, warnings: list):
             if not isinstance(handlers, list):
                 continue
             for handler_group in handlers:
-                for h in (handler_group.get("hooks") or []):
+                for h in handler_group.get("hooks") or []:
                     cmd = h.get("command", "")
                     if "gemini_hook" in cmd or "gemini_stop_hook" in cmd:
                         has_observal_hook = True
@@ -909,8 +909,6 @@ def doctor_sli(
 
         elif target in ("gemini-cli", "gemini_cli"):
             rprint("[cyan]Gemini CLI[/cyan]")
-            otlp_endpoint = cfg.get("otlp_http_url") or cfg.get("otlp_endpoint", "http://localhost:4318")
-
             gemini_settings = Path.home() / ".gemini" / "settings.json"
             gemini_data: dict = {}
             if gemini_settings.exists():

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -267,28 +267,43 @@ def _check_gemini(path: Path, data: dict, issues: list, warnings: list):
                 "Install via `observal install <id> --ide gemini-cli` to enable telemetry."
             )
 
-    # Check telemetry configuration — only warn if a telemetry block exists
-    # but is misconfigured. If there's no telemetry block at all, the user
-    # may not have configured Observal yet (observal scan will set it up).
+    # Native OTLP telemetry: Gemini CLI hardcodes gRPC which is incompatible
+    # with Observal's HTTP/JSON endpoint. We intentionally disable it and use
+    # hooks instead. Only warn if telemetry is enabled (causes gRPC errors).
     telemetry = data.get("telemetry", {})
-    if not isinstance(telemetry, dict) or not telemetry:
-        return
-
-    if not telemetry.get("enabled", False):
+    if isinstance(telemetry, dict) and telemetry.get("enabled", False):
         warnings.append(
-            f"{path}: Gemini telemetry is disabled. "
-            "Set `telemetry.enabled` to `true` in .gemini/settings.json to enable Observal telemetry."
+            f"{path}: Gemini native OTLP telemetry is enabled but uses gRPC (incompatible with Observal). "
+            "Run `observal scan --ide gemini-cli --home` to disable it — hooks handle telemetry instead."
+        )
+
+    # Check hooks configuration
+    hooks = data.get("hooks", {})
+    if not isinstance(hooks, dict) or not hooks:
+        warnings.append(
+            f"{path}: No Observal hooks configured for Gemini CLI. "
+            "Run `observal scan --ide gemini-cli --home` to inject hook bridge for telemetry collection."
         )
     else:
-        target = telemetry.get("target", "")
-        otlp_endpoint = telemetry.get("otlpEndpoint", "")
-        if target != "custom" or not otlp_endpoint:
-            cfg = config.load()
-            otlp_url = cfg.get("otlp_http_url", "http://localhost:4318")
+        # Verify hooks point to Observal scripts
+        has_observal_hook = False
+        for _evt, handlers in hooks.items():
+            if not isinstance(handlers, list):
+                continue
+            for handler_group in handlers:
+                for h in (handler_group.get("hooks") or []):
+                    cmd = h.get("command", "")
+                    if "gemini_hook" in cmd or "gemini_stop_hook" in cmd:
+                        has_observal_hook = True
+                        break
+                if has_observal_hook:
+                    break
+            if has_observal_hook:
+                break
+        if not has_observal_hook:
             warnings.append(
-                f"{path}: Gemini telemetry is enabled but not configured for Observal. "
-                "Set `telemetry.target` to `custom` and `telemetry.otlpEndpoint` to your Observal OTLP endpoint "
-                f"(e.g. `{otlp_url}`)."
+                f"{path}: Hooks block exists but no Observal hooks found. "
+                "Run `observal scan --ide gemini-cli --home` to inject hook bridge for telemetry collection."
             )
 
 
@@ -632,16 +647,8 @@ def doctor(
                 rprint("  Run: observal scan --ide kiro --home")
             elif "observal-shim" in issue and "Kiro" in issue:
                 rprint("  Run: observal scan --ide kiro")
-            elif "Gemini telemetry" in issue and "disabled" in issue:
-                rprint(
-                    "  Set `telemetry.enabled` to `true` and `telemetry.target` to `custom` in .gemini/settings.json"
-                )
-            elif "Gemini telemetry" in issue and "not configured" in issue:
-                cfg = config.load()
-                otlp = cfg.get("otlp_http_url", "http://localhost:4318")
-                rprint(
-                    f'  Add telemetry config to .gemini/settings.json:\n  {{"telemetry": {{"enabled": true, "target": "custom", "otlpEndpoint": "{otlp}", "logPrompts": true}}}}'
-                )
+            elif "native OTLP" in issue and "gRPC" in issue:
+                rprint("  Run: observal scan --ide gemini-cli --home")
             elif "observal-shim" in issue and "gemini-cli" in issue:
                 rprint("  Run: observal install <id> --ide gemini-cli")
 
@@ -913,28 +920,28 @@ def doctor_sli(
                     pass
 
             telemetry = gemini_data.get("telemetry", {})
+            # Native OTLP should be disabled (gRPC incompatible), hooks handle telemetry
             needs_update = (
                 not isinstance(telemetry, dict)
-                or not telemetry.get("enabled")
-                or telemetry.get("target") != "custom"
-                or telemetry.get("otlpEndpoint") != otlp_endpoint
+                or telemetry.get("enabled") is not False
+                or telemetry.get("logPrompts") is not True
             )
 
             if needs_update:
                 if dry_run:
-                    rprint("  [yellow]Would update telemetry config in ~/.gemini/settings.json[/yellow]")
+                    rprint("  [yellow]Would disable native OTLP in ~/.gemini/settings.json[/yellow]")
                 else:
                     gemini_data.setdefault("telemetry", {})
-                    gemini_data["telemetry"]["enabled"] = True
-                    gemini_data["telemetry"]["target"] = "custom"
-                    gemini_data["telemetry"]["otlpEndpoint"] = otlp_endpoint
+                    gemini_data["telemetry"]["enabled"] = False
                     gemini_data["telemetry"]["logPrompts"] = True
+                    gemini_data["telemetry"].pop("target", None)
+                    gemini_data["telemetry"].pop("otlpEndpoint", None)
                     gemini_settings.parent.mkdir(parents=True, exist_ok=True)
                     gemini_settings.write_text(json.dumps(gemini_data, indent=2) + "\n")
-                    rprint(f"  + Configured telemetry in {gemini_settings}")
+                    rprint(f"  + Disabled native OTLP in {gemini_settings} (hooks handle telemetry)")
                     any_changes = True
             else:
-                rprint("  [dim]Gemini telemetry already configured[/dim]")
+                rprint("  [dim]Gemini native OTLP already disabled[/dim]")
 
         else:
             rprint(f"[yellow]Unknown IDE: {target}. Use 'claude-code', 'kiro', or 'gemini-cli'.[/yellow]")

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -743,7 +743,12 @@ def _auto_shim_home_config(config_path: Path, ide: str):
 
 
 def inject_gemini_telemetry(otlp_endpoint: str) -> bool:
-    """Inject Observal OTLP telemetry settings into ~/.gemini/settings.json.
+    """Disable Gemini CLI's native OTLP telemetry (uses gRPC, incompatible).
+
+    Gemini CLI hardcodes GrpcExporterTransport which can't connect to
+    Observal's HTTP/JSON OTLP endpoint. Telemetry is captured via the
+    hook bridge instead. This disables native OTLP to suppress gRPC
+    error noise.
 
     Non-destructive: preserves all existing keys, only updates the `telemetry`
     block. Creates a timestamped backup before any write.
@@ -759,10 +764,11 @@ def inject_gemini_telemetry(otlp_endpoint: str) -> bool:
     if not isinstance(telemetry, dict):
         telemetry = {}
 
+    # Disable native OTLP (gRPC-only, can't reach Observal HTTP endpoint).
+    # Keep logPrompts=true so hook payloads include prompt content.
     needs_update = (
-        not telemetry.get("enabled")
-        or telemetry.get("target") != "custom"
-        or telemetry.get("otlpEndpoint") != otlp_endpoint
+        telemetry.get("enabled") is not False
+        or telemetry.get("logPrompts") is not True
     )
 
     if not needs_update:
@@ -771,10 +777,11 @@ def inject_gemini_telemetry(otlp_endpoint: str) -> bool:
     if gemini_settings.exists():
         _backup_config(gemini_settings)
     gemini_data.setdefault("telemetry", {})
-    gemini_data["telemetry"]["enabled"] = True
-    gemini_data["telemetry"]["target"] = "custom"
-    gemini_data["telemetry"]["otlpEndpoint"] = otlp_endpoint
+    gemini_data["telemetry"]["enabled"] = False
     gemini_data["telemetry"]["logPrompts"] = True
+    # Remove stale OTLP fields that would only apply if native OTLP worked
+    gemini_data["telemetry"].pop("target", None)
+    gemini_data["telemetry"].pop("otlpEndpoint", None)
     gemini_settings.parent.mkdir(parents=True, exist_ok=True)
     gemini_settings.write_text(json.dumps(gemini_data, indent=2) + "\n")
     return True
@@ -994,9 +1001,11 @@ def register_scan(app: typer.Typer):
 
             total = len(all_mcps) + len(all_skills) + len(all_hooks) + len(all_agents)
 
-        if total == 0:
+        if total == 0 and not home:
             rprint("[yellow]No components found.[/yellow]")
             raise typer.Exit(1)
+        elif total == 0:
+            rprint("[dim]No MCP/skill/hook components found, but configuring IDE telemetry...[/dim]")
 
         # ── Display discovery results ───────────────
         rprint(f"\n[bold]Discovered {total} components[/bold]\n")
@@ -1052,7 +1061,7 @@ def register_scan(app: typer.Typer):
             )
             return
 
-        if not yes and not typer.confirm("Instrument these components for telemetry?"):
+        if total > 0 and not yes and not typer.confirm("Instrument these components for telemetry?"):
             raise typer.Abort()
 
         # ── Optionally shim project MCP configs ─────
@@ -1357,14 +1366,94 @@ def register_scan(app: typer.Typer):
             try:
                 written = inject_gemini_telemetry(otlp_endpoint)
                 if written:
-                    rprint(f"\n[green]Configured Gemini CLI telemetry in {gemini_settings}[/green]")
-                    rprint(f"[dim]OTLP endpoint: {otlp_endpoint}[/dim]")
-                    rprint("[dim]Telemetry will be sent to Observal via OTLP.[/dim]")
+                    rprint(f"\n[green]Disabled native OTLP in {gemini_settings} (gRPC incompatible)[/green]")
+                    rprint("[dim]Telemetry is captured via hooks instead.[/dim]")
                 else:
-                    rprint(f"\n[dim]Gemini CLI telemetry already configured -> {otlp_endpoint}[/dim]")
+                    rprint(f"\n[dim]Gemini CLI native OTLP already disabled.[/dim]")
             except Exception as e:
                 rprint(f"\n[yellow]Could not configure Gemini CLI telemetry: {e}[/yellow]")
                 rprint("[dim]Add telemetry settings manually to ~/.gemini/settings.json.[/dim]")
+
+        # ── Auto-inject hooks into ~/.gemini/settings.json ─────
+        if scan_gemini:
+            from observal_cli.config import load as _load_gemini_hooks_config
+
+            ghcfg = _load_gemini_hooks_config()
+            gemini_server_url = ghcfg.get("server_url", "http://localhost:8000").rstrip("/")
+            gemini_hooks_url = f"{gemini_server_url}/api/v1/otel/hooks"
+
+            gemini_hooks_dir = Path(__file__).parent / "hooks"
+            gemini_hook_script = gemini_hooks_dir / "gemini_hook.py"
+            gemini_stop_script = gemini_hooks_dir / "gemini_stop_hook.py"
+
+            def _gemini_hook_cmd(script: Path) -> str:
+                """Build the Gemini hook command string for a given script."""
+                if sys.platform == "win32":
+                    return f"python {script.resolve().as_posix()}"
+                return f"python3 {script.resolve().as_posix()}"
+
+            def _gemini_hook_entry(script: Path) -> list:
+                return [{"hooks": [{"type": "command", "command": _gemini_hook_cmd(script)}]}]
+
+            cmd_hook = _gemini_hook_entry(gemini_hook_script)
+            stop_hook = _gemini_hook_entry(gemini_stop_script)
+
+            gemini_hooks_block = {
+                "SessionStart": cmd_hook,
+                "BeforeAgent": cmd_hook,
+                "AfterAgent": stop_hook,
+                "AfterModel": cmd_hook,
+                "BeforeTool": cmd_hook,
+                "AfterTool": cmd_hook,
+                "SessionEnd": stop_hook,
+                "Notification": cmd_hook,
+            }
+
+            gemini_settings = Path.home() / ".gemini" / "settings.json"
+            try:
+                gdata: dict = {}
+                if gemini_settings.exists():
+                    gdata = json.loads(gemini_settings.read_text())
+
+                existing_ghooks = gdata.get("hooks", {})
+                ghooks_needs_update = False
+
+                for event_name, entry in gemini_hooks_block.items():
+                    if event_name not in existing_ghooks:
+                        ghooks_needs_update = True
+                        break
+                    # Check if command matches
+                    existing_cmd = ""
+                    try:
+                        existing_cmd = existing_ghooks[event_name][0]["hooks"][0].get("command", "")
+                    except (KeyError, IndexError, TypeError):
+                        pass
+                    expected_cmd = entry[0]["hooks"][0].get("command", "")
+                    if existing_cmd != expected_cmd:
+                        ghooks_needs_update = True
+                        break
+
+                if ghooks_needs_update:
+                    _backup_config(gemini_settings)
+                    gdata["hooks"] = {**existing_ghooks, **gemini_hooks_block}
+                    # Set env vars so hook scripts can resolve the endpoint
+                    if "env" not in gdata:
+                        gdata["env"] = {}
+                    gdata["env"]["OBSERVAL_HOOKS_URL"] = gemini_hooks_url
+                    if ghcfg.get("user_id"):
+                        gdata["env"]["OBSERVAL_USER_ID"] = ghcfg["user_id"]
+                    if ghcfg.get("user_name"):
+                        gdata["env"]["OBSERVAL_USERNAME"] = ghcfg["user_name"]
+                    gemini_settings.parent.mkdir(parents=True, exist_ok=True)
+                    gemini_settings.write_text(json.dumps(gdata, indent=2) + "\n")
+                    rprint(f"\n[green]Injected hooks config into {gemini_settings}[/green]")
+                    rprint(f"[dim]Hooks endpoint: {gemini_hooks_url}[/dim]")
+                    rprint("[dim]Captures: prompts, tool I/O, agent responses, session lifecycle[/dim]")
+                else:
+                    rprint(f"\n[dim]Gemini hooks already configured -> {gemini_hooks_url}[/dim]")
+            except Exception as e:
+                rprint(f"\n[yellow]Could not auto-inject Gemini hooks: {e}[/yellow]")
+                rprint("[dim]Add hooks manually to ~/.gemini/settings.json — see docs.[/dim]")
 
         # ── Auto-shim Codex home MCP servers ──
         if scan_codex:

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -766,10 +766,7 @@ def inject_gemini_telemetry(otlp_endpoint: str) -> bool:
 
     # Disable native OTLP (gRPC-only, can't reach Observal HTTP endpoint).
     # Keep logPrompts=true so hook payloads include prompt content.
-    needs_update = (
-        telemetry.get("enabled") is not False
-        or telemetry.get("logPrompts") is not True
-    )
+    needs_update = telemetry.get("enabled") is not False or telemetry.get("logPrompts") is not True
 
     if not needs_update:
         return False
@@ -1369,7 +1366,7 @@ def register_scan(app: typer.Typer):
                     rprint(f"\n[green]Disabled native OTLP in {gemini_settings} (gRPC incompatible)[/green]")
                     rprint("[dim]Telemetry is captured via hooks instead.[/dim]")
                 else:
-                    rprint(f"\n[dim]Gemini CLI native OTLP already disabled.[/dim]")
+                    rprint("\n[dim]Gemini CLI native OTLP already disabled.[/dim]")
             except Exception as e:
                 rprint(f"\n[yellow]Could not configure Gemini CLI telemetry: {e}[/yellow]")
                 rprint("[dim]Add telemetry settings manually to ~/.gemini/settings.json.[/dim]")

--- a/observal_cli/constants.py
+++ b/observal_cli/constants.py
@@ -41,7 +41,7 @@ IDE_FEATURE_MATRIX: dict[str, set[str]] = {
     "claude-code": {"skills", "hook_bridge", "mcp_servers", "rules", "otlp_telemetry"},
     "kiro": {"superpowers", "hook_bridge", "mcp_servers", "rules", "steering_files", "otlp_telemetry"},
     "cursor": {"mcp_servers", "rules"},
-    "gemini-cli": {"mcp_servers", "rules"},
+    "gemini-cli": {"hook_bridge", "mcp_servers", "rules", "otlp_telemetry"},
     "codex": {"rules"},
     "copilot": {"mcp_servers", "rules"},
     "opencode": {"mcp_servers", "rules"},

--- a/observal_cli/hooks/gemini_hook.py
+++ b/observal_cli/hooks/gemini_hook.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Gemini CLI hook script for non-stop events.
+
+Injects ``service_name: "gemini-cli"`` and Observal user metadata into
+the hook payload, then forwards it to the Observal hooks endpoint.
+
+On POST failure, buffers the event locally in SQLite so it can be
+retried on the next successful hook delivery.
+
+Usage (in ~/.gemini/settings.json):
+    {"type": "command", "command": "python3 /abs/path/to/gemini_hook.py"}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _resolve_hooks_url() -> str:
+    """Read hooks URL from env or config file."""
+    url = os.environ.get("OBSERVAL_HOOKS_URL")
+    if url:
+        return url
+    cfg_path = Path.home() / ".observal" / "config.json"
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text())
+            server = cfg.get("server_url", "")
+            if server:
+                return f"{server.rstrip('/')}/api/v1/otel/hooks"
+        except Exception:
+            pass
+    return "http://localhost:8000/api/v1/otel/hooks"
+
+
+def _inject_user_metadata(payload: dict) -> None:
+    """Inject user_id and user_name from ~/.observal/config.json."""
+    try:
+        cfg_path = Path.home() / ".observal" / "config.json"
+        if cfg_path.exists():
+            cfg = json.loads(cfg_path.read_text())
+            if not payload.get("user_id") and cfg.get("user_id"):
+                payload["user_id"] = cfg["user_id"]
+            if not payload.get("user_name") and cfg.get("user_name"):
+                payload["user_name"] = cfg["user_name"]
+    except Exception:
+        pass
+
+
+def _post(url: str, payload: dict) -> bool:
+    """POST payload to the hooks endpoint. Returns True on success."""
+    import urllib.request
+
+    data = json.dumps(payload).encode("utf-8")
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+
+    uid = payload.get("user_id") or os.environ.get("OBSERVAL_USER_ID")
+    uname = payload.get("user_name") or os.environ.get("OBSERVAL_USERNAME")
+    if uid:
+        headers["X-Observal-User-Id"] = uid
+    if uname:
+        headers["X-Observal-Username"] = uname
+
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+def _buffer(payload: dict) -> None:
+    """Buffer the event locally for later retry."""
+    try:
+        hook_dir = Path(__file__).resolve().parent
+        buffer_script = hook_dir / "buffer_event.py"
+        if buffer_script.is_file():
+            import subprocess
+
+            subprocess.run(
+                [sys.executable, str(buffer_script)],
+                input=json.dumps(payload).encode("utf-8"),
+                timeout=5,
+                capture_output=True,
+            )
+    except Exception:
+        pass
+
+
+def _flush_buffer(url: str) -> None:
+    """Kick off a background flush of buffered events."""
+    try:
+        hook_dir = Path(__file__).resolve().parent
+        flush_script = hook_dir / "flush_buffer.py"
+        if flush_script.is_file():
+            import subprocess
+
+            subprocess.Popen(
+                [sys.executable, str(flush_script)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+    except Exception:
+        pass
+
+
+def _extract_token_usage(payload: dict) -> None:
+    """Extract token counts from AfterModel's llm_response.usageMetadata."""
+    llm_response = payload.get("llm_response")
+    if not isinstance(llm_response, dict):
+        return
+    usage = llm_response.get("usageMetadata")
+    if not isinstance(usage, dict):
+        return
+    if usage.get("promptTokenCount"):
+        payload["input_tokens"] = usage["promptTokenCount"]
+    if usage.get("candidatesTokenCount"):
+        payload["output_tokens"] = usage["candidatesTokenCount"]
+    if usage.get("totalTokenCount"):
+        payload["total_tokens"] = usage["totalTokenCount"]
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print('{"continue":true}')
+        return
+
+    payload["service_name"] = "gemini-cli"
+    _inject_user_metadata(payload)
+
+    hook_event = payload.get("hook_event_name", "")
+
+    # AfterModel fires on EVERY streaming chunk — don't forward them as
+    # events (they map to Stop and create noise). Only extract token usage
+    # from the final chunk (which has usageMetadata) and send that as a
+    # dedicated TokenUsage event.
+    if hook_event == "AfterModel":
+        _extract_token_usage(payload)
+        if not payload.get("input_tokens"):
+            # Intermediate chunk with no token data — skip entirely
+            print('{"continue":true}')
+            return
+        # Final chunk: send only token data, not the full model response
+        session_id = payload.get("session_id", "")
+        token_event = {
+            "hook_event_name": "Stop",
+            "session_id": session_id,
+            "service_name": "gemini-cli",
+            "tool_name": "token_usage",
+            "input_tokens": str(payload["input_tokens"]),
+            "output_tokens": str(payload.get("output_tokens", 0)),
+        }
+        if payload.get("model"):
+            token_event["model"] = payload["model"]
+        _inject_user_metadata(token_event)
+        url = _resolve_hooks_url()
+        _post(url, token_event)
+        print('{"continue":true}')
+        return
+
+    url = _resolve_hooks_url()
+
+    if _post(url, payload):
+        _flush_buffer(url)
+    else:
+        _buffer(payload)
+
+    # Gemini CLI requires JSON on stdout to proceed
+    print('{"continue":true}')
+
+
+if __name__ == "__main__":
+    main()

--- a/observal_cli/hooks/gemini_stop_hook.py
+++ b/observal_cli/hooks/gemini_stop_hook.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Gemini CLI stop hook for AfterAgent and SessionEnd events.
+
+Captures the assistant's response text from the hook payload and sends
+it to Observal as a Stop event. Unlike Claude Code's stop hook (which
+parses transcript JSONL), Gemini CLI provides ``prompt_response``
+directly in the AfterAgent payload.
+
+Usage (in ~/.gemini/settings.json):
+    {"type": "command", "command": "python3 /abs/path/to/gemini_stop_hook.py"}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _resolve_hooks_url() -> str:
+    """Read hooks URL from env or config file."""
+    url = os.environ.get("OBSERVAL_HOOKS_URL")
+    if url:
+        return url
+    cfg_path = Path.home() / ".observal" / "config.json"
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text())
+            server = cfg.get("server_url", "")
+            if server:
+                return f"{server.rstrip('/')}/api/v1/otel/hooks"
+        except Exception:
+            pass
+    return "http://localhost:8000/api/v1/otel/hooks"
+
+
+def _post(url: str, payload: dict) -> None:
+    """POST payload to the hooks endpoint (fire-and-forget)."""
+    import urllib.request
+
+    data = json.dumps(payload).encode("utf-8")
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+
+    uid = payload.get("user_id") or os.environ.get("OBSERVAL_USER_ID")
+    uname = payload.get("user_name") or os.environ.get("OBSERVAL_USERNAME")
+    if uid:
+        headers["X-Observal-User-Id"] = uid
+    if uname:
+        headers["X-Observal-Username"] = uname
+
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except Exception:
+        pass
+
+
+def _inject_user_metadata(payload: dict) -> None:
+    """Inject user_id and user_name from ~/.observal/config.json."""
+    try:
+        cfg_path = Path.home() / ".observal" / "config.json"
+        if cfg_path.exists():
+            cfg = json.loads(cfg_path.read_text())
+            if not payload.get("user_id") and cfg.get("user_id"):
+                payload["user_id"] = cfg["user_id"]
+            if not payload.get("user_name") and cfg.get("user_name"):
+                payload["user_name"] = cfg["user_name"]
+    except Exception:
+        pass
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print('{"continue":true}')
+        return
+
+    payload["service_name"] = "gemini-cli"
+    _inject_user_metadata(payload)
+
+    url = _resolve_hooks_url()
+    session_id = payload.get("session_id", "")
+    hook_event = payload.get("hook_event_name", "")
+
+    # First, forward the raw event (same as generic hook)
+    _post(url, payload)
+
+    # Then extract and send assistant response as a separate event
+    response_text = ""
+
+    if hook_event == "AfterAgent":
+        # AfterAgent provides prompt_response directly
+        response_text = payload.get("prompt_response", "")
+
+    if response_text:
+        # Truncate to 64KB
+        response_text = response_text[:65536]
+        stop_event = {
+            "hook_event_name": "Stop",
+            "session_id": session_id,
+            "service_name": "gemini-cli",
+            "tool_name": "assistant_response",
+            "tool_response": response_text,
+            "message_sequence": 1,
+            "message_total": 1,
+        }
+        _inject_user_metadata(stop_event)
+        _post(url, stop_event)
+
+    # Gemini CLI requires JSON on stdout to proceed
+    print('{"continue":true}')
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -92,8 +92,7 @@ class TestConstants:
 
     def test_gemini_cli_feature_matrix(self):
         assert "gemini-cli" in IDE_FEATURE_MATRIX
-        assert "mcp_servers" in IDE_FEATURE_MATRIX["gemini-cli"]
-        assert "rules" in IDE_FEATURE_MATRIX["gemini-cli"]
+        assert IDE_FEATURE_MATRIX["gemini-cli"] == {"hook_bridge", "mcp_servers", "rules", "otlp_telemetry"}
 
     def test_opencode_feature_matrix(self):
         assert "opencode" in IDE_FEATURE_MATRIX
@@ -1315,17 +1314,19 @@ class TestPullOpenCodeScope:
 
 
 class TestGeminiConfigGenerator:
-    def test_gemini_settings_uses_observal_url(self):
+    def test_gemini_settings_disables_native_otlp(self):
         from services.config_generator import _gemini_settings
 
         settings = _gemini_settings("http://custom-host:4318")
-        assert settings["telemetry"]["otlpEndpoint"] == "http://custom-host:4318"
+        assert settings["telemetry"]["enabled"] is False
+        assert settings["telemetry"]["logPrompts"] is True
 
-    def test_gemini_settings_default_localhost(self):
+    def test_gemini_settings_no_target(self):
         from services.config_generator import _gemini_settings
 
         settings = _gemini_settings("http://localhost:4318")
-        assert settings["telemetry"]["otlpEndpoint"] == "http://localhost:4318"
+        assert "target" not in settings["telemetry"]
+        assert "otlpEndpoint" not in settings["telemetry"]
 
     def test_gemini_otlp_env_uses_observal_url(self):
         from services.config_generator import _gemini_otlp_env
@@ -1338,9 +1339,10 @@ class TestGeminiConfigGenerator:
         cfg = generate_agent_config(agent, "gemini-cli")
         assert "gemini_settings_snippet" in cfg
         snippet = cfg["gemini_settings_snippet"]
-        assert snippet["telemetry"]["enabled"] is True
-        assert snippet["telemetry"]["target"] == "custom"
-        assert "otlpEndpoint" in snippet["telemetry"]
+        assert snippet["telemetry"]["enabled"] is False
+        assert snippet["telemetry"]["logPrompts"] is True
+        assert "target" not in snippet["telemetry"]
+        assert "otlpEndpoint" not in snippet["telemetry"]
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -1383,13 +1385,66 @@ class TestDoctorGemini:
 
         from observal_cli.cmd_doctor import _check_gemini
 
-        data = {"mcpServers": {"my-srv": {"command": "observal-shim", "args": ["--mcp-id", "test", "--", "npx"]}}}
+        data = {
+            "mcpServers": {"my-srv": {"command": "observal-shim", "args": ["--mcp-id", "test", "--", "npx"]}},
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "python3 /path/to/gemini_hook.py"}]}],
+            },
+        }
         issues = []
         warnings = []
         _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
         assert len(warnings) == 0
 
-    def test_check_gemini_warns_on_disabled_telemetry(self):
+    def test_check_gemini_warns_on_enabled_native_otlp(self):
+        """Native OTLP uses gRPC which is incompatible — doctor should warn."""
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {
+            "telemetry": {"enabled": True, "target": "local"},
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "python3 /path/to/gemini_hook.py"}]}],
+            },
+        }
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert any("gRPC" in w or "native OTLP" in w.lower() for w in warnings)
+
+    def test_check_gemini_no_warning_on_disabled_native_otlp(self):
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {
+            "telemetry": {"enabled": False, "logPrompts": True},
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "python3 /path/to/gemini_hook.py"}]}],
+            },
+        }
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+    def test_check_gemini_no_telemetry_block_means_no_otlp_warning(self):
+        """No telemetry block = no OTLP warning (but still hooks warning if missing)."""
+        from pathlib import Path
+
+        from observal_cli.cmd_doctor import _check_gemini
+
+        data = {}
+        issues = []
+        warnings = []
+        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
+        # No OTLP warning
+        assert not any("gRPC" in w or "native OTLP" in w.lower() for w in warnings)
+        # But hooks warning because no hooks block
+        assert any("hooks" in w.lower() for w in warnings)
+
+    def test_check_gemini_warns_on_missing_hooks(self):
         from pathlib import Path
 
         from observal_cli.cmd_doctor import _check_gemini
@@ -1398,55 +1453,35 @@ class TestDoctorGemini:
         issues = []
         warnings = []
         _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
-        assert any("telemetry" in w and "disabled" in w for w in warnings)
+        assert any("hooks" in w.lower() for w in warnings)
 
-    def test_check_gemini_warns_on_missing_custom_target(self):
-        from pathlib import Path
-
-        from observal_cli.cmd_doctor import _check_gemini
-
-        data = {"telemetry": {"enabled": True, "target": "default"}}
-        issues = []
-        warnings = []
-        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
-        assert any("not configured" in w for w in warnings)
-
-    def test_check_gemini_warns_on_missing_otlp_endpoint(self):
-        from pathlib import Path
-
-        from observal_cli.cmd_doctor import _check_gemini
-
-        data = {"telemetry": {"enabled": True, "target": "custom"}}
-        issues = []
-        warnings = []
-        _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
-        assert any("not configured" in w for w in warnings)
-
-    def test_check_gemini_no_warning_on_proper_telemetry(self):
+    def test_check_gemini_warns_on_non_observal_hooks(self):
         from pathlib import Path
 
         from observal_cli.cmd_doctor import _check_gemini
 
         data = {
-            "telemetry": {
-                "enabled": True,
-                "target": "custom",
-                "otlpEndpoint": "http://localhost:4318",
-                "logPrompts": True,
-            }
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "echo hello"}]}],
+            },
         }
         issues = []
         warnings = []
         _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
-        assert len(warnings) == 0
+        assert any("no Observal hooks found" in w for w in warnings)
 
-    def test_check_gemini_no_telemetry_block_means_no_warning(self):
-        """If there's no telemetry block at all, don't warn — user hasn't configured Observal yet."""
+    def test_check_gemini_no_warning_on_valid_hooks(self):
         from pathlib import Path
 
         from observal_cli.cmd_doctor import _check_gemini
 
-        data = {}
+        data = {
+            "telemetry": {"enabled": False, "logPrompts": True},
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "python3 /path/to/gemini_hook.py"}]}],
+                "AfterAgent": [{"hooks": [{"type": "command", "command": "python3 /path/to/gemini_stop_hook.py"}]}],
+            },
+        }
         issues = []
         warnings = []
         _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)
@@ -1457,7 +1492,12 @@ class TestDoctorGemini:
 
         from observal_cli.cmd_doctor import _check_gemini
 
-        data = {"mcpServers": {"my-srv": {"url": "http://localhost:3000/sse"}}}
+        data = {
+            "mcpServers": {"my-srv": {"url": "http://localhost:3000/sse"}},
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "python3 /path/to/gemini_hook.py"}]}],
+            },
+        }
         issues = []
         warnings = []
         _check_gemini(Path(".gemini/settings.json"), data, issues, warnings)

--- a/web/src/app/(user)/traces/[id]/page.tsx
+++ b/web/src/app/(user)/traces/[id]/page.tsx
@@ -1239,6 +1239,7 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
     let hookEvents = 0;
     let credits = 0;
     let isKiro = serviceName === "kiro" || sessionId.startsWith("kiro-");
+    const isGemini = serviceName === "gemini";
     const models = new Set<string>();
     const tools: Record<string, number> = {};
 
@@ -1256,6 +1257,10 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
         if (attrs.cache_read_tokens) totalCacheRead += parseInt(attrs.cache_read_tokens, 10);
         if (attrs.cache_creation_tokens) totalCacheWrite += parseInt(attrs.cache_creation_tokens, 10);
         if (attrs.model) models.add(attrs.model);
+      } else if (attrs.input_tokens || attrs.output_tokens) {
+        // Gemini CLI (and others) emit token data on hook_stop/token_usage events
+        if (attrs.input_tokens) totalInputTokens += parseInt(attrs.input_tokens, 10);
+        if (attrs.output_tokens) totalOutputTokens += parseInt(attrs.output_tokens, 10);
       }
 
       // Kiro enriched stop events carry credits and model
@@ -1277,7 +1282,7 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
       }
     }
 
-    return { totalInputTokens, totalOutputTokens, totalCacheRead, totalCacheWrite, apiCalls, toolCalls, hookEvents, credits, isKiro, models, tools };
+    return { totalInputTokens, totalOutputTokens, totalCacheRead, totalCacheWrite, apiCalls, toolCalls, hookEvents, credits, isKiro, isGemini, models, tools };
   }, [events, sessionId, serviceName]);
 
   const formatCredits = (c: number) => c < 0.01 ? c.toFixed(4) : c.toFixed(2);
@@ -1299,20 +1304,26 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
             <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Output Tokens</p>
             <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalOutputTokens)}</p>
           </div>
-          <div className="space-y-1">
-            <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Read</p>
-            <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheRead)}</p>
-          </div>
-          <div className="space-y-1">
-            <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Write</p>
-            <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheWrite)}</p>
-          </div>
+          {!stats.isGemini && (
+            <>
+              <div className="space-y-1">
+                <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Read</p>
+                <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheRead)}</p>
+              </div>
+              <div className="space-y-1">
+                <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Cache Write</p>
+                <p className="text-lg font-semibold tabular-nums">{formatTokens(stats.totalCacheWrite)}</p>
+              </div>
+            </>
+          )}
         </>
       )}
-      <div className="space-y-1">
-        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">API Calls</p>
-        <p className="text-lg font-semibold tabular-nums">{stats.apiCalls}</p>
-      </div>
+      {!stats.isGemini && (
+        <div className="space-y-1">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide">API Calls</p>
+          <p className="text-lg font-semibold tabular-nums">{stats.apiCalls}</p>
+        </div>
+      )}
       <div className="space-y-1">
         <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Tool Calls</p>
         <p className="text-lg font-semibold tabular-nums">{stats.toolCalls}</p>

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -214,9 +214,7 @@ function buildGeminiSettings(mcps: { id: string; name: string }[]): string {
   }
   const settings: Record<string, unknown> = {
     telemetry: {
-      enabled: true,
-      target: "custom",
-      otlpEndpoint: "http://localhost:4318",
+      enabled: false,
       logPrompts: true,
     },
     mcpServers: servers,
@@ -235,9 +233,7 @@ function generateGemini(
     path: ".gemini/settings.json",
     content: mcps.length > 0 ? buildGeminiSettings(mcps) : JSON.stringify({
       telemetry: {
-        enabled: true,
-        target: "custom",
-        otlpEndpoint: "http://localhost:4318",
+        enabled: false,
         logPrompts: true,
       },
     }, null, 2),

--- a/web/src/lib/ide-features.ts
+++ b/web/src/lib/ide-features.ts
@@ -32,7 +32,7 @@ export const IDE_FEATURE_MATRIX: Record<IdeName, ReadonlySet<IdeFeature>> = {
   "claude-code": new Set(["skills", "hook_bridge", "mcp_servers", "rules", "otlp_telemetry"]),
   kiro: new Set(["superpowers", "hook_bridge", "mcp_servers", "rules", "steering_files", "otlp_telemetry"]),
   cursor: new Set(["mcp_servers", "rules"]),
-  "gemini-cli": new Set(["mcp_servers", "rules"]),
+  "gemini-cli": new Set(["hook_bridge", "mcp_servers", "rules", "otlp_telemetry"]),
   codex: new Set(["rules"]),
   copilot: new Set(["mcp_servers", "rules"]),
   opencode: new Set(["mcp_servers", "rules"]),


### PR DESCRIPTION
## Purpose / Description

Gemini CLI traces weren't showing in the Observal dashboard. Root causes:

1. **Invalid telemetry target** — Observal wrote `"target": "custom"` but Gemini CLI only accepts `"local"` or `"gcp"`
2. **gRPC incompatibility** — Even with `"local"`, Gemini CLI hardcodes `GrpcExporterTransport` for OTLP export, which can't connect to Observal's HTTP/JSON endpoint on port 4318

This PR switches Gemini CLI telemetry from native OTLP to a **hook bridge** (same approach as Claude Code and Kiro), using Gemini CLI's v0.39.0 hook system.

## Fixes

* Fixes Gemini CLI traces not appearing in dashboard
* Fixes gRPC error noise on Gemini CLI exit
* Fixes duplicate end_turn/stop events from AfterModel streaming chunks
* Fixes tokens showing as 0 in session detail for Gemini sessions

## Approach

- **Hook scripts** (`gemini_hook.py`, `gemini_stop_hook.py`): Python scripts that read JSON from stdin, inject `service_name: "gemini-cli"` and user metadata, then POST to the hooks endpoint. AfterModel chunks are filtered — only the final chunk with `usageMetadata` forwards token data.
- **CLI injection**: `observal scan --ide gemini-cli --home` and `observal auth login` both inject hooks into `~/.gemini/settings.json` and disable native OTLP.
- **Doctor validation**: `_check_gemini()` warns on enabled native OTLP (gRPC) and missing/non-Observal hooks.
- **Server-side**: `_extract_gemini()` now extracts `input_tokens`/`output_tokens` from hook payloads.
- **Frontend**: Token counting handles any event with `input_tokens`/`output_tokens`. Cache Read/Write and API Calls are hidden for Gemini sessions (not derivable from hooks).
- **Feature matrix**: `hook_bridge` and `otlp_telemetry` added to gemini-cli across all 3 synced sources.

## How Has This Been Tested?

- `uv run python -m pytest tests/test_ide_config_e2e.py` — 170 tests pass
- `uv run python -m pytest tests/test_constants_sync.py` — 14 tests pass (feature matrix in sync)
- Manual: `observal scan --ide gemini-cli --home` injects hooks + disables OTLP
- Manual: `gemini` interactive session → traces appear in dashboard with token counts
- Manual: `observal doctor --ide gemini-cli` → no warnings with correct config

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code