### PR TITLE
fix(ci): disable provenance on per-arch Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,7 @@ jobs:
           context: .
           file: docker/Dockerfile.${{ matrix.image }}
           platforms: ${{ matrix.platform }}
+          provenance: false
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}-${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
           cache-to: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }},mode=max


### PR DESCRIPTION
## Purpose / Description
The Docker manifest merge step (`docker buildx imagetools create`) fails with "not found" when looking up per-arch image digests. This is because `build-push-action@v6` adds provenance attestations by default, which wraps the image in an OCI index and changes the digest returned to the caller.

## Fixes
`ERROR: ghcr.io/blazeup-ai/observal-web@sha256:...: not found` in the `docker-merge` job of Release workflow #37

## Approach
Set `provenance: false` on the `docker-build` per-arch jobs. This ensures the digest output is a plain image manifest that `imagetools create` can resolve in the registry. Build provenance attestation is already handled separately at the GitHub Release level via `actions/attest-build-provenance`.

## How Has This Been Tested?

- This is the documented fix from the [docker/build-push-action multi-platform guide](https://docs.docker.com/build/ci/github-actions/multi-platform/) for the digest-based merge pattern
- Single line change — only affects the `docker-build` job's provenance flag

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)