### PR TITLE
fix(api): resolve component delete 500 errors and e2e test failures

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -691,7 +691,9 @@ async def update_agent(
         # Remove ALL old components on the latest version
         version_id = agent.latest_version.id
         old_comps = (
-            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == version_id))).scalars().all()
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == version_id)))
+            .scalars()
+            .all()
         )
         for comp in old_comps:
             await db.delete(comp)
@@ -777,7 +779,9 @@ async def update_agent(
         if not agent.latest_version:
             raise HTTPException(status_code=400, detail="Agent has no version to update features on")
         current_comps = (
-            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == agent.latest_version.id))).scalars().all()
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == agent.latest_version.id)))
+            .scalars()
+            .all()
         )
         skill_comp_ids = [c.component_id for c in current_comps if c.component_type == "skill"]
         skill_listings_map_update: dict = {}

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -673,6 +673,9 @@ async def update_agent(
         # New components field replaces ALL components (type validated by Pydantic Literal)
         from services.agent_resolver import validate_component_ids
 
+        if not agent.latest_version:
+            raise HTTPException(status_code=400, detail="Agent has no version to update components on")
+
         errors = await validate_component_ids(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
             db,
@@ -685,31 +688,37 @@ async def update_agent(
                     for e in errors
                 ],
             )
-        # Remove ALL old components
+        # Remove ALL old components on the latest version
+        version_id = agent.latest_version.id
         old_comps = (
-            (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == version_id))).scalars().all()
         )
         for comp in old_comps:
             await db.delete(comp)
         for i, cref in enumerate(req.components):
             db.add(
                 AgentComponent(
-                    agent_id=agent.id,
+                    agent_version_id=version_id,
                     component_type=cref.component_type,
                     component_id=cref.component_id,
-                    version_ref="latest",
+                    component_name="",
+                    resolved_version="latest",
                     order_index=i,
                     config_override=cref.config_override,
                 )
             )
     elif req.mcp_server_ids is not None:
         # Legacy: only update MCP components
+        if not agent.latest_version:
+            raise HTTPException(status_code=400, detail="Agent has no version to update components on")
+
         mcp_listings = await _validate_mcp_ids(req.mcp_server_ids, db)
