### PR TITLE
fix(web): hide enterprise-only sidebar items, fix collapsed logo

### DIFF
--- a/web/src/components/nav/nav-user.tsx
+++ b/web/src/components/nav/nav-user.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LogOut, Settings, SunMoon } from "lucide-react";
+import { LogOut, Settings } from "lucide-react";
 import { ChevronsUpDown } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
@@ -69,14 +69,10 @@ export function NavUser({ user }: NavUserProps) {
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
-          <Link href="/settings">
+          <Link href="/account">
             <Settings className="mr-2 h-4 w-4" />
             Account Settings
           </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled>
-          <SunMoon className="mr-2 h-4 w-4" />
-          Theme
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import {
   Sidebar,
   SidebarContent,
@@ -15,7 +16,6 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from "@/components/ui/sidebar";
-import { ThemeSwitcher } from "@/components/ui/theme-switcher";
 import { NavUser } from "@/components/nav/nav-user";
 
 import {
@@ -39,8 +39,9 @@ import {
 import { useSyncExternalStore } from "react";
 import { getUserRole, getUserName, getUserEmail } from "@/lib/api";
 import { hasMinRole, type Role } from "@/hooks/use-role-guard";
+import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 
-type NavItem = { title: string; href: string; icon: typeof Home; requiresAuth?: boolean; minRole?: Role };
+type NavItem = { title: string; href: string; icon: typeof Home; requiresAuth?: boolean; minRole?: Role; enterpriseOnly?: boolean };
 
 const registryNav: NavItem[] = [
   { title: "Home", href: "/", icon: Home },
@@ -63,9 +64,9 @@ const adminNav: NavItem[] = [
   { title: "Errors", href: "/errors", icon: AlertTriangle, minRole: "admin" },
   { title: "Evals", href: "/eval", icon: FlaskConical, minRole: "admin" },
   { title: "Users", href: "/users", icon: Users, minRole: "admin" },
-  { title: "Audit Log", href: "/audit-log", icon: ScrollText, minRole: "admin" },
-  { title: "Security", href: "/security-events", icon: ShieldAlert, minRole: "admin" },
-  { title: "SSO & SCIM", href: "/sso", icon: KeyRound, minRole: "admin" },
+  { title: "Audit Log", href: "/audit-log", icon: ScrollText, minRole: "admin", enterpriseOnly: true },
+  { title: "Security", href: "/security-events", icon: ShieldAlert, minRole: "admin", enterpriseOnly: true },
+  { title: "SSO & SCIM", href: "/sso", icon: KeyRound, minRole: "admin", enterpriseOnly: true },
   { title: "Diagnostics", href: "/diagnostics", icon: Stethoscope, minRole: "admin" },
   { title: "Settings", href: "/settings", icon: Settings, minRole: "admin" },
 ];
@@ -90,6 +91,7 @@ export function RegistrySidebar() {
   const snap = useSyncExternalStore(storeSub, getAuthSnap, getServerSnap);
   const [token, role, userName, userEmail] = snap.split("|");
   const isAuthenticated = !!token;
+  const { deploymentMode } = useDeploymentConfig();
 
   function isActive(href: string) {
     if (href === "/") return pathname === "/";
@@ -115,17 +117,32 @@ export function RegistrySidebar() {
     : [];
 
   const visibleAdminNav = isAuthenticated
-    ? adminNav.filter((item) => !item.minRole || hasMinRole(role, item.minRole))
+    ? adminNav.filter(
+        (item) =>
+          (!item.minRole || hasMinRole(role, item.minRole)) &&
+          (!item.enterpriseOnly || deploymentMode === "enterprise"),
+      )
     : [];
 
   return (
     <Sidebar collapsible="icon">
       <SidebarHeader>
-        <div className="flex items-center gap-2.5 px-2 py-1.5">
-          <span className="text-base font-semibold tracking-tight font-[family-name:var(--font-display)]">
-            Observal
-          </span>
-        </div>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" asChild>
+              <Link href="/">
+                <div className="flex size-8 shrink-0 items-center justify-center">
+                  <Image src="/favicon.ico" alt="" width={20} height={20} />
+                </div>
+                <div className="flex flex-col gap-0.5 leading-none">
+                  <span className="text-base font-semibold tracking-tight font-[family-name:var(--font-display)]">
+                    Observal
+                  </span>
+                </div>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
@@ -215,7 +232,6 @@ export function RegistrySidebar() {
         )}
       </SidebarContent>
       <SidebarFooter>
-        <ThemeSwitcher />
         <NavUser user={{ name: userName || "User", email: userEmail || "" }} />
       </SidebarFooter>
       <SidebarRail />


### PR DESCRIPTION
## Purpose / Description
The sidebar shows enterprise-only items (Audit Log, Security, SSO & SCIM) in local deployments where they don't exist, and the collapsed sidebar logo was broken. The ThemeSwitcher also needed to move out of the sidebar footer now that the account page has a proper theme picker.

## Fixes
* Fixes #600 

## Approach
- Added `enterpriseOnly` flag to the sidebar `NavItem` type; items marked `enterpriseOnly: true` are filtered out unless `deploymentMode === "enterprise"`
- Replaced the text-based sidebar header with a favicon logo using `SidebarMenuButton size="lg"` so it scales correctly when collapsed
- Removed ThemeSwitcher from the sidebar footer (theme picker now lives on `/account`)
- Updated NavUser "Account Settings" link from `/settings` to `/account`

## How Has This Been Tested?
- Verified in local deployment mode that Audit Log, Security, and SSO & SCIM are hidden
- Collapsed the sidebar and confirmed the favicon logo renders at correct size
- Clicked "Account Settings" in user dropdown — navigates to `/account`
- Confirmed ThemeSwitcher no longer appears in sidebar footer

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)