### PR TITLE
fix(api): agent deletion 500 + observal pull broken (#667)

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -183,7 +183,9 @@ def _agent_to_response(
     agent_dict["created_by_username"] = created_by_username
     agent_dict["user_permission"] = user_permission
     # Populate version fields for CLI pull resolution
-    approved_versions = [v for v in getattr(agent, "versions", []) if getattr(v, "status", None) == AgentStatus.approved]
+    approved_versions = [
+        v for v in getattr(agent, "versions", []) if getattr(v, "status", None) == AgentStatus.approved
+    ]
     latest_approved = max(approved_versions, key=lambda v: v.created_at) if approved_versions else None
     agent_dict["latest_approved_version"] = latest_approved.version if latest_approved else None
     agent_dict["latest_version"] = agent.version if agent.version != "0.0.0" else None
@@ -1076,20 +1078,26 @@ async def delete_agent(
     ):
         await db.delete(r)
     for r in (
-        await db.execute(
-            select(Scorecard)
-            .where(Scorecard.agent_id == agent.id)
-            .options(selectinload(Scorecard.penalties))
+        (
+            await db.execute(
+                select(Scorecard).where(Scorecard.agent_id == agent.id).options(selectinload(Scorecard.penalties))
+            )
         )
-    ).scalars().all():
+        .scalars()
+        .all()
+    ):
         await db.delete(r)
     for r in (
-        await db.execute(
-            select(EvalRun)
-            .where(EvalRun.agent_id == agent.id)
-            .options(selectinload(EvalRun.scorecards).selectinload(Scorecard.penalties))
+        (
+            await db.execute(
+                select(EvalRun)
+                .where(EvalRun.agent_id == agent.id)
+                .options(selectinload(EvalRun.scorecards).selectinload(Scorecard.penalties))
+            )
         )
-    ).scalars().all():
+        .scalars()
+        .all()
+    ):
         await db.delete(r)
     for r in (
         (await db.execute(select(AgentDownloadRecord).where(AgentDownloadRecord.agent_id == agent.id))).scalars().all()

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -182,6 +182,11 @@ def _agent_to_response(
     agent_dict["created_by_email"] = created_by_email
     agent_dict["created_by_username"] = created_by_username
     agent_dict["user_permission"] = user_permission
+    # Populate version fields for CLI pull resolution
+    approved_versions = [v for v in getattr(agent, "versions", []) if getattr(v, "status", None) == AgentStatus.approved]
+    latest_approved = max(approved_versions, key=lambda v: v.created_at) if approved_versions else None
+    agent_dict["latest_approved_version"] = latest_approved.version if latest_approved else None
+    agent_dict["latest_version"] = agent.version if agent.version != "0.0.0" else None
     return AgentResponse(**agent_dict)
 
 
@@ -812,6 +817,8 @@ async def install_agent(
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to install this agent")
+    if not agent.latest_version:
+        raise HTTPException(status_code=400, detail="Agent has no published version available for install")
 
     # Pre-load MCP listings for config generation
     mcp_comp_ids = [c.component_id for c in agent.components if c.component_type == "mcp"]
@@ -1068,19 +1075,41 @@ async def delete_agent(
         .all()
     ):
         await db.delete(r)
-    for r in (await db.execute(select(Scorecard).where(Scorecard.agent_id == agent.id))).scalars().all():
+    for r in (
+        await db.execute(
+            select(Scorecard)
+            .where(Scorecard.agent_id == agent.id)
+            .options(selectinload(Scorecard.penalties))
+        )
+    ).scalars().all():
         await db.delete(r)
-    for r in (await db.execute(select(EvalRun).where(EvalRun.agent_id == agent.id))).scalars().all():
+    for r in (
+        await db.execute(
+            select(EvalRun)
+            .where(EvalRun.agent_id == agent.id)
+            .options(selectinload(EvalRun.scorecards).selectinload(Scorecard.penalties))
+        )
+    ).scalars().all():
         await db.delete(r)
     for r in (
         (await db.execute(select(AgentDownloadRecord).where(AgentDownloadRecord.agent_id == agent.id))).scalars().all()
     ):
         await db.delete(r)
-    # AgentComponent, AgentGoalTemplate, AgentGoalSection handled by cascade="all, delete-orphan"
+    # Break circular FK (Agent.latest_version_id ↔ AgentVersion.agent_id)
+    # then delete via raw SQL to avoid ORM cascade circular dependency.
+    from sqlalchemy import delete as sql_delete
 
     agent_id_str = str(agent.id)
     agent_name = agent.name
-    await db.delete(agent)
+
+    # Null out the self-referential FK first
+    agent.latest_version_id = None
+    await db.flush()
+
+    # Delete versions via SQL (DB-level CASCADE handles children: components, goals)
+    await db.execute(sql_delete(AgentVersion).where(AgentVersion.agent_id == agent.id))
+    # Delete agent via SQL (avoids ORM cascade re-triggering on stale identity map)
+    await db.execute(sql_delete(Agent).where(Agent.id == agent.id))
     await db.commit()
 
     emit_registry_event(

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -176,6 +176,8 @@ class AgentResponse(BaseModel):
     visibility: AgentVisibility
     team_accesses: list[TeamAccessResponse] = []
     user_permission: str | None = None
+    latest_approved_version: str | None = None
+    latest_version: str | None = None
 
     model_config = {"from_attributes": True}
 

--- a/observal-server/services/download_tracker.py
+++ b/observal-server/services/download_tracker.py
@@ -76,23 +76,13 @@ async def record_component_download(
 
 
 async def _update_agent_counts(agent_id: uuid.UUID, db: AsyncSession) -> None:
-    """Recompute download_count and unique_users for an agent."""
+    """Recompute download_count for an agent's latest version."""
     total = (
         await db.scalar(select(func.count(AgentDownloadRecord.id)).where(AgentDownloadRecord.agent_id == agent_id)) or 0
     )
-    unique = (
-        await db.scalar(
-            select(func.count(func.distinct(AgentDownloadRecord.user_id))).where(
-                AgentDownloadRecord.agent_id == agent_id,
-                AgentDownloadRecord.user_id.isnot(None),
-            )
-        )
-        or 0
-    )
     agent = await db.get(Agent, agent_id)
-    if agent:
-        agent.download_count = total
-        agent.unique_users = unique
+    if agent and agent.latest_version:
+        agent.latest_version.download_count = total
 
 
 async def get_download_stats(agent_id: uuid.UUID, db: AsyncSession) -> dict:

--- a/observal-server/tests/test_agent_delete.py
+++ b/observal-server/tests/test_agent_delete.py
@@ -1,0 +1,235 @@
+"""Tests for agent deletion with lazy='raise' relationships.
+
+Verifies that delete_agent eagerly loads Scorecard.penalties and
+EvalRun.scorecards so that cascade-delete does not trigger the
+lazy='raise' sentinel on those relationships.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.agent import AgentStatus
+from models.eval import EvalRun, Scorecard
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role_value: str = "admin"):
+    from models.user import UserRole
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "admin@example.com"
+    user.username = "admin"
+    user.role = UserRole(role_value)
+    user.org_id = None
+    return user
+
+
+def _make_agent(owner_id: uuid.UUID | None = None):
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "test-agent"
+    agent.created_by = owner_id or uuid.uuid4()
+    agent.co_maintainers = []
+    agent.status = AgentStatus.pending
+    agent.owner_org_id = None
+    agent.team_accesses = []
+    return agent
+
+
+def _make_scorecard(agent_id: uuid.UUID) -> MagicMock:
+    sc = MagicMock(spec=Scorecard)
+    sc.id = uuid.uuid4()
+    sc.agent_id = agent_id
+    return sc
+
+
+def _make_eval_run(agent_id: uuid.UUID) -> MagicMock:
+    er = MagicMock(spec=EvalRun)
+    er.id = uuid.uuid4()
+    er.agent_id = agent_id
+    return er
+
+
+def _build_db(execute_results: list) -> AsyncMock:
+    """Build an AsyncSession mock that returns successive results per execute call."""
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=execute_results)
+    db.delete = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+def _scalars_result(items: list) -> MagicMock:
+    """Mock execute result whose .scalars().all() returns *items*."""
+    scalars = MagicMock()
+    scalars.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    return result
+
+
+def _stmt_has_selectinload(stmt) -> bool:
+    """Return True if *stmt* has at least one selectinload option.
+
+    SQLAlchemy represents selectinload as a Load object whose context entries
+    have strategy == (('lazy', 'selectin'),).
+    """
+    for opt in getattr(stmt, "_with_options", ()):
+        for ctx_entry in getattr(opt, "context", ()):
+            if getattr(ctx_entry, "strategy", None) == (("lazy", "selectin"),):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Test: delete_agent calls db.execute with selectinload for Scorecard.penalties
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_scorecard_query_uses_selectinload_penalties():
+    """delete_agent must query Scorecard with selectinload(Scorecard.penalties).
+
+    Without the fix the query omits the eager-load option, which means
+    SQLAlchemy will trigger the lazy='raise' sentinel when the ORM cascade
+    tries to access scorecard.penalties during db.delete(scorecard).
+    """
+    from api.routes.agent import delete_agent
+
+    agent = _make_agent()
+    scorecard = _make_scorecard(agent.id)
+
+    captured_stmts: list = []
+
+    async def capturing_execute(stmt):
+        captured_stmts.append(stmt)
+        # feedback, scorecards, eval_runs, downloads — return empty for all except scorecards
+        # We return items on the scorecard query (2nd call) and empty for the rest
+        return _scalars_result([scorecard] if len(captured_stmts) == 2 else [])
+
+    db = AsyncMock()
+    db.execute = capturing_execute
+    db.delete = AsyncMock()
+    db.commit = AsyncMock()
+
+    user = _make_user()
+
+    with (
+        patch("api.routes.agent._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.get_effective_agent_permission", return_value="owner"),
+        patch("api.routes.agent.emit_registry_event"),
+        patch("api.routes.agent.audit", new=AsyncMock()),
+    ):
+        result = await delete_agent(agent_id=str(agent.id), db=db, current_user=user)
+
+    assert result == {"deleted": str(agent.id)}
+
+    # The scorecard query is the 2nd execute call (after feedback).
+    # It must include a selectinload option for Scorecard.penalties.
+    scorecard_stmt = captured_stmts[1]
+    assert _stmt_has_selectinload(scorecard_stmt), (
+        "Expected selectinload on the Scorecard query but none was found. "
+        "The query must use selectinload(Scorecard.penalties) to avoid lazy='raise' "
+        "being triggered during cascade-delete."
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_evalrun_query_uses_selectinload_scorecards():
+    """delete_agent must query EvalRun with selectinload(EvalRun.scorecards).
+
+    Without the fix the query omits the eager-load option, which means
+    SQLAlchemy will trigger the lazy='raise' sentinel when the ORM cascade
+    tries to access eval_run.scorecards during db.delete(eval_run).
+    """
+    from api.routes.agent import delete_agent
+
+    agent = _make_agent()
+    eval_run = _make_eval_run(agent.id)
+
+    captured_stmts: list = []
+
+    async def capturing_execute(stmt):
+        captured_stmts.append(stmt)
+        return _scalars_result([eval_run] if len(captured_stmts) == 3 else [])
+
+    db = AsyncMock()
+    db.execute = capturing_execute
+    db.delete = AsyncMock()
+    db.commit = AsyncMock()
+
+    user = _make_user()
+
+    with (
+        patch("api.routes.agent._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.get_effective_agent_permission", return_value="owner"),
+        patch("api.routes.agent.emit_registry_event"),
+        patch("api.routes.agent.audit", new=AsyncMock()),
+    ):
+        result = await delete_agent(agent_id=str(agent.id), db=db, current_user=user)
+
+    assert result == {"deleted": str(agent.id)}
+
+    # The eval_run query is the 3rd execute call (feedback, scorecards, eval_runs).
+    evalrun_stmt = captured_stmts[2]
+    assert _stmt_has_selectinload(evalrun_stmt), (
+        "Expected selectinload on the EvalRun query but none was found. "
+        "The query must use selectinload(EvalRun.scorecards) to avoid lazy='raise' "
+        "being triggered during cascade-delete."
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_deletes_all_returned_records():
+    """delete_agent deletes scorecards, eval_runs via ORM and agent+versions via SQL."""
+    from api.routes.agent import delete_agent
+
+    agent = _make_agent()
+    agent.versions = []  # No versions to simplify
+    agent.latest_version_id = None
+    scorecard = _make_scorecard(agent.id)
+    eval_run = _make_eval_run(agent.id)
+
+    call_count = 0
+
+    async def execute_with_data(stmt):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:  # scorecard query
+            return _scalars_result([scorecard])
+        if call_count == 3:  # eval_run query
+            return _scalars_result([eval_run])
+        return _scalars_result([])
+
+    db = AsyncMock()
+    db.execute = execute_with_data
+    db.delete = AsyncMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+
+    user = _make_user()
+
+    with (
+        patch("api.routes.agent._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.get_effective_agent_permission", return_value="owner"),
+        patch("api.routes.agent.emit_registry_event"),
+        patch("api.routes.agent.audit", new=AsyncMock()),
+    ):
+        result = await delete_agent(agent_id=str(agent.id), db=db, current_user=user)
+
+    assert result == {"deleted": str(agent.id)}
+
+    # Scorecards and eval_runs are deleted via ORM db.delete()
+    deleted_objects = [c.args[0] for c in db.delete.call_args_list]
+    assert scorecard in deleted_objects, "Scorecard was not deleted"
+    assert eval_run in deleted_objects, "EvalRun was not deleted"
+    # Agent + versions deleted via SQL DELETE (db.execute), commit confirms completion
+    db.commit.assert_called_once()

--- a/observal-server/tests/test_agent_pull.py
+++ b/observal-server/tests/test_agent_pull.py
@@ -1,0 +1,310 @@
+"""Tests for observal pull / observal agent pull fixes (Issue #667).
+
+Covers:
+1. AgentResponse includes `latest_approved_version` and `latest_version` fields.
+2. POST /api/v1/agents/{id}/install returns 400 (not 500) when no approved version exists.
+3. POST /api/v1/agents/{id}/install returns 200 when an approved version exists.
+
+Uses the same MagicMock/AsyncMock pattern as test_agent_versions_api.py — no real DB.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.agent import AgentStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role_value: str = "user"):
+    from models.user import UserRole
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "test@example.com"
+    user.username = "testuser"
+    user.org_id = None
+    user.role = UserRole(role_value)
+    return user
+
+
+def _make_version(
+    agent_id: uuid.UUID,
+    ver: str = "1.0.0",
+    status: AgentStatus = AgentStatus.approved,
+):
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.agent_id = agent_id
+    v.version = ver
+    v.description = "A test agent"
+    v.prompt = "Do something"
+    v.model_name = "claude-3-5-sonnet"
+    v.model_config_json = {}
+    v.external_mcps = []
+    v.supported_ides = ["claude-code"]
+    v.required_ide_features = []
+    v.inferred_supported_ides = ["claude-code"]
+    v.yaml_snapshot = None
+    v.ide_configs = None
+    v.status = status
+    v.is_prerelease = False
+    v.rejection_reason = None
+    v.download_count = 0
+    v.released_by = uuid.uuid4()
+    v.released_at = datetime.now(UTC)
+    v.reviewed_by = None
+    v.reviewed_at = None
+    v.created_at = datetime.now(UTC)
+    v.components = []
+    v.goal_template = None
+    return v
+
+
+def _make_agent(owner_id: uuid.UUID | None = None, *, with_approved_version: bool = True):
+    """Build a mock Agent.  If with_approved_version=True, attach an approved version."""
+    from models.agent import AgentVisibility
+
+    owner_id = owner_id or uuid.uuid4()
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "ruffchecker"
+    agent.owner = "testuser"
+    agent.created_by = owner_id
+    agent.owner_org_id = None
+    agent.co_maintainers = []
+    agent.team_accesses = []
+    agent.visibility = AgentVisibility.public
+
+    if with_approved_version:
+        ver = _make_version(agent.id)
+        agent.latest_version_id = ver.id
+        agent.latest_version = ver
+        agent.versions = [ver]
+        # Compat properties
+        agent.version = ver.version
+        agent.description = ver.description
+        agent.prompt = ver.prompt
+        agent.model_name = ver.model_name
+        agent.model_config_json = ver.model_config_json
+        agent.external_mcps = ver.external_mcps
+        agent.supported_ides = ver.supported_ides
+        agent.required_ide_features = ver.required_ide_features
+        agent.inferred_supported_ides = ver.inferred_supported_ides
+        agent.status = AgentStatus.approved
+        agent.rejection_reason = None
+        agent.components = []
+        agent.goal_template = None
+    else:
+        agent.latest_version_id = None
+        agent.latest_version = None
+        agent.versions = []
+        agent.version = "0.0.0"
+        agent.description = ""
+        agent.prompt = ""
+        agent.model_name = ""
+        agent.model_config_json = {}
+        agent.external_mcps = []
+        agent.supported_ides = []
+        agent.required_ide_features = []
+        agent.inferred_supported_ides = []
+        agent.status = AgentStatus.draft
+        agent.rejection_reason = None
+        agent.components = []
+        agent.goal_template = None
+
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Sub-issue 2: AgentResponse must include latest_approved_version + latest_version
+# ---------------------------------------------------------------------------
+
+
+def test_agent_response_schema_has_latest_approved_version_field():
+    """AgentResponse schema must declare latest_approved_version as an optional str field."""
+    from schemas.agent import AgentResponse
+
+    fields = AgentResponse.model_fields
+    assert "latest_approved_version" in fields, (
+        "AgentResponse must include latest_approved_version field so CLI can determine pull version"
+    )
+    # Field should be optional (default None)
+    assert fields["latest_approved_version"].default is None
+
+
+def test_agent_response_schema_has_latest_version_field():
+    """AgentResponse schema must declare latest_version as an optional str field."""
+    from schemas.agent import AgentResponse
+
+    fields = AgentResponse.model_fields
+    assert "latest_version" in fields, (
+        "AgentResponse must include latest_version field so CLI can determine pull version"
+    )
+    assert fields["latest_version"].default is None
+
+
+def test_agent_to_response_populates_latest_approved_version():
+    """_agent_to_response must set latest_approved_version from agent.versions."""
+    from api.routes.agent import _agent_to_response
+
+    agent = _make_agent(with_approved_version=True)
+    # Ensure the approved version is in agent.versions list
+    approved_ver = agent.latest_version
+    approved_ver.status = AgentStatus.approved
+    agent.versions = [approved_ver]
+
+    resp = _agent_to_response(
+        agent,
+        created_by_email="test@example.com",
+        created_by_username="testuser",
+    )
+
+    assert resp.latest_approved_version == approved_ver.version
+
+
+def test_agent_to_response_latest_approved_version_none_when_no_approved():
+    """_agent_to_response sets latest_approved_version=None when no approved version."""
+    from api.routes.agent import _agent_to_response
+
+    agent = _make_agent(with_approved_version=False)
+    # Add a pending version (not approved)
+    pending_ver = _make_version(agent.id, status=AgentStatus.pending)
+    agent.versions = [pending_ver]
+    agent.latest_version = pending_ver
+    agent.latest_version_id = pending_ver.id
+    agent.version = pending_ver.version
+    agent.description = pending_ver.description
+    agent.prompt = pending_ver.prompt
+    agent.model_name = pending_ver.model_name
+    agent.model_config_json = pending_ver.model_config_json
+    agent.external_mcps = pending_ver.external_mcps
+    agent.supported_ides = pending_ver.supported_ides
+    agent.required_ide_features = pending_ver.required_ide_features
+    agent.inferred_supported_ides = pending_ver.inferred_supported_ides
+    agent.status = AgentStatus.pending
+    agent.rejection_reason = None
+    agent.components = []
+    agent.goal_template = None
+
+    resp = _agent_to_response(
+        agent,
+        created_by_email="test@example.com",
+        created_by_username="testuser",
+    )
+
+    assert resp.latest_approved_version is None
+
+
+def test_agent_to_response_populates_latest_version_string():
+    """_agent_to_response sets latest_version to agent.version string."""
+    from api.routes.agent import _agent_to_response
+
+    agent = _make_agent(with_approved_version=True)
+
+    resp = _agent_to_response(
+        agent,
+        created_by_email="test@example.com",
+        created_by_username="testuser",
+    )
+
+    assert resp.latest_version == agent.version
+
+
+# ---------------------------------------------------------------------------
+# Sub-issue 1: install endpoint must return 400 (not 500) when no approved version
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_agent_no_latest_version_returns_400():
+    """install_agent returns 400 when agent has no approved/published version."""
+    from fastapi import HTTPException
+
+    from api.routes.agent import install_agent
+    from schemas.agent import AgentInstallRequest
+
+    agent = _make_agent(with_approved_version=False)
+    user = _make_user()
+    user.id = agent.created_by  # owner, so auth passes
+
+    req = AgentInstallRequest(ide="claude-code")
+    request = MagicMock()
+    request.url = MagicMock()
+    request.url.scheme = "http"
+    request.url.hostname = "localhost"
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(all=lambda: []))))
+    db.commit = AsyncMock()
+
+    with (
+        patch("api.routes.agent._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.get_effective_agent_permission", return_value="owner"),
+        patch("api.routes.agent.audit", new=AsyncMock()),
+        patch("services.download_tracker.record_agent_download", new=AsyncMock()),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await install_agent(
+            agent_id=str(agent.id),
+            req=req,
+            request=request,
+            db=db,
+            current_user=user,
+        )
+
+    assert exc.value.status_code == 400
+    assert "no" in exc.value.detail.lower() or "version" in exc.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_install_agent_with_approved_version_succeeds():
+    """install_agent returns 200 with config_snippet when agent has an approved version."""
+    from api.routes.agent import install_agent
+    from schemas.agent import AgentInstallRequest
+
+    user = _make_user()
+    agent = _make_agent(owner_id=user.id, with_approved_version=True)
+
+    req = AgentInstallRequest(ide="claude-code")
+    request = MagicMock()
+    request.url = MagicMock()
+    request.url.scheme = "http"
+    request.url.hostname = "localhost"
+    request.headers = {}
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(all=lambda: []))))
+    db.commit = AsyncMock()
+
+    fake_config = {"mcpServers": {}, "rules": "# ruffchecker\n"}
+
+    with (
+        patch("api.routes.agent._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.get_effective_agent_permission", return_value="owner"),
+        patch("api.routes.agent.generate_agent_config", return_value=fake_config),
+        patch("api.routes.agent.emit_registry_event"),
+        patch("api.routes.agent.audit", new=AsyncMock()),
+        patch("api.routes.config.derive_endpoints", return_value={"api": "http://localhost:8000", "otlp_http": ""}),
+        patch("services.download_tracker.record_agent_download", new=AsyncMock()),
+    ):
+        result = await install_agent(
+            agent_id=str(agent.id),
+            req=req,
+            request=request,
+            db=db,
+            current_user=user,
+        )
+
+    assert result.agent_id == agent.id
+    assert result.ide == "claude-code"
+    assert isinstance(result.config_snippet, dict)

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -917,8 +917,17 @@ def agent_pull(
         f"[dim]→[/dim] Pulling [bold]{agent.get('name', resolved)}[/bold] v[bold]{target_version}[/bold] for [cyan]{ide}[/cyan]..."
     )
 
-    with spinner("Fetching IDE config..."):
-        config_data = client.get(f"/api/v1/agents/{resolved}/versions/{target_version}/ide/{ide}")
+    # Try versioned IDE config endpoint first; fall back to install endpoint
+    config_data = None
+    try:
+        with spinner("Fetching IDE config..."):
+            config_data = client.get(f"/api/v1/agents/{resolved}/versions/{target_version}/ide/{ide}")
+    except (SystemExit, Exception):
+        # Versioned endpoint 404'd (no cached ide_configs) — fall back to install
+        rprint("[dim]  Pre-generated config not available, generating on-the-fly...[/dim]")
+        with spinner("Generating config via install endpoint..."):
+            result = client.post(f"/api/v1/agents/{resolved}/install", {"ide": ide})
+        config_data = result.get("config_snippet", {})
 
     files: dict[str, str] = config_data.get("files", {}) if isinstance(config_data, dict) else {}
 
@@ -935,9 +944,38 @@ def agent_pull(
             written += 1
         rprint(f"[green]✓ Agent config written to {written} file(s)[/green]")
     else:
-        # Fallback: write the entire config as a single JSON file
-        fallback_path = dir_path / f"{agent.get('name', resolved)}-config.json"
-        fallback_path.parent.mkdir(parents=True, exist_ok=True)
-        fallback_path.write_text(_json.dumps(config_data, indent=2))
-        rprint(f"  [green]✓[/green] created {fallback_path.name}")
-        rprint("[green]✓ Agent config written to 1 file[/green]")
+        # Fallback: write the config snippet files (install endpoint format)
+        from observal_cli.cmd_pull import _resolve_path, _write_file
+
+        snippet = config_data
+        written_files: list[tuple[str, str]] = []
+
+        agent_file = snippet.get("agent_file")
+        if agent_file:
+            p = _resolve_path(agent_file["path"], dir_path)
+            status = _write_file(p, agent_file["content"])
+            written_files.append((str(p), status))
+
+        rules = snippet.get("rules_file")
+        if rules:
+            p = _resolve_path(rules["path"], dir_path)
+            status = _write_file(p, rules["content"])
+            written_files.append((str(p), status))
+
+        mcp_cfg = snippet.get("mcp_config")
+        if mcp_cfg and isinstance(mcp_cfg, dict) and "path" in mcp_cfg:
+            p = _resolve_path(mcp_cfg["path"], dir_path)
+            status = _write_file(p, mcp_cfg["content"], merge_mcp=True)
+            written_files.append((str(p), status))
+
+        if written_files:
+            for path, status in written_files:
+                rprint(f"  [green]✓[/green] {status} {path}")
+            rprint(f"[green]✓ Agent config written to {len(written_files)} file(s)[/green]")
+        else:
+            # Last resort: dump raw JSON
+            fallback_path = dir_path / f"{agent.get('name', resolved)}-config.json"
+            fallback_path.parent.mkdir(parents=True, exist_ok=True)
+            fallback_path.write_text(_json.dumps(config_data, indent=2))
+            rprint(f"  [green]✓[/green] created {fallback_path.name}")
+            rprint("[green]✓ Agent config written to 1 file[/green]")


### PR DESCRIPTION
## Purpose / Description

Fixes two related agent API bugs that prevent agent deletion and agent pull from working:

1. **Agent Deletion 500**: `DELETE /api/v1/agents/{id}` crashes with Internal Server Error when the agent has eval runs/scorecards, due to `lazy="raise"` relationships and a circular FK dependency.
2. **Agent Pull Broken**: `observal pull` and `observal agent pull` fail because the API response lacks version resolution fields, install endpoint crashes on download tracking, and CLI has no fallback when cached IDE configs don't exist.

## Fixes

* Fixes #667

## Approach

### Deletion Fix
- Added `selectinload(Scorecard.penalties)` and `selectinload(EvalRun.scorecards)` to eagerly load children before ORM cascade-delete
- Break circular FK (`Agent.latest_version_id` ↔ `AgentVersion.agent_id`) by nulling the self-ref FK, then delete versions and agent via SQL DELETE (bypasses ORM topological sort)
- Fixed `download_tracker._update_agent_counts()` to write to `agent.latest_version.download_count` (the actual column) instead of the read-only compat property

### Pull Fix
- Added `latest_approved_version` and `latest_version` fields to `AgentResponse` schema
- Populated them in `_agent_to_response()` by finding the most recent approved version
- Added guard in `install_agent`: returns 400 (not 500) when no version exists
- CLI `agent pull` now catches 404 from versioned endpoint and falls back to `/install` for on-the-fly generation

## How Has This Been Tested?

- 10 new unit tests (3 deletion, 7 pull) — all passing
- Manual Docker testing against local stack:
  - `DELETE /api/v1/agents/{id}` → 200, agent gone
  - `POST /api/v1/agents/{id}/install` → 200, returns config
  - `observal pull {id} --ide kiro` → writes Kiro agent file
  - `observal agent pull {id} --ide kiro` → fallback to install, writes file
  - `GET /api/v1/agents/{id}` → includes `latest_approved_version: "1.0.0"`
- Ruff lint clean
- Existing test suite unaffected

## Learning

SQLAlchemy's `cascade="all, delete-orphan"` combined with `lazy="raise"` creates a trap: the cascade tries to load children to delete them, but `raise` prevents loading. Using `selectinload` pre-loads them. For circular FKs, ORM-level delete can't resolve the topological order — raw SQL DELETE is the clean escape hatch.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: N/A — backend + CLI only