### PR TITLE
fix(eval): broaden session matching for Claude Code telemetry

### DIFF
--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -82,6 +82,7 @@ async def run_evaluation(
             "  FROM otel_logs "
             "  WHERE LogAttributes['session.id'] != '' "
             "  AND (LogAttributes['tool_input'] LIKE {prompt_pattern:String} "
+            "       OR LogAttributes['tool_input'] LIKE {name_pattern:String} "
             "       OR LogAttributes['agent_name'] LIKE {name_pattern:String}) "
             "  GROUP BY sid "
             ") "


### PR DESCRIPTION
## Purpose / Description

Claude Code sends task descriptions (e.g. "Security audit of codebase") as `agent_name` in OTEL telemetry, not the Observal registry agent name (e.g. `security-checker`). When invoking agents via `@`, Claude Code formats it as `@"ruff-ci-checker (agent)"` in `tool_input`, not `@agent-ruff-ci-checker`. This means the eval fallback query never finds matching sessions, and eval silently returns `traces_evaluated: 0` for any agent run via Claude Code.

## Fixes

* Fixes eval returning zero scorecards for agents invoked via Claude Code
* Fixes session matching for both `@agent-<name>` and `@"<name> (agent)"` invocation patterns

## Approach

The eval fallback ClickHouse query now matches sessions three ways:
1. Exact match on `agent_name` attribute (existing behavior)
2. `tool_input` contains `@agent-<registry-name>` (CLI-style invocation)
3. `tool_input` or `agent_name` contains the registry name as a substring (catches `@"ruff-ci-checker (agent)"` and description-style names like "Ruff linting check")

## How Has This Been Tested?

1. Deployed to EC2 instance running `internal.observal.io`
2. Ran `security-checker` agent via Claude Code with `@agent-security-checker` -- eval found the session and produced a scorecard
3. Ran `ruff-ci-checker` agent via Claude Code with `@"ruff-ci-checker (agent)"` -- confirmed the substring match finds the session
4. Verified ClickHouse fallback query returns matching sessions by checking API logs (`eval_fallback_sessions count=2`)
5. Confirmed Groq LLM judge (`llama-3.1-8b-instant`) produces real scores through the eval pipeline

## Learning

Claude Code telemetry has two different agent name patterns depending on how the agent is invoked:
- Subagents spawned via the Agent tool get a task description as `agent_name` (e.g. "Security audit of Observal codebase")
- Agents invoked via `@` mention appear in `tool_input` as `@"agent-name (agent)"` with no `agent_name` attribute on most events

Exact string matching on `agent_name` alone will miss both patterns. Substring matching on `tool_input` is the reliable fallback.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
