### PR TITLE
fix(migrate): handle cross-version import and include all ClickHouse tables in deep copy

### DIFF
--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -112,6 +112,9 @@ CLICKHOUSE_TABLES: list[TableCfg] = [
     {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["actor_id"]},
     {"name": "mcp_tool_calls", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["mcp_server_id", "user_id"]},
     {"name": "agent_interactions", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["agent_id", "user_id"]},
+    {"name": "otel_logs", "engine": "mergetree", "time_col": "Timestamp", "fk_cols": []},
+    {"name": "security_events", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []},
+    {"name": "webhook_deliveries", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []},
 ]
 
 FK_PG_TABLE_MAP: dict[str, str] = {
@@ -411,7 +414,14 @@ async def _insert_table(
             row = json.loads(line)
 
             if columns is None:
-                columns = list(row.keys())
+                target_columns = set(col_types.keys())
+                columns = [k for k in row if k in target_columns]
+                skipped_cols = set(row) - target_columns
+                if skipped_cols:
+                    rprint(
+                        f"[dim]  {jsonl_path.stem}: skipping archive columns not in target: "
+                        f"{', '.join(sorted(skipped_cols))}[/dim]"
+                    )
 
             batch.append(row)
 
@@ -488,6 +498,22 @@ async def _ch_query(
     finally:
         if owns_client:
             await http_client.aclose()
+
+
+def _rewrite_project_id(parquet_path: Path, target_project_id: str) -> Path:
+    """Rewrite project_id column in a Parquet file, return path to temp file."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(parquet_path)
+    if "project_id" not in table.column_names:
+        return parquet_path
+    idx = table.column_names.index("project_id")
+    new_col = pa.array([target_project_id] * len(table), type=pa.string())
+    table = table.set_column(idx, "project_id", new_col)
+    tmp_path = parquet_path.with_suffix(".tmp.parquet")
+    pq.write_table(table, tmp_path)
+    return tmp_path
 
 
 async def _ch_import(
@@ -683,11 +709,11 @@ async def _import_archive(db_url: str, archive_path: Path) -> ImportResult:
             target_version = await conn.fetchval("SELECT version_num FROM alembic_version LIMIT 1")
             source_version = manifest["source_alembic_version"]
             if target_version != source_version:
-                rprint("[red]Schema version mismatch:[/red]")
+                rprint("[yellow]Schema version mismatch (non-fatal):[/yellow]")
                 rprint(f"  Archive: {source_version}")
                 rprint(f"  Target:  {target_version}")
-                rprint("\n[dim]  Run: cd observal-server && alembic upgrade head[/dim]")
-                raise typer.Exit(1)
+                rprint("[dim]  Extra columns from the archive will be filtered out automatically.[/dim]")
+                warnings.append(f"Schema version mismatch: archive={source_version}, target={target_version}")
 
             rows_inserted: dict[str, int] = {}
             rows_skipped: dict[str, int] = {}
@@ -716,6 +742,33 @@ async def _import_archive(db_url: str, archive_path: Path) -> ImportResult:
                 ins, sk = await _insert_table(conn, table, jsonl_path, col_types)
                 rows_inserted[table] = ins
                 rows_skipped[table] = sk
+
+            # Post-import fixup: backfill NULL owner_org_id from creator's org
+            _org_backfill = [
+                ("agents", "created_by"),
+                ("mcp_listings", "submitted_by"),
+                ("skill_listings", "submitted_by"),
+                ("hook_listings", "submitted_by"),
+                ("prompt_listings", "submitted_by"),
+                ("sandbox_listings", "submitted_by"),
+            ]
+            for tbl, creator_col in _org_backfill:
+                if tbl not in existing_tables:
+                    continue
+                tbl_cols = await _get_column_types(conn, tbl)
+                if "owner_org_id" not in tbl_cols:
+                    continue
+                result = await conn.execute(
+                    f"UPDATE {tbl} SET owner_org_id = u.org_id "
+                    f"FROM users u "
+                    f"WHERE {tbl}.{creator_col} = u.id "
+                    f"AND {tbl}.owner_org_id IS NULL "
+                    f"AND u.org_id IS NOT NULL"
+                )
+                count = int(result.split()[-1])
+                if count > 0:
+                    rprint(f"[dim]  Fixed {count} row(s) in {tbl} with NULL owner_org_id[/dim]")
+                    warnings.append(f"{tbl}: backfilled owner_org_id for {count} row(s)")
 
         finally:
             await conn.close()
@@ -1114,6 +1167,7 @@ async def _export_telemetry(
 async def _import_telemetry(
     clickhouse_url: str,
     input_dir: Path,
+    normalize_project_id: str | None = None,
 ) -> TelemetryImportResult:
     """Import Parquet files into target ClickHouse."""
     t0 = time.monotonic()
@@ -1169,6 +1223,36 @@ async def _import_telemetry(
     else:
         completed_tables = set()
 
+    # Validate resume state: check that "completed" tables actually have data
+    if completed_tables:
+        invalidated: list[str] = []
+        for table_cfg in CLICKHOUSE_TABLES:
+            tname = table_cfg["name"]
+            if tname not in completed_tables:
+                continue
+            if tname not in existing:
+                invalidated.append(tname)
+                continue
+            if table_cfg["engine"] == "replacing":
+                sql = f"SELECT 1 FROM {tname} FINAL WHERE is_deleted = 0 LIMIT 1 FORMAT JSON"
+            else:
+                sql = f"SELECT 1 FROM {tname} LIMIT 1 FORMAT JSON"
+            resp = await _ch_query(http_url, db, user, password, sql)
+            if not resp.json().get("data"):
+                invalidated.append(tname)
+        if invalidated:
+            for name in invalidated:
+                completed_tables.discard(name)
+            rprint(
+                f"[yellow]Resume state invalidated for {len(invalidated)} table(s) "
+                f"(no data found): {', '.join(sorted(invalidated))}[/yellow]"
+            )
+            warnings.append(f"Resume state invalidated for: {', '.join(sorted(invalidated))}")
+            state_path.write_text(
+                json.dumps({"completed": sorted(completed_tables)}, indent=2),
+                encoding="utf-8",
+            )
+
     for table_cfg in CLICKHOUSE_TABLES:
         table_name = table_cfg["name"]
         table_info = manifest["tables"].get(table_name, {})
@@ -1205,7 +1289,14 @@ async def _import_telemetry(
                 continue
 
             rprint(f"  Importing {filename}...")
-            await _ch_import(http_url, db, user, password, table_name, filepath)
+            import_path = filepath
+            if normalize_project_id is not None:
+                import_path = _rewrite_project_id(filepath, normalize_project_id)
+            try:
+                await _ch_import(http_url, db, user, password, table_name, import_path)
+            finally:
+                if import_path != filepath:
+                    import_path.unlink(missing_ok=True)
 
         rows_imported[table_name] = table_info.get("row_count", 0)
         rprint(f"  [green]✓[/green] {table_name}: {rows_imported[table_name]:,} rows")
@@ -1540,6 +1631,9 @@ def export_telemetry_cmd(
 def import_telemetry_cmd(
     clickhouse_url: str = typer.Option(..., "--clickhouse-url", help="Target ClickHouse connection string"),
     input_dir: str = typer.Option(..., "--input-dir", help="Directory containing Parquet files"),
+    project_id: str | None = typer.Option(
+        None, "--project-id", help="Rewrite project_id in all tables to this value (use when source/target orgs differ)"
+    ),
 ) -> None:
     """Import Parquet telemetry files into target ClickHouse."""
     _require_admin()
@@ -1550,8 +1644,11 @@ def import_telemetry_cmd(
         rprint(f"[red]Directory not found:[/red] {input_path}")
         raise typer.Exit(1)
 
+    if project_id:
+        rprint(f"[dim]  Normalizing project_id to: {project_id}[/dim]")
+
     rprint(f"[bold]Importing telemetry from:[/bold] {input_path}")
-    result = asyncio.run(_import_telemetry(clickhouse_url, input_path))
+    result = asyncio.run(_import_telemetry(clickhouse_url, input_path, normalize_project_id=project_id))
 
     total = sum(result.rows_imported.values())
     rprint("\n[bold green]✓ Telemetry import complete[/bold green]")

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -112,6 +112,7 @@ CLICKHOUSE_TABLES: list[TableCfg] = [
     {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["actor_id"]},
     {"name": "mcp_tool_calls", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["mcp_server_id", "user_id"]},
     {"name": "agent_interactions", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["agent_id", "user_id"]},
+    # otel_logs DDL uses capital-T "Timestamp" (OpenTelemetry convention)
     {"name": "otel_logs", "engine": "mergetree", "time_col": "Timestamp", "fk_cols": []},
     {"name": "security_events", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []},
     {"name": "webhook_deliveries", "engine": "mergetree", "time_col": "timestamp", "fk_cols": []},
@@ -404,7 +405,8 @@ async def _insert_table(
     inserted = 0
     skipped = 0
     batch: list[dict] = []
-    columns: list[str] | None = None
+    columns = sorted(col_types.keys())
+    logged_skipped = False
 
     with open(jsonl_path, encoding="utf-8") as f:
         for line in f:
@@ -413,15 +415,14 @@ async def _insert_table(
                 continue
             row = json.loads(line)
 
-            if columns is None:
-                target_columns = set(col_types.keys())
-                columns = [k for k in row if k in target_columns]
-                skipped_cols = set(row) - target_columns
+            if not logged_skipped:
+                skipped_cols = set(row) - set(columns)
                 if skipped_cols:
                     rprint(
                         f"[dim]  {jsonl_path.stem}: skipping archive columns not in target: "
                         f"{', '.join(sorted(skipped_cols))}[/dim]"
                     )
+                    logged_skipped = True
 
             batch.append(row)
 
@@ -509,7 +510,7 @@ def _rewrite_project_id(parquet_path: Path, target_project_id: str) -> Path:
     if "project_id" not in table.column_names:
         return parquet_path
     idx = table.column_names.index("project_id")
-    new_col = pa.array([target_project_id] * len(table), type=pa.string())
+    new_col = pa.nulls(len(table), type=pa.string()).fill_null(target_project_id)
     table = table.set_column(idx, "project_id", new_col)
     tmp_path = parquet_path.with_suffix(".tmp.parquet")
     pq.write_table(table, tmp_path)

--- a/tests/test_migrate_telemetry.py
+++ b/tests/test_migrate_telemetry.py
@@ -382,8 +382,8 @@ class TestReadCount:
 class TestConstants:
     """Verify CLICKHOUSE_TABLES, FK_PG_TABLE_MAP, and EPOCH_SENTINELS."""
 
-    def test_clickhouse_tables_has_6_entries(self):
-        assert len(CLICKHOUSE_TABLES) == 6
+    def test_clickhouse_tables_has_9_entries(self):
+        assert len(CLICKHOUSE_TABLES) == 9
 
     def test_each_table_has_required_keys(self):
         for table_cfg in CLICKHOUSE_TABLES:
@@ -394,7 +394,17 @@ class TestConstants:
 
     def test_table_names(self):
         names = {t["name"] for t in CLICKHOUSE_TABLES}
-        expected = {"traces", "spans", "scores", "audit_log", "mcp_tool_calls", "agent_interactions"}
+        expected = {
+            "traces",
+            "spans",
+            "scores",
+            "audit_log",
+            "mcp_tool_calls",
+            "agent_interactions",
+            "otel_logs",
+            "security_events",
+            "webhook_deliveries",
+        }
         assert names == expected
 
     def test_engine_types(self):
@@ -407,7 +417,14 @@ class TestConstants:
 
     def test_mergetree_tables(self):
         mergetree = [t["name"] for t in CLICKHOUSE_TABLES if t["engine"] == "mergetree"]
-        assert set(mergetree) == {"audit_log", "mcp_tool_calls", "agent_interactions"}
+        assert set(mergetree) == {
+            "audit_log",
+            "mcp_tool_calls",
+            "agent_interactions",
+            "otel_logs",
+            "security_events",
+            "webhook_deliveries",
+        }
 
     def test_typed_dict_structure(self):
         """Verify CLICKHOUSE_TABLES entries conform to TableCfg TypedDict."""


### PR DESCRIPTION
1. Filter archive columns to target schema -- extra columns from newer schemas are silently skipped instead of causing insert failures.

2. Schema version mismatch is now a warning, not a hard exit -- allows importing archives from newer Observal versions into older targets.

3. Validate stale .import_state.json -- if a "completed" table is actually empty (e.g., volumes were nuked after a prior import), the resume state is invalidated and the table is re-imported.

4. Backfill NULL owner_org_id after import -- agents and listings imported from older archives get their org inferred from the creator's user record, preventing them from being invisible in org-scoped API queries.

5. Add --project-id flag to import-telemetry that rewrites the project_id column in Parquet files before inserting, fixing invisible traces when source/target orgs differ.

6. Add otel_logs, security_events, and webhook_deliveries to CLICKHOUSE_TABLES so deep copy covers all ClickHouse tables. otel_logs powers the frontend Traces/Sessions page and was previously lost on volume nuke + rebuild.

## Purpose / Description
When migrating Observal across schema versions (e.g., main to v0.4.0), the shallow copy import would fail on column mismatches, hard-exit on version checks, skip tables due to stale resume state, and leave agents invisible due to NULL owner_org_id. The deep copy was also missing 3 of 9 ClickHouse tables, most critically otel_logs which powers the entire Traces/Sessions frontend page. This PR fixes all six issues so that export + import preserves all data without manual SQL intervention.

## Fixes
* Fixes #

## Approach
1. **Column filtering** (`_insert_table`): Intersect archive columns with target schema columns. Extra columns are logged and skipped.
2. **Schema version warning** (`_import_archive`): Changed version mismatch from `raise typer.Exit(1)` to a yellow warning appended to the result's warnings list.
3. **Resume state validation** (`_import_telemetry`): After loading `.import_state.json`, each "completed" table is checked for actual data. Empty tables get their resume state cleared.
4. **owner_org_id backfill** (`_import_archive`): After all table inserts, runs UPDATE on agents and listing tables to set `owner_org_id` from the creator's user record where NULL.
5. **--project-id flag** (`import-telemetry`): New `_rewrite_project_id` helper uses pyarrow to rewrite the `project_id` column in Parquet files before ClickHouse insert. Needed because `project_id` is a sort key and cannot be UPDATEd after insertion.
6. **Missing tables** (`CLICKHOUSE_TABLES`): Added `otel_logs` (time_col: `Timestamp`), `security_events`, and `webhook_deliveries` so deep copy covers all 9 ClickHouse tables.

## How Has This Been Tested?

- All 191 migration tests pass (`test_migrate.py` + `test_migrate_telemetry.py`)
- Full test suite: 2022 passed (20 pre-existing failures in `test_git_mirror`, `test_uninstall`, `test_cli_errors` unrelated to migration)
- ruff check and ruff format pass
- Manually tested end-to-end: exported from internal.observal.io running main (schema 0022), imported into a fresh v0.4.0 instance (schema 0018). All 13 agents visible in frontend after import.

## Learning (optional, can help others)
- ClickHouse ReplacingMergeTree sort key columns (like `project_id`) cannot be UPDATEd after insert. To change them you need to CREATE AS + INSERT SELECT + RENAME, or rewrite at import time.
- `otel_logs` is the table that powers the frontend Traces/Sessions page, not the `traces` table. The `traces` table is used by the GraphQL dashboard (overview, trends).
- `owner_org_id` was added in migration 0019. Archives from before that migration have NULL values that make records invisible to org-scoped API queries.
- ClickHouse block-level insert deduplication silently drops INSERT...SELECT even with different column values. Use `insert_deduplicate=0` or the temp table + RENAME approach to work around it.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
