### PR TITLE
chore: remove volumes in rebuild-clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ reset:  ## Nuke all Docker volumes and rebuild from scratch (fresh app, no file 
 	cd docker && docker compose restart observal-lb
 	@echo "API is healthy — all data has been reset."
 
-rebuild-clean:  ## Rebuild from scratch (no Docker cache) and restart
-	cd docker && docker compose build --no-cache && docker compose up -d
+rebuild-clean:  ## Rebuild from scratch (no Docker cache), remove volumes, and restart
+	cd docker && docker compose down -v && docker compose build --no-cache && docker compose up -d
 	@echo "Waiting for API to be healthy..."
 	@cd docker && until docker compose exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
 	cd docker && docker compose restart observal-lb


### PR DESCRIPTION
## Purpose / Description
`make rebuild-clean` should fully reset local state, but it wasn't removing Docker volumes. Stale ClickHouse data, Redis state, etc. survived across rebuilds.

## Approach
Add `docker compose down -v` before `build --no-cache` so volumes are wiped first.

## How Has This Been Tested?
Verified the generated command chain: `down -v && build --no-cache && up -d`.

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code