### PR TITLE
feat(cli): add observal support bundle and inspect commands

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -31,6 +31,16 @@ body:
       required: true
 
   - type: textarea
+    id: support_bundle
+    attributes:
+      label: Support bundle
+      description: |
+        Please attach a support bundle to help us diagnose the issue.
+        Generate one with `observal support bundle` and attach the resulting `.tar.gz` file.
+        You can review its contents before sharing with `observal support inspect <bundle.tar.gz>`.
+      placeholder: Drag and drop the .tar.gz file here, or paste the output of `observal support inspect`
+
+  - type: textarea
     id: extra_info
     attributes:
       label: (Optional) Anything else you want to share?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added — Support Bundle (`observal support`)
+
+New `observal support` CLI command group for generating and reviewing portable diagnostic archives. Operators can attach these to support tickets or GitHub issues to help debug deployment problems without exposing secrets or customer data.
+
+- **`observal support bundle`** — collects version info, sanitized config, health probes, aggregate table counts, recent error fingerprints, redacted structured logs, and optional system metrics into a `.tar.gz` archive
+  - All values pass through a single **Redaction Layer** before being written: JWTs, AWS keys, URL credentials, high-entropy tokens, and sensitive JSON keys are replaced with `<REDACTED>`
+  - Config filtering uses an explicit **allowlist** — keys not on the list are omitted entirely, not just redacted
+  - Server-side collectors run via `POST /api/v1/support/collect`; local collectors (system info, config filtering) run in parallel on the operator's machine
+  - Individual collector failures produce partial bundles (exit 0); total failure exits with code 1
+  - Archive permissions set to `0o600` (owner read/write only)
+  - Bundle manifest (`bundle_manifest.json`) includes schema version, collector results, redaction counts, and SHA-256 file inventory for tamper detection
+- **`observal support inspect <bundle.tar.gz>`** — opens a bundle read-only (never extracts to disk) and displays the manifest, a Rich file tree with human-readable sizes, and optionally prints a single file via `--show`
+  - Schema version warnings for bundles from newer CLI versions
+  - Path traversal protection on tar member filtering
+- No customer row data is ever included — only aggregate counts
+- GitHub issue template updated to ask for a support bundle attachment
+
 ## [0.4.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Admin approve/reject workflow for submissions
 | Instrument your existing MCP servers | [Observe MCP traffic](docs/use-cases/observe-mcp-traffic.md) |
 | Run Observal on your infrastructure  | [Self-Hosting](docs/self-hosting/README.md)                  |
 | Look up a CLI command                | [CLI Reference](docs/cli/README.md)                          |
