### PR TITLE
perf(docker): multi-stage API build, expand dockerignore, add nginx gzip

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,60 @@
-**/node_modules
-**/.next
+# Version control
 **/.git
+
+# Python artifacts
 **/__pycache__
 **/.venv
+*.pyc
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Node.js artifacts
+**/node_modules
+**/.next
+
+# Documentation (not copied by any Dockerfile)
+*.md
+LICENSE
+docs/
+screenshots/
+
+# Testing (not shipped in images)
+tests/
+
+# CLI tool (separate distribution, not in API or web image)
+observal_cli/
+
+# Development tooling
+.github/
+.vscode/
+.idea/
+*.code-workspace
+
+# Scripts and tools (not needed in containers)
+scripts/
+tools/
+
+# Demo configs
+demo/
+
+# Monitoring configs (volume-mounted at runtime, not baked in)
+grafana/
+prometheus.yml
+otel-collector-config.yaml
+
+# Docker sub-configs (not needed inside images)
+docker/docker-compose*.yml
+docker/clickhouse/
+docker/nginx*.conf
+docker/server-package/
+
+# Environment and logs
+.env
+.env.*
+!.env.example
+*.log
+
+# Misc
+renovate.json
+cliff.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- multi-stage API Dockerfile reduces image from 923MB to 532MB (42%) (**docker**)
+- expand .dockerignore to exclude non-build files for faster builds (**docker**)
+- enable nginx gzip compression for JSON API responses (**docker**)
+
 ## [0.3.3] - 2026-04-24
 
 ### Fixed

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,4 +1,5 @@
-FROM python:3.14-slim
+# Build stage
+FROM python:3.14-slim AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /bin/
 
@@ -9,15 +10,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends git xmlsec1 lib
 COPY observal-server/pyproject.toml observal-server/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
-COPY observal-server/ .
-COPY ee/ ./ee/
-COPY docker/entrypoint.sh /app/entrypoint.sh
-RUN sed -i 's/\r$//' /app/entrypoint.sh
+# Runtime stage
+FROM python:3.14-slim
 
 RUN groupadd --system --gid 1001 appgroup && \
     useradd --system --uid 1001 --gid appgroup appuser && \
-    chown -R appuser:appgroup /app && \
     mkdir -p /data && chown appuser:appgroup /data
+
+RUN apt-get update && apt-get install -y --no-install-recommends git xmlsec1 && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder --chown=appuser:appgroup /app/.venv /app/.venv
+COPY --chown=appuser:appgroup observal-server/ .
+COPY --chown=appuser:appgroup ee/ ./ee/
+COPY --chown=appuser:appgroup docker/entrypoint.sh /app/entrypoint.sh
+RUN sed -i 's/\r$//' /app/entrypoint.sh
 
 USER appuser
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,13 @@ upstream observal_api {
 server {
     listen 80;
 
+    gzip on;
+    gzip_types application/json application/javascript text/css text/plain text/xml application/xml;
+    gzip_min_length 256;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 5;
+
     location / {
         proxy_pass http://observal_api;
         proxy_set_header Host $http_host;

--- a/docker/nginx.production.conf
+++ b/docker/nginx.production.conf
@@ -21,6 +21,13 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
 
+    gzip on;
+    gzip_types application/json application/javascript text/css text/plain text/xml application/xml;
+    gzip_min_length 256;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 5;
+
     location /api/ {
         proxy_pass http://observal_api;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
Convert Dockerfile.api to multi-stage build — build-only deps (libxmlsec1-dev, pkg-config, uv/uvx) stay in builder stage, runtime keeps only git and xmlsec1. Use COPY --chown to eliminate the 126MB chown -R layer duplication. Reduces API image from 923MB to 532MB (42%).

Expand .dockerignore to exclude docs, tests, scripts, CLI, monitoring configs, and other files not copied by any Dockerfile. Faster build context transfer.

Enable gzip compression in both nginx configs (dev + production HTTPS) for JSON, JS, CSS, XML responses. 60-80% bandwidth reduction on API responses.

<!--- Please fill the necessary details below -->
The API Docker image is 923MB, which is huuuuuuugeeeeeeeee. Most of that bloat comes from build tim dependencies (dev headers, package manager binaries) that stick around in the final image, and a chown -R layer that duplicates everything. This PR cuts the image to 532MB (42% smaller) without changing any runtime behavior.

Also noticed nginx wasn't compressing responses, so JSON payloads were going over the wire uncompressed. Fixed that too.

## Fixes
Not an open issue, this was found during local development setup.

## Approach
 Three independent changes:

  1. Multi-stage Dockerfile.api: This essentially splits the thing into builder and runtime stages. build time deps (libxmlsec1-dev, pkg-config, uv/uvx) stay in the builder. Runtime stage only installs git (needed by GitPython for MCP validation and git mirror service) and xmlsec1 (needed by python3-saml for SAML auth in EE). Created the user before any COPY and used --chown flags to avoid the chown -R layer that was duplicating approx 126MB of files.
  2. Expanded .dockerignore: The old one only had 5 entries. Added exclusions for docs, tests, scripts, CLI, monitoring configs, demo, and other stuff that no Dockerfile ever copies. Doesn't change image size but supposedly speeds up build context transfer. Made sure web/, observal-server/, ee/, and docker/entrypoint.sh are NOT excluded since the dockerfiles need them.
  3. nginx gzip: Added gzip compression (level 5, min 256 bytes) in both nginx.conf and nginx.production.conf for JSON, JS, CSS, XML, and plain text. Only added to the HTTPS server block in production so the HTTP to HTTPS redirect block just serves 301s so it doesn't need it. gzip_proxied any ensures proxied responses from uvicorn actually get compressed.

## How Has This Been Tested?

Built all images fresh and ran the full stack from scratch (volumes nuked):
docker compose -f docker/docker-compose.yml down -v
docker compose -f docker/docker-compose.yml build
docker compose -f docker/docker-compose.yml up -d

Got an image size before after of 923 vs 532 MB

 All services healthy:
  - Init container: ran all 18 Alembic migrations + ClickHouse table setup
  - API: /health, /readyz, /livez all return OK (postgres, clickhouse, redis connected)
  - Worker: cron jobs running (alert evaluation, clickhouse maintenance)
  - Web UI: HTTP 200, page loads fine
  - Grafana + Prometheus: both responding

  Runtime dependency verification (inside the optimized container):
  - All 25 Python packages import successfully (fastapi, sqlalchemy, xmlsec, onelogin.saml2, git, cryptography, arq, etc.)
  - git --version works (v2.47.3)
  - xmlsec1 --version works (v1.2.41)
  - File ownership correct (appuser:appgroup)
  - /data directory exists with correct permissions
  - ee/ module present and accessible

  Trace collection tested:
  - Sent a test trace via OTEL HTTP endpoint (POST localhost:4318/v1/traces) — accepted successfully

Gzip verified:
  - curl -sI -H "Accept-Encoding: gzip" http://localhost:8000/health returns content-encoding: gzip

## Learning (optional, can help others)
chown -R in a Dockerfile creates a new layer that contains a full copy of every file it touches with updated ownership metadata. If you have 155MB of
   files and then chown -R them, that's 155MB duplicated. The fix is to create the user early and use COPY --chown=user:group so files are written with correct ownership in a
  single layer.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->