### PR TITLE
ci: add stale workflow with keep open label exemption

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: Stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs. Add the **keep open** label to prevent this.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs. Add the **keep open** label to prevent this.
+          close-issue-message: "Closed due to inactivity. Reopen if still relevant."
+          close-pr-message: "Closed due to inactivity. Reopen if still relevant."
+          days-before-stale: 60
+          days-before-close: 14
+          exempt-issue-labels: "keep open"
+          exempt-pr-labels: "keep open"
+          stale-issue-label: stale
+          stale-pr-label: stale


### PR DESCRIPTION
## Purpose / Description
Add a GitHub Actions stale workflow that automatically marks inactive issues and PRs as stale after 60 days, and closes them after 14 more days. Issues/PRs labelled with **keep open** are exempt from both stale marking and auto-close.

The "keep open" label has already been created on the repo.

## Fixes
* N/A — new housekeeping automation

## Approach
Uses `actions/stale@v9` with:
- 60-day inactivity threshold before marking stale
- 14-day grace period before closing
- `exempt-issue-labels` and `exempt-pr-labels` set to `keep open`
- Runs daily at 06:00 UTC and supports manual dispatch

## How Has This Been Tested?
- Validated YAML syntax
- Confirmed the "keep open" label exists on the repo (`gh label list`)
- Verified `actions/stale@v9` supports the `exempt-issue-labels` / `exempt-pr-labels` inputs per upstream docs

## Learning (optional, can help others)
- [actions/stale docs](https://github.com/actions/stale)

## Checklist
- [x] All commits are signed off per the DCO
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: N/A