### PR TITLE
feat(clickhouse): add agent_version column with bloom filter indexes (#636)

### DIFF
--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -1176,6 +1176,7 @@ def _convert_resource_spans(body: dict, project_id: str = _DEFAULT_PROJECT) -> t
     for rs in body.get("resourceSpans", []):
         res_attrs = _extract_attrs(rs.get("resource", {}).get("attributes", []))
         ide = _detect_ide(res_attrs)
+        agent_version = res_attrs.get("observal.agent.version")
 
         for ss in rs.get("scopeSpans", []):
             for span in ss.get("spans", []):
@@ -1256,6 +1257,7 @@ def _convert_resource_spans(body: dict, project_id: str = _DEFAULT_PROJECT) -> t
                         "token_count_output": tok_out,
                         "token_count_total": tok_total,
                         "cost": cost,
+                        "agent_version": agent_version,
                     }
                     spans.append(span_row)
 
@@ -1279,6 +1281,7 @@ def _convert_resource_spans(body: dict, project_id: str = _DEFAULT_PROJECT) -> t
                             "tags": [],
                             "input": input_text,
                             "output": output_text,
+                            "agent_version": agent_version,
                         }
                 except Exception:
                     logger.warning("Failed to convert OTLP span", exc_info=True)

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -256,6 +256,14 @@ INIT_SQL = [
     """ALTER TABLE traces ADD COLUMN IF NOT EXISTS hook_id Nullable(String)""",
     """ALTER TABLE traces ADD COLUMN IF NOT EXISTS skill_id Nullable(String)""",
     """ALTER TABLE traces ADD COLUMN IF NOT EXISTS prompt_id Nullable(String)""",
+    # Agent versioning: track which version produced telemetry
+    """ALTER TABLE traces ADD COLUMN IF NOT EXISTS agent_version Nullable(String)""",
+    """ALTER TABLE spans ADD COLUMN IF NOT EXISTS agent_version Nullable(String)""",
+    """ALTER TABLE scores ADD COLUMN IF NOT EXISTS agent_version Nullable(String)""",
+    # Bloom filter indexes for agent_version point lookups
+    """ALTER TABLE traces ADD INDEX IF NOT EXISTS idx_agent_version agent_version TYPE bloom_filter(0.01) GRANULARITY 1""",
+    """ALTER TABLE spans ADD INDEX IF NOT EXISTS idx_agent_version agent_version TYPE bloom_filter(0.01) GRANULARITY 1""",
+    """ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_agent_version agent_version TYPE bloom_filter(0.01) GRANULARITY 1""",
     # Security events table (SIEM integration — SOC 2 / ISO 27001)
     """CREATE TABLE IF NOT EXISTS security_events (
         event_id    UUID,
@@ -562,13 +570,15 @@ async def insert_traces(traces: list[dict]):
             "hook_id": t.get("hook_id"),
             "skill_id": t.get("skill_id"),
             "prompt_id": t.get("prompt_id"),
+            "agent_version": t.get("agent_version"),
         }
         lines.append(json.dumps(row, default=str))
     sql = (
         "INSERT INTO traces (trace_id, parent_trace_id, project_id, mcp_id, agent_id, "
         "user_id, session_id, ide, environment, start_time, end_time, trace_type, name, "
         "metadata, tags, input, output, event_ts, is_deleted, "
-        "tool_id, sandbox_id, graphrag_id, hook_id, skill_id, prompt_id) FORMAT JSONEachRow"
+        "tool_id, sandbox_id, graphrag_id, hook_id, skill_id, prompt_id, "
+        "agent_version) FORMAT JSONEachRow"
     )
     try:
         r = await _query(sql, data="\n".join(lines))
@@ -640,6 +650,7 @@ async def insert_spans(spans: list[dict]):
             "variables_provided": s.get("variables_provided"),
             "template_tokens": s.get("template_tokens"),
             "rendered_tokens": s.get("rendered_tokens"),
+            "agent_version": s.get("agent_version"),
         }
         lines.append(json.dumps(row, default=str))
     sql = (
@@ -653,7 +664,8 @@ async def insert_spans(spans: list[dict]):
         "disk_read_bytes, disk_write_bytes, oom_killed, query_interface, "
         "relevance_score, chunks_returned, embedding_latency_ms, "
         "hook_event, hook_scope, hook_action, hook_blocked, "
-        "variables_provided, template_tokens, rendered_tokens) FORMAT JSONEachRow"
+        "variables_provided, template_tokens, rendered_tokens, "
+        "agent_version) FORMAT JSONEachRow"
     )
     try:
         r = await _query(sql, data="\n".join(lines))
@@ -693,13 +705,14 @@ async def insert_scores(scores: list[dict]):
             "timestamp": _normalize_ts(sc["timestamp"]),
             "event_ts": event_ts,
             "is_deleted": 0,
+            "agent_version": sc.get("agent_version"),
         }
         lines.append(json.dumps(row, default=str))
     sql = (
         "INSERT INTO scores (score_id, trace_id, span_id, project_id, mcp_id, agent_id, "
         "user_id, name, source, data_type, value, string_value, comment, "
         "eval_template_id, eval_config_id, eval_run_id, environment, metadata, "
-        "timestamp, event_ts, is_deleted) FORMAT JSONEachRow"
+        "timestamp, event_ts, is_deleted, agent_version) FORMAT JSONEachRow"
     )
     try:
         r = await _query(sql, data="\n".join(lines))
@@ -783,6 +796,7 @@ async def query_traces(
     mcp_id: str | None = None,
     agent_id: str | None = None,
     user_id: str | None = None,
+    agent_version: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict]:
@@ -801,6 +815,9 @@ async def query_traces(
     if user_id:
         conditions.append("user_id = {uid:String}")
         params["param_uid"] = user_id
+    if agent_version:
+        conditions.append("agent_version = {av:String}")
+        params["param_av"] = agent_version
     where = " AND ".join(conditions)
     sql = (
         f"SELECT * FROM traces FINAL WHERE {where} "


### PR DESCRIPTION
## Purpose / Description

Adds `agent_version` column to ClickHouse traces, spans, and scores tables (#636), enabling version-level telemetry filtering. Part of Phase 1 of the Registry Update v1.0 epic (#615).

## Fixes
* Fixes #636

## Approach

- `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for the nullable string column (safe for clean-break alpha migration)
- Bloom filter indexes (granularity 1) for efficient point lookups (`WHERE agent_version = '1.2.0'`)
- OTLP resource attribute extraction (`observal.agent.version`) follows the existing pattern for `ide` detection
- Propagates version to both trace and span rows at ingest time

## How Has This Been Tested?

- All 1856 existing tests pass
- Schema uses `ADD COLUMN IF NOT EXISTS` / `ADD INDEX IF NOT EXISTS` — idempotent on restart
- OTLP extraction follows the same pattern as `_detect_ide(res_attrs)` which is already well-tested

## Checklist

- [x] All commits are signed off (git commit -s) per the DCO
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] No UI changes in this PR