### PR TITLE
fix(deploy): add production compose override for SSL and frontend rou…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
             git reset --hard origin/main
 
             cd docker
-            docker compose up -d --build --remove-orphans
+            docker compose -f docker-compose.yml -f docker-compose.production.yml up -d --build --remove-orphans
 
             # Phase 1: Wait for API container to be alive (bypasses nginx).
             # Uses direct container exec because curl through nginx fails
@@ -44,12 +44,12 @@ jobs:
 
             # Nginx caches upstream container IPs — after rebuild the API
             # gets a new IP but nginx still routes to the old one.
-            docker compose restart observal-lb
+            docker compose -f docker-compose.yml -f docker-compose.production.yml restart observal-lb
             sleep 3
 
             # Phase 2: Verify health through nginx (the path clients use)
             for i in $(seq 1 30); do
-              if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              if curl -sf https://localhost/health -k > /dev/null 2>&1; then
                 echo "API is healthy (full stack verified)"
                 exit 0
               fi

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -1,0 +1,12 @@
+services:
+  observal-web:
+    environment:
+      - NEXT_PUBLIC_API_URL=https://${DOMAIN:-internal.observal.io}
+
+  observal-lb:
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.production.conf:/etc/nginx/conf.d/default.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro

--- a/docker/nginx.production.conf
+++ b/docker/nginx.production.conf
@@ -1,0 +1,73 @@
+upstream observal_api {
+    server observal-api:8000;
+}
+
+upstream observal_web {
+    server observal-web:3000;
+}
+
+server {
+    listen 80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/letsencrypt/live/internal.observal.io/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/internal.observal.io/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location /api/ {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location /health {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $host;
+    }
+
+    location /livez {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $host;
+    }
+
+    location /readyz {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $host;
+    }
+
+    location /graphql {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location / {
+        proxy_pass http://observal_web;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
## Purpose / Description

Production config (SSL certificates, ports 80/443, frontend routing via nginx) was only applied as live edits on EC2 and got wiped on every deploy. The deploy workflow runs `git reset --hard origin/main`, so any manual changes to `docker-compose.yml` or `nginx.conf` on the server are lost. This meant SSL, frontend routing, and HTTPS all broke after every merge to main.

## Fixes

* Fixes production site going down after every deploy
* Fixes SSL/HTTPS config being wiped on deploy
* Fixes frontend not being accessible on port 80/443 after deploy

## Approach

Instead of modifying the base `docker-compose.yml` and `nginx.conf` (which are used for local dev), this adds a production overlay:

- `docker/docker-compose.production.yml` -- overrides LB ports to 80+443, mounts Let's Encrypt certs, swaps in the production nginx config, and sets `NEXT_PUBLIC_API_URL` to HTTPS
- `docker/nginx.production.conf` -- full nginx config with HTTP-to-HTTPS redirect, SSL termination, frontend routing (`/` to Next.js), and API routing (`/api/` to FastAPI)
- `.github/workflows/deploy.yml` -- updated to use `docker compose -f docker-compose.yml -f docker-compose.production.yml` so the overlay is applied on every deploy

Local dev is completely unchanged. The base compose file still uses port 8000 and the simple nginx config.

## How Has This Been Tested?

1. Applied the production overlay on EC2 (`internal.observal.io`) manually using the same compose override pattern
2. Verified HTTPS serves the frontend at `https://internal.observal.io`
3. Verified HTTP redirects to HTTPS (301)
4. Verified `/health`, `/api/v1/auth/login`, and `/graphql` all route correctly through nginx to the API
5. Verified the health check in the deploy script works with `curl -sf https://localhost/health -k`
6. Simulated a deploy by running `git reset --hard` followed by `docker compose -f docker-compose.yml -f docker-compose.production.yml up -d` and confirmed config survived

## Learning

Docker Compose supports layered override files via `-f base.yml -f override.yml`. The override only needs to specify the services and keys it wants to change. This keeps local dev config clean while letting production add SSL, different ports, and extra volume mounts without touching the base file.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
