### PR TITLE
fix(cli): detect and block conflicting observal package (#671)

### DIFF
--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -1,3 +1,4 @@
+from importlib.metadata import version as pkg_version
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, Request
@@ -7,6 +8,22 @@ from api.deps import get_db
 from config import settings
 
 router = APIRouter(prefix="/api/v1/config", tags=["config"])
+
+
+def _server_version() -> str:
+    try:
+        return pkg_version("observal-server")
+    except Exception:
+        return "dev"
+
+
+@router.get("/version")
+async def get_version():
+    """Server version and minimum compatible CLI version. No auth required."""
+    return {
+        "server_version": _server_version(),
+        "min_cli_version": settings.MIN_CLI_VERSION,
+    }
 
 
 def derive_endpoints(request: Request | None = None) -> dict[str, str]:

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -99,6 +99,10 @@ class Settings(BaseSettings):
     SAML_DEFAULT_ROLE: str = "user"
     SAML_SP_KEY_ENCRYPTION_PASSWORD: str = ""
 
+    # Minimum CLI version the server is compatible with.
+    # CLI will warn users to upgrade if their version is older.
+    MIN_CLI_VERSION: str = "0.4.0"
+
     # Demo accounts (seeded on first startup if set and no real users exist)
     DEMO_SUPER_ADMIN_EMAIL: str | None = None
     DEMO_SUPER_ADMIN_PASSWORD: str | None = None

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -264,3 +264,41 @@ def health() -> tuple[bool, float]:
         return r.status_code == 200, latency
     except Exception:
         return False, 0
+
+
+def check_version_compatibility(server_url: str) -> None:
+    """Warn if CLI version is older than server's minimum requirement."""
+    from importlib.metadata import version as pkg_version
+
+    try:
+        cli_ver_str = pkg_version("observal-cli")
+    except Exception:
+        return  # dev install, skip check
+
+    try:
+        r = httpx.get(f"{server_url.rstrip('/')}/api/v1/config/version", timeout=5)
+        if r.status_code != 200:
+            return
+        data = r.json()
+    except Exception:
+        return  # server doesn't support this endpoint yet, skip
+
+    min_cli = data.get("min_cli_version")
+    server_ver = data.get("server_version", "unknown")
+    if not min_cli:
+        return
+
+    try:
+        cli_tuple = tuple(int(x) for x in cli_ver_str.split("."))
+        min_tuple = tuple(int(x) for x in min_cli.split("."))
+        if cli_tuple < min_tuple:
+            rprint(
+                f"\n[bold yellow]⚠ CLI version {cli_ver_str} is older than the server requires "
+                f"(minimum {min_cli}).[/bold yellow]\n"
+                f"  Server version: {server_ver}\n"
+                f"  Please upgrade:\n\n"
+                f"    [cyan]uv tool upgrade observal-cli[/cyan]    "
+                f"[dim]# or: pip install --upgrade observal-cli[/dim]\n"
+            )
+    except (ValueError, TypeError):
+        pass

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -311,7 +311,7 @@ def version_callback():
     from importlib.metadata import version as pkg_version
 
     try:
-        v = pkg_version("observal")
+        v = pkg_version("observal-cli")
     except Exception:
         v = "dev"
     rprint(f"observal [bold]{v}[/bold]")

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -61,6 +61,9 @@ def login(
 
     initialized = health_data.get("initialized", True)
 
+    # Check CLI/server version compatibility
+    client.check_version_compatibility(server_url)
+
     # 2. Fresh server → prompt for admin credentials and initialize
     if not initialized:
         rprint("[green]Connected.[/green] No users yet — let's set up your admin account.\n")
@@ -229,6 +232,7 @@ def status():
     if ok:
         color = "green" if latency < 200 else "yellow" if latency < 1000 else "red"
         rprint(f"  Health:  [{color}]ok[/{color}] ({latency:.0f}ms)")
+        client.check_version_compatibility(url)
     else:
         rprint("  Health:  [red]unreachable[/red]")
 

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -1,10 +1,41 @@
 """Observal CLI: MCP Server & Agent Registry."""
 
 import logging
+import sys
 
 import typer
 
 from observal_cli.cmd_auth import version_callback
+
+
+def _check_package_conflict() -> None:
+    """Warn if the legacy 'observal' package is installed alongside 'observal-cli'."""
+    from importlib.metadata import PackageNotFoundError, metadata
+
+    try:
+        meta = metadata("observal")
+    except PackageNotFoundError:
+        return
+
+    # If we get here, a package literally named "observal" exists.
+    # Check it's not just our own package under a different dist name.
+    pkg_name = meta.get("Name", "")
+    if pkg_name.lower() == "observal-cli":
+        return
+
+    from rich import print as rprint
+
+    rprint(
+        "[bold yellow]⚠ Package conflict detected:[/bold yellow] "
+        "Both [bold]observal[/bold] and [bold]observal-cli[/bold] are installed.\n"
+        "  The legacy [dim]observal[/dim] package is no longer maintained and conflicts with the CLI.\n"
+        "  Please uninstall it:\n\n"
+        "    [cyan]uv pip uninstall observal[/cyan]    [dim]# or: pip uninstall observal[/dim]\n"
+    )
+    sys.exit(1)
+
+
+_check_package_conflict()
 
 # ── Version callback for --version flag ───────────────────
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -112,6 +112,11 @@ git checkout -b "$RELEASE_BRANCH"
 set_version_in_file "$PYPROJECT" "$NEW_VERSION"
 set_version_in_file "observal-server/pyproject.toml" "$NEW_VERSION"
 
+# ── Update uv.lock ──────────────────────────────────────────
+
+info "Updating uv.lock..."
+uv lock
+
 # ── Generate changelog ───────────────────────────────────────
 
 info "Generating changelog..."
@@ -119,7 +124,7 @@ run_git_cliff --config "$CLIFF_CONFIG" --tag "v$NEW_VERSION" --output CHANGELOG.
 
 # ── Commit and push branch ──────────────────────────────────
 
-git add "$PYPROJECT" observal-server/pyproject.toml CHANGELOG.md
+git add "$PYPROJECT" observal-server/pyproject.toml uv.lock CHANGELOG.md
 git commit -s -m "bump(release): v$NEW_VERSION"
 
 info "Pushing release branch to $FORK_REMOTE..."

--- a/uv.lock
+++ b/uv.lock
@@ -377,7 +377,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "0.3.4"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Purpose / Description
When both the legacy `observal` package (old package name) and `observal-cli` (current name) are installed via `uv tool install`, they both provide the `observal` entry point, causing import conflicts and unexpected behavior.

## Fixes
* Fixes #671

## Approach
Added a startup check in `observal_cli/main.py` that runs before any command:
1. Uses `importlib.metadata.metadata("observal")` to check if the old package exists
2. If found (and it's not just our own package under a different dist name), prints a clear error with uninstall instructions and exits with code 1
3. The check is lightweight — `PackageNotFoundError` is caught immediately on healthy installs

## How Has This Been Tested?

- Verified detection triggers when `observal` package metadata exists (had both installed locally — exact reproduction of the bug)
- Verified no false positive when only `observal-cli` is installed
- All 247 existing tests pass
- Lint clean (`ruff check` + `ruff format`)

## Learning (optional, can help others)
`importlib.metadata` can find stale `.dist-info` directories even after `uv pip uninstall` if the directory wasn't fully cleaned. The metadata `Name` field is the canonical way to distinguish packages.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: N/A