### PR TITLE
fix: prevent duplicate Observal hooks in Kiro agent configs

### DIFF
--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -1144,15 +1144,15 @@ def _install_kiro_hooks(server_url: str) -> tuple[list[str], bool]:
         current_hooks = data.get("hooks", {})
         updated = False
 
+        def _is_observal_hook(h: dict) -> bool:
+            cmd = h.get("command", "")
+            return "observal_cli" in cmd or "telemetry/hooks" in cmd
+
         for kiro_event, desired_entries in desired_kiro_hooks.items():
             existing = current_hooks.get(kiro_event, [])
-            # Check if Observal hook already present
-            has_observal = any(
-                "observal" in h.get("command", "") or "telemetry/hooks" in h.get("command", "") for h in existing
-            )
-            if not has_observal:
-                # Append our hooks, keep existing ones
-                current_hooks[kiro_event] = existing + desired_entries
+            cleaned = [h for h in existing if not _is_observal_hook(h)]
+            current_hooks[kiro_event] = cleaned + desired_entries
+            if current_hooks[kiro_event] != existing:
                 updated = True
 
         if updated:

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -94,10 +94,17 @@ def _maybe_auto_inject(url: str):
         pass
 
 
+def _is_observal_hook(h: dict) -> bool:
+    """Return True if a hook entry belongs to Observal."""
+    cmd = h.get("command", "")
+    return "observal_cli" in cmd or "telemetry/hooks" in cmd
+
+
 def _auto_inject_hooks(url: str):
     """Inject Observal hooks into any Kiro agent configs that lack them.
 
     Runs only on agentSpawn events so new agents get hooks on first use.
+    Replaces any existing Observal hooks to avoid duplicates.
     """
     agents_dir = Path.home() / ".kiro" / "agents"
     if not agents_dir.is_dir():
@@ -113,13 +120,6 @@ def _auto_inject_hooks(url: str):
         try:
             data = json.loads(af.read_text())
             hooks = data.get("hooks", {})
-            if any(
-                "telemetry/hooks" in h.get("command", "") or "telemetry/hooks" in h.get("command", "")
-                for hs in hooks.values()
-                if isinstance(hs, list)
-                for h in hs
-            ):
-                continue
             name = data.get("name") or af.stem
             cmd = f"{sys.executable} -m observal_cli.hooks.kiro_hook --url {url} --agent-name {name}"
             stop_cmd = f"{sys.executable} -m observal_cli.hooks.kiro_stop_hook --url {url} --agent-name {name}"
@@ -132,7 +132,8 @@ def _auto_inject_hooks(url: str):
             }
             merged = dict(hooks)
             for evt, entries in desired.items():
-                merged.setdefault(evt, []).extend(entries)
+                existing = [h for h in merged.get(evt, []) if not _is_observal_hook(h)]
+                merged[evt] = existing + entries
             data["hooks"] = merged
             af.write_text(json.dumps(data, indent=2) + "\n")
         except Exception:


### PR DESCRIPTION


Strip existing Observal hooks before adding the canonical one in both _auto_inject_hooks (kiro_hook.py) and _install_kiro_hooks (cmd_doctor.py).

<!--- Please fill the necessary details below -->
## Purpose / Description
Every Kiro hook event fires 5-7x because _auto_inject_hooks() in kiro_hook.py
  accumulates duplicate Observal hooks in agent configs without deduplicating.
  Three different code paths (observal pull, observal doctor/observal auth
  login, and _auto_inject_hooks on every agentSpawn) each append hooks with
  slightly different python paths (python3, sys.executable, cat | python3
  /full/path/...), and the guard meant to prevent re-injection has a no-op
  duplicate or condition. This results in inflated prompt/tool/token counts and
  redundant traces in the frontend UI.

## Fixes
* Fixes #589 

## Approach
 Added an _is_observal_hook(h) helper that identifies any hook belonging to Observal by
  checking for observal_cli or telemetry/hooks in the command string — this catches all three
  command formats regardless of python path.
  
  Changed both injection sites to strip-then-add instead of check-then-append:
  
  - kiro_hook.py _auto_inject_hooks(): Removed the broken guard + .extend(). Now filters out
  all existing Observal hooks per event, then appends exactly one canonical hook.
  - cmd_doctor.py _install_kiro_hooks(): Same pattern — strip existing Observal hooks before
  adding the desired ones, instead of skipping the whole event if any Observal hook is
  detected.
  
  This is idempotent: running it N times always results in exactly 1 Observal hook per event
  type.

## How Has This Been Tested?

  - All 296 tests in test_ide_config_e2e.py and test_agent_config_generator.py pass
  - All 42 kiro/hook-specific tests pass (pytest -k "kiro or hook or inject")
  - Manual testing: simulated 3 separate Kiro chat sessions (different session IDs) with
  cooldown stamp cleared between each to force re-injection — verified exactly 1 Observal hook
  per event after all 3 runs
  - Verified _is_observal_hook correctly matches all 3 command formats found in the wild
  (python3 -m, sys.executable -m, cat | python3 /full/path/...)

## Learning (optional, can help others)
  - The root cause was a copy-paste typo: "telemetry/hooks" in cmd or "telemetry/hooks" in cmd
   — identical expressions on both sides of or, making it a no-op duplicate check
  - Even with a correct guard, a check-then-skip approach is fragile when multiple code paths
  write to the same config file with different command formats. Strip-then-add is more robust
  since it's idempotent by design
  - No server-side or frontend dedup exists in the pipeline (ClickHouse ingestion, session
  queries, or React UI), so preventing duplicates at the source is the only fix

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->