### PR TITLE
feat(db): component version tables for all 5 types

### DIFF
--- a/observal-server/alembic/versions/0020_component_version_tables.py
+++ b/observal-server/alembic/versions/0020_component_version_tables.py
@@ -1,0 +1,537 @@
+"""add component version tables
+
+Revision ID: 0020
+Revises: e8e63ca6d74e
+Create Date: 2026-04-30 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0020"
+down_revision: Union[str, Sequence[str], None] = "e8e63ca6d74e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Reuse the existing listingstatus enum — do not create a new one.
+listing_status = postgresql.ENUM(
+    "draft", "pending", "approved", "rejected", "archived", name="listingstatus", create_type=False
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # ------------------------------------------------------------------
+    # mcp_versions
+    # ------------------------------------------------------------------
+    op.create_table(
+        "mcp_versions",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("listing_id", sa.UUID(), nullable=False),
+        sa.Column("version", sa.String(50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("changelog", sa.Text(), nullable=True),
+        sa.Column("supported_ides", sa.JSON(), server_default="[]", nullable=True),
+        sa.Column("source_url", sa.String(500), nullable=True),
+        sa.Column("source_ref", sa.String(255), nullable=True),
+        sa.Column("resolved_sha", sa.String(40), nullable=True),
+        sa.Column("status", listing_status, nullable=True, server_default="pending"),
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+        sa.Column("download_count", sa.Integer(), server_default="0", nullable=True),
+        sa.Column("released_by", sa.UUID(), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("reviewed_by", sa.UUID(), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        # mcp-specific
+        sa.Column("transport", sa.String(20), nullable=True),
+        sa.Column("framework", sa.String(100), nullable=True),
+        sa.Column("docker_image", sa.String(500), nullable=True),
+        sa.Column("command", sa.String(500), nullable=True),
+        sa.Column("args", sa.JSON(), nullable=True),
+        sa.Column("url", sa.String(1000), nullable=True),
+        sa.Column("headers", sa.JSON(), nullable=True),
+        sa.Column("auto_approve", sa.JSON(), nullable=True),
+        sa.Column("mcp_validated", sa.Boolean(), server_default="false", nullable=True),
+        sa.Column("tools_schema", sa.JSON(), nullable=True),
+        sa.Column("environment_variables", sa.JSON(), nullable=True),
+        sa.Column("setup_instructions", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["listing_id"], ["mcp_listings.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["released_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["reviewed_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("listing_id", "version"),
+    )
+    op.create_index("ix_mcp_versions_listing_id", "mcp_versions", ["listing_id"])
+    op.create_index("ix_mcp_versions_status", "mcp_versions", ["status"])
+
+    # ------------------------------------------------------------------
+    # skill_versions
+    # ------------------------------------------------------------------
+    op.create_table(
+        "skill_versions",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("listing_id", sa.UUID(), nullable=False),
+        sa.Column("version", sa.String(50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("changelog", sa.Text(), nullable=True),
+        sa.Column("supported_ides", sa.JSON(), server_default="[]", nullable=True),
+        sa.Column("source_url", sa.String(500), nullable=True),
+        sa.Column("source_ref", sa.String(255), nullable=True),
+        sa.Column("resolved_sha", sa.String(40), nullable=True),
+        sa.Column("status", listing_status, nullable=True, server_default="pending"),
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+        sa.Column("download_count", sa.Integer(), server_default="0", nullable=True),
+        sa.Column("released_by", sa.UUID(), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("reviewed_by", sa.UUID(), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        # skill-specific
+        sa.Column("skill_path", sa.String(500), server_default="/", nullable=True),
+        sa.Column("target_agents", sa.JSON(), server_default="[]", nullable=True),
+        sa.Column("task_type", sa.String(100), nullable=False),
+        sa.Column("triggers", sa.JSON(), nullable=True),
+        sa.Column("slash_command", sa.String(100), nullable=True),
+        sa.Column("has_scripts", sa.Boolean(), server_default="false", nullable=True),
+        sa.Column("has_templates", sa.Boolean(), server_default="false", nullable=True),
+        sa.Column("is_power", sa.Boolean(), server_default="false", nullable=True),
+        sa.Column("power_md", sa.Text(), nullable=True),
+        sa.Column("mcp_server_config", sa.JSON(), nullable=True),
+        sa.Column("activation_keywords", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["listing_id"], ["skill_listings.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["released_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["reviewed_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("listing_id", "version"),
+    )
+    op.create_index("ix_skill_versions_listing_id", "skill_versions", ["listing_id"])
+    op.create_index("ix_skill_versions_status", "skill_versions", ["status"])
+
+    # ------------------------------------------------------------------
+    # hook_versions
+    # ------------------------------------------------------------------
+    op.create_table(
+        "hook_versions",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("listing_id", sa.UUID(), nullable=False),
+        sa.Column("version", sa.String(50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("changelog", sa.Text(), nullable=True),
+        sa.Column("supported_ides", sa.JSON(), server_default="[]", nullable=True),
+        sa.Column("source_url", sa.String(500), nullable=True),
+        sa.Column("source_ref", sa.String(255), nullable=True),
+        sa.Column("resolved_sha", sa.String(40), nullable=True),
+        sa.Column("status", listing_status, nullable=True, server_default="pending"),
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+        sa.Column("download_count", sa.Integer(), server_default="0", nullable=True),
+        sa.Column("released_by", sa.UUID(), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("reviewed_by", sa.UUID(), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        # hook-specific
+        sa.Column("event", sa.String(50), nullable=False),
+        sa.Column("execution_mode", sa.String(10), server_default="async", nullable=True),
+        sa.Column("priority", sa.Integer(), server_default="100", nullable=True),
+        sa.Column("handler_type", sa.String(20), nullable=False),
+        sa.Column("handler_config", sa.JSON(), server_default="{}", nullable=True),
+        sa.Column("input_schema", sa.JSON(), nullable=True),
+        sa.Column("output_schema", sa.JSON(), nullable=True),
+        sa.Column("scope", sa.String(20), server_default="agent", nullable=True),
+        sa.Column("tool_filter", sa.JSON(), nullable=True),
+        sa.Column("file_pattern", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["listing_id"], ["hook_listings.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["released_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["reviewed_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("listing_id", "version"),
+    )
+    op.create_index("ix_hook_versions_listing_id", "hook_versions", ["listing_id"])
+    op.create_index("ix_hook_versions_status", "hook_versions", ["status"])
+
+    # ------------------------------------------------------------------
+    # prompt_versions
+    # ------------------------------------------------------------------
+    op.create_table(
+        "prompt_versions",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("listing_id", sa.UUID(), nullable=False),
+        sa.Column("version", sa.String(50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("changelog", sa.Text(), nullable=True),
+        sa.Column("supported_ides", sa.JSON(), server_default="[]", nullable=True),
+        sa.Column("source_url", sa.String(500), nullable=True),
+        sa.Column("source_ref", sa.String(255), nullable=True),
+        sa.Column("resolved_sha", sa.String(40), nullable=True),
+        sa.Column("status", listing_status, nullable=True, server_default="pending"),
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+        sa.Column("download_count", sa.Integer(), server_default="0", nullable=True),
+        sa.Column("released_by", sa.UUID(), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("reviewed_by", sa.UUID(), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        # prompt-specific
+        sa.Column("category", sa.String(100), nullable=False),
+        sa.Column("template", sa.Text(), nullable=False),
+        sa.Column("variables", sa.JSON(), server_default="[]", nullable=True),
+        sa.Column("model_hints", sa.JSON(), nullable=True),
+        sa.Column("tags", sa.JSON(), server_default="[]", nullable=True),
+        sa.ForeignKeyConstraint(["listing_id"], ["prompt_listings.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["released_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["reviewed_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("listing_id", "version"),
+    )
+    op.create_index("ix_prompt_versions_listing_id", "prompt_versions", ["listing_id"])
+    op.create_index("ix_prompt_versions_status", "prompt_versions", ["status"])
+
+    # ------------------------------------------------------------------
+    # sandbox_versions
+    # ------------------------------------------------------------------
+    op.create_table(
+        "sandbox_versions",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("listing_id", sa.UUID(), nullable=False),
+        sa.Column("version", sa.String(50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("changelog", sa.Text(), nullable=True),
+        sa.Column("supported_ides", sa.JSON(), server_default="[]", nullable=True),
+        sa.Column("source_url", sa.String(500), nullable=True),
+        sa.Column("source_ref", sa.String(255), nullable=True),
+        sa.Column("resolved_sha", sa.String(40), nullable=True),
+        sa.Column("status", listing_status, nullable=True, server_default="pending"),
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+        sa.Column("download_count", sa.Integer(), server_default="0", nullable=True),
+        sa.Column("released_by", sa.UUID(), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("reviewed_by", sa.UUID(), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        # sandbox-specific
+        sa.Column("runtime_type", sa.String(20), nullable=False),
+        sa.Column("image", sa.String(500), nullable=False),
+        sa.Column("dockerfile_url", sa.String(500), nullable=True),
+        sa.Column("resource_limits", sa.JSON(), server_default="{}", nullable=True),
+        sa.Column("network_policy", sa.String(20), server_default="none", nullable=True),
+        sa.Column("allowed_mounts", sa.JSON(), server_default="[]", nullable=True),
+        sa.Column("env_vars", sa.JSON(), server_default="{}", nullable=True),
+        sa.Column("entrypoint", sa.String(500), nullable=True),
+        sa.ForeignKeyConstraint(["listing_id"], ["sandbox_listings.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["released_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["reviewed_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("listing_id", "version"),
+    )
+    op.create_index("ix_sandbox_versions_listing_id", "sandbox_versions", ["listing_id"])
+    op.create_index("ix_sandbox_versions_status", "sandbox_versions", ["status"])
+
+    # ------------------------------------------------------------------
+    # Add latest_version_id to each listing table
+    # ------------------------------------------------------------------
+    op.add_column("mcp_listings", sa.Column("latest_version_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        "fk_mcp_listings_latest_version_id",
+        "mcp_listings",
+        "mcp_versions",
+        ["latest_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column("skill_listings", sa.Column("latest_version_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        "fk_skill_listings_latest_version_id",
+        "skill_listings",
+        "skill_versions",
+        ["latest_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column("hook_listings", sa.Column("latest_version_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        "fk_hook_listings_latest_version_id",
+        "hook_listings",
+        "hook_versions",
+        ["latest_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column("prompt_listings", sa.Column("latest_version_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        "fk_prompt_listings_latest_version_id",
+        "prompt_listings",
+        "prompt_versions",
+        ["latest_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column("sandbox_listings", sa.Column("latest_version_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        "fk_sandbox_listings_latest_version_id",
+        "sandbox_listings",
+        "sandbox_versions",
+        ["latest_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # ------------------------------------------------------------------
+    # Data migration: seed one version row per existing listing
+    # ------------------------------------------------------------------
+    conn = op.get_bind()
+
+    # mcp
+    conn.execute(
+        sa.text("""
+        INSERT INTO mcp_versions (
+            id, listing_id, version, description, changelog,
+            supported_ides, source_url, source_ref,
+            status, rejection_reason, download_count,
+            released_by, released_at, created_at,
+            transport, framework, docker_image, command, args,
+            url, headers, auto_approve, mcp_validated,
+            tools_schema, environment_variables, setup_instructions
+        )
+        SELECT
+            gen_random_uuid(),
+            id,
+            COALESCE(version, '1.0.0'),
+            description,
+            changelog,
+            supported_ides,
+            git_url,
+            git_ref,
+            status,
+            rejection_reason,
+            download_count,
+            submitted_by,
+            created_at,
+            now(),
+            transport,
+            framework,
+            docker_image,
+            command,
+            args,
+            url,
+            headers,
+            auto_approve,
+            mcp_validated,
+            tools_schema,
+            environment_variables,
+            setup_instructions
+        FROM mcp_listings
+    """)
+    )
+
+    conn.execute(
+        sa.text("""
+        UPDATE mcp_listings l
+        SET latest_version_id = v.id
+        FROM mcp_versions v
+        WHERE v.listing_id = l.id
+    """)
+    )
+
+    # skill
+    conn.execute(
+        sa.text("""
+        INSERT INTO skill_versions (
+            id, listing_id, version, description,
+            supported_ides, source_url, source_ref,
+            status, rejection_reason, download_count,
+            released_by, released_at, created_at,
+            skill_path, target_agents, task_type, triggers,
+            slash_command, has_scripts, has_templates, is_power,
+            power_md, mcp_server_config, activation_keywords
+        )
+        SELECT
+            gen_random_uuid(),
+            id,
+            COALESCE(version, '1.0.0'),
+            description,
+            supported_ides,
+            git_url,
+            git_ref,
+            status,
+            rejection_reason,
+            download_count,
+            submitted_by,
+            created_at,
+            now(),
+            skill_path,
+            target_agents,
+            task_type,
+            triggers,
+            slash_command,
+            has_scripts,
+            has_templates,
+            is_power,
+            power_md,
+            mcp_server_config,
+            activation_keywords
+        FROM skill_listings
+    """)
+    )
+
+    conn.execute(
+        sa.text("""
+        UPDATE skill_listings l
+        SET latest_version_id = v.id
+        FROM skill_versions v
+        WHERE v.listing_id = l.id
+    """)
+    )
+
+    # hook
+    conn.execute(
+        sa.text("""
+        INSERT INTO hook_versions (
+            id, listing_id, version, description,
+            supported_ides, source_url, source_ref,
+            status, rejection_reason, download_count,
+            released_by, released_at, created_at,
+            event, execution_mode, priority, handler_type,
+            handler_config, input_schema, output_schema, scope,
+            tool_filter, file_pattern
+        )
+        SELECT
+            gen_random_uuid(),
+            id,
+            COALESCE(version, '1.0.0'),
+            description,
+            supported_ides,
+            git_url,
+            git_ref,
+            status,
+            rejection_reason,
+            download_count,
+            submitted_by,
+            created_at,
+            now(),
+            event,
+            execution_mode,
+            priority,
+            handler_type,
+            handler_config,
+            input_schema,
+            output_schema,
+            scope,
+            tool_filter,
+            file_pattern
+        FROM hook_listings
+    """)
+    )
+
+    conn.execute(
+        sa.text("""
+        UPDATE hook_listings l
+        SET latest_version_id = v.id
+        FROM hook_versions v
+        WHERE v.listing_id = l.id
+    """)
+    )
+
+    # prompt
+    conn.execute(
+        sa.text("""
+        INSERT INTO prompt_versions (
+            id, listing_id, version, description,
+            supported_ides, source_url, source_ref,
+            status, rejection_reason, download_count,
+            released_by, released_at, created_at,
+            category, template, variables, model_hints, tags
+        )
+        SELECT
+            gen_random_uuid(),
+            id,
+            COALESCE(version, '1.0.0'),
+            description,
+            supported_ides,
+            git_url,
+            git_ref,
+            status,
+            rejection_reason,
+            download_count,
+            submitted_by,
+            created_at,
+            now(),
+            category,
+            template,
+            variables,
+            model_hints,
+            tags
+        FROM prompt_listings
+    """)
+    )
+
+    conn.execute(
+        sa.text("""
+        UPDATE prompt_listings l
+        SET latest_version_id = v.id
+        FROM prompt_versions v
+        WHERE v.listing_id = l.id
+    """)
+    )
+
+    # sandbox
+    conn.execute(
+        sa.text("""
+        INSERT INTO sandbox_versions (
+            id, listing_id, version, description,
+            supported_ides, source_url, source_ref,
+            status, rejection_reason, download_count,
+            released_by, released_at, created_at,
+            runtime_type, image, dockerfile_url, resource_limits,
+            network_policy, allowed_mounts, env_vars, entrypoint
+        )
+        SELECT
+            gen_random_uuid(),
+            id,
+            COALESCE(version, '1.0.0'),
+            description,
+            supported_ides,
+            git_url,
+            git_ref,
+            status,
+            rejection_reason,
+            download_count,
+            submitted_by,
+            created_at,
+            now(),
+            runtime_type,
+            image,
+            dockerfile_url,
+            resource_limits,
+            network_policy,
+            allowed_mounts,
+            env_vars,
+            entrypoint
+        FROM sandbox_listings
+    """)
+    )
+
+    conn.execute(
+        sa.text("""
+        UPDATE sandbox_listings l
+        SET latest_version_id = v.id
+        FROM sandbox_versions v
+        WHERE v.listing_id = l.id
+    """)
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise NotImplementedError("Clean-break migration")

--- a/observal-server/models/hook.py
+++ b/observal-server/models/hook.py
@@ -1,9 +1,9 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON, UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
 from models.mcp import ListingStatus
@@ -52,6 +52,18 @@ class HookListing(Base):
     scope: Mapped[str] = mapped_column(String(20), default="agent")
     tool_filter: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     file_pattern: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("hook_versions.id", use_alter=True, ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    versions: Mapped[list["HookVersion"]] = relationship(
+        back_populates="listing",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+        foreign_keys="HookVersion.listing_id",
+    )
 
 
 class HookDownload(Base):
@@ -62,3 +74,44 @@ class HookDownload(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     ide: Mapped[str] = mapped_column(String(50), nullable=False)
     downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+
+class HookVersion(Base):
+    __tablename__ = "hook_versions"
+    __table_args__ = (
+        UniqueConstraint("listing_id", "version"),
+        Index("ix_hook_versions_listing_id", "listing_id"),
+        Index("ix_hook_versions_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    listing_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("hook_listings.id", ondelete="CASCADE"), nullable=False
+    )
+    version: Mapped[str] = mapped_column(String(50), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    changelog: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    source_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    resolved_sha: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    download_count: Mapped[int] = mapped_column(Integer, default=0)
+    released_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    released_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    supported_ides: Mapped[list] = mapped_column(JSON, default=list)
+    event: Mapped[str] = mapped_column(String(50), nullable=False)
+    execution_mode: Mapped[str] = mapped_column(String(10), default="async")
+    priority: Mapped[int] = mapped_column(Integer, default=100)
+    handler_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    handler_config: Mapped[dict] = mapped_column(JSON, default=dict)
+    input_schema: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    output_schema: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    scope: Mapped[str] = mapped_column(String(20), default="agent")
+    tool_filter: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    file_pattern: Mapped[list | None] = mapped_column(JSON, nullable=True)
+
+    listing: Mapped["HookListing"] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -65,8 +65,20 @@ class McpListing(Base):
         onupdate=lambda: datetime.now(UTC),
     )
 
+    latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("mcp_versions.id", use_alter=True, ondelete="SET NULL"),
+        nullable=True,
+    )
+
     validation_results: Mapped[list["McpValidationResult"]] = relationship(
         back_populates="listing", lazy="selectin", cascade="all, delete-orphan"
+    )
+    versions: Mapped[list["McpVersion"]] = relationship(
+        back_populates="listing",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+        foreign_keys="McpVersion.listing_id",
     )
 
 
@@ -91,3 +103,46 @@ class McpValidationResult(Base):
     run_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
     listing: Mapped["McpListing"] = relationship(back_populates="validation_results")
+
+
+class McpVersion(Base):
+    __tablename__ = "mcp_versions"
+    __table_args__ = (
+        UniqueConstraint("listing_id", "version"),
+        Index("ix_mcp_versions_listing_id", "listing_id"),
+        Index("ix_mcp_versions_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    listing_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mcp_listings.id", ondelete="CASCADE"), nullable=False
+    )
+    version: Mapped[str] = mapped_column(String(50), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    changelog: Mapped[str | None] = mapped_column(Text, nullable=True)
+    transport: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    framework: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    docker_image: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    command: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    args: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    headers: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    auto_approve: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    mcp_validated: Mapped[bool] = mapped_column(Boolean, default=False)
+    tools_schema: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    environment_variables: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    supported_ides: Mapped[list] = mapped_column(JSON, default=list)
+    setup_instructions: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    source_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    resolved_sha: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    download_count: Mapped[int] = mapped_column(Integer, default=0)
+    released_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    released_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+    listing: Mapped["McpListing"] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/prompt.py
+++ b/observal-server/models/prompt.py
@@ -1,9 +1,9 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON, UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
 from models.mcp import ListingStatus
@@ -45,6 +45,18 @@ class PromptListing(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
     )
+    latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("prompt_versions.id", use_alter=True, ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    versions: Mapped[list["PromptVersion"]] = relationship(
+        back_populates="listing",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+        foreign_keys="PromptVersion.listing_id",
+    )
 
 
 class PromptDownload(Base):
@@ -55,3 +67,39 @@ class PromptDownload(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     ide: Mapped[str] = mapped_column(String(50), nullable=False)
     downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+
+class PromptVersion(Base):
+    __tablename__ = "prompt_versions"
+    __table_args__ = (
+        UniqueConstraint("listing_id", "version"),
+        Index("ix_prompt_versions_listing_id", "listing_id"),
+        Index("ix_prompt_versions_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    listing_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("prompt_listings.id", ondelete="CASCADE"), nullable=False
+    )
+    version: Mapped[str] = mapped_column(String(50), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    changelog: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    source_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    resolved_sha: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    download_count: Mapped[int] = mapped_column(Integer, default=0)
+    released_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    released_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    supported_ides: Mapped[list] = mapped_column(JSON, default=list)
+    category: Mapped[str] = mapped_column(String(100), nullable=False)
+    template: Mapped[str] = mapped_column(Text, nullable=False)
+    variables: Mapped[list] = mapped_column(JSON, default=list)
+    model_hints: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    tags: Mapped[list] = mapped_column(JSON, default=list)
+
+    listing: Mapped["PromptListing"] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/sandbox.py
+++ b/observal-server/models/sandbox.py
@@ -1,9 +1,9 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON, UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
 from models.mcp import ListingStatus
@@ -48,6 +48,18 @@ class SandboxListing(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
     )
+    latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sandbox_versions.id", use_alter=True, ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    versions: Mapped[list["SandboxVersion"]] = relationship(
+        back_populates="listing",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+        foreign_keys="SandboxVersion.listing_id",
+    )
 
 
 class SandboxDownload(Base):
@@ -58,3 +70,42 @@ class SandboxDownload(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     ide: Mapped[str] = mapped_column(String(50), nullable=False)
     downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+
+class SandboxVersion(Base):
+    __tablename__ = "sandbox_versions"
+    __table_args__ = (
+        UniqueConstraint("listing_id", "version"),
+        Index("ix_sandbox_versions_listing_id", "listing_id"),
+        Index("ix_sandbox_versions_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    listing_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sandbox_listings.id", ondelete="CASCADE"), nullable=False
+    )
+    version: Mapped[str] = mapped_column(String(50), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    changelog: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    source_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    resolved_sha: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    download_count: Mapped[int] = mapped_column(Integer, default=0)
+    released_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    released_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    supported_ides: Mapped[list] = mapped_column(JSON, default=list)
+    runtime_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    image: Mapped[str] = mapped_column(String(500), nullable=False)
+    dockerfile_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    resource_limits: Mapped[dict] = mapped_column(JSON, default=dict)
+    network_policy: Mapped[str] = mapped_column(String(20), default="none")
+    allowed_mounts: Mapped[list] = mapped_column(JSON, default=list)
+    env_vars: Mapped[dict] = mapped_column(JSON, default=dict)
+    entrypoint: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    listing: Mapped["SandboxListing"] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/skill.py
+++ b/observal-server/models/skill.py
@@ -1,9 +1,9 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON, UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
 from models.mcp import ListingStatus
@@ -53,6 +53,18 @@ class SkillListing(Base):
     power_md: Mapped[str | None] = mapped_column(Text, nullable=True)
     mcp_server_config: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     activation_keywords: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("skill_versions.id", use_alter=True, ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    versions: Mapped[list["SkillVersion"]] = relationship(
+        back_populates="listing",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+        foreign_keys="SkillVersion.listing_id",
+    )
 
 
 class SkillDownload(Base):
@@ -63,3 +75,45 @@ class SkillDownload(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     ide: Mapped[str] = mapped_column(String(50), nullable=False)
     downloaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+
+class SkillVersion(Base):
+    __tablename__ = "skill_versions"
+    __table_args__ = (
+        UniqueConstraint("listing_id", "version"),
+        Index("ix_skill_versions_listing_id", "listing_id"),
+        Index("ix_skill_versions_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    listing_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("skill_listings.id", ondelete="CASCADE"), nullable=False
+    )
+    version: Mapped[str] = mapped_column(String(50), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    changelog: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    source_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    resolved_sha: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    status: Mapped[ListingStatus] = mapped_column(Enum(ListingStatus), default=ListingStatus.pending)
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    download_count: Mapped[int] = mapped_column(Integer, default=0)
+    released_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    released_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    supported_ides: Mapped[list] = mapped_column(JSON, default=list)
+    skill_path: Mapped[str] = mapped_column(String(500), default="/")
+    target_agents: Mapped[list] = mapped_column(JSON, default=list)
+    task_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    triggers: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    slash_command: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    has_scripts: Mapped[bool] = mapped_column(Boolean, default=False)
+    has_templates: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_power: Mapped[bool] = mapped_column(Boolean, default=False)
+    power_md: Mapped[str | None] = mapped_column(Text, nullable=True)
+    mcp_server_config: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    activation_keywords: Mapped[list | None] = mapped_column(JSON, nullable=True)
+
+    listing: Mapped["SkillListing"] = relationship(back_populates="versions", foreign_keys=[listing_id])


### PR DESCRIPTION
## Purpose / Description

Adds version tables for all 5 component types (MCP, skill, hook, prompt, sandbox) as the foundation for the Registry Update v1.0 epic. Each listing type gets a corresponding `{Type}Version` model that holds version-specific fields, enabling multiple versions per listing while keeping listing tables as identity-only containers.

## Fixes
* Part of #616

## Approach

- Created `{Type}Version` SQLAlchemy models for all 5 component types with all version-specific columns
- Added `latest_version_id` FK and `versions` relationship on each listing model
- Alembic migration creates version tables and migrates existing data with version='1.0.0'
- Added source integrity fields (`source_url`, `source_ref`, `resolved_sha`) per design review

## How Has This Been Tested?

- `alembic upgrade head` succeeds on fresh DB
- Existing listing data correctly migrated to version rows
- `latest_version_id` set on all listings after migration
- Model imports work: `from models.mcp import McpVersion` etc.
- All existing tests pass (`make test`)

## Checklist
- [x] All commits are signed off (`git commit -s`) per the DCO
- [x] You have a descriptive commit message with a short title
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots