### PR TITLE
fix(auth): stop traces after logout by revoking tokens server-side

### DIFF
--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -38,6 +38,15 @@ async def _authenticate_via_jwt(token: str, db: AsyncSession) -> User | None:
     except jwt.InvalidTokenError:
         return None
 
+    jti = payload.get("jti")
+    if jti:
+        try:
+            redis = get_redis()
+            if await redis.get(f"revoked_jti:{jti}"):
+                return None
+        except RedisError:
+            pass  # Fail open if Redis is down
+
     user_id = payload.get("sub")
 
     if not user_id:

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import secrets
+from datetime import UTC, datetime
 
 import jwt as pyjwt
 from authlib.integrations.starlette_client import OAuth
@@ -21,6 +22,7 @@ from schemas.auth import (
     InitRequest,
     InitResponse,
     LoginRequest,
+    LogoutRequest,
     RefreshRequest,
     RevokeRequest,
     TokenRequest,
@@ -29,7 +31,7 @@ from schemas.auth import (
     UserResponse,
 )
 from services.audit_helpers import audit
-from services.jwt_service import create_access_token, create_refresh_token, decode_refresh_token
+from services.jwt_service import create_access_token, create_refresh_token, decode_access_token, decode_refresh_token
 from services.redis import get_redis
 from services.security_events import (
     EventType,
@@ -70,6 +72,8 @@ async def _issue_tokens(user: User, groups: list[str] | None = None) -> tuple[st
         redis = get_redis()
         refresh_ttl = settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400
         await redis.setex(f"refresh_jti:{jti}", refresh_ttl, str(user.id))
+        # Clear any logout revocation so hooks resume after re-login
+        await redis.delete(f"revoked_user:{user.id}")
     except RedisError as e:
         logger.warning("Redis unavailable when storing refresh JTI, failing open: %s", e)
 
@@ -386,6 +390,73 @@ async def exchange_code(req: CodeExchangeRequest, db: AsyncSession = Depends(get
 async def whoami(current_user: User = Depends(get_current_user)):
     await audit(current_user, "auth.whoami", resource_type="auth", resource_id=str(current_user.id))
     return UserResponse.model_validate(current_user)
+
+
+@router.post("/logout")
+async def logout(
+    request: Request,
+    req: LogoutRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Revoke the current access token and optionally a refresh token.
+
+    Blacklists the access token JTI in Redis so it can no longer be used,
+    and marks the user_id as revoked so hook scripts stop sending telemetry.
+    """
+    # Extract the raw token from the Authorization header so we can get jti/exp
+    auth_header = request.headers.get("authorization", "")
+    token = auth_header.removeprefix("Bearer ").strip() if auth_header.startswith("Bearer ") else ""
+
+    try:
+        payload = decode_access_token(token)
+        jti = payload.get("jti")
+        exp = payload.get("exp")
+    except Exception:
+        jti = None
+        exp = None
+
+    try:
+        redis = get_redis()
+        if jti and exp:
+            now_ts = int(datetime.now(UTC).timestamp())
+            ttl = max(exp - now_ts, 1)
+            await redis.setex(f"revoked_jti:{jti}", ttl, "1")
+
+        # Mark the user as revoked for 30 days (max hooks token lifetime)
+        hooks_ttl = 30 * 86400
+        await redis.setex(f"revoked_user:{current_user.id}", hooks_ttl, "1")
+    except RedisError as e:
+        logger.warning("Redis unavailable during logout: %s", e)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+
+    # Optionally revoke the refresh token
+    if req.refresh_token:
+        try:
+            refresh_payload = decode_refresh_token(req.refresh_token)
+            refresh_jti = refresh_payload.get("jti")
+            if refresh_jti:
+                try:
+                    await redis.delete(f"refresh_jti:{refresh_jti}")
+                except RedisError:
+                    pass
+        except Exception:
+            pass  # Best-effort
+
+    source_ip, user_agent = _extract_request_info(request)
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.LOGOUT,
+            severity=Severity.INFO,
+            outcome="success",
+            actor_id=str(current_user.id),
+            actor_email=current_user.email,
+            actor_role=current_user.role.value,
+            source_ip=source_ip,
+            user_agent=user_agent,
+        )
+    )
+    await audit(current_user, "auth.logout", resource_type="session", resource_id=str(current_user.id))
+    return {"detail": "Logged out"}
 
 
 # ── JWT Token Endpoints ────────────────────────────────────

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 import jwt
 from fastapi import APIRouter, Depends, Header, Request, Response
+from redis.exceptions import RedisError
 from sqlalchemy import select
 
 from api.deps import get_project_id, require_role
@@ -27,7 +28,7 @@ from services.clickhouse import (
     query_recent_events,
 )
 from services.jwt_service import decode_access_token
-from services.redis import publish
+from services.redis import get_redis, publish
 from services.secrets_redactor import get_and_reset_redaction_count, redact_secrets
 from services.security_events import (
     EventType,
@@ -860,6 +861,18 @@ async def ingest_hook(request: Request):
 
     # ── User identity (from Observal login, injected by CLI) ──
     user_id = body.get("user_id") or request.headers.get("x-observal-user-id") or ""
+
+    # Drop events silently for revoked users (post-logout).
+    # Return 200 so hook scripts don't break on error responses.
+    if user_id:
+        try:
+            redis = get_redis()
+            if await redis.get(f"revoked_user:{user_id}"):
+                logger.debug("hooks: dropping event for revoked user %s", user_id)
+                return {}
+        except RedisError:
+            pass  # Fail open if Redis is down
+
     if user_id:
         attrs["user.id"] = user_id
 
@@ -1095,6 +1108,15 @@ async def _resolve_project_id(request: Request) -> str:
         payload = decode_access_token(token)
     except jwt.InvalidTokenError:
         return _DEFAULT_PROJECT
+
+    jti = payload.get("jti")
+    if jti:
+        try:
+            redis = get_redis()
+            if await redis.get(f"revoked_jti:{jti}"):
+                return _DEFAULT_PROJECT
+        except RedisError:
+            pass  # Fail open if Redis is down
 
     user_id = payload.get("sub")
     if not user_id:

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -144,3 +144,7 @@ class DeviceTokenRequest(BaseModel):
 
 class DeviceConfirmRequest(BaseModel):
     user_code: str
+
+
+class LogoutRequest(BaseModel):
+    refresh_token: str | None = None

--- a/observal-server/services/security_events.py
+++ b/observal-server/services/security_events.py
@@ -30,6 +30,7 @@ class EventType(str, Enum):
     # Auth
     LOGIN_SUCCESS = "auth.login.success"
     LOGIN_FAILURE = "auth.login.failure"
+    LOGOUT = "auth.logout"
     SSO_SUCCESS = "auth.sso.success"
     SSO_FAILURE = "auth.sso.failure"
     API_KEY_CREATED = "auth.api_key.created"

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -180,16 +180,37 @@ def init():
 @auth_app.command()
 def logout():
     """Clear saved credentials."""
+    # Best-effort: revoke tokens on the server before clearing locally
     if config.CONFIG_FILE.exists():
         import json
 
         raw_cfg = json.loads(config.CONFIG_FILE.read_text())
+
+        access_token = raw_cfg.get("access_token")
+        refresh_token = raw_cfg.get("refresh_token")
+        server_url = raw_cfg.get("server_url", "").rstrip("/")
+
+        if access_token and server_url:
+            try:
+                resp = httpx.post(
+                    f"{server_url}/api/v1/auth/logout",
+                    json={"refresh_token": refresh_token or None},
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    timeout=5,
+                )
+                resp.raise_for_status()
+            except Exception:
+                pass  # Best-effort — proceed with local cleanup regardless
 
         for key in ("access_token", "refresh_token", "api_key"):
             raw_cfg.pop(key, None)
         config.CONFIG_FILE.write_text(json.dumps(raw_cfg, indent=2))
 
         rprint("[green]Logged out.[/green]")
+        rprint(
+            "[dim]Note: IDE hooks will stop sending telemetry. "
+            "To remove hook scripts from your IDE, run [bold]observal doctor unpatch[/bold].[/dim]"
+        )
     else:
         rprint("[dim]No config to clear.[/dim]")
 

--- a/web/src/components/nav/nav-user.tsx
+++ b/web/src/components/nav/nav-user.tsx
@@ -76,7 +76,25 @@ export function NavUser({ user }: NavUserProps) {
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
-          onClick={() => {
+          onClick={async () => {
+            try {
+              const token = localStorage.getItem("observal_access_token");
+              const refreshToken = localStorage.getItem("observal_refresh_token");
+              if (token) {
+                await fetch("/api/v1/auth/logout", {
+                  method: "POST",
+                  headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({
+                    refresh_token: refreshToken || undefined,
+                  }),
+                });
+              }
+            } catch {
+              // Best-effort — proceed with client-side cleanup regardless
+            }
             clearSession();
             router.push("/login");
           }}


### PR DESCRIPTION
## Purpose / Description
After logging out from the Observal UI or CLI, IDE hooks (Claude Code, Kiro, etc.) continued sending telemetry because the locally-stored 30-day hooks token and baked-in `user_id` in hook configs were never invalidated server-side.

## Fixes
* Fixes #668

## Approach
**Server-side token revocation:** Added `POST /api/v1/auth/logout` that blacklists the access token JTI in Redis (TTL = remaining token lifetime) and marks the user_id as revoked for 30 days (matching max hooks token lifetime).

**Auth enforcement:** The `get_current_user` dependency now checks the `revoked_jti:{jti}` Redis key before accepting a token. The unauthenticated `/api/v1/telemetry/hooks` endpoint checks `revoked_user:{user_id}` and silently drops events for revoked users (returns 200 to avoid breaking hook scripts). The OTLP `_resolve_project_id` also checks revocation.

**Login clears revocation:** When a user logs back in via `_issue_tokens`, the `revoked_user:{user_id}` key is deleted so hooks resume after re-authentication.

**UI + CLI:** The web UI now calls the logout endpoint before clearing localStorage. The CLI `observal auth logout` calls it before clearing config and prints a hint to run `observal doctor unpatch` to remove hook scripts.

## How Has This Been Tested?

- Full cycle tested against live server:
  - Login → token works → logout → token rejected (401) → hooks silently dropped → re-login → token works → hooks resume
- Verified Redis TTLs are set correctly
- Verified fail-open behavior (Redis unavailable = auth still works)

## Learning
OTLP/hook endpoints are intentionally unauthenticated (hooks can't carry tokens mid-session). The `user_id` is baked into hook configs at install time. To stop traces post-logout, you need a secondary revocation mechanism keyed on user_id, not just token JTI.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: minimal (logout button now calls API before redirect)