### PR TITLE
fix(kiro): fix Unix hook pipelines, prompt injection, and model reporting

### DIFF
--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -18,6 +18,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from services.agent_config_generator import _wrap_kiro_prompt
 from services.agent_resolver import ResolvedAgent, ResolvedComponent
 
 logger = logging.getLogger(__name__)
@@ -516,12 +517,21 @@ def _generate_kiro(manifest: AgentManifest) -> IdeAgentConfig:
     kiro_agent = {
         "name": safe_name,
         "description": manifest.description[:200] if manifest.description else "",
-        "prompt": manifest.prompt,
+        "prompt": _wrap_kiro_prompt(manifest.prompt, safe_name),
         "mcpServers": mcp_entries,
-        "tools": [f"@{n}" for n in mcp_entries] + ["read", "write", "shell"],
+        "tools": ["*"],
+        "toolAliases": {},
+        "allowedTools": [],
+        "resources": [
+            "file://AGENTS.md",
+            "file://README.md",
+            "skill://.kiro/skills/*/SKILL.md",
+            "skill://~/.kiro/skills/*/SKILL.md",
+        ],
         "hooks": {},
+        "toolsSettings": {},
         "includeMcpJson": True,
-        "model": manifest.model_name or "default",
+        "model": None,  # Kiro uses "auto" model selection; actual model captured via SQLite in hooks
     }
 
     skill_files = _build_skill_files(manifest, "kiro")

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -43,6 +43,24 @@ def _sanitize_name(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_-]", "-", name)
 
 
+def _wrap_kiro_prompt(prompt: str, agent_name: str) -> str:
+    """Wrap a user prompt in Kiro-compatible framing.
+
+    Kiro's model guardrails reject prompts that appear to override its
+    identity or restrict its behaviour (e.g. "You are X", "Say only Y").
+    Wrapping the prompt as *agent specialization* avoids false-positive
+    prompt-injection detection while preserving the user's intent.
+    """
+    if not prompt:
+        return prompt
+    return (
+        f"# {agent_name} — Agent Specialization\n\n"
+        f"You are a Kiro agent with the following specialization.\n\n"
+        f"## Instructions\n\n"
+        f"{prompt}"
+    )
+
+
 def _inject_agent_id(mcp_config: dict, agent_id: str):
     """Add OBSERVAL_AGENT_ID env var to all MCP server entries."""
     for _name, cfg in mcp_config.items():
