### PR TITLE
feat: add Copilot CLI trace support via hook bridge

### DIFF
--- a/docs/integrations/copilot-cli.md
+++ b/docs/integrations/copilot-cli.md
@@ -1,0 +1,170 @@
+# Copilot CLI
+
+[Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) is the standalone agentic coding CLI from GitHub (binary: `copilot`). Observal uses a hook-based bridge for session lifecycle events and `observal-shim` for MCP server instrumentation.
+
+## What you get
+
+* **MCP server instrumentation** via `observal-shim` (or `observal-proxy` for HTTP MCPs)
+* **Session lifecycle events** via hooks — session start/end, user prompts, tool use, errors
+* **Rules** (`.github/copilot-instructions.md`)
+
+## What you don't get (yet)
+
+| Limitation | Detail |
+| --- | --- |
+| **Token counts** | Copilot CLI does not expose token usage in hook payloads. |
+| **Cost per call** | No per-call cost data available. |
+| **Session enrichment** | No local conversation store to read turn counts or model info at session end. |
+
+## Setup
+
+### 1. Install Copilot CLI
+
+```bash
+curl -fsSL https://gh.io/copilot-install | bash
+copilot --version
+```
+
+### 2. Install the Observal CLI
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+observal auth login
+```
+
+### 3. Instrument Copilot CLI
+
+```bash
+observal scan --ide copilot-cli --home
+```
+
+This does three things:
+
+1. **Wraps MCP servers** in `~/.copilot/mcp-config.json` with `observal-shim`
+2. **Injects hooks** into `~/.copilot/config.json` for session lifecycle telemetry
+3. **Discovers** any project-level MCP servers in `.mcp.json`
+
+### 4. (Optional) Pull an agent from the registry
+
+```bash
+observal agent list
+observal pull <agent-id> --ide copilot-cli
+```
+
+This writes:
+
+| File | Purpose |
+| --- | --- |
+| `.github/copilot-instructions.md` | Rules / system instructions |
+| `.mcp.json` | MCP servers wrapped with `observal-shim` |
+
+### 5. Diagnose
+
+```bash
+observal doctor --ide copilot-cli
+```
+
+### 6. Repair hooks
+
+```bash
+observal doctor sli --ide copilot-cli
+```
+
+Then restart Copilot CLI.
+
+## Config locations
+
+| Purpose | Path |
+| --- | --- |
+| Settings + hooks | `~/.copilot/config.json` |
+| User MCP servers | `~/.copilot/mcp-config.json` |
+| Project MCP servers | `.mcp.json` (project root) |
+| Rules | `.github/copilot-instructions.md` |
+
+## How telemetry reaches Observal
+
+### Channel 1: MCP tool calls
+
+Same as everywhere else — `observal-shim` sits between Copilot CLI and each MCP server. Every call becomes a span.
+
+### Channel 2: Session lifecycle (via hooks)
+
+Observal installs hooks into `~/.copilot/config.json` under the `hooks` key. They fire at these events:
+
+| Copilot CLI event | What it captures |
+| --- | --- |
+| `sessionStart` | Session begins |
+| `userPromptSubmitted` | The user's prompt |
+| `preToolUse` | Tool name and input (before the call) |
+| `postToolUse` | Tool response (after the call) |
+| `sessionEnd` | Session ends |
+| `errorOccurred` | Errors during the session |
+
+Each hook runs a Python script that reads stdin JSON, injects Observal metadata (`service_name`, `session_id`, user identity), and POSTs to `http://localhost:8000/api/v1/otel/hooks`.
+
+### Example hook in config.json
+
+```json
+{
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "cat | python3 /path/to/copilot_cli_hook.py --url http://localhost:8000/api/v1/otel/hooks",
+        "powershell": "python /path/to/copilot_cli_hook.py --url http://localhost:8000/api/v1/otel/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}
+```
+
+You don't write these by hand — `observal scan --ide copilot-cli --home` generates them.
+
+## View your traces
+
+Open `http://localhost:3000/traces` and filter by **IDE -> copilot-cli**.
+
+Or CLI:
+
+```bash
+observal ops traces --limit 20
+```
+
+## Troubleshooting
+
+### Hooks not firing — sessions not appearing in the dashboard
+
+1. Confirm hooks are in `~/.copilot/config.json`:
+   ```bash
+   cat ~/.copilot/config.json | python3 -m json.tool
+   ```
+2. Verify `disableAllHooks` is not `true` in the config.
+3. Confirm the URL in the hook commands matches your server.
+4. Re-inject hooks: `observal doctor sli --ide copilot-cli`
+
+### `observal scan` wraps 0 servers
+
+Your Copilot CLI MCP config may be empty. Check:
+
+```bash
+cat ~/.copilot/mcp-config.json    # user-level
+cat .mcp.json                      # project-level
+```
+
+Add at least one MCP server first, then re-run `scan`.
+
+### `observal-shim` not found
+
+Reinstall:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+which observal-shim
+```
+
+## Related
+
+* [`observal pull`](../cli/pull.md)
+* [`observal scan`](../cli/scan.md)
+* [`observal doctor`](../cli/doctor.md)

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -349,8 +349,9 @@ async def telemetry_status(current_user: User = Depends(require_role(UserRole.ad
     )
 
 
-# Kiro CLI uses camelCase event names; normalize to PascalCase
+# Kiro CLI and Copilot CLI use camelCase event names; normalize to PascalCase
 _KIRO_EVENT_MAP = {
+    # Kiro events
     "agentSpawn": "SessionStart",
     "userPromptSubmit": "UserPromptSubmit",
     "promptSubmit": "UserPromptSubmit",
@@ -358,12 +359,17 @@ _KIRO_EVENT_MAP = {
     "postToolUse": "PostToolUse",
     "stop": "Stop",
     "agentStop": "Stop",
+    # Copilot CLI events
+    "sessionStart": "SessionStart",
+    "sessionEnd": "Stop",
+    "userPromptSubmitted": "UserPromptSubmit",
+    "errorOccurred": "StopFailure",
 }
 
 
 @router.post("/hooks")
 async def ingest_hook(request: Request, current_user: User = Depends(require_role(UserRole.user))):
-    """Ingest raw hook JSON from Claude Code/Kiro."""
+    """Ingest raw hook JSON from Claude Code/Kiro/Copilot CLI."""
     project_id = get_project_id(current_user)
     body = await request.json()
 
@@ -407,7 +413,7 @@ async def ingest_hook(request: Request, current_user: User = Depends(require_rol
         "end_time": now,
         "latency_ms": None,
         "status": "success",
-        "ide": "",
+        "ide": body.get("service_name", ""),
         "environment": "default",
         "metadata": {},
         "token_count_input": None,

--- a/observal-server/schemas/constants.py
+++ b/observal-server/schemas/constants.py
@@ -22,6 +22,7 @@ VALID_IDES: list[str] = [
     "vscode",
     "codex",
     "copilot",
+    "copilot-cli",
     "opencode",
 ]
 
@@ -48,6 +49,7 @@ IDE_FEATURE_MATRIX: dict[str, set[str]] = {
     "gemini-cli": {"hook_bridge", "mcp_servers", "rules", "otlp_telemetry"},
     "codex": {"rules"},
     "copilot": {"mcp_servers", "rules"},
+    "copilot-cli": {"mcp_servers", "rules", "hook_bridge"},
     "opencode": {"mcp_servers", "rules"},
     "vscode": {"mcp_servers", "rules"},
 }

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -610,6 +610,45 @@ def _generate_copilot(manifest: AgentManifest) -> IdeAgentConfig:
     )
 
 
+def _generate_copilot_cli(manifest: AgentManifest) -> IdeAgentConfig:
+    """Generate Copilot CLI agent config (.github/copilot-instructions.md + .mcp.json)."""
+    mcp_entries = _build_mcp_entries(manifest)
+    rules_content = _build_rules_markdown(manifest)
+
+    files = [
+        AgentFile(
+            path=".github/copilot-instructions.md",
+            content=rules_content,
+            format="markdown",
+        ),
+    ]
+
+    if mcp_entries:
+        copilot_cli_mcp_entries = {}
+        for k, v in mcp_entries.items():
+            copilot_cli_mcp_entries[k] = {
+                "type": "stdio",
+                "command": v["command"],
+                "args": v.get("args", []),
+                "tools": ["*"],
+            }
+            if v.get("env"):
+                copilot_cli_mcp_entries[k]["env"] = v["env"]
+        files.append(
+            AgentFile(
+                path=".mcp.json",
+                content={"mcpServers": copilot_cli_mcp_entries},
+                format="json",
+            ),
+        )
+
+    return IdeAgentConfig(
+        ide="copilot-cli",
+        files=files,
+        mcp_servers=mcp_entries,
+    )
+
+
 def _generate_opencode(manifest: AgentManifest) -> IdeAgentConfig:
     """Generate OpenCode agent config (AGENTS.md + opencode.json with flat command arrays)."""
     mcp_entries = _build_mcp_entries(manifest)
@@ -657,6 +696,8 @@ _IDE_GENERATORS = {
     "kiro": _generate_kiro,
     "codex": _generate_codex,
     "copilot": _generate_copilot,
+    "copilot-cli": _generate_copilot_cli,
+    "copilot_cli": _generate_copilot_cli,
     "opencode": _generate_opencode,
 }
 
@@ -669,6 +710,7 @@ SUPPORTED_IDES = list(
         "kiro",
         "codex",
         "copilot",
+        "copilot-cli",
         "opencode",
     }
 )

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -452,6 +452,32 @@ def generate_agent_config(
             result["_warnings"] = compatibility_warnings
         return result
 
+    if ide == "copilot-cli":
+        copilot_cli_configs = {}
+        for k, v in mcp_configs.items():
+            if v.get("url"):
+                transport_type = v.get("type", "sse")
+                copilot_cli_configs[k] = {"type": transport_type, "url": v["url"], "tools": ["*"]}
+                if "env" in v:
+                    copilot_cli_configs[k]["env"] = v["env"]
+            else:
+                copilot_cli_configs[k] = {
+                    "type": "stdio",
+                    "command": v["command"],
+                    "args": v.get("args", []),
+                    "tools": ["*"],
+                }
+                if "env" in v:
+                    copilot_cli_configs[k]["env"] = v["env"]
+        result = {
+            "rules_file": {"path": ".github/copilot-instructions.md", "content": rules_content},
+            "mcp_config": {"path": ".mcp.json", "content": {"mcpServers": copilot_cli_configs}},
+            "scope": "project",
+        }
+        if compatibility_warnings:
+            result["_warnings"] = compatibility_warnings
+        return result
+
     if ide == "opencode":
         opencode_configs = {}
         for k, v in mcp_configs.items():

--- a/observal-server/services/config_generator.py
+++ b/observal-server/services/config_generator.py
@@ -152,6 +152,8 @@ def generate_config(
             }
         if ide == "copilot":
             return {"mcpServers": {name: {**config, "type": transport_type}}}
+        if ide == "copilot-cli":
+            return {"mcpServers": {name: {**config, "type": transport_type, "tools": ["*"]}}}
         if ide == "opencode":
             opencode_config: dict = {"type": "remote", "url": listing.url}
             if header_values:
@@ -195,6 +197,8 @@ def generate_config(
             }
         if ide == "copilot":
             return {"mcpServers": {name: {"type": "sse", "url": proxy_url, "env": server_env}}}
+        if ide == "copilot-cli":
+            return {"mcpServers": {name: {"type": "sse", "url": proxy_url, "env": server_env, "tools": ["*"]}}}
         if ide == "opencode":
             return {"mcp": {name: {"type": "remote", "url": proxy_url, "env": server_env}}}
         return {"mcpServers": {name: {"url": proxy_url, "env": server_env}}}
@@ -249,6 +253,20 @@ def generate_config(
                     "command": "observal-shim",
                     "args": shim_args,
                     "env": server_env,
+                    **auto_approve_fields,
+                }
+            },
+        }
+
+    if ide == "copilot-cli":
+        return {
+            "mcpServers": {
+                name: {
+                    "type": "stdio",
+                    "command": "observal-shim",
+                    "args": shim_args,
+                    "env": server_env,
+                    "tools": ["*"],
                     **auto_approve_fields,
                 }
             },

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -65,6 +65,16 @@ IDE_CONFIGS = {
         ],
         "mcp": [],
     },
+    "copilot-cli": {
+        "user_settings": [
+            Path.home() / ".copilot" / "config.json",
+            Path.home() / ".copilot" / "mcp-config.json",
+        ],
+        "project_settings": [
+            Path(".mcp.json"),
+        ],
+        "mcp": [],
+    },
     "opencode": {
         "user_settings": [
             Path.home() / ".config" / "opencode" / "opencode.json",
@@ -356,6 +366,101 @@ def _check_copilot(path: Path, data: dict, issues: list, warnings: list):
             )
 
 
+def _check_copilot_cli(path: Path, data: dict, issues: list, warnings: list):
+    """Check Copilot CLI settings for Observal conflicts."""
+    path_name = path.name
+
+    if path_name == "config.json":
+        # Check hooks configuration
+        if data.get("disableAllHooks"):
+            issues.append(f"{path}: `disableAllHooks` is true. Observal hook telemetry will not fire.")
+
+        hooks = data.get("hooks", {})
+        if not hooks:
+            warnings.append(
+                f"{path}: No Observal hooks configured for Copilot CLI. "
+                "Run `observal scan --ide copilot-cli --home` to inject hook bridge."
+            )
+        else:
+            has_observal_hook = False
+            for _evt, handlers in hooks.items():
+                if not isinstance(handlers, list):
+                    continue
+                for h in handlers:
+                    if isinstance(h, dict) and "otel/hooks" in h.get("bash", ""):
+                        has_observal_hook = True
+                        break
+                if has_observal_hook:
+                    break
+            if not has_observal_hook:
+                warnings.append(
+                    f"{path}: Hooks block exists but no Observal hooks found. "
+                    "Run `observal scan --ide copilot-cli --home` to inject hook bridge."
+                )
+
+    elif path_name == "mcp-config.json":
+        servers = data.get("mcpServers", {})
+        for name, srv_cfg in servers.items():
+            if not isinstance(srv_cfg, dict):
+                continue
+            if "url" in srv_cfg:
+                continue
+            cmd = srv_cfg.get("command", "")
+            args = srv_cfg.get("args", [])
+            full_cmd = f"{cmd} {' '.join(str(a) for a in args)}"
+            if "observal-shim" not in full_cmd and "observal-proxy" not in full_cmd:
+                warnings.append(
+                    f"{path}: MCP server `{name}` is not wrapped with observal-shim. "
+                    "Run `observal scan --ide copilot-cli --home` to wrap them."
+                )
+
+
+def _check_copilot_cli_installation(issues: list, warnings: list):
+    """Check Copilot CLI installation and hook configuration."""
+    if not shutil.which("copilot"):
+        warnings.append(
+            "`copilot` CLI not found in PATH. "
+            "Install with: curl -fsSL https://gh.io/copilot-install | bash"
+        )
+
+    copilot_config = Path.home() / ".copilot" / "config.json"
+    if copilot_config.exists():
+        data = _load_json(copilot_config)
+        if data:
+            hooks = data.get("hooks", {})
+            has_observal = any(
+                "otel/hooks" in h.get("bash", "")
+                for handlers in hooks.values()
+                if isinstance(handlers, list)
+                for h in handlers
+                if isinstance(h, dict)
+            )
+            if not has_observal:
+                warnings.append(
+                    "Copilot CLI config exists but no Observal hooks found. "
+                    "Run `observal scan --ide copilot-cli --home` to inject hooks."
+                )
+
+    mcp_path = Path.home() / ".copilot" / "mcp-config.json"
+    if mcp_path.exists():
+        data = _load_json(mcp_path)
+        if data:
+            servers = data.get("mcpServers", {})
+            unwrapped = [
+                n
+                for n, c in servers.items()
+                if isinstance(c, dict)
+                and "observal-shim" not in c.get("command", "")
+                and "observal-proxy" not in c.get("command", "")
+                and "url" not in c
+            ]
+            if unwrapped:
+                warnings.append(
+                    f"Copilot CLI MCP servers not wrapped with observal-shim: {', '.join(unwrapped)}. "
+                    "Run `observal scan --ide copilot-cli --home` to wrap them."
+                )
+
+
 def _check_opencode(path: Path, data: dict, issues: list, warnings: list):
     """Check OpenCode config for Observal conflicts."""
     mcp = data.get("mcp", {})
@@ -522,7 +627,7 @@ def _check_environment(issues: list, warnings: list):
 def doctor(
     ctx: typer.Context,
     ide: str = typer.Option(
-        None, help="Check specific IDE only (claude-code, kiro, cursor, gemini-cli, copilot, opencode, codex)"
+        None, help="Check specific IDE only (claude-code, kiro, cursor, gemini-cli, copilot, copilot-cli, opencode, codex)"
     ),
     fix: bool = typer.Option(False, help="Show suggested fixes"),
 ):
@@ -552,7 +657,12 @@ def doctor(
         rprint("[cyan]Checking Gemini CLI installation...[/cyan]")
         _check_gemini_installation(issues, warnings)
 
-    # 3c. Codex-specific installation checks
+    # 3c. Copilot CLI-specific installation checks
+    if not ide or ide == "copilot-cli":
+        rprint("[cyan]Checking Copilot CLI installation...[/cyan]")
+        _check_copilot_cli_installation(issues, warnings)
+
+    # 3d. Codex-specific installation checks
     if not ide or ide == "codex":
         rprint("[cyan]Checking Codex installation...[/cyan]")
         _check_codex_installation(issues, warnings)
@@ -574,6 +684,7 @@ def doctor(
             "cursor": _check_cursor,
             "gemini-cli": _check_gemini,
             "copilot": _check_copilot,
+            "copilot-cli": _check_copilot_cli,
             "opencode": _check_opencode,
         }.get(ide_name)
 
@@ -843,17 +954,96 @@ def _install_kiro_hooks(server_url: str) -> tuple[list[str], bool]:
     return changes, changed
 
 
+def _install_copilot_cli_hooks(server_url: str) -> tuple[list[str], bool]:
+    """Install Observal hooks into ~/.copilot/config.json.
+
+    Returns (messages, changed) where changed is True if the file was modified.
+    """
+    import sys
+
+    changes: list[str] = []
+    changed = False
+
+    hooks_url = f"{server_url.rstrip('/')}/api/v1/otel/hooks"
+
+    hook_py = Path(__file__).parent / "hooks" / "copilot_cli_hook.py"
+    stop_py = Path(__file__).parent / "hooks" / "copilot_cli_stop_hook.py"
+
+    if not hook_py.is_file() or not stop_py.is_file():
+        return ["[red]Cannot find copilot_cli_hook.py / copilot_cli_stop_hook.py — reinstall Observal CLI[/red]"], False
+
+    if sys.platform == "win32":
+        bash_cmd = f"python {hook_py.resolve().as_posix()} --url {hooks_url}"
+        bash_stop = f"python {stop_py.resolve().as_posix()} --url {hooks_url}"
+    else:
+        bash_cmd = f"cat | python3 {hook_py.resolve().as_posix()} --url {hooks_url}"
+        bash_stop = f"cat | python3 {stop_py.resolve().as_posix()} --url {hooks_url}"
+    ps_cmd = f"python {hook_py.resolve().as_posix()} --url {hooks_url}"
+    ps_stop = f"python {stop_py.resolve().as_posix()} --url {hooks_url}"
+
+    def _hook_entry(bash: str, ps: str) -> dict:
+        return {"type": "command", "bash": bash, "powershell": ps, "timeoutSec": 10}
+
+    desired_hooks = {
+        "sessionStart": [_hook_entry(bash_cmd, ps_cmd)],
+        "userPromptSubmitted": [_hook_entry(bash_cmd, ps_cmd)],
+        "preToolUse": [_hook_entry(bash_cmd, ps_cmd)],
+        "postToolUse": [_hook_entry(bash_cmd, ps_cmd)],
+        "sessionEnd": [_hook_entry(bash_stop, ps_stop)],
+        "errorOccurred": [_hook_entry(bash_cmd, ps_cmd)],
+    }
+
+    copilot_config = Path.home() / ".copilot" / "config.json"
+    try:
+        data: dict = {}
+        if copilot_config.exists():
+            data = json.loads(copilot_config.read_text())
+
+        existing = data.get("hooks", {})
+
+        for evt, entries in desired_hooks.items():
+            cur = existing.get(evt, [])
+            has_obs = any("otel/hooks" in h.get("bash", "") for h in cur if isinstance(h, dict))
+            if not has_obs:
+                existing[evt] = cur + entries
+                changed = True
+                changes.append(f"+ {evt}: added Observal hook")
+            else:
+                # Check if URL matches
+                obs_bash = next(
+                    (h.get("bash", "") for h in cur if isinstance(h, dict) and "otel/hooks" in h.get("bash", "")),
+                    "",
+                )
+                if hooks_url not in obs_bash:
+                    existing[evt] = [
+                        h for h in cur if not isinstance(h, dict) or "otel/hooks" not in h.get("bash", "")
+                    ] + entries
+                    changed = True
+                    changes.append(f"~ {evt}: updated Observal hook URL")
+                else:
+                    changes.append(f"[dim]  {evt}: already configured[/dim]")
+
+        if changed:
+            data["hooks"] = existing
+            copilot_config.parent.mkdir(parents=True, exist_ok=True)
+            copilot_config.write_text(json.dumps(data, indent=2) + "\n")
+    except Exception as e:
+        return [f"[red]Error updating {copilot_config}: {e}[/red]"], False
+
+    return changes, changed
+
+
 @doctor_app.command(name="sli")
 def doctor_sli(
     ide: str = typer.Option(
         None,
         "--ide",
         "-i",
-        help="Target IDE only (claude-code, kiro, gemini-cli). Default: all.",
+        help="Target IDE only (claude-code, kiro, copilot-cli, gemini-cli). Default: all.",
     ),
     dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show changes without applying"),
 ):
-    """Re-install Observal telemetry hooks into Claude Code, Kiro, and/or Gemini CLI.
+    """Re-install Observal telemetry hooks into Claude Code, Kiro, Copilot CLI, and/or Gemini CLI.
 
     Repairs missing or outdated hooks non-destructively — your existing
     hooks and settings are preserved.
@@ -866,7 +1056,7 @@ def doctor_sli(
         rprint("[red]Not configured. Run [bold]observal auth login[/bold] first.[/red]")
         raise typer.Exit(1)
 
-    targets = [ide] if ide else ["claude-code", "kiro", "gemini-cli"]
+    targets = [ide] if ide else ["claude-code", "kiro", "copilot-cli", "gemini-cli"]
     any_changes = False
 
     for target in targets:
@@ -907,6 +1097,23 @@ def doctor_sli(
             for c in messages:
                 rprint(f"  {c}")
 
+        elif target in ("copilot-cli", "copilot_cli"):
+            rprint("[cyan]Copilot CLI[/cyan]")
+            copilot_dir = Path.home() / ".copilot"
+            if not copilot_dir.is_dir() and not shutil.which("copilot"):
+                rprint("[dim]Copilot CLI not detected — skipping[/dim]")
+                continue
+
+            if dry_run:
+                rprint("  [yellow]Dry run not supported for Copilot CLI — use without --dry-run[/yellow]")
+                continue
+
+            messages, ccli_changed = _install_copilot_cli_hooks(server_url)
+            if ccli_changed:
+                any_changes = True
+            for c in messages:
+                rprint(f"  {c}")
+
         elif target in ("gemini-cli", "gemini_cli"):
             rprint("[cyan]Gemini CLI[/cyan]")
             gemini_settings = Path.home() / ".gemini" / "settings.json"
@@ -942,7 +1149,7 @@ def doctor_sli(
                 rprint("  [dim]Gemini native OTLP already disabled[/dim]")
 
         else:
-            rprint(f"[yellow]Unknown IDE: {target}. Use 'claude-code', 'kiro', or 'gemini-cli'.[/yellow]")
+            rprint(f"[yellow]Unknown IDE: {target}. Use 'claude-code', 'kiro', 'copilot-cli', or 'gemini-cli'.[/yellow]")
 
     if any_changes:
         rprint("\n[green]✓ Hooks installed.[/green] Restart your IDE session to pick up changes.")

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -101,7 +101,10 @@ IDE_CONFIGS = {
 
 def _load_json(path: Path) -> dict | None:
     try:
-        return json.loads(path.read_text())
+        text = path.read_text()
+        # Strip // line comments (JSONC format used by Copilot CLI and others)
+        stripped = "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("//"))
+        return json.loads(stripped)
     except Exception:
         return None
 
@@ -419,8 +422,7 @@ def _check_copilot_cli_installation(issues: list, warnings: list):
     """Check Copilot CLI installation and hook configuration."""
     if not shutil.which("copilot"):
         warnings.append(
-            "`copilot` CLI not found in PATH. "
-            "Install with: curl -fsSL https://gh.io/copilot-install | bash"
+            "`copilot` CLI not found in PATH. Install with: curl -fsSL https://gh.io/copilot-install | bash"
         )
 
     copilot_config = Path.home() / ".copilot" / "config.json"
@@ -627,7 +629,8 @@ def _check_environment(issues: list, warnings: list):
 def doctor(
     ctx: typer.Context,
     ide: str = typer.Option(
-        None, help="Check specific IDE only (claude-code, kiro, cursor, gemini-cli, copilot, copilot-cli, opencode, codex)"
+        None,
+        help="Check specific IDE only (claude-code, kiro, cursor, gemini-cli, copilot, copilot-cli, opencode, codex)",
     ),
     fix: bool = typer.Option(False, help="Show suggested fixes"),
 ):
@@ -972,32 +975,32 @@ def _install_copilot_cli_hooks(server_url: str) -> tuple[list[str], bool]:
     if not hook_py.is_file() or not stop_py.is_file():
         return ["[red]Cannot find copilot_cli_hook.py / copilot_cli_stop_hook.py — reinstall Observal CLI[/red]"], False
 
-    if sys.platform == "win32":
-        bash_cmd = f"python {hook_py.resolve().as_posix()} --url {hooks_url}"
-        bash_stop = f"python {stop_py.resolve().as_posix()} --url {hooks_url}"
-    else:
-        bash_cmd = f"cat | python3 {hook_py.resolve().as_posix()} --url {hooks_url}"
-        bash_stop = f"cat | python3 {stop_py.resolve().as_posix()} --url {hooks_url}"
-    ps_cmd = f"python {hook_py.resolve().as_posix()} --url {hooks_url}"
-    ps_stop = f"python {stop_py.resolve().as_posix()} --url {hooks_url}"
+    hook_path = hook_py.resolve().as_posix()
+    stop_path = stop_py.resolve().as_posix()
 
-    def _hook_entry(bash: str, ps: str) -> dict:
+    def _hook_entry(event: str, is_stop: bool = False) -> dict:
+        script = stop_path if is_stop else hook_path
+        if sys.platform == "win32":
+            bash = f"python {script} --url {hooks_url} --event-name {event}"
+        else:
+            bash = f"cat | python3 {script} --url {hooks_url} --event-name {event}"
+        ps = f"python {script} --url {hooks_url} --event-name {event}"
         return {"type": "command", "bash": bash, "powershell": ps, "timeoutSec": 10}
 
     desired_hooks = {
-        "sessionStart": [_hook_entry(bash_cmd, ps_cmd)],
-        "userPromptSubmitted": [_hook_entry(bash_cmd, ps_cmd)],
-        "preToolUse": [_hook_entry(bash_cmd, ps_cmd)],
-        "postToolUse": [_hook_entry(bash_cmd, ps_cmd)],
-        "sessionEnd": [_hook_entry(bash_stop, ps_stop)],
-        "errorOccurred": [_hook_entry(bash_cmd, ps_cmd)],
+        "sessionStart": [_hook_entry("sessionStart")],
+        "userPromptSubmitted": [_hook_entry("userPromptSubmitted")],
+        "preToolUse": [_hook_entry("preToolUse")],
+        "postToolUse": [_hook_entry("postToolUse")],
+        "sessionEnd": [_hook_entry("sessionEnd", is_stop=True)],
+        "errorOccurred": [_hook_entry("errorOccurred")],
     }
 
     copilot_config = Path.home() / ".copilot" / "config.json"
     try:
         data: dict = {}
         if copilot_config.exists():
-            data = json.loads(copilot_config.read_text())
+            data = _load_json(copilot_config) or {}
 
         existing = data.get("hooks", {})
 
@@ -1149,7 +1152,9 @@ def doctor_sli(
                 rprint("  [dim]Gemini native OTLP already disabled[/dim]")
 
         else:
-            rprint(f"[yellow]Unknown IDE: {target}. Use 'claude-code', 'kiro', 'copilot-cli', or 'gemini-cli'.[/yellow]")
+            rprint(
+                f"[yellow]Unknown IDE: {target}. Use 'claude-code', 'kiro', 'copilot-cli', or 'gemini-cli'.[/yellow]"
+            )
 
     if any_changes:
         rprint("\n[green]✓ Hooks installed.[/green] Restart your IDE session to pick up changes.")

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -31,6 +31,7 @@ _IDE_PROJECT_CONFIGS = {
     "kiro": ".kiro/settings/mcp.json",
     "vscode": ".vscode/mcp.json",
     "copilot": ".vscode/mcp.json",
+    "copilot-cli": ".mcp.json",
     "gemini-cli": ".gemini/settings.json",
     "opencode": "opencode.json",
     "codex": ".codex/config.toml",
@@ -511,6 +512,38 @@ def _scan_copilot_home(
     return mcps, skills, hooks, agents
 
 
+def _scan_copilot_cli_home(
+    copilot_dir: Path,
+) -> tuple[list[DiscoveredMcp], list[DiscoveredSkill], list[DiscoveredHook], list[DiscoveredAgent]]:
+    """Scan ~/.copilot for MCP servers from mcp-config.json."""
+    mcps: list[DiscoveredMcp] = []
+    skills: list[DiscoveredSkill] = []
+    hooks: list[DiscoveredHook] = []
+    agents: list[DiscoveredAgent] = []
+
+    mcp_file = copilot_dir / "mcp-config.json"
+    if mcp_file.exists():
+        try:
+            data = json.loads(mcp_file.read_text())
+            servers = data.get("mcpServers", {})
+            for srv_name, srv_config in servers.items():
+                if isinstance(srv_config, dict):
+                    mcps.append(
+                        DiscoveredMcp(
+                            name=srv_name,
+                            command=srv_config.get("command"),
+                            args=srv_config.get("args", []),
+                            url=srv_config.get("url"),
+                            description=f"Copilot CLI MCP: {srv_name}",
+                            source="copilot-cli:global",
+                        )
+                    )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return mcps, skills, hooks, agents
+
+
 def _scan_opencode_home(
     opencode_dir: Path,
 ) -> tuple[list[DiscoveredMcp], list[DiscoveredSkill], list[DiscoveredHook], list[DiscoveredAgent]]:
@@ -664,6 +697,8 @@ def _parse_project_mcp_servers(config: dict, ide: str) -> dict[str, dict]:
     """Extract MCP servers dict from project-level IDE config."""
     if ide in ("vscode", "copilot"):
         return config.get("servers", config.get("mcpServers", {}))
+    if ide == "copilot-cli":
+        return config.get("mcpServers", {})
     if ide == "opencode":
         return config.get("mcp", {})
     if ide == "codex":
@@ -829,6 +864,7 @@ def register_scan(app: typer.Typer):
         scan_gemini = False
         scan_codex = False
         scan_copilot = False
+        scan_copilot_cli = False
         scan_opencode = False
 
         if all_ides:
@@ -838,6 +874,7 @@ def register_scan(app: typer.Typer):
             scan_gemini = True
             scan_codex = True
             scan_copilot = True
+            scan_copilot_cli = True
             scan_opencode = True
         elif home:
             if ide == "kiro":
@@ -848,6 +885,8 @@ def register_scan(app: typer.Typer):
                 scan_codex = True
             elif ide == "copilot":
                 scan_copilot = True
+            elif ide == "copilot-cli":
+                scan_copilot_cli = True
             elif ide == "opencode":
                 scan_opencode = True
             elif ide == "claude-code" or ide is None:
@@ -857,6 +896,7 @@ def register_scan(app: typer.Typer):
                     scan_gemini = True
                     scan_codex = True
                     scan_copilot = True
+                    scan_copilot_cli = True
                     scan_opencode = True
 
         # ── Scan ~/.claude ─────────────────────────────
@@ -929,6 +969,20 @@ def register_scan(app: typer.Typer):
             elif not all_ides:
                 rprint("[yellow]~/.vscode directory not found.[/yellow]")
 
+        # ── Scan ~/.copilot (Copilot CLI) ────────────
+        if scan_copilot_cli:
+            copilot_cli_dir = Path.home() / ".copilot"
+            if copilot_cli_dir.is_dir():
+                with spinner("Scanning ~/.copilot..."):
+                    ccli_mcps, ccli_skills, ccli_hooks, ccli_agents = _scan_copilot_cli_home(copilot_cli_dir)
+                all_mcps.extend(ccli_mcps)
+                all_skills.extend(ccli_skills)
+                all_hooks.extend(ccli_hooks)
+                all_agents.extend(ccli_agents)
+                scanned_ides.append("copilot-cli")
+            elif not all_ides:
+                rprint("[yellow]~/.copilot directory not found.[/yellow]")
+
         # ── Scan ~/.config/opencode ──────────────────
         if scan_opencode:
             opencode_dir = Path.home() / ".config" / "opencode"
@@ -974,6 +1028,7 @@ def register_scan(app: typer.Typer):
             scan_gemini = True
             scan_codex = True
             scan_copilot = True
+            scan_copilot_cli = True
             scan_opencode = True
 
             for _ide_name, _dir_path, _scan_fn, _label in [
@@ -982,6 +1037,7 @@ def register_scan(app: typer.Typer):
                 ("gemini-cli", Path.home() / ".gemini", _scan_gemini_home, "~/.gemini"),
                 ("codex", Path.home() / ".codex", _scan_codex_home, "~/.codex"),
                 ("copilot", Path.home() / ".vscode", _scan_copilot_home, "~/.vscode"),
+                ("copilot-cli", Path.home() / ".copilot", _scan_copilot_cli_home, "~/.copilot"),
                 ("opencode", Path.home() / ".config" / "opencode", _scan_opencode_home, "~/.config/opencode"),
             ]:
                 if _dir_path.is_dir():
@@ -1352,6 +1408,89 @@ def register_scan(app: typer.Typer):
             else:
                 rprint("[dim]Global Kiro hooks already configured.[/dim]")
 
+        # ── Auto-inject hooks into ~/.copilot/config.json ─────
+        if scan_copilot_cli:
+            from observal_cli.config import load as _load_copilot_cli_config
+
+            ccli_cfg = _load_copilot_cli_config()
+            ccli_server_url = ccli_cfg.get("server_url", "http://localhost:8000").rstrip("/")
+            ccli_hooks_url = f"{ccli_server_url}/api/v1/otel/hooks"
+
+            hooks_dir = Path(__file__).parent / "hooks"
+            ccli_hook_script = hooks_dir / "copilot_cli_hook.py"
+            ccli_stop_script = hooks_dir / "copilot_cli_stop_hook.py"
+
+            if ccli_hook_script.is_file() and ccli_stop_script.is_file():
+                if sys.platform == "win32":
+                    bash_cmd = f"python {ccli_hook_script.resolve().as_posix()} --url {ccli_hooks_url}"
+                    bash_stop = f"python {ccli_stop_script.resolve().as_posix()} --url {ccli_hooks_url}"
+                else:
+                    bash_cmd = f"cat | python3 {ccli_hook_script.resolve().as_posix()} --url {ccli_hooks_url}"
+                    bash_stop = f"cat | python3 {ccli_stop_script.resolve().as_posix()} --url {ccli_hooks_url}"
+                ps_cmd = f"python {ccli_hook_script.resolve().as_posix()} --url {ccli_hooks_url}"
+                ps_stop = f"python {ccli_stop_script.resolve().as_posix()} --url {ccli_hooks_url}"
+
+                def _copilot_hook_entry(bash: str, ps: str) -> dict:
+                    return {"type": "command", "bash": bash, "powershell": ps, "timeoutSec": 10}
+
+                desired_hooks = {
+                    "sessionStart": [_copilot_hook_entry(bash_cmd, ps_cmd)],
+                    "userPromptSubmitted": [_copilot_hook_entry(bash_cmd, ps_cmd)],
+                    "preToolUse": [_copilot_hook_entry(bash_cmd, ps_cmd)],
+                    "postToolUse": [_copilot_hook_entry(bash_cmd, ps_cmd)],
+                    "sessionEnd": [_copilot_hook_entry(bash_stop, ps_stop)],
+                    "errorOccurred": [_copilot_hook_entry(bash_cmd, ps_cmd)],
+                }
+
+                copilot_config_path = Path.home() / ".copilot" / "config.json"
+                try:
+                    copilot_data: dict = {}
+                    if copilot_config_path.exists():
+                        copilot_data = json.loads(copilot_config_path.read_text())
+
+                    existing_hooks = copilot_data.get("hooks", {})
+                    needs_update = False
+
+                    for event_name, entries in desired_hooks.items():
+                        if event_name not in existing_hooks:
+                            needs_update = True
+                            break
+                        existing_bash = ""
+                        try:
+                            existing_bash = existing_hooks[event_name][0].get("bash", "")
+                        except (IndexError, TypeError, AttributeError):
+                            pass
+                        if "otel/hooks" not in existing_bash:
+                            needs_update = True
+                            break
+
+                    if needs_update:
+                        if copilot_config_path.exists():
+                            _backup_config(copilot_config_path)
+                        # Merge non-destructively: preserve user hooks on events we don't own
+                        merged_hooks = dict(existing_hooks)
+                        for evt, entries in desired_hooks.items():
+                            cur = merged_hooks.get(evt, [])
+                            has_obs = any("otel/hooks" in h.get("bash", "") for h in cur if isinstance(h, dict))
+                            if not has_obs:
+                                merged_hooks[evt] = cur + entries
+                            else:
+                                # Update existing Observal hook entry
+                                merged_hooks[evt] = [
+                                    h for h in cur if not isinstance(h, dict) or "otel/hooks" not in h.get("bash", "")
+                                ] + entries
+                        copilot_data["hooks"] = merged_hooks
+                        copilot_config_path.parent.mkdir(parents=True, exist_ok=True)
+                        copilot_config_path.write_text(json.dumps(copilot_data, indent=2) + "\n")
+                        rprint(f"\n[green]Injected hooks config into {copilot_config_path}[/green]")
+                        rprint(f"[dim]Hooks endpoint: {ccli_hooks_url}[/dim]")
+                        rprint("[dim]Captures: session lifecycle, prompts, tool I/O, errors[/dim]")
+                    else:
+                        rprint(f"\n[dim]Copilot CLI hooks already configured -> {ccli_hooks_url}[/dim]")
+                except Exception as e:
+                    rprint(f"\n[yellow]Could not auto-inject Copilot CLI hooks: {e}[/yellow]")
+                    rprint("[dim]Add hooks manually to ~/.copilot/config.json — see docs.[/dim]")
+
         # ── Auto-inject telemetry into ~/.gemini/settings.json ──
         if scan_gemini:
             from observal_cli.config import load as _load_gemini_config
@@ -1464,6 +1603,13 @@ def register_scan(app: typer.Typer):
             _auto_shim_home_config(
                 Path.home() / ".vscode" / "mcp.json",
                 "copilot",
+            )
+
+        # ── Auto-shim Copilot CLI home MCP servers ──
+        if scan_copilot_cli:
+            _auto_shim_home_config(
+                Path.home() / ".copilot" / "mcp-config.json",
+                "copilot-cli",
             )
 
         # ── Auto-shim OpenCode home MCP servers ──

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -1023,15 +1023,8 @@ def register_scan(app: typer.Typer):
         if total == 0 and not home:
             rprint("[dim]No components in project directory. Scanning IDE home dirs...[/dim]")
             home = True
-            scan_claude = True
-            scan_kiro = True
-            scan_gemini = True
-            scan_codex = True
-            scan_copilot = True
-            scan_copilot_cli = True
-            scan_opencode = True
 
-            for _ide_name, _dir_path, _scan_fn, _label in [
+            _fallback_ides = [
                 ("claude-code", Path.home() / ".claude", _scan_claude_home, "~/.claude"),
                 ("kiro", Path.home() / ".kiro", _scan_kiro_home, "~/.kiro"),
                 ("gemini-cli", Path.home() / ".gemini", _scan_gemini_home, "~/.gemini"),
@@ -1039,7 +1032,11 @@ def register_scan(app: typer.Typer):
                 ("copilot", Path.home() / ".vscode", _scan_copilot_home, "~/.vscode"),
                 ("copilot-cli", Path.home() / ".copilot", _scan_copilot_cli_home, "~/.copilot"),
                 ("opencode", Path.home() / ".config" / "opencode", _scan_opencode_home, "~/.config/opencode"),
-            ]:
+            ]
+
+            for _ide_name, _dir_path, _scan_fn, _label in _fallback_ides:
+                if ide and _ide_name != ide:
+                    continue
                 if _dir_path.is_dir():
                     with spinner(f"Scanning {_label}..."):
                         h_mcps, h_skills, h_hooks, h_agents = _scan_fn(_dir_path)
@@ -1048,6 +1045,22 @@ def register_scan(app: typer.Typer):
                     all_hooks.extend(h_hooks)
                     all_agents.extend(h_agents)
                     scanned_ides.append(_ide_name)
+
+            # Set scan flags so hook injection runs for the right IDEs
+            if not ide or ide == "claude-code":
+                scan_claude = True
+            if not ide or ide == "kiro":
+                scan_kiro = True
+            if not ide or ide == "gemini-cli":
+                scan_gemini = True
+            if not ide or ide == "codex":
+                scan_codex = True
+            if not ide or ide == "copilot":
+                scan_copilot = True
+            if not ide or ide == "copilot-cli":
+                scan_copilot_cli = True
+            if not ide or ide == "opencode":
+                scan_opencode = True
 
             if root != Path.home():
                 _do_project_scan(Path.home())

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -19,6 +19,13 @@ from observal_cli.render import console, spinner
 _OBSERVAL_NS = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 
 
+def _load_jsonc(path: Path) -> dict:
+    """Load a JSON file that may contain // line comments (JSONC)."""
+    text = path.read_text()
+    stripped = "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("//"))
+    return json.loads(stripped)
+
+
 def _deterministic_mcp_id(name: str) -> str:
     """Generate a stable UUID for an MCP based on its name."""
     return str(uuid.uuid5(_OBSERVAL_NS, name))
@@ -1434,37 +1441,37 @@ def register_scan(app: typer.Typer):
             ccli_stop_script = hooks_dir / "copilot_cli_stop_hook.py"
 
             if ccli_hook_script.is_file() and ccli_stop_script.is_file():
-                if sys.platform == "win32":
-                    bash_cmd = f"python {ccli_hook_script.resolve().as_posix()} --url {ccli_hooks_url}"
-                    bash_stop = f"python {ccli_stop_script.resolve().as_posix()} --url {ccli_hooks_url}"
-                else:
-                    bash_cmd = f"cat | python3 {ccli_hook_script.resolve().as_posix()} --url {ccli_hooks_url}"
-                    bash_stop = f"cat | python3 {ccli_stop_script.resolve().as_posix()} --url {ccli_hooks_url}"
-                ps_cmd = f"python {ccli_hook_script.resolve().as_posix()} --url {ccli_hooks_url}"
-                ps_stop = f"python {ccli_stop_script.resolve().as_posix()} --url {ccli_hooks_url}"
+                hook_path = ccli_hook_script.resolve().as_posix()
+                stop_path = ccli_stop_script.resolve().as_posix()
 
-                def _copilot_hook_entry(bash: str, ps: str) -> dict:
+                def _copilot_hook_entry(event: str, is_stop: bool = False) -> dict:
+                    script = stop_path if is_stop else hook_path
+                    if sys.platform == "win32":
+                        bash = f"python {script} --url {ccli_hooks_url} --event-name {event}"
+                    else:
+                        bash = f"cat | python3 {script} --url {ccli_hooks_url} --event-name {event}"
+                    ps = f"python {script} --url {ccli_hooks_url} --event-name {event}"
                     return {"type": "command", "bash": bash, "powershell": ps, "timeoutSec": 10}
 
                 desired_hooks = {
-                    "sessionStart": [_copilot_hook_entry(bash_cmd, ps_cmd)],
-                    "userPromptSubmitted": [_copilot_hook_entry(bash_cmd, ps_cmd)],
-                    "preToolUse": [_copilot_hook_entry(bash_cmd, ps_cmd)],
-                    "postToolUse": [_copilot_hook_entry(bash_cmd, ps_cmd)],
-                    "sessionEnd": [_copilot_hook_entry(bash_stop, ps_stop)],
-                    "errorOccurred": [_copilot_hook_entry(bash_cmd, ps_cmd)],
+                    "sessionStart": [_copilot_hook_entry("sessionStart")],
+                    "userPromptSubmitted": [_copilot_hook_entry("userPromptSubmitted")],
+                    "preToolUse": [_copilot_hook_entry("preToolUse")],
+                    "postToolUse": [_copilot_hook_entry("postToolUse")],
+                    "sessionEnd": [_copilot_hook_entry("sessionEnd", is_stop=True)],
+                    "errorOccurred": [_copilot_hook_entry("errorOccurred")],
                 }
 
                 copilot_config_path = Path.home() / ".copilot" / "config.json"
                 try:
                     copilot_data: dict = {}
                     if copilot_config_path.exists():
-                        copilot_data = json.loads(copilot_config_path.read_text())
+                        copilot_data = _load_jsonc(copilot_config_path)
 
                     existing_hooks = copilot_data.get("hooks", {})
                     needs_update = False
 
-                    for event_name, entries in desired_hooks.items():
+                    for event_name, _entries in desired_hooks.items():
                         if event_name not in existing_hooks:
                             needs_update = True
                             break

--- a/observal_cli/constants.py
+++ b/observal_cli/constants.py
@@ -20,6 +20,7 @@ VALID_IDES: list[str] = [
     "vscode",
     "codex",
     "copilot",
+    "copilot-cli",
     "opencode",
 ]
 
@@ -44,6 +45,7 @@ IDE_FEATURE_MATRIX: dict[str, set[str]] = {
     "gemini-cli": {"hook_bridge", "mcp_servers", "rules", "otlp_telemetry"},
     "codex": {"rules"},
     "copilot": {"mcp_servers", "rules"},
+    "copilot-cli": {"mcp_servers", "rules", "hook_bridge"},
     "opencode": {"mcp_servers", "rules"},
     "vscode": {"mcp_servers", "rules"},
 }

--- a/observal_cli/hooks/copilot_cli_hook.py
+++ b/observal_cli/hooks/copilot_cli_hook.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Lightweight Copilot CLI hook script for non-stop events.
+
+Reads the hook JSON payload from stdin, injects Observal metadata
+(service_name, session_id, user identity), and forwards it to the
+Observal hooks endpoint.
+
+Usage (in ~/.copilot/config.json hooks):
+    Unix:    cat | python3 /path/to/copilot_cli_hook.py --url http://localhost:8000/api/v1/otel/hooks
+    Windows: python -m observal_cli.hooks.copilot_cli_hook --url http://localhost:8000/api/v1/otel/hooks
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _resolve_hooks_url() -> str:
+    """Read hooks URL from config file when no --url is provided."""
+    cfg_path = Path.home() / ".observal" / "config.json"
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text())
+            server = cfg.get("server_url", "")
+            if server:
+                return f"{server.rstrip('/')}/api/v1/otel/hooks"
+        except Exception:
+            pass
+    return "http://localhost:8000/api/v1/otel/hooks"
+
+
+def main():
+    import urllib.request
+
+    url = ""
+    model = ""
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--url" and i + 1 < len(args):
+            url = args[i + 1]
+        elif arg == "--model" and i + 1 < len(args):
+            model = args[i + 1]
+    if not url:
+        url = _resolve_hooks_url()
+
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    payload.setdefault("service_name", "copilot-cli")
+
+    if not payload.get("session_id"):
+        payload["session_id"] = f"copilot-cli-{os.getppid()}"
+
+    # Inject user_id and user_name from Observal config if not already present
+    if not payload.get("user_id") or not payload.get("user_name"):
+        try:
+            cfg_path = Path.home() / ".observal" / "config.json"
+            if cfg_path.exists():
+                cfg = json.loads(cfg_path.read_text())
+                if not payload.get("user_id") and cfg.get("user_id"):
+                    payload["user_id"] = cfg["user_id"]
+                if not payload.get("user_name") and cfg.get("user_name"):
+                    payload["user_name"] = cfg["user_name"]
+        except Exception:
+            pass
+
+    if model:
+        payload.setdefault("model", model)
+
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/observal_cli/hooks/copilot_cli_hook.py
+++ b/observal_cli/hooks/copilot_cli_hook.py
@@ -17,6 +17,50 @@ import os
 import sys
 from pathlib import Path
 
+# Copilot CLI sends camelCase fields; normalize to snake_case for the server.
+_FIELD_MAP = {
+    "sessionId": "session_id",
+    "conversationId": "session_id",
+    "threadId": "session_id",
+    "hookEventName": "hook_event_name",
+    "serviceName": "service_name",
+    "userId": "user_id",
+    "userName": "user_name",
+}
+
+
+def _normalize(payload: dict) -> dict:
+    """Map camelCase Copilot CLI fields to the snake_case the server expects."""
+    for camel, snake in _FIELD_MAP.items():
+        if camel in payload and snake not in payload:
+            payload[snake] = payload[camel]
+    return payload
+
+
+def _stable_session_id() -> str:
+    """Derive a session ID that stays the same across all hooks in one session.
+
+    Hook commands run as:  copilot (stable) → bash (new per hook) → python3
+    os.getppid() returns the bash PID which differs per hook invocation.
+    We walk up one level to the grandparent (the copilot process) for stability.
+    """
+    ppid = os.getppid()
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(ppid)],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        gppid = result.stdout.strip()
+        if gppid and gppid not in ("0", "1"):
+            return f"copilot-cli-{gppid}"
+    except Exception:
+        pass
+    return f"copilot-cli-{ppid}"
+
 
 def _resolve_hooks_url() -> str:
     """Read hooks URL from config file when no --url is provided."""
@@ -37,12 +81,15 @@ def main():
 
     url = ""
     model = ""
+    event_name = ""
     args = sys.argv[1:]
     for i, arg in enumerate(args):
         if arg == "--url" and i + 1 < len(args):
             url = args[i + 1]
         elif arg == "--model" and i + 1 < len(args):
             model = args[i + 1]
+        elif arg == "--event-name" and i + 1 < len(args):
+            event_name = args[i + 1]
     if not url:
         url = _resolve_hooks_url()
 
@@ -52,10 +99,35 @@ def main():
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
-    payload.setdefault("service_name", "copilot-cli")
+    _normalize(payload)
+
+    # Map Copilot CLI fields to what the server expects.
+    # Copilot CLI sends: prompt, initialPrompt, toolName, toolArgs, toolResult
+    if not payload.get("tool_name") and "toolName" in payload:
+        payload["tool_name"] = payload["toolName"]
+
+    if not payload.get("tool_input"):
+        for key in ("prompt", "initialPrompt", "toolArgs"):
+            if key in payload:
+                val = payload[key]
+                payload["tool_input"] = json.dumps(val) if isinstance(val, dict) else str(val)
+                break
+
+    if not payload.get("tool_response"):
+        # postToolUse sends toolResult: {resultType, textResultForLlm}
+        tr = payload.get("toolResult")
+        if isinstance(tr, dict):
+            payload["tool_response"] = tr.get("textResultForLlm", json.dumps(tr))
+        elif isinstance(tr, str):
+            payload["tool_response"] = tr
+
+    payload["service_name"] = "copilot-cli"
+
+    if event_name:
+        payload["hook_event_name"] = event_name
 
     if not payload.get("session_id"):
-        payload["session_id"] = f"copilot-cli-{os.getppid()}"
+        payload["session_id"] = _stable_session_id()
 
     # Inject user_id and user_name from Observal config if not already present
     if not payload.get("user_id") or not payload.get("user_name"):

--- a/observal_cli/hooks/copilot_cli_stop_hook.py
+++ b/observal_cli/hooks/copilot_cli_stop_hook.py
@@ -20,6 +20,50 @@ import os
 import sys
 from pathlib import Path
 
+# Copilot CLI sends camelCase fields; normalize to snake_case for the server.
+_FIELD_MAP = {
+    "sessionId": "session_id",
+    "conversationId": "session_id",
+    "threadId": "session_id",
+    "hookEventName": "hook_event_name",
+    "serviceName": "service_name",
+    "userId": "user_id",
+    "userName": "user_name",
+}
+
+
+def _normalize(payload: dict) -> dict:
+    """Map camelCase Copilot CLI fields to the snake_case the server expects."""
+    for camel, snake in _FIELD_MAP.items():
+        if camel in payload and snake not in payload:
+            payload[snake] = payload[camel]
+    return payload
+
+
+def _stable_session_id() -> str:
+    """Derive a session ID that stays the same across all hooks in one session.
+
+    Hook commands run as:  copilot (stable) → bash (new per hook) → python3
+    os.getppid() returns the bash PID which differs per hook invocation.
+    We walk up one level to the grandparent (the copilot process) for stability.
+    """
+    ppid = os.getppid()
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(ppid)],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        gppid = result.stdout.strip()
+        if gppid and gppid not in ("0", "1"):
+            return f"copilot-cli-{gppid}"
+    except Exception:
+        pass
+    return f"copilot-cli-{ppid}"
+
 
 def _resolve_hooks_url() -> str:
     """Read hooks URL from config file when no --url is provided."""
@@ -49,12 +93,15 @@ def main():
 
     url = ""
     model = ""
+    event_name = ""
     args = sys.argv[1:]
     for i, arg in enumerate(args):
         if arg == "--url" and i + 1 < len(args):
             url = args[i + 1]
         elif arg == "--model" and i + 1 < len(args):
             model = args[i + 1]
+        elif arg == "--event-name" and i + 1 < len(args):
+            event_name = args[i + 1]
     if not url:
         url = _resolve_hooks_url()
 
@@ -64,10 +111,33 @@ def main():
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
-    payload.setdefault("service_name", "copilot-cli")
+    _normalize(payload)
+
+    # Map Copilot CLI fields to what the server expects.
+    if not payload.get("tool_name") and "toolName" in payload:
+        payload["tool_name"] = payload["toolName"]
+
+    if not payload.get("tool_input"):
+        for key in ("prompt", "initialPrompt", "toolArgs"):
+            if key in payload:
+                val = payload[key]
+                payload["tool_input"] = json.dumps(val) if isinstance(val, dict) else str(val)
+                break
+
+    if not payload.get("tool_response"):
+        tr = payload.get("toolResult")
+        if isinstance(tr, dict):
+            payload["tool_response"] = tr.get("textResultForLlm", json.dumps(tr))
+        elif isinstance(tr, str):
+            payload["tool_response"] = tr
+
+    payload["service_name"] = "copilot-cli"
+
+    if event_name:
+        payload["hook_event_name"] = event_name
 
     if not payload.get("session_id"):
-        payload["session_id"] = f"copilot-cli-{os.getppid()}"
+        payload["session_id"] = _stable_session_id()
 
     # Inject user_id and user_name from Observal config if not already present
     if not payload.get("user_id") or not payload.get("user_name"):

--- a/observal_cli/hooks/copilot_cli_stop_hook.py
+++ b/observal_cli/hooks/copilot_cli_stop_hook.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Copilot CLI sessionEnd hook script.
+
+Handles the ``sessionEnd`` event separately so future enrichment
+(e.g. reading a local conversation store if Copilot CLI exposes one)
+can be added here without slowing down the hot-path hooks.
+
+Currently identical to copilot_cli_hook.py — the split exists to
+mirror the Kiro pattern and provide a clear extension point.
+
+Usage (in ~/.copilot/config.json hooks):
+    Unix:    cat | python3 /path/to/copilot_cli_stop_hook.py --url http://localhost:8000/api/v1/otel/hooks
+    Windows: python -m observal_cli.hooks.copilot_cli_stop_hook --url http://localhost:8000/api/v1/otel/hooks
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _resolve_hooks_url() -> str:
+    """Read hooks URL from config file when no --url is provided."""
+    cfg_path = Path.home() / ".observal" / "config.json"
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text())
+            server = cfg.get("server_url", "")
+            if server:
+                return f"{server.rstrip('/')}/api/v1/otel/hooks"
+        except Exception:
+            pass
+    return "http://localhost:8000/api/v1/otel/hooks"
+
+
+def _enrich(payload: dict) -> dict:
+    """Placeholder for future session-end enrichment.
+
+    When Copilot CLI exposes a local conversation store, this function
+    can read turn counts, token usage, etc. — similar to kiro_stop_hook._enrich().
+    """
+    return payload
+
+
+def main():
+    import urllib.request
+
+    url = ""
+    model = ""
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--url" and i + 1 < len(args):
+            url = args[i + 1]
+        elif arg == "--model" and i + 1 < len(args):
+            model = args[i + 1]
+    if not url:
+        url = _resolve_hooks_url()
+
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    payload.setdefault("service_name", "copilot-cli")
+
+    if not payload.get("session_id"):
+        payload["session_id"] = f"copilot-cli-{os.getppid()}"
+
+    # Inject user_id and user_name from Observal config if not already present
+    if not payload.get("user_id") or not payload.get("user_name"):
+        try:
+            cfg_path = Path.home() / ".observal" / "config.json"
+            if cfg_path.exists():
+                cfg = json.loads(cfg_path.read_text())
+                if not payload.get("user_id") and cfg.get("user_id"):
+                    payload["user_id"] = cfg["user_id"]
+                if not payload.get("user_name") and cfg.get("user_name"):
+                    payload["user_name"] = cfg["user_name"]
+        except Exception:
+            pass
+
+    if model:
+        payload.setdefault("model", model)
+
+    payload = _enrich(payload)
+
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -1184,11 +1184,7 @@ class TestDoctorCopilotCli:
     def test_check_copilot_cli_fn_no_warning_on_shimmed_mcp(self):
         from observal_cli.cmd_doctor import _check_copilot_cli
 
-        data = {
-            "mcpServers": {
-                "my-srv": {"command": "observal-shim", "args": ["--mcp-id", "test", "--", "npx"]}
-            }
-        }
+        data = {"mcpServers": {"my-srv": {"command": "observal-shim", "args": ["--mcp-id", "test", "--", "npx"]}}}
         issues = []
         warnings = []
         _check_copilot_cli(Path("mcp-config.json"), data, issues, warnings)
@@ -1230,9 +1226,7 @@ class TestConfigGeneratorCopilotCli:
     def test_copilot_cli_sse_has_type_sse(self):
         from services.config_generator import generate_config
 
-        cfg = generate_config(
-            self._make_listing(url="http://localhost:3000/sse", transport="sse"), "copilot-cli"
-        )
+        cfg = generate_config(self._make_listing(url="http://localhost:3000/sse", transport="sse"), "copilot-cli")
         server = cfg["mcpServers"]["my-mcp"]
         assert server["type"] == "sse"
         assert server["url"] == "http://localhost:3000/sse"

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -98,15 +98,24 @@ class TestConstants:
         assert "opencode" in IDE_FEATURE_MATRIX
         assert IDE_FEATURE_MATRIX["opencode"] == {"mcp_servers", "rules"}
 
+    def test_copilot_cli_in_valid_ides(self):
+        assert "copilot-cli" in VALID_IDES
+
+    def test_copilot_cli_feature_matrix(self):
+        assert "copilot-cli" in IDE_FEATURE_MATRIX
+        assert IDE_FEATURE_MATRIX["copilot-cli"] == {"mcp_servers", "rules", "hook_bridge"}
+
     def test_ide_project_configs_include_all_new_ides(self):
         assert "codex" in _IDE_PROJECT_CONFIGS
         assert "copilot" in _IDE_PROJECT_CONFIGS
+        assert "copilot-cli" in _IDE_PROJECT_CONFIGS
         assert "gemini-cli" in _IDE_PROJECT_CONFIGS
         assert "opencode" in _IDE_PROJECT_CONFIGS
 
     def test_ide_project_config_paths(self):
         assert _IDE_PROJECT_CONFIGS["codex"] == ".codex/config.toml"
         assert _IDE_PROJECT_CONFIGS["copilot"] == ".vscode/mcp.json"
+        assert _IDE_PROJECT_CONFIGS["copilot-cli"] == ".mcp.json"
         assert _IDE_PROJECT_CONFIGS["gemini-cli"] == ".gemini/settings.json"
         assert _IDE_PROJECT_CONFIGS["opencode"] == "opencode.json"
 
@@ -233,6 +242,73 @@ class TestGenerateCopilotConfig:
         servers = cfg["mcp_config"]["content"]["servers"]
         assert servers["srv-a"]["type"] == "stdio"
         assert servers["srv-b"]["type"] == "stdio"
+
+
+class TestGenerateCopilotCliConfig:
+    def test_rules_path(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot-cli")
+        assert cfg["rules_file"]["path"] == ".github/copilot-instructions.md"
+
+    def test_mcp_config_path(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot-cli")
+        assert cfg["mcp_config"]["path"] == ".mcp.json"
+
+    def test_mcp_config_root_key_is_mcpServers(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot-cli")
+        assert "mcpServers" in cfg["mcp_config"]["content"]
+        assert "servers" not in cfg["mcp_config"]["content"]
+        assert "my-server" in cfg["mcp_config"]["content"]["mcpServers"]
+
+    def test_copilot_cli_entries_have_type_stdio(self):
+        ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot-cli")
+        entry = cfg["mcp_config"]["content"]["mcpServers"]["my-server"]
+        assert entry["type"] == "stdio"
+        assert entry["command"] == "observal-shim"
+        assert isinstance(entry["args"], list)
+        assert entry["tools"] == ["*"]
+
+    def test_copilot_cli_preserves_env_vars(self):
+        ext = [{"name": "my-server", "command": "npx", "args": [], "env": {"API_KEY": "secret"}}]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot-cli")
+        entry = cfg["mcp_config"]["content"]["mcpServers"]["my-server"]
+        assert entry["env"]["API_KEY"] == "secret"
+        assert entry["env"]["OBSERVAL_AGENT_ID"] == str(agent.id)
+
+    def test_scope_is_project(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot-cli")
+        assert cfg["scope"] == "project"
+
+    def test_rules_content_not_empty(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot-cli")
+        assert len(cfg["rules_file"]["content"]) > 0
+
+    def test_empty_mcp_configs_still_produces_valid_structure(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "copilot-cli")
+        assert "mcp_config" in cfg
+        assert "mcpServers" in cfg["mcp_config"]["content"]
+
+    def test_multiple_mcps_all_get_type_stdio(self):
+        ext = [
+            {"name": "srv-a", "command": "npx", "args": ["-y", "a"]},
+            {"name": "srv-b", "command": "node", "args": ["b.js"]},
+        ]
+        agent = _make_agent(external_mcps=ext)
+        cfg = generate_agent_config(agent, "copilot-cli")
+        servers = cfg["mcp_config"]["content"]["mcpServers"]
+        assert servers["srv-a"]["type"] == "stdio"
+        assert servers["srv-b"]["type"] == "stdio"
+        assert servers["srv-a"]["tools"] == ["*"]
+        assert servers["srv-b"]["tools"] == ["*"]
 
 
 class TestGenerateOpenCodeConfig:
@@ -404,6 +480,18 @@ class TestIdeCompatibilityWarnings:
         agent.required_ide_features = ["mcp_servers", "rules"]
         warnings = _check_ide_compatibility(agent, "copilot")
         assert len(warnings) == 0
+
+    def test_copilot_cli_supports_hook_bridge(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["mcp_servers", "rules", "hook_bridge"]
+        warnings = _check_ide_compatibility(agent, "copilot-cli")
+        assert len(warnings) == 0
+
+    def test_copilot_cli_warns_on_unsupported_features(self):
+        agent = _make_agent()
+        agent.required_ide_features = ["skills", "otlp_telemetry"]
+        warnings = _check_ide_compatibility(agent, "copilot-cli")
+        assert len(warnings) == 2
 
     def test_codex_warns_on_skills_requirement(self):
         agent = _make_agent()
@@ -1027,6 +1115,201 @@ class TestDoctorCopilot:
         warnings = []
         _check_copilot(Path(".vscode/mcp.json"), data, issues, warnings)
         assert len(warnings) > 0
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 10b. DOCTOR — Copilot CLI IDE config checks
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestDoctorCopilotCli:
+    def test_copilot_cli_in_ide_configs(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        assert "copilot-cli" in IDE_CONFIGS
+        assert IDE_CONFIGS["copilot-cli"]["user_settings"] != []
+        assert IDE_CONFIGS["copilot-cli"]["project_settings"] != []
+
+    def test_copilot_cli_user_settings_paths(self):
+        from observal_cli.cmd_doctor import IDE_CONFIGS
+
+        paths = IDE_CONFIGS["copilot-cli"]["user_settings"]
+        assert any("config.json" in str(p) for p in paths)
+        assert any("mcp-config.json" in str(p) for p in paths)
+
+    def test_check_copilot_cli_fn_warns_on_missing_hooks(self):
+        from observal_cli.cmd_doctor import _check_copilot_cli
+
+        data = {}
+        issues = []
+        warnings = []
+        _check_copilot_cli(Path("config.json"), data, issues, warnings)
+        assert len(warnings) > 0
+        assert any("hooks" in w.lower() for w in warnings)
+
+    def test_check_copilot_cli_fn_warns_on_disable_all_hooks(self):
+        from observal_cli.cmd_doctor import _check_copilot_cli
+
+        data = {"disableAllHooks": True}
+        issues = []
+        warnings = []
+        _check_copilot_cli(Path("config.json"), data, issues, warnings)
+        assert len(issues) > 0
+        assert any("disableAllHooks" in i for i in issues)
+
+    def test_check_copilot_cli_fn_no_warning_with_observal_hooks(self):
+        from observal_cli.cmd_doctor import _check_copilot_cli
+
+        data = {
+            "hooks": {
+                "sessionStart": [{"type": "command", "bash": "cat | python3 /path/to/otel/hooks"}],
+            }
+        }
+        issues = []
+        warnings = []
+        _check_copilot_cli(Path("config.json"), data, issues, warnings)
+        assert len(warnings) == 0
+        assert len(issues) == 0
+
+    def test_check_copilot_cli_fn_warns_on_unwrapped_mcp(self):
+        from observal_cli.cmd_doctor import _check_copilot_cli
+
+        data = {"mcpServers": {"my-srv": {"command": "npx", "args": ["-y", "my-srv"]}}}
+        issues = []
+        warnings = []
+        _check_copilot_cli(Path("mcp-config.json"), data, issues, warnings)
+        assert len(warnings) > 0
+        assert any("observal-shim" in w for w in warnings)
+
+    def test_check_copilot_cli_fn_no_warning_on_shimmed_mcp(self):
+        from observal_cli.cmd_doctor import _check_copilot_cli
+
+        data = {
+            "mcpServers": {
+                "my-srv": {"command": "observal-shim", "args": ["--mcp-id", "test", "--", "npx"]}
+            }
+        }
+        issues = []
+        warnings = []
+        _check_copilot_cli(Path("mcp-config.json"), data, issues, warnings)
+        assert len(warnings) == 0
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 10c. CONFIG GENERATOR — Copilot CLI explicit branch
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestConfigGeneratorCopilotCli:
+    def _make_listing(self, name="my-mcp", listing_id="abc-123", **kw):
+        from unittest.mock import MagicMock
+
+        listing = MagicMock()
+        listing.name = name
+        listing.id = listing_id
+        listing.docker_image = kw.get("docker_image")
+        listing.framework = kw.get("framework")
+        listing.environment_variables = kw.get("environment_variables", [])
+        listing.command = kw.get("command")
+        listing.args = kw.get("args")
+        listing.url = kw.get("url")
+        listing.transport = kw.get("transport")
+        listing.auto_approve = kw.get("auto_approve")
+        return listing
+
+    def test_copilot_cli_stdio_has_type_stdio(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "copilot-cli")
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["type"] == "stdio"
+        assert server["command"] == "observal-shim"
+        assert "--mcp-id" in server["args"]
+        assert server["tools"] == ["*"]
+
+    def test_copilot_cli_sse_has_type_sse(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(
+            self._make_listing(url="http://localhost:3000/sse", transport="sse"), "copilot-cli"
+        )
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["type"] == "sse"
+        assert server["url"] == "http://localhost:3000/sse"
+        assert server["tools"] == ["*"]
+
+    def test_copilot_cli_proxy_has_tools(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(self._make_listing(), "copilot-cli", proxy_port=9999)
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["type"] == "sse"
+        assert server["tools"] == ["*"]
+
+    def test_copilot_cli_env_vars_preserved(self):
+        from services.config_generator import generate_config
+
+        cfg = generate_config(
+            self._make_listing(environment_variables=[{"name": "API_KEY", "required": True}]),
+            "copilot-cli",
+            env_values={"API_KEY": "secret"},
+        )
+        server = cfg["mcpServers"]["my-mcp"]
+        assert server["env"]["API_KEY"] == "secret"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 10d. SCAN — Copilot CLI parse and scan
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestParseCopilotCliMcpServers:
+    def test_copilot_cli_extracts_mcpservers(self):
+        config = {"mcpServers": {"my-srv": {"type": "stdio", "command": "npx", "args": ["-y", "my-srv"]}}}
+        result = _parse_project_mcp_servers(config, "copilot-cli")
+        assert "my-srv" in result
+
+    def test_copilot_cli_ignores_servers_key(self):
+        config = {"servers": {"my-srv": {"command": "npx"}}, "mcpServers": {"real-srv": {"command": "node"}}}
+        result = _parse_project_mcp_servers(config, "copilot-cli")
+        assert "real-srv" in result
+        assert "my-srv" not in result
+
+
+class TestScanCopilotCliHome:
+    def test_scan_copilot_cli_home_finds_mcp_servers(self, tmp_path):
+        from observal_cli.cmd_scan import _scan_copilot_cli_home
+
+        copilot_dir = tmp_path / ".copilot"
+        copilot_dir.mkdir()
+        mcp_config = copilot_dir / "mcp-config.json"
+        mcp_config.write_text(
+            json.dumps({"mcpServers": {"my-server": {"type": "stdio", "command": "npx", "args": ["-y", "srv"]}}})
+        )
+        mcps, skills, hooks, agents = _scan_copilot_cli_home(copilot_dir)
+        assert len(mcps) == 1
+        assert mcps[0].name == "my-server"
+        assert mcps[0].source == "copilot-cli:global"
+
+    def test_scan_copilot_cli_home_empty_dir(self, tmp_path):
+        from observal_cli.cmd_scan import _scan_copilot_cli_home
+
+        copilot_dir = tmp_path / ".copilot"
+        copilot_dir.mkdir()
+        mcps, skills, hooks, agents = _scan_copilot_cli_home(copilot_dir)
+        assert len(mcps) == 0
+
+    def test_scan_copilot_cli_home_no_skills_or_agents(self, tmp_path):
+        from observal_cli.cmd_scan import _scan_copilot_cli_home
+
+        copilot_dir = tmp_path / ".copilot"
+        copilot_dir.mkdir()
+        mcp_config = copilot_dir / "mcp-config.json"
+        mcp_config.write_text(json.dumps({"mcpServers": {"srv": {"command": "echo"}}}))
+        mcps, skills, hooks, agents = _scan_copilot_cli_home(copilot_dir)
+        assert len(skills) == 0
+        assert len(hooks) == 0
+        assert len(agents) == 0
 
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -255,7 +255,7 @@ class TestGenerateCopilotCliConfig:
         cfg = generate_agent_config(agent, "copilot-cli")
         assert cfg["mcp_config"]["path"] == ".mcp.json"
 
-    def test_mcp_config_root_key_is_mcpServers(self):
+    def test_mcp_config_root_key_is_mcp_servers(self):
         ext = [{"name": "my-server", "command": "npx", "args": ["-y", "my-server"]}]
         agent = _make_agent(external_mcps=ext)
         cfg = generate_agent_config(agent, "copilot-cli")

--- a/web/src/app/(user)/traces/[id]/page.tsx
+++ b/web/src/app/(user)/traces/[id]/page.tsx
@@ -1240,6 +1240,7 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
     let credits = 0;
     let isKiro = serviceName === "kiro" || sessionId.startsWith("kiro-");
     const isGemini = serviceName === "gemini";
+    const isCopilotCli = isCopilotCliService(serviceName ?? "", sessionId);
     const models = new Set<string>();
     const tools: Record<string, number> = {};
 
@@ -1282,7 +1283,7 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
       }
     }
 
-    return { totalInputTokens, totalOutputTokens, totalCacheRead, totalCacheWrite, apiCalls, toolCalls, hookEvents, credits, isKiro, isGemini, models, tools };
+    return { totalInputTokens, totalOutputTokens, totalCacheRead, totalCacheWrite, apiCalls, toolCalls, hookEvents, credits, isKiro, isGemini, isCopilotCli, models, tools };
   }, [events, sessionId, serviceName]);
 
   const formatCredits = (c: number) => c < 0.01 ? c.toFixed(4) : c.toFixed(2);
@@ -1294,7 +1295,7 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
           <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Credits</p>
           <p className="text-lg font-semibold tabular-nums text-orange-500">{formatCredits(stats.credits)}</p>
         </div>
-      ) : (
+      ) : !stats.isCopilotCli ? (
         <>
           <div className="space-y-1">
             <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Input Tokens</p>
@@ -1317,8 +1318,8 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
             </>
           )}
         </>
-      )}
-      {!stats.isGemini && (
+      ) : null}
+      {!stats.isGemini && !stats.isCopilotCli && (
         <div className="space-y-1">
           <p className="text-[11px] text-muted-foreground uppercase tracking-wide">API Calls</p>
           <p className="text-lg font-semibold tabular-nums">{stats.apiCalls}</p>
@@ -1334,12 +1335,14 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawOtelEvent
           <p className="text-lg font-semibold tabular-nums text-orange-500">{stats.hookEvents}</p>
         </div>
       )}
-      <div className="space-y-1">
-        <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Models</p>
-        <div className="flex flex-wrap gap-1">
-          {[...stats.models].map((m) => <Badge key={m}>{m.replace("claude-", "")}</Badge>)}
+      {!stats.isCopilotCli && (
+        <div className="space-y-1">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Models</p>
+          <div className="flex flex-wrap gap-1">
+            {[...stats.models].map((m) => <Badge key={m}>{m.replace("claude-", "")}</Badge>)}
+          </div>
         </div>
-      </div>
+      )}
       {Object.keys(stats.tools).length > 0 && (
         <div className="col-span-full space-y-1">
           <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Tools Used</p>
@@ -1422,17 +1425,47 @@ const KIRO_HOOK_CAPABILITIES: HookCapGroup[] = [
   },
 ];
 
+const COPILOT_CLI_HOOK_CAPABILITIES: HookCapGroup[] = [
+  {
+    category: "Capture",
+    hooks: [
+      { event: "hook_userpromptsubmit", label: "User Prompts", description: "Captures prompts submitted by the user" },
+    ],
+  },
+  {
+    category: "Tool Use",
+    hooks: [
+      { event: "hook_pretooluse", label: "Pre Tool Use", description: "Fires before each tool call" },
+      { event: "hook_posttooluse", label: "Post Tool Use", description: "Captures tool results after execution" },
+    ],
+  },
+  {
+    category: "Lifecycle",
+    hooks: [
+      { event: "hook_sessionstart", label: "Session Start", description: "Fires when a session begins" },
+      { event: "hook_stop", label: "Session End", description: "Fires when the session ends" },
+      { event: "hook_stopfailure", label: "Error", description: "Fires when an error occurs during the session" },
+    ],
+  },
+];
+
 function isKiroService(serviceName: string, sessionId: string): boolean {
   return serviceName === "kiro" || sessionId.startsWith("kiro-");
 }
 
+function isCopilotCliService(serviceName: string, sessionId: string): boolean {
+  return serviceName === "copilot-cli" || serviceName === "copilot" || serviceName === "GitHub Copilot" || sessionId.startsWith("copilot-cli-");
+}
+
 function getHookCapabilities(serviceName: string, sessionId: string): HookCapGroup[] {
   if (isKiroService(serviceName, sessionId)) return KIRO_HOOK_CAPABILITIES;
+  if (isCopilotCliService(serviceName, sessionId)) return COPILOT_CLI_HOOK_CAPABILITIES;
   return CLAUDE_CODE_HOOK_CAPABILITIES;
 }
 
 function SessionInfoTab({ events, sessionId, serviceName }: { events: RawOtelEvent[]; sessionId: string; serviceName: string }) {
   const isKiro = isKiroService(serviceName, sessionId);
+  const isCopilotCli = isCopilotCliService(serviceName, sessionId);
   const hookCapabilities = useMemo(() => getHookCapabilities(serviceName, sessionId), [serviceName, sessionId]);
 
   // Derive active hooks from events actually present in this session
@@ -1513,6 +1546,8 @@ function SessionInfoTab({ events, sessionId, serviceName }: { events: RawOtelEve
           Hook types detected in this session.{" "}
           {isKiro
             ? "Kiro supports 5 native hook events. Missing hooks mean those event types were not captured."
+            : isCopilotCli
+            ? "Copilot CLI supports 6 hook events. Token usage and model info are not available."
             : "Missing hooks mean those event types were not captured — check your hook configuration."}
         </p>
         <div className="space-y-4">

--- a/web/src/app/(user)/traces/page.tsx
+++ b/web/src/app/(user)/traces/page.tsx
@@ -55,6 +55,15 @@ function isKiroSession(row: OtelSession): boolean {
   return row.service_name === "kiro" || row.session_id.startsWith("kiro-");
 }
 
+function isCopilotCliSession(row: OtelSession): boolean {
+  return (
+    row.service_name === "copilot-cli" ||
+    row.service_name === "copilot" ||
+    row.service_name === "GitHub Copilot" ||
+    row.session_id.startsWith("copilot-cli-")
+  );
+}
+
 function fmtTokens(n: number | string | undefined): string {
   if (n == null) return "0";
   const num = typeof n === "string" ? parseInt(n, 10) : n;
@@ -115,7 +124,9 @@ function shortModel(raw?: string): string {
 
 function derivePlatform(row: OtelSession): string {
   if (row.platform) return row.platform;
-  return isKiroSession(row) ? "Kiro" : "Claude Code";
+  if (isKiroSession(row)) return "Kiro";
+  if (isCopilotCliSession(row)) return "Copilot CLI";
+  return "Claude Code";
 }
 
 function sessionLabel(row: OtelSession): string {
@@ -167,6 +178,11 @@ const columns: ColumnDef<OtelSession>[] = [
     accessorFn: (row) => row.total_input_tokens ?? 0,
     cell: ({ row }) => {
       const r = row.original;
+      if (isCopilotCliSession(r)) {
+        return (
+          <span className="text-[13px] text-muted-foreground">{"\u2014"}</span>
+        );
+      }
       if (isKiroSession(r)) {
         return (
           <span className="text-[13px] font-mono tabular-nums text-orange-400">
@@ -365,6 +381,7 @@ export default function TracesPage() {
                 <SelectContent>
                   <SelectItem value="all">All platforms</SelectItem>
                   <SelectItem value="claude-code">Claude Code</SelectItem>
+                  <SelectItem value="copilot-cli">Copilot CLI</SelectItem>
                   <SelectItem value="kiro">Kiro</SelectItem>
                 </SelectContent>
               </Select>

--- a/web/src/components/traces/trace-list.tsx
+++ b/web/src/components/traces/trace-list.tsx
@@ -33,6 +33,8 @@ const IDE_BADGE_STYLES: Record<string, string> = {
   vscode: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
   codex: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-400",
   copilot: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  "copilot-cli": "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  "GitHub Copilot": "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
 };
 
 const IDE_LABELS: Record<string, string> = {
@@ -43,6 +45,8 @@ const IDE_LABELS: Record<string, string> = {
   vscode: "VS Code",
   codex: "Codex",
   copilot: "Copilot",
+  "copilot-cli": "Copilot CLI",
+  "GitHub Copilot": "Copilot CLI",
 };
 
 const TRACE_TYPES = [
@@ -65,6 +69,7 @@ const IDES = [
   "vscode",
   "codex",
   "copilot",
+  "copilot-cli",
 ];
 
 export function TraceList() {

--- a/web/src/lib/ide-features.ts
+++ b/web/src/lib/ide-features.ts
@@ -7,6 +7,7 @@ export const VALID_IDES = [
   "claude-code",
   "codex",
   "copilot",
+  "copilot-cli",
   "cursor",
   "gemini-cli",
   "kiro",
@@ -35,6 +36,7 @@ export const IDE_FEATURE_MATRIX: Record<IdeName, ReadonlySet<IdeFeature>> = {
   "gemini-cli": new Set(["hook_bridge", "mcp_servers", "rules", "otlp_telemetry"]),
   codex: new Set(["rules"]),
   copilot: new Set(["mcp_servers", "rules"]),
+  "copilot-cli": new Set(["mcp_servers", "rules", "hook_bridge"]),
   opencode: new Set(["mcp_servers", "rules"]),
   vscode: new Set(["mcp_servers", "rules"]),
 };
@@ -46,6 +48,7 @@ export const IDE_DISPLAY_NAMES: Record<IdeName, string> = {
   "gemini-cli": "Gemini CLI",
   codex: "Codex",
   copilot: "Copilot",
+  "copilot-cli": "Copilot CLI",
   opencode: "OpenCode",
   vscode: "VS Code",
 };


### PR DESCRIPTION
## Purpose / Description

Adds full Copilot CLI (standalone `copilot` binary) as a supported IDE target in Observal with hook-based telemetry. Copilot CLI doesn't support native OTLP, so we use its hook system to capture session lifecycle, prompts, and tool usage events.

## Fixes

* Closes #<!-- N/A — greenfield feature -->

## Approach

**Hook bridge architecture** — same pattern as Kiro:
- Two hook scripts (`copilot_cli_hook.py`, `copilot_cli_stop_hook.py`) injected into `~/.copilot/config.json` via `observal scan --ide copilot-cli --home`
- Scripts normalize Copilot CLI's camelCase payloads (sessionId, toolName, etc.) to the snake_case the server expects
- Each hook receives `--event-name <event>` so the server can identify the hook type (sessionStart, userPromptSubmitted, preToolUse, postToolUse, sessionEnd, errorOccurred)
- Stable session grouping via Copilot CLI's own `sessionId` UUID (with grandparent PID fallback)
- JSONC parsing for `~/.copilot/config.json` which contains `//` comments

