### PR TITLE
feat(web): add 10 curated IDE themes with hand-tuned oklch palettes

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @plugin "tailwindcss-animate";
 
-@custom-variant dark (&:is(.dark *, .midnight *, .forest *, .sunset *));
+@custom-variant dark (&:is(.dark *, .midnight *, .forest *, .sunset *, .solarized-dark *, .dracula *, .nord *, .monokai *, .gruvbox *, .catppuccin *, .tokyo-night *, .one-dark *, .rose-pine *));
 
 @theme inline {
   /* ── Typography ─────────────────────────────────── */
@@ -495,6 +495,796 @@
     --chart-7: 0.65 0.13 145;
     --chart-8: 0.65 0.15 340;
     --chart-grid: 0.24 0.02 50;
+  }
+
+  /* ══════════════════════════════════════════════════
+     SOLARIZED DARK — cyan-tinted dark, canonical palette
+     ══════════════════════════════════════════════════ */
+  .solarized-dark {
+    --bg: 0.27 0.049 220;
+    --fg: 0.65 0.020 205;
+
+    --muted: 0.31 0.052 220;
+    --muted-fg: 0.55 0.025 210;
+
+    --popover: 0.29 0.050 220;
+    --popover-fg: 0.65 0.020 205;
+
+    --card: 0.31 0.052 220;
+    --card-fg: 0.65 0.020 205;
+
+    --header: 0.33 0.050 220;
+    --header-fg: 0.65 0.020 205;
+
+    --border: 0.45 0.035 218;
+    --input: 0.45 0.035 218;
+
+    --primary: 0.65 0.020 205;
+    --primary-fg: 0.27 0.049 220;
+
+    --secondary: 0.31 0.052 220;
+    --secondary-fg: 0.65 0.020 205;
+
+    --accent: 0.34 0.050 220;
+    --accent-fg: 0.65 0.020 205;
+
+    --destructive: 0.59 0.206 27;
+    --destructive-fg: 0.97 0.01 27;
+
+    --ring: 0.40 0.040 220;
+
+    --primary-accent: 0.61 0.139 245;
+
+    --surface-raised: 0.33 0.050 220;
+    --surface-sunken: 0.24 0.048 220;
+
+    --success: 0.64 0.151 119;
+    --success-fg: 0.15 0.02 119;
+    --warning: 0.65 0.134 86;
+    --warning-fg: 0.20 0.04 86;
+    --info: 0.64 0.102 187;
+    --info-fg: 0.15 0.02 187;
+
+    --muted-gray: 0.38 0.030 215;
+
+    --light-red: 0.38 0.08 27;
+    --dark-red: 0.59 0.206 27;
+    --light-yellow: 0.40 0.07 86;
+    --dark-yellow: 0.65 0.134 86;
+    --light-green: 0.35 0.07 119;
+    --dark-green: 0.64 0.151 119;
+    --light-blue: 0.35 0.07 245;
+    --dark-blue: 0.61 0.139 245;
+
+    --sidebar-bg: 0.24 0.048 220;
+    --sidebar-fg: 0.60 0.022 205;
+    --sidebar-primary: 0.65 0.020 205;
+    --sidebar-primary-fg: 0.27 0.049 220;
+    --sidebar-accent: 0.30 0.052 220;
+    --sidebar-accent-fg: 0.62 0.020 205;
+    --sidebar-border: 0.42 0.032 218;
+    --sidebar-ring: 0.61 0.139 245;
+
+    --chart-1: 0.61 0.139 245;
+    --chart-2: 0.64 0.102 187;
+    --chart-3: 0.64 0.151 119;
+    --chart-4: 0.59 0.202 356;
+    --chart-5: 0.65 0.134 86;
+    --chart-6: 0.59 0.206 27;
+    --chart-7: 0.64 0.102 187;
+    --chart-8: 0.59 0.202 356;
+    --chart-grid: 0.38 0.030 215;
+  }
+
+  /* ══════════════════════════════════════════════════
+     SOLARIZED LIGHT — warm cream tones, same accent palette
+     ══════════════════════════════════════════════════ */
+  .solarized-light {
+    --bg: 0.97 0.026 90;
+    --fg: 0.52 0.028 219;
+
+    --muted: 0.93 0.026 92;
+    --muted-fg: 0.60 0.025 215;
+
+    --popover: 0.97 0.026 90;
+    --popover-fg: 0.52 0.028 219;
+
+    --card: 0.95 0.026 91;
+    --card-fg: 0.52 0.028 219;
+
+    --header: 0.93 0.026 92;
+    --header-fg: 0.52 0.028 219;
+
+    --border: 0.70 0.016 197;
+    --input: 0.70 0.016 197;
+
+    --primary: 0.52 0.028 219;
+    --primary-fg: 0.97 0.026 90;
+
+    --secondary: 0.93 0.026 92;
+    --secondary-fg: 0.52 0.028 219;
+
+    --accent: 0.91 0.026 92;
+    --accent-fg: 0.52 0.028 219;
+
+    --destructive: 0.59 0.206 27;
+    --destructive-fg: 0.97 0.01 27;
+
+    --ring: 0.70 0.016 197;
+
+    --primary-accent: 0.61 0.139 245;
+
+    --surface-raised: 0.99 0.020 90;
+    --surface-sunken: 0.90 0.028 92;
+
+    --success: 0.55 0.15 119;
+    --success-fg: 0.97 0.01 119;
+    --warning: 0.58 0.134 86;
+    --warning-fg: 0.25 0.05 86;
+    --info: 0.61 0.139 245;
+    --info-fg: 0.97 0.01 245;
+
+    --muted-gray: 0.88 0.022 92;
+
+    --light-red: 0.88 0.04 27;
+    --dark-red: 0.59 0.206 27;
+    --light-yellow: 0.90 0.05 86;
+    --dark-yellow: 0.65 0.134 86;
+    --light-green: 0.88 0.04 119;
+    --dark-green: 0.40 0.10 119;
+    --light-blue: 0.88 0.04 245;
+    --dark-blue: 0.61 0.139 245;
+
+    --sidebar-bg: 0.93 0.026 92;
+    --sidebar-fg: 0.52 0.028 219;
+    --sidebar-primary: 0.52 0.028 219;
+    --sidebar-primary-fg: 0.97 0.026 90;
+    --sidebar-accent: 0.89 0.026 92;
+    --sidebar-accent-fg: 0.52 0.028 219;
+    --sidebar-border: 0.70 0.016 197;
+    --sidebar-ring: 0.61 0.139 245;
+
+    --chart-1: 0.55 0.2 270;
+    --chart-2: 0.61 0.139 245;
+    --chart-3: 0.64 0.102 187;
+    --chart-4: 0.59 0.202 356;
+    --chart-5: 0.65 0.134 86;
+    --chart-6: 0.59 0.206 27;
+    --chart-7: 0.64 0.151 119;
+    --chart-8: 0.59 0.202 356;
+    --chart-grid: 0.82 0.020 92;
+  }
+
+  /* ══════════════════════════════════════════════════
+     DRACULA — purple-tinted dark, vivid palette
+     ══════════════════════════════════════════════════ */
+  .dracula {
+    --bg: 0.26 0.030 278;
+    --fg: 0.98 0.008 107;
+
+    --muted: 0.35 0.038 278;
+    --muted-fg: 0.58 0.050 268;
+
+    --popover: 0.31 0.034 278;
+    --popover-fg: 0.98 0.008 107;
+
+    --card: 0.35 0.038 278;
+    --card-fg: 0.98 0.008 107;
+
+    --header: 0.36 0.028 278;
+    --header-fg: 0.98 0.008 107;
+
+    --border: 0.50 0.055 270;
+    --input: 0.50 0.055 270;
+
+    --primary: 0.98 0.008 107;
+    --primary-fg: 0.26 0.030 278;
+
+    --secondary: 0.35 0.038 278;
+    --secondary-fg: 0.98 0.008 107;
+
+    --accent: 0.38 0.038 278;
+    --accent-fg: 0.98 0.008 107;
+
+    --destructive: 0.68 0.206 24;
+    --destructive-fg: 0.15 0.01 24;
+
+    --ring: 0.48 0.045 278;
+
+    --primary-accent: 0.74 0.149 302;
+
+    --surface-raised: 0.38 0.035 278;
+    --surface-sunken: 0.22 0.028 278;
+
+    --success: 0.85 0.22 148;
+    --success-fg: 0.15 0.02 148;
+    --warning: 0.94 0.10 115;
+    --warning-fg: 0.20 0.03 115;
+    --info: 0.88 0.10 205;
+    --info-fg: 0.15 0.02 205;
+
+    --muted-gray: 0.45 0.028 275;
+
+    --light-red: 0.40 0.08 24;
+    --dark-red: 0.68 0.206 24;
+    --light-yellow: 0.55 0.07 113;
+    --dark-yellow: 0.96 0.134 113;
+    --light-green: 0.45 0.10 148;
+    --dark-green: 0.87 0.220 148;
+    --light-blue: 0.45 0.05 213;
+    --dark-blue: 0.88 0.093 213;
+
+    --sidebar-bg: 0.22 0.028 278;
+    --sidebar-fg: 0.85 0.010 107;
+    --sidebar-primary: 0.98 0.008 107;
+    --sidebar-primary-fg: 0.26 0.030 278;
+    --sidebar-accent: 0.34 0.036 278;
+    --sidebar-accent-fg: 0.90 0.008 107;
+    --sidebar-border: 0.45 0.050 270;
+    --sidebar-ring: 0.74 0.149 302;
+
+    --chart-1: 0.74 0.149 302;
+    --chart-2: 0.88 0.093 213;
+    --chart-3: 0.87 0.220 148;
+    --chart-4: 0.75 0.183 347;
+    --chart-5: 0.96 0.134 113;
+    --chart-6: 0.68 0.206 24;
+    --chart-7: 0.87 0.220 148;
+    --chart-8: 0.75 0.183 347;
+    --chart-grid: 0.45 0.028 275;
+  }
+
+  /* ══════════════════════════════════════════════════
+     NORD — arctic blue-grey, soft contrast
+     ══════════════════════════════════════════════════ */
+  .nord {
+    --bg: 0.30 0.018 230;
+    --fg: 0.93 0.010 230;
+
+    --muted: 0.40 0.024 234;
+    --muted-fg: 0.58 0.018 235;
+
+    --popover: 0.33 0.020 232;
+    --popover-fg: 0.93 0.010 230;
+
+    --card: 0.35 0.022 232;
+    --card-fg: 0.93 0.010 230;
+
+    --header: 0.37 0.020 232;
+    --header-fg: 0.93 0.010 230;
+
+    --border: 0.43 0.022 234;
+    --input: 0.43 0.022 234;
+
+    --primary: 0.93 0.010 230;
+    --primary-fg: 0.30 0.018 230;
+
+    --secondary: 0.40 0.024 234;
+    --secondary-fg: 0.93 0.010 230;
+
+    --accent: 0.42 0.024 234;
+    --accent-fg: 0.93 0.010 230;
+
+    --destructive: 0.61 0.121 15;
+    --destructive-fg: 0.15 0.01 15;
+
+    --ring: 0.40 0.020 232;
+
+    --primary-accent: 0.78 0.065 205;
+
+    --surface-raised: 0.40 0.024 234;
+    --surface-sunken: 0.26 0.016 230;
+
+    --success: 0.77 0.075 131;
+    --success-fg: 0.15 0.02 131;
+    --warning: 0.85 0.089 84;
+    --warning-fg: 0.20 0.03 84;
+    --info: 0.74 0.060 215;
+    --info-fg: 0.15 0.02 215;
+
+    --muted-gray: 0.43 0.020 232;
+
+    --light-red: 0.38 0.06 15;
+    --dark-red: 0.61 0.121 15;
+    --light-yellow: 0.50 0.05 84;
+    --dark-yellow: 0.85 0.089 84;
+    --light-green: 0.45 0.04 131;
+    --dark-green: 0.77 0.075 131;
+    --light-blue: 0.40 0.025 230;
+    --dark-blue: 0.70 0.055 215;
+
+    --sidebar-bg: 0.26 0.016 230;
+    --sidebar-fg: 0.82 0.012 230;
+    --sidebar-primary: 0.93 0.010 230;
+    --sidebar-primary-fg: 0.30 0.018 230;
+    --sidebar-accent: 0.36 0.022 232;
+    --sidebar-accent-fg: 0.88 0.010 230;
+    --sidebar-border: 0.40 0.020 232;
+    --sidebar-ring: 0.78 0.065 205;
+
+    --chart-1: 0.78 0.065 205;
+    --chart-2: 0.77 0.075 131;
+    --chart-3: 0.70 0.055 215;
+    --chart-4: 0.61 0.121 15;
+    --chart-5: 0.85 0.089 84;
+    --chart-6: 0.65 0.060 200;
+    --chart-7: 0.77 0.075 131;
+    --chart-8: 0.61 0.121 15;
+    --chart-grid: 0.43 0.020 232;
+  }
+
+  /* ══════════════════════════════════════════════════
+     MONOKAI — olive-tinted dark, saturated accents
+     ══════════════════════════════════════════════════ */
+  .monokai {
+    --bg: 0.25 0.012 110;
+    --fg: 0.98 0.008 107;
+
+    --muted: 0.36 0.018 103;
+    --muted-fg: 0.57 0.020 95;
+
+    --popover: 0.29 0.012 115;
+    --popover-fg: 0.98 0.008 107;
+
+    --card: 0.33 0.015 100;
+    --card-fg: 0.98 0.008 107;
+
+    --header: 0.32 0.015 110;
+    --header-fg: 0.98 0.008 107;
+
+    --border: 0.55 0.029 97;
+    --input: 0.55 0.029 97;
+
+    --primary: 0.98 0.008 107;
+    --primary-fg: 0.25 0.012 110;
+
+    --secondary: 0.33 0.015 100;
+    --secondary-fg: 0.98 0.008 107;
+
+    --accent: 0.36 0.015 100;
+    --accent-fg: 0.98 0.008 107;
+
+    --destructive: 0.58 0.26 345;
+    --destructive-fg: 0.15 0.01 350;
+
+    --ring: 0.45 0.022 103;
+
+    --primary-accent: 0.84 0.20 128;
+
+    --surface-raised: 0.38 0.015 100;
+    --surface-sunken: 0.21 0.010 110;
+
+    --success: 0.80 0.175 133;
+    --success-fg: 0.15 0.02 133;
+    --warning: 0.88 0.125 103;
+    --warning-fg: 0.20 0.03 103;
+    --info: 0.82 0.10 200;
+    --info-fg: 0.15 0.02 200;
+
+    --muted-gray: 0.40 0.015 100;
+
+    --light-red: 0.35 0.10 345;
+    --dark-red: 0.58 0.26 345;
+    --light-yellow: 0.55 0.07 103;
+    --dark-yellow: 0.88 0.125 103;
+    --light-green: 0.45 0.10 127;
+    --dark-green: 0.84 0.204 127;
+    --light-blue: 0.45 0.06 212;
+    --dark-blue: 0.83 0.108 212;
+
+    --sidebar-bg: 0.21 0.010 110;
+    --sidebar-fg: 0.85 0.008 107;
+    --sidebar-primary: 0.98 0.008 107;
+    --sidebar-primary-fg: 0.25 0.012 110;
+    --sidebar-accent: 0.32 0.014 100;
+    --sidebar-accent-fg: 0.90 0.008 107;
+    --sidebar-border: 0.50 0.025 97;
+    --sidebar-ring: 0.84 0.20 128;
+
+    --chart-1: 0.84 0.20 128;
+    --chart-2: 0.82 0.10 200;
+    --chart-3: 0.77 0.168 62;
+    --chart-4: 0.58 0.26 345;
+    --chart-5: 0.88 0.125 103;
+    --chart-6: 0.77 0.168 62;
+    --chart-7: 0.80 0.175 133;
+    --chart-8: 0.58 0.26 345;
+    --chart-grid: 0.40 0.015 100;
+  }
+
+  /* ══════════════════════════════════════════════════
+     GRUVBOX — warm retro dark, earthy tones
+     ══════════════════════════════════════════════════ */
+  .gruvbox {
+    --bg: 0.28 0.000 90;
+    --fg: 0.88 0.055 85;
+
+    --muted: 0.34 0.007 49;
+    --muted-fg: 0.60 0.025 70;
+
+    --popover: 0.30 0.002 90;
+    --popover-fg: 0.88 0.055 85;
+
+    --card: 0.34 0.007 49;
+    --card-fg: 0.88 0.055 85;
+
+    --header: 0.32 0.004 70;
+    --header-fg: 0.88 0.055 85;
+
+    --border: 0.48 0.018 61;
+    --input: 0.48 0.018 61;
+
+    --primary: 0.88 0.055 85;
+    --primary-fg: 0.28 0.000 90;
+
+    --secondary: 0.34 0.007 49;
+    --secondary-fg: 0.88 0.055 85;
+
+    --accent: 0.37 0.007 49;
+    --accent-fg: 0.88 0.055 85;
+
+    --destructive: 0.66 0.218 30;
+    --destructive-fg: 0.15 0.01 30;
+
+    --ring: 0.42 0.012 61;
+
+    --primary-accent: 0.73 0.182 52;
+
+    --surface-raised: 0.37 0.007 49;
+    --surface-sunken: 0.24 0.000 90;
+
+    --success: 0.77 0.158 111;
+    --success-fg: 0.15 0.02 111;
+    --warning: 0.83 0.159 83;
+    --warning-fg: 0.20 0.03 83;
+    --info: 0.55 0.065 200;
+    --info-fg: 0.90 0.01 200;
+
+    --muted-gray: 0.38 0.008 61;
+
+    --light-red: 0.38 0.09 30;
+    --dark-red: 0.66 0.218 30;
+    --light-yellow: 0.50 0.08 83;
+    --dark-yellow: 0.83 0.159 83;
+    --light-green: 0.45 0.08 111;
+    --dark-green: 0.77 0.158 111;
+    --light-blue: 0.38 0.030 200;
+    --dark-blue: 0.55 0.065 200;
+
+    --sidebar-bg: 0.24 0.000 90;
+    --sidebar-fg: 0.78 0.040 85;
+    --sidebar-primary: 0.88 0.055 85;
+    --sidebar-primary-fg: 0.28 0.000 90;
+    --sidebar-accent: 0.32 0.006 49;
+    --sidebar-accent-fg: 0.82 0.040 85;
+    --sidebar-border: 0.44 0.015 61;
+    --sidebar-ring: 0.73 0.182 52;
+
+    --chart-1: 0.73 0.182 52;
+    --chart-2: 0.55 0.065 200;
+    --chart-3: 0.77 0.158 111;
+    --chart-4: 0.71 0.098 2;
+    --chart-5: 0.83 0.159 83;
+    --chart-6: 0.66 0.218 30;
+    --chart-7: 0.77 0.158 111;
+    --chart-8: 0.71 0.098 2;
+    --chart-grid: 0.38 0.008 61;
+  }
+
+  /* ══════════════════════════════════════════════════
+     CATPPUCCIN MOCHA — purple-tinted soft dark
+     ══════════════════════════════════════════════════ */
+  .catppuccin {
+    --bg: 0.22 0.035 290;
+    --fg: 0.86 0.045 270;
+
+    --muted: 0.30 0.038 288;
+    --muted-fg: 0.56 0.028 280;
+
+    --popover: 0.26 0.036 290;
+    --popover-fg: 0.86 0.045 270;
+
+    --card: 0.30 0.038 288;
+    --card-fg: 0.86 0.045 270;
+
+    --header: 0.28 0.036 289;
+    --header-fg: 0.86 0.045 270;
+
+    --border: 0.42 0.035 285;
+    --input: 0.42 0.035 285;
+
+    --primary: 0.86 0.045 270;
+    --primary-fg: 0.22 0.035 290;
+
+    --secondary: 0.30 0.038 288;
+    --secondary-fg: 0.86 0.045 270;
+
+    --accent: 0.34 0.038 288;
+    --accent-fg: 0.86 0.045 270;
+
+    --destructive: 0.76 0.130 3;
+    --destructive-fg: 0.15 0.01 3;
+
+    --ring: 0.38 0.035 287;
+
+    --primary-accent: 0.72 0.14 305;
+
+    --surface-raised: 0.34 0.038 288;
+    --surface-sunken: 0.18 0.032 290;
+
+    --success: 0.80 0.12 143;
+    --success-fg: 0.15 0.02 143;
+    --warning: 0.92 0.070 87;
+    --warning-fg: 0.20 0.03 87;
+    --info: 0.72 0.12 255;
+    --info-fg: 0.15 0.02 255;
+
+    --muted-gray: 0.36 0.030 285;
+
+    --light-red: 0.40 0.06 3;
+    --dark-red: 0.76 0.130 3;
+    --light-yellow: 0.55 0.04 87;
+    --dark-yellow: 0.92 0.070 87;
+    --light-green: 0.44 0.06 143;
+    --dark-green: 0.80 0.12 143;
+    --light-blue: 0.40 0.06 255;
+    --dark-blue: 0.72 0.12 255;
+
+    --sidebar-bg: 0.18 0.032 290;
+    --sidebar-fg: 0.78 0.038 270;
+    --sidebar-primary: 0.86 0.045 270;
+    --sidebar-primary-fg: 0.22 0.035 290;
+    --sidebar-accent: 0.28 0.036 288;
+    --sidebar-accent-fg: 0.82 0.040 270;
+    --sidebar-border: 0.38 0.032 285;
+    --sidebar-ring: 0.72 0.14 305;
+
+    --chart-1: 0.72 0.14 305;
+    --chart-2: 0.72 0.12 255;
+    --chart-3: 0.80 0.12 143;
+    --chart-4: 0.76 0.130 3;
+    --chart-5: 0.92 0.070 87;
+    --chart-6: 0.87 0.075 336;
+    --chart-7: 0.80 0.12 143;
+    --chart-8: 0.76 0.130 3;
+    --chart-grid: 0.36 0.030 285;
+  }
+
+  /* ══════════════════════════════════════════════════
+     TOKYO NIGHT — deep navy dark, vibrant neon accents
+     ══════════════════════════════════════════════════ */
+  .tokyo-night {
+    --bg: 0.20 0.025 260;
+    --fg: 0.76 0.050 268;
+
+    --muted: 0.27 0.035 262;
+    --muted-fg: 0.50 0.040 262;
+
+    --popover: 0.23 0.030 260;
+    --popover-fg: 0.76 0.050 268;
+
+    --card: 0.27 0.035 262;
+    --card-fg: 0.76 0.050 268;
+
+    --header: 0.25 0.030 261;
+    --header-fg: 0.76 0.050 268;
+
+    --border: 0.38 0.045 262;
+    --input: 0.38 0.045 262;
+
+    --primary: 0.76 0.050 268;
+    --primary-fg: 0.20 0.025 260;
+
+    --secondary: 0.27 0.035 262;
+    --secondary-fg: 0.76 0.050 268;
+
+    --accent: 0.30 0.035 262;
+    --accent-fg: 0.76 0.050 268;
+
+    --destructive: 0.65 0.18 355;
+    --destructive-fg: 0.15 0.01 355;
+
+    --ring: 0.35 0.040 262;
+
+    --primary-accent: 0.68 0.15 260;
+
+    --surface-raised: 0.30 0.035 262;
+    --surface-sunken: 0.17 0.020 260;
+
+    --success: 0.80 0.139 130;
+    --success-fg: 0.15 0.02 130;
+    --warning: 0.78 0.106 75;
+    --warning-fg: 0.20 0.03 75;
+    --info: 0.72 0.132 264;
+    --info-fg: 0.15 0.02 264;
+
+    --muted-gray: 0.35 0.038 274;
+
+    --light-red: 0.38 0.07 10;
+    --dark-red: 0.72 0.159 10;
+    --light-yellow: 0.45 0.06 75;
+    --dark-yellow: 0.78 0.106 75;
+    --light-green: 0.42 0.07 130;
+    --dark-green: 0.80 0.139 130;
+    --light-blue: 0.38 0.07 264;
+    --dark-blue: 0.72 0.132 264;
+
+    --sidebar-bg: 0.19 0.018 281;
+    --sidebar-fg: 0.68 0.045 276;
+    --sidebar-primary: 0.77 0.054 276;
+    --sidebar-primary-fg: 0.23 0.021 281;
+    --sidebar-accent: 0.26 0.034 275;
+    --sidebar-accent-fg: 0.72 0.048 276;
+    --sidebar-border: 0.38 0.050 274;
+    --sidebar-ring: 0.72 0.132 264;
+
+    --chart-1: 0.72 0.132 264;
+    --chart-2: 0.80 0.139 130;
+    --chart-3: 0.75 0.134 300;
+    --chart-4: 0.72 0.159 10;
+    --chart-5: 0.78 0.106 75;
+    --chart-6: 0.72 0.159 10;
+    --chart-7: 0.80 0.139 130;
+    --chart-8: 0.75 0.134 300;
+    --chart-grid: 0.35 0.038 274;
+  }
+
+  /* ══════════════════════════════════════════════════
+     ONE DARK — Atom-inspired, balanced blue-grey
+     ══════════════════════════════════════════════════ */
+  .one-dark {
+    --bg: 0.27 0.012 240;
+    --fg: 0.78 0.018 250;
+
+    --muted: 0.33 0.014 240;
+    --muted-fg: 0.52 0.015 245;
+
+    --popover: 0.29 0.013 240;
+    --popover-fg: 0.78 0.018 250;
+
+    --card: 0.33 0.014 240;
+    --card-fg: 0.78 0.018 250;
+
+    --header: 0.31 0.013 240;
+    --header-fg: 0.78 0.018 250;
+
+    --border: 0.38 0.016 242;
+    --input: 0.38 0.016 242;
+
+    --primary: 0.78 0.018 250;
+    --primary-fg: 0.27 0.012 240;
+
+    --secondary: 0.33 0.014 240;
+    --secondary-fg: 0.78 0.018 250;
+
+    --accent: 0.36 0.014 240;
+    --accent-fg: 0.78 0.018 250;
+
+    --destructive: 0.62 0.15 5;
+    --destructive-fg: 0.15 0.01 17;
+
+    --ring: 0.36 0.015 242;
+
+    --primary-accent: 0.70 0.13 240;
+
+    --surface-raised: 0.36 0.014 240;
+    --surface-sunken: 0.23 0.010 240;
+
+    --success: 0.77 0.110 133;
+    --success-fg: 0.15 0.02 133;
+    --warning: 0.82 0.097 82;
+    --warning-fg: 0.20 0.03 82;
+    --info: 0.73 0.121 245;
+    --info-fg: 0.15 0.02 245;
+
+    --muted-gray: 0.35 0.012 242;
+
+    --light-red: 0.38 0.06 17;
+    --dark-red: 0.67 0.145 17;
+    --light-yellow: 0.48 0.05 82;
+    --dark-yellow: 0.82 0.097 82;
+    --light-green: 0.42 0.06 133;
+    --dark-green: 0.77 0.110 133;
+    --light-blue: 0.38 0.06 245;
+    --dark-blue: 0.73 0.121 245;
+
+    --sidebar-bg: 0.23 0.010 240;
+    --sidebar-fg: 0.65 0.015 245;
+    --sidebar-primary: 0.78 0.018 250;
+    --sidebar-primary-fg: 0.27 0.012 240;
+    --sidebar-accent: 0.30 0.013 240;
+    --sidebar-accent-fg: 0.72 0.016 245;
+    --sidebar-border: 0.36 0.015 242;
+    --sidebar-ring: 0.70 0.13 240;
+
+    --chart-1: 0.73 0.121 245;
+    --chart-2: 0.77 0.110 133;
+    --chart-3: 0.69 0.164 318;
+    --chart-4: 0.67 0.145 17;
+    --chart-5: 0.82 0.097 82;
+    --chart-6: 0.67 0.145 17;
+    --chart-7: 0.77 0.110 133;
+    --chart-8: 0.69 0.164 318;
+    --chart-grid: 0.35 0.012 242;
+  }
+
+  /* ══════════════════════════════════════════════════
+     ROSÉ PINE — dusty purple dark, misty warmth
+     ══════════════════════════════════════════════════ */
+  .rose-pine {
+    --bg: 0.19 0.030 300;
+    --fg: 0.90 0.028 295;
+
+    --muted: 0.26 0.045 298;
+    --muted-fg: 0.55 0.032 295;
+
+    --popover: 0.21 0.032 300;
+    --popover-fg: 0.90 0.028 295;
+
+    --card: 0.26 0.045 298;
+    --card-fg: 0.90 0.028 295;
+
+    --header: 0.23 0.035 300;
+    --header-fg: 0.90 0.028 295;
+
+    --border: 0.36 0.038 298;
+    --input: 0.36 0.038 298;
+
+    --primary: 0.90 0.028 295;
+    --primary-fg: 0.19 0.030 300;
+
+    --secondary: 0.26 0.045 298;
+    --secondary-fg: 0.90 0.028 295;
+
+    --accent: 0.29 0.045 298;
+    --accent-fg: 0.90 0.028 295;
+
+    --destructive: 0.68 0.16 358;
+    --destructive-fg: 0.15 0.01 4;
+
+    --ring: 0.33 0.040 300;
+
+    --primary-accent: 0.74 0.10 305;
+
+    --surface-raised: 0.29 0.045 298;
+    --surface-sunken: 0.15 0.025 300;
+
+    --success: 0.78 0.07 190;
+    --success-fg: 0.15 0.02 210;
+    --warning: 0.80 0.12 70;
+    --warning-fg: 0.20 0.03 75;
+    --info: 0.56 0.08 220;
+    --info-fg: 0.15 0.02 228;
+
+    --muted-gray: 0.30 0.036 298;
+
+    --light-red: 0.36 0.07 358;
+    --dark-red: 0.68 0.16 358;
+    --light-yellow: 0.48 0.06 75;
+    --dark-yellow: 0.84 0.110 75;
+    --light-green: 0.40 0.035 190;
+    --dark-green: 0.78 0.07 190;
+    --light-blue: 0.33 0.045 220;
+    --dark-blue: 0.56 0.08 220;
+
+    --sidebar-bg: 0.15 0.025 300;
+    --sidebar-fg: 0.76 0.025 295;
+    --sidebar-primary: 0.90 0.028 295;
+    --sidebar-primary-fg: 0.19 0.030 300;
+    --sidebar-accent: 0.23 0.042 298;
+    --sidebar-accent-fg: 0.80 0.025 295;
+    --sidebar-border: 0.33 0.036 300;
+    --sidebar-ring: 0.74 0.10 305;
+
+    --chart-1: 0.74 0.10 305;
+    --chart-2: 0.78 0.07 190;
+    --chart-3: 0.68 0.16 358;
+    --chart-4: 0.80 0.06 25;
+    --chart-5: 0.80 0.12 70;
+    --chart-6: 0.56 0.08 220;
+    --chart-7: 0.78 0.07 190;
+    --chart-8: 0.68 0.16 358;
+    --chart-grid: 0.30 0.036 298;
   }
 }
 

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -15,7 +15,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         defaultTheme="system"
         enableSystem
         disableTransitionOnChange