+        version_id = agent.latest_version.id
         old_comps = (
             (
                 await db.execute(
                     select(AgentComponent).where(
-                        AgentComponent.agent_id == agent.id,
+                        AgentComponent.agent_version_id == version_id,
                         AgentComponent.component_type == "mcp",
                     )
                 )
@@ -722,15 +731,19 @@ async def update_agent(
         for i, (mid, listing) in enumerate(zip(req.mcp_server_ids, mcp_listings, strict=False)):
             db.add(
                 AgentComponent(
-                    agent_id=agent.id,
+                    agent_version_id=version_id,
                     component_type="mcp",
                     component_id=mid,
-                    version_ref=listing.version,
+                    component_name="",
+                    resolved_version=listing.version,
                     order_index=i,
                 )
             )
 
     if req.goal_template is not None:
+        if not agent.latest_version:
+            raise HTTPException(status_code=400, detail="Agent has no version to update goal template on")
+        version_id = agent.latest_version.id
         if agent.goal_template:
             old_sections = (
                 (
@@ -745,7 +758,7 @@ async def update_agent(
                 await db.delete(sec)
             await db.delete(agent.goal_template)
             await db.flush()
-        goal = AgentGoalTemplate(agent_id=agent.id, description=req.goal_template.description)
+        goal = AgentGoalTemplate(agent_version_id=version_id, description=req.goal_template.description)
         db.add(goal)
         await db.flush()
         for i, sec in enumerate(req.goal_template.sections):
@@ -761,8 +774,10 @@ async def update_agent(
 
     # Re-infer IDE features only when components or external_mcps changed
     if req.components is not None or req.mcp_server_ids is not None or req.external_mcps is not None:
+        if not agent.latest_version:
+            raise HTTPException(status_code=400, detail="Agent has no version to update features on")
         current_comps = (
-            (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == agent.latest_version.id))).scalars().all()
         )
         skill_comp_ids = [c.component_id for c in current_comps if c.component_type == "skill"]
         skill_listings_map_update: dict = {}

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -306,11 +306,15 @@ async def delete_hook(
     for r in (await db.execute(select(HookDownload).where(HookDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
-    # Clear the circular FK reference before deleting to avoid constraint violation
-    listing.latest_version_id = None
-    await db.flush()
-
+    # Break the circular FK (listing → latest_version → listing) before delete
     listing_name = listing.name
+    listing.latest_version_id = None
+    listing.latest_version = None
+    await db.flush()
+    # Delete versions explicitly to avoid SQLAlchemy circular dependency detection
+    for ver in list(listing.versions):
+        await db.delete(ver)
+    await db.flush()
     await db.delete(listing)
     await db.commit()
     await audit(

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -306,6 +306,10 @@ async def delete_hook(
     for r in (await db.execute(select(HookDownload).where(HookDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
+    # Clear the circular FK reference before deleting to avoid constraint violation
+    listing.latest_version_id = None
+    await db.flush()
+
     listing_name = listing.name
     await db.delete(listing)
     await db.commit()

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -426,6 +426,10 @@ async def delete_mcp(
     for r in (await db.execute(select(McpDownload).where(McpDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
+    # Clear the circular FK reference before deleting to avoid constraint violation
+    listing.latest_version_id = None
+    await db.flush()
+
     listing_name = listing.name
     await db.delete(listing)
     await db.commit()

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -426,11 +426,15 @@ async def delete_mcp(
     for r in (await db.execute(select(McpDownload).where(McpDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
-    # Clear the circular FK reference before deleting to avoid constraint violation
-    listing.latest_version_id = None
-    await db.flush()
-
+    # Break the circular FK (listing → latest_version → listing) before delete
     listing_name = listing.name
+    listing.latest_version_id = None
+    listing.latest_version = None
+    await db.flush()
+    # Delete versions explicitly to avoid SQLAlchemy circular dependency detection
+    for ver in list(listing.versions):
+        await db.delete(ver)
+    await db.flush()
     await db.delete(listing)
     await db.commit()
     await audit(

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -359,11 +359,15 @@ async def delete_prompt(
     for r in (await db.execute(select(PromptDownload).where(PromptDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
-    # Clear the circular FK reference before deleting to avoid constraint violation
-    listing.latest_version_id = None
-    await db.flush()
-
+    # Break the circular FK (listing → latest_version → listing) before delete
     listing_name = listing.name
+    listing.latest_version_id = None
+    listing.latest_version = None
+    await db.flush()
+    # Delete versions explicitly to avoid SQLAlchemy circular dependency detection
+    for ver in list(listing.versions):
+        await db.delete(ver)
+    await db.flush()
     await db.delete(listing)
     await db.commit()
     await audit(

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -359,6 +359,10 @@ async def delete_prompt(
     for r in (await db.execute(select(PromptDownload).where(PromptDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
+    # Clear the circular FK reference before deleting to avoid constraint violation
+    listing.latest_version_id = None
+    await db.flush()
+
     listing_name = listing.name
     await db.delete(listing)
     await db.commit()

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -327,11 +327,15 @@ async def delete_sandbox(
     ):
         await db.delete(r)
 
-    # Clear the circular FK reference before deleting to avoid constraint violation
-    listing.latest_version_id = None
-    await db.flush()
-
+    # Break the circular FK (listing → latest_version → listing) before delete
     listing_name = listing.name
+    listing.latest_version_id = None
+    listing.latest_version = None
+    await db.flush()
+    # Delete versions explicitly to avoid SQLAlchemy circular dependency detection
+    for ver in list(listing.versions):
+        await db.delete(ver)
+    await db.flush()
     await db.delete(listing)
     await db.commit()
     await audit(

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -327,6 +327,10 @@ async def delete_sandbox(
     ):
         await db.delete(r)
 
+    # Clear the circular FK reference before deleting to avoid constraint violation
+    listing.latest_version_id = None
+    await db.flush()
+
     listing_name = listing.name
     await db.delete(listing)
     await db.commit()

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -323,6 +323,10 @@ async def delete_skill(
     for r in (await db.execute(select(SkillDownload).where(SkillDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
+    # Clear the circular FK reference before deleting to avoid constraint violation
+    listing.latest_version_id = None
+    await db.flush()
+
     listing_name = listing.name
     await db.delete(listing)
     await db.commit()

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -323,11 +323,15 @@ async def delete_skill(
     for r in (await db.execute(select(SkillDownload).where(SkillDownload.listing_id == listing.id))).scalars().all():
         await db.delete(r)
 
-    # Clear the circular FK reference before deleting to avoid constraint violation
-    listing.latest_version_id = None
-    await db.flush()
-
+    # Break the circular FK (listing → latest_version → listing) before delete
     listing_name = listing.name
+    listing.latest_version_id = None
+    listing.latest_version = None
+    await db.flush()
+    # Delete versions explicitly to avoid SQLAlchemy circular dependency detection
+    for ver in list(listing.versions):
+        await db.delete(ver)
+    await db.flush()
     await db.delete(listing)
     await db.commit()
     await audit(

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -129,21 +129,46 @@ class Agent(Base):
     def version(self) -> str:
         return self.latest_version.version if self.latest_version else "0.0.0"
 
+    @version.setter
+    def version(self, value: str) -> None:
+        if self.latest_version:
+            self.latest_version.version = value
+
     @property
     def description(self) -> str:
         return self.latest_version.description if self.latest_version else ""
+
+    @description.setter
+    def description(self, value: str) -> None:
+        if self.latest_version:
+            self.latest_version.description = value
 
     @property
     def prompt(self) -> str:
         return self.latest_version.prompt if self.latest_version else ""
 
+    @prompt.setter
+    def prompt(self, value: str) -> None:
+        if self.latest_version:
+            self.latest_version.prompt = value
+
     @property
     def model_name(self) -> str:
         return self.latest_version.model_name if self.latest_version else ""
 
+    @model_name.setter
+    def model_name(self, value: str) -> None:
+        if self.latest_version:
+            self.latest_version.model_name = value
+
     @property
     def model_config_json(self) -> dict:
         return self.latest_version.model_config_json if self.latest_version else {}
+
+    @model_config_json.setter
+    def model_config_json(self, value: dict) -> None:
+        if self.latest_version:
+            self.latest_version.model_config_json = value
 
     @property
     def external_mcps(self) -> list:
@@ -157,6 +182,11 @@ class Agent(Base):
     @property
     def supported_ides(self) -> list:
         return self.latest_version.supported_ides if self.latest_version else []
+
+    @supported_ides.setter
+    def supported_ides(self, value: list) -> None:
+        if self.latest_version:
+            self.latest_version.supported_ides = value
 
     @property
     def required_ide_features(self) -> list:

--- a/web/e2e/agent-edit-form.spec.ts
+++ b/web/e2e/agent-edit-form.spec.ts
@@ -19,6 +19,7 @@ test.describe("Agent Edit Form", () => {
         version: "1.0.0",
         description: "Original description for edit form test",
         owner: "test",
+        model_name: "claude-sonnet-4-20250514",
         visibility: "private",
         components: [],
         goal_template: {
@@ -91,8 +92,13 @@ test.describe("Agent Edit Form", () => {
 
     await page.getByRole("tab", { name: "Edit" }).click();
 
+    // Make a change to enable the button (form must be dirty)
+    const descInput = page.getByLabel("Description");
+    await descInput.fill("Updated for release test");
+
     // Click Save & Release
     const releaseBtn = page.getByRole("button", { name: /Save.*Release/i });
+    await expect(releaseBtn).toBeEnabled();
     await releaseBtn.click();
 
     // Version bump dialog should appear

--- a/web/e2e/real-edit-release.spec.ts
+++ b/web/e2e/real-edit-release.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect } from "@playwright/test";
+import { loginToWebUI, API_BASE, getAccessToken } from "./helpers";
+
+test.describe("Full Edit → Release → Review Flow", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let agentId: string;
+  let token: string;
+
+  test.beforeAll(async () => {
+    token = await getAccessToken();
+
+    // Create a test agent via API
+    const res = await fetch(`${API_BASE}/api/v1/agents`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: `full-flow-test-${Date.now()}`,
+        version: "1.0.0",
+        description: "Initial description",
+        owner: "test",
+        model_name: "claude-sonnet-4-20250514",
+        visibility: "private",
+        components: [],
+        goal_template: {
+          description: "Test agent goal",
+          sections: [{ name: "Default", description: "Default section" }],
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to create test agent: ${res.status} ${body}`);
+    }
+
+    const agent = await res.json();
+    agentId = agent.id;
+    console.log("Created agent:", agentId);
+  });
+
+  test.afterAll(async () => {
+    if (!agentId) return;
+    await fetch(`${API_BASE}/api/v1/agents/${agentId}`, {
+      method: "DELETE",
+      headers: { "Authorization": `Bearer ${token}` },
+    });
+  });
+
+  test("Save Draft updates agent without version bump", async ({ page }) => {
+    const apiErrors: string[] = [];
+    page.on("response", async (response) => {
+      if (response.url().includes("/api/v1/agents") && response.status() >= 400) {
+        const body = await response.text().catch(() => "");
+        apiErrors.push(`${response.status()} ${response.url()} → ${body}`);
+      }
+    });
+
+    await loginToWebUI(page);
+    await page.goto(`/agents/${agentId}`);
+    await page.waitForLoadState("networkidle");
+
+    // Go to Edit tab
+    await page.getByRole("tab", { name: "Edit" }).click();
+
+    // Modify description
+    const descInput = page.getByLabel("Description");
+    await descInput.clear();
+    await descInput.fill("Draft update - no version bump");
+
+    // Click Save Draft
+    const saveDraftBtn = page.getByRole("button", { name: "Save Draft" });
+    await expect(saveDraftBtn).toBeEnabled();
+    await saveDraftBtn.click();
+
+    // Wait for save to complete
+    await page.waitForTimeout(2000);
+
+    expect(apiErrors).toHaveLength(0);
+
+    // Verify still version 1.0.0 (no bump)
+    await page.getByRole("tab", { name: "Overview" }).click();
+    await expect(page.locator("body")).toContainText("1.0.0");
+  });
+
+  test("Save & Release bumps version to 1.0.1", async ({ page }) => {
+    const apiErrors: string[] = [];
+    page.on("response", async (response) => {
+      if (response.url().includes("/api/v1/agents") && response.status() >= 400) {
+        const body = await response.text().catch(() => "");
+        apiErrors.push(`${response.status()} ${response.url()} → ${body}`);
+      }
+    });
+
+    await loginToWebUI(page);
+    await page.goto(`/agents/${agentId}`);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("tab", { name: "Edit" }).click();
+
+    // Modify description
+    const descInput = page.getByLabel("Description");
+    await descInput.clear();
+    await descInput.fill("Released description - version bump");
+
+    // Click Save & Release
+    const releaseBtn = page.getByRole("button", { name: /Save.*Release/i });
+    await expect(releaseBtn).toBeEnabled();
+    await releaseBtn.click();
+
+    // Version bump dialog
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByText("Release New Version")).toBeVisible();
+
+    // Patch is pre-selected by default (1.0.0 → 1.0.1)
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Patch", { exact: true })).toBeVisible();
+
+    // Confirm release
+    await page.getByRole("button", { name: "Release" }).click();
+
+    // Wait for release to complete
+    await page.waitForTimeout(3000);
+
+    expect(apiErrors).toHaveLength(0);
+  });
+
+  test("New version appears in Versions list as pending", async ({ page }) => {
+    await loginToWebUI(page);
+    await page.goto(`/agents/${agentId}`);
+    await page.waitForLoadState("networkidle");
+
+    // Check if there's a Versions tab or version indicator
+    const versionsTab = page.getByRole("tab", { name: /Version/i });
+    if (await versionsTab.isVisible()) {
+      await versionsTab.click();
+      await page.waitForTimeout(1000);
+      // Should show 1.0.1 as pending
+      await expect(page.locator("body")).toContainText("1.0.1");
+    }
+
+    // Verify via API
+    const res = await fetch(`${API_BASE}/api/v1/agents/${agentId}/versions`, {
+      headers: { "Authorization": `Bearer ${token}` },
+    });
+    const data = await res.json();
+    const items = data.items || data;
+    const v101 = items.find((v: { version: string }) => v.version === "1.0.1");
+    expect(v101).toBeTruthy();
+    expect(v101.status).toBe("pending");
+  });
+
+  test("Admin can approve the new version via review", async ({ page }) => {
+    // Approve via API (admin) - the review endpoint uses the version string, not UUID
+    const approveRes = await fetch(`${API_BASE}/api/v1/agents/${agentId}/versions/1.0.1/review`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ action: "approve" }),
+    });
+
+    if (!approveRes.ok) {
+      const body = await approveRes.text();
+      console.log(`Approve response: ${approveRes.status} ${body}`);
+    }
+    expect(approveRes.status).toBeLessThan(500);
+
+    // After approval, the agent's displayed version should be 1.0.1
+    await loginToWebUI(page);
+    await page.goto(`/agents/${agentId}`);
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("body")).toContainText("1.0.1");
+  });
+});


### PR DESCRIPTION
## Purpose / Description
Component delete endpoints (MCP, Sandbox, Skill, Hook, Prompt) return 500 due to circular FK constraint between `listing.latest_version_id` and the `versions` cascade. Additionally, the agent update (Save Draft) endpoint crashes because the Agent model was restructured to use read-only properties delegating to `latest_version`, but no setters were added.

## Fixes
* Fixes #677
* Fixes #678

## Approach
**Delete fix:** Break the circular dependency by nulling `latest_version_id`, clearing the relationship reference, explicitly deleting all versions, then deleting the listing. This avoids SQLAlchemy's `CircularDependencyError` in the unit-of-work topological sort.

**Agent update fix:** Add property setters for `description`, `prompt`, `model_name`, `version`, `model_config_json`, `supported_ides` on the Agent model that delegate writes to `latest_version`. Update the component/goal_template logic to use `agent_version_id` (the new FK) instead of the removed `agent_id` column.

**E2E test fix:** Add missing required `model_name` field to test agent creation, and make the "Save & Release" test dirty the form before clicking (button is disabled when clean).

## How Has This Been Tested?

- Ran `DELETE /api/v1/mcps/:id` against live server -> 200
- Ran `PUT /api/v1/agents/:id` (Save Draft) against live server -> 200
- Ran `POST /api/v1/agents/:id/versions` (Release) against live server -> 200
- All 6 Playwright tests pass in headed Chromium (agent-edit-form + real edit/release flow)
- Server unit tests pass (delete tests 4/4)

## Learning
SQLAlchemy's unit-of-work tracks relationship objects in memory. Simply nulling a FK column and flushing is not enough to break a circular cascade — the loaded relationship reference still causes the topological sort to detect a cycle. You must also clear the relationship attribute and explicitly delete the child objects before deleting the parent.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: N/A (backend-only fix)