@@ -268,45 +286,33 @@ def generate_agent_config(
     if ide == "kiro":
         # Kiro agent JSON: drop into ~/.kiro/agents/<name>.json
         # Telemetry collected via observal-shim + hook bridge
-        model_field = f',\\"model\\":\\"{agent.model_name}\\"' if agent.model_name else ""
-
         if platform == "win32":
             # PowerShell-compatible: pipe stdin through the Python hook script.
             # No cat/sed/curl/$PPID/$TERM/$SHELL — those don't exist in PowerShell.
-            model_arg = f" --model {agent.model_name}" if agent.model_name else ""
             hook_cmd = (
                 f"python -m observal_cli.hooks.kiro_hook "
                 f"--url {observal_url}/api/v1/otel/hooks "
-                f"--agent-name {safe_name}{model_arg}"
+                f"--agent-name {safe_name}"
             )
             stop_cmd = (
                 f"python -m observal_cli.hooks.kiro_stop_hook "
                 f"--url {observal_url}/api/v1/otel/hooks "
-                f"--agent-name {safe_name}{model_arg}"
+                f"--agent-name {safe_name}"
             )
             spawn_cmd = hook_cmd  # Windows: Python script handles session IDs
         else:
-            # Unix: stable UUID session IDs instead of $PPID.
-            # agentSpawn creates a new UUID; other events read the existing one.
-            _sf = "/tmp/observal-kiro-session"  # nosec B108
-            _sid_create = f'$(python3 -c "import uuid; print(uuid.uuid4())" | tee {_sf})'
-            _sid_read = f'$(cat {_sf} 2>/dev/null || echo "kiro-$PPID")'
-
-            def _sed_cmd(sid_expr, pipe_to):
-                return (
-                    'cat | sed \'s/^{{/{{"session_id":"\'"' + sid_expr + '"\'",'
-                    f'"service_name":"kiro","agent_name":"{safe_name}"{model_field},/\' ' + pipe_to
-                )
-
-            _curl_pipe = (
-                f'| curl -sf -X POST {observal_url}/api/v1/otel/hooks -H "Content-Type: application/json" -d @-'
+            # Unix: use the same Python hook scripts as Windows.
+            hook_cmd = (
+                f"python3 -m observal_cli.hooks.kiro_hook "
+                f"--url {observal_url}/api/v1/otel/hooks "
+                f"--agent-name {safe_name}"
             )
-            spawn_cmd = _sed_cmd(_sid_create, _curl_pipe)
-            hook_cmd = _sed_cmd(_sid_read, _curl_pipe)
-            stop_cmd = _sed_cmd(
-                _sid_read,
-                f"| python3 -m observal_cli.hooks.kiro_stop_hook --url {observal_url}/api/v1/otel/hooks",
+            stop_cmd = (
+                f"python3 -m observal_cli.hooks.kiro_stop_hook "
+                f"--url {observal_url}/api/v1/otel/hooks "
+                f"--agent-name {safe_name}"
             )
+            spawn_cmd = hook_cmd  # Python script handles session IDs
         hooks = {
             "agentSpawn": [{"command": spawn_cmd}],
             "userPromptSubmit": [{"command": hook_cmd}],
@@ -322,12 +328,21 @@ def generate_agent_config(
                 "content": {
                     "name": safe_name,
                     "description": agent.description[:200] if agent.description else "",
-                    "prompt": agent.prompt,
+                    "prompt": _wrap_kiro_prompt(agent.prompt, safe_name),
                     "mcpServers": mcp_configs,
-                    "tools": [f"@{n}" for n in mcp_configs] + ["read", "write", "shell"],
+                    "tools": ["*"],
+                    "toolAliases": {},
+                    "allowedTools": [],
+                    "resources": [
+                        "file://AGENTS.md",
+                        "file://README.md",
+                        "skill://.kiro/skills/*/SKILL.md",
+                        "skill://~/.kiro/skills/*/SKILL.md",
+                    ],
                     "hooks": hooks,
+                    "toolsSettings": {},
                     "includeMcpJson": True,
-                    "model": agent.model_name,
+                    "model": None,  # Kiro uses "auto" model selection; actual model captured via SQLite in hooks
                 },
             },
             "scope": kiro_scope,
@@ -339,7 +354,7 @@ def generate_agent_config(
                 "content": (
                     f"---\ninclusion: always\nname: {safe_name}\n"
                     f"description: {(agent.description or safe_name)[:100]}\n---\n\n"
-                    f"{agent.prompt}"
+                    f"{_wrap_kiro_prompt(agent.prompt, safe_name)}"
                 ),
             }
         skill_files = [_generate_skill_file(s, "kiro") for s in skill_configs]

--- a/observal-server/services/hook_config_generator.py
+++ b/observal-server/services/hook_config_generator.py
@@ -26,26 +26,13 @@ def generate_hook_telemetry_config(
                 hook_entry["matcher"] = "*"
             return {"hooks": {kiro_event: [hook_entry]}}
 
-        # Unix: cat | sed | curl pipeline (unchanged)
-        curl_cmd = (
-            'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro",'
-            '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
-            f"| curl -sf -X POST {server_url}/api/v1/otel/hooks "
-            f'-H "Content-Type: application/json" '
-            f"-d @-"
-        )
-
-        # For stop events, use the enrichment script to capture model/tokens
+        # Unix: use the same Python hook scripts as Windows.
         if kiro_event == "stop":
-            stop_cmd = (
-                'cat | sed \'s/^{/{"session_id":"kiro-\'$PPID\'","service_name":"kiro",'
-                '"terminal_type":"\'$TERM\'","shell":"\'$SHELL\'",/\' '
-                f"| python3 -m observal_cli.hooks.kiro_stop_hook "
-                f"--url {server_url}/api/v1/otel/hooks"
-            )
+            stop_cmd = f"python3 -m observal_cli.hooks.kiro_stop_hook --url {server_url}/api/v1/otel/hooks"
             return {"hooks": {kiro_event: [{"command": stop_cmd}]}}
 
-        hook_entry = {"command": curl_cmd}
+        cmd = f"python3 -m observal_cli.hooks.kiro_hook --url {server_url}/api/v1/otel/hooks"
+        hook_entry = {"command": cmd}
         if kiro_event in ("preToolUse", "postToolUse"):
             hook_entry["matcher"] = "*"
         return {"hooks": {kiro_event: [hook_entry]}}

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -1261,11 +1261,12 @@ class TestGenerateIdeAgentFiles:
         assert agent_file.format == "json"
         content = agent_file.content
         assert content["name"] == "test-agent"
-        assert content["prompt"] == "You are a helpful coding assistant."
+        assert "You are a helpful coding assistant." in content["prompt"]
+        assert "Agent Specialization" in content["prompt"]
         assert "mcpServers" in content
         assert "github-mcp" in content["mcpServers"]
-        assert "@github-mcp" in content["tools"]
-        assert content["model"] == "claude-sonnet-4-20250514"
+        assert "*" in content["tools"]
+        assert content["model"] is None  # Kiro uses auto model selection
 
     # ── Codex ──────────────────────────────────────────────────
 

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -309,8 +309,9 @@ class TestGenerateKiro:
         cfg = generate_agent_config(agent, "kiro")
         content = cfg["agent_file"]["content"]
         assert content["name"] == "test-agent"
-        assert content["prompt"] == "You are helpful."
-        assert content["model"] == "claude-sonnet-4"
+        assert "You are helpful." in content["prompt"]
+        assert "Agent Specialization" in content["prompt"]
+        assert content["model"] is None  # Kiro uses auto model selection
         assert "mcpServers" in content
         assert "hooks" in content
 
@@ -338,13 +339,21 @@ class TestGenerateKiro:
         cfg = generate_agent_config(agent, "kiro")
         assert len(cfg["agent_file"]["content"]["description"]) == 200
 
-    def test_tools_include_builtins(self):
+    def test_tools_include_wildcard(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "kiro")
         tools = cfg["agent_file"]["content"]["tools"]
-        assert "read" in tools
-        assert "write" in tools
-        assert "shell" in tools
+        assert "*" in tools
+
+    def test_kiro_native_schema_fields(self):
+        agent = _make_agent()
+        cfg = generate_agent_config(agent, "kiro")
+        content = cfg["agent_file"]["content"]
+        assert content["toolAliases"] == {}
+        assert content["allowedTools"] == []
+        assert content["toolsSettings"] == {}
+        assert isinstance(content["resources"], list)
+        assert any("AGENTS.md" in r for r in content["resources"])
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -645,14 +654,12 @@ class TestBuilderKiro:
         assert "~/.kiro/agents/" in json_file.path
         assert json_file.content["name"] == "test-agent"
 
-    def test_tools_include_builtins(self):
+    def test_tools_include_wildcard(self):
         manifest = _make_manifest()
         result = generate_ide_agent_files(manifest, "kiro")
         json_file = next(f for f in result.files if f.format == "json")
         tools = json_file.content["tools"]
-        assert "read" in tools
-        assert "write" in tools
-        assert "shell" in tools
+        assert "*" in tools
 
 
 class TestBuilderGemini:
@@ -792,15 +799,9 @@ class TestGenerateKiroWin32:
         for cmd in cmds:
             assert "--agent-name my-cool-agent" in cmd
 
-    def test_win32_hooks_include_model_when_present(self):
+    def test_hooks_omit_model_flag(self):
+        """Model is detected from Kiro SQLite at runtime, not baked into hook commands."""
         agent = _make_agent(model_name="claude-sonnet-4")
-        cfg = generate_agent_config(agent, "kiro", platform="win32")
-        cmds = self._all_hook_commands(cfg)
-        for cmd in cmds:
-            assert "--model claude-sonnet-4" in cmd
-
-    def test_win32_hooks_omit_model_when_empty(self):
-        agent = _make_agent(model_name="")
         cfg = generate_agent_config(agent, "kiro", platform="win32")
         cmds = self._all_hook_commands(cfg)
         for cmd in cmds:
@@ -840,14 +841,15 @@ class TestGenerateKiroPreservation:
         cfg_empty = generate_agent_config(agent, "kiro", platform="")
         assert cfg_default == cfg_empty
 
-    def test_unix_hooks_still_use_cat_sed_curl(self):
+    def test_unix_hooks_use_python_hook_scripts(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "kiro", platform="linux")
         hooks = cfg["agent_file"]["content"]["hooks"]
         spawn_cmd = hooks["agentSpawn"][0]["command"]
-        assert "cat |" in spawn_cmd
-        assert "sed '" in spawn_cmd
-        assert "curl" in spawn_cmd
+        assert "python3 -m observal_cli.hooks.kiro_hook" in spawn_cmd
+        assert "cat |" not in spawn_cmd
+        assert "sed " not in spawn_cmd
+        assert "curl" not in spawn_cmd
 
     def test_non_kiro_ides_unaffected_by_platform(self):
         agent = _make_agent()

--- a/tests/test_shim_phase3.py
+++ b/tests/test_shim_phase3.py
@@ -346,4 +346,4 @@ class TestAgentConfigGenerator:
         agent = cfg["agent_file"]["content"]
         assert agent["name"] == "test-agent"
         assert agent["mcpServers"]["ext-mcp"]["env"]["OBSERVAL_AGENT_ID"] == "agent-xyz"
-        assert "@ext-mcp" in agent["tools"]
+        assert "*" in agent["tools"]


### PR DESCRIPTION
## Purpose / Description

Unix Kiro hook generation produced fragile `cat|sed|curl` shell pipelines that silently failed when serialized into agent JSON configs. Additionally, Kiro rejected Observal-generated agent prompts as prompt injection, and the model field reported incorrect values in telemetry.

## Fixes

* Fixes #570

## Approach

**1. Replace shell pipelines with Python hook scripts**
The Unix code path built `cat | sed '...' | curl -sf` commands that broke due to nested quoting when serialized into JSON. Replace with `python3 -m observal_cli.hooks.kiro_hook` — matching the Windows path that already works. The Python scripts handle session_id, service_name, agent_name, and HTTP POST internally.

**2. Fix Kiro prompt injection false positives**
Kiro's model guardrails flagged user prompts (e.g. "You are pikachu") as identity-override injection attempts. Two fixes:
- Add missing Kiro-native schema fields (`toolAliases`, `allowedTools`, `resources`, `toolsSettings`, `tools: ["*"]`) so configs match Kiro's own format
- Wrap user prompts in agent-specialization framing (`"# {name} — Agent Specialization\n\nYou are a Kiro agent with the following specialization.\n\n## Instructions\n\n{prompt}"`) to avoid triggering guardrails

**3. Fix inaccurate model reporting**
Agent configs specified `model: "claude-opus-4"` but Kiro doesn't support that identifier and falls back to "auto." The `--model` hook flag then reported the wrong model in telemetry. Fix: set `model: null` in Kiro configs (auto selection) and drop `--model` from hook commands — actual model is detected from Kiro's SQLite database at runtime.

## How Has This Been Tested?

- Full test suite: 1858 tests passing
- Manual testing: created pika-kirpo agent with restrictive prompt ("Say only pikachu lines"), verified Kiro follows the wrapped prompt correctly
- Verified both new UX (`kiro-cli chat --agent`) and classic mode (`kiro-cli chat --classic --agent`)

## Learning

Kiro's model has strong guardrails against prompts that try to override its identity or restrict its behavior. Wrapping prompts as "agent specialization" frames them as legitimate customization rather than injection. This was discovered through systematic testing of different prompt phrasings.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)