### PR TITLE
feat(web): review queue YAML diff view (#633)

### DIFF
--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -69,13 +69,13 @@ async def _find_listing(listing_id: str, db: AsyncSession):
     return None, None
 
 
-async def _check_agent_components_ready(agent: Agent, db: AsyncSession) -> tuple[bool, list[dict]]:
-    """Check if all of an agent's components are approved."""
-    if not agent.components:
+async def _check_agent_components_ready(components, db: AsyncSession) -> tuple[bool, list[dict]]:
+    """Check if all of an agent version's components are approved."""
+    if not components:
         return True, []
 
     by_type: dict[str, list[uuid.UUID]] = {}
-    for comp in agent.components:
+    for comp in components:
         by_type.setdefault(comp.component_type, []).append(comp.component_id)
 
     blocking: list[dict] = []
@@ -105,35 +105,52 @@ async def _check_agent_components_ready(agent: Agent, db: AsyncSession) -> tuple
 
 
 async def _query_pending_agents(db: AsyncSession) -> list[dict]:
-    result = await db.execute(
-        select(Agent)
-        .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
-        .where(AgentVersion.status == AgentStatus.pending)
-        .order_by(Agent.created_at.desc())
+    # Find agents that have ANY pending version (not just latest_version_id).
+    # This ensures version updates appear in the review queue after the first
+    # version is approved.
+    pending_versions_stmt = (
+        select(AgentVersion).where(AgentVersion.status == AgentStatus.pending).order_by(AgentVersion.created_at.desc())
     )
-    agents = result.scalars().all()
+    pending_versions = (await db.execute(pending_versions_stmt)).scalars().all()
 
-    user_ids = {a.created_by for a in agents}
+    if not pending_versions:
+        return []
+
+    # Group by agent_id, take the newest pending version per agent
+    seen_agents: dict[uuid.UUID, AgentVersion] = {}
+    for v in pending_versions:
+        if v.agent_id not in seen_agents:
+            seen_agents[v.agent_id] = v
+
+    # Load the agents
+    agent_ids = list(seen_agents.keys())
+    agents_result = await db.execute(select(Agent).where(Agent.id.in_(agent_ids)))
+    agents_map = {a.id: a for a in agents_result.scalars().all()}
+
+    user_ids = {a.created_by for a in agents_map.values()}
     user_map: dict[uuid.UUID, str] = {}
     if user_ids:
         rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
         user_map = {r[0]: r[1] for r in rows.all()}
 
     items = []
-    for a in agents:
-        components_ready, blocking = await _check_agent_components_ready(a, db)
+    for agent_id, pending_ver in seen_agents.items():
+        a = agents_map.get(agent_id)
+        if not a:
+            continue
+        components_ready, blocking = await _check_agent_components_ready(pending_ver.components, db)
         items.append(
             {
                 "type": "agent",
                 "id": str(a.id),
                 "name": a.name,
-                "description": a.description or "",
-                "version": a.version or "",
+                "description": pending_ver.description or a.description or "",
+                "version": pending_ver.version,
                 "owner": a.owner or "",
-                "status": a.status.value,
+                "status": pending_ver.status.value,
                 "submitted_by": user_map.get(a.created_by, str(a.created_by)),
-                "created_at": a.created_at.isoformat() if a.created_at else "",
-                "component_count": len(a.components),
+                "created_at": pending_ver.created_at.isoformat() if pending_ver.created_at else "",
+                "component_count": len(pending_ver.components) if pending_ver.components else 0,
                 "components_ready": components_ready,
                 "blocking_components": blocking,
             }
@@ -388,7 +405,7 @@ async def get_review(
         agent = (await db.execute(select(Agent).where(Agent.id == agent_uuid))).scalar_one_or_none()
         if not agent:
             raise HTTPException(status_code=404, detail="Listing not found")
-        components_ready, blocking = await _check_agent_components_ready(agent, db)
+        components_ready, blocking = await _check_agent_components_ready(agent.components, db)
         result = {
             "type": "agent",
             "id": str(agent.id),
@@ -510,7 +527,7 @@ async def approve_agent(
     if agent.status != AgentStatus.pending:
         raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', not pending")
 
-    components_ready, blocking = await _check_agent_components_ready(agent, db)
+    components_ready, blocking = await _check_agent_components_ready(agent.components, db)
     if not components_ready:
         raise HTTPException(
             status_code=422,

--- a/web/e2e/review-diff-screenshots.spec.ts
+++ b/web/e2e/review-diff-screenshots.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Screenshots for the review diff dialog.
+ * Creates an agent, submits v1 (pending), screenshots the review dialog,
+ * then creates v2 (pending) with changes and screenshots the diff view.
+ *
+ * Run: npx playwright test e2e/review-diff-screenshots.spec.ts --project=chromium
+ */
+import { test } from "@playwright/test";
+import { loginToWebUI, API_BASE, getAccessToken } from "./helpers";
+
+const SCREENSHOT_DIR = "e2e/screenshots";
+
+test.describe("Review Diff Dialog Screenshots", () => {
+  let agentId: string;
+  let token: string;
+
+  test.beforeAll(async () => {
+    token = await getAccessToken();
+
+    // Create a test agent (starts as draft)
+    const createRes = await fetch(`${API_BASE}/api/v1/agents`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: `review-diff-test-${Date.now()}`,
+        version: "1.0.0",
+        description: "A security-focused code review agent that scans PRs for OWASP Top 10 vulnerabilities.",
+        owner: "platform-team",
+        model_name: "claude-sonnet-4-20250514",
+        prompt: "## Security Review Agent\n\nYou are a security-focused code reviewer. Your job is to analyze code changes for vulnerabilities.\n\n## Focus Areas\n- SQL injection (A03)\n- Broken authentication (A07)\n- Sensitive data exposure (A02)\n\n## Output Format\nProvide findings as a structured report with severity levels.",
+        components: [],
+        goal_template: {
+          description: "Review code for security issues",
+          sections: [
+            { name: "Scan", description: "Scan for vulnerabilities" },
+            { name: "Report", description: "Generate findings report" },
+          ],
+        },
+      }),
+    });
+
+    if (!createRes.ok) {
+      const body = await createRes.text();
+      throw new Error(`Failed to create agent: ${createRes.status} ${body}`);
+    }
+
+    const agent = await createRes.json();
+    agentId = agent.id;
+    // Agent creation already creates v1.0.0 as pending — it shows in the review queue
+  });
+
+  test.afterAll(async () => {
+    if (!agentId) return;
+    await fetch(`${API_BASE}/api/v1/agents/${agentId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  });
+
+  test("1 - Review dialog first release (no diff, shows snapshot)", async ({ page }) => {
+    await loginToWebUI(page);
+    await page.goto("/review");
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(500);
+
+    // Click the agent name in the review list to open the diff dialog
+    const agentCard = page.locator("button:has-text('review-diff-test')").first();
+    await agentCard.click();
+    await page.waitForTimeout(1000);
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/07-review-dialog-first-release.png`,
+      fullPage: false,
+    });
+  });
+
+  test("2 - Review dialog with diff (v1 approved, v2 pending)", async ({ page }) => {
+    // Approve v1 via the review router so we have a previous approved version
+    const approveRes = await fetch(
+      `${API_BASE}/api/v1/review/agents/${agentId}/approve`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!approveRes.ok) {
+      const body = await approveRes.text();
+      throw new Error(`Failed to approve v1: ${approveRes.status} ${body}`);
+    }
+
+    // Create v2 with changes (pending, shows up in review queue)
+    const v2Res = await fetch(`${API_BASE}/api/v1/agents/${agentId}/versions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        version: "1.1.0",
+        description: "Added XSS detection and improved output format with CVSS scoring",
+        model_name: "claude-sonnet-4-20250514",
+        prompt: "## Security Review Agent\n\nYou are a security-focused code reviewer. Your job is to analyze code changes for vulnerabilities and compliance issues.\n\n## Focus Areas\n- SQL injection (A03)\n- Cross-site scripting / XSS (A07)\n- Broken authentication (A07)\n- Sensitive data exposure (A02)\n- Server-side request forgery (A10)\n\n## Output Format\nProvide findings as a structured report with:\n- Severity (critical/high/medium/low)\n- CVSS score\n- Remediation steps\n- Code references",
+        supported_ides: ["claude_code", "copilot_cli", "kiro"],
+        components: [],
+      }),
+    });
+
+    if (!v2Res.ok) {
+      const body = await v2Res.text();
+      throw new Error(`Failed to create v2: ${v2Res.status} ${body}`);
+    }
+
+    await loginToWebUI(page);
+    await page.goto("/review");
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(500);
+
+    // Click the agent to open the diff dialog
+    const agentCard = page.locator("button:has-text('review-diff-test')").first();
+    await agentCard.click();
+    await page.waitForTimeout(1500);
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/08-review-dialog-diff-view.png`,
+      fullPage: false,
+    });
+  });
+
+  test("3 - Reject dialog", async ({ page }) => {
+    await loginToWebUI(page);
+    await page.goto("/review");
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(500);
+
+    // Click our specific agent (the v2 pending from test 2)
+    const agentCard = page.locator("button:has-text('review-diff-test')").first();
+    await agentCard.click();
+
+    // Wait for the main review dialog to open
+    const mainDialog = page.locator("[role='dialog']").first();
+    await mainDialog.waitFor({ state: "visible", timeout: 5000 });
+    await page.waitForTimeout(1000);
+
+    // Click Reject inside the main dialog footer
+    const rejectBtn = mainDialog.locator("button", { hasText: "Reject" });
+    await rejectBtn.click();
+
+    // Wait for the nested reject-reason dialog to appear
+    // It will be the second [role='dialog'] on the page
+    const rejectDialog = page.locator("[role='dialog']").nth(1);
+    await rejectDialog.waitFor({ state: "visible", timeout: 5000 });
+    await page.waitForTimeout(300);
+
+    // Type a reason
+    const textarea = rejectDialog.locator("textarea");
+    await textarea.fill("Missing CSRF detection in focus areas. Please add A05 (Security Misconfiguration) coverage before approval.");
+    await page.waitForTimeout(300);
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/09-review-reject-dialog.png`,
+      fullPage: false,
+    });
+  });
+});

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { CheckCircle2, X, Trash2, LayoutGrid, TableProperties } from "lucide-react";
 import { useReviewAgents, useReviewComponents, useReviewAction, useReviewDelete } from "@/hooks/use-api";
+import { useAuthGuard } from "@/hooks/use-auth";
 import type { ReviewItem } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -15,16 +16,18 @@ import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { ValidationBadge, ValidationDetails, ComponentReadinessBadge } from "@/components/review/validation-badges";
 import { ReviewDetailSheet } from "@/components/review/review-detail-sheet";
+import { ReviewDiffSheet } from "@/components/review/review-diff-sheet";
 
 type ViewMode = "list" | "grid";
 
-function ReviewCard({ item, onApprove, onReject, onDelete, onItemClick, disableApprove }: {
+function ReviewCard({ item, onApprove, onReject, onDelete, onItemClick, disableApprove, isAdmin }: {
   item: ReviewItem;
   onApprove: (id: string, type?: string) => void;
   onReject: (id: string, reason: string, type?: string) => void;
   onDelete: (id: string, type?: string) => void;
   onItemClick: (item: ReviewItem) => void;
   disableApprove?: boolean;
+  isAdmin?: boolean;
 }) {
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
@@ -152,36 +155,39 @@ function ReviewCard({ item, onApprove, onReject, onDelete, onItemClick, disableA
         >
           {showRejectInput ? "Confirm" : "Reject"}
         </Button>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-                onClick={() => setConfirmDelete(true)}
-                aria-label="Delete submission"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Withdraw / delete submission</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        {isAdmin && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                  onClick={() => setConfirmDelete(true)}
+                  aria-label="Delete submission"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Permanently delete (admin only)</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
       </div>
     </div>
   );
 }
 
-function ReviewRow({ item, onApprove, onReject, onDelete, onItemClick, disableApprove }: {
+function ReviewRow({ item, onApprove, onReject, onDelete, onItemClick, disableApprove, isAdmin }: {
   item: ReviewItem;
   onApprove: (id: string, type?: string) => void;
   onReject: (id: string, reason: string, type?: string) => void;
   onDelete: (id: string, type?: string) => void;
   onItemClick: (item: ReviewItem) => void;
   disableApprove?: boolean;
+  isAdmin?: boolean;
 }) {
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
@@ -314,24 +320,26 @@ function ReviewRow({ item, onApprove, onReject, onDelete, onItemClick, disableAp
             >
               Reject
             </Button>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                    onClick={() => setConfirmDelete(true)}
-                    aria-label="Delete submission"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Withdraw / delete submission</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            {isAdmin && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => setConfirmDelete(true)}
+                      aria-label="Delete submission"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Permanently delete (admin only)</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
           </div>
         )}
       </div>
@@ -346,6 +354,7 @@ function AgentItemList({
   onReject,
   onDelete,
   onItemClick,
+  isAdmin,
 }: {
   items: ReviewItem[];
   view: ViewMode;
@@ -353,6 +362,7 @@ function AgentItemList({
   onReject: (id: string, reason: string, type?: string) => void;
   onDelete: (id: string, type?: string) => void;
   onItemClick: (item: ReviewItem) => void;
+  isAdmin?: boolean;
 }) {
   const grouped = useMemo(() => {
     const bundles = new Map<string, { name: string; items: ReviewItem[] }>();
@@ -384,6 +394,7 @@ function AgentItemList({
             onDelete={onDelete}
             onItemClick={onItemClick}
             disableApprove={item.components_ready === false}
+            isAdmin={isAdmin}
           />
         ))}
       </div>
@@ -398,6 +409,7 @@ function AgentItemList({
             onDelete={onDelete}
             onItemClick={onItemClick}
             disableApprove={item.components_ready === false}
+            isAdmin={isAdmin}
           />
         ))}
       </div>
@@ -436,6 +448,7 @@ function ReviewItemList({
   onReject,
   onDelete,
   onItemClick,
+  isAdmin,
 }: {
   items: ReviewItem[];
   view: ViewMode;
@@ -443,6 +456,7 @@ function ReviewItemList({
   onReject: (id: string, reason: string, type?: string) => void;
   onDelete: (id: string, type?: string) => void;
   onItemClick: (item: ReviewItem) => void;
+  isAdmin?: boolean;
 }) {
   return view === "list" ? (
     <div className="animate-in rounded-md border border-border overflow-hidden">
@@ -454,6 +468,7 @@ function ReviewItemList({
           onReject={onReject}
           onDelete={onDelete}
           onItemClick={onItemClick}
+          isAdmin={isAdmin}
         />
       ))}
     </div>
@@ -467,6 +482,7 @@ function ReviewItemList({
           onReject={onReject}
           onDelete={onDelete}
           onItemClick={onItemClick}
+          isAdmin={isAdmin}
         />
       ))}
     </div>
@@ -474,6 +490,8 @@ function ReviewItemList({
 }
 
 export default function ReviewPage() {
+  const { role } = useAuthGuard();
+  const isAdmin = role === "admin" || role === "super_admin";
   const { data: agents, isLoading: agentsLoading, isError: agentsError, error: agentsErr, refetch: refetchAgents } = useReviewAgents();
   const { data: components, isLoading: componentsLoading, isError: componentsError, error: componentsErr, refetch: refetchComponents } = useReviewComponents();
   const reviewAction = useReviewAction();
@@ -481,6 +499,7 @@ export default function ReviewPage() {
   const [view, setView] = useState<ViewMode>("grid");
   const [activeTab, setActiveTab] = useState("agents");
   const [selectedItem, setSelectedItem] = useState<ReviewItem | null>(null);
+  const [diffItem, setDiffItem] = useState<ReviewItem | null>(null);
 
   const agentCount = (agents ?? []).length;
   const componentCount = (components ?? []).length;
@@ -502,7 +521,13 @@ export default function ReviewPage() {
   );
 
   const handleItemClick = useCallback(
-    (item: ReviewItem) => setSelectedItem(item),
+    (item: ReviewItem) => {
+      if (item.type === "agent") {
+        setDiffItem(item);
+      } else {
+        setSelectedItem(item);
+      }
+    },
     [],
   );
 
@@ -578,6 +603,7 @@ export default function ReviewPage() {
                 onReject={handleReject}
                 onDelete={handleDelete}
                 onItemClick={handleItemClick}
+                isAdmin={isAdmin}
               />
             )}
           </TabsContent>
@@ -605,6 +631,7 @@ export default function ReviewPage() {
                 onReject={handleReject}
                 onDelete={handleDelete}
                 onItemClick={handleItemClick}
+                isAdmin={isAdmin}
               />
             )}
           </TabsContent>
@@ -618,6 +645,14 @@ export default function ReviewPage() {
         onApprove={handleApprove}
         onReject={handleReject}
         onDelete={handleDelete}
+      />
+
+      <ReviewDiffSheet
+        item={diffItem}
+        open={!!diffItem}
+        onOpenChange={(open) => { if (!open) setDiffItem(null); }}
+        onApprove={handleApprove}
+        onReject={handleReject}
       />
     </>
   );

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -66,7 +66,7 @@ function ReviewCard({ item, onApprove, onReject, onDelete, onItemClick, disableA
         </div>
         {item.type && (
           <Badge variant="outline" className="text-[10px] shrink-0">
-            {item.type ?? item.listing_type ?? "-"}
+            {item.type}
           </Badge>
         )}
       </div>
@@ -222,7 +222,7 @@ function ReviewRow({ item, onApprove, onReject, onDelete, onItemClick, disableAp
             </button>
             {item.type && (
               <Badge variant="outline" className="text-[10px] shrink-0">
-                {item.type ?? item.listing_type ?? "-"}
+                {item.type}
               </Badge>
             )}
             {item.version && (

--- a/web/src/components/review/review-diff-sheet.tsx
+++ b/web/src/components/review/review-diff-sheet.tsx
@@ -1,0 +1,528 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { ArrowRight, Plus, Minus, RefreshCw } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { YamlDiffView } from "./yaml-diff-view";
+import { useAgentVersions, useVersionDiff, useAgentVersionDetail } from "@/hooks/use-api";
+import type { ReviewItem, ComponentChange } from "@/lib/types";
+
+function semverBumpType(from: string, to: string): "major" | "minor" | "patch" | null {
+  const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
+  const [fa, fb, fc] = parse(from);
+  const [ta, tb, tc] = parse(to);
+  if (isNaN(fa) || isNaN(ta)) return null;
+  if (ta > fa) return "major";
+  if (tb > fb) return "minor";
+  if (tc > fc) return "patch";
+  return null;
+}
+
+const bumpBadgeClasses: Record<string, string> = {
+  major: "bg-destructive/10 text-destructive border-destructive/25",
+  minor: "bg-warning/10 text-warning border-warning/25",
+  patch: "bg-success/10 text-success border-success/25",
+};
+
+const changeBadgeClasses: Record<string, string> = {
+  added: "bg-success/10 text-success border-success/25",
+  removed: "bg-destructive/10 text-destructive border-destructive/25",
+  updated: "bg-warning/10 text-warning border-warning/25",
+};
+
+const changeIcon: Record<string, React.ReactNode> = {
+  added: <Plus className="h-3 w-3" />,
+  removed: <Minus className="h-3 w-3" />,
+  updated: <RefreshCw className="h-3 w-3" />,
+};
+
+function ComponentChangesList({ changes }: { changes: ComponentChange[] }) {
+  if (!changes.length) return null;
+
+  return (
+    <div className="space-y-2">
+      {changes.map((c, i) => (
+        <div
+          key={i}
+          className="flex items-start gap-2 text-xs py-1.5 px-2 rounded bg-muted/40"
+        >
+          <Badge
+            variant="outline"
+            className={`text-[10px] shrink-0 flex items-center gap-1 ${changeBadgeClasses[c.change] ?? ""}`}
+          >
+            {changeIcon[c.change]}
+            {c.change}
+          </Badge>
+          <div className="min-w-0 flex-1">
+            <span className="font-medium truncate block">{c.name}</span>
+            <span className="text-muted-foreground">{c.type}</span>
+            {c.from && c.to && (
+              <span className="ml-1 text-muted-foreground">
+                {c.from} <ArrowRight className="h-2.5 w-2.5 inline" /> {c.to}
+              </span>
+            )}
+            {c.version && !c.from && (
+              <span className="ml-1 text-muted-foreground">v{c.version}</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface ReviewDiffSheetProps {
+  item: ReviewItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onApprove: (id: string, type?: string) => void;
+  onReject: (id: string, reason: string, type?: string) => void;
+}
+
+export function ReviewDiffSheet({
+  item,
+  open,
+  onOpenChange,
+  onApprove,
+  onReject,
+}: ReviewDiffSheetProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-7xl w-[95vw] h-[85vh] flex flex-col p-0 gap-0 overflow-hidden">
+        {item ? (
+          <DiffDialogBody
+            key={item.id}
+            item={item}
+            onOpenChange={onOpenChange}
+            onApprove={onApprove}
+            onReject={onReject}
+          />
+        ) : (
+          <div className="p-6 space-y-4">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-full" />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DiffDialogBody({
+  item,
+  onOpenChange,
+  onApprove,
+  onReject,
+}: {
+  item: ReviewItem;
+  onOpenChange: (open: boolean) => void;
+  onApprove: (id: string, type?: string) => void;
+  onReject: (id: string, reason: string, type?: string) => void;
+}) {
+  const [showRejectDialog, setShowRejectDialog] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const { data: versionsData, isLoading: versionsLoading } = useAgentVersions(item.id);
+
+  // Find the most recent approved version before the pending one.
+  // Versions are returned newest-first (created_at DESC), so [0] is the most recent.
+  const previousVersion = useMemo(() => {
+    if (!versionsData?.items || !item.version) return undefined;
+    const approved = versionsData.items.filter(
+      (v) => v.status === "approved" && v.version !== item.version,
+    );
+    return approved[0]?.version;
+  }, [versionsData, item.version]);
+
+  const { data: diffData, isLoading: diffLoading } = useVersionDiff(
+    item.id,
+    previousVersion,
+    item.version,
+  );
+
+  // Always fetch version detail for the left pane (prompt, model, components, yaml_snapshot)
+  const { data: versionDetail, isLoading: detailLoading } = useAgentVersionDetail(
+    item.id,
+    item.version ?? null,
+  );
+
+  const bumpType = useMemo(() => {
+    if (!previousVersion || !item.version) return null;
+    return semverBumpType(previousVersion, item.version);
+  }, [previousVersion, item.version]);
+
+  const handleApprove = useCallback(() => {
+    onApprove(item.id, item.type);
+    onOpenChange(false);
+  }, [item, onApprove, onOpenChange]);
+
+  const handleRejectConfirm = useCallback(() => {
+    if (!rejectReason.trim()) return;
+    onReject(item.id, rejectReason, item.type);
+    setShowRejectDialog(false);
+    setRejectReason("");
+    onOpenChange(false);
+  }, [rejectReason, item, onReject, onOpenChange]);
+
+  const disableApprove = item.components_ready === false;
+
+  const isLoading = versionsLoading || (!!previousVersion && diffLoading);
+
+  const detail = versionDetail as Record<string, unknown> | undefined;
+  const yamlSnapshot = detail?.yaml_snapshot as string | null | undefined;
+  // Prefer version detail fields over the sparse review item fields
+  const prompt = (detail?.prompt as string) || item.prompt || "";
+  const modelName = (detail?.model_name as string) || item.model_name || "";
+  const supportedIdes = (detail?.supported_ides as string[]) || item.supported_ides || [];
+  const components = (detail?.components as { component_type: string; component_id: string }[]) || item.components || [];
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Header */}
+      <div className="shrink-0 px-5 py-4 border-b border-border">
+        <DialogHeader className="space-y-1.5">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant="outline" className="text-[10px]">
+              agent
+            </Badge>
+            {bumpType && (
+              <Badge
+                variant="outline"
+                className={`text-[10px] ${bumpBadgeClasses[bumpType]}`}
+              >
+                {bumpType}
+              </Badge>
+            )}
+            {item.submitted_by && (
+              <span className="text-xs text-muted-foreground">
+                by {item.submitted_by}
+              </span>
+            )}
+          </div>
+          <DialogTitle className="text-base font-[family-name:var(--font-display)] leading-tight">
+            {item.name ?? "Unnamed"}
+            {previousVersion && item.version ? (
+              <span className="ml-2 text-sm font-normal text-muted-foreground font-mono">
+                v{previousVersion}
+                <ArrowRight className="h-3 w-3 inline mx-1" />
+                v{item.version}
+              </span>
+            ) : item.version ? (
+              <span className="ml-2 text-sm font-normal text-muted-foreground font-mono">
+                v{item.version} — first release
+              </span>
+            ) : null}
+          </DialogTitle>
+          {item.description && (
+            <p className="text-xs text-muted-foreground line-clamp-2">{item.description}</p>
+          )}
+        </DialogHeader>
+      </div>
+
+      {/* Body: left details pane + right diff/snapshot pane */}
+      <div className="flex flex-1 min-h-0">
+        {/* Left pane: version details (~40%) */}
+        <ScrollArea className="w-[40%] shrink-0 border-r border-border">
+          <div className="p-5 space-y-5">
+            {/* Submission metadata */}
+            <div className="space-y-2">
+              <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                Submission
+              </h4>
+              <dl className="space-y-1.5 text-xs">
+                {item.submitted_by && (
+                  <div>
+                    <dt className="text-muted-foreground">Submitted by</dt>
+                    <dd className="font-medium">{item.submitted_by}</dd>
+                  </div>
+                )}
+                {(item.submitted_at || item.created_at) && (
+                  <div>
+                    <dt className="text-muted-foreground">Date</dt>
+                    <dd className="font-medium">
+                      {new Date(
+                        (item.submitted_at ?? item.created_at)!,
+                      ).toLocaleDateString()}
+                    </dd>
+                  </div>
+                )}
+                {bumpType && (
+                  <div>
+                    <dt className="text-muted-foreground">Bump type</dt>
+                    <dd>
+                      <Badge
+                        variant="outline"
+                        className={`text-[10px] ${bumpBadgeClasses[bumpType]}`}
+                      >
+                        {bumpType}
+                      </Badge>
+                    </dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+
+            {/* Model */}
+            {modelName && (
+              <>
+                <Separator />
+                <div className="space-y-2">
+                  <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                    Model
+                  </h4>
+                  <p className="text-xs font-[family-name:var(--font-mono)]">{modelName}</p>
+                </div>
+              </>
+            )}
+
+            {/* Supported IDEs */}
+            {supportedIdes.length > 0 && (
+              <>
+                <Separator />
+                <div className="space-y-2">
+                  <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                    Supported IDEs
+                  </h4>
+                  <p className="text-xs font-medium">{supportedIdes.join(", ")}</p>
+                </div>
+              </>
+            )}
+
+            {/* Prompt */}
+            {prompt && (
+              <>
+                <Separator />
+                <div className="space-y-2">
+                  <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                    Prompt
+                  </h4>
+                  <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words bg-muted/40 rounded p-3 leading-relaxed max-h-64 overflow-y-auto">
+                    {prompt}
+                  </pre>
+                </div>
+              </>
+            )}
+
+            {/* Component changes (from diff) or component list */}
+            {diffData?.component_changes?.length ? (
+              <>
+                <Separator />
+                <div className="space-y-2">
+                  <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                    Component Changes ({diffData.component_changes.length})
+                  </h4>
+                  <ComponentChangesList changes={diffData.component_changes} />
+                </div>
+              </>
+            ) : components.length ? (
+              <>
+                <Separator />
+                <div className="space-y-2">
+                  <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                    Components ({components.length})
+                  </h4>
+                  <div className="space-y-1.5">
+                    {components.map((c, i) => (
+                      <div
+                        key={i}
+                        className="flex items-center gap-2 text-xs py-1.5 px-2 rounded bg-muted/40"
+                      >
+                        <Badge variant="outline" className="text-[10px] shrink-0">
+                          {c.component_type}
+                        </Badge>
+                        <span className="text-muted-foreground font-[family-name:var(--font-mono)] truncate">
+                          {c.component_id}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </>
+            ) : null}
+          </div>
+        </ScrollArea>
+
+        {/* Right pane: diff or YAML snapshot (~60%) */}
+        <div className="flex-1 min-w-0 flex flex-col min-h-0">
+          {isLoading ? (
+            <div className="flex-1 p-4 space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6" />
+              <Skeleton className="h-4 w-4/6" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+            </div>
+          ) : diffData ? (
+            <YamlDiffView
+              diff={diffData.yaml_diff}
+              versionA={diffData.version_a}
+              versionB={diffData.version_b}
+            />
+          ) : !previousVersion && !versionsLoading ? (
+            <div className="flex flex-col h-full min-h-0">
+              <div className="shrink-0 flex items-center px-4 py-2 border-b border-border text-xs font-medium text-muted-foreground">
+                <span>v{item.version}</span>
+                <span className="ml-2 italic">— initial release</span>
+              </div>
+              {yamlSnapshot ? (
+                <div className="flex-1 min-h-0 overflow-y-auto">
+                  <div className="overflow-x-auto">
+                    <table className="w-full border-collapse font-[family-name:var(--font-mono)] text-xs leading-5">
+                      <tbody>
+                        {yamlSnapshot.split("\n").map((line, i) => (
+                          <tr key={i} className="hover:bg-muted/30">
+                            <td className="select-none w-10 shrink-0 px-2 text-right tabular-nums text-muted-foreground/50 border-r border-border/40">
+                              {i + 1}
+                            </td>
+                            <td className="px-3 whitespace-pre-wrap break-all text-foreground">
+                              {line}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex-1 min-h-0 overflow-y-auto">
+                  <div className="overflow-x-auto">
+                    <table className="w-full border-collapse font-[family-name:var(--font-mono)] text-xs leading-5">
+                      <tbody>
+                        {(() => {
+                          const structural = JSON.stringify(
+                            {
+                              description: item.description || undefined,
+                              prompt: prompt || undefined,
+                              model_name: modelName || undefined,
+                              supported_ides: supportedIdes.length ? supportedIdes : undefined,
+                              components: components.length
+                                ? components.map((c) => `${c.component_type}:${c.component_id}`)
+                                : undefined,
+                            },
+                            null,
+                            2,
+                          );
+                          return structural.split("\n").map((line, i) => (
+                            <tr key={i} className="hover:bg-muted/30">
+                              <td className="select-none w-10 shrink-0 px-2 text-right tabular-nums text-muted-foreground/50 border-r border-border/40">
+                                {i + 1}
+                              </td>
+                              <td className="px-3 whitespace-pre-wrap break-all text-foreground">
+                                {line}
+                              </td>
+                            </tr>
+                          ));
+                        })()}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center flex-1 text-sm text-muted-foreground">
+              Unable to load diff.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer actions */}
+      <div className="shrink-0 border-t border-border px-5 py-4">
+        <div className="flex items-center gap-2">
+          {disableApprove ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="flex-1">
+                    <Button
+                      size="sm"
+                      className="h-8 text-xs w-full bg-success/10 text-success border border-success/25 shadow-none opacity-50 cursor-not-allowed"
+                      disabled
+                    >
+                      Approve
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Cannot approve until all required components are ready</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <Button
+              size="sm"
+              className="h-8 text-xs flex-1 bg-success/10 hover:bg-success/20 text-success border border-success/25 shadow-none"
+              onClick={handleApprove}
+            >
+              Approve
+            </Button>
+          )}
+          <Button
+            size="sm"
+            className="h-8 text-xs flex-1 bg-destructive/10 hover:bg-destructive/20 text-destructive border border-destructive/25 shadow-none"
+            onClick={() => setShowRejectDialog(true)}
+          >
+            Reject
+          </Button>
+        </div>
+      </div>
+
+      {/* Reject reason dialog */}
+      <Dialog open={showRejectDialog} onOpenChange={setShowRejectDialog}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-sm font-[family-name:var(--font-display)]">
+              Reject {item.name ?? "submission"}
+            </DialogTitle>
+          </DialogHeader>
+          <Textarea
+            placeholder="Why is this being rejected? Be specific so the submitter can fix and resubmit."
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            className="min-h-[100px] text-sm"
+            autoFocus
+          />
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setShowRejectDialog(false);
+                setRejectReason("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              className="bg-destructive hover:bg-destructive/90 text-destructive-foreground"
+              disabled={!rejectReason.trim()}
+              onClick={handleRejectConfirm}
+            >
+              Reject
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/web/src/components/review/yaml-diff-view.tsx
+++ b/web/src/components/review/yaml-diff-view.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+export interface YamlDiffViewProps {
+  diff: string;
+  versionA: string;
+  versionB: string;
+}
+
+type DiffLineKind = "context" | "add" | "remove" | "hunk-header" | "file-header";
+
+interface DiffLine {
+  kind: DiffLineKind;
+  text: string;
+}
+
+interface SplitRow {
+  leftNum: number | null;
+  rightNum: number | null;
+  leftText: string | null;
+  rightText: string | null;
+  leftKind: "context" | "remove" | "empty" | "hunk-header";
+  rightKind: "context" | "add" | "empty" | "hunk-header";
+}
+
+function parseDiffLines(raw: string): DiffLine[] {
+  return raw.split("\n").map((line): DiffLine => {
+    if (line.startsWith("@@")) return { kind: "hunk-header", text: line };
+    if (line.startsWith("---") || line.startsWith("+++")) return { kind: "file-header", text: line };
+    if (line.startsWith("+")) return { kind: "add", text: line.slice(1) };
+    if (line.startsWith("-")) return { kind: "remove", text: line.slice(1) };
+    // context lines have a leading space in unified diff; strip it
+    return { kind: "context", text: line.startsWith(" ") ? line.slice(1) : line };
+  });
+}
+
+/**
+ * Convert parsed diff lines into aligned split rows.
+ * Removes and adds within the same hunk are interleaved: we pair them
+ * (remove[0] ↔ add[0], …) then flush the longer side with empty partners.
+ */
+function buildSplitRows(lines: DiffLine[]): SplitRow[] {
+  const rows: SplitRow[] = [];
+  let leftNum = 0;
+  let rightNum = 0;
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.kind === "file-header") {
+      i++;
+      continue;
+    }
+
+    if (line.kind === "hunk-header") {
+      // Parse @@ -l,s +l,s @@ and reset counters
+      const m = line.text.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (m) {
+        leftNum = parseInt(m[1], 10) - 1;
+        rightNum = parseInt(m[2], 10) - 1;
+      }
+      rows.push({
+        leftNum: null, rightNum: null,
+        leftText: line.text, rightText: null,
+        leftKind: "hunk-header", rightKind: "empty",
+      });
+      i++;
+      continue;
+    }
+
+    if (line.kind === "context") {
+      leftNum++;
+      rightNum++;
+      rows.push({
+        leftNum, rightNum,
+        leftText: line.text, rightText: line.text,
+        leftKind: "context", rightKind: "context",
+      });
+      i++;
+      continue;
+    }
+
+    // Collect a contiguous block of removes then adds
+    const removes: string[] = [];
+    const adds: string[] = [];
+    while (i < lines.length && lines[i].kind === "remove") {
+      removes.push(lines[i].text);
+      i++;
+    }
+    while (i < lines.length && lines[i].kind === "add") {
+      adds.push(lines[i].text);
+      i++;
+    }
+
+    const pairCount = Math.max(removes.length, adds.length);
+    for (let p = 0; p < pairCount; p++) {
+      const hasLeft = p < removes.length;
+      const hasRight = p < adds.length;
+      if (hasLeft) leftNum++;
+      if (hasRight) rightNum++;
+      rows.push({
+        leftNum: hasLeft ? leftNum : null,
+        rightNum: hasRight ? rightNum : null,
+        leftText: hasLeft ? removes[p] : null,
+        rightText: hasRight ? adds[p] : null,
+        leftKind: hasLeft ? "remove" : "empty",
+        rightKind: hasRight ? "add" : "empty",
+      });
+    }
+  }
+
+  return rows;
+}
+
+const kindClasses: Record<string, string> = {
+  context: "bg-transparent text-foreground",
+  remove: "bg-[rgba(248,81,73,0.10)] text-foreground",
+  add: "bg-[rgba(63,185,80,0.10)] text-foreground",
+  empty: "bg-muted/30",
+  "hunk-header": "bg-muted/50 text-muted-foreground italic",
+};
+
+const lineNumClasses: Record<string, string> = {
+  context: "text-muted-foreground/50",
+  remove: "text-[rgba(248,81,73,0.5)]",
+  add: "text-[rgba(63,185,80,0.5)]",
+  empty: "text-transparent",
+  "hunk-header": "text-transparent",
+};
+
+function DiffPane({
+  rows,
+  side,
+}: {
+  rows: SplitRow[];
+  side: "left" | "right";
+}) {
+  return (
+    <div className="flex-1 min-w-0 overflow-x-auto font-[family-name:var(--font-mono)] text-xs leading-5">
+      <table className="w-full border-collapse">
+        <tbody>
+          {rows.map((row, idx) => {
+            const num = side === "left" ? row.leftNum : row.rightNum;
+            const text = side === "left" ? row.leftText : row.rightText;
+            const kind = side === "left" ? row.leftKind : row.rightKind;
+
+            return (
+              <tr key={idx} className={kindClasses[kind]}>
+                <td
+                  className={`select-none w-10 shrink-0 px-2 text-right tabular-nums ${lineNumClasses[kind]} border-r border-border/40`}
+                >
+                  {num ?? ""}
+                </td>
+                <td className="px-3 whitespace-pre-wrap break-all">
+                  {text ?? ""}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function YamlDiffView({ diff, versionA, versionB }: YamlDiffViewProps) {
+  if (!diff || diff.trim() === "") {
+    return (
+      <div className="flex items-center justify-center h-32 text-sm text-muted-foreground">
+        No changes between these versions.
+      </div>
+    );
+  }
+
+  const lines = parseDiffLines(diff);
+  // Check if this is an all-additions diff (first version, no prior)
+  const isNewFile = lines.every(
+    (l) => l.kind === "add" || l.kind === "file-header" || l.kind === "hunk-header",
+  );
+
+  const rows = buildSplitRows(lines);
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Column headers */}
+      <div className="flex shrink-0 border-b border-border text-xs font-medium text-muted-foreground">
+        <div className="flex-1 px-4 py-2 border-r border-border">
+          {isNewFile ? (
+            <span className="italic">No previous version</span>
+          ) : (
+            <span>v{versionA}</span>
+          )}
+        </div>
+        <div className="flex-1 px-4 py-2">
+          <span>v{versionB}</span>
+        </div>
+      </div>
+
+      {/* Split panes */}
+      <div className="flex flex-1 min-h-0 overflow-y-auto">
+        <div className="flex-1 border-r border-border overflow-x-auto">
+          {isNewFile ? (
+            <div className="flex items-center justify-center h-full text-sm text-muted-foreground/50 italic select-none">
+              (empty)
+            </div>
+          ) : (
+            <DiffPane rows={rows} side="left" />
+          )}
+        </div>
+        <div className="flex-1 overflow-x-auto">
+          <DiffPane rows={rows} side="right" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -137,6 +137,18 @@ export function useAgentVersionDetail(agentId: string | undefined, version: stri
   });
 }
 
+export function useVersionDiff(
+  agentId: string | undefined,
+  v1: string | undefined,
+  v2: string | undefined,
+) {
+  return useQuery({
+    queryKey: ["version-diff", agentId, v1, v2],
+    enabled: !!agentId && !!v1 && !!v2,
+    queryFn: () => registry.getVersionDiff(agentId!, v1!, v2!),
+  });
+}
+
 // ── Review ──────────────────────────────────────────────────────────
 
 export function useReviewList(typeFilter?: string) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -36,55 +36,61 @@ import type {
 
 const API = "/api/v1";
 
+const STORAGE_KEY_ACCESS_TOKEN = "observal_access_token";
+const STORAGE_KEY_REFRESH_TOKEN = "observal_refresh_token";
+const STORAGE_KEY_USER_ROLE = "observal_user_role";
+const STORAGE_KEY_USER_NAME = "observal_user_name";
+const STORAGE_KEY_USER_EMAIL = "observal_user_email";
+
 function getAccessToken(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem("observal_access_token");
+  return localStorage.getItem(STORAGE_KEY_ACCESS_TOKEN);
 }
 
 function getRefreshToken(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem("observal_refresh_token");
+  return localStorage.getItem(STORAGE_KEY_REFRESH_TOKEN);
 }
 
 export function setTokens(accessToken: string, refreshToken: string) {
-  localStorage.setItem("observal_access_token", accessToken);
-  localStorage.setItem("observal_refresh_token", refreshToken);
+  localStorage.setItem(STORAGE_KEY_ACCESS_TOKEN, accessToken);
+  localStorage.setItem(STORAGE_KEY_REFRESH_TOKEN, refreshToken);
 }
 
 export function clearSession() {
-  localStorage.removeItem("observal_access_token");
-  localStorage.removeItem("observal_refresh_token");
+  localStorage.removeItem(STORAGE_KEY_ACCESS_TOKEN);
+  localStorage.removeItem(STORAGE_KEY_REFRESH_TOKEN);
   localStorage.removeItem("observal_api_key"); // clean up legacy
-  localStorage.removeItem("observal_user_role");
-  localStorage.removeItem("observal_user_name");
-  localStorage.removeItem("observal_user_email");
+  localStorage.removeItem(STORAGE_KEY_USER_ROLE);
+  localStorage.removeItem(STORAGE_KEY_USER_NAME);
+  localStorage.removeItem(STORAGE_KEY_USER_EMAIL);
 }
 
 export function setUserRole(role: string) {
-  localStorage.setItem("observal_user_role", role);
+  localStorage.setItem(STORAGE_KEY_USER_ROLE, role);
 }
 
 export function getUserRole(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem("observal_user_role");
+  return localStorage.getItem(STORAGE_KEY_USER_ROLE);
 }
 
 export function setUserName(name: string) {
-  localStorage.setItem("observal_user_name", name);
+  localStorage.setItem(STORAGE_KEY_USER_NAME, name);
 }
 
 export function getUserName(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem("observal_user_name");
+  return localStorage.getItem(STORAGE_KEY_USER_NAME);
 }
 
 export function setUserEmail(email: string) {
-  localStorage.setItem("observal_user_email", email);
+  localStorage.setItem(STORAGE_KEY_USER_EMAIL, email);
 }
 
 export function getUserEmail(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem("observal_user_email");
+  return localStorage.getItem(STORAGE_KEY_USER_EMAIL);
 }
 
 let _refreshPromise: Promise<boolean> | null = null;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -26,6 +26,7 @@ import type {
   ValidationResult,
   VersionSuggestions,
   AgentVersionsResponse,
+  VersionDiff,
   BulkResult,
   ComponentLeaderboardItem,
   AuditLogEntry,
@@ -273,6 +274,8 @@ export const registry = {
     get<unknown>(`/agents/${agentId}/versions/${version}`),
   createVersion: (agentId: string, body: unknown) =>
     post<unknown>(`/agents/${agentId}/versions`, body),
+  getVersionDiff: (agentId: string, v1: string, v2: string) =>
+    get<VersionDiff>(`/agents/${agentId}/versions/${v1}/diff/${v2}`),
 };
 
 // ── Review ──────────────────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -184,6 +184,25 @@ export interface ValidationResult {
   issues: ValidationIssue[];
 }
 
+// ── Version Diff ────────────────────────────────────────────────────
+
+export interface ComponentChange {
+  type: string;
+  name: string;
+  change: "added" | "removed" | "updated";
+  version?: string;
+  from?: string;
+  to?: string;
+}
+
+export interface VersionDiff {
+  agent_id: string;
+  version_a: string;
+  version_b: string;
+  yaml_diff: string;
+  component_changes: ComponentChange[];
+}
+
 // ── Review ──────────────────────────────────────────────────────────
 
 export interface McpValidationResult {


### PR DESCRIPTION
## Purpose / Description

Implements the YAML diff view for the review queue (#633), Phase 1 of the Registry Update v1.0 epic. When a reviewer clicks a pending agent version, a full-viewport dialog opens showing a split-pane layout: left pane with version details (prompt, model, components) and right pane with either the YAML diff or a structural code block for first releases.

## Fixes
* Fixes #633

## Approach

**No external diff library** — the backend already computes the unified diff via `GET /agents/{id}/versions/{v1}/diff/{v2}`. The frontend just parses and renders it.

### Key changes:

1. **`YamlDiffView`** — Split-pane diff renderer with GitHub dark-mode style colors (subtle rgba background tints, normal text color, pre-wrap for long lines)

2. **`ReviewDiffSheet`** — Full-viewport Dialog (not Sheet) with two-pane layout:
   - Left (40%): version metadata — submission info, model, IDEs, prompt, component changes
   - Right (60%): diff view OR structural JSON code block for first releases
   - Footer: Approve / Reject with nested reject-reason dialog

3. **Backend fix**: Review queue now queries `AgentVersion` directly for pending status instead of joining on `Agent.latest_version_id` (which only updates on approval)

4. **Admin-gated delete**: Trash button on review cards/rows only visible to admin/super_admin roles

5. **Playwright screenshots**: Automated test creates agent, screenshots first-release view, approves v1, creates v2, screenshots diff view and reject dialog

## Screenshots

### First Release (structured JSON code block)
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/4e59152a-734c-4963-a784-8bbc7df3f3fd" />

### Diff View (GitHub-style colors, v1.0.0 → v1.1.0)
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/931f4311-86ab-4900-8be6-fcdb5222aa34" />

### Reject Dialog
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/c2423307-2d09-4656-ab61-7b161efc8eaa" />

## How Has This Been Tested?

- TypeScript compiles cleanly (zero new errors)
- Playwright E2E screenshots verify all three states
- Backend review queue tested with multi-version workflow (v1 approved → v2 pending)
- Admin role gating verified via useAuthGuard() hook
- `test_returns_422_when_components_not_ready` passes with updated function signature

## Checklist

- [x] All commits are signed off (git commit -s) per the DCO
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens