### PR TITLE
feat(db): add AgentVersion table and restructure Agent to identity-only

### DIFF
--- a/observal-server/alembic/versions/0021_agent_version_tables.py
+++ b/observal-server/alembic/versions/0021_agent_version_tables.py
@@ -1,0 +1,246 @@
+"""add agent version tables and restructure agent to identity-only
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-04-30 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0021"
+down_revision: Union[str, Sequence[str], None] = "0020"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Reuse the existing agentstatus enum — do not create a new one.
+agent_status = postgresql.ENUM(
+    "draft", "pending", "approved", "rejected", "archived", name="agentstatus", create_type=False
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    conn = op.get_bind()
+
+    # ------------------------------------------------------------------
+    # 1. Rename 'active' -> 'approved' on the agentstatus enum
+    # ------------------------------------------------------------------
+    conn.execute(sa.text("ALTER TYPE agentstatus RENAME VALUE 'active' TO 'approved'"))
+
+    # ------------------------------------------------------------------
+    # 2. Create agent_versions table
+    # ------------------------------------------------------------------
+    op.create_table(
+        "agent_versions",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("agent_id", sa.UUID(), nullable=False),
+        sa.Column("version", sa.String(50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("prompt", sa.Text(), nullable=False, server_default=""),
+        sa.Column("model_name", sa.String(100), nullable=False, server_default=""),
+        sa.Column("model_config_json", sa.JSON(), server_default="{}"),
+        sa.Column("external_mcps", sa.JSON(), server_default="[]"),
+        sa.Column("supported_ides", sa.JSON(), server_default="[]"),
+        sa.Column("required_ide_features", sa.JSON(), server_default="[]"),
+        sa.Column("inferred_supported_ides", sa.JSON(), server_default="[]"),
+        sa.Column("yaml_snapshot", sa.Text(), nullable=True),
+        sa.Column("ide_configs", sa.JSON(), nullable=True),
+        sa.Column("lock_snapshot", sa.Text(), nullable=True),
+        sa.Column("status", agent_status, nullable=True, server_default="pending"),
+        sa.Column("is_prerelease", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("promoted_from", sa.UUID(), nullable=True),
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+        sa.Column("download_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("released_by", sa.UUID(), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("reviewed_by", sa.UUID(), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["agent_id"], ["agents.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["released_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["reviewed_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("agent_id", "version", name="uq_agent_versions_agent_version"),
+    )
+    op.create_index("ix_agent_versions_agent_id", "agent_versions", ["agent_id"])
+    op.create_index("ix_agent_versions_status", "agent_versions", ["status"])
+
+    # ------------------------------------------------------------------
+    # 3. Data migration: seed one agent_version row per existing agent
+    # ------------------------------------------------------------------
+    conn.execute(
+        sa.text("""
+        INSERT INTO agent_versions (
+            id, agent_id, version, description, prompt,
+            model_name, model_config_json, external_mcps,
+            supported_ides, required_ide_features, inferred_supported_ides,
+            status, rejection_reason, download_count,
+            released_by, released_at, created_at
+        )
+        SELECT
+            gen_random_uuid(),
+            id,
+            COALESCE(version, '1.0.0'),
+            description,
+            prompt,
+            model_name,
+            model_config_json,
+            external_mcps,
+            supported_ides,
+            required_ide_features,
+            inferred_supported_ides,
+            status,
+            rejection_reason,
+            download_count,
+            created_by,
+            created_at,
+            now()
+        FROM agents
+    """)
+    )
+
+    # ------------------------------------------------------------------
+    # 4. Add latest_version_id + co_maintainers to agents
+    # ------------------------------------------------------------------
+    op.add_column("agents", sa.Column("latest_version_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        "fk_agents_latest_version_id",
+        "agents",
+        "agent_versions",
+        ["latest_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.add_column("agents", sa.Column("co_maintainers", sa.JSON(), server_default="[]", nullable=False))
+
+    # Set latest_version_id to the newly created version row for each agent
+    conn.execute(
+        sa.text("""
+        UPDATE agents a
+        SET latest_version_id = av.id
+        FROM agent_versions av
+        WHERE av.agent_id = a.id
+    """)
+    )
+
+    # ------------------------------------------------------------------
+    # 5. Migrate agent_components: agent_id -> agent_version_id
+    # ------------------------------------------------------------------
+    op.add_column("agent_components", sa.Column("agent_version_id", sa.UUID(), nullable=True))
+    op.add_column(
+        "agent_components",
+        sa.Column("component_name", sa.String(255), server_default="", nullable=False),
+    )
+
+    conn.execute(
+        sa.text("""
+        UPDATE agent_components ac
+        SET agent_version_id = (
+            SELECT av.id
+            FROM agent_versions av
+            WHERE av.agent_id = ac.agent_id
+            LIMIT 1
+        )
+    """)
+    )
+
+    # Rename version_ref -> resolved_version and change type to varchar(50)
+    op.alter_column(
+        "agent_components",
+        "version_ref",
+        new_column_name="resolved_version",
+        type_=sa.String(50),
+        existing_type=sa.Text(),
+        existing_nullable=False,
+    )
+
+    # Make agent_version_id NOT NULL
+    op.alter_column("agent_components", "agent_version_id", nullable=False)
+
+    # Drop old constraints before dropping the column they reference
+    op.drop_constraint("uq_agent_components_agent_type_component", "agent_components", type_="unique")
+    op.drop_constraint("agent_components_agent_id_fkey", "agent_components", type_="foreignkey")
+    op.drop_column("agent_components", "agent_id")
+
+    # Add new unique constraint
+    op.create_unique_constraint(
+        "uq_agent_components_version_type_component",
+        "agent_components",
+        ["agent_version_id", "component_type", "component_id"],
+    )
+
+    # Add FK from agent_version_id to agent_versions.id
+    op.create_foreign_key(
+        "fk_agent_components_agent_version_id",
+        "agent_components",
+        "agent_versions",
+        ["agent_version_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # ------------------------------------------------------------------
+    # 6. Migrate agent_goal_templates: agent_id -> agent_version_id
+    # ------------------------------------------------------------------
+    op.add_column("agent_goal_templates", sa.Column("agent_version_id", sa.UUID(), nullable=True))
+
+    conn.execute(
+        sa.text("""
+        UPDATE agent_goal_templates agt
+        SET agent_version_id = (
+            SELECT av.id
+            FROM agent_versions av
+            WHERE av.agent_id = agt.agent_id
+            LIMIT 1
+        )
+    """)
+    )
+
+    op.alter_column("agent_goal_templates", "agent_version_id", nullable=False)
+    op.drop_constraint("agent_goal_templates_agent_id_fkey", "agent_goal_templates", type_="foreignkey")
+    op.drop_column("agent_goal_templates", "agent_id")
+
+    op.create_foreign_key(
+        "fk_agent_goal_templates_agent_version_id",
+        "agent_goal_templates",
+        "agent_versions",
+        ["agent_version_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_unique_constraint(
+        "uq_agent_goal_templates_agent_version_id",
+        "agent_goal_templates",
+        ["agent_version_id"],
+    )
+
+    # ------------------------------------------------------------------
+    # 7. Drop version-specific columns from agents
+    # ------------------------------------------------------------------
+    op.drop_column("agents", "version")
+    op.drop_column("agents", "description")
+    op.drop_column("agents", "git_url")
+    op.drop_column("agents", "prompt")
+    op.drop_column("agents", "model_name")
+    op.drop_column("agents", "model_config_json")
+    op.drop_column("agents", "external_mcps")
+    op.drop_column("agents", "supported_ides")
+    op.drop_column("agents", "required_ide_features")
+    op.drop_column("agents", "inferred_supported_ides")
+    op.drop_column("agents", "status")
+    op.drop_column("agents", "rejection_reason")
+    op.drop_column("agents", "download_count")
+    op.drop_column("agents", "unique_users")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise NotImplementedError("Clean-break migration")

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -22,6 +22,7 @@ from models.agent import (
     AgentGoalTemplate,
     AgentStatus,
     AgentTeamAccess,
+    AgentVersion,
     AgentVisibility,
 )
 from models.agent_component import AgentComponent
@@ -51,10 +52,9 @@ from services.registry_telemetry import emit_registry_event
 
 router = APIRouter(prefix="/api/v1/agents", tags=["agents"])
 
-# Eager-load options for Agent queries to avoid MissingGreenlet in async
+# Eager-load options for Agent queries to avoid MissingGreenlet in async.
+# Agent.latest_version (selectin) auto-loads AgentVersion.components and .goal_template.
 _agent_load_options = [
-    selectinload(Agent.components),
-    selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections),
     selectinload(Agent.team_accesses),
 ]
 
@@ -98,7 +98,12 @@ async def _load_agent(
             return mine
 
     # Fall back to global name lookup — only active, org-scoped agents
-    stmt = select(Agent).where(Agent.name == agent_id, Agent.status == AgentStatus.active).options(*_agent_load_options)
+    stmt = (
+        select(Agent)
+        .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
+        .where(Agent.name == agent_id, AgentVersion.status == AgentStatus.approved)
+        .options(*_agent_load_options)
+    )
     if extra_conditions:
         stmt = stmt.where(*extra_conditions)
     if org_id is not None:
@@ -135,7 +140,7 @@ def _agent_to_response(
             component_type=comp.component_type,
             component_id=comp.component_id,
             component_name=name_map.get(str(comp.component_id), ""),
-            version_ref=comp.version_ref,
+            version_ref=comp.resolved_version,
             order=comp.order_index,
             config_override=comp.config_override,
         )
@@ -151,7 +156,22 @@ def _agent_to_response(
         ]
         goal_template = GoalTemplateResponse(description=agent.goal_template.description, sections=sections)
 
+    # Build agent_dict from table columns (identity fields) plus version-delegate properties.
     agent_dict = {c.key: getattr(agent, c.key) for c in Agent.__table__.columns}
+    for field in (
+        "version",
+        "description",
+        "prompt",
+        "model_name",
+        "model_config_json",
+        "external_mcps",
+        "supported_ides",
+        "required_ide_features",
+        "inferred_supported_ides",
+        "status",
+        "rejection_reason",
+    ):
+        agent_dict[field] = getattr(agent, field)
     agent_dict["mcp_links"] = mcp_links
     agent_dict["component_links"] = component_links
     agent_dict["goal_template"] = goal_template
@@ -245,14 +265,7 @@ async def create_agent(
 
     agent = Agent(
         name=req.name,
-        version=req.version,
-        description=req.description,
         owner=req.owner or current_user.username or current_user.email,
-        prompt=req.prompt,
-        model_name=req.model_name,
-        model_config_json=req.model_config_json,
-        external_mcps=[m.model_dump() for m in req.external_mcps],
-        supported_ides=req.supported_ides,
         visibility=req.visibility,
         created_by=current_user.id,
         owner_org_id=current_user.org_id,
@@ -263,15 +276,33 @@ async def create_agent(
     for acc in req.team_accesses:
         db.add(AgentTeamAccess(agent_id=agent.id, group_name=acc.group_name, permission=acc.permission))
 
+    version = AgentVersion(
+        agent_id=agent.id,
+        version=req.version,
+        description=req.description,
+        prompt=req.prompt,
+        model_name=req.model_name,
+        model_config_json=req.model_config_json,
+        external_mcps=[m.model_dump() for m in req.external_mcps],
+        supported_ides=req.supported_ides,
+        status=AgentStatus.pending,
+        released_by=current_user.id,
+    )
+    db.add(version)
+    await db.flush()
+
+    agent.latest_version_id = version.id
+
     # Legacy: mcp_server_ids → AgentComponent(type=mcp)
     order = 0
     for mid, listing in zip(req.mcp_server_ids, mcp_listings, strict=False):
         db.add(
             AgentComponent(
-                agent_id=agent.id,
+                agent_version_id=version.id,
                 component_type="mcp",
                 component_id=mid,
-                version_ref=listing.version,
+                component_name="",
+                resolved_version=listing.version,
                 order_index=order,
             )
         )
@@ -281,17 +312,18 @@ async def create_agent(
     for cref in req.components:
         db.add(
             AgentComponent(
-                agent_id=agent.id,
+                agent_version_id=version.id,
                 component_type=cref.component_type,
                 component_id=cref.component_id,
-                version_ref="latest",
+                component_name="",
+                resolved_version="latest",
                 order_index=order,
                 config_override=cref.config_override,
             )
         )
         order += 1
 
-    goal = AgentGoalTemplate(agent_id=agent.id, description=req.goal_template.description)
+    goal = AgentGoalTemplate(agent_version_id=version.id, description=req.goal_template.description)
     db.add(goal)
     await db.flush()
 
@@ -320,10 +352,10 @@ async def create_agent(
     # Build a lightweight stand-in so the inference function can iterate components
     class _AgentProxy:
         components = all_crefs
-        external_mcps = agent.external_mcps
+        external_mcps = version.external_mcps
 
-    agent.required_ide_features = infer_required_features(_AgentProxy(), skill_listings=skill_listings_map)
-    agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
+    version.required_ide_features = infer_required_features(_AgentProxy(), skill_listings=skill_listings_map)
+    version.inferred_supported_ides = compute_supported_ides(version.required_ide_features)
 
     try:
         await db.commit()
@@ -383,21 +415,23 @@ async def list_agents(
                     AgentTeamAccess.group_name.in_(user_groups)
                 )
 
-    base_filter = Agent.status == AgentStatus.active
+    base_filter = AgentVersion.status == AgentStatus.approved
     if not is_admin:
         base_filter = base_filter & visibility_filter
     search_filter = None
     if search:
         safe = escape_like(search)
-        search_filter = Agent.name.ilike(f"%{safe}%") | Agent.description.ilike(f"%{safe}%")
+        search_filter = Agent.name.ilike(f"%{safe}%") | AgentVersion.description.ilike(f"%{safe}%")
 
     # Org-scoping: when the caller belongs to an org, only show agents owned by that org
     org_filter = None
     if current_user is not None and current_user.org_id is not None:
         org_filter = Agent.owner_org_id == current_user.org_id
 
-    # Total count for pagination header (cheap: no joins, no eager loads)
-    count_stmt = select(func.count(Agent.id)).where(base_filter)
+    # Total count for pagination header
+    count_stmt = (
+        select(func.count(Agent.id)).join(AgentVersion, Agent.latest_version_id == AgentVersion.id).where(base_filter)
+    )
     if search_filter is not None:
         count_stmt = count_stmt.where(search_filter)
     if org_filter is not None:
@@ -405,7 +439,12 @@ async def list_agents(
     total = (await db.execute(count_stmt)).scalar_one()
     response.headers["X-Total-Count"] = str(total)
 
-    stmt = select(Agent).where(base_filter).options(selectinload(Agent.components))
+    stmt = (
+        select(Agent)
+        .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
+        .where(base_filter)
+        .options(*_agent_load_options)
+    )
     if search_filter is not None:
         stmt = stmt.where(search_filter)
     if org_filter is not None:
@@ -470,7 +509,7 @@ async def my_agents(
     stmt = (
         select(Agent)
         .where(Agent.created_by == current_user.id)
-        .options(selectinload(Agent.components))
+        .options(*_agent_load_options)
         .order_by(Agent.created_at.desc())
     )
     agents = (await db.execute(stmt)).scalars().all()
@@ -762,14 +801,13 @@ async def install_agent(
     agent = await _load_agent(
         db,
         agent_id,
-        extra_conditions=[Agent.status == AgentStatus.active],
         prefer_user_id=current_user.id,
         org_id=current_user.org_id,
     )
-    if not agent:
-        agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
-        if not agent or agent.created_by != current_user.id:
+    if not agent or (agent.status != AgentStatus.approved and agent.created_by != current_user.id):
+        if not agent:
             raise HTTPException(status_code=404, detail="Agent not found or not active")
+        raise HTTPException(status_code=404, detail="Agent not found or not active")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
@@ -1020,7 +1058,7 @@ async def delete_agent(
     perm = get_effective_agent_permission(agent, current_user)
     if perm != "owner" and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
-    if agent.status == AgentStatus.active and not is_admin:
+    if agent.status == AgentStatus.approved and not is_admin:
         raise HTTPException(status_code=400, detail="Cannot delete an approved listing. Contact an admin.")
 
     # Delete related records with correct type filters
@@ -1102,7 +1140,7 @@ async def unarchive_agent(
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.status != AgentStatus.archived:
         raise HTTPException(status_code=400, detail="Agent is not archived")
-    agent.status = AgentStatus.active
+    agent.status = AgentStatus.approved
     await db.commit()
 
     emit_registry_event(
@@ -1135,20 +1173,30 @@ async def save_draft(
     """Create an agent as a draft (relaxed validation, not submitted for review)."""
     agent = Agent(
         name=req.name,
+        owner=req.owner or current_user.username or current_user.email,
+        visibility=req.visibility,
+        created_by=current_user.id,
+        owner_org_id=current_user.org_id,
+    )
+    db.add(agent)
+    await db.flush()
+
+    version = AgentVersion(
+        agent_id=agent.id,
         version=req.version,
         description=req.description,
-        owner=req.owner or current_user.username or current_user.email,
         prompt=req.prompt,
         model_name=req.model_name,
         model_config_json=req.model_config_json,
         external_mcps=[m.model_dump() for m in req.external_mcps],
         supported_ides=req.supported_ides,
-        created_by=current_user.id,
-        owner_org_id=current_user.org_id,
         status=AgentStatus.draft,
+        released_by=current_user.id,
     )
-    db.add(agent)
+    db.add(version)
     await db.flush()
+
+    agent.latest_version_id = version.id
 
     # Legacy: mcp_server_ids -> AgentComponent(type=mcp)
     order = 0
@@ -1156,10 +1204,11 @@ async def save_draft(
         for mid in req.mcp_server_ids:
             db.add(
                 AgentComponent(
-                    agent_id=agent.id,
+                    agent_version_id=version.id,
                     component_type="mcp",
                     component_id=mid,
-                    version_ref="latest",
+                    component_name="",
+                    resolved_version="latest",
                     order_index=order,
                 )
             )
@@ -1169,16 +1218,17 @@ async def save_draft(
     for cref in req.components:
         db.add(
             AgentComponent(
-                agent_id=agent.id,
+                agent_version_id=version.id,
                 component_type=cref.component_type,
                 component_id=cref.component_id,
-                version_ref="latest",
+                component_name="",
+                resolved_version="latest",
                 order_index=order,
                 config_override=cref.config_override,
             )
         )
         order += 1
-    goal = AgentGoalTemplate(agent_id=agent.id, description=req.goal_template.description)
+    goal = AgentGoalTemplate(agent_version_id=version.id, description=req.goal_template.description)
     db.add(goal)
     await db.flush()
     for i, sec in enumerate(req.goal_template.sections):
@@ -1204,10 +1254,10 @@ async def save_draft(
 
     class _DraftProxy:
         components = all_crefs_draft
-        external_mcps = agent.external_mcps
+        external_mcps = version.external_mcps
 
-    agent.required_ide_features = infer_required_features(_DraftProxy(), skill_listings=skill_listings_map_draft)
-    agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
+    version.required_ide_features = infer_required_features(_DraftProxy(), skill_listings=skill_listings_map_draft)
+    version.inferred_supported_ides = compute_supported_ides(version.required_ide_features)
 
     await db.commit()
     agent = await _load_agent(db, str(agent.id))

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -805,8 +805,6 @@ async def install_agent(
         org_id=current_user.org_id,
     )
     if not agent or (agent.status != AgentStatus.approved and agent.created_by != current_user.id):
-        if not agent:
-            raise HTTPException(status_code=404, detail="Agent not found or not active")
         raise HTTPException(status_code=404, detail="Agent not found or not active")
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/observal-server/api/routes/bulk.py
+++ b/observal-server/api/routes/bulk.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role
-from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus
+from models.agent import Agent, AgentGoalSection, AgentGoalTemplate, AgentStatus, AgentVersion
 from models.agent_component import AgentComponent
 from models.user import User, UserRole
 from schemas.bulk import BulkAgentItem, BulkAgentRequest, BulkResult, BulkResultItem
@@ -29,31 +29,41 @@ async def _create_single_agent(
     user: User,
     db: AsyncSession,
 ) -> Agent:
-    """Create a single Agent row (with components and goal template) from a BulkAgentItem."""
+    """Create a single Agent + AgentVersion row (with components and goal template)."""
     agent = Agent(
         name=item.name,
+        owner=item.owner or user.email,
+        created_by=user.id,
+    )
+    db.add(agent)
+    await db.flush()
+
+    version = AgentVersion(
+        agent_id=agent.id,
         version=item.version,
         description=item.description,
-        owner=item.owner or user.email,
         prompt=item.prompt,
         model_name=item.model_name,
         model_config_json=item.model_config_json,
         external_mcps=item.external_mcps,
         supported_ides=item.supported_ides,
-        created_by=user.id,
         status=AgentStatus.pending,
+        released_by=user.id,
     )
-    db.add(agent)
+    db.add(version)
     await db.flush()
+
+    agent.latest_version_id = version.id
 
     # Attach components
     for i, comp in enumerate(item.components):
         db.add(
             AgentComponent(
-                agent_id=agent.id,
+                agent_version_id=version.id,
                 component_type=comp.get("component_type", "mcp"),
                 component_id=comp["component_id"],
-                version_ref="latest",
+                component_name=comp.get("component_name", ""),
+                resolved_version="latest",
                 order_index=i,
                 config_override=comp.get("config_override"),
             )
@@ -62,7 +72,7 @@ async def _create_single_agent(
     # Attach goal template when provided
     if item.goal_template:
         goal = AgentGoalTemplate(
-            agent_id=agent.id,
+            agent_version_id=version.id,
             description=item.goal_template.get("description", ""),
         )
         db.add(goal)

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -345,7 +345,7 @@ async def agent_leaderboard(
             )
         extra_stmt = extra_stmt.order_by(Agent.created_at.desc()).limit(limit - len(rows))
         extra = (await db.execute(extra_stmt)).scalars().all()
-        missing_ids = {a.created_by for a in extra} - set(email_map.keys())
+        missing_ids = {a.created_by for a in extra} - set(email_map)
         if missing_ids:
             extra_user_rows = await db.execute(
                 select(User.id, User.email, User.username).where(User.id.in_(missing_ids))
@@ -467,7 +467,7 @@ async def trends(
 
     submissions = {str(r.day.date()): r.cnt for r in mcp_rows.all()}
     users = {str(r.day.date()): r.cnt for r in user_rows.all()}
-    all_dates = sorted(set(list(submissions.keys()) + list(users.keys())))
+    all_dates = sorted(set(submissions) | set(users))
 
     result = [TrendPoint(date=d, submissions=submissions.get(d, 0), users=users.get(d, 0)) for d in all_dates]
     await audit(current_user, "dashboard.trends", resource_type="dashboard")

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.deps import get_db, require_role
 from api.sanitize import escape_like
 from config import settings
-from models.agent import Agent, AgentStatus
+from models.agent import Agent, AgentStatus, AgentVersion
 from models.download import AgentDownloadRecord
 from models.mcp import ListingStatus, McpDownload, McpListing
 from models.user import User, UserRole
@@ -177,7 +177,14 @@ async def overview_stats(
     total_mcps = (
         await db.scalar(select(func.count(McpListing.id)).where(McpListing.status == ListingStatus.approved)) or 0
     )
-    total_agents = await db.scalar(select(func.count(Agent.id)).where(Agent.status == AgentStatus.active)) or 0
+    total_agents = (
+        await db.scalar(
+            select(func.count(Agent.id))
+            .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
+            .where(AgentVersion.status == AgentStatus.approved)
+        )
+        or 0
+    )
     total_users = await db.scalar(select(func.count(User.id))) or 0
 
     days = _range_days(range_)
@@ -223,13 +230,14 @@ async def top_agents(
             AgentDownloadRecord.agent_id,
             func.count(AgentDownloadRecord.id).label("cnt"),
             Agent.name,
-            Agent.description,
+            AgentVersion.description,
             Agent.owner,
-            Agent.version,
+            AgentVersion.version,
         )
         .join(Agent, AgentDownloadRecord.agent_id == Agent.id)
-        .where(Agent.status == AgentStatus.active)
-        .group_by(AgentDownloadRecord.agent_id, Agent.name, Agent.description, Agent.owner, Agent.version)
+        .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
+        .where(AgentVersion.status == AgentStatus.approved)
+        .group_by(AgentDownloadRecord.agent_id, Agent.name, AgentVersion.description, Agent.owner, AgentVersion.version)
         .order_by(func.count(AgentDownloadRecord.id).desc())
         .limit(limit)
     )
@@ -278,13 +286,14 @@ async def agent_leaderboard(
             AgentDownloadRecord.agent_id,
             func.count(AgentDownloadRecord.id).label("cnt"),
             Agent.name,
-            Agent.description,
+            AgentVersion.description,
             Agent.owner,
-            Agent.version,
+            AgentVersion.version,
             Agent.created_by,
         )
         .join(Agent, AgentDownloadRecord.agent_id == Agent.id)
-        .where(Agent.status == AgentStatus.active)
+        .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
+        .where(AgentVersion.status == AgentStatus.approved)
     )
     if user:
         stmt = stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{escape_like(user)}%"))
@@ -294,9 +303,9 @@ async def agent_leaderboard(
     group_cols = [
         AgentDownloadRecord.agent_id,
         Agent.name,
-        Agent.description,
+        AgentVersion.description,
         Agent.owner,
-        Agent.version,
+        AgentVersion.version,
         Agent.created_by,
     ]
     stmt = stmt.group_by(*group_cols).order_by(func.count(AgentDownloadRecord.id).desc()).limit(limit)
@@ -325,7 +334,11 @@ async def agent_leaderboard(
     # Also include agents with no downloads if window=all and we have fewer than limit
     if window == "all" and len(rows) < limit:
         existing_ids = {r.agent_id for r in rows}
-        extra_stmt = select(Agent).where(Agent.status == AgentStatus.active, Agent.id.notin_(existing_ids))
+        extra_stmt = (
+            select(Agent)
+            .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
+            .where(AgentVersion.status == AgentStatus.approved, Agent.id.notin_(existing_ids))
+        )
         if user:
             extra_stmt = extra_stmt.join(User, Agent.created_by == User.id).where(
                 User.email.ilike(f"%{escape_like(user)}%")

--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from api.deps import get_db, require_role, resolve_prefix_id
-from models.agent import Agent, AgentGoalTemplate
+from models.agent import Agent
 from models.eval import EvalRun, EvalRunStatus, Scorecard
 from models.user import User, UserRole
 from schemas.eval import EvalRequest, EvalRunDetailResponse, EvalRunResponse, ScorecardResponse
@@ -44,7 +44,7 @@ async def run_evaluation(
         Agent,
         agent_id,
         db,
-        load_options=[selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections)],
+        load_options=[selectinload(Agent.team_accesses)],
     )
 
     # Org-scope check: verify agent belongs to user's org
@@ -290,7 +290,7 @@ async def eval_session(
             Agent,
             agent_id,
             db,
-            load_options=[selectinload(Agent.goal_template).selectinload(AgentGoalTemplate.sections)],
+            load_options=[selectinload(Agent.team_accesses)],
         )
         # Org-scope check: verify agent belongs to user's org
         if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -5,11 +5,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import String, cast, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from api.deps import get_db, require_role, resolve_prefix_id
 from api.sanitize import escape_like
-from models.agent import Agent, AgentStatus
+from models.agent import Agent, AgentStatus, AgentVersion
 from models.component_bundle import ComponentBundle
 from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
@@ -93,8 +92,8 @@ async def _check_agent_components_ready(agent: Agent, db: AsyncSession) -> tuple
 async def _query_pending_agents(db: AsyncSession) -> list[dict]:
     result = await db.execute(
         select(Agent)
-        .where(Agent.status == AgentStatus.pending)
-        .options(selectinload(Agent.components))
+        .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
+        .where(AgentVersion.status == AgentStatus.pending)
         .order_by(Agent.created_at.desc())
     )
     agents = result.scalars().all()
@@ -367,9 +366,7 @@ async def get_review(
             agent_uuid = uuid.UUID(listing_id)
         except ValueError:
             raise HTTPException(status_code=404, detail="Listing not found")
-        agent = (
-            await db.execute(select(Agent).where(Agent.id == agent_uuid).options(selectinload(Agent.components)))
-        ).scalar_one_or_none()
+        agent = (await db.execute(select(Agent).where(Agent.id == agent_uuid))).scalar_one_or_none()
         if not agent:
             raise HTTPException(status_code=404, detail="Listing not found")
         components_ready, blocking = await _check_agent_components_ready(agent, db)
@@ -488,9 +485,7 @@ async def approve_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
-    agent = (
-        await db.execute(select(Agent).where(Agent.id == agent_id).options(selectinload(Agent.components)))
-    ).scalar_one_or_none()
+    agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.status != AgentStatus.pending:
@@ -506,7 +501,7 @@ async def approve_agent(
             },
         )
 
-    agent.status = AgentStatus.active
+    agent.status = AgentStatus.approved
     agent.rejection_reason = None
     await db.commit()
     await audit(
@@ -529,7 +524,7 @@ async def reject_agent(
     agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
-    if agent.status not in (AgentStatus.pending, AgentStatus.active):
+    if agent.status not in (AgentStatus.pending, AgentStatus.approved):
         raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', cannot reject")
 
     agent.status = AgentStatus.rejected

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -12,7 +12,7 @@ from models.base import Base
 class AgentStatus(str, enum.Enum):
     draft = "draft"
     pending = "pending"
-    active = "active"
+    approved = "approved"
     rejected = "rejected"
     archived = "archived"
 
@@ -35,31 +35,70 @@ class AgentTeamAccess(Base):
     agent: Mapped["Agent"] = relationship(back_populates="team_accesses")
 
 
-class Agent(Base):
-    __tablename__ = "agents"
-    __table_args__ = (UniqueConstraint("name", "created_by", name="uq_agents_name_created_by"),)
+class AgentVersion(Base):
+    __tablename__ = "agent_versions"
+    __table_args__ = (
+        UniqueConstraint("agent_id", "version", name="uq_agent_versions_agent_version"),
+        Index("ix_agent_versions_agent_id", "agent_id"),
+        Index("ix_agent_versions_status", "status"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
+    )
     version: Mapped[str] = mapped_column(String(50), nullable=False)
-    description: Mapped[str] = mapped_column(Text, nullable=False)
-    owner: Mapped[str] = mapped_column(String(255), nullable=False)
-    git_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
-    prompt: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    prompt: Mapped[str] = mapped_column(Text, nullable=False, default="")
     model_name: Mapped[str] = mapped_column(String(100), nullable=False)
     model_config_json: Mapped[dict] = mapped_column(JSON, default=dict)
     external_mcps: Mapped[list] = mapped_column(JSON, default=list)
     supported_ides: Mapped[list] = mapped_column(JSON, default=list)
     required_ide_features: Mapped[list] = mapped_column(JSON, default=list)
     inferred_supported_ides: Mapped[list] = mapped_column(JSON, default=list)
+    yaml_snapshot: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ide_configs: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    lock_snapshot: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[AgentStatus] = mapped_column(Enum(AgentStatus), default=AgentStatus.pending)
+    is_prerelease: Mapped[bool] = mapped_column(Boolean, default=False)
+    promoted_from: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    download_count: Mapped[int] = mapped_column(Integer, default=0)
+    released_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    released_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+
+    agent: Mapped["Agent"] = relationship(back_populates="versions", foreign_keys=[agent_id])
+    components: Mapped[list["AgentComponent"]] = relationship(
+        back_populates="agent_version",
+        lazy="selectin",
+        order_by="AgentComponent.order_index",
+        cascade="all, delete-orphan",
+    )
+    goal_template: Mapped["AgentGoalTemplate | None"] = relationship(
+        back_populates="agent_version", lazy="selectin", uselist=False, cascade="all, delete-orphan"
+    )
+
+
+class Agent(Base):
+    __tablename__ = "agents"
+    __table_args__ = (UniqueConstraint("name", "created_by", name="uq_agents_name_created_by"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    owner: Mapped[str] = mapped_column(String(255), nullable=False)
     visibility: Mapped[AgentVisibility] = mapped_column(Enum(AgentVisibility), default=AgentVisibility.private)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
-    status: Mapped[AgentStatus] = mapped_column(Enum(AgentStatus), default=AgentStatus.pending)
-    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
-    download_count: Mapped[int] = mapped_column(Integer, default=0)
-    unique_users: Mapped[int] = mapped_column(Integer, default=0)
+    co_maintainers: Mapped[list] = mapped_column(JSON, default=list)
+    latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_versions.id", use_alter=True, ondelete="SET NULL"),
+        nullable=True,
+    )
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(
@@ -68,27 +107,124 @@ class Agent(Base):
         onupdate=lambda: datetime.now(UTC),
     )
 
-    components: Mapped[list["AgentComponent"]] = relationship(
-        back_populates="agent", lazy="selectin", order_by="AgentComponent.order_index", cascade="all, delete-orphan"
+    versions: Mapped[list["AgentVersion"]] = relationship(
+        back_populates="agent",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+        foreign_keys="AgentVersion.agent_id",
     )
-    goal_template: Mapped["AgentGoalTemplate | None"] = relationship(
-        back_populates="agent", lazy="selectin", uselist=False, cascade="all, delete-orphan"
+    latest_version: Mapped["AgentVersion | None"] = relationship(
+        foreign_keys=[latest_version_id], lazy="selectin", uselist=False
     )
     team_accesses: Mapped[list["AgentTeamAccess"]] = relationship(
         back_populates="agent", lazy="selectin", cascade="all, delete-orphan"
     )
+
+    # ------------------------------------------------------------------
+    # Deprecated compatibility properties — delegate to latest_version.
+    # These allow existing route/service code to keep working until the
+    # version-aware API endpoints (issues #620/#621) replace them.
+    # ------------------------------------------------------------------
+    @property
+    def version(self) -> str:
+        return self.latest_version.version if self.latest_version else "0.0.0"
+
+    @property
+    def description(self) -> str:
+        return self.latest_version.description if self.latest_version else ""
+
+    @property
+    def prompt(self) -> str:
+        return self.latest_version.prompt if self.latest_version else ""
+
+    @property
+    def model_name(self) -> str:
+        return self.latest_version.model_name if self.latest_version else ""
+
+    @property
+    def model_config_json(self) -> dict:
+        return self.latest_version.model_config_json if self.latest_version else {}
+
+    @property
+    def external_mcps(self) -> list:
+        return self.latest_version.external_mcps if self.latest_version else []
+
+    @external_mcps.setter
+    def external_mcps(self, value: list) -> None:
+        if self.latest_version:
+            self.latest_version.external_mcps = value
+
+    @property
+    def supported_ides(self) -> list:
+        return self.latest_version.supported_ides if self.latest_version else []
+
+    @property
+    def required_ide_features(self) -> list:
+        return self.latest_version.required_ide_features if self.latest_version else []
+
+    @required_ide_features.setter
+    def required_ide_features(self, value: list) -> None:
+        if self.latest_version:
+            self.latest_version.required_ide_features = value
+
+    @property
+    def inferred_supported_ides(self) -> list:
+        return self.latest_version.inferred_supported_ides if self.latest_version else []
+
+    @inferred_supported_ides.setter
+    def inferred_supported_ides(self, value: list) -> None:
+        if self.latest_version:
+            self.latest_version.inferred_supported_ides = value
+
+    @property
+    def status(self) -> "AgentStatus":
+        return self.latest_version.status if self.latest_version else AgentStatus.draft
+
+    @status.setter
+    def status(self, value: "AgentStatus") -> None:
+        if self.latest_version:
+            self.latest_version.status = value
+
+    @property
+    def rejection_reason(self) -> str | None:
+        return self.latest_version.rejection_reason if self.latest_version else None
+
+    @rejection_reason.setter
+    def rejection_reason(self, value: str | None) -> None:
+        if self.latest_version:
+            self.latest_version.rejection_reason = value
+
+    @property
+    def download_count(self) -> int:
+        return self.latest_version.download_count if self.latest_version else 0
+
+    @property
+    def unique_users(self) -> int:
+        return 0
+
+    @property
+    def git_url(self) -> str | None:
+        return None
+
+    @property
+    def components(self) -> list:
+        return self.latest_version.components if self.latest_version else []
+
+    @property
+    def goal_template(self):
+        return self.latest_version.goal_template if self.latest_version else None
 
 
 class AgentGoalTemplate(Base):
     __tablename__ = "agent_goal_templates"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), unique=True, nullable=False
+    agent_version_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agent_versions.id", ondelete="CASCADE"), unique=True, nullable=False
     )
     description: Mapped[str] = mapped_column(Text, nullable=False)
 
-    agent: Mapped["Agent"] = relationship(back_populates="goal_template")
+    agent_version: Mapped["AgentVersion"] = relationship(back_populates="goal_template")
     sections: Mapped[list["AgentGoalSection"]] = relationship(
         back_populates="goal_template", lazy="selectin", order_by="AgentGoalSection.order", cascade="all, delete-orphan"
     )
@@ -111,4 +247,4 @@ class AgentGoalSection(Base):
 
 from models.agent_component import AgentComponent  # noqa: E402
 
-AgentComponent.agent = relationship("Agent", back_populates="components")
+AgentComponent.agent_version = relationship("AgentVersion", back_populates="components")

--- a/observal-server/models/agent_component.py
+++ b/observal-server/models/agent_component.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -11,16 +11,22 @@ from models.base import Base
 class AgentComponent(Base):
     __tablename__ = "agent_components"
     __table_args__ = (
-        UniqueConstraint("agent_id", "component_type", "component_id", name="uq_agent_components_agent_type_component"),
+        UniqueConstraint(
+            "agent_version_id",
+            "component_type",
+            "component_id",
+            name="uq_agent_components_version_type_component",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
+    agent_version_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agent_versions.id", ondelete="CASCADE"), nullable=False
     )
     component_type: Mapped[str] = mapped_column(String(50), nullable=False)
     component_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
-    version_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    component_name: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    resolved_version: Mapped[str] = mapped_column(String(50), nullable=False)
     order_index: Mapped[int] = mapped_column(Integer, default=0)
     config_override: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/observal-server/tests/test_multi_tenancy.py
+++ b/observal-server/tests/test_multi_tenancy.py
@@ -14,7 +14,7 @@ import pytest
 from fastapi import HTTPException
 
 from api.deps import get_project_id, optional_current_user, require_org_scope, require_role
-from models.agent import Agent, AgentStatus
+from models.agent import Agent, AgentStatus, AgentVersion
 from models.organization import Organization
 from models.user import User, UserRole
 
@@ -49,18 +49,30 @@ def _make_agent(
     name: str = "test-agent",
     org: Organization | None = None,
 ) -> Agent:
-    return Agent(
-        id=uuid.uuid4(),
-        name=name,
+    agent_id = uuid.uuid4()
+    version_id = uuid.uuid4()
+    version = AgentVersion(
+        id=version_id,
+        agent_id=agent_id,
         version="1.0.0",
         description="A test agent",
-        owner="test-owner",
         prompt="You are a test agent.",
         model_name="claude-sonnet-4-5-20250514",
+        status=AgentStatus.approved,
+        released_by=user.id,
+    )
+    agent = Agent(
+        id=agent_id,
+        name=name,
+        owner="test-owner",
         created_by=user.id,
         owner_org_id=org.id if org else user.org_id,
-        status=AgentStatus.active,
+        latest_version_id=version_id,
     )
+    # Wire up the relationship for in-memory access
+    agent.latest_version = version
+    agent.versions = [version]
+    return agent
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_name_lookup.py
+++ b/tests/test_agent_name_lookup.py
@@ -53,7 +53,7 @@ def _app_with(user=None, db=None):
     return app, db, user
 
 
-def _agent_mock(status=AgentStatus.active, created_by=None, **extra):
+def _agent_mock(status=AgentStatus.approved, created_by=None, **extra):
     m = MagicMock()
     m.id = extra.get("id", uuid.uuid4())
     m.name = extra.get("name", "test-agent")

--- a/tests/test_agent_review.py
+++ b/tests/test_agent_review.py
@@ -105,8 +105,8 @@ class TestAgentApprove:
             r = await ac.post(f"/api/v1/review/agents/{agent.id}/approve")
 
         assert r.status_code == 200
-        assert agent.status == AgentStatus.active
-        assert r.json()["status"] == "active"
+        assert agent.status == AgentStatus.approved
+        assert r.json()["status"] == "approved"
         db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -154,7 +154,7 @@ class TestAgentApprove:
         data = r.json()
         assert data["name"] == "my-agent"
         assert data["id"] == str(agent.id)
-        assert data["status"] == "active"
+        assert data["status"] == "approved"
 
 
 # ═══════════════════════════════════════════════════════════
@@ -188,7 +188,7 @@ class TestAgentReject:
     async def test_reject_active_agent(self):
         """An active agent can also be rejected."""
         app, db, _ = _app_with()
-        agent = _agent_mock(status=AgentStatus.active)
+        agent = _agent_mock(status=AgentStatus.approved)
         db.execute = AsyncMock(return_value=_result_with_agent(agent))
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -328,7 +328,7 @@ class TestDraftSubmitNotDraft:
         """Submitting an active agent returns 400."""
         user = _user()
         app, db, _ = _app_with(user=user)
-        agent = _agent_mock(status=AgentStatus.active, created_by=user.id)
+        agent = _agent_mock(status=AgentStatus.approved, created_by=user.id)
         mock_load.return_value = agent
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:

--- a/tests/test_schema_redesign.py
+++ b/tests/test_schema_redesign.py
@@ -185,24 +185,27 @@ class TestAgentModelUpdate:
         assert "visibility" in cols
         assert "owner_org_id" in cols
 
-    def test_agent_has_git_url(self):
+    def test_agent_has_version_fields(self):
         from models.agent import Agent
 
         cols = {c.name for c in Agent.__table__.columns}
-        assert "git_url" in cols
+        assert "latest_version_id" in cols
+        assert "co_maintainers" in cols
 
-    def test_agent_has_download_metrics(self):
-        from models.agent import Agent
+    def test_agent_version_has_download_metrics(self):
+        from models.agent import AgentVersion
 
-        cols = {c.name for c in Agent.__table__.columns}
+        cols = {c.name for c in AgentVersion.__table__.columns}
         assert "download_count" in cols
-        assert "unique_users" in cols
 
-    def test_agent_git_url_is_nullable(self):
+    def test_agent_is_identity_only(self):
         from models.agent import Agent
 
-        git_col = Agent.__table__.c.git_url
-        assert git_col.nullable is True
+        cols = {c.name for c in Agent.__table__.columns}
+        # These moved to AgentVersion
+        assert "prompt" not in cols
+        assert "model_name" not in cols
+        assert "description" not in cols
 
     def test_agent_mcp_link_removed(self):
         """AgentMcpLink should no longer exist — replaced by AgentComponent."""
@@ -223,10 +226,11 @@ class TestAgentComponentModel:
         cols = {c.name for c in AgentComponent.__table__.columns}
         required = {
             "id",
-            "agent_id",
+            "agent_version_id",
             "component_type",
             "component_id",
-            "version_ref",
+            "component_name",
+            "resolved_version",
             "order_index",
             "config_override",
             "created_at",
@@ -239,7 +243,7 @@ class TestAgentComponentModel:
         table = AgentComponent.__table__
         unique_constraints = [uc for uc in table.constraints if hasattr(uc, "columns") and len(uc.columns) == 3]
         col_sets = [frozenset(c.name for c in uc.columns) for uc in unique_constraints]
-        assert frozenset({"agent_id", "component_type", "component_id"}) in col_sets
+        assert frozenset({"agent_version_id", "component_type", "component_id"}) in col_sets
 
     def test_agent_component_no_fk_on_component_id(self):
         """component_id should NOT have a FK constraint (polymorphic, future flexibility)."""
@@ -443,15 +447,11 @@ class TestDownloadTracking:
         # Only the PK constraint, no multi-column uniques
         assert len(unique_constraints) == 0
 
-    def test_agent_has_download_count_fields(self):
-        from models.agent import Agent
+    def test_agent_version_has_download_count_field(self):
+        from models.agent import AgentVersion
 
-        assert hasattr(Agent, "download_count")
-        assert hasattr(Agent, "unique_users")
-        col_dl = Agent.__table__.columns["download_count"]
-        col_uu = Agent.__table__.columns["unique_users"]
+        col_dl = AgentVersion.__table__.columns["download_count"]
         assert col_dl.default.arg == 0
-        assert col_uu.default.arg == 0
 
     def test_download_tracker_module_exists(self):
         from services.download_tracker import (


### PR DESCRIPTION
## Purpose / Description

Adds `agent_versions` table and restructures the `agents` table to identity-only, matching the same pattern applied to component listings. This enables multiple versions per agent with independent status, config snapshots, and download counts.

## Fixes
* Closes #617

## Approach

- Added `agent_versions` table with all version-specific fields (prompt, model, IDE configs, yaml/lock snapshots, status, download count)
- Restructured `agents` table to identity-only: keeps id, name, owner, visibility, co_maintainers, latest_version_id
- Migrated `agent_components` FK from `agent_id` → `agent_version_id`; renamed `version_ref` → `resolved_version`; added `component_name`
- Migrated `agent_goal_templates` FK from `agent_id` → `agent_version_id`
- Renamed `AgentStatus.active` → `AgentStatus.approved` for consistency with component listings
- Data migration creates one version row per existing agent, links `latest_version_id`

## How Has This Been Tested?

- Migration tested locally with seeded data in PostgreSQL 16
- Models import cleanly (`python -c "from models.agent import Agent, AgentVersion, AgentStatus"`)
- Constraint ordering verified (drop unique before dropping column it references)
- CI lint passes

## Learning

The migration order matters: must drop unique constraints referencing a column before dropping the column itself. Also, `create_type=False` is needed for `postgresql.ENUM` when reusing an existing PG enum type.

## Checklist
- [x] All commits are signed off (`git commit -s`) per the DCO
- [x] You have a descriptive commit message with a short title
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots