### PR TITLE
fix(api): complete agent versioning spec compliance

### DIFF
--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import difflib
 import json
+import logging
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -37,6 +38,8 @@ from services.agent_resolver import validate_component_ids
 from services.audit_helpers import audit
 from services.ide_feature_inference import compute_supported_ides, infer_required_features
 from services.versioning import parse_semver, validate_semver
+
+logger = logging.getLogger(__name__)
 
 agent_version_router = APIRouter()
 
@@ -170,8 +173,10 @@ async def _create_agent_version(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    if agent.created_by != current_user.id:
-        raise HTTPException(status_code=403, detail="Only the agent owner can publish versions")
+    is_owner = agent.created_by == current_user.id
+    is_co_maintainer = str(current_user.id) in [str(uid) for uid in (agent.co_maintainers or [])]
+    if not is_owner and not is_co_maintainer:
+        raise HTTPException(status_code=403, detail="Not authorized to release versions")
 
     # Duplicate check
     dup_stmt = select(AgentVersion).where(
@@ -196,6 +201,13 @@ async def _create_agent_version(
                 ],
             )
 
+    # Check for existing pending versions to warn the caller
+    pending_stmt = select(func.count(AgentVersion.id)).where(
+        AgentVersion.agent_id == agent.id,
+        AgentVersion.status == AgentStatus.pending,
+    )
+    pending_count = (await db.execute(pending_stmt)).scalar() or 0
+
     now = datetime.now(UTC)
     ver = AgentVersion(
         agent_id=agent.id,
@@ -206,6 +218,8 @@ async def _create_agent_version(
         model_config_json=req.model_config_json,
         external_mcps=[m.model_dump() for m in req.external_mcps] if req.external_mcps else [],
         supported_ides=req.supported_ides,
+        yaml_snapshot=req.yaml_snapshot,
+        is_prerelease=req.is_prerelease,
         status=AgentStatus.pending,
         released_by=current_user.id,
         released_at=now,
@@ -259,6 +273,28 @@ async def _create_agent_version(
     ver.required_ide_features = infer_required_features(_VersionProxy(), skill_listings=skill_listings_map)
     ver.inferred_supported_ides = compute_supported_ides(ver.required_ide_features)
 
+    # Pre-generate IDE configs at release time (spec: no generation at request time)
+    mcp_comp_ids = [c.component_id for c in req.components if c.component_type == "mcp"]
+    mcp_listings_map: dict = {}
+    if mcp_comp_ids:
+        rows = (await db.execute(select(McpListing).where(McpListing.id.in_(mcp_comp_ids)))).scalars().all()
+        mcp_listings_map = {row.id: row for row in rows}
+
+    # Pre-generate IDE configs for supported_ides (the user-declared list).
+    # inferred_supported_ides is a compatibility analysis result used for display/filtering,
+    # but supported_ides is authoritative for which configs to generate.
+    ide_configs: dict = {}
+    failed_ides: list[str] = []
+    for ide in ver.supported_ides or []:
+        try:
+            ide_configs[ide] = generate_agent_config(ver, ide, mcp_listings=mcp_listings_map)
+        except Exception:
+            logger.exception(
+                "IDE config generation failed for agent=%s version=%s ide=%s", agent.name, req.version, ide
+            )
+            failed_ides.append(ide)
+    ver.ide_configs = ide_configs or {}
+
     # Do NOT update latest_version_id — that happens on approval
     await db.commit()
 
@@ -271,7 +307,15 @@ async def _create_agent_version(
         detail=req.version,
     )
 
-    return {
+    warnings: list[str] = []
+    if pending_count > 0:
+        warnings.append(f"This agent already has {pending_count} pending version(s)")
+    if failed_ides:
+        warnings.append(
+            f"IDE config generation failed for: {', '.join(failed_ides)}. These will 404 until regenerated."
+        )
+
+    result = {
         "id": str(ver.id),
         "agent_id": str(ver.agent_id),
         "version": ver.version,
@@ -283,6 +327,9 @@ async def _create_agent_version(
         "released_at": ver.released_at,
         "created_at": ver.created_at,
     }
+    if warnings:
+        result["warnings"] = warnings
+    return result
 
 
 async def _review_agent_version(
@@ -368,18 +415,14 @@ async def _get_agent_ide_config(
     if not ver:
         raise HTTPException(status_code=404, detail="Version not found")
 
-    # Return cached config if available
-    if ver.ide_configs and ide in ver.ide_configs:
-        return ver.ide_configs[ide]
+    # Serve pre-generated config only — no generation at request time (spec requirement #8)
+    if not ver.ide_configs or ide not in ver.ide_configs:
+        raise HTTPException(
+            status_code=404,
+            detail=f"IDE '{ide}' not supported by this agent version. Available: {list(ver.ide_configs or {})}",
+        )
 
-    # Generate on the fly — load MCP listings for components
-    mcp_comp_ids = [c.component_id for c in (ver.components or []) if c.component_type == "mcp"]
-    mcp_listings_map = {}
-    if mcp_comp_ids:
-        rows = (await db.execute(select(McpListing).where(McpListing.id.in_(mcp_comp_ids)))).scalars().all()
-        mcp_listings_map = {row.id: row for row in rows}
-
-    return generate_agent_config(ver, ide, mcp_listings=mcp_listings_map)
+    return ver.ide_configs[ide]
 
 
 async def _get_version_diff(
@@ -407,26 +450,22 @@ async def _get_version_diff(
     if not ver2:
         raise HTTPException(status_code=404, detail=f"Version {v2!r} not found")
 
-    if ver1.yaml_snapshot is not None and ver2.yaml_snapshot is not None:
-        text1 = ver1.yaml_snapshot
-        text2 = ver2.yaml_snapshot
-    else:
-        # Fall back to a structural comparison of key fields
-        def _structural_text(ver: AgentVersion) -> str:
-            data = {
-                "description": ver.description,
-                "prompt": ver.prompt,
-                "model_name": ver.model_name,
-                "model_config_json": ver.model_config_json,
-                "supported_ides": ver.supported_ides,
-                "external_mcps": ver.external_mcps,
-            }
-            return json.dumps(data, indent=2, default=str)
+    # Build YAML diff text
+    def _structural_text(ver: AgentVersion) -> str:
+        data = {
+            "description": ver.description,
+            "prompt": ver.prompt,
+            "model_name": ver.model_name,
+            "model_config_json": ver.model_config_json,
+            "supported_ides": ver.supported_ides,
+            "external_mcps": ver.external_mcps,
+        }
+        return json.dumps(data, indent=2, default=str)
 
-        text1 = _structural_text(ver1)
-        text2 = _structural_text(ver2)
+    text1 = ver1.yaml_snapshot if ver1.yaml_snapshot is not None else _structural_text(ver1)
+    text2 = ver2.yaml_snapshot if ver2.yaml_snapshot is not None else _structural_text(ver2)
 
-    diff_lines = [
+    yaml_diff = "\n".join(
         line.rstrip("\n")
         for line in difflib.unified_diff(
             text1.splitlines(keepends=True),
@@ -434,9 +473,50 @@ async def _get_version_diff(
             fromfile=f"v{v1}",
             tofile=f"v{v2}",
         )
-    ]
+    )
 
-    return {"v1": v1, "v2": v2, "diff": diff_lines}
+    # Compute component changes between versions
+    comp1 = {(c.component_type, str(c.component_id)): c for c in (ver1.components or [])}
+    comp2 = {(c.component_type, str(c.component_id)): c for c in (ver2.components or [])}
+    component_changes = []
+    for key, c in comp2.items():
+        if key not in comp1:
+            component_changes.append(
+                {
+                    "type": c.component_type,
+                    "name": c.component_name or "",
+                    "change": "added",
+                    "version": c.resolved_version or "",
+                }
+            )
+        elif comp1[key].resolved_version != c.resolved_version:
+            component_changes.append(
+                {
+                    "type": c.component_type,
+                    "name": c.component_name or "",
+                    "change": "updated",
+                    "from": comp1[key].resolved_version or "",
+                    "to": c.resolved_version or "",
+                }
+            )
+    for key, c in comp1.items():
+        if key not in comp2:
+            component_changes.append(
+                {
+                    "type": c.component_type,
+                    "name": c.component_name or "",
+                    "change": "removed",
+                    "version": c.resolved_version or "",
+                }
+            )
+
+    return {
+        "agent_id": str(agent.id),
+        "version_a": v1,
+        "version_b": v2,
+        "yaml_diff": yaml_diff,
+        "component_changes": component_changes,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -246,6 +246,8 @@ class AgentVersionCreateRequest(BaseModel):
     supported_ides: list[str] = []
     components: list[ComponentRef] = []
     goal_template: GoalTemplateRequest | None = None
+    yaml_snapshot: str | None = None
+    is_prerelease: bool = False
 
     @field_validator("version")
     @classmethod

--- a/observal-server/tests/test_agent_versions_api.py
+++ b/observal-server/tests/test_agent_versions_api.py
@@ -39,6 +39,7 @@ def _make_agent(owner_id: uuid.UUID | None = None):
     agent.id = uuid.uuid4()
     agent.name = "my-agent"
     agent.created_by = owner_id or uuid.uuid4()
+    agent.co_maintainers = []
     agent.latest_version_id = None
     agent.latest_version = None
     return agent
@@ -300,11 +301,13 @@ async def test_create_version_happy_path():
         goal_template=None,
     )
 
-    # DB: dup check returns None, then flush/commit succeed
+    # DB: dup check returns None, pending count returns 0
     db = AsyncMock()
     dup_result = MagicMock()
     dup_result.scalar_one_or_none.return_value = None
-    db.execute = AsyncMock(return_value=dup_result)
+    count_result = MagicMock()
+    count_result.scalar.return_value = 0
+    db.execute = AsyncMock(side_effect=[dup_result, count_result])
     db.commit = AsyncMock()
     db.add = MagicMock()
     db.flush = AsyncMock()
@@ -314,6 +317,7 @@ async def test_create_version_happy_path():
         patch("api.routes.agent_versions.validate_component_ids", new=AsyncMock(return_value=[])),
         patch("api.routes.agent_versions.infer_required_features", return_value=["rules"]),
         patch("api.routes.agent_versions.compute_supported_ides", return_value=["claude-code"]),
+        patch("api.routes.agent_versions.generate_agent_config", return_value={"mcpServers": {}}),
         patch("api.routes.agent_versions.audit", new=AsyncMock()),
     ):
         result = await _create_agent_version(
@@ -428,6 +432,105 @@ async def test_create_version_not_owner_403():
         )
 
     assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_version_co_maintainer_allowed():
+    """create_agent_version succeeds for a co-maintainer (not just owner)."""
+    from api.routes.agent_versions import _create_agent_version
+    from schemas.agent import AgentVersionCreateRequest
+
+    owner_id = uuid.uuid4()
+    co_maintainer_id = uuid.uuid4()
+    agent = _make_agent(owner_id)
+    agent.co_maintainers = [str(co_maintainer_id)]
+
+    co_user = _make_user()
+    co_user.id = co_maintainer_id
+
+    req = AgentVersionCreateRequest(
+        version=SEMVER_VALID,
+        description="Co-maintainer release",
+        prompt="You are helpful",
+        model_name="claude-3-5-sonnet",
+    )
+
+    # DB: dup check returns None, pending count returns 0, flush/commit succeed
+    db = AsyncMock()
+    dup_result = MagicMock()
+    dup_result.scalar_one_or_none.return_value = None
+    count_result = MagicMock()
+    count_result.scalar.return_value = 0
+    db.execute = AsyncMock(side_effect=[dup_result, count_result])
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+
+    with (
+        patch("api.routes.agent_versions._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent_versions.validate_component_ids", new=AsyncMock(return_value=[])),
+        patch("api.routes.agent_versions.infer_required_features", return_value=[]),
+        patch("api.routes.agent_versions.compute_supported_ides", return_value=[]),
+        patch("api.routes.agent_versions.generate_agent_config", return_value={}),
+        patch("api.routes.agent_versions.audit", new=AsyncMock()),
+    ):
+        result = await _create_agent_version(
+            agent_id=str(agent.id),
+            req=req,
+            db=db,
+            current_user=co_user,
+        )
+
+    assert result["version"] == SEMVER_VALID
+    assert result["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_create_version_warns_multiple_pending():
+    """create_agent_version includes warning when other pending versions exist."""
+    from api.routes.agent_versions import _create_agent_version
+    from schemas.agent import AgentVersionCreateRequest
+
+    owner_id = uuid.uuid4()
+    agent = _make_agent(owner_id)
+    user = _make_user()
+    user.id = owner_id
+
+    req = AgentVersionCreateRequest(
+        version=SEMVER_VALID,
+        description="Another release",
+        prompt="You are helpful",
+        model_name="claude-3-5-sonnet",
+    )
+
+    # DB: dup check returns None, pending count returns 2
+    db = AsyncMock()
+    dup_result = MagicMock()
+    dup_result.scalar_one_or_none.return_value = None
+    count_result = MagicMock()
+    count_result.scalar.return_value = 2
+    db.execute = AsyncMock(side_effect=[dup_result, count_result])
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+
+    with (
+        patch("api.routes.agent_versions._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent_versions.validate_component_ids", new=AsyncMock(return_value=[])),
+        patch("api.routes.agent_versions.infer_required_features", return_value=[]),
+        patch("api.routes.agent_versions.compute_supported_ides", return_value=[]),
+        patch("api.routes.agent_versions.generate_agent_config", return_value={}),
+        patch("api.routes.agent_versions.audit", new=AsyncMock()),
+    ):
+        result = await _create_agent_version(
+            agent_id=str(agent.id),
+            req=req,
+            db=db,
+            current_user=user,
+        )
+
+    assert "warnings" in result
+    assert "2 pending" in result["warnings"][0]
 
 
 # ---------------------------------------------------------------------------
@@ -600,21 +703,22 @@ async def test_get_ide_config_from_cache():
 
 
 @pytest.mark.asyncio
-async def test_get_ide_config_generated_on_the_fly():
-    """get_agent_ide_config calls generate_agent_config when ide_configs is empty."""
+async def test_get_ide_config_404_when_not_cached():
+    """get_agent_ide_config raises 404 when IDE config is not pre-generated."""
+    from fastapi import HTTPException
+
     from api.routes.agent_versions import _get_agent_ide_config
 
     agent = _make_agent()
     ver = _make_version(agent.id)
-    ver.ide_configs = {}  # no cached config
-    generated_cfg = {"mcpServers": {"test": {}}}
+    ver.ide_configs = {}  # no cached config for requested IDE
     db = _db_returning_one(ver)
 
     with (
         patch("api.routes.agent_versions._load_agent", new=AsyncMock(return_value=agent)),
-        patch("api.routes.agent_versions.generate_agent_config", return_value=generated_cfg),
+        pytest.raises(HTTPException) as exc,
     ):
-        result = await _get_agent_ide_config(
+        await _get_agent_ide_config(
             agent_id=str(agent.id),
             version=SEMVER_VALID,
             ide="claude-code",
@@ -622,7 +726,8 @@ async def test_get_ide_config_generated_on_the_fly():
             current_user=_make_user(),
         )
 
-    assert result == generated_cfg
+    assert exc.value.status_code == 404
+    assert "claude-code" in exc.value.detail
 
 
 # ---------------------------------------------------------------------------
@@ -631,24 +736,19 @@ async def test_get_ide_config_generated_on_the_fly():
 
 
 @pytest.mark.asyncio
-async def test_diff_versions_returns_diff_lines():
-    """get_version_diff returns unified diff lines between two version snapshots."""
+async def test_diff_versions_returns_yaml_diff():
+    """get_version_diff returns unified diff and component_changes."""
     from api.routes.agent_versions import _get_version_diff
 
     agent = _make_agent()
     ver1 = _make_version(agent.id, ver="1.0.0")
     ver1.yaml_snapshot = "prompt: hello\nmodel: claude\n"
+    ver1.components = []
     ver2 = _make_version(agent.id, ver="1.1.0")
     ver2.yaml_snapshot = "prompt: hello world\nmodel: claude\n"
+    ver2.components = []
 
     db = AsyncMock()
-
-    def _side_effect(stmt):
-        """Return ver1 on first call, ver2 on second."""
-        mock = MagicMock()
-        mock.scalar_one_or_none.return_value = None
-        return mock
-
     calls = [0]
 
     async def _execute(stmt):
@@ -668,11 +768,12 @@ async def test_diff_versions_returns_diff_lines():
             current_user=_make_user(),
         )
 
-    assert result["v1"] == "1.0.0"
-    assert result["v2"] == "1.1.0"
-    assert isinstance(result["diff"], list)
-    # Should contain diff output (at least some lines changed)
-    assert len(result["diff"]) > 0
+    assert result["agent_id"] == str(agent.id)
+    assert result["version_a"] == "1.0.0"
+    assert result["version_b"] == "1.1.0"
+    assert isinstance(result["yaml_diff"], str)
+    assert len(result["yaml_diff"]) > 0
+    assert isinstance(result["component_changes"], list)
 
 
 @pytest.mark.asyncio
@@ -689,6 +790,7 @@ async def test_diff_versions_structural_when_no_snapshot():
     ver1.model_config_json = {}
     ver1.supported_ides = ["claude-code"]
     ver1.external_mcps = []
+    ver1.components = []
 
     ver2 = _make_version(agent.id, ver="1.1.0")
     ver2.yaml_snapshot = None
@@ -698,6 +800,7 @@ async def test_diff_versions_structural_when_no_snapshot():
     ver2.model_config_json = {}
     ver2.supported_ides = ["claude-code"]
     ver2.external_mcps = []
+    ver2.components = []
 
     calls = [0]
 
@@ -719,6 +822,8 @@ async def test_diff_versions_structural_when_no_snapshot():
             current_user=_make_user(),
         )
 
-    assert result["v1"] == "1.0.0"
-    assert result["v2"] == "1.1.0"
-    assert isinstance(result["diff"], list)
+    assert result["agent_id"] == str(agent.id)
+    assert result["version_a"] == "1.0.0"
+    assert result["version_b"] == "1.1.0"
+    assert isinstance(result["yaml_diff"], str)
+    assert isinstance(result["component_changes"], list)


### PR DESCRIPTION
## Purpose/Description

The initial agent versioning PR (#655) implemented the 6 endpoints but diverged from the issue spec on several behavioral requirements. This PR closes the gaps.

## Fixes

Closes: #622

## Approach

### Changes

| Gap | Fix |
|-----|-----|
| Only owner could publish | Now owner OR `co_maintainers[]` can release |
| `yaml_snapshot` not accepted in create | Added to `AgentVersionCreateRequest` |
| `is_prerelease` not accepted in create | Added to `AgentVersionCreateRequest` |
| IDE config generated on-the-fly | Now pre-generated at release time; endpoint returns 404 if not cached |
| Diff returned `{v1, v2, diff: []}` | Now returns `{agent_id, version_a, version_b, yaml_diff, component_changes}` |
| No warning for multiple pending | Create response includes `warnings` array when pending versions exist |

### Not addressed (explicitly deferred)

- `lock_snapshot` generation with integrity hashes → #625
- Beta releases (`is_prerelease=true`) skipping review → Phase 3
- `PUT /agents/{id}` updating identity fields only → separate scope

## How Has This Been Tested?

- 22 unit tests (added: co-maintainer access, multiple-pending warning, 404 on uncached IDE)
- Updated existing tests for new response shapes
- `ruff check` and `ruff format` pass

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated
- [x] Lint passes
- [x] Single commit with DCO sign-off
- [x] Uses `Closes: #622` to auto-close the issue on merge