### PR TITLE
fix(web): replace hardcoded colors with semantic theme tokens

### DIFF
--- a/web/src/app/(admin)/diagnostics/page.tsx
+++ b/web/src/app/(admin)/diagnostics/page.tsx
@@ -9,20 +9,20 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { ErrorState } from "@/components/shared/error-state";
 
 function StatusIcon({ status }: { status: string }) {
-  if (status === "ok") return <CheckCircle2 className="h-5 w-5 text-emerald-500" />;
+  if (status === "ok") return <CheckCircle2 className="h-5 w-5 text-success" />;
   if (status === "degraded" || status === "misconfigured" || status === "missing")
-    return <AlertTriangle className="h-5 w-5 text-amber-500" />;
+    return <AlertTriangle className="h-5 w-5 text-warning" />;
   return <XCircle className="h-5 w-5 text-red-500" />;
 }
 
 function statusBadge(status: string) {
   switch (status) {
     case "ok":
-      return <Badge className="bg-emerald-500/15 text-emerald-600 border-emerald-500/20">{status}</Badge>;
+      return <Badge className="bg-success/15 text-success border-success/20">{status}</Badge>;
     case "degraded":
     case "misconfigured":
     case "missing":
-      return <Badge className="bg-amber-500/15 text-amber-600 border-amber-500/20">{status}</Badge>;
+      return <Badge className="bg-warning/15 text-warning border-warning/20">{status}</Badge>;
     default:
       return <Badge variant="destructive">{status}</Badge>;
   }
@@ -149,7 +149,7 @@ export default function DiagnosticsPage() {
                       <ul className="space-y-1.5">
                         {(data.checks.enterprise.issues as string[]).map((issue: string, i: number) => (
                           <li key={i} className="flex items-start gap-2 text-xs">
-                            <AlertTriangle className="h-3.5 w-3.5 text-amber-500 mt-0.5 shrink-0" />
+                            <AlertTriangle className="h-3.5 w-3.5 text-warning mt-0.5 shrink-0" />
                             <span>{issue}</span>
                           </li>
                         ))}

--- a/web/src/app/(admin)/errors/page.tsx
+++ b/web/src/app/(admin)/errors/page.tsx
@@ -31,9 +31,9 @@ function errorTypeLabel(t: ErrorType): string {
 
 function errorTypeColor(t: ErrorType): string {
   switch (t) {
-    case "tool_failure": return "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20";
-    case "stop_failure": return "bg-red-500/10 text-red-500 border-red-500/20";
-    case "api_error": return "bg-rose-500/10 text-rose-500 border-rose-500/20";
+    case "tool_failure": return "bg-warning/10 text-warning border-warning/20";
+    case "stop_failure": return "bg-destructive/10 text-destructive border-destructive/20";
+    case "api_error": return "bg-destructive/10 text-destructive border-destructive/20";
   }
 }
 
@@ -90,7 +90,7 @@ function ErrorRow({ event }: { event: SessionErrorEvent }) {
           {event.error && (
             <div className="space-y-1">
               <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Error</span>
-              <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-all bg-red-500/5 border border-red-500/20 rounded-md p-2.5 max-h-[200px] overflow-auto text-red-600 dark:text-red-400">
+              <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-all bg-destructive/5 border border-destructive/20 rounded-md p-2.5 max-h-[200px] overflow-auto text-destructive">
                 {event.error}
               </pre>
             </div>

--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -240,7 +240,7 @@ export default function UsersPage() {
                     {createdPassword}
                   </code>
                   <Button variant="ghost" size="sm" className="h-7 w-7 p-0 shrink-0" onClick={handleCopyPassword}>
-                    {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+                    {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
                   </Button>
                 </div>
               </div>
@@ -329,7 +329,7 @@ export default function UsersPage() {
                     {resetResult}
                   </code>
                   <Button variant="ghost" size="sm" className="h-7 w-7 p-0 shrink-0" onClick={handleCopyResetPassword}>
-                    {resetCopied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+                    {resetCopied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
                   </Button>
                 </div>
               </div>

--- a/web/src/app/(auth)/device/page.tsx
+++ b/web/src/app/(auth)/device/page.tsx
@@ -95,7 +95,7 @@ function DeviceContent() {
           <div className="px-8 py-6">
             {success ? (
               <div className="flex flex-col items-center gap-4 py-4 animate-in">
-                <CheckCircle2 className="h-12 w-12 text-green-500" />
+                <CheckCircle2 className="h-12 w-12 text-success" />
                 <p className="text-center text-sm text-muted-foreground">
                   Device authorized! You can close this tab and return to your terminal.
                 </p>

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -781,8 +781,8 @@ function AgentBuilderInner() {
       <div className="p-6 lg:p-8 w-full mx-auto">
         {/* Restore draft banner */}
         {showRestoreBanner && (
-          <div className="mb-4 flex items-center gap-3 rounded-lg border border-blue-500/20 bg-blue-500/5 px-4 py-3">
-            <p className="flex-1 text-sm text-blue-700 dark:text-blue-300">
+          <div className="mb-4 flex items-center gap-3 rounded-lg border border-info/20 bg-info/5 px-4 py-3">
+            <p className="flex-1 text-sm text-info">
               You have an unsaved draft.
             </p>
             <Button variant="outline" size="sm" onClick={restoreLocalDraft}>

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -199,7 +199,7 @@ function UnarchiveAgentButton({ agent }: { agent: RegistryItem }) {
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 w-7 p-0 text-muted-foreground hover:text-green-600"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-success"
               onClick={(e) => {
                 e.stopPropagation();
                 setConfirmOpen(true);
@@ -269,7 +269,7 @@ const columns: ColumnDef<RegistryItem>[] = [
             {row.original.name}
           </Link>
           {row.original.status && row.original.status !== "active" && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-yellow-500/10 px-2 py-0.5 text-[10px] font-medium text-yellow-600 dark:text-yellow-400 ring-1 ring-yellow-500/20">
+            <span className="inline-flex items-center gap-1 rounded-full bg-warning/10 px-2 py-0.5 text-[10px] font-medium text-warning ring-1 ring-warning/20">
               <Clock className="h-2.5 w-2.5" />
               Pending Review
             </span>
@@ -597,9 +597,9 @@ function AgentListContent() {
         )}
 
         {pendingCount > 0 && (
-          <div className="flex items-start gap-3 rounded-lg border border-yellow-500/20 bg-yellow-500/5 px-4 py-3">
-            <Clock className="h-4 w-4 mt-0.5 text-yellow-600 dark:text-yellow-400 shrink-0" />
-            <p className="text-sm text-yellow-700 dark:text-yellow-300">
+          <div className="flex items-start gap-3 rounded-lg border border-warning/20 bg-warning/5 px-4 py-3">
+            <Clock className="h-4 w-4 mt-0.5 text-warning shrink-0" />
+            <p className="text-sm text-warning">
               You have {pendingCount} agent{pendingCount > 1 ? "s" : ""} pending review.
               An admin must approve {pendingCount > 1 ? "them" : "it"} before {pendingCount > 1 ? "they become" : "it becomes"} visible to other users.
             </p>

--- a/web/src/app/(registry)/components/[id]/page.tsx
+++ b/web/src/app/(registry)/components/[id]/page.tsx
@@ -301,7 +301,7 @@ function InstallSnippet({ type, name }: { type: string; name: string }) {
         aria-label="Copy command"
       >
         {copied ? (
-          <Check className="h-3.5 w-3.5 text-green-500" />
+          <Check className="h-3.5 w-3.5 text-success" />
         ) : (
           <Copy className="h-3.5 w-3.5" />
         )}

--- a/web/src/app/(user)/traces/[id]/page.tsx
+++ b/web/src/app/(user)/traces/[id]/page.tsx
@@ -48,7 +48,7 @@ import { SessionDAG } from "@/components/dashboard/session-dag";
 function Badge({ children, variant = "default" }: { children: React.ReactNode; variant?: "default" | "success" | "warning" | "muted" }) {
   const cls = {
     default: "bg-primary/10 text-primary",
-    success: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    success: "bg-success/10 text-success",
     warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
     muted: "bg-muted text-muted-foreground",
   }[variant];
@@ -120,21 +120,21 @@ function eventIcon(eventName: string) {
 }
 
 function eventColor(eventName: string): string {
-  if (eventName === "api_request") return "text-blue-500";
-  if (eventName === "tool_result") return "text-emerald-500";
+  if (eventName === "api_request") return "text-info";
+  if (eventName === "tool_result") return "text-success";
   if (eventName === "tool_decision") return "text-amber-500";
   if (eventName === "user_prompt" || eventName === "hook_userpromptsubmit") return "text-purple-500";
   if (eventName === "hook_posttooluse") return "text-cyan-500";
   if (eventName === "hook_pretooluse") return "text-sky-400";
-  if (eventName === "hook_posttoolusefailure" || eventName === "hook_stopfailure") return "text-red-500";
+  if (eventName === "hook_posttoolusefailure" || eventName === "hook_stopfailure") return "text-destructive";
   if (eventName === "hook_subagentstart" || eventName === "hook_subagentstop") return "text-indigo-500";
   if (eventName === "hook_assistant_response") return "text-violet-500";
   if (eventName === "hook_assistant_thinking") return "text-fuchsia-500";
   if (eventName === "hook_stop") return "text-rose-500";
-  if (eventName === "hook_sessionstart") return "text-green-500";
-  if (eventName === "hook_notification") return "text-yellow-500";
+  if (eventName === "hook_sessionstart") return "text-success";
+  if (eventName === "hook_notification") return "text-warning";
   if (eventName === "hook_taskcreated" || eventName === "hook_taskcompleted") return "text-lime-500";
-  if (eventName === "hook_precompact" || eventName === "hook_postcompact") return "text-slate-400";
+  if (eventName === "hook_precompact" || eventName === "hook_postcompact") return "text-muted-foreground";
   if (eventName === "hook_worktreecreate" || eventName === "hook_worktreeremove") return "text-amber-400";
   if (eventName === "hook_elicitation" || eventName === "hook_elicitationresult") return "text-teal-500";
   if (isShimEvent(eventName)) return "text-teal-500";
@@ -156,13 +156,13 @@ const FILTER_CATEGORIES: FilterCategory[] = [
   { key: "responses", label: "Responses", match: (e) => e === "hook_assistant_response", color: "bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20" },
   { key: "thinking", label: "Thinking", match: (e) => e === "hook_assistant_thinking", color: "bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400 border-fuchsia-500/20" },
   { key: "tools", label: "Tools", match: (e) => ["tool_result", "tool_decision", "hook_posttooluse", "hook_pretooluse", "hook_posttoolusefailure", "shim_tool_call"].includes(e), color: "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 border-cyan-500/20" },
-  { key: "api", label: "API", match: (e) => e === "api_request", color: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20" },
+  { key: "api", label: "API", match: (e) => e === "api_request", color: "bg-info/10 text-info border-info/20" },
   { key: "agents", label: "Agents", match: (e) => e === "hook_subagentstart" || e === "hook_subagentstop", color: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/20" },
   { key: "lifecycle", label: "Lifecycle", match: (e) => ["hook_sessionstart", "hook_stop", "hook_stopfailure", "hook_precompact", "hook_postcompact"].includes(e), color: "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20" },
   { key: "tasks", label: "Tasks", match: (e) => e === "hook_taskcreated" || e === "hook_taskcompleted", color: "bg-lime-500/10 text-lime-600 dark:text-lime-400 border-lime-500/20" },
   { key: "mcp", label: "MCP", match: (e) => e === "hook_elicitation" || e === "hook_elicitationresult", color: "bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20" },
-  { key: "errors", label: "Errors", match: (e) => e === "hook_posttoolusefailure" || e === "hook_stopfailure", color: "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20" },
-  { key: "notifications", label: "Notifications", match: (e) => e === "hook_notification", color: "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border-yellow-500/20" },
+  { key: "errors", label: "Errors", match: (e) => e === "hook_posttoolusefailure" || e === "hook_stopfailure", color: "bg-destructive/10 text-destructive border-destructive/20" },
+  { key: "notifications", label: "Notifications", match: (e) => e === "hook_notification", color: "bg-warning/10 text-warning border-warning/20" },
   { key: "worktree", label: "Worktrees", match: (e) => e === "hook_worktreecreate" || e === "hook_worktreeremove", color: "bg-amber-400/10 text-amber-600 dark:text-amber-300 border-amber-400/20" },
 ];
 
@@ -474,7 +474,7 @@ function EventSummary({ event }: { event: RawSessionEvent }) {
         {attrs.duration_ms && <Stat label="" value={formatDuration(attrs.duration_ms)} icon={Clock} />}
         {attrs.mcp_latency_ms && <Stat label="MCP" value={formatDuration(attrs.mcp_latency_ms)} icon={Clock} />}
         {hasMcp && (
-          <span className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${schemaValid ? "text-emerald-500" : "text-red-400"}`}>
+          <span className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${schemaValid ? "text-success" : "text-destructive"}`}>
             {schemaValid ? <CheckCircle2 className="h-3 w-3" /> : <XCircle className="h-3 w-3" />}
             schema
           </span>
@@ -489,7 +489,7 @@ function EventSummary({ event }: { event: RawSessionEvent }) {
     return (
       <div className="flex items-center gap-3 flex-wrap">
         <Badge variant="warning">{attrs.tool_name || "?"}</Badge>
-        <span className="text-xs text-red-500">failed</span>
+        <span className="text-xs text-destructive">failed</span>
         {attrs.error && <span className="text-xs text-muted-foreground truncate max-w-md">{attrs.error.slice(0, 80)}</span>}
       </div>
     );
@@ -499,7 +499,7 @@ function EventSummary({ event }: { event: RawSessionEvent }) {
     return (
       <div className="flex items-center gap-3 flex-wrap">
         <Badge variant="warning">API error</Badge>
-        {attrs.error && <span className="text-xs text-red-500 truncate max-w-md">{attrs.error.slice(0, 80)}</span>}
+        {attrs.error && <span className="text-xs text-destructive truncate max-w-md">{attrs.error.slice(0, 80)}</span>}
       </div>
     );
   }
@@ -562,7 +562,7 @@ function EventSummary({ event }: { event: RawSessionEvent }) {
         )}
         {attrs.mcp_latency_ms && <Stat label="MCP" value={formatDuration(attrs.mcp_latency_ms)} icon={Clock} />}
         {attrs.tool_schema_valid && (
-          <span className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${schemaValid ? "text-emerald-500" : "text-red-400"}`}>
+          <span className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${schemaValid ? "text-success" : "text-destructive"}`}>
             {schemaValid ? <CheckCircle2 className="h-3 w-3" /> : <XCircle className="h-3 w-3" />}
             schema
           </span>
@@ -675,8 +675,8 @@ function DiffBlock({ filePath, oldStr, newStr }: { filePath: string; oldStr: str
       <div className="flex items-center gap-2">
         <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Diff</span>
         <span className="text-[11px] font-[family-name:var(--font-mono)] text-muted-foreground">{filePath.split("/").pop()}</span>
-        <span className="text-[11px] text-emerald-500">+{addCount}</span>
-        <span className="text-[11px] text-red-400">-{removeCount}</span>
+        <span className="text-[11px] text-success">+{addCount}</span>
+        <span className="text-[11px] text-destructive">-{removeCount}</span>
       </div>
       <div className="text-xs font-[family-name:var(--font-mono)] border border-border rounded-md overflow-hidden max-h-[400px] overflow-auto">
         {visible.map((line, idx) => {
@@ -687,8 +687,8 @@ function DiffBlock({ filePath, oldStr, newStr }: { filePath: string; oldStr: str
               </div>
             );
           }
-          const bgCls = line.type === "add" ? "bg-emerald-500/10" : line.type === "remove" ? "bg-red-500/10" : "";
-          const textCls = line.type === "add" ? "text-emerald-600 dark:text-emerald-400" : line.type === "remove" ? "text-red-400" : "text-foreground/60";
+          const bgCls = line.type === "add" ? "bg-success/10" : line.type === "remove" ? "bg-destructive/10" : "";
+          const textCls = line.type === "add" ? "text-success" : line.type === "remove" ? "text-destructive" : "text-foreground/60";
           const prefix = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
           const ln = line.type === "remove" ? oldLine : line.type === "add" ? newLine : oldLine;
           if (line.type === "remove" || line.type === "same") oldLine++;
@@ -1567,7 +1567,7 @@ function SessionInfoTab({ events, sessionId, serviceName }: { events: RawSession
                       }`}
                     >
                       {active
-                        ? <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+                        ? <CheckCircle2 className="h-3.5 w-3.5 text-success shrink-0" />
                         : <XCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />}
                       <div className="flex-1 min-w-0">
                         <span className="font-medium">{hook.label}</span>

--- a/web/src/components/registry/install-dialog.tsx
+++ b/web/src/components/registry/install-dialog.tsx
@@ -79,9 +79,9 @@ export function InstallDialog({ type, id, name }: InstallDialogProps) {
         </Select>
         {loading && <p className="text-sm text-muted-foreground">Loading config…</p>}
         {warnings.length > 0 && (
-          <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3 space-y-1">
+          <div className="rounded-md border border-warning/30 bg-warning/10 p-3 space-y-1">
             {warnings.map((w, i) => (
-              <p key={i} className="text-xs text-yellow-700 dark:text-yellow-400 flex items-start gap-1.5">
+              <p key={i} className="text-xs text-warning flex items-start gap-1.5">
                 <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
                 {w}
               </p>

--- a/web/src/components/registry/status-badge.tsx
+++ b/web/src/components/registry/status-badge.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 
 const statusConfig: Record<string, { bg: string; text: string; dot?: string; ping?: boolean }> = {
-  draft:     { bg: "bg-zinc-100 dark:bg-zinc-800", text: "text-zinc-600 dark:text-zinc-400", dot: "bg-zinc-400" },
+  draft:     { bg: "bg-muted", text: "text-muted-foreground", dot: "bg-muted-foreground" },
   pending:   { bg: "bg-light-yellow", text: "text-dark-yellow", dot: "bg-dark-yellow", ping: true },
   approved:  { bg: "bg-light-green",  text: "text-dark-green",  dot: "bg-dark-green",  ping: true },
   active:    { bg: "bg-light-green",  text: "text-dark-green",  dot: "bg-dark-green",  ping: true },
@@ -12,7 +12,7 @@ const statusConfig: Record<string, { bg: string; text: string; dot?: string; pin
   running:   { bg: "bg-light-blue",   text: "text-dark-blue",   dot: "bg-dark-blue",   ping: true },
   completed: { bg: "bg-light-green",  text: "text-dark-green" },
   success:   { bg: "bg-light-green",  text: "text-dark-green" },
-  archived:  { bg: "bg-zinc-100 dark:bg-zinc-800", text: "text-zinc-600 dark:text-zinc-400" },
+  archived:  { bg: "bg-muted", text: "text-muted-foreground" },
 };
 
 const fallback = { bg: "bg-muted", text: "text-muted-foreground" };

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -556,7 +556,7 @@ export function SubmitComponentDialog({
                         <span className="flex items-center gap-2">
                           {mcp.name}
                           {mcp.status === "pending" && (
-                            <span className="text-[10px] rounded bg-yellow-500/15 text-yellow-500 px-1.5 py-0.5">
+                            <span className="text-[10px] rounded bg-warning/15 text-warning px-1.5 py-0.5">
                               pending
                             </span>
                           )}

--- a/web/src/components/traces/span-tree.tsx
+++ b/web/src/components/traces/span-tree.tsx
@@ -63,13 +63,13 @@ function countDescendants(node: SpanNode): number {
 }
 
 const threadColor: Record<string, { line: string; hover: string; bg: string }> = {
-  tool_call:    { line: "bg-blue-400",   hover: "bg-blue-500",   bg: "bg-blue-100 text-blue-700" },
+  tool_call:    { line: "bg-info",        hover: "bg-info",       bg: "bg-light-blue text-dark-blue" },
   llm:          { line: "bg-purple-400", hover: "bg-purple-500", bg: "bg-purple-100 text-purple-700" },
   retrieval:    { line: "bg-amber-400",  hover: "bg-amber-500",  bg: "bg-amber-100 text-amber-700" },
-  sandbox_exec: { line: "bg-green-400",  hover: "bg-green-500",  bg: "bg-green-100 text-green-700" },
+  sandbox_exec: { line: "bg-success",    hover: "bg-success",    bg: "bg-light-green text-dark-green" },
   hook:         { line: "bg-pink-400",   hover: "bg-pink-500",   bg: "bg-pink-100 text-pink-700" },
   prompt:       { line: "bg-teal-400",   hover: "bg-teal-500",   bg: "bg-teal-100 text-teal-700" },
-  lifecycle:    { line: "bg-gray-300",   hover: "bg-gray-400",   bg: "bg-gray-100 text-gray-500" },
+  lifecycle:    { line: "bg-muted-foreground", hover: "bg-muted-foreground", bg: "bg-muted text-muted-foreground" },
 };
 
 function isLifecycleSpan(span: Span): boolean {
@@ -77,14 +77,14 @@ function isLifecycleSpan(span: Span): boolean {
 }
 
 function getColors(type: string) {
-  return threadColor[type] ?? { line: "bg-gray-300", hover: "bg-gray-400", bg: "bg-gray-100 text-gray-700" };
+  return threadColor[type] ?? { line: "bg-muted-foreground", hover: "bg-muted-foreground", bg: "bg-muted text-muted-foreground" };
 }
 
 function statusDot(status: string) {
   const color =
-    status === "error" ? "bg-red-500" :
-    status === "timeout" ? "bg-yellow-500" :
-    "bg-green-500";
+    status === "error" ? "bg-destructive" :
+    status === "timeout" ? "bg-warning" :
+    "bg-success";
   return <span className={cn("inline-block h-2 w-2 rounded-full shrink-0", color)} />;
 }
 
@@ -124,7 +124,7 @@ function SpanRow({
         {Array.from({ length: depth }, (_, i) => (
           <div
             key={i}
-            className="absolute top-0 bottom-0 w-0.5 bg-gray-200 dark:bg-gray-700"
+            className="absolute top-0 bottom-0 w-0.5 bg-border"
             style={{ left: `${i * INDENT + 11}px` }}
           />
         ))}

--- a/web/src/components/traces/trace-detail.tsx
+++ b/web/src/components/traces/trace-detail.tsx
@@ -126,8 +126,8 @@ export function TraceDetail({ trace, isLoading }: { trace?: Trace; isLoading: bo
                   </Card>
                 )}
                 {selectedSpan.error && (
-                  <Card className="border-red-200"><CardHeader className="py-2 px-4"><CardTitle className="text-sm text-red-600">Error</CardTitle></CardHeader>
-                    <CardContent className="px-4 pb-3 text-sm text-red-700 font-mono whitespace-pre-wrap">{selectedSpan.error}</CardContent>
+                  <Card className="border-destructive/20"><CardHeader className="py-2 px-4"><CardTitle className="text-sm text-destructive">Error</CardTitle></CardHeader>
+                    <CardContent className="px-4 pb-3 text-sm text-destructive font-mono whitespace-pre-wrap">{selectedSpan.error}</CardContent>
                   </Card>
                 )}
                 {selectedSpan.metadata && Object.keys(selectedSpan.metadata).length > 0 && (

--- a/web/src/components/traces/trace-list.tsx
+++ b/web/src/components/traces/trace-list.tsx
@@ -26,11 +26,11 @@ import { QueryError } from "@/components/dashboard/query-error";
 import { ListTree } from "lucide-react";
 
 const IDE_BADGE_STYLES: Record<string, string> = {
-  "claude-code": "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  "claude-code": "bg-light-yellow text-dark-yellow",
   kiro: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
   cursor: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400",
-  "gemini-cli": "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-  vscode: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  "gemini-cli": "bg-light-red text-dark-red",
+  vscode: "bg-light-blue text-dark-blue",
   codex: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-400",
   copilot: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
   "copilot-cli": "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",


### PR DESCRIPTION
## Purpose / Description
Many UI elements used hardcoded Tailwind color classes (text-red-500, bg-green-400, bg-zinc-800, text-slate-400, etc.) that ignore the active theme, causing visual inconsistency when switching away from the default dark theme.

## Fixes
* Fixes #602

## Approach
- Replaced hardcoded Tailwind classes with semantic theme tokens (text-destructive, bg-success, bg-muted, text-muted-foreground, etc.) across 14 files
- Covers status badges, score displays, span tree, trace list/detail, error page, diagnostics, users, device auth, agent pages, builder, install dialog, and submit component dialog
- Intentionally skips session-dag.tsx which is handled separately in #605

## How Has This Been Tested?
- Switched to each theme and verified status badges (draft, pending, approved, rejected) are visible
- Checked error page — error/warning badges use theme destructive/warning colors
- Checked trace timeline — span colors, status dots, diff view all adapt to theme
- Verified no visual regressions on the default dark theme

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)