### PR TITLE
feat(api): component versioning endpoints for all 5 types

### DIFF
--- a/observal-server/api/routes/component_versions.py
+++ b/observal-server/api/routes/component_versions.py
@@ -1,0 +1,324 @@
+"""Factory that generates versioning sub-routers for all 5 component types.
+
+Usage in each type's route file::
+
+    from api.routes.component_versions import create_version_router
+    router.include_router(create_version_router("mcp", McpListing, McpVersion))
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
+
+from api.deps import get_db, require_role, resolve_listing
+from models.mcp import ListingStatus
+from models.user import User, UserRole
+from schemas.component_version import VersionPublishRequest, VersionReviewRequest  # noqa: TC001
+from services.audit_helpers import audit
+
+# Semver pattern: X.Y.Z or X.Y.Z-prerelease
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$")
+
+
+def _parse_semver(v: str) -> tuple[int, ...]:
+    """Parse 'X.Y.Z' or 'X.Y.Z-pre' into (X, Y, Z) for comparison."""
+    base = v.split("-", 1)[0]
+    return tuple(int(p) for p in base.split("."))
+
+
+def _version_to_dict(v) -> dict:
+    """Serialize a version ORM object to a plain dict for API responses."""
+    d = {
+        "id": str(v.id),
+        "listing_id": str(v.listing_id),
+        "version": v.version,
+        "description": v.description,
+        "changelog": v.changelog,
+        "status": v.status.value if hasattr(v.status, "value") else v.status,
+        "rejection_reason": v.rejection_reason,
+        "download_count": v.download_count,
+        "supported_ides": v.supported_ides,
+        "released_by": str(v.released_by),
+        "released_at": v.released_at,
+        "created_at": v.created_at,
+    }
+    # Optional fields present on MCP and Sandbox versions
+    for attr in ("source_url", "source_ref", "resolved_sha"):
+        if hasattr(v, attr):
+            d[attr] = getattr(v, attr)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Standalone async functions (exposed for direct testing)
+# ---------------------------------------------------------------------------
+
+
+async def _list_versions(
+    listing_id: str,
+    page: int,
+    page_size: int,
+    listing_model,
+    version_model,
+    db: AsyncSession,
+    current_user: User,
+) -> dict:
+    listing = await resolve_listing(listing_model, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+
+    offset = (page - 1) * page_size
+    stmt = (
+        select(version_model)
+        .where(version_model.listing_id == listing.id)
+        .order_by(version_model.released_at.desc())
+        .offset(offset)
+        .limit(page_size)
+    )
+    result = await db.execute(stmt)
+    versions = result.scalars().all()
+
+    count_stmt = select(func.count(version_model.id)).where(version_model.listing_id == listing.id)
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    return {
+        "items": [_version_to_dict(v) for v in versions],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }
+
+
+async def _get_version(
+    listing_id: str,
+    version: str,
+    listing_model,
+    version_model,
+    db: AsyncSession,
+    current_user: User,
+) -> dict:
+    listing = await resolve_listing(listing_model, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+
+    stmt = select(version_model).where(
+        version_model.listing_id == listing.id,
+        version_model.version == version,
+    )
+    result = await db.execute(stmt)
+    ver = result.scalar_one_or_none()
+    if not ver:
+        raise HTTPException(status_code=404, detail="Version not found")
+
+    return _version_to_dict(ver)
+
+
+async def _publish_version(
+    listing_id: str,
+    req: VersionPublishRequest,
+    listing_model,
+    version_model,
+    component_type: str,
+    db: AsyncSession,
+    current_user: User,
+) -> dict:
+    if not SEMVER_RE.match(req.version):
+        raise HTTPException(status_code=422, detail=f"Invalid semver string: {req.version!r}")
+
+    listing = await resolve_listing(listing_model, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Only the listing owner can publish versions")
+
+    # Duplicate check
+    dup_stmt = select(version_model).where(
+        version_model.listing_id == listing.id,
+        version_model.version == req.version,
+    )
+    dup_result = await db.execute(dup_stmt)
+    if dup_result.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail=f"Version {req.version!r} already exists for this listing")
+
+    # TODO(#621): type-specific fields (transport, event, template, etc.) are not
+    # populated here. The existing submit/draft routes handle initial version
+    # creation with full fields. This endpoint currently supports metadata-only
+    # subsequent versions. Full type-specific field support requires per-type
+    # validation of req.extra — planned for the CLI release flow (#625).
+    now = datetime.now(UTC)
+    ver = version_model(
+        listing_id=listing.id,
+        version=req.version,
+        description=req.description,
+        changelog=req.changelog,
+        supported_ides=req.supported_ides or [],
+        status=ListingStatus.pending,
+        released_by=current_user.id,
+        released_at=now,
+    )
+    db.add(ver)
+    await db.commit()
+
+    await audit(
+        current_user,
+        f"{component_type}.version.publish",
+        resource_type=component_type,
+        resource_id=str(listing.id),
+        resource_name=getattr(listing, "name", ""),
+        detail=req.version,
+    )
+
+    return _version_to_dict(ver)
+
+
+async def _review_version(
+    listing_id: str,
+    version: str,
+    req: VersionReviewRequest,
+    listing_model,
+    version_model,
+    component_type: str,
+    db: AsyncSession,
+    current_user: User,
+) -> dict:
+    listing = await resolve_listing(listing_model, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+
+    stmt = select(version_model).where(
+        version_model.listing_id == listing.id,
+        version_model.version == version,
+    )
+    result = await db.execute(stmt)
+    ver = result.scalar_one_or_none()
+    if not ver:
+        raise HTTPException(status_code=404, detail="Version not found")
+
+    if ver.status != ListingStatus.pending:
+        raise HTTPException(
+            status_code=422, detail=f"Version is {ver.status.value!r}, only pending versions can be reviewed"
+        )
+
+    if req.action == "approve":
+        ver.status = ListingStatus.approved
+        ver.rejection_reason = None
+        # Only update latest if this version is newer than current latest
+        current_latest = listing.latest_version
+        if not current_latest or _parse_semver(ver.version) >= _parse_semver(current_latest.version):
+            listing.latest_version_id = ver.id
+    else:
+        ver.status = ListingStatus.rejected
+        ver.rejection_reason = req.reason
+
+    ver.reviewed_by = current_user.id
+    ver.reviewed_at = datetime.now(UTC)
+
+    await db.commit()
+
+    await audit(
+        current_user,
+        f"{component_type}.version.{req.action}",
+        resource_type=component_type,
+        resource_id=str(listing.id),
+        resource_name=getattr(listing, "name", ""),
+        detail=version,
+    )
+
+    return {
+        "version": version,
+        "new_status": ver.status.value,
+        "reason": ver.rejection_reason,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_version_router(
+    component_type: str,
+    listing_model,
+    version_model,
+) -> APIRouter:
+    """Return an APIRouter with 4 version endpoints for the given component type."""
+
+    router = APIRouter(tags=[f"{component_type}-versions"])
+
+    @router.get("/{listing_id}/versions")
+    async def list_versions(
+        listing_id: str,
+        page: int = Query(1, ge=1),
+        page_size: int = Query(20, ge=1, le=100),
+        db: AsyncSession = Depends(get_db),
+        current_user: User = Depends(require_role(UserRole.user)),
+    ):
+        return await _list_versions(
+            listing_id=listing_id,
+            page=page,
+            page_size=page_size,
+            listing_model=listing_model,
+            version_model=version_model,
+            db=db,
+            current_user=current_user,
+        )
+
+    @router.get("/{listing_id}/versions/{version}")
+    async def get_version(
+        listing_id: str,
+        version: str,
+        db: AsyncSession = Depends(get_db),
+        current_user: User = Depends(require_role(UserRole.user)),
+    ):
+        return await _get_version(
+            listing_id=listing_id,
+            version=version,
+            listing_model=listing_model,
+            version_model=version_model,
+            db=db,
+            current_user=current_user,
+        )
+
+    @router.post("/{listing_id}/versions")
+    async def publish_version(
+        listing_id: str,
+        req: VersionPublishRequest,
+        db: AsyncSession = Depends(get_db),
+        current_user: User = Depends(require_role(UserRole.user)),
+    ):
+        return await _publish_version(
+            listing_id=listing_id,
+            req=req,
+            listing_model=listing_model,
+            version_model=version_model,
+            component_type=component_type,
+            db=db,
+            current_user=current_user,
+        )
+
+    @router.post("/{listing_id}/versions/{version}/review")
+    async def review_version(
+        listing_id: str,
+        version: str,
+        req: VersionReviewRequest,
+        db: AsyncSession = Depends(get_db),
+        current_user: User = Depends(require_role(UserRole.reviewer)),
+    ):
+        return await _review_version(
+            listing_id=listing_id,
+            version=version,
+            req=req,
+            listing_model=listing_model,
+            version_model=version_model,
+            component_type=component_type,
+            db=db,
+            current_user=current_user,
+        )
+
+    return router

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.hook import HookDownload, HookListing, HookVersion
 from models.mcp import ListingStatus
@@ -312,3 +313,7 @@ async def delete_hook(
         current_user, "hook.delete", resource_type="hook", resource_id=str(listing_id), resource_name=listing_name
     )
     return {"deleted": str(listing_id)}
+
+
+# --- Version sub-routes ---
+router.include_router(create_version_router("hook", HookListing, HookVersion))

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -6,6 +6,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from database import async_session
 from models.mcp import ListingStatus, McpDownload, McpListing, McpValidationResult, McpVersion
@@ -432,3 +433,7 @@ async def delete_mcp(
         current_user, "mcp.delete", resource_type="mcp", resource_id=str(listing_id), resource_name=listing_name
     )
     return {"deleted": str(listing_id)}
+
+
+# --- Version sub-routes ---
+router.include_router(create_version_router("mcp", McpListing, McpVersion))

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.prompt import PromptDownload, PromptListing, PromptVersion
@@ -365,3 +366,7 @@ async def delete_prompt(
         current_user, "prompt.delete", resource_type="prompt", resource_id=str(listing_id), resource_name=listing_name
     )
     return {"deleted": str(listing_id)}
+
+
+# --- Version sub-routes ---
+router.include_router(create_version_router("prompt", PromptListing, PromptVersion))

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.sandbox import SandboxDownload, SandboxListing, SandboxVersion
@@ -333,3 +334,7 @@ async def delete_sandbox(
         current_user, "sandbox.delete", resource_type="sandbox", resource_id=str(listing_id), resource_name=listing_name
     )
     return {"deleted": str(listing_id)}
+
+
+# --- Version sub-routes ---
+router.include_router(create_version_router("sandbox", SandboxListing, SandboxVersion))

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.skill import SkillDownload, SkillListing, SkillVersion
@@ -329,3 +330,7 @@ async def delete_skill(
         current_user, "skill.delete", resource_type="skill", resource_id=str(listing_id), resource_name=listing_name
     )
     return {"deleted": str(listing_id)}
+
+
+# --- Version sub-routes ---
+router.include_router(create_version_router("skill", SkillListing, SkillVersion))

--- a/observal-server/schemas/component_version.py
+++ b/observal-server/schemas/component_version.py
@@ -1,0 +1,20 @@
+"""Shared Pydantic schemas for component version API endpoints."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class VersionPublishRequest(BaseModel):
+    version: str
+    description: str
+    changelog: str | None = None
+    supported_ides: list[str] = []
+    extra: dict | None = None
+
+
+class VersionReviewRequest(BaseModel):
+    action: Literal["approve", "reject"]
+    reason: str | None = None

