### PR TITLE
fix(nginx): preserve host port in proxy headers to fix Kiro agent tra…

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -7,7 +7,7 @@ server {
 
     location / {
         proxy_pass http://observal_api;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/docker/nginx.production.conf
+++ b/docker/nginx.production.conf
@@ -23,7 +23,7 @@ server {
 
     location /api/ {
         proxy_pass http://observal_api;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -36,22 +36,22 @@ server {
 
     location /health {
         proxy_pass http://observal_api;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
     }
 
     location /livez {
         proxy_pass http://observal_api;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
     }
 
     location /readyz {
         proxy_pass http://observal_api;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
     }
 
     location /graphql {
         proxy_pass http://observal_api;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -62,7 +62,7 @@ server {
 
     location / {
         proxy_pass http://observal_web;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Purpose / Description
nginx `$host` strips the port from the Host header, so `derive_endpoints()` returns `http://localhost` instead of `http://localhost:8000`. Agents pulled via `observal pull --ide kiro` get hooks pointing to port 80, silently dropping all trace data.

## Fixes
* Fixes #563

## Approach
Changed `proxy_set_header Host $host` to `$http_host` in both `nginx.conf` and `nginx.production.conf`. `$http_host` preserves the original port.

## How Has This Been Tested?
- Verified `GET /api/v1/config/endpoints` returns `"api":"http://localhost:8000"` (with port)
- Pulled a Kiro agent via Observal, confirmed hooks URL includes `:8000`
- Ran Kiro agent session, traces appeared in ClickHouse
- nginx config syntax validated (`nginx -t`)

## Learning
`$host` in nginx returns just the hostname. `$http_host` passes through the full `Host` header from the client, including the port.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code
