### PR TITLE
fix(ci): filter release artifact download to skip Docker metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,10 +336,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download all artifacts
+      - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: observal-*
 
       - name: Flatten artifacts
         run: |


### PR DESCRIPTION
## Purpose / Description
The GitHub Release job in the release workflow fails because `actions/download-artifact@v4` tries to download **all** artifacts, including Docker buildx metadata files (`BlazeUp-AI~Observal~*.dockerbuild`) which are large and fail after 5 retries.

## Fixes
* Fixes `Artifact download failed after 5 retries` in GitHub Release job (Release #43)

## Approach
Add `pattern: observal-*` to the download step so it only fetches release-relevant artifacts (CLI binaries + server tarball), skipping Docker digest files and buildx metadata.

## How Has This Been Tested?

- Verified artifact names from Release #43 logs: all needed artifacts match `observal-*` pattern
- Docker metadata artifacts (`BlazeUp-AI~Observal~*.dockerbuild`, `docker-digest-*`) are correctly excluded

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)