### PR TITLE
Feat/deploy dev workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,7 +27,7 @@ jobs:
             git reset --hard origin/main
 
             cd docker
-            docker compose up -d --build --remove-orphans
+            docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build --remove-orphans
 
             echo "Waiting for API container to start..."
             for i in $(seq 1 60); do
@@ -39,11 +39,11 @@ jobs:
               sleep 5
             done
 
-            docker compose restart observal-lb
+            docker compose -f docker-compose.yml -f docker-compose.dev.yml restart observal-lb
             sleep 3
 
             for i in $(seq 1 30); do
-              if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              if curl -sf http://localhost/health > /dev/null 2>&1; then
                 echo "API is healthy"
                 exit 0
               fi

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,10 @@
+services:
+  observal-web:
+    environment:
+      - NEXT_PUBLIC_API_URL=http://dev.observal.io
+
+  observal-lb:
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro

--- a/docker/nginx.dev.conf
+++ b/docker/nginx.dev.conf
@@ -1,0 +1,79 @@
+upstream observal_api {
+    server observal-api:8000;
+}
+
+upstream observal_web {
+    server observal-web:3000;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    gzip on;
+    gzip_types application/json application/javascript text/css text/plain text/xml application/xml;
+    gzip_min_length 256;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 5;
+
+    location /api/ {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location /health {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $http_host;
+    }
+
+    location /livez {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $http_host;
+    }
+
+    location /readyz {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $http_host;
+    }
+
+    location /graphql {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location /v1/ {
+        proxy_pass http://observal_api;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+        client_max_body_size 10m;
+    }
+
+    location / {
+        proxy_pass http://observal_web;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
## Purpose / Description
The dev EC2 instance (dev.observal.io) needs to serve traffic on port 80 with nginx routing -- frontend at `/`, API at `/api/` -- same as the production setup on internal.observal.io but without SSL. The initial deploy-dev workflow used the base compose file which maps individual service ports instead of going through nginx.

## Fixes
* N/A -- enhancement to the deploy-dev workflow merged in 4393ce0

## Approach
- Added `docker-compose.dev.yml` override that maps nginx to port 80 and sets `NEXT_PUBLIC_API_URL=http://dev.observal.io`
- Added `nginx.dev.conf` -- HTTP-only reverse proxy config (same routing as production but no SSL redirect or certs)
- Updated `deploy-dev.yml` to use `-f docker-compose.yml -f docker-compose.dev.yml` so deploys use the override
- Health check now hits port 80 (through nginx) instead of 8000 directly

## How Has This Been Tested?

- SSH'd into dev server, ran `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build --remove-orphans`
- Verified all 9 containers healthy via `docker compose ps`
- Confirmed `curl http://localhost/health` returns `{"status":"ok"}` through nginx on port 80
- Confirmed `curl http://localhost/` returns 200 (frontend served at root)

## Learning (optional, can help others)
- `docker compose -f base.yml -f override.yml` layers overrides cleanly -- the dev override only needs to declare the services/keys it changes
- The production nginx config has SSL termination hardcoded to `internal.observal.io` certs, so a separate `nginx.dev.conf` is needed for HTTP-only dev environments

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
