### PR TITLE
feat: move review actions to detail page

### DIFF
--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
-import { CheckCircle2, X, Trash2, LayoutGrid, TableProperties } from "lucide-react";
+import { CheckCircle2, X, Trash2, LayoutGrid, TableProperties, Eye } from "lucide-react";
 import { useReviewAgents, useReviewComponents, useReviewAction, useReviewDelete } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import type { ReviewItem } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { PageHeader } from "@/components/layouts/page-header";
@@ -20,34 +19,13 @@ import { ReviewDiffSheet } from "@/components/review/review-diff-sheet";
 
 type ViewMode = "list" | "grid";
 
-function ReviewCard({ item, onApprove, onReject, onDelete, onItemClick, disableApprove, isAdmin }: {
+function ReviewCard({ item, onDelete, onItemClick, isAdmin }: {
   item: ReviewItem;
-  onApprove: (id: string, type?: string) => void;
-  onReject: (id: string, reason: string, type?: string) => void;
   onDelete: (id: string, type?: string) => void;
   onItemClick: (item: ReviewItem) => void;
-  disableApprove?: boolean;
   isAdmin?: boolean;
 }) {
-  const [showRejectInput, setShowRejectInput] = useState(false);
-  const [rejectReason, setRejectReason] = useState("");
   const [confirmDelete, setConfirmDelete] = useState(false);
-
-  const handleReject = useCallback(() => {
-    if (!showRejectInput) {
-      setShowRejectInput(true);
-      return;
-    }
-    if (!rejectReason.trim()) return;
-    onReject(item.id, rejectReason, item.type);
-    setShowRejectInput(false);
-    setRejectReason("");
-  }, [showRejectInput, rejectReason, item.id, item.type, onReject]);
-
-  const cancelReject = useCallback(() => {
-    setShowRejectInput(false);
-    setRejectReason("");
-  }, []);
 
   return (
     <div className="rounded-md border border-border bg-card p-4 space-y-3 hover:bg-muted/20 transition-colors">
@@ -83,26 +61,6 @@ function ReviewCard({ item, onApprove, onReject, onDelete, onItemClick, disableA
       <ValidationDetails results={item.validation_results} />
       <ComponentReadinessBadge item={item} />
 
-      {/* Reject reason input */}
-      {showRejectInput && (
-        <div className="flex items-center gap-2 animate-in">
-          <Input
-            placeholder="Reason for rejection..."
-            value={rejectReason}
-            onChange={(e) => setRejectReason(e.target.value)}
-            className="h-7 text-xs flex-1"
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleReject();
-              if (e.key === "Escape") cancelReject();
-            }}
-            autoFocus
-          />
-          <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={cancelReject}>
-            <X className="h-3 w-3" />
-          </Button>
-        </div>
-      )}
-
       {confirmDelete && (
         <div className="flex items-center gap-2 p-2 rounded bg-destructive/5 border border-destructive/15 animate-in">
           <p className="text-xs text-destructive flex-1">Permanently delete this submission?</p>
@@ -120,40 +78,13 @@ function ReviewCard({ item, onApprove, onReject, onDelete, onItemClick, disableA
       )}
 
       <div className="flex items-center gap-2">
-        {disableApprove ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="flex-1">
-                  <Button
-                    size="sm"
-                    className="h-7 text-xs w-full bg-success/10 text-success border border-success/25 shadow-none opacity-50 cursor-not-allowed"
-                    disabled
-                  >
-                    Approve
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Cannot approve until all required components are ready</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        ) : (
-          <Button
-            size="sm"
-            className="h-7 text-xs flex-1 bg-success/10 hover:bg-success/20 text-success border border-success/25 shadow-none"
-            onClick={() => onApprove(item.id, item.type)}
-          >
-            Approve
-          </Button>
-        )}
         <Button
           size="sm"
-          className="h-7 text-xs flex-1 bg-destructive/10 hover:bg-destructive/20 text-destructive border border-destructive/25 shadow-none"
-          onClick={handleReject}
+          className="h-7 text-xs flex-1 bg-info/10 hover:bg-info/20 text-info border border-info/25 shadow-none"
+          onClick={() => onItemClick(item)}
         >
-          {showRejectInput ? "Confirm" : "Reject"}
+          <Eye className="h-3 w-3 mr-1.5" />
+          Review
         </Button>
         {isAdmin && (
           <TooltipProvider>
@@ -180,34 +111,13 @@ function ReviewCard({ item, onApprove, onReject, onDelete, onItemClick, disableA
   );
 }
 
-function ReviewRow({ item, onApprove, onReject, onDelete, onItemClick, disableApprove, isAdmin }: {
+function ReviewRow({ item, onDelete, onItemClick, isAdmin }: {
   item: ReviewItem;
-  onApprove: (id: string, type?: string) => void;
-  onReject: (id: string, reason: string, type?: string) => void;
   onDelete: (id: string, type?: string) => void;
   onItemClick: (item: ReviewItem) => void;
-  disableApprove?: boolean;
   isAdmin?: boolean;
 }) {
-  const [showRejectInput, setShowRejectInput] = useState(false);
-  const [rejectReason, setRejectReason] = useState("");
   const [confirmDelete, setConfirmDelete] = useState(false);
-
-  const handleReject = useCallback(() => {
-    if (!showRejectInput) {
-      setShowRejectInput(true);
-      return;
-    }
-    if (!rejectReason.trim()) return;
-    onReject(item.id, rejectReason, item.type);
-    setShowRejectInput(false);
-    setRejectReason("");
-  }, [showRejectInput, rejectReason, item.id, item.type, onReject]);
-
-  const cancelReject = useCallback(() => {
-    setShowRejectInput(false);
-    setRejectReason("");
-  }, []);
 
   return (
     <div className="px-5 py-4 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors space-y-3">
@@ -259,66 +169,15 @@ function ReviewRow({ item, onApprove, onReject, onDelete, onItemClick, disableAp
               <X className="h-3.5 w-3.5" />
             </Button>
           </div>
-        ) : showRejectInput ? (
-          <div className="flex items-center gap-2 shrink-0">
-            <Input
-              placeholder="Reason for rejection..."
-              value={rejectReason}
-              onChange={(e) => setRejectReason(e.target.value)}
-              className="h-8 text-xs w-52"
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleReject();
-                if (e.key === "Escape") cancelReject();
-              }}
-              autoFocus
-            />
-            <Button
-              size="sm"
-              className="h-8 text-xs bg-destructive/10 hover:bg-destructive/20 text-destructive border border-destructive/25 shadow-none"
-              onClick={handleReject}
-            >
-              Confirm
-            </Button>
-            <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={cancelReject}>
-              <X className="h-3.5 w-3.5" />
-            </Button>
-          </div>
         ) : (
           <div className="flex items-center gap-2 shrink-0">
-            {disableApprove ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span>
-                      <Button
-                        size="sm"
-                        className="h-8 text-xs bg-success/10 text-success border border-success/25 shadow-none opacity-50 cursor-not-allowed"
-                        disabled
-                      >
-                        Approve
-                      </Button>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>Cannot approve until all required components are ready</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : (
-              <Button
-                size="sm"
-                className="h-8 text-xs bg-success/10 hover:bg-success/20 text-success border border-success/25 shadow-none"
-                onClick={() => onApprove(item.id, item.type)}
-              >
-                Approve
-              </Button>
-            )}
             <Button
               size="sm"
-              className="h-8 text-xs bg-destructive/10 hover:bg-destructive/20 text-destructive border border-destructive/25 shadow-none"
-              onClick={handleReject}
+              className="h-8 text-xs bg-info/10 hover:bg-info/20 text-info border border-info/25 shadow-none"
+              onClick={() => onItemClick(item)}
             >
-              Reject
+              <Eye className="h-3.5 w-3.5 mr-1.5" />
+              Review
             </Button>
             {isAdmin && (
               <TooltipProvider>
@@ -350,16 +209,12 @@ function ReviewRow({ item, onApprove, onReject, onDelete, onItemClick, disableAp
 function AgentItemList({
   items,
   view,
-  onApprove,
-  onReject,
   onDelete,
   onItemClick,
   isAdmin,
 }: {
   items: ReviewItem[];
   view: ViewMode;
-  onApprove: (id: string, type?: string) => void;
-  onReject: (id: string, reason: string, type?: string) => void;
   onDelete: (id: string, type?: string) => void;
   onItemClick: (item: ReviewItem) => void;
   isAdmin?: boolean;
@@ -389,11 +244,8 @@ function AgentItemList({
           <ReviewRow
             key={item.id}
             item={item}
-            onApprove={onApprove}
-            onReject={onReject}
             onDelete={onDelete}
             onItemClick={onItemClick}
-            disableApprove={item.components_ready === false}
             isAdmin={isAdmin}
           />
         ))}
@@ -404,11 +256,8 @@ function AgentItemList({
           <ReviewCard
             key={item.id}
             item={item}
-            onApprove={onApprove}
-            onReject={onReject}
             onDelete={onDelete}
             onItemClick={onItemClick}
-            disableApprove={item.components_ready === false}
             isAdmin={isAdmin}
           />
         ))}
@@ -444,16 +293,12 @@ function AgentItemList({
 function ReviewItemList({
   items,
   view,
-  onApprove,
-  onReject,
   onDelete,
   onItemClick,
   isAdmin,
 }: {
   items: ReviewItem[];
   view: ViewMode;
-  onApprove: (id: string, type?: string) => void;
-  onReject: (id: string, reason: string, type?: string) => void;
   onDelete: (id: string, type?: string) => void;
   onItemClick: (item: ReviewItem) => void;
   isAdmin?: boolean;
@@ -464,8 +309,6 @@ function ReviewItemList({
         <ReviewRow
           key={item.id}
           item={item}
-          onApprove={onApprove}
-          onReject={onReject}
           onDelete={onDelete}
           onItemClick={onItemClick}
           isAdmin={isAdmin}
@@ -478,8 +321,6 @@ function ReviewItemList({
         <ReviewCard
           key={item.id}
           item={item}
-          onApprove={onApprove}
-          onReject={onReject}
           onDelete={onDelete}
           onItemClick={onItemClick}
           isAdmin={isAdmin}
@@ -599,8 +440,6 @@ export default function ReviewPage() {
               <AgentItemList
                 items={agents!}
                 view={view}
-                onApprove={handleApprove}
-                onReject={handleReject}
                 onDelete={handleDelete}
                 onItemClick={handleItemClick}
                 isAdmin={isAdmin}
@@ -627,8 +466,6 @@ export default function ReviewPage() {
               <ReviewItemList
                 items={components!}
                 view={view}
-                onApprove={handleApprove}
-                onReject={handleReject}
                 onDelete={handleDelete}
                 onItemClick={handleItemClick}
                 isAdmin={isAdmin}


### PR DESCRIPTION
Replace Approve/Reject buttons on review queue list with a single Review button that opens the detail page. Approve and Reject actions stay on the detail page.

<img width="1919" height="939" alt="image" src="https://github.com/user-attachments/assets/d22e607f-d0c4-4e07-8543-122a19bb6065" />


<img width="1918" height="937" alt="image" src="https://github.com/user-attachments/assets/e129bddc-afbb-4e76-b51a-26464639cf7c" />


Examples shown for when signed in an admin and a reviewer.

Closes #688
