### PR TITLE
feat(web): agent detail version dropdown + role-based tabs

### DIFF
--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -327,7 +327,7 @@ def agent_bulk_create(
             if status == "created"
             else ("[yellow]skipped[/yellow]" if status == "skipped" else f"[red]{status}[/red]")
         )
-        agent_id = str(item["agent_id"])[:8] + "…" if item.get("agent_id") else ""
+        agent_id = f"{str(item['agent_id'])[:8]}…" if item.get("agent_id") else ""
         results_table.add_row(str(i), item.get("name", ""), badge, agent_id, item.get("error", "") or "")
     console.print(results_table)
 
@@ -407,7 +407,7 @@ def agent_list(
         creator = item.get("created_by_username") or item.get("created_by_email", "")
         row = [str(i), item["name"], item.get("version", ""), item.get("model_name", ""), creator]
         if include_id:
-            row.append(str(item["id"]) if full_id else str(item["id"])[:8] + "…")
+            row.append(str(item["id"]) if full_id else f"{str(item['id'])[:8]}…")
         table.add_row(*row)
     console.print(table)
 

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -31,12 +31,14 @@ import {
   useEvalAggregate,
   useWhoami,
   useUpdateAgent,
+  useAgentVersions,
 } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 import type { FeedbackItem } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
+import { VersionDropdown } from "@/components/registry/version-dropdown";
 import { StatusBadge } from "@/components/registry/status-badge";
 import { IdeBadges } from "@/components/registry/ide-badges";
 import { FEATURE_LABELS, type IdeFeature } from "@/lib/ide-features";
@@ -471,6 +473,8 @@ export default function AgentDetailPage({
     useFeedbackSummary(id);
 
   const { data: whoami } = useWhoami();
+  const { data: versionsData } = useAgentVersions(id);
+  const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
 
   const storeSub = useCallback((cb: () => void) => {
     window.addEventListener("storage", cb);
@@ -488,7 +492,11 @@ export default function AgentDetailPage({
   );
 
   const a = agent as unknown as AgentDetail | undefined;
+  const versions = versionsData?.items ?? [];
+  const latestApprovedVersion = versions.find((v) => v.status === "approved")?.version;
+  const effectiveVersion = selectedVersion ?? latestApprovedVersion ?? a?.version;
   const canDelete = isAdmin || (whoami?.id && a?.created_by && whoami.id === String(a.created_by));
+  const canEdit = isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit";
   const components: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];
   const goalTemplate = a?.goal_template;
   const agentName = a?.name ?? id.slice(0, 8);
@@ -534,11 +542,17 @@ export default function AgentDetailPage({
                     {a.name}
                   </h1>
                   {a.status && <StatusBadge status={a.status} />}
-                  {a.version && (
+                  {versions.length > 0 ? (
+                    <VersionDropdown
+                      versions={versions}
+                      currentVersion={effectiveVersion ?? ""}
+                      onSelect={setSelectedVersion}
+                    />
+                  ) : a?.version ? (
                     <Badge variant="secondary" className="text-xs">
                       {a.version}
                     </Badge>
-                  )}
+                  ) : null}
                 </div>
 
                 {a.owner && (
@@ -598,6 +612,7 @@ export default function AgentDetailPage({
                     )}
                   </TabsTrigger>
                   <TabsTrigger value="install">Install</TabsTrigger>
+                  {canEdit && <TabsTrigger value="edit">Edit</TabsTrigger>}
                   {isAdmin && <TabsTrigger value="analytics">Analytics</TabsTrigger>}
                 </TabsList>
 
@@ -820,6 +835,15 @@ export default function AgentDetailPage({
                   </div>
                 </TabsContent>
 
+                {canEdit && (
+                  <TabsContent value="edit" className="mt-6">
+                    <EmptyState
+                      icon={Edit}
+                      title="Agent Editor"
+                      description="Form-based editing coming soon. Use the CLI to make changes: observal agent release"
+                    />
+                  </TabsContent>
+                )}
                 {isAdmin && (
                   <TabsContent value="analytics" className="mt-6">
                     <AnalyticsTab agentId={id} />

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -32,6 +32,7 @@ import {
   useWhoami,
   useUpdateAgent,
   useAgentVersions,
+  useAgentVersionDetail,
 } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
 import { hasMinRole } from "@/hooks/use-role-guard";
@@ -475,6 +476,7 @@ export default function AgentDetailPage({
   const { data: whoami } = useWhoami();
   const { data: versionsData } = useAgentVersions(id);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
+  const { data: versionDetail } = useAgentVersionDetail(id, selectedVersion);
 
   const storeSub = useCallback((cb: () => void) => {
     window.addEventListener("storage", cb);
@@ -495,6 +497,14 @@ export default function AgentDetailPage({
   const versions = versionsData?.items ?? [];
   const latestApprovedVersion = versions.find((v) => v.status === "approved")?.version;
   const effectiveVersion = selectedVersion ?? latestApprovedVersion ?? a?.version;
+  // Overlay version-specific fields when viewing a non-default version
+  const vd = versionDetail as Record<string, unknown> | undefined;
+  const versionDescription = (vd?.description as string) ?? a?.description;
+  const versionPrompt = (vd?.prompt as string) ?? a?.prompt;
+  const versionModelName = (vd?.model_name as string) ?? a?.model_name;
+  const versionSupportedIdes = (vd?.supported_ides as string[]) ?? a?.supported_ides;
+  const versionRequiredFeatures = (vd?.required_ide_features as string[]) ?? a?.required_ide_features;
+  const versionInferredIdes = (vd?.inferred_supported_ides as string[]) ?? a?.inferred_supported_ides;
   const canDelete = isAdmin || (whoami?.id && a?.created_by && whoami.id === String(a.created_by));
   const canEdit = isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit";
   const components: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];
@@ -559,9 +569,9 @@ export default function AgentDetailPage({
                   <p className="text-sm text-muted-foreground">{a.owner}</p>
                 )}
 
-                {a.description && (
+                {versionDescription && (
                   <p className="text-sm text-foreground/80 leading-relaxed max-w-2xl">
-                    {a.description}
+                    {versionDescription}
                   </p>
                 )}
               </div>
@@ -617,24 +627,24 @@ export default function AgentDetailPage({
                 </TabsList>
 
                 <TabsContent value="overview" className="space-y-6 mt-6">
-                  {a.description && (
+                  {versionDescription && (
                     <div className="space-y-2">
                       <h3 className="text-sm font-semibold font-display">
                         About
                       </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        {a.description}
+                        {versionDescription}
                       </p>
                     </div>
                   )}
 
-                  {a.model_name && (
+                  {versionModelName && (
                     <div className="space-y-1">
                       <h3 className="text-sm font-semibold font-display">
                         Model
                       </h3>
                       <p className="text-sm text-muted-foreground font-mono">
-                        {a.model_name}
+                        {versionModelName}
                       </p>
                     </div>
                   )}
@@ -666,7 +676,7 @@ export default function AgentDetailPage({
                     </div>
                   )}
 
-                  {!a.description && !goalTemplate && (
+                  {!versionDescription && !goalTemplate && (
                     <p className="text-sm text-muted-foreground">
                       No additional details provided for this agent.
                     </p>
@@ -676,7 +686,7 @@ export default function AgentDetailPage({
                 <TabsContent value="components" className="mt-6">
                   <div className="min-h-[300px]">
                   {components.length === 0 ? (
-                    a.prompt ? (
+                    versionPrompt ? (
                       <div className="space-y-3">
                         <p className="text-xs text-muted-foreground">
                           This agent was registered via scan and uses an inline system prompt instead of linked components.
@@ -684,7 +694,7 @@ export default function AgentDetailPage({
                         <div className="rounded-md border border-border bg-muted/20 p-4">
                           <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">System Prompt</h4>
                           <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words text-foreground/80 leading-relaxed max-h-[400px] overflow-y-auto">
-                            {String(a.prompt)}
+                            {String(versionPrompt)}
                           </pre>
                         </div>
                       </div>
@@ -906,11 +916,11 @@ export default function AgentDetailPage({
                       {components.length}
                     </span>
                   </div>
-                  {a.model_name && (
+                  {versionModelName && (
                     <div className="flex items-center justify-between text-sm">
                       <span className="text-muted-foreground">Model</span>
                       <span className="font-mono text-xs truncate max-w-[140px]">
-                        {a.model_name}
+                        {versionModelName}
                       </span>
                     </div>
                   )}
@@ -922,17 +932,17 @@ export default function AgentDetailPage({
                   IDE Compatibility
                 </h3>
                 <IdeBadges
-                  supportedIdes={a.supported_ides}
-                  inferredSupportedIdes={a.inferred_supported_ides}
+                  supportedIdes={versionSupportedIdes}
+                  inferredSupportedIdes={versionInferredIdes}
                   max={7}
                 />
-                {a.required_ide_features && a.required_ide_features.length > 0 && (
+                {versionRequiredFeatures && versionRequiredFeatures.length > 0 && (
                   <div className="space-y-1">
                     <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60">
                       Required features
                     </p>
                     <div className="flex flex-wrap gap-1">
-                      {a.required_ide_features.map((f: string) => (
+                      {versionRequiredFeatures.map((f: string) => (
                         <span key={f} className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
                           {FEATURE_LABELS[f as IdeFeature] ?? f}
                         </span>

--- a/web/src/components/registry/pull-command.tsx
+++ b/web/src/components/registry/pull-command.tsx
@@ -27,7 +27,7 @@ export function PullCommand({ agentName }: { agentName: string }) {
   const [ide, setIde] = useState("cursor");
   const [copied, setCopied] = useState(false);
 
-  const command = `observal pull ${agentName} --ide ${ide}`;
+  const command = `observal agent pull ${agentName} --ide ${ide}`;
 
   function handleCopy() {
     copyToClipboard(command);

--- a/web/src/components/registry/version-dropdown.tsx
+++ b/web/src/components/registry/version-dropdown.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useMemo } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { AgentVersionSummary } from "@/lib/types";
+
+interface VersionDropdownProps {
+  versions: AgentVersionSummary[];
+  currentVersion: string;
+  onSelect: (version: string) => void;
+}
+
+export function VersionDropdown({ versions, currentVersion, onSelect }: VersionDropdownProps) {
+  const approvedVersions = useMemo(
+    () => versions.filter((v) => v.status === "approved"),
+    [versions]
+  );
+
+  const latestApproved = approvedVersions[0]?.version;
+  const isOlderVersion = currentVersion && latestApproved && currentVersion !== latestApproved;
+
+  if (approvedVersions.length <= 1) {
+    return (
+      <Badge variant="secondary" className="text-xs">
+        v{currentVersion || approvedVersions[0]?.version || "—"}
+      </Badge>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Select value={currentVersion} onValueChange={onSelect}>
+        <SelectTrigger className="h-7 w-[140px] text-xs">
+          <SelectValue placeholder="Version" />
+        </SelectTrigger>
+        <SelectContent>
+          {approvedVersions.map((v) => (
+            <SelectItem key={v.id} value={v.version}>
+              <span className="flex items-center gap-2">
+                <span>v{v.version}</span>
+                {v.version === latestApproved && (
+                  <Badge variant="outline" className="text-[9px] px-1 py-0">latest</Badge>
+                )}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {isOlderVersion && (
+        <span className="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+          <AlertTriangle className="h-3 w-3" />
+          Not the latest version
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/registry/version-dropdown.tsx
+++ b/web/src/components/registry/version-dropdown.tsx
@@ -18,9 +18,23 @@ interface VersionDropdownProps {
   onSelect: (version: string) => void;
 }
 
+/** Compare two semver strings (descending). Falls back to string compare. */
+function semverCompareDesc(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
 export function VersionDropdown({ versions, currentVersion, onSelect }: VersionDropdownProps) {
   const approvedVersions = useMemo(
-    () => versions.filter((v) => v.status === "approved"),
+    () =>
+      versions
+        .filter((v) => v.status === "approved")
+        .sort((a, b) => semverCompareDesc(a.version, b.version)),
     [versions]
   );
 

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -129,6 +129,14 @@ export function useAgentVersions(agentId: string | undefined) {
   });
 }
 
+export function useAgentVersionDetail(agentId: string | undefined, version: string | null) {
+  return useQuery({
+    queryKey: ["agent-version-detail", agentId, version],
+    enabled: !!agentId && !!version,
+    queryFn: () => registry.getVersion(agentId!, version!),
+  });
+}
+
 // ── Review ──────────────────────────────────────────────────────────
 
 export function useReviewList(typeFilter?: string) {

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -121,6 +121,14 @@ export function useRegistryMetrics(type: RegistryType, id: string | undefined) {
   });
 }
 
+export function useAgentVersions(agentId: string | undefined) {
+  return useQuery({
+    queryKey: ["agent-versions", agentId],
+    enabled: !!agentId,
+    queryFn: () => registry.listVersions(agentId!),
+  });
+}
+
 // ── Review ──────────────────────────────────────────────────────────
 
 export function useReviewList(typeFilter?: string) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   LeaderboardWindow,
   ValidationResult,
   VersionSuggestions,
+  AgentVersionsResponse,
   BulkResult,
   ComponentLeaderboardItem,
   AuditLogEntry,
@@ -266,6 +267,10 @@ export const registry = {
     post<RegistryItem>(`/${type}/submit`, body),
   versionSuggestions: (id: string) =>
     get<VersionSuggestions>(`/agents/${id}/version-suggestions`),
+  listVersions: (agentId: string, page = 1, pageSize = 50) =>
+    get<AgentVersionsResponse>(`/agents/${agentId}/versions?page=${page}&page_size=${pageSize}`),
+  getVersion: (agentId: string, version: string) =>
+    get<unknown>(`/agents/${agentId}/versions/${version}`),
 };
 
 // ── Review ──────────────────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -125,6 +125,29 @@ export interface VersionSuggestions {
   major: string;
 }
 
+export interface AgentVersionSummary {
+  id: string;
+  agent_id: string;
+  version: string;
+  description: string;
+  status: string;
+  is_prerelease: boolean;
+  download_count: number;
+  supported_ides: string[];
+  released_by: string;
+  released_at: string | null;
+  created_at: string | null;
+  rejection_reason: string | null;
+  component_count: number;
+}
+
+export interface AgentVersionsResponse {
+  items: AgentVersionSummary[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
 export interface BulkResultItem {
   name: string;
   status: "created" | "skipped" | "error";


### PR DESCRIPTION
## Summary
- Adds `VersionDropdown` component to the agent detail page header — shows all approved versions, highlights "latest", warns when viewing an older version
- Adds `registry.listVersions()` API function + `useAgentVersions()` React Query hook calling `GET /agents/{id}/versions`
- Adds "Edit" tab stub (visible to owner/co-maintainers only) as placeholder for #630
- Updates pull command display from `observal pull` to `observal agent pull` (versioned format)

Closes #629

## Test plan
- [ ] Version dropdown renders with multiple approved versions
- [ ] Single-version agents show a static badge (no dropdown)
- [ ] Selecting an older version shows the amber "Not the latest version" warning
- [ ] "Edit" tab only visible when `user_permission` is `owner` or `edit`
- [ ] Pull command shows correct `observal agent pull <name> --ide <ide>` format
- [ ] No TypeScript errors in modified files