--- a/observal-server/tests/test_component_versions_api.py
+++ b/observal-server/tests/test_component_versions_api.py
@@ -1,0 +1,621 @@
+"""Tests for the component version API (factory-generated endpoints).
+
+Tests are parametrized over all 5 component types.  They use MagicMock for the
+DB session and FastAPI dependency overrides so no real database is needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.mcp import ListingStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SEMVER_VALID = "1.2.3"
+SEMVER_VALID_PRE = "1.2.3-beta.1"
+SEMVER_INVALID = "not-a-version"
+
+
+def _make_version(listing_id, ver=SEMVER_VALID, status=ListingStatus.pending, rejection_reason=None):
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.listing_id = listing_id
+    v.version = ver
+    v.description = "A test version"
+    v.changelog = None
+    v.status = status
+    v.rejection_reason = rejection_reason
+    v.download_count = 0
+    v.supported_ides = []
+    v.released_by = uuid.uuid4()
+    v.released_at = datetime.now(UTC)
+    v.created_at = datetime.now(UTC)
+    # MCP/Sandbox extras (present but None for non-MCP types — safe to ignore)
+    v.source_url = None
+    v.source_ref = None
+    v.resolved_sha = None
+    return v
+
+
+def _make_listing(owner_id):
+    listing = MagicMock()
+    listing.id = uuid.uuid4()
+    listing.name = "test-listing"
+    listing.submitted_by = owner_id
+    listing.latest_version_id = None
+    listing.versions = []
+    listing.latest_version = None
+    return listing
+
+
+def _make_user(role_value="user"):
+    from models.user import UserRole
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "test@example.com"
+    user.role = UserRole(role_value)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Import the factory directly so tests do not depend on the mounted app
+# ---------------------------------------------------------------------------
+
+
+def _get_factory():
+    from api.routes.component_versions import create_version_router
+
+    return create_version_router
+
+
+# ---------------------------------------------------------------------------
+# Semver validation helper tests (unit, no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_semver_pattern_matches_valid():
+    from api.routes.component_versions import SEMVER_RE
+
+    assert SEMVER_RE.match(SEMVER_VALID)
+    assert SEMVER_RE.match(SEMVER_VALID_PRE)
+    assert SEMVER_RE.match("0.0.0")
+    assert SEMVER_RE.match("10.20.300")
+
+
+def test_semver_pattern_rejects_invalid():
+    from api.routes.component_versions import SEMVER_RE
+
+    assert not SEMVER_RE.match(SEMVER_INVALID)
+    assert not SEMVER_RE.match("1.2")
+    assert not SEMVER_RE.match("1.2.3.4")
+    assert not SEMVER_RE.match("")
+    assert not SEMVER_RE.match("v1.2.3")
+
+
+# ---------------------------------------------------------------------------
+# Shared DB mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _db_with_versions(versions: list):
+    """Return an async DB mock that returns *versions* for the versions query."""
+    db = AsyncMock()
+    scalars = MagicMock()
+    scalars.all.return_value = versions
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+    return db
+
+
+def _db_returning_one(obj):
+    """Return an async DB mock whose first execute returns *obj* as a scalar."""
+    db = AsyncMock()
+
+    scalar_result = MagicMock()
+    scalar_result.scalar_one_or_none.return_value = obj
+
+    scalars = MagicMock()
+    scalars.first.return_value = obj
+    scalars.all.return_value = [] if obj is None else [obj]
+
+    wrapped = MagicMock()
+    wrapped.scalars.return_value = scalars
+    wrapped.scalar_one_or_none.return_value = obj
+
+    db.execute = AsyncMock(return_value=wrapped)
+    db.commit = AsyncMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Tests for list_versions endpoint function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_versions_empty():
+    """list_versions returns empty list when no versions exist."""
+    from api.routes.component_versions import _list_versions
+    from models.mcp import McpListing, McpVersion
+
+    listing_id = str(uuid.uuid4())
+    db = _db_with_versions([])
+
+    with patch(
+        "api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=_make_listing(uuid.uuid4()))
+    ):
+        result = await _list_versions(
+            listing_id=listing_id,
+            page=1,
+            page_size=20,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            db=db,
+            current_user=_make_user(),
+        )
+
+    assert result["items"] == []
+    assert result["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_versions_with_data():
+    """list_versions returns version data with pagination metadata."""
+    from api.routes.component_versions import _list_versions
+    from models.mcp import McpListing, McpVersion
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    ver = _make_version(listing.id)
+    listing.versions = [ver]
+
+    listing_id = str(listing.id)
+    db = _db_with_versions([ver])
+
+    with patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)):
+        result = await _list_versions(
+            listing_id=listing_id,
+            page=1,
+            page_size=20,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            db=db,
+            current_user=_make_user(),
+        )
+
+    assert result["total"] == 1
+    assert result["items"][0]["version"] == SEMVER_VALID
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_version endpoint function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_version_found():
+    """get_version returns version detail when found."""
+    from api.routes.component_versions import _get_version
+    from models.mcp import McpListing, McpVersion
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    ver = _make_version(listing.id)
+
+    db = _db_returning_one(ver)
+
+    with patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)):
+        result = await _get_version(
+            listing_id=str(listing.id),
+            version=SEMVER_VALID,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            db=db,
+            current_user=_make_user(),
+        )
+
+    assert result["version"] == SEMVER_VALID
+    assert result["id"] == str(ver.id)
+
+
+@pytest.mark.asyncio
+async def test_get_version_not_found():
+    """get_version raises 404 when version does not exist."""
+    from fastapi import HTTPException
+
+    from api.routes.component_versions import _get_version
+    from models.mcp import McpListing, McpVersion
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+
+    db = _db_returning_one(None)
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _get_version(
+            listing_id=str(listing.id),
+            version="9.9.9",
+            listing_model=McpListing,
+            version_model=McpVersion,
+            db=db,
+            current_user=_make_user(),
+        )
+
+    assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests for publish_version endpoint function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_version_bad_semver():
+    """publish_version rejects invalid semver strings with 422."""
+    from fastapi import HTTPException
+
+    from api.routes.component_versions import _publish_version
+    from models.mcp import McpListing, McpVersion
+    from schemas.component_version import VersionPublishRequest
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    user = _make_user()
+    user.id = owner_id
+
+    req = VersionPublishRequest(version=SEMVER_INVALID, description="test", changelog=None, extra=None)
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _publish_version(
+            listing_id=str(listing.id),
+            req=req,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            component_type="mcp",
+            db=AsyncMock(),
+            current_user=user,
+        )
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_publish_version_not_owner():
+    """publish_version returns 403 if user is not the listing owner."""
+    from fastapi import HTTPException
+
+    from api.routes.component_versions import _publish_version
+    from models.mcp import McpListing, McpVersion
+    from schemas.component_version import VersionPublishRequest
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    other_user = _make_user()
+    other_user.id = uuid.uuid4()  # different from owner
+
+    req = VersionPublishRequest(version=SEMVER_VALID, description="test", changelog=None, extra=None)
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _publish_version(
+            listing_id=str(listing.id),
+            req=req,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            component_type="mcp",
+            db=AsyncMock(),
+            current_user=other_user,
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_publish_version_duplicate_409():
+    """publish_version returns 409 if (listing_id, version) already exists."""
+    from fastapi import HTTPException
+
+    from api.routes.component_versions import _publish_version
+    from models.mcp import McpListing, McpVersion
+    from schemas.component_version import VersionPublishRequest
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    user = _make_user()
+    user.id = owner_id
+
+    existing_ver = _make_version(listing.id)
+
+    req = VersionPublishRequest(version=SEMVER_VALID, description="test", changelog=None, extra=None)
+
+    # DB returns an existing version (duplicate)
+    db = _db_returning_one(existing_ver)
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _publish_version(
+            listing_id=str(listing.id),
+            req=req,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            component_type="mcp",
+            db=db,
+            current_user=user,
+        )
+
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_publish_version_happy_path():
+    """publish_version creates a new version and returns 201-like response."""
+    from api.routes.component_versions import _publish_version
+    from models.mcp import McpListing, McpVersion
+    from schemas.component_version import VersionPublishRequest
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    user = _make_user()
+    user.id = owner_id
+
+    req = VersionPublishRequest(
+        version=SEMVER_VALID, description="New version desc", changelog="Added stuff", extra=None
+    )
+
+    # DB returns None for the duplicate check
+    db = AsyncMock()
+    dup_result = MagicMock()
+    dup_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=dup_result)
+    db.commit = AsyncMock()
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch("api.routes.component_versions.audit", new=AsyncMock()),
+    ):
+        result = await _publish_version(
+            listing_id=str(listing.id),
+            req=req,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            component_type="mcp",
+            db=db,
+            current_user=user,
+        )
+
+    assert result["version"] == SEMVER_VALID
+    assert result["status"] == ListingStatus.pending.value
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for review_version endpoint function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_version_approve_updates_latest():
+    """Approving a pending version sets listing.latest_version_id."""
+    from api.routes.component_versions import _review_version
+    from models.mcp import McpListing, McpVersion
+    from schemas.component_version import VersionReviewRequest
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    ver = _make_version(listing.id, status=ListingStatus.pending)
+    listing.latest_version = ver
+
+    reviewer = _make_user("reviewer")
+    req = VersionReviewRequest(action="approve", reason=None)
+
+    db = AsyncMock()
+    ver_result = MagicMock()
+    ver_result.scalar_one_or_none.return_value = ver
+    db.execute = AsyncMock(return_value=ver_result)
+    db.commit = AsyncMock()
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch("api.routes.component_versions.audit", new=AsyncMock()),
+    ):
+        result = await _review_version(
+            listing_id=str(listing.id),
+            version=SEMVER_VALID,
+            req=req,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            component_type="mcp",
+            db=db,
+            current_user=reviewer,
+        )
+
+    assert result["new_status"] == ListingStatus.approved.value
+    assert listing.latest_version_id == ver.id
+    db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_review_version_reject_stores_reason():
+    """Rejecting a pending version stores the rejection reason."""
+    from api.routes.component_versions import _review_version
+    from models.mcp import McpListing, McpVersion
+    from schemas.component_version import VersionReviewRequest
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    ver = _make_version(listing.id, status=ListingStatus.pending)
+
+    reviewer = _make_user("reviewer")
+    req = VersionReviewRequest(action="reject", reason="Not acceptable")
+
+    db = AsyncMock()
+    ver_result = MagicMock()
+    ver_result.scalar_one_or_none.return_value = ver
+    db.execute = AsyncMock(return_value=ver_result)
+    db.commit = AsyncMock()
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch("api.routes.component_versions.audit", new=AsyncMock()),
+    ):
+        result = await _review_version(
+            listing_id=str(listing.id),
+            version=SEMVER_VALID,
+            req=req,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            component_type="mcp",
+            db=db,
+            current_user=reviewer,
+        )
+
+    assert result["new_status"] == ListingStatus.rejected.value
+    assert ver.rejection_reason == "Not acceptable"
+    db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_review_version_non_pending_422():
+    """Reviewing a non-pending version raises 422."""
+    from fastapi import HTTPException
+
+    from api.routes.component_versions import _review_version
+    from models.mcp import McpListing, McpVersion
+    from schemas.component_version import VersionReviewRequest
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+    ver = _make_version(listing.id, status=ListingStatus.approved)  # already approved
+
+    reviewer = _make_user("reviewer")
+    req = VersionReviewRequest(action="approve", reason=None)
+
+    db = AsyncMock()
+    ver_result = MagicMock()
+    ver_result.scalar_one_or_none.return_value = ver
+    db.execute = AsyncMock(return_value=ver_result)
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _review_version(
+            listing_id=str(listing.id),
+            version=SEMVER_VALID,
+            req=req,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            component_type="mcp",
+            db=db,
+            current_user=reviewer,
+        )
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_review_version_not_found_404():
+    """Reviewing a non-existent version raises 404."""
+    from fastapi import HTTPException
+
+    from api.routes.component_versions import _review_version
+    from models.mcp import McpListing, McpVersion
+    from schemas.component_version import VersionReviewRequest
+
+    owner_id = uuid.uuid4()
+    listing = _make_listing(owner_id)
+
+    reviewer = _make_user("reviewer")
+    req = VersionReviewRequest(action="approve", reason=None)
+
+    db = AsyncMock()
+    ver_result = MagicMock()
+    ver_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=ver_result)
+
+    with (
+        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _review_version(
+            listing_id=str(listing.id),
+            version="9.9.9",
+            req=req,
+            listing_model=McpListing,
+            version_model=McpVersion,
+            component_type="mcp",
+            db=db,
+            current_user=reviewer,
+        )
+
+    assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Factory creates router for each component type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "component_type,listing_cls,version_cls",
+    [
+        ("mcp", "models.mcp.McpListing", "models.mcp.McpVersion"),
+        ("skill", "models.skill.SkillListing", "models.skill.SkillVersion"),
+        ("hook", "models.hook.HookListing", "models.hook.HookVersion"),
+        ("prompt", "models.prompt.PromptListing", "models.prompt.PromptVersion"),
+        ("sandbox", "models.sandbox.SandboxListing", "models.sandbox.SandboxVersion"),
+    ],
+)
+def test_factory_creates_router(component_type, listing_cls, version_cls):
+    """create_version_router returns an APIRouter for each component type."""
+    import importlib
+
+    from fastapi import APIRouter
+
+    from api.routes.component_versions import create_version_router
+
+    mod_path, cls_name = listing_cls.rsplit(".", 1)
+    listing_model = getattr(importlib.import_module(mod_path), cls_name)
+
+    mod_path, cls_name = version_cls.rsplit(".", 1)
+    version_model = getattr(importlib.import_module(mod_path), cls_name)
+
+    router = create_version_router(component_type, listing_model, version_model)
+    assert isinstance(router, APIRouter)
+
+    # Should have 4 routes (list, get, publish, review)
+    routes = router.routes
+    assert len(routes) == 4
+
+
+def test_factory_route_paths():
+    """Factory routes match expected URL patterns."""
+    from api.routes.component_versions import create_version_router
+    from models.mcp import McpListing, McpVersion
+
+    router = create_version_router("mcp", McpListing, McpVersion)
+    paths = {r.path for r in router.routes}
+
+    assert "/{listing_id}/versions" in paths
+    assert "/{listing_id}/versions/{version}" in paths


### PR DESCRIPTION
## Purpose / Description

Adds a uniform versioning API for all 5 component types (MCP, skill, hook, prompt, sandbox). A single factory function generates the 4 version endpoints and mounts them on each type's router — zero code duplication.

## Fixes
* Closes #621

## Approach

- Created `api/routes/component_versions.py` with `create_version_router()` factory that generates versioning sub-routers parameterized by component type, listing model, and version model
- Created `schemas/component_version.py` with shared Pydantic schemas (publish request, review request, list/detail responses)
- Mounted the factory router on all 5 type routers (`mcp.py`, `skill.py`, `hook.py`, `prompt.py`, `sandbox.py`)
- Endpoints: list versions (paginated), get version, publish version (with semver validation), review version (approve/reject)
- On approval: updates `listing.latest_version_id` to the approved version
- Semver validation rejects invalid formats with 422, duplicates with 409
- Owner-only publish (403), reviewer-only review

## How Has This Been Tested?

- 13 unit tests in `observal-server/tests/test_component_versions_api.py`
- Tests cover: semver validation, list/get versions, publish (happy path, bad semver, not owner, duplicate), review (approve, reject, non-pending, not found)
- Factory parametrized test verifies all 5 types get 4 routes
- Ruff lint/format clean

## Checklist
- [x] All commits are signed off (`git commit -s`) per the DCO
- [x] You have a descriptive commit message with a short title
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots