### PR TITLE
ci: add deploy-dev workflow for main branch auto-deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,56 @@
+name: Deploy Dev to EC2
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-dev-ec2
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Deploy to EC2 (dev)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST_DEV }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY_DEV }}
+          script: |
+            set -e
+            cd ~/Observal
+            git fetch origin main
+            git reset --hard origin/main
+
+            cd docker
+            docker compose up -d --build --remove-orphans
+
+            echo "Waiting for API container to start..."
+            for i in $(seq 1 60); do
+              if docker compose exec -T observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/livez')" 2>/dev/null; then
+                echo "API process is alive"
+                break
+              fi
+              echo "Waiting for API process... ($i/60)"
+              sleep 5
+            done
+
+            docker compose restart observal-lb
+            sleep 3
+
+            for i in $(seq 1 30); do
+              if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+                echo "API is healthy"
+                exit 0
+              fi
+              echo "Waiting for health check... ($i/30)"
+              sleep 5
+            done
+
+            echo "API failed health check"
+            docker compose logs observal-api observal-init observal-lb observal-db observal-clickhouse --tail 20
+            exit 1


### PR DESCRIPTION
## Purpose / Description
We now have two EC2 instances: a stable/release server that deploys on version tags, and a new dev server that should track `main`. This PR adds a dedicated workflow for the dev instance so every merge to main is automatically deployed without touching the stable server.

## Fixes
* N/A -- new capability, no linked issue

## Approach
- New workflow file `.github/workflows/deploy-dev.yml` that triggers on `push` to `main` and `workflow_dispatch`
- Uses separate GitHub secrets (`EC2_HOST_DEV`, `EC2_SSH_KEY_DEV`) so it targets only the dev instance
- Runs `docker compose up -d --build --remove-orphans` without `-v`, so Docker volumes (Postgres, ClickHouse, Redis data) survive across deploys
- Same two-phase health check pattern as the existing release deploy: first checks the API container directly, then restarts the LB and verifies through nginx
- Concurrency group `deploy-dev-ec2` prevents overlapping deploys

## How Has This Been Tested?

- Manually SSH'd into the dev server (40.192.18.230), cloned the repo, ran `make up`, and confirmed all 9 containers come up healthy
- Verified `docker compose up -d --build --remove-orphans` rebuilds containers while preserving named volumes
- Health check loop tested against the running API (`/livez` and `/health` endpoints both respond)

## Learning (optional, can help others)
- `docker compose up -d --build --remove-orphans` is the right command for "rebuild everything but keep data" -- the `--remove-orphans` cleans up containers from removed services, and omitting `-v` keeps all named volumes intact
- Separate concurrency groups (`deploy-ec2` vs `deploy-dev-ec2`) ensure the two deployment pipelines never block each other

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