+| Report a bug with diagnostics        | [Reporting Issues](#reporting-issues)                        |
 
 See [CHANGELOG.md](CHANGELOG.md) for recent updates.
 
@@ -169,6 +170,20 @@ All tests mock external services. No Docker needed.
 Have a question, idea, or want to share what you've built? Head to [GitHub Discussions](https://github.com/BlazeUp-AI/Observal/discussions). Please use Discussions for questions; open Issues for confirmed bugs and concrete feature requests.
 
 Join the [Observal Discord](https://discord.observal.io) to chat directly with the maintainers and other community members.
+
+## Reporting issues
+
+When filing a bug report, please attach a support bundle so maintainers can diagnose the problem quickly:
+
+```bash
+observal support bundle
+```
+
+This produces a `.tar.gz` archive containing version info, sanitized configuration, health probes, aggregate table counts, and optional system metrics. All values pass through a redaction layer — no customer data, row contents, or credentials are included. Review the bundle before sharing:
+
+```bash
+observal support inspect observal-support-*.tar.gz
+```
 
 ## Security
 

--- a/observal-server/api/routes/support.py
+++ b/observal-server/api/routes/support.py
@@ -1,0 +1,489 @@
+"""Server-side diagnostic collection endpoint for support bundles.
+
+Runs collectors for versions, health, config, aggregates, errors, and
+logs data. Each collector is wrapped in ``_run_collector`` with a
+10-second ``asyncio.wait_for`` timeout. Partial failures are reported
+in the response — the endpoint always returns 200 if at least one
+collector succeeds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import re
+import time
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+from sqlalchemy import text
+
+from api.deps import get_current_user, get_db
+from api.ratelimit import limiter
+from config import Settings, settings
+from services.clickhouse import CLICKHOUSE_DB, _query
+from services.redis import get_redis
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from models.user import User
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/support", tags=["support"])
+
+COLLECTOR_TIMEOUT_SECONDS = 10
+
+# Valid ClickHouse/PG table name: alphanumeric + underscores, starting with a letter or underscore
+_SAFE_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+# ── Request / Response models ────────────────────────────────────────
+
+
+class CollectRequest(BaseModel):
+    collectors: list[str] = ["all"]
+    logs_since: str = "1h"
+
+
+class CollectorData(BaseModel):
+    ok: bool
+    duration_ms: int
+    data: Any = None
+    error: str | None = None
+
+
+class CollectResponse(BaseModel):
+    server_version: str
+    collectors: dict[str, CollectorData]
+
+
+# ── Collector wrapper ────────────────────────────────────────────────
+
+
+async def _run_collector(name: str, coro) -> tuple[str, CollectorData]:
+    """Run a single collector coroutine with a 10-second timeout.
+
+    Returns a (name, CollectorData) tuple regardless of success or failure.
+    """
+    start = time.monotonic()
+    try:
+        data = await asyncio.wait_for(coro, timeout=COLLECTOR_TIMEOUT_SECONDS)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        return name, CollectorData(ok=True, duration_ms=elapsed_ms, data=data)
+    except TimeoutError:
+        return name, CollectorData(
+            ok=False,
+            duration_ms=COLLECTOR_TIMEOUT_SECONDS * 1000,
+            error=f"Collector timed out after {COLLECTOR_TIMEOUT_SECONDS}s",
+        )
+    except Exception as exc:
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        return name, CollectorData(ok=False, duration_ms=elapsed_ms, error=type(exc).__name__)
+
+
+# ── Individual collectors ────────────────────────────────────────────
+
+
+async def _collect_versions(db: AsyncSession) -> dict:
+    """Collect app version, build hash, Alembic revision, ClickHouse version + tables."""
+    result: dict[str, Any] = {}
+
+    # App version — try importlib.metadata first, fall back to hardcoded
+    try:
+        from importlib.metadata import version
+
+        result["app_version"] = version("observal-server")
+    except Exception:
+        result["app_version"] = "0.1.0"
+
+    # Build hash — read from BUILD_HASH env var or fall back to unknown
+    result["build_hash"] = os.environ.get("BUILD_HASH", "unknown")
+
+    # Alembic revision from PG
+    try:
+        row = await db.execute(text("SELECT version_num FROM alembic_version LIMIT 1"))
+        rev = row.scalar_one_or_none()
+        result["alembic_revision"] = rev or "unknown"
+    except Exception as exc:
+        result["alembic_revision"] = f"error: {type(exc).__name__}"
+
+    # ClickHouse version
+    try:
+        resp = await _query("SELECT version()")
+        if resp.status_code == 200:
+            result["clickhouse_version"] = resp.text.strip()
+        else:
+            result["clickhouse_version"] = f"error: HTTP {resp.status_code}"
+    except Exception as exc:
+        result["clickhouse_version"] = f"error: {type(exc).__name__}"
+
+    # ClickHouse table list
+    try:
+        resp = await _query(
+            "SELECT name FROM system.tables WHERE database = {db:String} FORMAT JSON",
+            {"param_db": CLICKHOUSE_DB},
+        )
+        if resp.status_code == 200:
+            rows = resp.json().get("data", [])
+            result["clickhouse_tables"] = [r["name"] for r in rows]
+        else:
+            result["clickhouse_tables"] = []
+    except Exception as exc:
+        result["clickhouse_tables"] = f"error: {type(exc).__name__}"
+
+    return result
+
+
+async def _collect_health(db: AsyncSession) -> dict:
+    """Run health probes against PG, CH, Redis, and OTEL collector."""
+    result: dict[str, Any] = {}
+
+    # PostgreSQL health
+    pg_start = time.monotonic()
+    try:
+        await db.execute(text("SELECT 1"))
+        pg_ms = int((time.monotonic() - pg_start) * 1000)
+        result["postgres"] = {"status": "ok", "latency_ms": pg_ms}
+    except Exception as exc:
+        pg_ms = int((time.monotonic() - pg_start) * 1000)
+        result["postgres"] = {"status": "error", "latency_ms": pg_ms, "error": type(exc).__name__}
+
+    # ClickHouse health
+    ch_start = time.monotonic()
+    try:
+        resp = await _query("SELECT 1")
+        ch_ms = int((time.monotonic() - ch_start) * 1000)
+        if resp.status_code == 200:
+            result["clickhouse"] = {"status": "ok", "latency_ms": ch_ms}
+        else:
+            result["clickhouse"] = {"status": "error", "latency_ms": ch_ms, "error": f"HTTP {resp.status_code}"}
+    except Exception as exc:
+        ch_ms = int((time.monotonic() - ch_start) * 1000)
+        result["clickhouse"] = {"status": "error", "latency_ms": ch_ms, "error": type(exc).__name__}
+
+    # Redis health
+    redis_start = time.monotonic()
+    try:
+        r = get_redis()
+        pong = await r.ping()
+        redis_ms = int((time.monotonic() - redis_start) * 1000)
+        result["redis"] = {"status": "ok" if pong else "error", "latency_ms": redis_ms}
+    except Exception as exc:
+        redis_ms = int((time.monotonic() - redis_start) * 1000)
+        result["redis"] = {"status": "error", "latency_ms": redis_ms, "error": type(exc).__name__}
+
+    return result
+
+
+CONFIG_ALLOWLIST = frozenset(
+    {
+        "DATABASE_URL",
+        "CLICKHOUSE_URL",
+        "REDIS_URL",
+        "REDIS_SOCKET_TIMEOUT",
+        "EVAL_MODEL_NAME",
+        "EVAL_MODEL_PROVIDER",
+        "AWS_REGION",
+        "FRONTEND_URL",
+        "JWT_ACCESS_TOKEN_EXPIRE_MINUTES",
+        "JWT_REFRESH_TOKEN_EXPIRE_DAYS",
+        "JWT_SIGNING_ALGORITHM",
+        "JWT_HOOKS_TOKEN_EXPIRE_MINUTES",
+        "RATE_LIMIT_AUTH",
+        "RATE_LIMIT_AUTH_STRICT",
+        "DATA_RETENTION_DAYS",
+        "DEPLOYMENT_MODE",
+    }
+)
+
+
+async def _collect_config() -> dict:
+    """Return only allowlisted Settings fields as a dict.
+
+    Secrets like SECRET_KEY, OAUTH_CLIENT_SECRET, etc. are never sent
+    over the wire.  The CLI applies its own allowlist filter and
+    redaction as a second layer of defence.
+    """
+    return {
+        field_name: getattr(settings, field_name)
+        for field_name in Settings.model_fields
+        if field_name in CONFIG_ALLOWLIST
+    }
+
+
+async def _collect_aggregates(db: AsyncSession) -> dict:
+    """Collect row counts per PG and CH table.
+
+    Only counts are returned — never row contents.
+    """
+    result: dict[str, Any] = {"pg_table_counts": {}, "ch_table_counts": {}}
+
+    # PostgreSQL table counts
+    try:
+        rows = await db.execute(text("SELECT tablename FROM pg_tables WHERE schemaname = 'public'"))
+        table_names = [r[0] for r in rows.fetchall()]
+        for table_name in table_names:
+            try:
+                # Table names come from pg_tables (system catalog), not user input.
+                # Use quoted identifier to handle any special characters safely.
+                count_row = await db.execute(text(f'SELECT count(*) FROM "{table_name}"'))
+                result["pg_table_counts"][table_name] = count_row.scalar()
+            except Exception as exc:
+                result["pg_table_counts"][table_name] = f"error: {type(exc).__name__}"
+    except Exception as exc:
+        result["pg_table_counts"] = {"error": type(exc).__name__}
+
+    # ClickHouse table counts (no FINAL — fast approximate counts)
+    try:
+        resp = await _query(
+            "SELECT name FROM system.tables WHERE database = {db:String} FORMAT JSON",
+            {"param_db": CLICKHOUSE_DB},
+        )
+        if resp.status_code == 200:
+            ch_tables = [r["name"] for r in resp.json().get("data", [])]
+            for table_name in ch_tables:
+                if not _SAFE_TABLE_NAME_RE.match(table_name):
+                    result["ch_table_counts"][table_name] = "error: unsafe table name, skipped"
+                    continue
+                try:
+                    count_resp = await _query(f"SELECT count() FROM `{table_name}` FORMAT JSON")
+                    if count_resp.status_code == 200:
+                        count_data = count_resp.json().get("data", [])
+                        if count_data:
+                            result["ch_table_counts"][table_name] = count_data[0].get("count()", 0)
+                        else:
+                            result["ch_table_counts"][table_name] = 0
+                    else:
+                        result["ch_table_counts"][table_name] = f"error: HTTP {count_resp.status_code}"
+                except Exception as exc:
+                    result["ch_table_counts"][table_name] = f"error: {type(exc).__name__}"
+        else:
+            result["ch_table_counts"] = {"error": f"HTTP {resp.status_code}"}
+    except Exception as exc:
+        result["ch_table_counts"] = {"error": type(exc).__name__}
+
+    return result
+
+
+def _extract_stack_template(error_text: str) -> str:
+    """Extract file paths and function names from a stack trace.
+
+    Returns a sanitised template with only structural information —
+    no argument values, no exception messages.
+    """
+    lines = error_text.splitlines()
+    template_parts: list[str] = []
+
+    # Match Python traceback file/function lines:
+    #   File "path/to/file.py", line N, in function_name
+    file_line_re = re.compile(r'File\s+"([^"]+)",\s+line\s+\d+,\s+in\s+(\S+)')
+
+    for line in lines:
+        m = file_line_re.search(line)
+        if m:
+            filepath, funcname = m.group(1), m.group(2)
+            template_parts.append(f"{filepath}:{funcname}")
+
+    if template_parts:
+        return " -> ".join(template_parts)
+
+    # Fallback: if no traceback pattern found, return a generic marker
+    # with just the first line stripped of any argument-like content
+    first_line = lines[0].strip() if lines else ""
+    # Strip anything that looks like arguments or values (after a colon)
+    sanitised = re.sub(r":.*", "", first_line).strip()
+    return sanitised or "unknown"
+
+
+async def _collect_errors(db: AsyncSession) -> dict:
+    """Collect up to 50 error fingerprints from the last 24 hours.
+
+    Each fingerprint includes a SHA-256 hash, count, first_seen,
+    last_seen, and stack_template (file paths + function names only).
+    No argument values or exception messages are included.
+    """
+    result: dict[str, Any] = {"fingerprints": []}
+
+    try:
+        resp = await _query(
+            "SELECT error, start_time FROM spans "
+            "WHERE error IS NOT NULL AND error != '' "
+            "AND start_time >= now() - INTERVAL 24 HOUR "
+            "ORDER BY start_time DESC "
+            "LIMIT 500 "
+            "FORMAT JSON"
+        )
+        if resp.status_code != 200:
+            result["error"] = f"ClickHouse query failed: HTTP {resp.status_code}"
+            return result
+
+        rows = resp.json().get("data", [])
+        if not rows:
+            return result
+
+        # Group errors by their stack template fingerprint
+        fingerprint_groups: dict[str, dict] = {}
+        for row in rows:
+            error_text = row.get("error", "")
+            start_time = row.get("start_time", "")
+
+            template = _extract_stack_template(error_text)
+            fp_hash = hashlib.sha256(template.encode("utf-8")).hexdigest()
+
+            if fp_hash not in fingerprint_groups:
+                fingerprint_groups[fp_hash] = {
+                    "fingerprint": fp_hash,
+                    "count": 0,
+                    "first_seen": start_time,
+                    "last_seen": start_time,
+                    "stack_template": template,
+                }
+
+            group = fingerprint_groups[fp_hash]
+            group["count"] += 1
+            if start_time < group["first_seen"]:
+                group["first_seen"] = start_time
+            if start_time > group["last_seen"]:
+                group["last_seen"] = start_time
+
+        # Sort by count descending, take top 50
+        sorted_fps = sorted(fingerprint_groups.values(), key=lambda x: x["count"], reverse=True)
+        result["fingerprints"] = sorted_fps[:50]
+
+    except Exception as exc:
+        result["error"] = type(exc).__name__
+
+    return result
+
+
+def _parse_duration(duration_str: str) -> timedelta:
+    """Parse a human-friendly duration string into a timedelta.
+
+    Supported formats: '1h', '30m', '2d', '1h30m', '90s'.
+    Falls back to 1 hour on invalid input.
+    """
+    total_seconds = 0
+    pattern = re.compile(r"(\d+)\s*([dhms])", re.IGNORECASE)
+    matches = pattern.findall(duration_str)
+
+    if not matches:
+        return timedelta(hours=1)
+
+    for value, unit in matches:
+        n = int(value)
+        if unit.lower() == "d":
+            total_seconds += n * 86400
+        elif unit.lower() == "h":
+            total_seconds += n * 3600
+        elif unit.lower() == "m":
+            total_seconds += n * 60
+        elif unit.lower() == "s":
+            total_seconds += n
+
+    return timedelta(seconds=total_seconds) if total_seconds > 0 else timedelta(hours=1)
+
+
+async def _collect_logs(logs_since: str = "1h") -> dict:
+    """Collect structured log lines from the in-memory ring buffer.
+
+    Filters entries by the ``logs_since`` duration. The CLI is
+    responsible for redacting the returned lines before writing.
+    Returns an empty list gracefully if the buffer is empty.
+    """
+    try:
+        from services.log_buffer import get_log_buffer
+
+        buf = get_log_buffer()
+        duration = _parse_duration(logs_since)
+        cutoff = datetime.now(UTC) - duration
+        entries = buf.get_since(cutoff)
+
+        if not entries:
+            return {
+                "lines": [],
+                "note": "Log buffer empty or server recently restarted",
+            }
+
+        # Sanitize entries: remove non-serializable objects like LogRecord
+        sanitized = []
+        for entry in entries:
+            clean = {}
+            for k, v in entry.items():
+                if k.startswith("_"):
+                    continue  # skip internal structlog keys (_record, _logger, etc.)
+                if isinstance(v, (str, int, float, bool, type(None), list, dict)):
+                    clean[k] = v
+                else:
+                    clean[k] = str(v)
+            sanitized.append(clean)
+
+        return {"lines": sanitized}
+    except ImportError:
+        return {
+            "lines": [],
+            "note": "Log buffer module not available",
+        }
+    except Exception as exc:
+        return {
+            "lines": [],
+            "error": type(exc).__name__,
+        }
+
+
+# ── Collector registry ───────────────────────────────────────────────
+
+# Maps collector name to a factory that accepts (db, logs_since) and returns
+# a coroutine.  Collectors that don't need all arguments ignore them.
+COLLECTORS: dict[str, Any] = {
+    "versions": lambda db, logs_since: _collect_versions(db),
+    "health": lambda db, logs_since: _collect_health(db),
+    "config": lambda db, logs_since: _collect_config(),
+    "aggregates": lambda db, logs_since: _collect_aggregates(db),
+    "errors": lambda db, logs_since: _collect_errors(db),
+    "logs": lambda db, logs_since: _collect_logs(logs_since),
+}
+
+
+# ── Endpoint ─────────────────────────────────────────────────────────
+
+
+@router.post("/collect", response_model=CollectResponse)
+@limiter.limit("5/minute")
+async def collect_diagnostics(
+    request: Request,
+    body: CollectRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> CollectResponse:
+    """Run server-side diagnostic collectors and return results.
+
+    Each collector runs with a 10-second timeout. Partial failures
+    are reported in the response — the endpoint always returns 200
+    if at least one collector succeeds.
+    """
+    # Determine which collectors to run
+    requested = list(COLLECTORS.keys()) if "all" in body.collectors else [c for c in body.collectors if c in COLLECTORS]
+
+    # Run all requested collectors concurrently
+    tasks = [_run_collector(name, COLLECTORS[name](db, body.logs_since)) for name in requested]
+    results = await asyncio.gather(*tasks)
+
+    collectors_out: dict[str, CollectorData] = {}
+    for name, collector_data in results:
+        collectors_out[name] = collector_data
+
+    # Server version
+    try:
+        from importlib.metadata import version
+
+        server_version = version("observal-server")
+    except Exception:
+        server_version = "0.1.0"
+
+    return CollectResponse(server_version=server_version, collectors=collectors_out)

--- a/observal-server/logging_config.py
+++ b/observal-server/logging_config.py
@@ -2,10 +2,36 @@
 
 import logging
 import sys
+from datetime import UTC, datetime
 
 import structlog
 
 from config import settings
+
+
+def _ring_buffer_processor(
+    logger: structlog.types.WrappedLogger,
+    method_name: str,
+    event_dict: structlog.types.EventDict,
+) -> structlog.types.EventDict:
+    """Capture structured log entries into the in-memory ring buffer.
+
+    This processor stores a copy of each log event so the support
+    bundle ``logs`` collector can return recent entries without
+    touching the filesystem.
+    """
+    try:
+        from services.log_buffer import get_log_buffer
+
+        buf = get_log_buffer()
+        entry = dict(event_dict)
+        if "timestamp" not in entry:
+            entry["timestamp"] = datetime.now(UTC).isoformat()
+        buf.append(entry)
+    except Exception:
+        # Never let the ring buffer break logging
+        pass
+    return event_dict
 
 
 def setup_logging() -> None:
@@ -17,6 +43,7 @@ def setup_logging() -> None:
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
+        _ring_buffer_processor,
     ]
 
     if settings.LOG_FORMAT == "json":

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -46,6 +46,7 @@ from api.routes.review import router as review_router
 from api.routes.sandbox import router as sandbox_router
 from api.routes.sessions import router as sessions_router
 from api.routes.skill import router as skill_router
+from api.routes.support import router as support_router
 from api.routes.telemetry import router as telemetry_router
 from config import settings
 from database import engine
@@ -315,6 +316,7 @@ app.include_router(component_source_router)
 app.include_router(bulk_router)
 app.include_router(config_router)
 app.include_router(registry_models_router)
+app.include_router(support_router)
 
 # --- Prometheus metrics ---
 Instrumentator(

--- a/observal-server/services/log_buffer.py
+++ b/observal-server/services/log_buffer.py
@@ -1,0 +1,56 @@
+"""Thread-safe bounded ring buffer for structured log entries.
+
+Used by the support bundle ``logs`` collector to return recent log
+lines without touching the filesystem.  A structlog processor
+(configured in ``logging_config.py``) appends entries here.
+"""
+
+from __future__ import annotations
+
+import collections
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+class LogRingBuffer:
+    """Thread-safe bounded ring buffer for structured log entries."""
+
+    def __init__(self, maxlen: int = 2000) -> None:
+        self._buffer: collections.deque[dict] = collections.deque(maxlen=maxlen)
+        self._lock = threading.Lock()
+
+    def append(self, entry: dict) -> None:
+        """Append a structured log entry to the buffer."""
+        with self._lock:
+            self._buffer.append(entry)
+
+    def get_since(self, since: datetime) -> list[dict]:
+        """Return entries with a timestamp at or after *since*."""
+        since_iso = since.isoformat()
+        with self._lock:
+            return [e for e in self._buffer if e.get("timestamp", "") >= since_iso]
+
+    def get_all(self) -> list[dict]:
+        """Return all entries currently in the buffer."""
+        with self._lock:
+            return list(self._buffer)
+
+    def clear(self) -> None:
+        """Remove all entries from the buffer."""
+        with self._lock:
+            self._buffer.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._buffer)
+
+
+_log_buffer = LogRingBuffer()
+
+
+def get_log_buffer() -> LogRingBuffer:
+    """Return the singleton log ring buffer instance."""
+    return _log_buffer

--- a/observal_cli/cmd_support.py
+++ b/observal_cli/cmd_support.py
@@ -1,0 +1,582 @@
+"""observal support: generate and inspect diagnostic support bundles.
+
+Bundles contain no customer data or row contents — only aggregate counts,
+version info, sanitised configuration, health probes, and optional system
+metrics.  Every value passes through the central Redaction Layer before
+being written to the archive.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import platform
+import socket
+import tarfile
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import typer
+from rich import print as rprint
+from rich.tree import Tree
+
+from observal_cli import config, render
+from observal_cli.render import console, spinner
+from observal_cli.support.manifest import BundleManifest, compute_file_entry
+from observal_cli.support.redaction import RedactionStats, redact_value
+
+# ── Schema version ───────────────────────────────────────────────────
+
+CURRENT_SCHEMA_VERSION = 1
+
+support_app = typer.Typer(
+    help="Generate and inspect diagnostic support bundles. Bundles contain no customer data or row contents.",
+    no_args_is_help=True,
+)
+
+# ── Config allowlist ─────────────────────────────────────────────────
+
+CONFIG_ALLOWLIST = frozenset(
+    {
+        "DATABASE_URL",
+        "CLICKHOUSE_URL",
+        "REDIS_URL",
+        "REDIS_SOCKET_TIMEOUT",
+        "EVAL_MODEL_NAME",
+        "EVAL_MODEL_PROVIDER",
+        "AWS_REGION",
+        "FRONTEND_URL",
+        "JWT_ACCESS_TOKEN_EXPIRE_MINUTES",
+        "JWT_REFRESH_TOKEN_EXPIRE_DAYS",
+        "JWT_SIGNING_ALGORITHM",
+        "JWT_HOOKS_TOKEN_EXPIRE_MINUTES",
+        "RATE_LIMIT_AUTH",
+        "RATE_LIMIT_AUTH_STRICT",
+        "DATA_RETENTION_DAYS",
+        "DEPLOYMENT_MODE",
+    }
+)
+
+
+SIZE_BUDGET_BYTES = 100 * 1024 * 1024  # 100 MB uncompressed warning threshold
+
+
+# ── CollectorResult ──────────────────────────────────────────────────
+
+
+@dataclass
+class CollectorResult:
+    """Result from a single diagnostic collector."""
+
+    name: str  # e.g. "versions", "health_postgres"
+    ok: bool
+    duration_ms: int
+    data: dict | list | str | None
+    error: str | None = None
+
+    @property
+    def target_path(self) -> str:
+        """Relative path in the archive, e.g. 'versions/app.json'."""
+        # Map collector names to archive paths
+        _path_map: dict[str, str] = {
+            "versions": "versions/app.json",
+            "health": "health/health.json",
+            "config": "config/config.json",
+            "aggregates": "aggregates/aggregates.json",
+            "errors": "errors/recent_errors.json",
+            "logs": "logs/recent.ndjson",
+            "config_allowlisted": "config/config.json",
+            "system_info": "system/system.json",
+        }
+        return _path_map.get(self.name, f"{self.name}.json")
+
+
+# ── Local collectors ─────────────────────────────────────────────────
+
+
+def _config_allowlisted(server_response: dict) -> CollectorResult:
+    """Filter server config response to allowlist keys, then redact values."""
+    t0 = time.monotonic()
+    try:
+        collectors = server_response.get("collectors", {})
+        config_data = collectors.get("config", {})
+        raw_config = config_data.get("data", {}) if isinstance(config_data, dict) else {}
+
+        if not isinstance(raw_config, dict):
+            raw_config = {}
+
+        # Filter to allowlist only
+        filtered = {k: v for k, v in raw_config.items() if k in CONFIG_ALLOWLIST}
+
+        # Redact values
+        redacted, _count = redact_value(filtered)
+
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        return CollectorResult(
+            name="config_allowlisted",
+            ok=True,
+            duration_ms=elapsed_ms,
+            data=redacted,
+        )
+    except Exception as exc:
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        return CollectorResult(
+            name="config_allowlisted",
+            ok=False,
+            duration_ms=elapsed_ms,
+            data=None,
+            error=str(exc),
+        )
+
+
+# ── Archive helpers ──────────────────────────────────────────────────
+
+
+def _add_bytes_to_tar(tar: tarfile.TarFile, name: str, data: bytes) -> None:
+    """Add in-memory bytes to a tarfile as a regular file."""
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    info.mtime = int(time.time())
+    tar.addfile(info, io.BytesIO(data))
+
+
+def _write_archive(
+    output_path: Path,
+    files: dict[str, bytes],
+    manifest: BundleManifest,
+) -> None:
+    """Write a .tar.gz archive with 0o600 permissions.
+
+    Uses a temp file + os.replace for atomic rename on POSIX.
+    """
+    # Ensure parent directory exists
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".tar.gz",
+        dir=str(output_path.parent),
+        delete=False,
+    ) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        with tarfile.open(tmp_path, "w:gz") as tar:
+            # Write manifest first
+            manifest_bytes = manifest.to_json().encode("utf-8")
+            _add_bytes_to_tar(tar, "bundle_manifest.json", manifest_bytes)
+
+            # Write all collected files
+            for rel_path, content in sorted(files.items()):
+                _add_bytes_to_tar(tar, rel_path, content)
+
+        # Set restrictive permissions before moving to final location
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, str(output_path))
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+def _human_size(size_bytes: int) -> str:
+    """Format bytes as a human-readable string."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if abs(size_bytes) < 1024:
+            return f"{size_bytes:.1f} {unit}" if unit != "B" else f"{size_bytes} {unit}"
+        size_bytes /= 1024  # type: ignore[assignment]
+    return f"{size_bytes:.1f} TB"
+
+
+# ── CLI version helper ───────────────────────────────────────────────
+
+
+def _get_cli_version() -> str:
+    try:
+        from importlib.metadata import version as pkg_version
+
+        return pkg_version("observal-cli")
+    except Exception:
+        return "dev"
+
+
+# ── Bundle command ───────────────────────────────────────────────────
+
+
+@support_app.command()
+def bundle(
+    output: Path = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Archive output path (default: ./observal-support-{timestamp}.tar.gz)",
+    ),
+    logs_since: str = typer.Option(
+        "1h",
+        "--logs-since",
+        help="Duration of logs to include (e.g. 1h, 30m, 2d)",
+    ),
+    include_system: bool = typer.Option(
+        True,
+        "--include-system/--no-include-system",
+        help="Include OS/CPU/memory/disk metrics",
+    ),
+) -> None:
+    """Generate a diagnostic support bundle. No customer data or row contents are included."""
+    # Determine output path
+    if output is None:
+        timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+        output = Path(f"observal-support-{timestamp}.tar.gz")
+
+    redaction_stats = RedactionStats()
+
+    # ── Collect remote diagnostics ────────────────────────
+    server_response: dict = {}
+    with spinner("Collecting diagnostics..."):
+        try:
+            cfg = config.get_or_exit()
+            base_url = cfg["server_url"].rstrip("/")
+            headers = {"Authorization": f"Bearer {cfg['access_token']}"}
+            timeout = config.get_timeout()
+            r = httpx.post(
+                f"{base_url}/api/v1/support/collect",
+                json={"collectors": ["all"], "logs_since": logs_since},
+                headers=headers,
+                timeout=timeout,
+            )
+            r.raise_for_status()
+            server_response = r.json()
+        except httpx.HTTPStatusError as exc:
+            code = exc.response.status_code
+            if code == 404:
+                rprint(
+                    "[yellow]Warning:[/yellow] Server does not have the support endpoint yet. "
+                    "Rebuild the server container to enable remote collectors."
+                )
+            elif code == 401:
+                rprint(
+                    "[yellow]Warning:[/yellow] Authentication failed. Run [bold]observal auth login[/bold] to re-authenticate."
+                )
+            else:
+                rprint(f"[yellow]Warning:[/yellow] Server returned HTTP {code}. Remote collectors skipped.")
+            server_response = {}
+        except (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout):
+            rprint("[yellow]Warning:[/yellow] Could not reach server. Bundle will contain only local data.")
+            server_response = {}
+        except SystemExit:
+            # config.get_or_exit() may raise if not configured
+            rprint("[yellow]Warning:[/yellow] CLI not configured. Run [bold]observal auth login[/bold] first.")
+            server_response = {}
+
+    if not isinstance(server_response, dict):
+        server_response = {}
+
+    # ── Parse remote collector results ────────────────────
+    remote_results: list[CollectorResult] = []
+    server_version = server_response.get("server_version", "unknown")
+    for name, cdata in server_response.get("collectors", {}).items():
+        if isinstance(cdata, dict):
+            remote_results.append(
+                CollectorResult(
+                    name=name,
+                    ok=cdata.get("ok", False),
+                    duration_ms=cdata.get("duration_ms", 0),
+                    data=cdata.get("data"),
+                    error=cdata.get("error"),
+                )
+            )
+
+    # ── Run local collectors in parallel ──────────────────
+    local_results: list[CollectorResult] = []
+
+    def _run_config_collector() -> CollectorResult:
+        return _config_allowlisted(server_response)
+
+    local_tasks = [_run_config_collector]
+
+    if include_system:
+        try:
+            from observal_cli.support.collectors import system_info as _system_info_fn
+
+            def _run_system_collector() -> CollectorResult:
+                return _system_info_fn({}, server_response)
+
+            local_tasks.append(_run_system_collector)
+        except ImportError:
+            pass
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(fn) for fn in local_tasks]
+        for future in futures:
+            try:
+                # Note: timeout only stops waiting — it does not kill the worker
+                # thread. For these short collectors (system info, config filter)
+                # this is fine; a hanging thread will be cleaned up at process exit.
+                result = future.result(timeout=10)
+                local_results.append(result)
+            except Exception as exc:
+                local_results.append(
+                    CollectorResult(
+                        name="unknown",
+                        ok=False,
+                        duration_ms=10000,
+                        data=None,
+                        error=f"Collector timed out or failed: {type(exc).__name__}",
+                    )
+                )
+
+    all_results = remote_results + local_results
+
+    # ── Redact all values and build file dict ─────────────
+    files: dict[str, bytes] = {}
+
+    for result in all_results:
+        if not result.ok or result.data is None:
+            continue
+
+        # Handle special cases for remote collectors that map to multiple files.
+        # These branches redact internally and continue, so the generic redaction
+        # at the bottom of the loop only runs for simple single-file collectors.
+        if result.name == "versions":
+            # Split versions data into separate files
+            if isinstance(result.data, dict):
+                redacted_versions, ver_count = redact_value(result.data)
+                redaction_stats.record("versions/app.json", ver_count)
+
+                app_data = {
+                    "cli_version": _get_cli_version(),
+                    "server_version": server_version,
+                    "build_hash": redacted_versions.get("build_hash", "unknown"),
+                    "app_version": redacted_versions.get("app_version", "unknown"),
+                }
+                files["versions/app.json"] = json.dumps(app_data, indent=2).encode("utf-8")
+
+                alembic_data = {"current_revision": redacted_versions.get("alembic_revision", "unknown")}
+                files["versions/alembic.json"] = json.dumps(alembic_data, indent=2).encode("utf-8")
+
+                ch_data = {
+                    "server_version": redacted_versions.get("clickhouse_version", "unknown"),
+                    "tables": redacted_versions.get("clickhouse_tables", []),
+                }
+                files["versions/clickhouse.json"] = json.dumps(ch_data, indent=2).encode("utf-8")
+            continue
+
+        if result.name == "health":
+            # Split health data into separate files per service
+            if isinstance(result.data, dict):
+                redacted_health, health_count = redact_value(result.data)
+                redaction_stats.record("health/health.json", health_count)
+                for svc_name, svc_data in redacted_health.items():
+                    svc_bytes = json.dumps(svc_data, indent=2, default=str).encode("utf-8")
+                    files[f"health/{svc_name}.json"] = svc_bytes
+            continue
+
+        if result.name == "aggregates":
+            # Split aggregates into PG and CH count files
+            if isinstance(result.data, dict):
+                redacted_agg, agg_count = redact_value(result.data)
+                redaction_stats.record("aggregates/aggregates.json", agg_count)
+                pg_counts = redacted_agg.get("pg_table_counts", {})
+                ch_counts = redacted_agg.get("ch_table_counts", {})
+                files["aggregates/pg_table_counts.json"] = json.dumps(pg_counts, indent=2, default=str).encode("utf-8")
+                files["aggregates/ch_table_counts.json"] = json.dumps(ch_counts, indent=2, default=str).encode("utf-8")
+            continue
+
+        if result.name == "logs":
+            # Log lines: redact each line individually, write as newline-delimited JSON
+            if isinstance(result.data, dict):
+                lines = result.data.get("lines", [])
+                redacted_lines: list[str] = []
+                for line in lines:
+                    redacted_line, line_count = redact_value(line)
+                    redaction_stats.record("logs/recent.ndjson", line_count)
+                    redacted_lines.append(json.dumps(redacted_line, default=str))
+                if redacted_lines:
+                    files["logs/recent.ndjson"] = "\n".join(redacted_lines).encode("utf-8")
+                elif result.data.get("note"):
+                    # Write the note so the bundle still has the logs file
+                    files["logs/recent.ndjson"] = json.dumps({"note": result.data["note"]}, indent=2).encode("utf-8")
+            continue
+
+        # Generic single-file collectors (config_allowlisted, system_info, etc.)
+        redacted_data, count = redact_value(result.data)
+        redaction_stats.record(result.target_path, count)
+
+        if isinstance(redacted_data, str):
+            file_bytes = redacted_data.encode("utf-8")
+        else:
+            file_bytes = json.dumps(redacted_data, indent=2, default=str).encode("utf-8")
+
+        files[result.target_path] = file_bytes
+
+    # If no data at all, exit with error
+    if not files:
+        rprint("[red]Error:[/red] No diagnostic data could be collected. Bundle not created.")
+        raise typer.Exit(1)
+
+    # ── Build manifest ────────────────────────────────────
+    cli_version = _get_cli_version()
+
+    # Compute file inventory (SHA-256 hashes)
+    file_inventory = [compute_file_entry(path, content) for path, content in sorted(files.items())]
+
+    # Build collector results summary
+    collector_summary = {}
+    for r in all_results:
+        collector_summary[r.name] = {"ok": r.ok, "duration_ms": r.duration_ms}
+        if r.error:
+            collector_summary[r.name]["error"] = r.error
+
+    manifest = BundleManifest(
+        bundle_schema_version="1",
+        created_at=datetime.now(UTC).isoformat(),
+        cli_version=cli_version,
+        host_os=platform.system(),
+        node_id=hashlib.sha256(socket.gethostname().encode()).hexdigest()[:12],
+        flags_used={
+            "output": output.name,
+            "logs_since": logs_since,
+            "include_system": include_system,
+        },
+        collector_results=collector_summary,
+        redaction_counts=redaction_stats.counts,
+        file_inventory=file_inventory,
+    )
+
+    # ── Size budget check ─────────────────────────────────
+    manifest_bytes = manifest.to_json().encode("utf-8")
+    total_uncompressed = sum(len(v) for v in files.values()) + len(manifest_bytes)
+
+    if total_uncompressed > SIZE_BUDGET_BYTES:
+        rprint(
+            f"[yellow]Warning:[/yellow] Uncompressed bundle size is "
+            f"{_human_size(total_uncompressed)} (exceeds 100 MB budget)."
+        )
+        if not typer.confirm("Continue writing the archive?"):
+            rprint("[dim]Bundle creation cancelled.[/dim]")
+            raise typer.Exit(0)
+
+    # ── Write archive ─────────────────────────────────────
+    with spinner("Writing archive..."):
+        _write_archive(output, files, manifest)
+
+    archive_size = output.stat().st_size
+    rprint(f"[green]✓[/green] Support bundle written to [bold]{output}[/bold] ({_human_size(archive_size)})")
+    rprint("[dim]  Review contents with: observal support inspect " + str(output) + "[/dim]")
+
+
+# ── Inspect helpers ──────────────────────────────────────────────────
+
+
+def _print_file_tree(members: list[tarfile.TarInfo]) -> None:
+    """Print a Rich tree view of all files in the archive with human-readable sizes.
+
+    Accepts a pre-filtered list of safe tar members to avoid displaying
+    entries with path traversal attacks.
+    """
+    tree = Tree("[bold]Bundle contents[/bold]")
+    for member in sorted(members, key=lambda m: m.name):
+        if member.isfile():
+            size = _human_size(member.size)
+            tree.add(f"{member.name}  [dim]{size}[/dim]")
+    console.print(tree)
+
+
+def _is_safe_tar_member(member: tarfile.TarInfo) -> bool:
+    """Reject tar members with path traversal attacks.
+
+    Uses os.path.normpath to catch normalized traversal (e.g. foo/../../etc)
+    while allowing legitimate names like 'foo..bar.json'.
+    """
+    normalized = os.path.normpath(member.name)
+    return not normalized.startswith(("..", os.sep)) and not os.path.isabs(normalized)
+
+
+# ── Inspect command ──────────────────────────────────────────────────
+
+
+@support_app.command()
+def inspect(
+    bundle_path: Path = typer.Argument(
+        ...,
+        help="Path to a .tar.gz support bundle",
+    ),
+    show: str | None = typer.Option(
+        None,
+        "--show",
+        help="Print contents of a specific file from the archive",
+    ),
+) -> None:
+    """Inspect a support bundle. Displays the manifest, file tree, and optionally a single file."""
+    if not bundle_path.exists():
+        render.error(f"Bundle not found: {bundle_path}")
+        raise typer.Exit(1)
+
+    try:
+        tar = tarfile.open(bundle_path, "r:gz")  # noqa: SIM115
+    except (tarfile.TarError, OSError):
+        render.error(f"Cannot open bundle: {bundle_path}")
+        raise typer.Exit(1)
+
+    with tar:
+        # Safety: filter members to prevent path traversal attacks
+        safe_members = [m for m in tar.getmembers() if _is_safe_tar_member(m)]
+
+        # Read and display manifest
+        try:
+            manifest_member = tar.getmember("bundle_manifest.json")
+            manifest_file = tar.extractfile(manifest_member)
+            if manifest_file is None:
+                render.error("Invalid bundle: bundle_manifest.json is not a regular file")
+                raise typer.Exit(1)
+            manifest_data = json.loads(manifest_file.read())
+        except KeyError:
+            render.error("Invalid bundle: bundle_manifest.json missing or malformed")
+            raise typer.Exit(1)
+        except json.JSONDecodeError:
+            render.error("Invalid bundle: bundle_manifest.json missing or malformed")
+            raise typer.Exit(1)
+
+        # Schema version warning
+        schema_version = manifest_data.get("bundle_schema_version", "1")
+        try:
+            version_int = int(schema_version)
+            if version_int > CURRENT_SCHEMA_VERSION:
+                render.warning(
+                    f"Bundle created by a newer CLI (schema v{schema_version}). Some fields may not be recognized."
+                )
+        except (ValueError, TypeError):
+            render.warning(f"Unrecognized bundle schema version: {schema_version}")
+
+        # Print manifest as formatted JSON
+        console.print_json(json.dumps(manifest_data, indent=2))
+
+        # Print file tree with sizes (using safe_members to exclude path traversal entries)
+        _print_file_tree(safe_members)
+
+        # --show: print specific file contents
+        if show:
+            try:
+                member = tar.getmember(show)
+                if not _is_safe_tar_member(member):
+                    render.error(f"Unsafe path rejected: {show}")
+                    raise typer.Exit(1)
+                extracted = tar.extractfile(member)
+                if extracted is None:
+                    render.error(f"Cannot read file from archive: {show}")
+                    raise typer.Exit(1)
+                content = extracted.read().decode("utf-8", errors="replace")
+                console.print(content)
+            except KeyError:
+                available = sorted(m.name for m in safe_members if m.isfile())
+                render.error(f"File not found in archive: {show}")
+                rprint("[dim]Available files:[/dim]")
+                for f in available:
+                    rprint(f"  {f}")
+                raise typer.Exit(1)

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -100,6 +100,7 @@ from observal_cli.cmd_pull import register_pull
 from observal_cli.cmd_sandbox import sandbox_app
 from observal_cli.cmd_scan import register_scan
 from observal_cli.cmd_skill import skill_app
+from observal_cli.cmd_support import support_app
 from observal_cli.cmd_uninstall import register_uninstall
 
 # ═══════════════════════════════════════════════════════════
@@ -142,6 +143,7 @@ app.add_typer(ops_app, name="ops")
 app.add_typer(admin_app, name="admin")
 app.add_typer(self_app, name="self")
 app.add_typer(doctor_app, name="doctor")
+app.add_typer(support_app, name="support")
 app.add_typer(migrate_app, name="migrate")
 
 

--- a/observal_cli/support/__init__.py
+++ b/observal_cli/support/__init__.py
@@ -1,0 +1,1 @@
+# observal_cli/support — diagnostic support bundle helpers

--- a/observal_cli/support/collectors.py
+++ b/observal_cli/support/collectors.py
@@ -1,0 +1,110 @@
+"""Local diagnostic collectors for the support bundle.
+
+Each collector returns a CollectorResult with structured data.
+Collectors do NOT perform their own redaction — all output passes
+through the central Redaction Layer in cmd_support.py.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import time
+
+from observal_cli.cmd_support import CollectorResult
+
+
+def system_info(flags: dict, server_response: dict) -> CollectorResult:
+    """Collect local system metrics: OS, kernel, CPU, memory, disk, container runtime.
+
+    Returns a CollectorResult with name="system_info".
+    No hostnames, IP addresses, or usernames are included.
+    Only runs when --include-system flag is active (default).
+    """
+    t0 = time.monotonic()
+    try:
+        data: dict = {}
+
+        # OS name and version
+        data["os_name"] = platform.system()
+        data["os_version"] = platform.version()
+
+        # Kernel version
+        data["kernel_version"] = platform.release()
+
+        # CPU count
+        data["cpu_count"] = os.cpu_count()
+
+        # Memory: use os.sysconf on POSIX, fallback to None
+        data["memory_total_bytes"] = _get_memory_total()
+        data["memory_available_bytes"] = _get_memory_available()
+
+        # Disk usage (root partition)
+        try:
+            usage = shutil.disk_usage("/")
+            data["disk_total_bytes"] = usage.total
+            data["disk_free_bytes"] = usage.free
+        except OSError:
+            data["disk_total_bytes"] = None
+            data["disk_free_bytes"] = None
+
+        # Container runtime detection
+        data["container_runtime"] = _detect_container_runtime()
+
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        return CollectorResult(
+            name="system_info",
+            ok=True,
+            duration_ms=elapsed_ms,
+            data=data,
+        )
+    except Exception as exc:
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        return CollectorResult(
+            name="system_info",
+            ok=False,
+            duration_ms=elapsed_ms,
+            data=None,
+            error=str(exc),
+        )
+
+
+def _get_memory_total() -> int | None:
+    """Get total physical memory in bytes using os.sysconf (POSIX only)."""
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page_size > 0:
+            return pages * page_size
+    except (ValueError, OSError, AttributeError):
+        pass
+    return None
+
+
+def _get_memory_available() -> int | None:
+    """Get available memory in bytes using os.sysconf (POSIX only)."""
+    try:
+        pages = os.sysconf("SC_AVPHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page_size > 0:
+            return pages * page_size
+    except (ValueError, OSError, AttributeError):
+        pass
+    return None
+
+
+def _detect_container_runtime() -> str | None:
+    """Detect if running inside a container.
+
+    Checks for Docker (/.dockerenv), Podman (/run/.containerenv),
+    and Kubernetes (KUBERNETES_SERVICE_HOST env var).
+    Returns the runtime name or None if not in a container.
+    """
+    if os.path.exists("/.dockerenv"):
+        return "docker"
+    if os.path.exists("/run/.containerenv"):
+        return "podman"
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return "kubernetes"
+    return None

--- a/observal_cli/support/manifest.py
+++ b/observal_cli/support/manifest.py
@@ -1,0 +1,75 @@
+"""Bundle manifest schema and file inventory builder.
+
+Defines the BundleManifest and FileEntry dataclasses used to describe
+the contents of a support bundle archive. Every file in the archive
+is recorded in the manifest with its path, size, and SHA-256 hash.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FileEntry:
+    path: str
+    size_bytes: int
+    sha256: str
+
+
+@dataclass
+class BundleManifest:
+    bundle_schema_version: str = "1"
+    created_at: str = ""
+    cli_version: str = ""
+    host_os: str = ""
+    node_id: str = ""  # socket.gethostname() — identifies which machine produced this bundle
+    flags_used: dict = field(default_factory=dict)
+    collector_results: dict = field(default_factory=dict)
+    redaction_counts: dict = field(default_factory=dict)
+    file_inventory: list[FileEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "bundle_schema_version": self.bundle_schema_version,
+            "created_at": self.created_at,
+            "cli_version": self.cli_version,
+            "host_os": self.host_os,
+            "node_id": self.node_id,
+            "flags_used": self.flags_used,
+            "collector_results": self.collector_results,
+            "redaction_counts": self.redaction_counts,
+            "file_inventory": [
+                {"path": f.path, "size_bytes": f.size_bytes, "sha256": f.sha256} for f in self.file_inventory
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "BundleManifest":
+        inventory = [
+            FileEntry(path=f["path"], size_bytes=f["size_bytes"], sha256=f["sha256"])
+            for f in data.get("file_inventory", [])
+        ]
+        return cls(
+            bundle_schema_version=data.get("bundle_schema_version", "1"),
+            created_at=data.get("created_at", ""),
+            cli_version=data.get("cli_version", ""),
+            host_os=data.get("host_os", ""),
+            node_id=data.get("node_id", ""),
+            flags_used=data.get("flags_used", {}),
+            collector_results=data.get("collector_results", {}),
+            redaction_counts=data.get("redaction_counts", {}),
+            file_inventory=inventory,
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+
+def compute_file_entry(path: str, content: bytes) -> FileEntry:
+    """Compute a FileEntry with SHA-256 hash for a file's content."""
+    return FileEntry(
+        path=path,
+        size_bytes=len(content),
+        sha256=hashlib.sha256(content).hexdigest(),
+    )

--- a/observal_cli/support/redaction.py
+++ b/observal_cli/support/redaction.py
@@ -1,0 +1,118 @@
+"""Single redaction chokepoint for the support bundle.
+
+Every value passes through this module before being written to the archive.
+No collector performs its own redaction.
+"""
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+REDACTED = "<REDACTED>"
+
+# Sensitive JSON key names (case-insensitive)
+SENSITIVE_KEYS = re.compile(
+    r"(?i)(password|secret|token|api_key|apikey|api[-_]key|access_key|"
+    r"private_key|credential|authorization|client_secret|bearer)"
+)
+
+# JWT pattern: eyJ prefix, three base64url segments separated by dots
+JWT_PATTERN = re.compile(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
+
+# AWS access key pattern
+AWS_KEY_PATTERN = re.compile(r"AKIA[0-9A-Z]{16}")
+
+# URL userinfo: scheme://user:password@host (any scheme)
+URL_USERINFO_PATTERN = re.compile(
+    r"([a-z][a-z0-9+\-.]*://)"
+    r"([^@/\s]+)@"
+)
+
+
+def shannon_entropy(s: str) -> float:
+    """Calculate Shannon entropy of a string."""
+    if not s:
+        return 0.0
+    counts = Counter(s)
+    length = len(s)
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())
+
+
+@dataclass
+class RedactionStats:
+    """Tracks redaction counts per source file."""
+
+    counts: dict[str, int] = field(default_factory=dict)
+
+    def record(self, source: str, count: int) -> None:
+        self.counts[source] = self.counts.get(source, 0) + count
+
+
+def redact_string(value: str) -> tuple[str, int]:
+    """Redact sensitive patterns from a string.
+
+    Returns (redacted_string, redaction_count).
+    Pattern application order: JWT → AWS keys → URL userinfo → high-entropy strings.
+    """
+    count = 0
+    result = value
+
+    # 1. JWT tokens
+    matches = JWT_PATTERN.findall(result)
+    count += len(matches)
+    result = JWT_PATTERN.sub(REDACTED, result)
+
+    # 2. AWS access keys
+    matches = AWS_KEY_PATTERN.findall(result)
+    count += len(matches)
+    result = AWS_KEY_PATTERN.sub(REDACTED, result)
+
+    # 3. URL userinfo (preserve structure)
+    def _redact_userinfo(m: re.Match) -> str:
+        nonlocal count
+        count += 1
+        return f"{m.group(1)}{REDACTED}@"
+
+    result = URL_USERINFO_PATTERN.sub(_redact_userinfo, result)
+
+    # 4. High-entropy strings (Shannon > 4.5, length >= 32)
+    #    Applied to individual tokens (whitespace/quote-delimited)
+    tokens = re.split(r'([\s"\'`,;=\[\]{}()])', result)
+    for i, token in enumerate(tokens):
+        if len(token) >= 32 and shannon_entropy(token) > 4.5 and token != REDACTED and REDACTED not in token:
+            tokens[i] = REDACTED
+            count += 1
+    result = "".join(tokens)
+
+    return result, count
+
+
+def redact_value(value, *, key: str = "") -> tuple:
+    """Redact a value, with context about its JSON key.
+
+    If the key matches a sensitive pattern, the entire value is redacted.
+    Handles recursive dict/list/str redaction.
+    """
+    if isinstance(value, str):
+        if key and SENSITIVE_KEYS.search(key):
+            return REDACTED, 1
+        return redact_string(value)
+    elif isinstance(value, dict):
+        total = 0
+        result = {}
+        for k, v in value.items():
+            redacted_v, c = redact_value(v, key=k)
+            result[k] = redacted_v
+            total += c
+        return result, total
+    elif isinstance(value, list):
+        total = 0
+        result = []
+        for item in value:
+            redacted_item, c = redact_value(item, key=key)
+            result.append(redacted_item)
+            total += c
+        return result, total
+    else:
+        return value, 0

--- a/tests/test_cmd_support.py
+++ b/tests/test_cmd_support.py
@@ -1,0 +1,343 @@
+"""Tests for observal_cli/cmd_support.py — bundle command module.
+
+Covers:
+- CONFIG_ALLOWLIST contents and count
+- CollectorResult dataclass and target_path mapping
+- _config_allowlisted local collector
+- _add_bytes_to_tar helper
+- _write_archive with atomic rename and 0o600 permissions
+- _human_size formatting
+- bundle command orchestration (mocked server)
+- Size budget warning threshold
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tarfile
+from unittest.mock import patch
+
+import pytest
+
+from observal_cli.cmd_support import (
+    CONFIG_ALLOWLIST,
+    SIZE_BUDGET_BYTES,
+    CollectorResult,
+    _add_bytes_to_tar,
+    _config_allowlisted,
+    _human_size,
+    _write_archive,
+    support_app,
+)
+from observal_cli.support.manifest import BundleManifest
+
+# ── CONFIG_ALLOWLIST ─────────────────────────────────────────────────
+
+
+class TestConfigAllowlist:
+    def test_allowlist_is_frozenset(self):
+        assert isinstance(CONFIG_ALLOWLIST, frozenset)
+
+    def test_allowlist_has_16_keys(self):
+        assert len(CONFIG_ALLOWLIST) == 16
+
+    def test_allowlist_contains_expected_keys(self):
+        expected = {
+            "DATABASE_URL",
+            "CLICKHOUSE_URL",
+            "REDIS_URL",
+            "REDIS_SOCKET_TIMEOUT",
+            "EVAL_MODEL_NAME",
+            "EVAL_MODEL_PROVIDER",
+            "AWS_REGION",
+            "FRONTEND_URL",
+            "JWT_ACCESS_TOKEN_EXPIRE_MINUTES",
+            "JWT_REFRESH_TOKEN_EXPIRE_DAYS",
+            "JWT_SIGNING_ALGORITHM",
+            "JWT_HOOKS_TOKEN_EXPIRE_MINUTES",
+            "RATE_LIMIT_AUTH",
+            "RATE_LIMIT_AUTH_STRICT",
+            "DATA_RETENTION_DAYS",
+            "DEPLOYMENT_MODE",
+        }
+        assert expected == CONFIG_ALLOWLIST
+
+    def test_allowlist_excludes_secrets(self):
+        """Keys that must never appear in the allowlist."""
+        forbidden = {
+            "SECRET_KEY",
+            "EVAL_MODEL_API_KEY",
+            "EVAL_MODEL_URL",
+            "OAUTH_CLIENT_ID",
+            "OAUTH_CLIENT_SECRET",
+            "OAUTH_SERVER_METADATA_URL",
+            "JWT_KEY_DIR",
+            "JWT_KEY_PASSWORD",
+        }
+        assert CONFIG_ALLOWLIST.isdisjoint(forbidden)
+
+
+# ── CollectorResult ──────────────────────────────────────────────────
+
+
+class TestCollectorResult:
+    def test_basic_creation(self):
+        r = CollectorResult(name="versions", ok=True, duration_ms=42, data={"v": "1"})
+        assert r.name == "versions"
+        assert r.ok is True
+        assert r.duration_ms == 42
+        assert r.data == {"v": "1"}
+        assert r.error is None
+
+    def test_error_field(self):
+        r = CollectorResult(name="health", ok=False, duration_ms=100, data=None, error="timeout")
+        assert r.error == "timeout"
+
+    def test_target_path_versions(self):
+        r = CollectorResult(name="versions", ok=True, duration_ms=0, data={})
+        assert r.target_path == "versions/app.json"
+
+    def test_target_path_health(self):
+        r = CollectorResult(name="health", ok=True, duration_ms=0, data={})
+        assert r.target_path == "health/health.json"
+
+    def test_target_path_config_allowlisted(self):
+        r = CollectorResult(name="config_allowlisted", ok=True, duration_ms=0, data={})
+        assert r.target_path == "config/config.json"
+
+    def test_target_path_system_info(self):
+        r = CollectorResult(name="system_info", ok=True, duration_ms=0, data={})
+        assert r.target_path == "system/system.json"
+
+    def test_target_path_unknown_collector(self):
+        r = CollectorResult(name="custom_thing", ok=True, duration_ms=0, data={})
+        assert r.target_path == "custom_thing.json"
+
+
+# ── _config_allowlisted ─────────────────────────────────────────────
+
+
+class TestConfigAllowlistedCollector:
+    def test_filters_to_allowlist(self):
+        server_response = {
+            "collectors": {
+                "config": {
+                    "ok": True,
+                    "duration_ms": 5,
+                    "data": {
+                        "DATABASE_URL": "postgresql+asyncpg://user:pass@localhost/db",
+                        "SECRET_KEY": "super-secret-value",
+                        "AWS_REGION": "us-east-1",
+                        "DEPLOYMENT_MODE": "docker",
+                    },
+                }
+            }
+        }
+        result = _config_allowlisted(server_response)
+        assert result.ok is True
+        assert result.name == "config_allowlisted"
+        assert isinstance(result.data, dict)
+        # SECRET_KEY must be filtered out
+        assert "SECRET_KEY" not in result.data
+        # Allowlisted keys should be present
+        assert "AWS_REGION" in result.data
+        assert "DEPLOYMENT_MODE" in result.data
+        # DATABASE_URL should be present but redacted (URL userinfo)
+        assert "DATABASE_URL" in result.data
+
+    def test_redacts_url_userinfo(self):
+        server_response = {
+            "collectors": {
+                "config": {
+                    "ok": True,
+                    "duration_ms": 5,
+                    "data": {
+                        "DATABASE_URL": "postgresql+asyncpg://admin:s3cret@localhost:5432/observal",
+                    },
+                }
+            }
+        }
+        result = _config_allowlisted(server_response)
+        assert result.ok is True
+        db_url = result.data["DATABASE_URL"]
+        # The credential portion must be redacted
+        assert "s3cret" not in db_url
+        assert "<REDACTED>" in db_url
+
+    def test_handles_empty_server_response(self):
+        result = _config_allowlisted({})
+        assert result.ok is True
+        assert result.data == {}
+
+    def test_handles_missing_config_collector(self):
+        result = _config_allowlisted({"collectors": {}})
+        assert result.ok is True
+        assert result.data == {}
+
+    def test_handles_non_dict_config_data(self):
+        server_response = {
+            "collectors": {
+                "config": {
+                    "ok": True,
+                    "duration_ms": 5,
+                    "data": "not a dict",
+                }
+            }
+        }
+        result = _config_allowlisted(server_response)
+        assert result.ok is True
+        assert result.data == {}
+
+
+# ── _add_bytes_to_tar ────────────────────────────────────────────────
+
+
+class TestAddBytesToTar:
+    def test_adds_file_to_tar(self):
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            _add_bytes_to_tar(tar, "test/file.json", b'{"key": "value"}')
+
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+            member = tar.getmember("test/file.json")
+            assert member.size == len(b'{"key": "value"}')
+            content = tar.extractfile(member).read()
+            assert json.loads(content) == {"key": "value"}
+
+    def test_adds_empty_file(self):
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            _add_bytes_to_tar(tar, "empty.txt", b"")
+
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+            member = tar.getmember("empty.txt")
+            assert member.size == 0
+
+
+# ── _write_archive ───────────────────────────────────────────────────
+
+
+class TestWriteArchive:
+    def test_creates_valid_tar_gz(self, tmp_path):
+        output = tmp_path / "test.tar.gz"
+        files = {
+            "config/config.json": b'{"key": "value"}',
+            "versions/app.json": b'{"version": "1.0"}',
+        }
+        manifest = BundleManifest(
+            bundle_schema_version="1",
+            created_at="2025-01-01T00:00:00+00:00",
+            cli_version="1.0.0",
+        )
+
+        _write_archive(output, files, manifest)
+
+        assert output.exists()
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+            assert "bundle_manifest.json" in names
+            assert "config/config.json" in names
+            assert "versions/app.json" in names
+
+    def test_sets_0o600_permissions(self, tmp_path):
+        output = tmp_path / "test.tar.gz"
+        files = {"test.json": b"{}"}
+        manifest = BundleManifest()
+
+        _write_archive(output, files, manifest)
+
+        # On POSIX, check permissions
+        if os.name != "nt":
+            mode = oct(os.stat(output).st_mode & 0o777)
+            assert mode == "0o600"
+
+    def test_manifest_is_first_entry(self, tmp_path):
+        output = tmp_path / "test.tar.gz"
+        files = {"a.json": b"{}", "z.json": b"{}"}
+        manifest = BundleManifest()
+
+        _write_archive(output, files, manifest)
+
+        with tarfile.open(output, "r:gz") as tar:
+            members = tar.getnames()
+            assert members[0] == "bundle_manifest.json"
+
+    def test_atomic_write_cleans_up_on_failure(self, tmp_path):
+        output = tmp_path / "test.tar.gz"
+
+        # Create a manifest that will cause serialization to fail
+        manifest = BundleManifest()
+
+        # Patch tarfile.open to raise after creating temp file
+        with (
+            patch("observal_cli.cmd_support.tarfile.open", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            _write_archive(output, {"test.json": b"{}"}, manifest)
+
+        # Output should not exist
+        assert not output.exists()
+
+    def test_creates_parent_directories(self, tmp_path):
+        output = tmp_path / "nested" / "dir" / "test.tar.gz"
+        files = {"test.json": b"{}"}
+        manifest = BundleManifest()
+
+        _write_archive(output, files, manifest)
+        assert output.exists()
+
+
+# ── _human_size ──────────────────────────────────────────────────────
+
+
+class TestHumanSize:
+    def test_bytes(self):
+        assert _human_size(42) == "42 B"
+
+    def test_kilobytes(self):
+        result = _human_size(2048)
+        assert "KB" in result
+
+    def test_megabytes(self):
+        result = _human_size(5 * 1024 * 1024)
+        assert "MB" in result
+
+    def test_zero(self):
+        assert _human_size(0) == "0 B"
+
+
+# ── Size budget ──────────────────────────────────────────────────────
+
+
+class TestSizeBudget:
+    def test_budget_is_100mb(self):
+        assert SIZE_BUDGET_BYTES == 100 * 1024 * 1024
+
+
+# ── support_app registration ─────────────────────────────────────────
+
+
+class TestSupportApp:
+    def test_support_app_has_help_text(self):
+        assert "no customer data" in support_app.info.help.lower()
+
+    def test_bundle_command_registered(self):
+        # Check that 'bundle' is a registered command
+        command_names = []
+        for cmd_info in support_app.registered_commands:
+            if hasattr(cmd_info, "name") and cmd_info.name:
+                command_names.append(cmd_info.name)
+            elif hasattr(cmd_info, "callback") and cmd_info.callback:
+                command_names.append(cmd_info.callback.__name__)
+        assert "bundle" in command_names
+
+    def test_bundle_docstring_mentions_no_customer_data(self):
+        from observal_cli.cmd_support import bundle
+
+        assert bundle.__doc__ is not None
+        first_line = bundle.__doc__.strip().split("\n")[0]
+        assert "no customer data" in first_line.lower()

--- a/tests/test_support_bundle_wiring.py
+++ b/tests/test_support_bundle_wiring.py
@@ -1,0 +1,389 @@
+"""Tests for support bundle wiring: CLI registration, directory structure, and failure handling.
+
+Covers:
+- support_app is registered on the root Typer app as 'support'
+- bundle subcommand produces correct directory structure
+- Partial failure: individual collector failures still produce a valid bundle (exit 0)
+- Total failure: when no data can be collected, exit with code 1
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tarfile
+from unittest.mock import MagicMock, patch
+
+import httpx
+from typer.testing import CliRunner
+
+from observal_cli.main import app
+
+runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _mock_httpx_response(data: dict, status_code: int = 200) -> MagicMock:
+    """Create a mock httpx.Response that behaves like a real one."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# ── CLI registration ─────────────────────────────────────────────────
+
+
+class TestSupportAppRegistration:
+    """Verify support_app is wired into the root Typer app."""
+
+    def test_support_group_exists(self):
+        """The 'support' subgroup should appear in the root app."""
+        result = runner.invoke(app, ["support", "--help"])
+        assert result.exit_code == 0
+        output = _ANSI_RE.sub("", result.output)
+        assert "bundle" in output
+        assert "inspect" in output
+
+    def test_support_bundle_help(self):
+        """The 'bundle' subcommand should be accessible."""
+        result = runner.invoke(app, ["support", "bundle", "--help"])
+        assert result.exit_code == 0
+        output = _ANSI_RE.sub("", result.output)
+        assert "--output" in output
+        assert "--logs-since" in output
+        assert "--include-system" in output
+
+    def test_support_help_mentions_no_customer_data(self):
+        """The support group help should mention no customer data."""
+        result = runner.invoke(app, ["support", "--help"])
+        assert result.exit_code == 0
+        output = _ANSI_RE.sub("", result.output).lower()
+        assert "no customer data" in output
+
+
+# ── Directory structure ──────────────────────────────────────────────
+
+
+def _make_server_response(
+    versions_ok=True,
+    health_ok=True,
+    config_ok=True,
+):
+    """Build a mock server response with controllable collector success."""
+    collectors = {}
+
+    if versions_ok:
+        collectors["versions"] = {
+            "ok": True,
+            "duration_ms": 50,
+            "data": {
+                "app_version": "0.9.0",
+                "alembic_revision": "abc123",
+                "clickhouse_version": "24.1",
+                "clickhouse_tables": ["traces", "spans"],
+            },
+        }
+    else:
+        collectors["versions"] = {
+            "ok": False,
+            "duration_ms": 10000,
+            "data": None,
+            "error": "Collector timed out",
+        }
+
+    if health_ok:
+        collectors["health"] = {
+            "ok": True,
+            "duration_ms": 30,
+            "data": {
+                "postgres": {"status": "ok", "latency_ms": 5},
+                "clickhouse": {"status": "ok", "latency_ms": 8},
+                "redis": {"status": "ok", "latency_ms": 2},
+            },
+        }
+    else:
+        collectors["health"] = {
+            "ok": False,
+            "duration_ms": 10000,
+            "data": None,
+            "error": "Health check failed",
+        }
+
+    if config_ok:
+        collectors["config"] = {
+            "ok": True,
+            "duration_ms": 10,
+            "data": {
+                "DATABASE_URL": "postgresql+asyncpg://user:pass@localhost/db",
+                "REDIS_URL": "redis://localhost:6379",
+                "SECRET_KEY": "should-be-filtered-out",
+                "DEPLOYMENT_MODE": "docker",
+            },
+        }
+    else:
+        collectors["config"] = {
+            "ok": False,
+            "duration_ms": 10000,
+            "data": None,
+            "error": "Config collection failed",
+        }
+
+    return {"server_version": "0.9.0", "collectors": collectors}
+
+
+class TestBundleDirectoryStructure:
+    """Verify the bundle archive contains the expected directory structure."""
+
+    def test_bundle_contains_expected_directories(self, tmp_path):
+        """Bundle should contain versions/, health/, system/, config/, and bundle_manifest.json."""
+        output_path = tmp_path / "test-bundle.tar.gz"
+        server_resp = _make_server_response()
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", return_value=_mock_httpx_response(server_resp)),
+        ):
+            result = runner.invoke(app, ["support", "bundle", "--output", str(output_path)])
+
+        assert result.exit_code == 0, f"Unexpected exit code: {result.output}"
+        assert output_path.exists()
+
+        with tarfile.open(output_path, "r:gz") as tar:
+            names = [m.name for m in tar.getmembers()]
+
+        # Check required files/directories
+        assert "bundle_manifest.json" in names
+
+        # Check versions directory files
+        version_files = [n for n in names if n.startswith("versions/")]
+        assert len(version_files) > 0, "Should have files in versions/"
+
+        # Check health directory files
+        health_files = [n for n in names if n.startswith("health/")]
+        assert len(health_files) > 0, "Should have files in health/"
+
+        # Check config directory files
+        config_files = [n for n in names if n.startswith("config/")]
+        assert len(config_files) > 0, "Should have files in config/"
+
+        # Check system directory files (default --include-system)
+        system_files = [n for n in names if n.startswith("system/")]
+        assert len(system_files) > 0, "Should have files in system/ by default"
+
+    def test_bundle_manifest_is_valid_json(self, tmp_path):
+        """bundle_manifest.json should be valid JSON with required fields."""
+        output_path = tmp_path / "test-bundle.tar.gz"
+        server_resp = _make_server_response()
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", return_value=_mock_httpx_response(server_resp)),
+        ):
+            result = runner.invoke(app, ["support", "bundle", "--output", str(output_path)])
+
+        assert result.exit_code == 0
+
+        with tarfile.open(output_path, "r:gz") as tar:
+            manifest_member = tar.getmember("bundle_manifest.json")
+            manifest_data = json.loads(tar.extractfile(manifest_member).read())
+
+        assert "bundle_schema_version" in manifest_data
+        assert "created_at" in manifest_data
+        assert "cli_version" in manifest_data
+        assert "host_os" in manifest_data
+        assert "node_id" in manifest_data
+        assert "flags_used" in manifest_data
+        assert "collector_results" in manifest_data
+        assert "redaction_counts" in manifest_data
+        assert "file_inventory" in manifest_data
+
+    def test_bundle_no_system_when_flag_disabled(self, tmp_path):
+        """With --no-include-system, system/ directory should be absent."""
+        output_path = tmp_path / "test-bundle.tar.gz"
+        server_resp = _make_server_response()
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", return_value=_mock_httpx_response(server_resp)),
+        ):
+            result = runner.invoke(
+                app,
+                ["support", "bundle", "--output", str(output_path), "--no-include-system"],
+            )
+
+        assert result.exit_code == 0
+
+        with tarfile.open(output_path, "r:gz") as tar:
+            names = [m.name for m in tar.getmembers()]
+
+        system_files = [n for n in names if n.startswith("system/")]
+        assert len(system_files) == 0, "system/ should not be present with --no-include-system"
+
+
+# ── Partial failure handling ─────────────────────────────────────────
+
+
+class TestPartialFailure:
+    """Individual collector failures should still produce a valid bundle (exit 0)."""
+
+    def test_versions_failure_still_produces_bundle(self, tmp_path):
+        """When versions collector fails, bundle is still created with remaining data."""
+        output_path = tmp_path / "test-bundle.tar.gz"
+        server_resp = _make_server_response(versions_ok=False)
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", return_value=_mock_httpx_response(server_resp)),
+        ):
+            result = runner.invoke(app, ["support", "bundle", "--output", str(output_path)])
+
+        assert result.exit_code == 0, f"Should exit 0 on partial failure: {result.output}"
+        assert output_path.exists()
+
+        with tarfile.open(output_path, "r:gz") as tar:
+            names = [m.name for m in tar.getmembers()]
+
+        # Manifest should still be present
+        assert "bundle_manifest.json" in names
+        # versions/ should be absent since that collector failed
+        version_files = [n for n in names if n.startswith("versions/")]
+        assert len(version_files) == 0
+
+        # But health and config should still be present
+        health_files = [n for n in names if n.startswith("health/")]
+        assert len(health_files) > 0
+
+    def test_health_failure_still_produces_bundle(self, tmp_path):
+        """When health collector fails, bundle is still created."""
+        output_path = tmp_path / "test-bundle.tar.gz"
+        server_resp = _make_server_response(health_ok=False)
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", return_value=_mock_httpx_response(server_resp)),
+        ):
+            result = runner.invoke(app, ["support", "bundle", "--output", str(output_path)])
+
+        assert result.exit_code == 0, f"Should exit 0 on partial failure: {result.output}"
+        assert output_path.exists()
+
+    def test_server_unreachable_still_produces_bundle(self, tmp_path):
+        """When the server is unreachable, local collectors still run and produce a bundle."""
+        output_path = tmp_path / "test-bundle.tar.gz"
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        # Simulate server unreachable by raising ConnectError
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", side_effect=httpx.ConnectError("Connection refused")),
+        ):
+            result = runner.invoke(app, ["support", "bundle", "--output", str(output_path)])
+
+        assert result.exit_code == 0, f"Should exit 0 with local-only data: {result.output}"
+        assert output_path.exists()
+
+        with tarfile.open(output_path, "r:gz") as tar:
+            names = [m.name for m in tar.getmembers()]
+
+        # Should still have manifest and system info from local collectors
+        assert "bundle_manifest.json" in names
+        system_files = [n for n in names if n.startswith("system/")]
+        assert len(system_files) > 0, "Local system collector should still run"
+
+    def test_partial_failure_manifest_records_failures(self, tmp_path):
+        """Failed collectors should be recorded in the manifest with ok=false."""
+        output_path = tmp_path / "test-bundle.tar.gz"
+        server_resp = _make_server_response(versions_ok=False, health_ok=False)
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", return_value=_mock_httpx_response(server_resp)),
+        ):
+            result = runner.invoke(app, ["support", "bundle", "--output", str(output_path)])
+
+        assert result.exit_code == 0
+
+        with tarfile.open(output_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        collector_results = manifest_data["collector_results"]
+        assert collector_results["versions"]["ok"] is False
+        assert collector_results["health"]["ok"] is False
+
+
+# ── Total failure ────────────────────────────────────────────────────
+
+
+class TestTotalFailure:
+    """When no data can be collected at all, exit with code 1."""
+
+    def test_all_collectors_fail_exits_1(self, tmp_path):
+        """When all collectors fail and no data is available, exit code should be 1."""
+        from observal_cli.cmd_support import CollectorResult
+
+        output_path = tmp_path / "test-bundle.tar.gz"
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        # All remote collectors fail
+        server_resp = _make_server_response(
+            versions_ok=False,
+            health_ok=False,
+            config_ok=False,
+        )
+
+        failed_system = CollectorResult(name="system_info", ok=False, duration_ms=0, data=None, error="fail")
+        failed_config = CollectorResult(name="config_allowlisted", ok=False, duration_ms=0, data=None, error="fail")
+
+        # Mock both local collectors to fail, and disable system import
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", return_value=_mock_httpx_response(server_resp)),
+            patch("observal_cli.cmd_support._config_allowlisted", return_value=failed_config),
+            patch(
+                "observal_cli.support.collectors.system_info",
+                return_value=failed_system,
+            ),
+        ):
+            result = runner.invoke(app, ["support", "bundle", "--output", str(output_path)])
+
+        assert result.exit_code == 1, f"Should exit 1 when no data collected: {result.output}"
+        assert not output_path.exists(), "No archive should be written on total failure"
+
+    def test_empty_server_response_with_failed_local_exits_1(self, tmp_path):
+        """Empty server response + failed local collectors = exit 1."""
+        from observal_cli.cmd_support import CollectorResult
+
+        output_path = tmp_path / "test-bundle.tar.gz"
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        failed_config = CollectorResult(name="config_allowlisted", ok=False, duration_ms=0, data=None, error="fail")
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch("observal_cli.cmd_support.httpx.post", side_effect=httpx.ConnectError("Connection refused")),
+            patch("observal_cli.cmd_support._config_allowlisted", return_value=failed_config),
+        ):
+            result = runner.invoke(
+                app,
+                ["support", "bundle", "--output", str(output_path), "--no-include-system"],
+            )
+
+        assert result.exit_code == 1, f"Should exit 1 when no data collected: {result.output}"

--- a/tests/test_support_collectors.py
+++ b/tests/test_support_collectors.py
@@ -1,0 +1,216 @@
+"""Tests for observal_cli/support/collectors.py — local system collector.
+
+Covers:
+- system_info collector returns correct structure
+- No hostnames, IP addresses, or usernames in output
+- OS/kernel/CPU fields populated from platform/os modules
+- Memory fields populated via os.sysconf (POSIX)
+- Disk usage fields populated via shutil.disk_usage
+- Container runtime detection (Docker, Podman, none)
+- Graceful error handling (ok=False on exception)
+- Only runs when --include-system flag is active
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from observal_cli.cmd_support import CollectorResult
+from observal_cli.support.collectors import (
+    _detect_container_runtime,
+    _get_memory_available,
+    _get_memory_total,
+    system_info,
+)
+
+# ── system_info collector ────────────────────────────────────────────
+
+
+class TestSystemInfo:
+    def test_returns_collector_result(self):
+        result = system_info({}, {})
+        assert isinstance(result, CollectorResult)
+
+    def test_result_name(self):
+        result = system_info({}, {})
+        assert result.name == "system_info"
+
+    def test_result_ok_on_success(self):
+        result = system_info({}, {})
+        assert result.ok is True
+
+    def test_result_has_duration(self):
+        result = system_info({}, {})
+        assert isinstance(result.duration_ms, int)
+        assert result.duration_ms >= 0
+
+    def test_result_error_is_none_on_success(self):
+        result = system_info({}, {})
+        assert result.error is None
+
+    def test_data_contains_required_keys(self):
+        result = system_info({}, {})
+        assert result.ok is True
+        data = result.data
+        required_keys = {
+            "os_name",
+            "os_version",
+            "kernel_version",
+            "cpu_count",
+            "memory_total_bytes",
+            "memory_available_bytes",
+            "disk_total_bytes",
+            "disk_free_bytes",
+            "container_runtime",
+        }
+        assert required_keys == set(data.keys())
+
+    def test_os_name_is_string(self):
+        result = system_info({}, {})
+        assert isinstance(result.data["os_name"], str)
+        assert len(result.data["os_name"]) > 0
+
+    def test_os_version_is_string(self):
+        result = system_info({}, {})
+        assert isinstance(result.data["os_version"], str)
+
+    def test_kernel_version_is_string(self):
+        result = system_info({}, {})
+        assert isinstance(result.data["kernel_version"], str)
+
+    def test_cpu_count_is_positive_int(self):
+        result = system_info({}, {})
+        cpu = result.data["cpu_count"]
+        assert isinstance(cpu, int)
+        assert cpu > 0
+
+    def test_disk_total_is_positive(self):
+        result = system_info({}, {})
+        assert result.data["disk_total_bytes"] is None or result.data["disk_total_bytes"] > 0
+
+    def test_disk_free_is_non_negative(self):
+        result = system_info({}, {})
+        assert result.data["disk_free_bytes"] is None or result.data["disk_free_bytes"] >= 0
+
+    def test_container_runtime_is_string_or_none(self):
+        result = system_info({}, {})
+        rt = result.data["container_runtime"]
+        assert rt is None or isinstance(rt, str)
+
+    def test_target_path(self):
+        result = system_info({}, {})
+        assert result.target_path == "system/system.json"
+
+
+# ── No PII in output ────────────────────────────────────────────────
+
+
+class TestNoPII:
+    """Verify no hostnames, IP addresses, or usernames leak into system_info."""
+
+    def test_no_hostname_in_data(self):
+        import socket
+
+        hostname = socket.gethostname()
+        result = system_info({}, {})
+        data_str = str(result.data)
+        # Only check if hostname is non-trivial (not a common word)
+        if len(hostname) > 3 and hostname not in ("Linux", "Darwin", "Windows"):
+            assert hostname not in data_str
+
+    def test_no_username_in_data(self):
+        import os
+
+        try:
+            username = os.getlogin()
+        except OSError:
+            username = os.environ.get("USER", os.environ.get("USERNAME", ""))
+        result = system_info({}, {})
+        data_str = str(result.data)
+        # Only check if username is non-trivial
+        if len(username) > 3 and username not in ("root", "Linux", "Darwin", "Windows"):
+            assert username not in data_str
+
+    def test_data_keys_contain_no_hostname_field(self):
+        result = system_info({}, {})
+        for key in result.data:
+            assert "hostname" not in key.lower()
+            assert "ip_address" not in key.lower()
+            assert "username" not in key.lower()
+
+
+# ── Memory helpers ───────────────────────────────────────────────────
+
+
+class TestMemoryHelpers:
+    def test_memory_total_returns_int_or_none(self):
+        val = _get_memory_total()
+        assert val is None or (isinstance(val, int) and val > 0)
+
+    def test_memory_available_returns_int_or_none(self):
+        val = _get_memory_available()
+        assert val is None or (isinstance(val, int) and val > 0)
+
+    def test_memory_total_fallback_on_non_posix(self):
+        with patch("observal_cli.support.collectors.os.sysconf", create=True, side_effect=AttributeError):
+            val = _get_memory_total()
+            assert val is None
+
+    def test_memory_available_fallback_on_non_posix(self):
+        with patch("observal_cli.support.collectors.os.sysconf", create=True, side_effect=AttributeError):
+            val = _get_memory_available()
+            assert val is None
+
+    def test_memory_total_fallback_on_os_error(self):
+        with patch("observal_cli.support.collectors.os.sysconf", create=True, side_effect=OSError):
+            val = _get_memory_total()
+            assert val is None
+
+    def test_memory_available_fallback_on_value_error(self):
+        with patch("observal_cli.support.collectors.os.sysconf", create=True, side_effect=ValueError):
+            val = _get_memory_available()
+            assert val is None
+
+
+# ── Container runtime detection ──────────────────────────────────────
+
+
+class TestContainerRuntimeDetection:
+    def test_detects_docker(self):
+        with patch("observal_cli.support.collectors.os.path.exists") as mock_exists:
+            mock_exists.side_effect = lambda p: p == "/.dockerenv"
+            assert _detect_container_runtime() == "docker"
+
+    def test_detects_podman(self):
+        with patch("observal_cli.support.collectors.os.path.exists") as mock_exists:
+            mock_exists.side_effect = lambda p: p == "/run/.containerenv"
+            assert _detect_container_runtime() == "podman"
+
+    def test_returns_none_when_no_container(self):
+        with patch("observal_cli.support.collectors.os.path.exists", return_value=False):
+            assert _detect_container_runtime() is None
+
+    def test_docker_takes_precedence_over_podman(self):
+        """If both markers exist, Docker is detected first."""
+        with patch("observal_cli.support.collectors.os.path.exists", return_value=True):
+            assert _detect_container_runtime() == "docker"
+
+
+# ── Error handling ───────────────────────────────────────────────────
+
+
+class TestErrorHandling:
+    def test_returns_ok_false_on_exception(self):
+        with patch("observal_cli.support.collectors.platform.system", side_effect=RuntimeError("boom")):
+            result = system_info({}, {})
+            assert result.ok is False
+            assert result.error == "boom"
+            assert result.data is None
+            assert result.name == "system_info"
+
+    def test_disk_usage_failure_sets_none(self):
+        with patch("observal_cli.support.collectors.shutil.disk_usage", side_effect=OSError("no disk")):
+            result = system_info({}, {})
+            assert result.ok is True
+            assert result.data["disk_total_bytes"] is None
+            assert result.data["disk_free_bytes"] is None

--- a/tests/test_support_endpoint.py
+++ b/tests/test_support_endpoint.py
@@ -1,0 +1,1080 @@
+"""Tests for server-side support bundle collectors and endpoint.
+
+Covers:
+- _run_collector wrapper: success, timeout, exception handling
+- _collect_versions: app version, alembic revision, CH version + tables
+- _collect_health: PG, CH, Redis, OTEL probes
+- _collect_config: returns allowlisted Settings fields only
+- _collect_aggregates: row counts per PG/CH table, no row contents
+- _collect_errors: error fingerprints from last 24h, max 50, stack_template only
+- _collect_logs: structured log lines from ring buffer, duration filtering
+- _parse_duration: human-friendly duration parsing
+- _extract_stack_template: stack trace file/function extraction
+- collect_diagnostics endpoint: partial failure still returns 200
+- Config allowlist filtering (CLI-side): only CONFIG_ALLOWLIST keys in output
+
+Requirements: 2.4, 2.5, 2.6, 2.8, 2.9, 2.10, 2.11, 6.5, 6.6, 7.4, 8.1, 8.2
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.routes.support import (
+    CONFIG_ALLOWLIST,
+    CollectRequest,
+    _collect_aggregates,
+    _collect_config,
+    _collect_errors,
+    _collect_health,
+    _collect_logs,
+    _collect_versions,
+    _extract_stack_template,
+    _parse_duration,
+    _run_collector,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _mock_db():
+    """Return an AsyncMock that behaves like an AsyncSession."""
+    return AsyncMock()
+
+
+def _mock_ch_response(status_code=200, text="", json_data=None):
+    """Return a mock httpx Response for ClickHouse queries."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    if json_data is not None:
+        resp.json.return_value = json_data
+    return resp
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _run_collector wrapper
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestRunCollector:
+    """Tests for the _run_collector timeout/error wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_ok_true(self):
+        async def good_collector():
+            return {"key": "value"}
+
+        name, data = await _run_collector("test", good_collector())
+        assert name == "test"
+        assert data.ok is True
+        assert data.data == {"key": "value"}
+        assert data.error is None
+        assert data.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_ok_false(self):
+        async def slow_collector():
+            await asyncio.sleep(30)
+            return {}
+
+        with patch("api.routes.support.COLLECTOR_TIMEOUT_SECONDS", 0.05):
+            name, data = await _run_collector("slow", slow_collector())
+
+        assert name == "slow"
+        assert data.ok is False
+        assert "timed out" in data.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_ok_false(self):
+        async def bad_collector():
+            raise RuntimeError("database exploded")
+
+        name, data = await _run_collector("bad", bad_collector())
+        assert name == "bad"
+        assert data.ok is False
+        assert data.error == "RuntimeError"
+        assert data.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_duration_ms_equals_timeout_seconds(self):
+        async def slow_collector():
+            await asyncio.sleep(30)
+            return {}
+
+        with patch("api.routes.support.COLLECTOR_TIMEOUT_SECONDS", 0.05):
+            _, data = await _run_collector("slow", slow_collector())
+
+        # duration_ms should be approximately the timeout value (50ms)
+        # Allow generous tolerance since CI can be slow
+        assert data.duration_ms <= 5000
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _collect_versions
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestCollectVersions:
+    """Tests for the versions collector (app, alembic, CH)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_app_version(self):
+        db = _mock_db()
+        # Mock alembic query
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "abc123"
+        db.execute.return_value = mock_result
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, text="24.3.1"),
+                _mock_ch_response(200, json_data={"data": [{"name": "traces"}, {"name": "spans"}]}),
+            ]
+            result = await _collect_versions(db)
+
+        assert "app_version" in result
+        assert isinstance(result["app_version"], str)
+
+    @pytest.mark.asyncio
+    async def test_returns_alembic_revision(self):
+        db = _mock_db()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "rev_42"
+        db.execute.return_value = mock_result
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, text="24.3.1"),
+                _mock_ch_response(200, json_data={"data": []}),
+            ]
+            result = await _collect_versions(db)
+
+        assert result["alembic_revision"] == "rev_42"
+
+    @pytest.mark.asyncio
+    async def test_alembic_error_recorded(self):
+        db = _mock_db()
+        db.execute.side_effect = RuntimeError("pg down")
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, text="24.3.1"),
+                _mock_ch_response(200, json_data={"data": []}),
+            ]
+            result = await _collect_versions(db)
+
+        assert "error" in result["alembic_revision"]
+
+    @pytest.mark.asyncio
+    async def test_returns_clickhouse_version(self):
+        db = _mock_db()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "abc"
+        db.execute.return_value = mock_result
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, text="24.3.1.5"),
+                _mock_ch_response(200, json_data={"data": [{"name": "traces"}]}),
+            ]
+            result = await _collect_versions(db)
+
+        assert result["clickhouse_version"] == "24.3.1.5"
+
+    @pytest.mark.asyncio
+    async def test_returns_clickhouse_tables(self):
+        db = _mock_db()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "abc"
+        db.execute.return_value = mock_result
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, text="24.3.1"),
+                _mock_ch_response(200, json_data={"data": [{"name": "traces"}, {"name": "spans"}, {"name": "scores"}]}),
+            ]
+            result = await _collect_versions(db)
+
+        assert result["clickhouse_tables"] == ["traces", "spans", "scores"]
+
+    @pytest.mark.asyncio
+    async def test_clickhouse_error_recorded(self):
+        db = _mock_db()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "abc"
+        db.execute.return_value = mock_result
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = ConnectionError("CH unreachable")
+            result = await _collect_versions(db)
+
+        assert "error" in result["clickhouse_version"]
+
+    @pytest.mark.asyncio
+    async def test_build_hash_from_env(self):
+        db = _mock_db()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "abc"
+        db.execute.return_value = mock_result
+
+        with (
+            patch("api.routes.support._query", new_callable=AsyncMock) as mock_query,
+            patch.dict("os.environ", {"BUILD_HASH": "deadbeef"}),
+        ):
+            mock_query.side_effect = [
+                _mock_ch_response(200, text="24.3.1"),
+                _mock_ch_response(200, json_data={"data": []}),
+            ]
+            result = await _collect_versions(db)
+
+        assert result["build_hash"] == "deadbeef"
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _collect_health
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestCollectHealth:
+    """Tests for health probes against PG, CH, Redis, OTEL."""
+
+    @pytest.mark.asyncio
+    async def test_postgres_ok(self):
+        db = _mock_db()
+        db.execute.return_value = MagicMock()
+
+        with (
+            patch("api.routes.support._query", new_callable=AsyncMock) as mock_query,
+            patch("api.routes.support.get_redis") as mock_get_redis,
+        ):
+            mock_query.return_value = _mock_ch_response(200)
+            mock_redis = AsyncMock()
+            mock_redis.ping.return_value = True
+            mock_get_redis.return_value = mock_redis
+
+            result = await _collect_health(db)
+
+        assert result["postgres"]["status"] == "ok"
+        assert "latency_ms" in result["postgres"]
+
+    @pytest.mark.asyncio
+    async def test_postgres_error(self):
+        db = _mock_db()
+        db.execute.side_effect = RuntimeError("connection refused")
+
+        with (
+            patch("api.routes.support._query", new_callable=AsyncMock) as mock_query,
+            patch("api.routes.support.get_redis") as mock_get_redis,
+        ):
+            mock_query.return_value = _mock_ch_response(200)
+            mock_redis = AsyncMock()
+            mock_redis.ping.return_value = True
+            mock_get_redis.return_value = mock_redis
+
+            result = await _collect_health(db)
+
+        assert result["postgres"]["status"] == "error"
+        assert result["postgres"]["error"] == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_clickhouse_ok(self):
+        db = _mock_db()
+
+        with (
+            patch("api.routes.support._query", new_callable=AsyncMock) as mock_query,
+            patch("api.routes.support.get_redis") as mock_get_redis,
+        ):
+            mock_query.return_value = _mock_ch_response(200)
+            mock_redis = AsyncMock()
+            mock_redis.ping.return_value = True
+            mock_get_redis.return_value = mock_redis
+
+            result = await _collect_health(db)
+
+        assert result["clickhouse"]["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_clickhouse_error(self):
+        db = _mock_db()
+
+        with (
+            patch("api.routes.support._query", new_callable=AsyncMock) as mock_query,
+            patch("api.routes.support.get_redis") as mock_get_redis,
+        ):
+            mock_query.side_effect = ConnectionError("CH down")
+            mock_redis = AsyncMock()
+            mock_redis.ping.return_value = True
+            mock_get_redis.return_value = mock_redis
+
+            result = await _collect_health(db)
+
+        assert result["clickhouse"]["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_redis_ok(self):
+        db = _mock_db()
+
+        with (
+            patch("api.routes.support._query", new_callable=AsyncMock) as mock_query,
+            patch("api.routes.support.get_redis") as mock_get_redis,
+        ):
+            mock_query.return_value = _mock_ch_response(200)
+            mock_redis = AsyncMock()
+            mock_redis.ping.return_value = True
+            mock_get_redis.return_value = mock_redis
+
+            result = await _collect_health(db)
+
+        assert result["redis"]["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_redis_error(self):
+        db = _mock_db()
+
+        with (
+            patch("api.routes.support._query", new_callable=AsyncMock) as mock_query,
+            patch("api.routes.support.get_redis") as mock_get_redis,
+        ):
+            mock_query.return_value = _mock_ch_response(200)
+            mock_get_redis.side_effect = ConnectionError("Redis down")
+
+            result = await _collect_health(db)
+
+        assert result["redis"]["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_all_probes_have_latency_ms(self):
+        db = _mock_db()
+
+        with (
+            patch("api.routes.support._query", new_callable=AsyncMock) as mock_query,
+            patch("api.routes.support.get_redis") as mock_get_redis,
+        ):
+            mock_query.return_value = _mock_ch_response(200)
+            mock_redis = AsyncMock()
+            mock_redis.ping.return_value = True
+            mock_get_redis.return_value = mock_redis
+
+            result = await _collect_health(db)
+
+        for probe_name in ("postgres", "clickhouse", "redis"):
+            assert "latency_ms" in result[probe_name], f"{probe_name} missing latency_ms"
+            assert isinstance(result[probe_name]["latency_ms"], int)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _collect_config
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestCollectConfig:
+    """Tests for the config collector — only allowlisted keys returned."""
+
+    @pytest.mark.asyncio
+    async def test_returns_only_allowlisted_keys(self):
+        result = await _collect_config()
+        for key in result:
+            assert key in CONFIG_ALLOWLIST, f"Key '{key}' not in CONFIG_ALLOWLIST"
+
+    @pytest.mark.asyncio
+    async def test_excludes_secret_key(self):
+        result = await _collect_config()
+        assert "SECRET_KEY" not in result
+
+    @pytest.mark.asyncio
+    async def test_excludes_oauth_secrets(self):
+        result = await _collect_config()
+        assert "OAUTH_CLIENT_SECRET" not in result
+        assert "OAUTH_CLIENT_ID" not in result
+
+    @pytest.mark.asyncio
+    async def test_excludes_eval_model_api_key(self):
+        result = await _collect_config()
+        assert "EVAL_MODEL_API_KEY" not in result
+
+    @pytest.mark.asyncio
+    async def test_includes_database_url(self):
+        result = await _collect_config()
+        assert "DATABASE_URL" in result
+
+    @pytest.mark.asyncio
+    async def test_includes_deployment_mode(self):
+        result = await _collect_config()
+        assert "DEPLOYMENT_MODE" in result
+
+    @pytest.mark.asyncio
+    async def test_result_is_dict(self):
+        result = await _collect_config()
+        assert isinstance(result, dict)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _collect_aggregates
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestCollectAggregates:
+    """Tests for aggregate row counts — counts only, never row contents."""
+
+    @pytest.mark.asyncio
+    async def test_returns_pg_table_counts(self):
+        db = _mock_db()
+        # pg_tables query returns table names
+        tables_result = MagicMock()
+        tables_result.fetchall.return_value = [("users",), ("agents",)]
+        # count queries return integers
+        count_result = MagicMock()
+        count_result.scalar.return_value = 42
+        db.execute.side_effect = [tables_result, count_result, count_result]
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, json_data={"data": []}),
+            ]
+            result = await _collect_aggregates(db)
+
+        assert "pg_table_counts" in result
+        assert result["pg_table_counts"]["users"] == 42
+        assert result["pg_table_counts"]["agents"] == 42
+
+    @pytest.mark.asyncio
+    async def test_returns_ch_table_counts(self):
+        db = _mock_db()
+        tables_result = MagicMock()
+        tables_result.fetchall.return_value = []
+        db.execute.return_value = tables_result
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                # CH table list
+                _mock_ch_response(200, json_data={"data": [{"name": "traces"}, {"name": "spans"}]}),
+                # count for traces
+                _mock_ch_response(200, json_data={"data": [{"count()": 1000000}]}),
+                # count for spans
+                _mock_ch_response(200, json_data={"data": [{"count()": 5000000}]}),
+            ]
+            result = await _collect_aggregates(db)
+
+        assert "ch_table_counts" in result
+        assert result["ch_table_counts"]["traces"] == 1000000
+        assert result["ch_table_counts"]["spans"] == 5000000
+
+    @pytest.mark.asyncio
+    async def test_counts_are_integers_not_row_contents(self):
+        """Requirement 8.1, 8.2: only aggregate counts, never row contents."""
+        db = _mock_db()
+        tables_result = MagicMock()
+        tables_result.fetchall.return_value = [("users",)]
+        count_result = MagicMock()
+        count_result.scalar.return_value = 99
+        db.execute.side_effect = [tables_result, count_result]
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, json_data={"data": [{"name": "traces"}]}),
+                _mock_ch_response(200, json_data={"data": [{"count()": 500}]}),
+            ]
+            result = await _collect_aggregates(db)
+
+        # PG counts are plain integers
+        for table, count in result["pg_table_counts"].items():
+            assert isinstance(count, int), f"PG table {table} has non-int count: {count}"
+
+        # CH counts are plain integers
+        for table, count in result["ch_table_counts"].items():
+            assert isinstance(count, int), f"CH table {table} has non-int count: {count}"
+
+    @pytest.mark.asyncio
+    async def test_pg_error_recorded_per_table(self):
+        db = _mock_db()
+        tables_result = MagicMock()
+        tables_result.fetchall.return_value = [("broken_table",)]
+        db.execute.side_effect = [tables_result, RuntimeError("permission denied")]
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, json_data={"data": []}),
+            ]
+            result = await _collect_aggregates(db)
+
+        assert "error" in result["pg_table_counts"]["broken_table"]
+
+    @pytest.mark.asyncio
+    async def test_ch_error_recorded_per_table(self):
+        db = _mock_db()
+        tables_result = MagicMock()
+        tables_result.fetchall.return_value = []
+        db.execute.return_value = tables_result
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, json_data={"data": [{"name": "broken"}]}),
+                ConnectionError("CH query failed"),
+            ]
+            result = await _collect_aggregates(db)
+
+        assert "error" in result["ch_table_counts"]["broken"]
+
+    @pytest.mark.asyncio
+    async def test_unsafe_ch_table_name_skipped(self):
+        db = _mock_db()
+        tables_result = MagicMock()
+        tables_result.fetchall.return_value = []
+        db.execute.return_value = tables_result
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.side_effect = [
+                _mock_ch_response(200, json_data={"data": [{"name": "Robert'; DROP TABLE--"}]}),
+            ]
+            result = await _collect_aggregates(db)
+
+        assert "unsafe table name" in result["ch_table_counts"]["Robert'; DROP TABLE--"]
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _collect_errors
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestCollectErrors:
+    """Tests for error fingerprint collection."""
+
+    @pytest.mark.asyncio
+    async def test_returns_fingerprints_list(self):
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.return_value = _mock_ch_response(
+                200,
+                json_data={
+                    "data": [
+                        {
+                            "error": 'File "app.py", line 10, in main\nValueError: bad',
+                            "start_time": "2025-07-15T10:00:00",
+                        },
+                    ]
+                },
+            )
+            db = _mock_db()
+            result = await _collect_errors(db)
+
+        assert "fingerprints" in result
+        assert len(result["fingerprints"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_fingerprint_has_required_fields(self):
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.return_value = _mock_ch_response(
+                200,
+                json_data={
+                    "data": [
+                        {"error": 'File "app.py", line 10, in main\nError', "start_time": "2025-07-15T10:00:00"},
+                    ]
+                },
+            )
+            db = _mock_db()
+            result = await _collect_errors(db)
+
+        fp = result["fingerprints"][0]
+        assert "fingerprint" in fp
+        assert "count" in fp
+        assert "first_seen" in fp
+        assert "last_seen" in fp
+        assert "stack_template" in fp
+
+    @pytest.mark.asyncio
+    async def test_fingerprint_is_sha256_of_template(self):
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.return_value = _mock_ch_response(
+                200,
+                json_data={
+                    "data": [
+                        {"error": 'File "app.py", line 10, in main\nError', "start_time": "2025-07-15T10:00:00"},
+                    ]
+                },
+            )
+            db = _mock_db()
+            result = await _collect_errors(db)
+
+        fp = result["fingerprints"][0]
+        expected_hash = hashlib.sha256(fp["stack_template"].encode("utf-8")).hexdigest()
+        assert fp["fingerprint"] == expected_hash
+
+    @pytest.mark.asyncio
+    async def test_max_50_fingerprints(self):
+        """Requirement 2.10: up to 50 error fingerprints."""
+        errors = []
+        for i in range(100):
+            errors.append(
+                {
+                    "error": f'File "mod{i}.py", line {i}, in func{i}\nError{i}',
+                    "start_time": f"2025-07-15T10:{i % 60:02d}:00",
+                }
+            )
+
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.return_value = _mock_ch_response(200, json_data={"data": errors})
+            db = _mock_db()
+            result = await _collect_errors(db)
+
+        assert len(result["fingerprints"]) <= 50
+
+    @pytest.mark.asyncio
+    async def test_stack_template_has_no_exception_messages(self):
+        """Requirement 2.10: stack_template has file paths + function names only."""
+        error_text = (
+            "Traceback (most recent call last):\n"
+            '  File "/app/server.py", line 42, in handle_request\n'
+            "    result = process(data)\n"
+            '  File "/app/processor.py", line 15, in process\n'
+            '    raise ValueError("secret data: password=hunter2")\n'
+            "ValueError: secret data: password=hunter2"
+        )
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.return_value = _mock_ch_response(
+                200, json_data={"data": [{"error": error_text, "start_time": "2025-07-15T10:00:00"}]}
+            )
+            db = _mock_db()
+            result = await _collect_errors(db)
+
+        template = result["fingerprints"][0]["stack_template"]
+        assert "hunter2" not in template
+        assert "password" not in template
+        assert "secret data" not in template
+        # But file paths and function names should be present
+        assert "server.py" in template
+        assert "handle_request" in template
+
+    @pytest.mark.asyncio
+    async def test_empty_errors_returns_empty_list(self):
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.return_value = _mock_ch_response(200, json_data={"data": []})
+            db = _mock_db()
+            result = await _collect_errors(db)
+
+        assert result["fingerprints"] == []
+
+    @pytest.mark.asyncio
+    async def test_duplicate_errors_grouped_by_fingerprint(self):
+        same_error = 'File "app.py", line 10, in main\nError'
+        with patch("api.routes.support._query", new_callable=AsyncMock) as mock_query:
+            mock_query.return_value = _mock_ch_response(
+                200,
+                json_data={
+                    "data": [
+                        {"error": same_error, "start_time": "2025-07-15T10:00:00"},
+                        {"error": same_error, "start_time": "2025-07-15T11:00:00"},
+                        {"error": same_error, "start_time": "2025-07-15T12:00:00"},
+                    ]
+                },
+            )
+            db = _mock_db()
+            result = await _collect_errors(db)
+
+        assert len(result["fingerprints"]) == 1
+        assert result["fingerprints"][0]["count"] == 3
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _collect_logs
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestCollectLogs:
+    """Tests for the logs collector (ring buffer + duration filtering)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_lines_from_buffer(self):
+        now = datetime.now(UTC)
+        entries = [
+            {"timestamp": now.isoformat(), "event": "test log", "level": "info"},
+        ]
+        mock_buffer = MagicMock()
+        mock_buffer.get_since.return_value = entries
+
+        with patch("services.log_buffer.get_log_buffer", return_value=mock_buffer):
+            result = await _collect_logs("1h")
+
+        assert "lines" in result
+        assert len(result["lines"]) == 1
+        assert result["lines"][0]["event"] == "test log"
+
+    @pytest.mark.asyncio
+    async def test_empty_buffer_returns_empty_with_note(self):
+        mock_buffer = MagicMock()
+        mock_buffer.get_since.return_value = []
+
+        with patch("services.log_buffer.get_log_buffer", return_value=mock_buffer):
+            result = await _collect_logs("1h")
+
+        assert result["lines"] == []
+        assert "note" in result
+
+    @pytest.mark.asyncio
+    async def test_import_error_returns_empty(self):
+        # Simulate ImportError by temporarily removing the module from sys.modules
+        # and making the import fail
+
+        with patch.dict("sys.modules", {"services.log_buffer": None}):
+            result = await _collect_logs("1h")
+
+        assert result["lines"] == []
+
+    @pytest.mark.asyncio
+    async def test_strips_internal_structlog_keys(self):
+        now = datetime.now(UTC)
+        entries = [
+            {
+                "timestamp": now.isoformat(),
+                "event": "test",
+                "level": "info",
+                "_record": "should be stripped",
+                "_logger": "should be stripped",
+            },
+        ]
+        mock_buffer = MagicMock()
+        mock_buffer.get_since.return_value = entries
+
+        with patch("services.log_buffer.get_log_buffer", return_value=mock_buffer):
+            result = await _collect_logs("1h")
+
+        line = result["lines"][0]
+        assert "_record" not in line
+        assert "_logger" not in line
+        assert "event" in line
+
+    @pytest.mark.asyncio
+    async def test_non_serializable_values_converted_to_string(self):
+        now = datetime.now(UTC)
+        entries = [
+            {
+                "timestamp": now.isoformat(),
+                "event": "test",
+                "custom_obj": object(),  # not JSON-serializable
+            },
+        ]
+        mock_buffer = MagicMock()
+        mock_buffer.get_since.return_value = entries
+
+        with patch("services.log_buffer.get_log_buffer", return_value=mock_buffer):
+            result = await _collect_logs("1h")
+
+        # Should be converted to string, not raise
+        assert isinstance(result["lines"][0]["custom_obj"], str)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _parse_duration
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestParseDuration:
+    """Tests for human-friendly duration string parsing."""
+
+    def test_hours(self):
+        assert _parse_duration("1h") == timedelta(hours=1)
+
+    def test_minutes(self):
+        assert _parse_duration("30m") == timedelta(minutes=30)
+
+    def test_days(self):
+        assert _parse_duration("2d") == timedelta(days=2)
+
+    def test_seconds(self):
+        assert _parse_duration("90s") == timedelta(seconds=90)
+
+    def test_combined(self):
+        assert _parse_duration("1h30m") == timedelta(hours=1, minutes=30)
+
+    def test_invalid_falls_back_to_1h(self):
+        assert _parse_duration("invalid") == timedelta(hours=1)
+
+    def test_empty_falls_back_to_1h(self):
+        assert _parse_duration("") == timedelta(hours=1)
+
+    def test_case_insensitive(self):
+        assert _parse_duration("2H") == timedelta(hours=2)
+        assert _parse_duration("30M") == timedelta(minutes=30)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# _extract_stack_template
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestExtractStackTemplate:
+    """Tests for stack trace sanitisation."""
+
+    def test_extracts_file_and_function(self):
+        trace = (
+            "Traceback (most recent call last):\n"
+            '  File "/app/main.py", line 42, in run\n'
+            "    do_stuff()\n"
+            '  File "/app/utils.py", line 10, in do_stuff\n'
+            '    raise ValueError("oops")\n'
+            "ValueError: oops"
+        )
+        template = _extract_stack_template(trace)
+        assert "/app/main.py:run" in template
+        assert "/app/utils.py:do_stuff" in template
+
+    def test_no_exception_message_in_template(self):
+        trace = (
+            "Traceback (most recent call last):\n"
+            '  File "/app/main.py", line 42, in run\n'
+            "ValueError: secret password=hunter2"
+        )
+        template = _extract_stack_template(trace)
+        assert "hunter2" not in template
+        assert "secret password" not in template
+
+    def test_arrow_separator(self):
+        trace = '  File "/a.py", line 1, in foo\n  File "/b.py", line 2, in bar\n'
+        template = _extract_stack_template(trace)
+        assert " -> " in template
+
+    def test_fallback_for_non_traceback(self):
+        template = _extract_stack_template("SomeError: something went wrong")
+        assert template  # should return something, not empty
+        assert "something went wrong" not in template  # message stripped
+
+    def test_empty_input(self):
+        template = _extract_stack_template("")
+        assert template == "unknown"
+
+
+# ═════════════════════════════════════════════════════════════════════
+# collect_diagnostics endpoint — partial failure
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestCollectDiagnosticsEndpoint:
+    """Tests for the POST /collect endpoint behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_still_returns_results(self):
+        """Requirement 6.5, 6.6: partial failures reported, endpoint returns 200."""
+        from api.ratelimit import limiter
+        from api.routes.support import COLLECTORS, collect_diagnostics
+
+        db = _mock_db()
+        user = MagicMock()
+
+        # Make versions succeed and health fail
+        async def good_versions(db_arg, logs_since):
+            return {"app_version": "1.0.0"}
+
+        async def bad_health(db_arg, logs_since):
+            raise RuntimeError("all probes failed")
+
+        old_enabled = limiter.enabled
+        limiter.enabled = False
+        try:
+            with patch.dict(
+                COLLECTORS,
+                {
+                    "versions": lambda db, ls: good_versions(db, ls),
+                    "health": lambda db, ls: bad_health(db, ls),
+                },
+                clear=True,
+            ):
+                body = CollectRequest(collectors=["versions", "health"])
+                response = await collect_diagnostics(
+                    request=MagicMock(),
+                    body=body,
+                    user=user,
+                    db=db,
+                )
+        finally:
+            limiter.enabled = old_enabled
+
+        assert response.collectors["versions"].ok is True
+        assert response.collectors["health"].ok is False
+        assert response.collectors["health"].error == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_all_collectors_requested_by_default(self):
+        from api.ratelimit import limiter
+        from api.routes.support import COLLECTORS, collect_diagnostics
+
+        db = _mock_db()
+        user = MagicMock()
+
+        async def noop(db_arg, logs_since):
+            return {}
+
+        old_enabled = limiter.enabled
+        limiter.enabled = False
+        try:
+            with patch.dict(COLLECTORS, {name: lambda db, ls: noop(db, ls) for name in COLLECTORS}):
+                body = CollectRequest()  # default: collectors=["all"]
+                response = await collect_diagnostics(
+                    request=MagicMock(),
+                    body=body,
+                    user=user,
+                    db=db,
+                )
+        finally:
+            limiter.enabled = old_enabled
+
+        # Should have run all registered collectors
+        assert len(response.collectors) == len(COLLECTORS)
+
+    @pytest.mark.asyncio
+    async def test_specific_collectors_requested(self):
+        from api.ratelimit import limiter
+        from api.routes.support import COLLECTORS, collect_diagnostics
+
+        db = _mock_db()
+        user = MagicMock()
+
+        async def noop(db_arg, logs_since):
+            return {}
+
+        old_enabled = limiter.enabled
+        limiter.enabled = False
+        try:
+            with patch.dict(COLLECTORS, {name: lambda db, ls: noop(db, ls) for name in COLLECTORS}):
+                body = CollectRequest(collectors=["versions", "health"])
+                response = await collect_diagnostics(
+                    request=MagicMock(),
+                    body=body,
+                    user=user,
+                    db=db,
+                )
+        finally:
+            limiter.enabled = old_enabled
+
+        assert set(response.collectors.keys()) == {"versions", "health"}
+
+    @pytest.mark.asyncio
+    async def test_response_includes_server_version(self):
+        from api.ratelimit import limiter
+        from api.routes.support import COLLECTORS, collect_diagnostics
+
+        db = _mock_db()
+        user = MagicMock()
+
+        async def noop(db_arg, logs_since):
+            return {}
+
+        old_enabled = limiter.enabled
+        limiter.enabled = False
+        try:
+            with patch.dict(
+                COLLECTORS,
+                {
+                    "versions": lambda db, ls: noop(db, ls),
+                },
+                clear=True,
+            ):
+                body = CollectRequest(collectors=["versions"])
+                response = await collect_diagnostics(
+                    request=MagicMock(),
+                    body=body,
+                    user=user,
+                    db=db,
+                )
+        finally:
+            limiter.enabled = old_enabled
+
+        assert isinstance(response.server_version, str)
+        assert len(response.server_version) > 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_collector_name_ignored(self):
+        from api.ratelimit import limiter
+        from api.routes.support import COLLECTORS, collect_diagnostics
+
+        db = _mock_db()
+        user = MagicMock()
+
+        async def noop(db_arg, logs_since):
+            return {}
+
+        old_enabled = limiter.enabled
+        limiter.enabled = False
+        try:
+            with patch.dict(
+                COLLECTORS,
+                {
+                    "versions": lambda db, ls: noop(db, ls),
+                },
+                clear=True,
+            ):
+                body = CollectRequest(collectors=["versions", "nonexistent_collector"])
+                response = await collect_diagnostics(
+                    request=MagicMock(),
+                    body=body,
+                    user=user,
+                    db=db,
+                )
+        finally:
+            limiter.enabled = old_enabled
+
+        assert "versions" in response.collectors
+        assert "nonexistent_collector" not in response.collectors
+
+
+# ═════════════════════════════════════════════════════════════════════
+# CLI-side config allowlist filtering
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestConfigAllowlistFiltering:
+    """Tests for CLI-side CONFIG_ALLOWLIST filtering (Requirement 7.4)."""
+
+    def test_allowlist_contains_expected_keys(self):
+        expected = {
+            "DATABASE_URL",
+            "CLICKHOUSE_URL",
+            "REDIS_URL",
+            "REDIS_SOCKET_TIMEOUT",
+            "EVAL_MODEL_NAME",
+            "EVAL_MODEL_PROVIDER",
+            "AWS_REGION",
+            "FRONTEND_URL",
+            "JWT_ACCESS_TOKEN_EXPIRE_MINUTES",
+            "JWT_REFRESH_TOKEN_EXPIRE_DAYS",
+            "JWT_SIGNING_ALGORITHM",
+            "JWT_HOOKS_TOKEN_EXPIRE_MINUTES",
+            "RATE_LIMIT_AUTH",
+            "RATE_LIMIT_AUTH_STRICT",
+            "DATA_RETENTION_DAYS",
+            "DEPLOYMENT_MODE",
+        }
+        assert expected.issubset(CONFIG_ALLOWLIST)
+
+    def test_allowlist_excludes_secrets(self):
+        forbidden = {
+            "SECRET_KEY",
+            "EVAL_MODEL_API_KEY",
+            "EVAL_MODEL_URL",
+            "OAUTH_CLIENT_ID",
+            "OAUTH_CLIENT_SECRET",
+            "OAUTH_SERVER_METADATA_URL",
+            "JWT_KEY_DIR",
+            "JWT_KEY_PASSWORD",
+        }
+        assert forbidden.isdisjoint(CONFIG_ALLOWLIST)
+
+    def test_filtering_with_mixed_keys(self):
+        """Simulate CLI-side filtering: only allowlisted keys survive."""
+        raw_config = {
+            "DATABASE_URL": "postgresql://user:pass@localhost/db",
+            "SECRET_KEY": "super-secret-key-value",
+            "DEPLOYMENT_MODE": "docker",
+            "OAUTH_CLIENT_SECRET": "oauth-secret",
+            "AWS_REGION": "us-east-1",
+        }
+        filtered = {k: v for k, v in raw_config.items() if k in CONFIG_ALLOWLIST}
+
+        assert "DATABASE_URL" in filtered
+        assert "DEPLOYMENT_MODE" in filtered
+        assert "AWS_REGION" in filtered
+        assert "SECRET_KEY" not in filtered
+        assert "OAUTH_CLIENT_SECRET" not in filtered

--- a/tests/test_support_inspect.py
+++ b/tests/test_support_inspect.py
@@ -1,0 +1,416 @@
+"""Tests for the `observal support inspect` subcommand.
+
+Covers:
+- Manifest display from a known bundle
+- Tree view output
+- --show with valid and invalid paths
+- Missing bundle file (exit 1)
+- Invalid tar.gz (exit 1)
+- Missing manifest (exit 1)
+- Schema version warnings (higher, current, lower, non-integer)
+
+Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 10.4, 10.5
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path  # noqa: TC003
+
+from typer.testing import CliRunner
+
+from observal_cli.main import app
+
+runner = CliRunner()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_manifest(
+    schema_version: str = "1",
+    cli_version: str = "0.9.0",
+    host_os: str = "Linux",
+    extra_fields: dict | None = None,
+) -> dict:
+    """Build a valid bundle manifest dict."""
+    manifest = {
+        "bundle_schema_version": schema_version,
+        "created_at": "2025-07-15T14:30:22Z",
+        "cli_version": cli_version,
+        "host_os": host_os,
+        "node_id": "test-node",
+        "flags_used": {"output": "test.tar.gz", "logs_since": "1h", "include_system": True},
+        "collector_results": {
+            "versions": {"ok": True, "duration_ms": 50},
+            "health": {"ok": True, "duration_ms": 30},
+        },
+        "redaction_counts": {"config/config.json": 2},
+        "file_inventory": [
+            {"path": "versions/app.json", "size_bytes": 42, "sha256": "abc123"},
+            {"path": "config/config.json", "size_bytes": 100, "sha256": "def456"},
+        ],
+    }
+    if extra_fields:
+        manifest.update(extra_fields)
+    return manifest
+
+
+def _add_bytes_to_tar(tar: tarfile.TarFile, name: str, data: bytes) -> None:
+    """Add in-memory bytes to a tarfile."""
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    tar.addfile(info, io.BytesIO(data))
+
+
+def _create_bundle(
+    path: Path,
+    manifest: dict | None = None,
+    files: dict[str, bytes] | None = None,
+    include_manifest: bool = True,
+) -> Path:
+    """Create a .tar.gz bundle at the given path with optional manifest and files.
+
+    Args:
+        path: Output path for the archive.
+        manifest: Manifest dict. Uses default if None.
+        files: Mapping of relative path -> content bytes to include.
+        include_manifest: Whether to include bundle_manifest.json.
+
+    Returns:
+        The path to the created archive.
+    """
+    if manifest is None:
+        manifest = _make_manifest()
+    if files is None:
+        files = {
+            "versions/app.json": json.dumps({"cli_version": "0.9.0", "server_version": "0.9.0"}).encode(),
+            "config/config.json": json.dumps({"DEPLOYMENT_MODE": "docker"}).encode(),
+        }
+
+    with tarfile.open(path, "w:gz") as tar:
+        if include_manifest:
+            manifest_bytes = json.dumps(manifest, indent=2).encode("utf-8")
+            _add_bytes_to_tar(tar, "bundle_manifest.json", manifest_bytes)
+        for rel_path, content in files.items():
+            _add_bytes_to_tar(tar, rel_path, content)
+
+    return path
+
+
+# ── Manifest display ─────────────────────────────────────────────────
+
+
+class TestInspectManifestDisplay:
+    """Verify inspect prints the manifest as formatted JSON."""
+
+    def test_manifest_displayed_as_json(self, tmp_path):
+        """inspect should print the manifest contents as formatted JSON."""
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz")
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        # The manifest fields should appear in the output
+        assert "bundle_schema_version" in result.output
+        assert "0.9.0" in result.output  # cli_version
+        assert "test-node" in result.output  # node_id
+        assert "collector_results" in result.output
+
+    def test_manifest_fields_present(self, tmp_path):
+        """All required manifest fields should be visible in the output."""
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz")
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        for field in [
+            "bundle_schema_version",
+            "created_at",
+            "cli_version",
+            "host_os",
+            "node_id",
+            "flags_used",
+            "collector_results",
+            "redaction_counts",
+            "file_inventory",
+        ]:
+            assert field in result.output, f"Expected field '{field}' in output"
+
+
+# ── Tree view ────────────────────────────────────────────────────────
+
+
+class TestInspectTreeView:
+    """Verify inspect prints a tree view of archive contents with sizes."""
+
+    def test_tree_shows_file_names(self, tmp_path):
+        """The tree view should list all files in the archive."""
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz")
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        assert "versions/app.json" in result.output
+        assert "config/config.json" in result.output
+        assert "bundle_manifest.json" in result.output
+
+    def test_tree_shows_bundle_contents_label(self, tmp_path):
+        """The tree view should have a 'Bundle contents' label."""
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz")
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        assert "Bundle contents" in result.output
+
+
+# ── --show flag ──────────────────────────────────────────────────────
+
+
+class TestInspectShowFlag:
+    """Verify --show prints a specific file's contents or errors on invalid paths."""
+
+    def test_show_valid_file(self, tmp_path):
+        """--show should print the contents of the specified file."""
+        file_content = {"cli_version": "0.9.0", "server_version": "0.9.0", "build_hash": "abc123"}
+        files = {
+            "versions/app.json": json.dumps(file_content).encode(),
+            "config/config.json": json.dumps({"DEPLOYMENT_MODE": "docker"}).encode(),
+        }
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz", files=files)
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path), "--show", "versions/app.json"])
+
+        assert result.exit_code == 0
+        assert "0.9.0" in result.output
+        assert "abc123" in result.output
+
+    def test_show_manifest_file(self, tmp_path):
+        """--show should work for bundle_manifest.json itself."""
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz")
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path), "--show", "bundle_manifest.json"])
+
+        assert result.exit_code == 0
+        # The manifest content should appear (it's printed twice: once as formatted JSON, once via --show)
+        assert "bundle_schema_version" in result.output
+
+    def test_show_invalid_path_exits_1(self, tmp_path):
+        """--show with a non-existent path should exit 1 and list available files."""
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz")
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path), "--show", "nonexistent/file.json"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower() or "File not found" in result.output
+        # Should list available files
+        assert "versions/app.json" in result.output
+        assert "config/config.json" in result.output
+
+    def test_show_lists_available_files_on_miss(self, tmp_path):
+        """When --show path doesn't exist, the error should list all available files."""
+        files = {
+            "versions/app.json": b'{"v": 1}',
+            "health/postgres.json": b'{"status": "ok"}',
+            "config/config.json": b'{"mode": "docker"}',
+        }
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz", files=files)
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path), "--show", "does-not-exist.txt"])
+
+        assert result.exit_code == 1
+        # All real files should be listed as available
+        for f in ["versions/app.json", "health/postgres.json", "config/config.json", "bundle_manifest.json"]:
+            assert f in result.output, f"Expected '{f}' in available files listing"
+
+
+# ── Missing bundle file ─────────────────────────────────────────────
+
+
+class TestInspectMissingBundle:
+    """Verify inspect exits 1 when the bundle file doesn't exist."""
+
+    def test_missing_file_exits_1(self, tmp_path):
+        """Inspecting a non-existent file should exit 1 with an error message."""
+        fake_path = tmp_path / "does-not-exist.tar.gz"
+
+        result = runner.invoke(app, ["support", "inspect", str(fake_path)])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower() or "Bundle not found" in result.output
+
+
+# ── Invalid tar.gz ───────────────────────────────────────────────────
+
+
+class TestInspectInvalidArchive:
+    """Verify inspect exits 1 when the file is not a valid tar.gz."""
+
+    def test_invalid_tar_exits_1(self, tmp_path):
+        """A file that isn't a valid tar.gz should cause exit 1."""
+        bad_file = tmp_path / "not-a-tarball.tar.gz"
+        bad_file.write_bytes(b"this is not a tar.gz file at all")
+
+        result = runner.invoke(app, ["support", "inspect", str(bad_file)])
+
+        assert result.exit_code == 1
+        assert "cannot open" in result.output.lower() or "Cannot open" in result.output
+
+    def test_empty_file_exits_1(self, tmp_path):
+        """An empty file should cause exit 1."""
+        empty_file = tmp_path / "empty.tar.gz"
+        empty_file.write_bytes(b"")
+
+        result = runner.invoke(app, ["support", "inspect", str(empty_file)])
+
+        assert result.exit_code == 1
+
+
+# ── Missing manifest ────────────────────────────────────────────────
+
+
+class TestInspectMissingManifest:
+    """Verify inspect exits 1 when bundle_manifest.json is missing or malformed."""
+
+    def test_missing_manifest_exits_1(self, tmp_path):
+        """A valid tar.gz without bundle_manifest.json should exit 1."""
+        bundle_path = _create_bundle(
+            tmp_path / "no-manifest.tar.gz",
+            files={"versions/app.json": b'{"v": 1}'},
+            include_manifest=False,
+        )
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 1
+        assert "missing" in result.output.lower() or "malformed" in result.output.lower()
+
+    def test_malformed_manifest_exits_1(self, tmp_path):
+        """A bundle with invalid JSON in bundle_manifest.json should exit 1."""
+        bundle_path = tmp_path / "bad-manifest.tar.gz"
+        with tarfile.open(bundle_path, "w:gz") as tar:
+            _add_bytes_to_tar(tar, "bundle_manifest.json", b"not valid json {{{")
+            _add_bytes_to_tar(tar, "versions/app.json", b'{"v": 1}')
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 1
+        assert "missing" in result.output.lower() or "malformed" in result.output.lower()
+
+
+# ── Schema version warnings ─────────────────────────────────────────
+
+
+class TestInspectSchemaVersionWarnings:
+    """Verify schema version warning behavior per requirements 10.4 and 10.5."""
+
+    def test_current_version_no_warning(self, tmp_path):
+        """Schema version equal to current should produce no warning."""
+        manifest = _make_manifest(schema_version="1")
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz", manifest=manifest)
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        assert "warning" not in result.output.lower()
+        assert "newer CLI" not in result.output
+
+    def test_lower_version_no_warning(self, tmp_path):
+        """Schema version lower than current should produce no warning."""
+        # CURRENT_SCHEMA_VERSION is 1, so version "0" is lower
+        # Note: in practice version starts at 1, but the logic should handle it
+        manifest = _make_manifest(schema_version="0")
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz", manifest=manifest)
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        assert "newer CLI" not in result.output
+
+    def test_higher_version_shows_warning(self, tmp_path):
+        """Schema version higher than current should show a warning but still display."""
+        manifest = _make_manifest(schema_version="99")
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz", manifest=manifest)
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        assert "newer CLI" in result.output or "newer" in result.output.lower()
+        # Should still display the manifest despite the warning
+        assert "bundle_schema_version" in result.output
+        assert "99" in result.output
+
+    def test_higher_version_still_shows_tree(self, tmp_path):
+        """Even with a higher schema version, the file tree should still be displayed."""
+        manifest = _make_manifest(schema_version="5")
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz", manifest=manifest)
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        # Tree should still render
+        assert "Bundle contents" in result.output
+        assert "versions/app.json" in result.output
+
+    def test_non_integer_version_shows_warning(self, tmp_path):
+        """A non-integer schema version should show an 'unrecognized' warning."""
+        manifest = _make_manifest(schema_version="beta")
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz", manifest=manifest)
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        assert "unrecognized" in result.output.lower() or "Unrecognized" in result.output
+        # Should still display the manifest
+        assert "bundle_schema_version" in result.output
+
+    def test_non_integer_version_still_shows_manifest(self, tmp_path):
+        """Even with a non-integer version, the manifest and tree should display."""
+        manifest = _make_manifest(schema_version="v2.0")
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz", manifest=manifest)
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        assert "v2.0" in result.output
+        assert "Bundle contents" in result.output
+
+
+# ── Read-only / no extraction ────────────────────────────────────────
+
+
+class TestInspectNoExtraction:
+    """Verify inspect never extracts files to disk (Requirement 5.4)."""
+
+    def test_inspect_does_not_create_files(self, tmp_path):
+        """After inspect, no new files should appear in the working directory."""
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz")
+        work_dir = tmp_path / "workdir"
+        work_dir.mkdir()
+
+        # List files before
+        before = set(work_dir.iterdir())
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path)])
+
+        assert result.exit_code == 0
+        # No new files should have been created
+        after = set(work_dir.iterdir())
+        assert before == after, "inspect should not extract files to disk"
+
+    def test_show_does_not_create_files(self, tmp_path):
+        """--show should print to stdout without extracting to disk."""
+        bundle_path = _create_bundle(tmp_path / "bundle.tar.gz")
+        work_dir = tmp_path / "workdir"
+        work_dir.mkdir()
+
+        before = set(work_dir.iterdir())
+
+        result = runner.invoke(app, ["support", "inspect", str(bundle_path), "--show", "versions/app.json"])
+
+        assert result.exit_code == 0
+        after = set(work_dir.iterdir())
+        assert before == after, "--show should not extract files to disk"

