### PR TITLE
fix(eval): broaden session matching for Claude Code telemetry

### DIFF
--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import UTC, datetime
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,7 +13,7 @@ from models.eval import EvalRun, EvalRunStatus, Scorecard
 from models.user import User, UserRole
 from schemas.eval import EvalRequest, EvalRunDetailResponse, EvalRunResponse, ScorecardResponse
 from services.audit_helpers import audit
-from services.clickhouse import query_spans
+from services.clickhouse import _query, query_spans
 from services.eval.eval_service import (
     evaluate_trace,
     fetch_traces,
@@ -22,6 +23,8 @@ from services.eval.eval_service import (
 )
 from services.eval.score_aggregator import ScoreAggregator
 from services.hook_materializer import build_agent_eval_context, materialize_agent_eval, materialize_session_spans
+
+_log = structlog.get_logger("eval.route")
 
 router = APIRouter(prefix="/api/v1/eval", tags=["eval"])
 
@@ -62,6 +65,56 @@ async def run_evaluation(
         mat_trace, mat_spans = await materialize_session_spans(session_id)
         if mat_trace and mat_spans:
             traces = [mat_trace]
+
+    # Fallback: find sessions in otel_logs by agent name, prompt mention, or substring match
+    if not traces:
+        agent_name = agent.name
+        _log.info("eval_fallback_start", agent_name=agent_name, agent_id=str(agent.id))
+        sql = (
+            "SELECT DISTINCT sid, latest FROM ("
+            "  SELECT LogAttributes['session.id'] AS sid, max(Timestamp) AS latest "
+            "  FROM otel_logs "
+            "  WHERE LogAttributes['agent_name'] = {aname:String} "
+            "  AND LogAttributes['session.id'] != '' "
+            "  GROUP BY sid "
+            "  UNION ALL "
+            "  SELECT LogAttributes['session.id'] AS sid, max(Timestamp) AS latest "
+            "  FROM otel_logs "
+            "  WHERE LogAttributes['session.id'] != '' "
+            "  AND (LogAttributes['tool_input'] LIKE {prompt_pattern:String} "
+            "       OR LogAttributes['agent_name'] LIKE {name_pattern:String}) "
+            "  GROUP BY sid "
+            ") "
+            "ORDER BY latest DESC "
+            "LIMIT 5 "
+        )
+        try:
+            r = await _query(
+                f"{sql} FORMAT JSON",
+                {
+                    "param_aname": agent_name,
+                    "param_prompt_pattern": f"%@agent-{agent_name}%",
+                    "param_name_pattern": f"%{agent_name}%",
+                },
+            )
+            _log.info("eval_fallback_ch_response", status=r.status_code, body=r.text[:500])
+            if r.status_code == 200:
+                sessions = r.json().get("data", [])
+                _log.info("eval_fallback_sessions", count=len(sessions))
+                for row in sessions:
+                    sid = row.get("sid", "")
+                    if sid:
+                        mat_trace, mat_spans = await materialize_session_spans(sid)
+                        _log.info(
+                            "eval_materialize_result",
+                            sid=sid,
+                            has_trace=bool(mat_trace),
+                            span_count=len(mat_spans) if mat_spans else 0,
+                        )
+                        if mat_trace and mat_spans:
+                            traces.append(mat_trace)
+        except Exception as e:
+            _log.exception("eval_fallback_error", error=str(e))
 
     if not traces:
         eval_run.status = EvalRunStatus.completed

--- a/observal-server/services/hook_materializer.py
+++ b/observal-server/services/hook_materializer.py
@@ -91,7 +91,7 @@ async def _fetch_session_events(session_id: str) -> list[dict]:
     sql = (
         "SELECT "
         "Timestamp AS timestamp, "
-        "EventName AS event_name, "
+        "LogAttributes['event.name'] AS event_name, "
         "Body AS body, "
         "LogAttributes AS attributes, "
         "ServiceName AS service_name "


### PR DESCRIPTION
## Purpose / Description

Claude Code sends task descriptions (e.g. "Security audit of codebase") as `agent_name` in OTEL telemetry, not the Observal registry agent name (e.g. `security-checker`). This means the eval fallback query never finds matching sessions, and eval silently returns `traces_evaluated: 0` for any agent run via Claude Code.

Additionally, the `_fetch_session_events` query references an `EventName` column that only exists when Observal's custom init SQL created the `otel_logs` table. Deployments where the OTEL Collector created the table (the default) hit a 404 because that column does not exist.

## Fixes

* Fixes eval returning zero scorecards for agents run via Claude Code
* Fixes session materialization failing on default OTEL Collector ClickHouse schema

## Approach

**eval.py**: The fallback session lookup now uses a UNION query that matches sessions three ways:
1. Exact match on `agent_name` (existing behavior)
2. User prompt contains `@agent-<registry-name>` (how Claude Code invokes installed agents)
3. `agent_name` attribute contains the registry name as a substring

**hook_materializer.py**: Changed `EventName AS event_name` to `LogAttributes['event.name'] AS event_name`. The `LogAttributes` map contains the event name on both custom and default ClickHouse schemas, so this works universally.

## How Has This Been Tested?

1. Deployed to EC2 instance running `internal.observal.io`
2. Ran `security-checker` agent via Claude Code with `@agent-security-checker`
3. Hit "Run Eval" from the UI - confirmed it found the session and produced a scorecard
4. Verified the ClickHouse fallback query returns matching sessions by checking API logs (`eval_fallback_sessions count=2`)
5. Confirmed Groq LLM judge (`llama-3.1-8b-instant`) produces real scores through the eval pipeline

## Learning

- OTEL Collector's default ClickHouse exporter schema does not include an `EventName` column. Event names are stored in `LogAttributes['event.name']`. Observal's custom init SQL adds `EventName` as a top-level column, but this cannot be assumed in all deployments.
- Claude Code telemetry uses the conversation/task description as `agent_name`, not the registry agent slug. The `@agent-<name>` pattern appears in the `tool_input` attribute of `hook_userpromptsubmit` events.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
