### PR TITLE
fix(cli): use SPECPATH for absolute paths in pyinstaller spec

### DIFF
--- a/observal_cli/pyinstaller.spec
+++ b/observal_cli/pyinstaller.spec
@@ -10,14 +10,17 @@ from pathlib import Path
 
 block_cipher = None
 
-cli_dir = Path("observal_cli")
+spec_dir = Path(SPECPATH)
+repo_root = spec_dir.parent
+
+cli_dir = spec_dir
 
 # Collect all CLI modules
 cli_modules = [str(p) for p in cli_dir.glob("*.py") if p.name != "__pycache__"]
 
 a = Analysis(
-    ["observal_cli/main.py"],
-    pathex=["."],
+    [str(spec_dir / "main.py")],
+    pathex=[str(repo_root)],
     binaries=[],
     datas=[],
     hiddenimports=[


### PR DESCRIPTION
## Purpose / Description
The PyInstaller spec file used hardcoded relative paths (`observal_cli/main.py`), which caused a doubled path error (`observal_cli/observal_cli/main.py`) during CI release builds. PyInstaller resolves paths relative to the spec file's directory, not the working directory, so invoking `pyinstaller observal_cli/pyinstaller.spec` from the repo root prepended the spec's directory a second time.

## Fixes
* Fixes CLI binary build failure in the Release workflow (all 6 platform matrix jobs)

## Approach
Use PyInstaller's built-in `SPECPATH` variable to construct absolute paths to `main.py` and the repo root. This makes the spec work regardless of which directory `pyinstaller` is invoked from.

- `spec_dir = Path(SPECPATH)` — absolute path to the spec file's directory
- `repo_root = spec_dir.parent` — used for `pathex`
- Entry point becomes `str(spec_dir / "main.py")` — always resolves correctly

## How Has This Been Tested?

- Verified the path resolution logic matches PyInstaller's documented `SPECPATH` behavior
- The previous release run failed with `ERROR: script 'observal_cli/observal_cli/main.py' not found` — this fix eliminates the doubled path

## Learning (optional, can help others)
PyInstaller's `SPECPATH` is a global variable available inside `.spec` files that contains the absolute path to the directory where the spec file lives. Always use it instead of hardcoded relative paths when the spec file isn't at the repo root.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)