### PR TITLE
fix(docker): resolve entrypoint migration incompatibility on fresh DB

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,8 +15,8 @@ async def init():
 asyncio.run(init())
 "
 
-echo "Running database migrations..."
-/app/.venv/bin/python -m alembic upgrade head
+echo "Stamping alembic to head (models are canonical)..."
+/app/.venv/bin/python -m alembic stamp head
 
 echo "Ensuring ClickHouse database exists..."
 # Parse credentials from CLICKHOUSE_URL using Python to handle special chars

--- a/observal-server/alembic/versions/0011_agent_review_and_bundles.py
+++ b/observal-server/alembic/versions/0011_agent_review_and_bundles.py
@@ -77,8 +77,19 @@ def upgrade() -> None:
         END $$;
     """)
 
-    # Index on agents.status for review queries
-    op.execute("CREATE INDEX IF NOT EXISTS ix_agents_status ON agents(status)")
+    # Index on agents.status for review queries (guard: column may not exist if
+    # create_all ran with newer models that moved status to agent_versions)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'agents' AND column_name = 'status'
+            ) THEN
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ix_agents_status ON agents(status)';
+            END IF;
+        END $$;
+    """)
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Purpose / Description

Fix Docker entrypoint failing on fresh DB initialization. The entrypoint ran `Base.metadata.create_all` (which reflects the current models) followed by `alembic upgrade head` (which assumes starting from an older schema). On a fresh DB this caused conflicts — migrations tried to create tables or index columns that either already existed or had been removed in newer model versions.

## Fixes
* Fixes fresh DB initialization failure when running `make rebuild-clean`

## Approach

Two changes:

1. **`docker/entrypoint.sh`** — Replace `alembic upgrade head` with `alembic stamp head`. Since `create_all` already produces the canonical schema from current models, we just stamp alembic to mark the DB as up-to-date without replaying historical migrations.

2. **`observal-server/alembic/versions/0011_agent_review_and_bundles.py`** — Guard the `CREATE INDEX ON agents(status)` with a conditional check. The `status` column was moved from `agents` to `agent_versions` in migration 0022, so on incremental upgrades this index creation must be skipped if the column doesn't exist.

## How Has This Been Tested?

- `make rebuild-clean` now completes successfully (previously failed with `column "status" does not exist`)
- Full docker stack starts with API healthy on port 8000 and web on port 3000

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
