### PR TITLE
fix(docker): replace wget with urllib in init entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,9 +34,17 @@ CH_PROTO_HOST="http://${CH_HOST}"
 CH_CREATE_RETRIES=15
 CH_CREATE_COUNT=0
 while [ $CH_CREATE_COUNT -lt $CH_CREATE_RETRIES ]; do
-  HTTP_CODE=$(wget -q -O- --user="$CH_USER" --password="$CH_PASS" \
-    --post-data="CREATE DATABASE IF NOT EXISTS ${CH_DB}" \
-    "${CH_PROTO_HOST}/" 2>/dev/null && echo "ok" || echo "fail")
+  HTTP_CODE=$(/app/.venv/bin/python -c "
+import urllib.request, base64, sys
+url = '${CH_PROTO_HOST}/'
+auth = base64.b64encode('${CH_USER}:${CH_PASS}'.encode()).decode()
+req = urllib.request.Request(url, data=b'CREATE DATABASE IF NOT EXISTS ${CH_DB}', headers={'Authorization': 'Basic ' + auth})
+try:
+    urllib.request.urlopen(req, timeout=5)
+    print('ok')
+except Exception:
+    print('fail')
+" 2>/dev/null)
   if [ "$HTTP_CODE" = "ok" ]; then
     echo "ClickHouse database '${CH_DB}' ready"
     break


### PR DESCRIPTION
## Purpose / Description

The Docker init container fails to connect to ClickHouse, hanging indefinitely with "Waiting for ClickHouse to accept connections" retries.

Root cause: `python:3.14-slim` moved from Debian bookworm to trixie, which no longer ships `wget` by default. The entrypoint used `wget` for the ClickHouse readiness check — it silently failed and retried 15 times with exponential backoff.

## Fixes

* Fixes init container hanging on `make rebuild` / `docker compose up`

## Approach

Replace the `wget` call with Python's `urllib.request` (always available in the stdlib). No new dependencies needed.

## How Has This Been Tested?

- `make rebuild` → init container starts, connects to ClickHouse, and exits successfully in seconds
- Verified `wget` is not available in the current `python:3.14-slim` image (`dpkg -l wget` → no packages found)

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code