-        themes={["light", "dark", "midnight", "forest", "sunset"]}
+        themes={["light", "dark", "midnight", "forest", "sunset", "solarized-dark", "solarized-light", "dracula", "nord", "monokai", "gruvbox", "catppuccin", "tokyo-night", "one-dark", "rose-pine"]}
       >
         {children}
       </ThemeProvider>

--- a/web/src/components/ui/theme-switcher.tsx
+++ b/web/src/components/ui/theme-switcher.tsx
@@ -12,11 +12,21 @@ import { SidebarMenuButton } from "@/components/ui/sidebar";
 
 const themes = [
   { value: "light", label: "Light", color: "bg-white border border-gray-300" },
+  { value: "solarized-light", label: "Solarized Light", color: "bg-[#fdf6e3] border border-gray-300" },
   { value: "dark", label: "Dark", color: "bg-zinc-800" },
   { value: "midnight", label: "Midnight", color: "bg-[hsl(230,35%,7%)]" },
   { value: "forest", label: "Forest", color: "bg-[hsl(150,20%,7%)]" },
   { value: "sunset", label: "Sunset", color: "bg-[hsl(25,30%,8%)]" },
-] as const;
+  { value: "solarized-dark", label: "Solarized Dark", color: "bg-[#002b36]" },
+  { value: "dracula", label: "Dracula", color: "bg-[#282a36]" },
+  { value: "nord", label: "Nord", color: "bg-[#2e3440]" },
+  { value: "monokai", label: "Monokai", color: "bg-[#272822]" },
+  { value: "gruvbox", label: "Gruvbox", color: "bg-[#282828]" },
+  { value: "catppuccin", label: "Catppuccin", color: "bg-[#1e1e2e]" },
+  { value: "tokyo-night", label: "Tokyo Night", color: "bg-[#1a1b26]" },
+  { value: "one-dark", label: "One Dark", color: "bg-[#282c34]" },
+  { value: "rose-pine", label: "Rosé Pine", color: "bg-[#191724]" },
+];
 
 export function ThemeSwitcher() {
   const { theme, setTheme } = useTheme();


### PR DESCRIPTION
## Summary
- Add Solarized Dark/Light, Dracula, Nord, Monokai, Gruvbox, Catppuccin Mocha, Tokyo Night, One Dark, and Rosé Pine themes — each hand-tuned from canonical hex palettes with distinct hue families so they are visually distinguishable
- Register all 10 theme class names in `@custom-variant dark` and the next-themes provider
- Update theme-switcher dropdown with swatch color previews

### Hue distribution across dark themes
| Theme | Hue | Character |
|-------|-----|-----------|
| Dark (base) | 260 | Cool blue |
| Midnight | 270 | Deep blue-purple |
| Solarized Dark | 220 | Teal-blue |
| Nord | 230 | Steely arctic blue |
| One Dark | 240 | Neutral grey |
| Tokyo Night | 260 | Deep navy (darkest bg) |
| Dracula | 278 | Purple-blue, high saturation |
| Catppuccin | 290 | Rich purple |
| Rosé Pine | 300 | Magenta-purple |
| Monokai | 110 | Olive/warm |
| Gruvbox | 90 | Warm brown/earthy |
| Forest | 155 | Green |
| Sunset | 45 | Amber |

## Test plan
- [ ] Switch between all 15 themes via account page picker — each should be visually distinct
- [ ] Verify status colors (destructive, success, warning, info) have adequate contrast on every theme
- [ ] Check the Efficiency/DAG page renders cleanly on each dark theme
- [ ] Verify Solarized Light renders with proper contrast (cream bg, readable text)