--- a/tests/test_support_integration.py
+++ b/tests/test_support_integration.py
@@ -1,0 +1,566 @@
+"""End-to-end integration test for the support bundle feature.
+
+Mocks the API server's /api/v1/support/collect endpoint, runs
+`observal support bundle` via Typer's CliRunner, and verifies:
+- The archive is a valid .tar.gz
+- Directory structure matches spec: bundle_manifest.json, versions/,
+  config/, health/, aggregates/, errors/, logs/, system/
+- File permissions are 0o600
+- Manifest contains all required fields
+- File inventory SHA-256 hashes are correct
+
+Validates: Requirements 1.1, 1.2, 2.1, 2.2, 4.1, 4.5, 7.1, 7.3
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tarfile
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from observal_cli.main import app
+
+runner = CliRunner()
+
+
+# ── Realistic mock server response ───────────────────────────────────
+
+
+def _full_server_response() -> dict:
+    """Build a realistic /api/v1/support/collect response with all collectors."""
+    return {
+        "server_version": "0.9.5",
+        "collectors": {
+            "versions": {
+                "ok": True,
+                "duration_ms": 45,
+                "data": {
+                    "app_version": "0.9.5",
+                    "build_hash": "abc123def456",
+                    "alembic_revision": "a1b2c3d4e5f6",
+                    "clickhouse_version": "24.3.1.2672",
+                    "clickhouse_tables": ["traces", "spans", "scores"],
+                },
+            },
+            "health": {
+                "ok": True,
+                "duration_ms": 28,
+                "data": {
+                    "postgres": {"status": "ok", "latency_ms": 3},
+                    "clickhouse": {"status": "ok", "latency_ms": 7},
+                    "redis": {"status": "ok", "latency_ms": 1},
+                    "otel_collector": {"status": "ok", "latency_ms": 12},
+                },
+            },
+            "config": {
+                "ok": True,
+                "duration_ms": 5,
+                "data": {
+                    "DATABASE_URL": "postgresql+asyncpg://admin:s3cret@localhost:5432/observal",
+                    "CLICKHOUSE_URL": "clickhouse://default:pass@localhost:8123/observal",
+                    "REDIS_URL": "redis://localhost:6379",
+                    "REDIS_SOCKET_TIMEOUT": 5,
+                    "EVAL_MODEL_NAME": "gpt-4",
+                    "EVAL_MODEL_PROVIDER": "openai",
+                    "AWS_REGION": "us-east-1",
+                    "FRONTEND_URL": "http://localhost:3000",
+                    "JWT_ACCESS_TOKEN_EXPIRE_MINUTES": 30,
+                    "JWT_REFRESH_TOKEN_EXPIRE_DAYS": 7,
+                    "JWT_SIGNING_ALGORITHM": "RS256",
+                    "JWT_HOOKS_TOKEN_EXPIRE_MINUTES": 60,
+                    "RATE_LIMIT_AUTH": "10/minute",
+                    "RATE_LIMIT_AUTH_STRICT": "3/minute",
+                    "DATA_RETENTION_DAYS": 90,
+                    "DEPLOYMENT_MODE": "docker",
+                    # These should be filtered out by the allowlist
+                    "SECRET_KEY": "super-secret-key-value",
+                    "OAUTH_CLIENT_SECRET": "oauth-secret-123",
+                },
+            },
+            "aggregates": {
+                "ok": True,
+                "duration_ms": 120,
+                "data": {
+                    "pg_table_counts": {
+                        "users": 42,
+                        "agents": 15,
+                        "mcp_listings": 8,
+                        "feedback": 200,
+                    },
+                    "ch_table_counts": {
+                        "traces": 1000000,
+                        "spans": 5000000,
+                        "scores": 50000,
+                    },
+                },
+            },
+            "errors": {
+                "ok": True,
+                "duration_ms": 80,
+                "data": {
+                    "fingerprints": [
+                        {
+                            "fingerprint": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                            "count": 12,
+                            "first_seen": "2025-07-14T10:00:00Z",
+                            "last_seen": "2025-07-15T08:30:00Z",
+                            "stack_template": "api/routes/telemetry.py:ingest -> services/clickhouse.py:insert_batch",
+                        }
+                    ]
+                },
+            },
+            "logs": {
+                "ok": True,
+                "duration_ms": 15,
+                "data": {
+                    "lines": [
+                        {
+                            "timestamp": "2025-07-15T09:00:00Z",
+                            "level": "info",
+                            "event": "Request processed",
+                            "path": "/api/v1/traces",
+                            "status": 200,
+                        },
+                        {
+                            "timestamp": "2025-07-15T09:01:00Z",
+                            "level": "warning",
+                            "event": "Slow query detected",
+                            "duration_ms": 1500,
+                        },
+                    ]
+                },
+            },
+        },
+    }
+
+
+def _mock_httpx_response(data: dict, status_code: int = 200) -> MagicMock:
+    """Create a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# ── Required directories in the archive ──────────────────────────────
+
+REQUIRED_PREFIXES = [
+    "versions/",
+    "config/",
+    "health/",
+    "aggregates/",
+    "errors/",
+    "logs/",
+    "system/",
+]
+
+
+# ── Required manifest fields ─────────────────────────────────────────
+
+REQUIRED_MANIFEST_FIELDS = [
+    "bundle_schema_version",
+    "created_at",
+    "cli_version",
+    "host_os",
+    "flags_used",
+    "collector_results",
+    "redaction_counts",
+    "file_inventory",
+]
+
+
+# ── Integration test ─────────────────────────────────────────────────
+
+
+class TestSupportBundleIntegration:
+    """Full end-to-end integration test for `observal support bundle`."""
+
+    @pytest.fixture()
+    def bundle_path(self, tmp_path):
+        """Generate a bundle archive and return its path."""
+        output = tmp_path / "integration-test-bundle.tar.gz"
+        server_resp = _full_server_response()
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch(
+                "observal_cli.cmd_support.httpx.post",
+                return_value=_mock_httpx_response(server_resp),
+            ),
+        ):
+            result = runner.invoke(app, ["support", "bundle", "--output", str(output)])
+
+        assert result.exit_code == 0, f"Bundle command failed: {result.output}"
+        assert output.exists(), "Archive file was not created"
+        return output
+
+    # ── 1. Archive is valid tar.gz ───────────────────────
+
+    def test_archive_is_valid_tar_gz(self, bundle_path):
+        """The produced file must be a valid gzip-compressed tar archive."""
+        assert tarfile.is_tarfile(bundle_path)
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            members = tar.getmembers()
+            assert len(members) > 0, "Archive should not be empty"
+
+    # ── 2. Directory structure matches spec ──────────────
+
+    def test_bundle_manifest_present(self, bundle_path):
+        """bundle_manifest.json must be at the root of the archive."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+            assert "bundle_manifest.json" in names
+
+    def test_all_required_directories_present(self, bundle_path):
+        """Archive must contain files under each required directory prefix."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+
+        for prefix in REQUIRED_PREFIXES:
+            matching = [n for n in names if n.startswith(prefix)]
+            assert len(matching) > 0, (
+                f"Expected files under '{prefix}' but found none. Archive contents: {sorted(names)}"
+            )
+
+    def test_versions_directory_files(self, bundle_path):
+        """versions/ should contain app.json, alembic.json, clickhouse.json."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "versions/app.json" in names
+        assert "versions/alembic.json" in names
+        assert "versions/clickhouse.json" in names
+
+    def test_health_directory_files(self, bundle_path):
+        """health/ should contain per-service JSON files."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+
+        health_files = [n for n in names if n.startswith("health/")]
+        assert "health/postgres.json" in names
+        assert "health/clickhouse.json" in names
+        assert "health/redis.json" in names
+        assert "health/otel_collector.json" in names
+
+    def test_aggregates_directory_files(self, bundle_path):
+        """aggregates/ should contain pg_table_counts.json and ch_table_counts.json."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "aggregates/pg_table_counts.json" in names
+        assert "aggregates/ch_table_counts.json" in names
+
+    def test_errors_directory_files(self, bundle_path):
+        """errors/ should contain recent_errors.json."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "errors/recent_errors.json" in names
+
+    def test_logs_directory_files(self, bundle_path):
+        """logs/ should contain recent.ndjson."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "logs/recent.ndjson" in names
+
+    def test_system_directory_files(self, bundle_path):
+        """system/ should contain system.json (default --include-system)."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "system/system.json" in names
+
+    def test_config_directory_files(self, bundle_path):
+        """config/ should contain config.json."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "config/config.json" in names
+
+    # ── 3. File permissions are 0o600 ────────────────────
+
+    def test_archive_permissions_0o600(self, bundle_path):
+        """The archive file must have 0o600 permissions (owner read/write only)."""
+        if os.name == "nt":
+            pytest.skip("File permission check not applicable on Windows")
+
+        mode = os.stat(bundle_path).st_mode & 0o777
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    # ── 4. Manifest contains all required fields ─────────
+
+    def test_manifest_has_all_required_fields(self, bundle_path):
+        """bundle_manifest.json must contain all fields from the spec."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        for field_name in REQUIRED_MANIFEST_FIELDS:
+            assert field_name in manifest_data, (
+                f"Manifest missing required field: '{field_name}'. Present fields: {list(manifest_data.keys())}"
+            )
+
+    def test_manifest_schema_version_is_1(self, bundle_path):
+        """bundle_schema_version must be '1'."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        assert manifest_data["bundle_schema_version"] == "1"
+
+    def test_manifest_created_at_is_iso8601(self, bundle_path):
+        """created_at must be a valid ISO 8601 timestamp."""
+        from datetime import datetime
+
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        created_at = manifest_data["created_at"]
+        # Should parse without error
+        dt = datetime.fromisoformat(created_at)
+        assert dt is not None
+
+    def test_manifest_cli_version_present(self, bundle_path):
+        """cli_version must be a non-empty string."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        assert isinstance(manifest_data["cli_version"], str)
+        assert len(manifest_data["cli_version"]) > 0
+
+    def test_manifest_host_os_present(self, bundle_path):
+        """host_os must be a non-empty string."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        assert isinstance(manifest_data["host_os"], str)
+        assert len(manifest_data["host_os"]) > 0
+
+    def test_manifest_flags_used_records_options(self, bundle_path):
+        """flags_used must record the flags passed to the bundle command."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        flags = manifest_data["flags_used"]
+        assert isinstance(flags, dict)
+        assert "output" in flags
+        assert "logs_since" in flags
+        assert "include_system" in flags
+
+    def test_manifest_collector_results_present(self, bundle_path):
+        """collector_results must map collector names to ok/duration_ms."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        results = manifest_data["collector_results"]
+        assert isinstance(results, dict)
+        assert len(results) > 0
+        # Each entry should have 'ok' and 'duration_ms'
+        for name, entry in results.items():
+            assert "ok" in entry, f"Collector '{name}' missing 'ok' field"
+            assert "duration_ms" in entry, f"Collector '{name}' missing 'duration_ms' field"
+
+    def test_manifest_file_inventory_present(self, bundle_path):
+        """file_inventory must be a non-empty list of file entries."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+        inventory = manifest_data["file_inventory"]
+        assert isinstance(inventory, list)
+        assert len(inventory) > 0
+
+        # Each entry must have path, size_bytes, sha256
+        for entry in inventory:
+            assert "path" in entry, f"Inventory entry missing 'path': {entry}"
+            assert "size_bytes" in entry, f"Inventory entry missing 'size_bytes': {entry}"
+            assert "sha256" in entry, f"Inventory entry missing 'sha256': {entry}"
+
+    # ── 5. File inventory SHA-256 hashes are correct ─────
+
+    def test_file_inventory_sha256_integrity(self, bundle_path):
+        """Every SHA-256 hash in file_inventory must match the actual file content."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            manifest_data = json.loads(tar.extractfile(tar.getmember("bundle_manifest.json")).read())
+
+            inventory = manifest_data["file_inventory"]
+            assert len(inventory) > 0, "File inventory should not be empty"
+
+            for entry in inventory:
+                rel_path = entry["path"]
+                expected_sha = entry["sha256"]
+                expected_size = entry["size_bytes"]
+
+                # Read the actual file content from the archive
+                member = tar.getmember(rel_path)
+                content = tar.extractfile(member).read()
+
+                # Verify SHA-256
+                actual_sha = hashlib.sha256(content).hexdigest()
+                assert actual_sha == expected_sha, (
+                    f"SHA-256 mismatch for '{rel_path}': manifest={expected_sha}, actual={actual_sha}"
+                )
+
+                # Verify size
+                assert len(content) == expected_size, (
+                    f"Size mismatch for '{rel_path}': manifest={expected_size}, actual={len(content)}"
+                )
+
+    # ── 6. Content correctness spot checks ───────────────
+
+    def test_versions_app_json_content(self, bundle_path):
+        """versions/app.json should contain cli_version and server_version."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            data = json.loads(tar.extractfile(tar.getmember("versions/app.json")).read())
+
+        assert "cli_version" in data
+        assert "server_version" in data
+        assert data["server_version"] == "0.9.5"
+
+    def test_versions_alembic_json_content(self, bundle_path):
+        """versions/alembic.json should contain current_revision."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            data = json.loads(tar.extractfile(tar.getmember("versions/alembic.json")).read())
+
+        assert "current_revision" in data
+        assert data["current_revision"] == "a1b2c3d4e5f6"
+
+    def test_versions_clickhouse_json_content(self, bundle_path):
+        """versions/clickhouse.json should contain server_version and tables."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            data = json.loads(tar.extractfile(tar.getmember("versions/clickhouse.json")).read())
+
+        assert "server_version" in data
+        assert "tables" in data
+        assert data["server_version"] == "24.3.1.2672"
+        assert isinstance(data["tables"], list)
+
+    def test_config_excludes_secrets(self, bundle_path):
+        """config/config.json must not contain SECRET_KEY or OAUTH_CLIENT_SECRET."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            data = json.loads(tar.extractfile(tar.getmember("config/config.json")).read())
+
+        assert "SECRET_KEY" not in data
+        assert "OAUTH_CLIENT_SECRET" not in data
+
+    def test_config_redacts_url_credentials(self, bundle_path):
+        """DATABASE_URL in config should have credentials redacted."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            data = json.loads(tar.extractfile(tar.getmember("config/config.json")).read())
+
+        if "DATABASE_URL" in data:
+            assert "s3cret" not in data["DATABASE_URL"]
+            assert "<REDACTED>" in data["DATABASE_URL"]
+
+    def test_aggregates_contain_counts(self, bundle_path):
+        """Aggregate files should contain table count data."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            pg_data = json.loads(tar.extractfile(tar.getmember("aggregates/pg_table_counts.json")).read())
+            ch_data = json.loads(tar.extractfile(tar.getmember("aggregates/ch_table_counts.json")).read())
+
+        assert isinstance(pg_data, dict)
+        assert isinstance(ch_data, dict)
+        assert pg_data.get("users") == 42
+        assert ch_data.get("traces") == 1000000
+
+    def test_errors_contain_fingerprints(self, bundle_path):
+        """errors/recent_errors.json should contain fingerprint data."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            data = json.loads(tar.extractfile(tar.getmember("errors/recent_errors.json")).read())
+
+        assert "fingerprints" in data
+        assert len(data["fingerprints"]) == 1
+        fp = data["fingerprints"][0]
+        assert "fingerprint" in fp
+        assert "count" in fp
+        assert "stack_template" in fp
+
+    def test_system_json_has_required_keys(self, bundle_path):
+        """system/system.json should contain OS, CPU, memory, disk info."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            data = json.loads(tar.extractfile(tar.getmember("system/system.json")).read())
+
+        expected_keys = {
+            "os_name",
+            "os_version",
+            "kernel_version",
+            "cpu_count",
+            "memory_total_bytes",
+            "memory_available_bytes",
+            "disk_total_bytes",
+            "disk_free_bytes",
+            "container_runtime",
+        }
+        assert expected_keys == set(data.keys())
+
+    # ── 7. Manifest is valid JSON (round-trip) ───────────
+
+    def test_manifest_is_valid_json(self, bundle_path):
+        """The manifest must be valid JSON that can be parsed and re-serialized."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            raw = tar.extractfile(tar.getmember("bundle_manifest.json")).read()
+
+        # Parse
+        data = json.loads(raw)
+        # Re-serialize
+        reserialized = json.dumps(data, indent=2)
+        # Re-parse
+        data2 = json.loads(reserialized)
+        assert data == data2
+
+    # ── 8. All archive files are valid JSON or text ──────
+
+    def test_all_json_files_are_valid(self, bundle_path):
+        """Every .json file in the archive must be valid JSON."""
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            for member in tar.getmembers():
+                if member.isfile() and member.name.endswith(".json"):
+                    content = tar.extractfile(member).read()
+                    try:
+                        json.loads(content)
+                    except json.JSONDecodeError:
+                        pytest.fail(f"File '{member.name}' is not valid JSON: {content[:200]!r}")
+
+
+# ── No --include-system variant ──────────────────────────────────────
+
+
+class TestBundleWithoutSystem:
+    """Verify --no-include-system excludes the system/ directory."""
+
+    def test_no_system_directory(self, tmp_path):
+        output = tmp_path / "no-system-bundle.tar.gz"
+        server_resp = _full_server_response()
+        mock_cfg = {"server_url": "http://localhost:8000", "access_token": "test-token"}
+
+        with (
+            patch("observal_cli.cmd_support.config.get_or_exit", return_value=mock_cfg),
+            patch("observal_cli.cmd_support.config.get_timeout", return_value=30),
+            patch(
+                "observal_cli.cmd_support.httpx.post",
+                return_value=_mock_httpx_response(server_resp),
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["support", "bundle", "--output", str(output), "--no-include-system"],
+            )
+
+        assert result.exit_code == 0
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+
+        system_files = [n for n in names if n.startswith("system/")]
+        assert len(system_files) == 0, "system/ should be absent with --no-include-system"
+
+        # All other required directories should still be present
+        for prefix in ["versions/", "config/", "health/", "aggregates/", "errors/", "logs/"]:
+            matching = [n for n in names if n.startswith(prefix)]
+            assert len(matching) > 0, f"Expected files under '{prefix}'"

--- a/tests/test_support_manifest.py
+++ b/tests/test_support_manifest.py
@@ -1,0 +1,339 @@
+"""Unit tests for the support bundle manifest module."""
+
+import hashlib
+import json
+
+from observal_cli.support.manifest import (
+    BundleManifest,
+    FileEntry,
+    compute_file_entry,
+)
+
+# --- FileEntry ---
+
+
+class TestFileEntry:
+    def test_creation(self):
+        entry = FileEntry(path="versions/app.json", size_bytes=128, sha256="abc123")
+        assert entry.path == "versions/app.json"
+        assert entry.size_bytes == 128
+        assert entry.sha256 == "abc123"
+
+    def test_fields_are_accessible(self):
+        entry = FileEntry(path="config/config.json", size_bytes=0, sha256="e3b0c44298fc1c149afbf4c8996fb924")
+        assert entry.path == "config/config.json"
+        assert entry.size_bytes == 0
+        assert entry.sha256 == "e3b0c44298fc1c149afbf4c8996fb924"
+
+
+# --- BundleManifest creation ---
+
+
+class TestBundleManifestCreation:
+    def test_defaults(self):
+        m = BundleManifest()
+        assert m.bundle_schema_version == "1"
+        assert m.created_at == ""
+        assert m.cli_version == ""
+        assert m.host_os == ""
+        assert m.node_id == ""
+        assert m.flags_used == {}
+        assert m.collector_results == {}
+        assert m.redaction_counts == {}
+        assert m.file_inventory == []
+
+    def test_all_fields(self):
+        entry = FileEntry(path="versions/app.json", size_bytes=42, sha256="deadbeef")
+        m = BundleManifest(
+            bundle_schema_version="1",
+            created_at="2025-07-15T14:30:22Z",
+            cli_version="0.9.0",
+            host_os="Linux",
+            node_id="prod-node-01",
+            flags_used={"include_system": True, "logs_since": "1h"},
+            collector_results={"versions_app": {"ok": True, "duration_ms": 50}},
+            redaction_counts={"config/config.json": 3},
+            file_inventory=[entry],
+        )
+        assert m.bundle_schema_version == "1"
+        assert m.created_at == "2025-07-15T14:30:22Z"
+        assert m.cli_version == "0.9.0"
+        assert m.host_os == "Linux"
+        assert m.node_id == "prod-node-01"
+        assert m.flags_used == {"include_system": True, "logs_since": "1h"}
+        assert m.collector_results == {"versions_app": {"ok": True, "duration_ms": 50}}
+        assert m.redaction_counts == {"config/config.json": 3}
+        assert len(m.file_inventory) == 1
+        assert m.file_inventory[0].path == "versions/app.json"
+
+    def test_node_id_defaults_to_empty_string(self):
+        m = BundleManifest()
+        assert m.node_id == ""
+
+    def test_node_id_can_be_set(self):
+        m = BundleManifest(node_id="my-hostname")
+        assert m.node_id == "my-hostname"
+
+
+# --- to_dict ---
+
+
+class TestToDict:
+    def test_empty_manifest(self):
+        m = BundleManifest()
+        d = m.to_dict()
+        assert d["bundle_schema_version"] == "1"
+        assert d["created_at"] == ""
+        assert d["cli_version"] == ""
+        assert d["host_os"] == ""
+        assert d["node_id"] == ""
+        assert d["flags_used"] == {}
+        assert d["collector_results"] == {}
+        assert d["redaction_counts"] == {}
+        assert d["file_inventory"] == []
+
+    def test_with_file_inventory(self):
+        m = BundleManifest(
+            file_inventory=[
+                FileEntry(path="a.json", size_bytes=10, sha256="aaa"),
+                FileEntry(path="b.json", size_bytes=20, sha256="bbb"),
+            ]
+        )
+        d = m.to_dict()
+        assert len(d["file_inventory"]) == 2
+        assert d["file_inventory"][0] == {"path": "a.json", "size_bytes": 10, "sha256": "aaa"}
+        assert d["file_inventory"][1] == {"path": "b.json", "size_bytes": 20, "sha256": "bbb"}
+
+    def test_node_id_in_dict(self):
+        m = BundleManifest(node_id="worker-3")
+        d = m.to_dict()
+        assert d["node_id"] == "worker-3"
+
+    def test_all_fields_present(self):
+        m = BundleManifest(
+            bundle_schema_version="1",
+            created_at="2025-07-15T14:30:22Z",
+            cli_version="0.9.0",
+            host_os="Linux",
+            node_id="prod-node-01",
+            flags_used={"include_system": True},
+            collector_results={"health_pg": {"ok": True, "duration_ms": 12}},
+            redaction_counts={"config/config.json": 5},
+            file_inventory=[FileEntry(path="f.json", size_bytes=99, sha256="fff")],
+        )
+        d = m.to_dict()
+        expected_keys = {
+            "bundle_schema_version",
+            "created_at",
+            "cli_version",
+            "host_os",
+            "node_id",
+            "flags_used",
+            "collector_results",
+            "redaction_counts",
+            "file_inventory",
+        }
+        assert set(d.keys()) == expected_keys
+
+
+# --- from_dict ---
+
+
+class TestFromDict:
+    def test_empty_dict(self):
+        m = BundleManifest.from_dict({})
+        assert m.bundle_schema_version == "1"
+        assert m.created_at == ""
+        assert m.cli_version == ""
+        assert m.host_os == ""
+        assert m.node_id == ""
+        assert m.flags_used == {}
+        assert m.collector_results == {}
+        assert m.redaction_counts == {}
+        assert m.file_inventory == []
+
+    def test_full_dict(self):
+        data = {
+            "bundle_schema_version": "1",
+            "created_at": "2025-07-15T14:30:22Z",
+            "cli_version": "0.9.0",
+            "host_os": "Linux",
+            "node_id": "prod-node-01",
+            "flags_used": {"include_system": True, "logs_since": "2h"},
+            "collector_results": {"versions_app": {"ok": True, "duration_ms": 50}},
+            "redaction_counts": {"config/config.json": 3},
+            "file_inventory": [
+                {"path": "versions/app.json", "size_bytes": 42, "sha256": "deadbeef"},
+            ],
+        }
+        m = BundleManifest.from_dict(data)
+        assert m.bundle_schema_version == "1"
+        assert m.created_at == "2025-07-15T14:30:22Z"
+        assert m.cli_version == "0.9.0"
+        assert m.host_os == "Linux"
+        assert m.node_id == "prod-node-01"
+        assert m.flags_used == {"include_system": True, "logs_since": "2h"}
+        assert m.collector_results == {"versions_app": {"ok": True, "duration_ms": 50}}
+        assert m.redaction_counts == {"config/config.json": 3}
+        assert len(m.file_inventory) == 1
+        assert m.file_inventory[0].path == "versions/app.json"
+        assert m.file_inventory[0].size_bytes == 42
+        assert m.file_inventory[0].sha256 == "deadbeef"
+
+    def test_missing_optional_fields_use_defaults(self):
+        data = {"bundle_schema_version": "2"}
+        m = BundleManifest.from_dict(data)
+        assert m.bundle_schema_version == "2"
+        assert m.node_id == ""
+        assert m.file_inventory == []
+
+    def test_node_id_round_trips(self):
+        data = {"node_id": "my-host-name"}
+        m = BundleManifest.from_dict(data)
+        assert m.node_id == "my-host-name"
+
+    def test_multiple_file_inventory_entries(self):
+        data = {
+            "file_inventory": [
+                {"path": "a.json", "size_bytes": 10, "sha256": "aaa"},
+                {"path": "b.json", "size_bytes": 20, "sha256": "bbb"},
+                {"path": "c.json", "size_bytes": 30, "sha256": "ccc"},
+            ]
+        }
+        m = BundleManifest.from_dict(data)
+        assert len(m.file_inventory) == 3
+        assert m.file_inventory[2].path == "c.json"
+
+
+# --- to_json ---
+
+
+class TestToJson:
+    def test_output_is_valid_json(self):
+        m = BundleManifest(
+            created_at="2025-07-15T14:30:22Z",
+            cli_version="0.9.0",
+            host_os="Linux",
+            node_id="test-node",
+        )
+        json_str = m.to_json()
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+
+    def test_json_contains_all_keys(self):
+        m = BundleManifest()
+        parsed = json.loads(m.to_json())
+        expected_keys = {
+            "bundle_schema_version",
+            "created_at",
+            "cli_version",
+            "host_os",
+            "node_id",
+            "flags_used",
+            "collector_results",
+            "redaction_counts",
+            "file_inventory",
+        }
+        assert set(parsed.keys()) == expected_keys
+
+    def test_json_is_indented(self):
+        m = BundleManifest()
+        json_str = m.to_json()
+        # json.dumps with indent=2 produces newlines
+        assert "\n" in json_str
+
+    def test_json_with_file_inventory(self):
+        m = BundleManifest(file_inventory=[FileEntry(path="test.json", size_bytes=100, sha256="abc")])
+        parsed = json.loads(m.to_json())
+        assert len(parsed["file_inventory"]) == 1
+        assert parsed["file_inventory"][0]["path"] == "test.json"
+
+
+# --- JSON round-trip ---
+
+
+class TestJsonRoundTrip:
+    def test_empty_manifest_round_trip(self):
+        original = BundleManifest()
+        restored = BundleManifest.from_dict(json.loads(original.to_json()))
+        assert restored.to_dict() == original.to_dict()
+
+    def test_full_manifest_round_trip(self):
+        original = BundleManifest(
+            bundle_schema_version="1",
+            created_at="2025-07-15T14:30:22Z",
+            cli_version="0.9.0",
+            host_os="Linux",
+            node_id="prod-node-01",
+            flags_used={"include_system": True, "logs_since": "1h"},
+            collector_results={
+                "versions_app": {"ok": True, "duration_ms": 50},
+                "health_pg": {"ok": False, "duration_ms": 10000, "error": "timeout"},
+            },
+            redaction_counts={"config/config.json": 3, "logs/recent.ndjson": 7},
+            file_inventory=[
+                FileEntry(path="versions/app.json", size_bytes=42, sha256="deadbeef"),
+                FileEntry(path="config/config.json", size_bytes=256, sha256="cafebabe"),
+            ],
+        )
+        json_str = original.to_json()
+        restored = BundleManifest.from_dict(json.loads(json_str))
+        assert restored.to_dict() == original.to_dict()
+
+    def test_round_trip_preserves_node_id(self):
+        original = BundleManifest(node_id="special-host-name")
+        restored = BundleManifest.from_dict(json.loads(original.to_json()))
+        assert restored.node_id == "special-host-name"
+
+    def test_round_trip_preserves_file_inventory_order(self):
+        entries = [FileEntry(path=f"file_{i}.json", size_bytes=i * 10, sha256=f"hash_{i}") for i in range(5)]
+        original = BundleManifest(file_inventory=entries)
+        restored = BundleManifest.from_dict(json.loads(original.to_json()))
+        for i, entry in enumerate(restored.file_inventory):
+            assert entry.path == f"file_{i}.json"
+            assert entry.size_bytes == i * 10
+            assert entry.sha256 == f"hash_{i}"
+
+
+# --- compute_file_entry ---
+
+
+class TestComputeFileEntry:
+    def test_correct_sha256(self):
+        content = b"hello world"
+        expected_hash = hashlib.sha256(content).hexdigest()
+        entry = compute_file_entry("test.txt", content)
+        assert entry.sha256 == expected_hash
+
+    def test_correct_size(self):
+        content = b"some content here"
+        entry = compute_file_entry("test.txt", content)
+        assert entry.size_bytes == len(content)
+
+    def test_correct_path(self):
+        entry = compute_file_entry("versions/app.json", b"{}")
+        assert entry.path == "versions/app.json"
+
+    def test_empty_content(self):
+        content = b""
+        expected_hash = hashlib.sha256(content).hexdigest()
+        entry = compute_file_entry("empty.txt", content)
+        assert entry.size_bytes == 0
+        assert entry.sha256 == expected_hash
+
+    def test_binary_content(self):
+        content = bytes(range(256))
+        expected_hash = hashlib.sha256(content).hexdigest()
+        entry = compute_file_entry("binary.bin", content)
+        assert entry.size_bytes == 256
+        assert entry.sha256 == expected_hash
+
+    def test_returns_file_entry_instance(self):
+        entry = compute_file_entry("test.txt", b"data")
+        assert isinstance(entry, FileEntry)
+
+    def test_known_hash_value(self):
+        # SHA-256 of empty bytes is a well-known constant
+        content = b""
+        entry = compute_file_entry("empty", content)
+        assert entry.sha256 == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/tests/test_support_pbt.py
+++ b/tests/test_support_pbt.py
@@ -1,0 +1,554 @@
+"""Property-based tests for the support bundle redaction, manifest, and config modules.
+
+Uses Hypothesis to verify universal correctness properties across randomized inputs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import string
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from observal_cli.cmd_support import CONFIG_ALLOWLIST
+from observal_cli.support.manifest import BundleManifest, FileEntry, compute_file_entry
+from observal_cli.support.redaction import (
+    AWS_KEY_PATTERN,
+    JWT_PATTERN,
+    REDACTED,
+    URL_USERINFO_PATTERN,
+    redact_string,
+    redact_value,
+    shannon_entropy,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _has_jwt(s: str) -> bool:
+    return bool(JWT_PATTERN.search(s))
+
+
+def _has_aws_key(s: str) -> bool:
+    return bool(AWS_KEY_PATTERN.search(s))
+
+
+def _has_url_userinfo(s: str) -> bool:
+    return bool(URL_USERINFO_PATTERN.search(s))
+
+
+def _has_high_entropy_token(s: str) -> bool:
+    """Check if any token in the string would trigger the entropy rule."""
+    tokens = re.split(r'([\s"\'`,;=\[\]{}()])', s)
+    return any(len(token) >= 32 and shannon_entropy(token) > 4.5 for token in tokens)
+
+
+def _is_safe_string(s: str) -> bool:
+    """Return True if the string contains no patterns that would trigger redaction."""
+    return not _has_jwt(s) and not _has_aws_key(s) and not _has_url_userinfo(s) and not _has_high_entropy_token(s)
+
+
+# ── Strategies ───────────────────────────────────────────────────────
+
+# Safe text: ASCII printable strings that won't accidentally match secret patterns.
+# We use a limited alphabet and short lengths to avoid entropy triggers.
+_safe_alphabet = string.ascii_lowercase + string.digits + " .,!?-_:/"
+safe_text_strategy = st.text(
+    alphabet=_safe_alphabet,
+    min_size=0,
+    max_size=80,
+).filter(_is_safe_string)
+
+
+# JWT strategy: generate realistic JWT-shaped tokens
+def _jwt_strategy():
+    """Generate a JWT-like token: eyJ<base64url>.<base64url>.<base64url>."""
+    b64_chars = string.ascii_letters + string.digits + "_-"
+    segment = st.text(alphabet=b64_chars, min_size=4, max_size=30)
+    return st.tuples(segment, segment, segment).map(lambda parts: f"eyJ{parts[0]}.eyJ{parts[1]}.{parts[2]}")
+
+
+# AWS key strategy
+def _aws_key_strategy():
+    suffix_chars = string.digits + string.ascii_uppercase
+    return st.text(alphabet=suffix_chars, min_size=16, max_size=16).map(lambda s: f"AKIA{s}")
+
+
+# URL userinfo strategy with supported schemes
+_SUPPORTED_SCHEMES = ["https", "http", "postgresql+asyncpg", "postgres", "redis", "clickhouse"]
+
+
+def _url_userinfo_strategy():
+    scheme = st.sampled_from(_SUPPORTED_SCHEMES)
+    # Use simple alphanumeric user/pass to avoid regex issues
+    user = st.text(alphabet=string.ascii_lowercase + string.digits, min_size=1, max_size=10)
+    password = st.text(alphabet=string.ascii_lowercase + string.digits, min_size=1, max_size=10)
+    host = st.text(alphabet=string.ascii_lowercase + string.digits, min_size=1, max_size=10)
+    path = st.text(alphabet=string.ascii_lowercase + string.digits + "/", min_size=0, max_size=15)
+    return st.tuples(scheme, user, password, host, path).map(lambda t: f"{t[0]}://{t[1]}:{t[2]}@{t[3]}/{t[4]}")
+
+
+# High-entropy string strategy: 32+ chars with high character diversity
+def _high_entropy_strategy():
+    """Generate strings with length >= 32 and Shannon entropy > 4.5."""
+    # Use a wide alphabet to ensure high entropy
+    wide_alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    return st.text(
+        alphabet=wide_alphabet,
+        min_size=40,
+        max_size=60,
+    ).filter(lambda s: shannon_entropy(s) > 4.5)
+
+
+# Low-entropy string strategy: repetitive characters
+def _low_entropy_strategy(min_size=0, max_size=80):
+    """Generate strings with low entropy (repetitive characters)."""
+    return st.text(
+        alphabet="abc",
+        min_size=min_size,
+        max_size=max_size,
+    )
+
+
+# Sensitive key names
+_SENSITIVE_KEY_NAMES = [
+    "password",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "api-key",
+    "access_key",
+    "private_key",
+    "credential",
+    "authorization",
+    "client_secret",
+    "bearer",
+    "MY_PASSWORD",
+    "db_secret_key",
+    "AUTH_TOKEN",
+]
+
+# Non-sensitive key names
+_NON_SENSITIVE_KEY_NAMES = [
+    "hostname",
+    "port",
+    "database",
+    "log_level",
+    "region",
+    "name",
+    "version",
+    "status",
+    "count",
+    "enabled",
+]
+
+
+# ── Property 1: Redaction identity — safe strings pass through unchanged ──
+
+
+class TestRedactionIdentity:
+    """**Validates: Requirements 3.9**"""
+
+    @given(s=safe_text_strategy)
+    @settings(max_examples=200)
+    def test_safe_strings_pass_through_unchanged(self, s: str):
+        """For any string with no secret patterns, redact_string returns it unchanged."""
+        result, count = redact_string(s)
+        assert result == s, f"Safe string was modified: {s!r} -> {result!r}"
+        assert count == 0, f"Safe string had {count} redactions"
+
+
+# ── Property 2: Redaction completeness — output contains no secret patterns ──
+
+
+@st.composite
+def mixed_text_with_secrets(draw):
+    """Generate text that mixes safe content with injected secrets."""
+    parts = []
+    # Add 1-3 safe segments and 1-2 secret segments
+    num_safe = draw(st.integers(min_value=1, max_value=3))
+    for _ in range(num_safe):
+        parts.append(draw(st.text(alphabet=string.ascii_lowercase + " ", min_size=1, max_size=15)))
+
+    secret_type = draw(st.sampled_from(["jwt", "aws", "url", "entropy"]))
+    if secret_type == "jwt":
+        parts.append(draw(_jwt_strategy()))
+    elif secret_type == "aws":
+        parts.append(draw(_aws_key_strategy()))
+    elif secret_type == "url":
+        parts.append(draw(_url_userinfo_strategy()))
+    elif secret_type == "entropy":
+        parts.append(draw(_high_entropy_strategy()))
+
+    draw(st.randoms()).shuffle(parts)
+    return " ".join(parts)
+
+
+class TestRedactionCompleteness:
+    """**Validates: Requirements 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.10**"""
+
+    @given(s=mixed_text_with_secrets())
+    @settings(max_examples=200)
+    def test_output_contains_no_secret_patterns(self, s: str):
+        """After redaction, output contains no JWT, AWS key, URL userinfo, or high-entropy tokens."""
+        result, count = redact_string(s)
+
+        # No JWT tokens in output
+        assert not JWT_PATTERN.search(result.replace(REDACTED, "")), f"JWT pattern found in redacted output: {result!r}"
+
+        # No AWS keys in output
+        assert not AWS_KEY_PATTERN.search(result.replace(REDACTED, "")), (
+            f"AWS key pattern found in redacted output: {result!r}"
+        )
+
+        # No URL userinfo in output (check the non-redacted parts)
+        cleaned = result.replace(REDACTED, "SAFE")
+        # URL userinfo should have credentials replaced
+        for m in URL_USERINFO_PATTERN.finditer(result):
+            userinfo = m.group(2)
+            assert userinfo == REDACTED or userinfo == "<REDACTED>", (
+                f"URL userinfo not redacted: {userinfo!r} in {result!r}"
+            )
+
+        # No high-entropy tokens in output
+        tokens = re.split(r'([\s"\'`,;=\[\]{}()])', result)
+        for token in tokens:
+            if token == REDACTED or REDACTED in token:
+                continue
+            if len(token) >= 32 and shannon_entropy(token) > 4.5:
+                raise AssertionError(f"High-entropy token found in output: {token!r}")
+
+        # At least one redaction should have occurred
+        assert count >= 1, "Expected at least 1 redaction for input with secrets"
+
+
+# ── Property 3: Redaction idempotence ──
+
+
+class TestRedactionIdempotence:
+    """**Validates: Requirements 3.11**"""
+
+    @given(s=st.text(min_size=0, max_size=200))
+    @settings(max_examples=200)
+    def test_double_redaction_equals_single(self, s: str):
+        """redact_string(redact_string(x)[0]) == redact_string(x) for all inputs."""
+        first_result, first_count = redact_string(s)
+        second_result, second_count = redact_string(first_result)
+        assert second_result == first_result, (
+            f"Idempotence violated:\n  input:  {s!r}\n  first:  {first_result!r}\n  second: {second_result!r}"
+        )
+
+
+# ── Property 4: Shannon entropy detection threshold ──
+
+
+class TestShannonEntropyThreshold:
+    """**Validates: Requirements 3.3**"""
+
+    @given(s=_high_entropy_strategy())
+    @settings(max_examples=200)
+    def test_high_entropy_long_strings_are_redacted(self, s: str):
+        """Strings with length >= 32 and entropy > 4.5 are redacted."""
+        assert len(s) >= 32
+        assert shannon_entropy(s) > 4.5
+        result, count = redact_string(s)
+        assert REDACTED in result, f"High-entropy string not redacted: {s!r} (entropy={shannon_entropy(s):.2f})"
+        assert count >= 1
+
+    @given(s=_low_entropy_strategy(min_size=32, max_size=80))
+    @settings(max_examples=200)
+    def test_low_entropy_long_strings_not_redacted_by_entropy(self, s: str):
+        """Strings with length >= 32 but entropy <= 4.5 are NOT redacted by entropy rule."""
+        assume(len(s) >= 32)
+        assume(shannon_entropy(s) <= 4.5)
+        # Also ensure no other patterns match
+        assume(_is_safe_string(s))
+        result, count = redact_string(s)
+        assert result == s, f"Low-entropy string was redacted: {s!r}"
+        assert count == 0
+
+    @given(s=st.text(alphabet=string.ascii_letters + string.digits + "!@#$%^&*", min_size=1, max_size=31))
+    @settings(max_examples=200)
+    def test_short_strings_not_redacted_by_entropy(self, s: str):
+        """Strings with length < 32 are NOT redacted by the entropy rule."""
+        assume(len(s) < 32)
+        # Ensure no other patterns match
+        assume(_is_safe_string(s))
+        result, count = redact_string(s)
+        assert result == s, f"Short string was redacted: {s!r} (len={len(s)})"
+        assert count == 0
+
+
+# ── Property 5: URL structure preservation under redaction ──
+
+
+class TestURLStructurePreservation:
+    """**Validates: Requirements 3.5**"""
+
+    @given(data=_url_userinfo_strategy())
+    @settings(max_examples=200)
+    def test_url_scheme_and_host_preserved(self, data: str):
+        """For URLs with userinfo, scheme and host/path are preserved, credentials replaced.
+
+        After URL userinfo redaction, the resulting string may itself be a single
+        token >= 32 chars with high entropy, which would then be fully redacted by
+        the entropy rule. This is correct layered behavior. We verify:
+        1. The original credentials are always removed.
+        2. When the post-userinfo-redaction string is short enough to avoid the
+           entropy rule, the scheme and host structure are preserved.
+        """
+        result, count = redact_string(data)
+
+        # Parse the original URL to extract components
+        m = URL_USERINFO_PATTERN.search(data)
+        assert m is not None, f"Test URL doesn't match pattern: {data!r}"
+
+        original_scheme = m.group(1)  # e.g. "https://"
+        original_userinfo = m.group(2)  # e.g. "user:pass"
+
+        # The original credentials must never appear in the output
+        assert original_userinfo not in result, (
+            f"Original credentials {original_userinfo!r} still in output: {result!r}"
+        )
+
+        # At least one redaction for the userinfo
+        assert count >= 1
+
+        # Build what the URL looks like after just the userinfo redaction step
+        intermediate = URL_USERINFO_PATTERN.sub(lambda m_: f"{m_.group(1)}{REDACTED}@", data)
+
+        # Check if the intermediate result would trigger the entropy rule on any token
+        intermediate_tokens = re.split(r'([\s"\'`,;=\[\]{}()])', intermediate)
+        entropy_would_fire = any(
+            len(t) >= 32 and shannon_entropy(t) > 4.5 and t != REDACTED for t in intermediate_tokens
+        )
+
+        if not entropy_would_fire:
+            # When entropy doesn't fire, full URL structure is preserved
+            assert result.startswith(original_scheme), (
+                f"Scheme not preserved: {result!r} doesn't start with {original_scheme!r}"
+            )
+            assert f"{REDACTED}@" in result, f"Credentials not replaced with {REDACTED}@: {result!r}"
+
+
+# ── Property 6: Sensitive JSON key redaction with count tracking ──
+
+
+class TestSensitiveKeyRedaction:
+    """**Validates: Requirements 3.7, 3.8**"""
+
+    @given(
+        keys=st.lists(
+            st.sampled_from(_SENSITIVE_KEY_NAMES),
+            min_size=1,
+            max_size=5,
+            unique=True,
+        ),
+        values=st.lists(
+            st.text(alphabet=string.ascii_lowercase + string.digits, min_size=1, max_size=20),
+            min_size=5,
+            max_size=5,
+        ),
+    )
+    @settings(max_examples=200)
+    def test_sensitive_keys_redacted_with_correct_count(self, keys, values):
+        """All values under sensitive keys are redacted, count equals number of sensitive pairs."""
+        # Build a dict with sensitive keys mapped to safe values
+        data = {}
+        for i, key in enumerate(keys):
+            data[key] = values[i % len(values)]
+
+        result, count = redact_value(data)
+
+        # All sensitive key values should be redacted
+        for key in keys:
+            assert result[key] == REDACTED, f"Value for sensitive key {key!r} not redacted: {result[key]!r}"
+
+        # Count should equal number of sensitive keys
+        assert count == len(keys), f"Redaction count {count} != number of sensitive keys {len(keys)}"
+
+    @given(
+        keys=st.lists(
+            st.sampled_from(_NON_SENSITIVE_KEY_NAMES),
+            min_size=1,
+            max_size=5,
+            unique=True,
+        ),
+        values=st.lists(
+            st.text(alphabet=string.ascii_lowercase, min_size=1, max_size=10),
+            min_size=5,
+            max_size=5,
+        ),
+    )
+    @settings(max_examples=200)
+    def test_non_sensitive_keys_not_redacted(self, keys, values):
+        """Values under non-sensitive keys with safe values are not redacted."""
+        data = {}
+        for i, key in enumerate(keys):
+            data[key] = values[i % len(values)]
+
+        result, count = redact_value(data)
+
+        for key in keys:
+            assert result[key] == data[key], f"Non-sensitive key {key!r} value was modified"
+        assert count == 0
+
+
+# ── Property 7: Config allowlist filtering ──
+
+
+class TestConfigAllowlistFiltering:
+    """**Validates: Requirements 7.4**"""
+
+    @given(
+        allowed_keys=st.lists(
+            st.sampled_from(sorted(CONFIG_ALLOWLIST)),
+            min_size=0,
+            max_size=5,
+            unique=True,
+        ),
+        disallowed_keys=st.lists(
+            st.sampled_from(
+                [
+                    "SECRET_KEY",
+                    "EVAL_MODEL_API_KEY",
+                    "EVAL_MODEL_URL",
+                    "OAUTH_CLIENT_ID",
+                    "OAUTH_CLIENT_SECRET",
+                    "JWT_KEY_DIR",
+                    "JWT_KEY_PASSWORD",
+                    "DEMO_USER",
+                    "DEMO_PASSWORD",
+                    "SOME_RANDOM_KEY",
+                ]
+            ),
+            min_size=0,
+            max_size=5,
+            unique=True,
+        ),
+    )
+    @settings(max_examples=200)
+    def test_only_allowlisted_keys_in_output(self, allowed_keys, disallowed_keys):
+        """Output of allowlist filtering contains only keys in CONFIG_ALLOWLIST."""
+        # Build a config dict with a mix of allowed and disallowed keys
+        config = {}
+        for key in allowed_keys:
+            config[key] = f"value_for_{key}"
+        for key in disallowed_keys:
+            config[key] = f"secret_value_for_{key}"
+
+        # Apply the allowlist filter (same logic as _config_allowlisted)
+        filtered = {k: v for k, v in config.items() if k in CONFIG_ALLOWLIST}
+
+        # All keys in filtered output must be in the allowlist
+        for key in filtered:
+            assert key in CONFIG_ALLOWLIST, f"Key {key!r} not in CONFIG_ALLOWLIST but present in output"
+
+        # No disallowed keys should be present
+        for key in disallowed_keys:
+            assert key not in filtered, f"Disallowed key {key!r} found in filtered output"
+
+        # All allowed keys from input should be present
+        for key in allowed_keys:
+            assert key in filtered, f"Allowed key {key!r} missing from filtered output"
+
+
+# ── Property 8: Bundle manifest JSON round-trip ──
+
+
+# Strategy for generating random BundleManifest objects
+_file_entry_strategy = st.builds(
+    FileEntry,
+    path=st.text(alphabet=string.ascii_lowercase + string.digits + "/._-", min_size=1, max_size=30),
+    size_bytes=st.integers(min_value=0, max_value=10_000_000),
+    sha256=st.text(alphabet=string.hexdigits[:16], min_size=64, max_size=64),
+)
+
+_manifest_strategy = st.builds(
+    BundleManifest,
+    bundle_schema_version=st.just("1"),
+    created_at=st.text(alphabet=string.digits + "-T:Z+", min_size=10, max_size=30),
+    cli_version=st.from_regex(r"[0-9]+\.[0-9]+\.[0-9]+", fullmatch=True),
+    host_os=st.sampled_from(["Linux", "Darwin", "Windows"]),
+    node_id=st.text(alphabet=string.ascii_lowercase + string.digits + "-", min_size=1, max_size=20),
+    flags_used=st.fixed_dictionaries(
+        {
+            "output": st.text(alphabet=string.ascii_lowercase + string.digits + "/.-", min_size=1, max_size=30),
+            "logs_since": st.sampled_from(["1h", "30m", "2d", "6h"]),
+            "include_system": st.booleans(),
+        }
+    ),
+    collector_results=st.fixed_dictionaries(
+        {
+            "versions": st.fixed_dictionaries(
+                {"ok": st.booleans(), "duration_ms": st.integers(min_value=0, max_value=10000)}
+            ),
+        }
+    ),
+    redaction_counts=st.dictionaries(
+        keys=st.text(alphabet=string.ascii_lowercase + "/._", min_size=1, max_size=20),
+        values=st.integers(min_value=0, max_value=1000),
+        min_size=0,
+        max_size=5,
+    ),
+    file_inventory=st.lists(_file_entry_strategy, min_size=0, max_size=5),
+)
+
+
+class TestBundleManifestRoundTrip:
+    """**Validates: Requirements 4.2, 4.3**"""
+
+    @given(manifest=_manifest_strategy)
+    @settings(max_examples=200)
+    def test_json_round_trip(self, manifest: BundleManifest):
+        """from_dict(json.loads(manifest.to_json())) produces equivalent object."""
+        json_str = manifest.to_json()
+
+        # Verify it's valid JSON
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+
+        # Round-trip
+        restored = BundleManifest.from_dict(parsed)
+
+        # Compare all fields
+        assert restored.bundle_schema_version == manifest.bundle_schema_version
+        assert restored.created_at == manifest.created_at
+        assert restored.cli_version == manifest.cli_version
+        assert restored.host_os == manifest.host_os
+        assert restored.node_id == manifest.node_id
+        assert restored.flags_used == manifest.flags_used
+        assert restored.collector_results == manifest.collector_results
+        assert restored.redaction_counts == manifest.redaction_counts
+
+        # Compare file inventory
+        assert len(restored.file_inventory) == len(manifest.file_inventory)
+        for orig, rest in zip(manifest.file_inventory, restored.file_inventory, strict=True):
+            assert rest.path == orig.path
+            assert rest.size_bytes == orig.size_bytes
+            assert rest.sha256 == orig.sha256
+
+
+# ── Property 9: File inventory SHA-256 integrity ──
+
+
+class TestFileInventorySHA256:
+    """**Validates: Requirements 4.5, 7.3**"""
+
+    @given(
+        content=st.binary(min_size=0, max_size=10_000),
+        path=st.text(alphabet=string.ascii_lowercase + string.digits + "/._-", min_size=1, max_size=30),
+    )
+    @settings(max_examples=200)
+    def test_sha256_matches_hashlib(self, content: bytes, path: str):
+        """compute_file_entry(path, content).sha256 == hashlib.sha256(content).hexdigest()."""
+        entry = compute_file_entry(path, content)
+
+        expected_hash = hashlib.sha256(content).hexdigest()
+        assert entry.sha256 == expected_hash, f"SHA-256 mismatch for {path!r}: {entry.sha256} != {expected_hash}"
+        assert entry.size_bytes == len(content), f"Size mismatch: {entry.size_bytes} != {len(content)}"
+        assert entry.path == path

--- a/tests/test_support_redaction.py
+++ b/tests/test_support_redaction.py
@@ -1,0 +1,301 @@
+"""Unit tests for the support bundle redaction module."""
+
+import math
+from collections import Counter
+
+import pytest
+
+from observal_cli.support.redaction import (
+    AWS_KEY_PATTERN,
+    JWT_PATTERN,
+    REDACTED,
+    SENSITIVE_KEYS,
+    URL_USERINFO_PATTERN,
+    RedactionStats,
+    redact_string,
+    redact_value,
+    shannon_entropy,
+)
+
+# --- Shannon entropy ---
+
+
+class TestShannonEntropy:
+    def test_empty_string(self):
+        assert shannon_entropy("") == 0.0
+
+    def test_single_char_repeated(self):
+        # All same characters → entropy 0
+        assert shannon_entropy("aaaa") == 0.0
+
+    def test_two_equal_chars(self):
+        # "ab" → each char has probability 0.5 → entropy = 1.0
+        assert shannon_entropy("ab") == pytest.approx(1.0)
+
+    def test_known_entropy(self):
+        # "aabb" → 2 chars each with p=0.5 → entropy = 1.0
+        assert shannon_entropy("aabb") == pytest.approx(1.0)
+
+    def test_high_entropy_random_string(self):
+        # A string with many distinct characters should have high entropy
+        s = "aB3$xZ9!mK7@pQ2&wL5#"
+        assert shannon_entropy(s) > 3.0
+
+    def test_manual_calculation(self):
+        s = "aab"
+        counts = Counter(s)
+        length = len(s)
+        expected = -sum((c / length) * math.log2(c / length) for c in counts.values())
+        assert shannon_entropy(s) == pytest.approx(expected)
+
+
+# --- Pattern constants ---
+
+
+class TestPatterns:
+    def test_jwt_pattern_matches(self):
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456"
+        assert JWT_PATTERN.search(jwt)
+
+    def test_jwt_pattern_requires_eyj_prefix(self):
+        not_jwt = "abc.def.ghi"
+        assert not JWT_PATTERN.search(not_jwt)
+
+    def test_aws_key_pattern_matches(self):
+        key = "AKIAIOSFODNN7EXAMPLE"
+        assert AWS_KEY_PATTERN.search(key)
+
+    def test_aws_key_pattern_rejects_wrong_prefix(self):
+        assert not AWS_KEY_PATTERN.search("BKIAIOSFODNN7EXAMPLE")
+
+    def test_aws_key_pattern_rejects_short(self):
+        assert not AWS_KEY_PATTERN.search("AKIA1234")
+
+    def test_url_userinfo_postgres(self):
+        url = "postgresql+asyncpg://user:pass@localhost:5432/db"
+        m = URL_USERINFO_PATTERN.search(url)
+        assert m
+        assert m.group(1) == "postgresql+asyncpg://"
+        assert m.group(2) == "user:pass"
+
+    def test_url_userinfo_redis(self):
+        url = "redis://default:mypassword@localhost:6379"
+        m = URL_USERINFO_PATTERN.search(url)
+        assert m
+        assert m.group(2) == "default:mypassword"
+
+    def test_url_userinfo_http(self):
+        url = "https://admin:secret@example.com/path"
+        m = URL_USERINFO_PATTERN.search(url)
+        assert m
+
+    def test_sensitive_keys_matches(self):
+        for key in [
+            "password",
+            "SECRET",
+            "Token",
+            "api_key",
+            "apikey",
+            "api-key",
+            "access_key",
+            "private_key",
+            "credential",
+            "authorization",
+            "client_secret",
+            "bearer",
+            "MY_PASSWORD",
+            "db_secret_key",
+        ]:
+            assert SENSITIVE_KEYS.search(key), f"Should match: {key}"
+
+    def test_sensitive_keys_no_false_positives(self):
+        for key in ["hostname", "port", "database", "log_level", "region"]:
+            assert not SENSITIVE_KEYS.search(key), f"Should not match: {key}"
+
+
+# --- RedactionStats ---
+
+
+class TestRedactionStats:
+    def test_record_new_source(self):
+        stats = RedactionStats()
+        stats.record("config/config.json", 3)
+        assert stats.counts == {"config/config.json": 3}
+
+    def test_record_accumulates(self):
+        stats = RedactionStats()
+        stats.record("config/config.json", 3)
+        stats.record("config/config.json", 2)
+        assert stats.counts["config/config.json"] == 5
+
+    def test_record_multiple_sources(self):
+        stats = RedactionStats()
+        stats.record("a.json", 1)
+        stats.record("b.json", 2)
+        assert stats.counts == {"a.json": 1, "b.json": 2}
+
+    def test_empty_by_default(self):
+        stats = RedactionStats()
+        assert stats.counts == {}
+
+
+# --- redact_string ---
+
+
+class TestRedactString:
+    def test_safe_string_unchanged(self):
+        result, count = redact_string("hello world")
+        assert result == "hello world"
+        assert count == 0
+
+    def test_jwt_redacted(self):
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+        result, count = redact_string(f"Bearer {jwt}")
+        assert REDACTED in result
+        assert jwt not in result
+        assert count >= 1
+
+    def test_aws_key_redacted(self):
+        result, count = redact_string("key=AKIAIOSFODNN7EXAMPLE")
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+        assert REDACTED in result
+        assert count >= 1
+
+    def test_url_userinfo_redacted_preserves_structure(self):
+        url = "postgresql+asyncpg://myuser:mypass@localhost:5432/observal"
+        result, count = redact_string(url)
+        assert "myuser" not in result
+        assert "mypass" not in result
+        # The URL after userinfo redaction may itself exceed the entropy
+        # threshold (length >= 32, entropy > 4.5) and get fully redacted.
+        # The important thing is credentials are removed.
+        assert count >= 1
+        assert "myuser:mypass" not in result
+
+    def test_short_url_userinfo_preserves_structure(self):
+        # A shorter URL that won't trigger entropy after redaction
+        url = "redis://u:p@host:6379"
+        result, count = redact_string(url)
+        assert "u:p" not in result
+        assert result.startswith("redis://")
+        assert "@host:6379" in result
+        assert count == 1
+
+    def test_high_entropy_string_redacted(self):
+        # A 32+ char high-entropy string
+        high_entropy = "aB3xZ9mK7pQ2wL5nR8tY4uI6oP0sD1fG"
+        assert len(high_entropy) >= 32
+        assert shannon_entropy(high_entropy) > 4.5
+        result, count = redact_string(high_entropy)
+        assert result == REDACTED
+        assert count == 1
+
+    def test_short_high_entropy_not_redacted(self):
+        # Short string, even if high entropy, should not be redacted by entropy rule
+        short = "aB3$xZ9!"
+        assert len(short) < 32
+        result, count = redact_string(short)
+        assert result == short
+        assert count == 0
+
+    def test_redacted_sentinel_not_re_redacted(self):
+        # Idempotence: the sentinel itself should not trigger any pattern
+        result, count = redact_string(REDACTED)
+        assert result == REDACTED
+        assert count == 0
+
+    def test_multiple_patterns_in_one_string(self):
+        s = "jwt=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig key=AKIAIOSFODNN7EXAMPLE"
+        result, count = redact_string(s)
+        assert "eyJ" not in result
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+        assert count >= 2
+
+    def test_empty_string(self):
+        result, count = redact_string("")
+        assert result == ""
+        assert count == 0
+
+
+# --- redact_value ---
+
+
+class TestRedactValue:
+    def test_string_value(self):
+        result, count = redact_value("hello")
+        assert result == "hello"
+        assert count == 0
+
+    def test_sensitive_key_redacts_entire_value(self):
+        result, count = redact_value("my-safe-value", key="password")
+        assert result == REDACTED
+        assert count == 1
+
+    def test_sensitive_key_case_insensitive(self):
+        result, count = redact_value("value", key="SECRET_KEY")
+        assert result == REDACTED
+        assert count == 1
+
+    def test_dict_redaction(self):
+        data = {
+            "password": "hunter2",
+            "hostname": "localhost",
+            "api_key": "sk-1234",
+        }
+        result, count = redact_value(data)
+        assert result["password"] == REDACTED
+        assert result["hostname"] == "localhost"
+        assert result["api_key"] == REDACTED
+        assert count == 2
+
+    def test_nested_dict_redaction(self):
+        data = {
+            "db": {
+                "password": "secret123",
+                "host": "localhost",
+            }
+        }
+        result, count = redact_value(data)
+        assert result["db"]["password"] == REDACTED
+        assert result["db"]["host"] == "localhost"
+        assert count == 1
+
+    def test_list_redaction(self):
+        data = ["safe", "AKIAIOSFODNN7EXAMPLE", "also safe"]
+        result, count = redact_value(data)
+        assert result[0] == "safe"
+        assert "AKIAIOSFODNN7EXAMPLE" not in result[1]
+        assert result[2] == "also safe"
+        assert count >= 1
+
+    def test_list_with_sensitive_key_context(self):
+        # When a list is under a sensitive key, all items get redacted
+        data = ["val1", "val2"]
+        result, count = redact_value(data, key="password")
+        assert result == [REDACTED, REDACTED]
+        assert count == 2
+
+    def test_non_string_passthrough(self):
+        assert redact_value(42) == (42, 0)
+        assert redact_value(3.14) == (3.14, 0)
+        assert redact_value(True) == (True, 0)
+        assert redact_value(None) == (None, 0)
+
+    def test_complex_nested_structure(self):
+        data = {
+            "config": {
+                "database_url": "postgresql+asyncpg://admin:pass@localhost/db",
+                "settings": [
+                    {"token": "abc123"},
+                    {"name": "test"},
+                ],
+            },
+            "version": "1.0.0",
+        }
+        result, count = redact_value(data)
+        assert "admin" not in str(result)
+        assert "pass" not in str(result["config"]["database_url"])
+        assert result["config"]["settings"][0]["token"] == REDACTED
+        assert result["config"]["settings"][1]["name"] == "test"
+        assert result["version"] == "1.0.0"
+        assert count >= 2


### PR DESCRIPTION
## Purpose / Description

Add `observal support` CLI command group with `bundle` and `inspect` subcommands for generating and reviewing portable diagnostic archives that operators can attach to support tickets or GitHub issues.

**`observal support bundle`** produces a small, safe `.tar.gz` containing version info, sanitized config, health probes, aggregate table counts, error fingerprints, redacted logs, and system metrics. **`observal support inspect`** lets operators review bundle contents before sharing.


## Approach

- **Server-side collection**: New `POST /api/v1/support/collect` endpoint runs 6 collectors (versions, health, config, aggregates, errors, logs) with 10s timeouts. Preserves existing architecture: CLI → HTTP → API Server → {PG, CH, Redis}.
- **Local collectors**: System info and config allowlist filtering run in a thread pool on the operator's machine.
- **Redaction Layer**: Single chokepoint module — JWTs, AWS keys, URL credentials (any scheme via generic regex), high-entropy tokens, and sensitive JSON keys replaced with `<REDACTED>`. Entropy check skips already-redacted tokens to preserve URL structure.
- **Manifest**: SHA-256 file inventory for tamper detection. `node_id` is a truncated hash (not raw hostname). `flags_used["output"]` stores filename only.
- **Inspect**: Read-only via `tarfile`, path traversal protection via `os.path.normpath`, schema version warnings.
- **Error safety**: All exception messages use `type(exc).__name__` only — no credential leaks from SQLAlchemy connection errors.


## How Has This Been Tested?

**Unit/integration tests (268 pass, 1 skip):**
```bash
cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml \
  --with typer --with rich --with docker --with hypothesis \
  pytest ../tests/test_support_redaction.py ../tests/test_support_manifest.py \
  ../tests/test_support_collectors.py ../tests/test_support_bundle_wiring.py \
  ../tests/test_support_inspect.py ../tests/test_support_integration.py \
  ../tests/test_support_pbt.py ../tests/test_support_endpoint.py \
  ../tests/test_cmd_support.py -v
```

**Manual CLI verification (requires `make rebuild` + `observal auth login`):**
```bash
# Generate and inspect a full bundle
observal support bundle --output test-bundle.tar.gz
observal support inspect test-bundle.tar.gz
observal support inspect test-bundle.tar.gz --show config/config.json
observal support inspect test-bundle.tar.gz --show aggregates/pg_table_counts.json

# Verify --no-include-system excludes system directory
observal support bundle --output no-system.tar.gz --no-include-system
observal support inspect no-system.tar.gz

# Error handling
observal support inspect nonexistent.tar.gz
observal support inspect test-bundle.tar.gz --show nonexistent.json

# Cleanup
rm test-bundle.tar.gz no-system.tar.gz
```

## Learning (optional, can help others)

- Property-based testing (Hypothesis) is effective for validating redaction correctness — it found the entropy/URL interaction edge case where a redacted URL token could trigger the entropy rule.
- `tarfile.open(mode="r:gz")` with member filtering is the safe pattern for reading archives without extraction.
- `os.path.normpath` is the correct way to check path traversal — substring checks on `..` reject legitimate filenames.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
