### PR TITLE
fix(config): assigned model should reflect when agent is called

### DIFF
--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -18,18 +18,17 @@ from services.config_generator import (
 
 _SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-_MODEL_SHORT_NAMES = {"sonnet": "sonnet", "opus": "opus", "haiku": "haiku"}
+_DATE_SUFFIX = re.compile(r"-\d{8}$")
 
 
 def _model_name_to_frontmatter(model_name: str) -> str:
-    """Convert a stored model_name (e.g. 'claude-sonnet-4') to a frontmatter short name."""
+    """Strip the date suffix from a stored model_name, keeping the full model ID.
+
+    e.g. 'claude-sonnet-4-6-20250725' -> 'claude-sonnet-4-6'
+    """
     if not model_name:
         return ""
-    lower = model_name.lower()
-    for key in _MODEL_SHORT_NAMES:
-        if key in lower:
-            return _MODEL_SHORT_NAMES[key]
-    return model_name
+    return _DATE_SUFFIX.sub("", model_name)
 
 
 _FEATURE_LABELS: dict[str, str] = {

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -18,6 +18,20 @@ from services.config_generator import (
 
 _SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
 
+_MODEL_SHORT_NAMES = {"sonnet": "sonnet", "opus": "opus", "haiku": "haiku"}
+
+
+def _model_name_to_frontmatter(model_name: str) -> str:
+    """Convert a stored model_name (e.g. 'claude-sonnet-4') to a frontmatter short name."""
+    if not model_name:
+        return ""
+    lower = model_name.lower()
+    for key in _MODEL_SHORT_NAMES:
+        if key in lower:
+            return _MODEL_SHORT_NAMES[key]
+    return model_name
+
+
 _FEATURE_LABELS: dict[str, str] = {
     "skills": "slash-command skills",
     "superpowers": "Kiro superpowers",
@@ -369,6 +383,10 @@ def generate_agent_config(
         tools = options.get("tools", "")  # comma-separated whitelist
         color = options.get("color", "")
 
+        # Fall back to the agent's stored model_name when no explicit choice
+        if not model_choice or model_choice == "inherit":
+            model_choice = _model_name_to_frontmatter(getattr(agent, "model_name", ""))
+
         # Build Claude Code agent file with YAML frontmatter
         desc_line = (agent.description or safe_name).replace("\n", " ").strip()
         frontmatter_lines = [
@@ -376,7 +394,7 @@ def generate_agent_config(
             f"name: {safe_name}",
             f'description: "{desc_line}"',
         ]
-        if model_choice and model_choice != "inherit":
+        if model_choice:
             frontmatter_lines.append(f"model: {model_choice}")
         if tools:
             frontmatter_lines.append(f"tools: {tools}")

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -21,6 +21,7 @@ from services.agent_builder import (
 from services.agent_config_generator import (
     _build_rules_content,
     _inject_agent_id,
+    _model_name_to_frontmatter,
     _sanitize_name,
     generate_agent_config,
 )
@@ -262,6 +263,60 @@ class TestGenerateClaudeCode:
         parts = content.split("---", 2)
         fm = yaml.safe_load(parts[1])
         assert "\n" not in fm["description"]
+
+    def test_model_fallback_from_agent_when_no_option(self):
+        agent = _make_agent(model_name="claude-sonnet-4")
+        cfg = generate_agent_config(agent, "claude-code")
+        content = cfg["rules_file"]["content"]
+        parts = content.split("---", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["model"] == "sonnet"
+
+    def test_model_fallback_from_agent_when_inherit(self):
+        agent = _make_agent(model_name="claude-opus-4")
+        cfg = generate_agent_config(agent, "claude-code", options={"model": "inherit"})
+        content = cfg["rules_file"]["content"]
+        parts = content.split("---", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["model"] == "opus"
+
+    def test_explicit_model_option_overrides_agent(self):
+        agent = _make_agent(model_name="claude-sonnet-4")
+        cfg = generate_agent_config(agent, "claude-code", options={"model": "haiku"})
+        content = cfg["rules_file"]["content"]
+        parts = content.split("---", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["model"] == "haiku"
+
+    def test_no_model_when_agent_has_empty_model_name(self):
+        agent = _make_agent(model_name="")
+        cfg = generate_agent_config(agent, "claude-code")
+        content = cfg["rules_file"]["content"]
+        parts = content.split("---", 2)
+        fm = yaml.safe_load(parts[1])
+        assert "model" not in fm
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 4b. _model_name_to_frontmatter
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestModelNameToFrontmatter:
+    def test_sonnet(self):
+        assert _model_name_to_frontmatter("claude-sonnet-4") == "sonnet"
+
+    def test_opus(self):
+        assert _model_name_to_frontmatter("claude-opus-4") == "opus"
+
+    def test_haiku(self):
+        assert _model_name_to_frontmatter("claude-haiku-4-5-20251001") == "haiku"
+
+    def test_empty(self):
+        assert _model_name_to_frontmatter("") == ""
+
+    def test_unknown_model_passthrough(self):
+        assert _model_name_to_frontmatter("gpt-4o") == "gpt-4o"
 
 
 # ═══════════════════════════════════════════════════════════════════

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -265,23 +265,23 @@ class TestGenerateClaudeCode:
         assert "\n" not in fm["description"]
 
     def test_model_fallback_from_agent_when_no_option(self):
-        agent = _make_agent(model_name="claude-sonnet-4")
+        agent = _make_agent(model_name="claude-sonnet-4-6-20250725")
         cfg = generate_agent_config(agent, "claude-code")
         content = cfg["rules_file"]["content"]
         parts = content.split("---", 2)
         fm = yaml.safe_load(parts[1])
-        assert fm["model"] == "sonnet"
+        assert fm["model"] == "claude-sonnet-4-6"
 
     def test_model_fallback_from_agent_when_inherit(self):
-        agent = _make_agent(model_name="claude-opus-4")
+        agent = _make_agent(model_name="claude-opus-4-6-20250725")
         cfg = generate_agent_config(agent, "claude-code", options={"model": "inherit"})
         content = cfg["rules_file"]["content"]
         parts = content.split("---", 2)
         fm = yaml.safe_load(parts[1])
-        assert fm["model"] == "opus"
+        assert fm["model"] == "claude-opus-4-6"
 
     def test_explicit_model_option_overrides_agent(self):
-        agent = _make_agent(model_name="claude-sonnet-4")
+        agent = _make_agent(model_name="claude-sonnet-4-6-20250725")
         cfg = generate_agent_config(agent, "claude-code", options={"model": "haiku"})
         content = cfg["rules_file"]["content"]
         parts = content.split("---", 2)
@@ -303,19 +303,19 @@ class TestGenerateClaudeCode:
 
 
 class TestModelNameToFrontmatter:
-    def test_sonnet(self):
-        assert _model_name_to_frontmatter("claude-sonnet-4") == "sonnet"
+    def test_strips_date_suffix(self):
+        assert _model_name_to_frontmatter("claude-sonnet-4-6-20250725") == "claude-sonnet-4-6"
 
-    def test_opus(self):
-        assert _model_name_to_frontmatter("claude-opus-4") == "opus"
+    def test_no_date_suffix_unchanged(self):
+        assert _model_name_to_frontmatter("claude-opus-4-6") == "claude-opus-4-6"
 
-    def test_haiku(self):
-        assert _model_name_to_frontmatter("claude-haiku-4-5-20251001") == "haiku"
+    def test_haiku_with_date(self):
+        assert _model_name_to_frontmatter("claude-haiku-4-5-20251001") == "claude-haiku-4-5"
 
     def test_empty(self):
         assert _model_name_to_frontmatter("") == ""
 
-    def test_unknown_model_passthrough(self):
+    def test_non_claude_model_passthrough(self):
         assert _model_name_to_frontmatter("gpt-4o") == "gpt-4o"
 
 


### PR DESCRIPTION
## Purpose / Description
When pulling an agent with `observal pull` without passing the `--model` flag, the generated Claude Code agent config has no `model:` line in the frontmatter. This causes the IDE to fall back to its default session model (e.g. opus) instead of using the model configured on the agent (e.g. sonnet).

## Fixes
* Fixes #646

## Approach
- Added `_model_name_to_frontmatter()` helper that converts stored model names (e.g. `claude-sonnet-4`) to frontmatter short names (`sonnet`, `opus`, `haiku`)
- When `options.get("model")` is empty or `"inherit"`, the config generator now falls back to `agent.model_name` from the database
- Explicit `--model` flag still takes priority over the stored value

## How Has This Been Tested?

- Added 9 new tests in `test_agent_config_generator.py`:
  - `test_model_fallback_from_agent_when_no_option` -- no flag, agent has sonnet, frontmatter gets sonnet
  - `test_model_fallback_from_agent_when_inherit` -- inherit flag, agent has opus, frontmatter gets opus
  - `test_explicit_model_option_overrides_agent` -- haiku flag overrides agent's sonnet
  - `test_no_model_when_agent_has_empty_model_name` -- empty model_name, no model in frontmatter
  - 5 unit tests for `_model_name_to_frontmatter` (sonnet, opus, haiku, empty, unknown passthrough)
- Full test suite: 1942 passed, 20 pre-existing failures (git_mirror, uninstall)

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
