### PR TITLE
ci(deploy): trigger on release tags only, not push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
 
 concurrency:
@@ -23,8 +23,8 @@ jobs:
           script: |
             set -e
             cd ~/Observal
-            git fetch origin main
-            git reset --hard origin/main
+            git fetch origin --tags
+            git checkout ${{ github.ref_name }}
 
             cd docker
             docker compose -f docker-compose.yml -f docker-compose.production.yml up -d --build --remove-orphans


### PR DESCRIPTION
Deploy was firing on every push to main, which pulled unreleased code onto the production server. Internal broke when main had migrations (0019-0022) that the v0.4.0 database didn't have.

Now deploys only on v* tags and checks out the tagged ref instead of hard-resetting to origin/main.

## Purpose / Description
The deploy workflow triggered on every push to main, causing the production server (internal.observal.io) to pull unreleased code. This broke the server when main had alembic migrations 0019-0022 that the production database (pinned at v0.4.0 / schema 0018) did not have, resulting in `UndefinedColumnError: column agents.latest_version_id does not exist` and all agents becoming invisible.

## Fixes
* Fixes #

## Approach
1. Changed the workflow trigger from `push: branches: [main]` to `push: tags: ['v*']` so deploys only happen when a release tag is pushed.
2. Replaced `git fetch origin main && git reset --hard origin/main` with `git fetch origin --tags && git checkout ${{ github.ref_name }}` so the server checks out the exact tagged release instead of always tracking the latest main.
3. `workflow_dispatch` is kept so manual deploys are still possible.

## How Has This Been Tested?

- Verified the workflow YAML is valid
- Manually fixed internal.observal.io by checking out v0.4.0, stamping alembic back to 0018, and rebuilding. Server is healthy and agents are visible again.
- Confirmed that pushing to main no longer triggers the deploy workflow (the trigger condition changed from branch to tag)

## Learning (optional, can help others)
- `git reset --hard origin/main` in a deploy script is dangerous when the production database schema is pinned to a release version. The server code and database schema must always be in sync.
- Alembic will fail with `Can't locate revision identified by 'XXXX'` if the stamped version is newer than the migration files the codebase knows about. The fix is to manually UPDATE alembic_version back to the correct revision.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