**Full stack coverage:**
- **Constants**: `copilot-cli` added to feature matrix (CLI, server, web) with `{mcp_servers, rules, hook_bridge}`
- **Server**: Config generation for MCP servers (`.mcp.json` with `mcpServers` key), agent builder, telemetry event mapping
- **CLI scan**: Home directory scanning (`~/.copilot/`), hook injection, MCP auto-shimming
- **CLI doctor**: Health checks, installation verification, SLI hook repair
- **Frontend**: Platform detection, badge styles, hide unsupported fields (tokens, cache, API calls, models) since Copilot CLI doesn't expose them in hook payloads

## How Has This Been Tested?

- 199 e2e tests passing (`tests/test_ide_config_e2e.py`) including new copilot-cli specific tests for constants, config generation, and scan behavior
- `ruff check` and `ruff format` pass
- ESLint and TypeScript typecheck pass
- Manual testing: `observal scan --ide copilot-cli --home` injects hooks, Copilot CLI sessions appear in traces dashboard with correct event names, session grouping, and prompt capture
- Verified: tokens/cache/model fields correctly hidden for copilot-cli sessions in the UI

## Learning (optional, can help others)

- Copilot CLI's `~/.copilot/config.json` uses JSONC format (has `//` line comments) — `json.loads()` fails without stripping them first
- Copilot CLI hook payloads use `sessionId` (UUID), not a PID-based ID — much better for session grouping than the grandparent PID approach
- Copilot CLI does NOT expose token usage, model info, or API call counts in any hook payload — the terminal display of tokens is internal only
- Hook format uses `{"type": "command", "bash": "...", "powershell": "..."}` (not `"command"` field like Claude Code)
- Event names differ from Kiro: `userPromptSubmitted` (not `userPromptSubmit`), `sessionEnd` (not `stop`), `errorOccurred` (new)

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)