### PR TITLE
feat(cli): agent release, versions, and pull commands

### DIFF
--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -781,3 +781,165 @@ def agent_publish(
         status = result.get("status", "pending")
         rprint(f"[green]✓ Agent submitted for review![/green] ID: [bold]{result['id']}[/bold]")
         rprint(f"[yellow]Status: {status} — an admin must approve it before it becomes visible.[/yellow]")
+
+
+@agent_app.command(name="release")
+def agent_release(
+    name: str = typer.Argument(..., help="Agent name, ID, row number, or @alias"),
+    bump: str = typer.Option(..., "--bump", help="Version bump type: patch, minor, or major"),
+    directory: str = typer.Option(".", "--dir", "-d", help="Directory containing observal-agent.yaml"),
+):
+    """Bump version and push a versioned release to the registry."""
+    if bump not in ("patch", "minor", "major"):
+        rprint("[red]Error:[/red] --bump must be one of: patch, minor, major")
+        raise typer.Exit(code=1)
+
+    dir_path = Path(directory)
+    data = _load_agent_yaml(dir_path)
+
+    # Resolve agent by name search (same pattern as agent_publish --update)
+    with spinner("Looking up agent..."):
+        results = client.get("/api/v1/agents", params={"search": data["name"]})
+    match = next((a for a in results if a["name"] == data["name"]), None)
+    if not match:
+        rprint(f"[red]Error:[/red] No agent found with name '{data['name']}'")
+        raise typer.Exit(code=1)
+    agent_id = match["id"]
+
+    # Fetch version suggestions
+    with spinner("Fetching version suggestions..."):
+        suggestions = client.get(f"/api/v1/agents/{agent_id}/version-suggestions")
+
+    current = suggestions.get("current", data.get("version", "1.0.0"))
+    new_version = suggestions.get("suggestions", {}).get(bump)
+    if not new_version:
+        rprint(f"[red]Error:[/red] Could not determine new version for bump type '{bump}'")
+        raise typer.Exit(code=1)
+
+    rprint(f"[dim]→[/dim] Bumping version: [bold]{current}[/bold] → [bold cyan]{new_version}[/bold cyan]")
+
+    # Build release payload from YAML
+    raw_yaml = (dir_path / YAML_FILE).read_text()
+    payload = {
+        "version": new_version,
+        "description": data.get("description", ""),
+        "prompt": data.get("prompt", ""),
+        "model_name": data.get("model_name", "claude-sonnet-4"),
+        "model_config_json": data.get("model_config_json"),
+        "external_mcps": data.get("external_mcps"),
+        "supported_ides": data.get("supported_ides", []),
+        "components": data.get("components", []),
+        "goal_template": data.get("goal_template"),
+        "yaml_snapshot": raw_yaml,
+    }
+
+    rprint("[dim]→[/dim] Pushing definition to registry...")
+    with spinner("Creating version..."):
+        result = client.post(f"/api/v1/agents/{agent_id}/versions", payload)
+
+    rprint(f"[green]✓ Version {new_version} submitted for review[/green]")
+
+    pending_count = result.get("pending_version_count", 0)
+    if pending_count and pending_count > 0:
+        rprint(f"[yellow]⚠ This agent already has {pending_count} pending version(s)[/yellow]")
+
+    # Update local YAML version field
+    data["version"] = new_version
+    _save_agent_yaml(dir_path, data)
+
+
+@agent_app.command(name="versions")
+def agent_versions(
+    name: str = typer.Argument(..., help="Agent name, ID, row number, or @alias"),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+):
+    """List all versions for an agent."""
+    resolved = config.resolve_alias(name)
+
+    with spinner("Fetching versions..."):
+        data = client.get(f"/api/v1/agents/{resolved}/versions", params={"page": 1, "page_size": 50})
+
+    items = data.get("items", [])
+
+    if output == "json":
+        output_json(data)
+        return
+
+    if not items:
+        rprint("[dim]No versions found.[/dim]")
+        return
+
+    table = Table(show_lines=False, padding=(0, 1))
+    table.add_column("VERSION", style="bold cyan", no_wrap=True)
+    table.add_column("STATUS")
+    table.add_column("DATE")
+    table.add_column("RELEASED BY", style="dim")
+    table.add_column("COMPONENTS")
+
+    for item in items:
+        table.add_row(
+            item.get("version", ""),
+            status_badge(item.get("status", "")),
+            relative_time(item.get("created_at")),
+            item.get("created_by_email", "") or item.get("created_by_username", ""),
+            str(item.get("component_count", "")),
+        )
+
+    console.print(table)
+
+
+@agent_app.command(name="pull")
+def agent_pull(
+    name: str = typer.Argument(..., help="Agent name, ID, row number, or @alias"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Version to pull (default: latest approved)"),
+    ide: str | None = typer.Option(None, "--ide", "-i", help="Target IDE (auto-detected if not set)"),
+    directory: str = typer.Option(".", "--dir", "-d", help="Directory to write files into"),
+):
+    """Fetch the IDE config for an agent version and write files to disk."""
+    resolved = config.resolve_alias(name)
+    dir_path = Path(directory)
+
+    # Get agent detail to find latest version
+    with spinner("Fetching agent..."):
+        agent = client.get(f"/api/v1/agents/{resolved}")
+
+    target_version = version or agent.get("latest_approved_version") or agent.get("latest_version")
+    if not target_version:
+        rprint("[red]Error:[/red] Could not determine a version to pull. Use --version to specify one.")
+        raise typer.Exit(code=1)
+
+    # Detect IDE
+    if not ide:
+        from observal_cli.ide_registry import get_scope_aware_ides
+
+        detected = get_scope_aware_ides()
+        ide = detected[0][0] if detected else None
+    if not ide:
+        rprint("[red]Error:[/red] Could not detect IDE. Use --ide to specify one.")
+        raise typer.Exit(code=1)
+
+    rprint(
+        f"[dim]→[/dim] Pulling [bold]{agent.get('name', resolved)}[/bold] v[bold]{target_version}[/bold] for [cyan]{ide}[/cyan]..."
+    )
+
+    with spinner("Fetching IDE config..."):
+        config_data = client.get(f"/api/v1/agents/{resolved}/versions/{target_version}/ide/{ide}")
+
+    files: dict[str, str] = config_data.get("files", {}) if isinstance(config_data, dict) else {}
+
+    if files:
+        written = 0
+        for rel_path, content in files.items():
+            abs_path = dir_path / rel_path
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            abs_path.write_text(content if isinstance(content, str) else _json.dumps(content, indent=2))
+            rprint(f"  [green]✓[/green] created {rel_path}")
+            written += 1
+        rprint(f"[green]✓ Agent config written to {written} file(s)[/green]")
+    else:
+        # Fallback: write the entire config as a single JSON file
+        fallback_path = dir_path / f"{agent.get('name', resolved)}-config.json"
+        fallback_path.parent.mkdir(parents=True, exist_ok=True)
+        fallback_path.write_text(_json.dumps(config_data, indent=2))
+        rprint(f"  [green]✓[/green] created {fallback_path.name}")
+        rprint("[green]✓ Agent config written to 1 file[/green]")

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -797,14 +797,10 @@ def agent_release(
     dir_path = Path(directory)
     data = _load_agent_yaml(dir_path)
 
-    # Resolve agent by name search (same pattern as agent_publish --update)
+    resolved = config.resolve_alias(name)
     with spinner("Looking up agent..."):
-        results = client.get("/api/v1/agents", params={"search": data["name"]})
-    match = next((a for a in results if a["name"] == data["name"]), None)
-    if not match:
-        rprint(f"[red]Error:[/red] No agent found with name '{data['name']}'")
-        raise typer.Exit(code=1)
-    agent_id = match["id"]
+        agent = client.get(f"/api/v1/agents/{resolved}")
+    agent_id = agent["id"]
 
     # Fetch version suggestions
     with spinner("Fetching version suggestions..."):
@@ -818,8 +814,12 @@ def agent_release(
 
     rprint(f"[dim]→[/dim] Bumping version: [bold]{current}[/bold] → [bold cyan]{new_version}[/bold cyan]")
 
-    # Build release payload from YAML
+    # Update version in data BEFORE capturing snapshot
+    data["version"] = new_version
+    _save_agent_yaml(dir_path, data)
     raw_yaml = (dir_path / YAML_FILE).read_text()
+
+    # Build release payload from YAML
     payload = {
         "version": new_version,
         "description": data.get("description", ""),
@@ -839,13 +839,8 @@ def agent_release(
 
     rprint(f"[green]✓ Version {new_version} submitted for review[/green]")
 
-    pending_count = result.get("pending_version_count", 0)
-    if pending_count and pending_count > 0:
-        rprint(f"[yellow]⚠ This agent already has {pending_count} pending version(s)[/yellow]")
-
-    # Update local YAML version field
-    data["version"] = new_version
-    _save_agent_yaml(dir_path, data)
+    for warning in result.get("warnings", []):
+        rprint(f"[yellow]⚠ {warning}[/yellow]")
 
 
 @agent_app.command(name="versions")
@@ -930,7 +925,10 @@ def agent_pull(
     if files:
         written = 0
         for rel_path, content in files.items():
-            abs_path = dir_path / rel_path
+            abs_path = (dir_path / rel_path).resolve()
+            if not abs_path.is_relative_to(dir_path.resolve()):
+                rprint(f"  [red]⚠ Skipping unsafe path: {rel_path}[/red]")
+                continue
             abs_path.parent.mkdir(parents=True, exist_ok=True)
             abs_path.write_text(content if isinstance(content, str) else _json.dumps(content, indent=2))
             rprint(f"  [green]✓[/green] created {rel_path}")

--- a/observal_cli/tests/test_cmd_agent_versions.py
+++ b/observal_cli/tests/test_cmd_agent_versions.py
@@ -1,0 +1,314 @@
+"""Tests for agent release, versions, and pull commands."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from observal_cli.main import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+# ── Shared fixtures ────────────────────────────────────────────
+
+
+@pytest.fixture()
+def agent_yaml_dir(tmp_path: Path) -> Path:
+    """Write a minimal observal-agent.yaml into tmp_path and return the dir."""
+    data = {
+        "name": "my-agent",
+        "version": "1.2.0",
+        "description": "A test agent",
+        "owner": "team-alpha",
+        "model_name": "claude-sonnet-4",
+        "prompt": "You are a helpful agent.",
+        "supported_ides": ["claude-code"],
+        "components": [{"component_type": "mcp", "component_id": "abc-123"}],
+        "goal_template": {"description": "Do things", "sections": [{"name": "default", "description": "default"}]},
+    }
+    (tmp_path / "observal-agent.yaml").write_text(yaml.dump(data))
+    return tmp_path
+
+
+# ── agent release ──────────────────────────────────────────────
+
+
+def test_agent_release_bumps_version(agent_yaml_dir: Path) -> None:
+    """release bumps version via version-suggestions and POSTs to /versions."""
+    agent_id = "agent-uuid-1234"
+    suggestions = {
+        "current": "1.2.0",
+        "suggestions": {"patch": "1.2.1", "minor": "1.3.0", "major": "2.0.0"},
+    }
+    version_result = {
+        "version": "1.3.0",
+        "status": "pending",
+        "pending_version_count": 0,
+    }
+
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get") as mock_get,
+        patch("observal_cli.client.post", return_value=version_result) as mock_post,
+    ):
+        # GET /agents?search=my-agent → list result
+        # GET /agents/{id}/version-suggestions → suggestions
+        mock_get.side_effect = [
+            [{"id": agent_id, "name": "my-agent"}],
+            suggestions,
+        ]
+
+        result = runner.invoke(
+            app,
+            ["agent", "release", "my-agent", "--bump", "minor", "--dir", str(agent_yaml_dir)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "1.2.0" in result.output
+    assert "1.3.0" in result.output
+
+    # Verify POST was called with correct path and version
+    post_call = mock_post.call_args
+    assert f"/api/v1/agents/{agent_id}/versions" in post_call[0][0]
+    payload = post_call[0][1]
+    assert payload["version"] == "1.3.0"
+    assert payload["yaml_snapshot"] is not None
+
+
+def test_agent_release_updates_local_yaml(agent_yaml_dir: Path) -> None:
+    """release writes the new version back into observal-agent.yaml."""
+    agent_id = "agent-uuid-5678"
+    suggestions = {
+        "current": "1.2.0",
+        "suggestions": {"patch": "1.2.1", "minor": "1.3.0", "major": "2.0.0"},
+    }
+    version_result = {"version": "1.2.1", "status": "pending", "pending_version_count": 0}
+
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get") as mock_get,
+        patch("observal_cli.client.post", return_value=version_result),
+    ):
+        mock_get.side_effect = [
+            [{"id": agent_id, "name": "my-agent"}],
+            suggestions,
+        ]
+        result = runner.invoke(
+            app,
+            ["agent", "release", "my-agent", "--bump", "patch", "--dir", str(agent_yaml_dir)],
+        )
+
+    assert result.exit_code == 0, result.output
+    saved = yaml.safe_load((agent_yaml_dir / "observal-agent.yaml").read_text())
+    assert saved["version"] == "1.2.1"
+
+
+def test_agent_release_shows_pending_warning(agent_yaml_dir: Path) -> None:
+    """release shows a warning when pending_version_count > 0."""
+    agent_id = "agent-uuid-9999"
+    suggestions = {
+        "current": "1.2.0",
+        "suggestions": {"patch": "1.2.1", "minor": "1.3.0", "major": "2.0.0"},
+    }
+    version_result = {"version": "1.3.0", "status": "pending", "pending_version_count": 2}
+
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get") as mock_get,
+        patch("observal_cli.client.post", return_value=version_result),
+    ):
+        mock_get.side_effect = [
+            [{"id": agent_id, "name": "my-agent"}],
+            suggestions,
+        ]
+        result = runner.invoke(
+            app,
+            ["agent", "release", "my-agent", "--bump", "minor", "--dir", str(agent_yaml_dir)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "pending" in result.output.lower()
+    assert "2" in result.output
+
+
+# ── agent versions ─────────────────────────────────────────────
+
+
+def test_agent_versions_table_output() -> None:
+    """versions renders a table with VERSION, STATUS, DATE, COMPONENTS columns."""
+    agent_id = "agent-uuid-abc"
+    versions_response = {
+        "items": [
+            {
+                "version": "1.3.0",
+                "status": "pending",
+                "created_at": "2026-04-30T10:00:00Z",
+                "created_by_email": "alice@example.com",
+                "component_count": 5,
+            },
+            {
+                "version": "1.2.0",
+                "status": "approved",
+                "created_at": "2026-04-20T10:00:00Z",
+                "created_by_email": "bob@example.com",
+                "component_count": 4,
+            },
+        ],
+        "total": 2,
+        "page": 1,
+        "page_size": 50,
+    }
+
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get", return_value=versions_response) as mock_get,
+    ):
+        result = runner.invoke(app, ["agent", "versions", "my-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert "1.3.0" in result.output
+    assert "1.2.0" in result.output
+    assert "pending" in result.output.lower()
+    assert "approved" in result.output.lower()
+
+    # Verify correct API was called
+    mock_get.assert_called_once_with(
+        f"/api/v1/agents/{agent_id}/versions",
+        params={"page": 1, "page_size": 50},
+    )
+
+
+def test_agent_versions_json_output() -> None:
+    """versions --output json dumps raw JSON."""
+    agent_id = "agent-uuid-def"
+    versions_response = {
+        "items": [{"version": "1.0.0", "status": "approved", "created_at": None, "component_count": 0}],
+        "total": 1,
+        "page": 1,
+        "page_size": 50,
+    }
+
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get", return_value=versions_response),
+    ):
+        result = runner.invoke(app, ["agent", "versions", "my-agent", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    # Output must be valid JSON
+    parsed = json.loads(result.output)
+    assert isinstance(parsed, (dict, list))
+
+
+# ── agent pull ─────────────────────────────────────────────────
+
+
+def test_agent_pull_writes_files(tmp_path: Path) -> None:
+    """pull writes each entry in the files dict to disk."""
+    agent_id = "agent-uuid-pull"
+    agent_detail = {
+        "id": agent_id,
+        "name": "my-agent",
+        "latest_version": "1.2.0",
+        "latest_approved_version": "1.2.0",
+    }
+    ide_config = {
+        "files": {
+            ".claude/agents/my-agent/settings.json": '{"key": "value"}',
+            ".claude/agents/my-agent/AGENTS.md": "# My Agent\n",
+        }
+    }
+
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get") as mock_get,
+    ):
+        mock_get.side_effect = [agent_detail, ide_config]
+
+        result = runner.invoke(
+            app,
+            ["agent", "pull", "my-agent", "--ide", "claude-code", "--dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    settings_path = tmp_path / ".claude" / "agents" / "my-agent" / "settings.json"
+    agents_md_path = tmp_path / ".claude" / "agents" / "my-agent" / "AGENTS.md"
+    assert settings_path.exists(), f"Expected {settings_path} to exist"
+    assert agents_md_path.exists(), f"Expected {agents_md_path} to exist"
+    assert settings_path.read_text() == '{"key": "value"}'
+    assert agents_md_path.read_text() == "# My Agent\n"
+
+    # Output should mention the written files
+    assert "settings.json" in result.output or ".claude" in result.output
+
+
+def test_agent_pull_explicit_version(tmp_path: Path) -> None:
+    """pull --version uses the specified version instead of latest."""
+    agent_id = "agent-uuid-ver"
+    agent_detail = {
+        "id": agent_id,
+        "name": "my-agent",
+        "latest_version": "1.3.0",
+        "latest_approved_version": "1.3.0",
+    }
+    ide_config = {
+        "files": {
+            ".claude/agents/my-agent/AGENTS.md": "# pinned version\n",
+        }
+    }
+
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get") as mock_get,
+    ):
+        mock_get.side_effect = [agent_detail, ide_config]
+
+        result = runner.invoke(
+            app,
+            ["agent", "pull", "my-agent", "--ide", "claude-code", "--version", "1.2.0", "--dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    # Second GET call must use the explicit version, not latest
+    second_call = mock_get.call_args_list[1]
+    called_path = second_call[0][0]
+    assert "1.2.0" in called_path
+
+
+def test_agent_pull_raw_config_fallback(tmp_path: Path) -> None:
+    """pull handles a raw config dict (no 'files' key) by writing a single file."""
+    agent_id = "agent-uuid-raw"
+    agent_detail = {
+        "id": agent_id,
+        "name": "my-agent",
+        "latest_version": "1.0.0",
+        "latest_approved_version": "1.0.0",
+    }
+    # No 'files' key — just a plain config dict
+    ide_config = {"mcpServers": {"my-agent": {"command": "npx", "args": ["-y", "@my-agent"]}}}
+
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get") as mock_get,
+    ):
+        mock_get.side_effect = [agent_detail, ide_config]
+
+        result = runner.invoke(
+            app,
+            ["agent", "pull", "my-agent", "--ide", "claude-code", "--dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    # A fallback file should have been written
+    written = list(tmp_path.rglob("*"))
+    assert any(f.is_file() for f in written), "Expected at least one file to be written"

--- a/observal_cli/tests/test_cmd_agent_versions.py
+++ b/observal_cli/tests/test_cmd_agent_versions.py
@@ -51,7 +51,6 @@ def test_agent_release_bumps_version(agent_yaml_dir: Path) -> None:
     version_result = {
         "version": "1.3.0",
         "status": "pending",
-        "pending_version_count": 0,
     }
 
     with (
@@ -59,10 +58,10 @@ def test_agent_release_bumps_version(agent_yaml_dir: Path) -> None:
         patch("observal_cli.client.get") as mock_get,
         patch("observal_cli.client.post", return_value=version_result) as mock_post,
     ):
-        # GET /agents?search=my-agent → list result
+        # GET /agents/{id} → single agent dict
         # GET /agents/{id}/version-suggestions → suggestions
         mock_get.side_effect = [
-            [{"id": agent_id, "name": "my-agent"}],
+            {"id": agent_id, "name": "my-agent"},
             suggestions,
         ]
 
@@ -90,7 +89,7 @@ def test_agent_release_updates_local_yaml(agent_yaml_dir: Path) -> None:
         "current": "1.2.0",
         "suggestions": {"patch": "1.2.1", "minor": "1.3.0", "major": "2.0.0"},
     }
-    version_result = {"version": "1.2.1", "status": "pending", "pending_version_count": 0}
+    version_result = {"version": "1.2.1", "status": "pending"}
 
     with (
         patch("observal_cli.config.resolve_alias", return_value=agent_id),
@@ -98,7 +97,7 @@ def test_agent_release_updates_local_yaml(agent_yaml_dir: Path) -> None:
         patch("observal_cli.client.post", return_value=version_result),
     ):
         mock_get.side_effect = [
-            [{"id": agent_id, "name": "my-agent"}],
+            {"id": agent_id, "name": "my-agent"},
             suggestions,
         ]
         result = runner.invoke(
@@ -112,13 +111,17 @@ def test_agent_release_updates_local_yaml(agent_yaml_dir: Path) -> None:
 
 
 def test_agent_release_shows_pending_warning(agent_yaml_dir: Path) -> None:
-    """release shows a warning when pending_version_count > 0."""
+    """release shows a warning when the server returns warnings."""
     agent_id = "agent-uuid-9999"
     suggestions = {
         "current": "1.2.0",
         "suggestions": {"patch": "1.2.1", "minor": "1.3.0", "major": "2.0.0"},
     }
-    version_result = {"version": "1.3.0", "status": "pending", "pending_version_count": 2}
+    version_result = {
+        "version": "1.3.0",
+        "status": "pending",
+        "warnings": ["This agent already has 2 pending version(s)"],
+    }
 
     with (
         patch("observal_cli.config.resolve_alias", return_value=agent_id),
@@ -126,7 +129,7 @@ def test_agent_release_shows_pending_warning(agent_yaml_dir: Path) -> None:
         patch("observal_cli.client.post", return_value=version_result),
     ):
         mock_get.side_effect = [
-            [{"id": agent_id, "name": "my-agent"}],
+            {"id": agent_id, "name": "my-agent"},
             suggestions,
         ]
         result = runner.invoke(
@@ -135,8 +138,7 @@ def test_agent_release_shows_pending_warning(agent_yaml_dir: Path) -> None:
         )
 
     assert result.exit_code == 0, result.output
-    assert "pending" in result.output.lower()
-    assert "2" in result.output
+    assert "This agent already has 2 pending version(s)" in result.output
 
 
 # ── agent versions ─────────────────────────────────────────────
@@ -312,3 +314,30 @@ def test_agent_pull_raw_config_fallback(tmp_path: Path) -> None:
     # A fallback file should have been written
     written = list(tmp_path.rglob("*"))
     assert any(f.is_file() for f in written), "Expected at least one file to be written"
+
+
+def test_agent_pull_path_traversal_rejected(tmp_path: Path) -> None:
+    """pull rejects file paths containing directory traversal."""
+    agent_id = "agent-uuid-evil"
+    agent_detail = {"id": agent_id, "name": "evil-agent", "latest_approved_version": "1.0.0"}
+    ide_config = {
+        "files": {
+            "../../etc/evil.txt": "pwned",
+            ".claude/safe.json": '{"ok": true}',
+        }
+    }
+    with (
+        patch("observal_cli.config.resolve_alias", return_value=agent_id),
+        patch("observal_cli.client.get") as mock_get,
+    ):
+        mock_get.side_effect = [agent_detail, ide_config]
+        result = runner.invoke(
+            app,
+            ["agent", "pull", "evil-agent", "--ide", "claude-code", "--dir", str(tmp_path)],
+        )
+    assert result.exit_code == 0
+    # The traversal path must NOT exist outside tmp_path
+    assert not (tmp_path / ".." / ".." / "etc" / "evil.txt").resolve().exists()
+    # Safe file should exist
+    assert (tmp_path / ".claude" / "safe.json").exists()
+    assert "unsafe" in result.output.lower() or "Skipping" in result.output


### PR DESCRIPTION
## Summary
- Adds `observal agent release <name> --bump <patch|minor|major>` — bumps version via server suggestions, POSTs to `/agents/{id}/versions`, updates local YAML
- Adds `observal agent versions <name>` — lists all versions with status, date, component count
- Adds `observal agent pull <name> [--version X] [--ide Y]` — fetches pre-generated IDE config from `GET /agents/{id}/versions/{version}/ide/{ide}`, writes files to disk

Closes #625 (partial — Phase 1 CLI commands only)

## Details
- `agent pull` defaults to latest approved version, auto-detects IDE if `--ide` not specified
- `agent release` shows pending version warnings from the API response
- Follows existing CLI patterns: typer commands, rich tables/spinners, `client` module for HTTP

## Test plan
- [x] 8 unit tests covering all three commands (release bump, YAML update, pending warning, versions table/json, pull files/explicit-version/fallback)
- [ ] Manual: `observal agent release my-agent --bump minor` against staging
- [ ] Manual: `observal agent pull my-agent --ide kiro` writes correct files