### PR TITLE
feat(ci): add /take and /drop commands for issue assignment

### DIFF
--- a/.github/workflows/take-command.yml
+++ b/.github/workflows/take-command.yml
@@ -1,0 +1,59 @@
+name: /take Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  take:
+    if: >-
+      github.event.issue.pull_request == null &&
+      github.event.comment.body == '/take'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check labels and assign
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const commenter = context.payload.comment.user.login;
+
+            const labels = issue.labels.map(l => l.name.toLowerCase());
+            const eligible = labels.includes('good first issue') || labels.includes('help wanted');
+
+            if (!eligible) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `@${commenter} This issue is not open for community assignment. The \`/take\` command only works on issues labeled \`good first issue\` or \`help wanted\`.`
+              });
+              return;
+            }
+
+            if (issue.assignees.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `@${commenter} This issue is already assigned to @${issue.assignees[0].login}.`
+              });
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [commenter]
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `@${commenter} You've been assigned to this issue. Welcome aboard! 🎉\n\nPlease read our [contributing guide](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) before submitting a PR.`
+            });

--- a/.github/workflows/take-command.yml
+++ b/.github/workflows/take-command.yml
@@ -1,4 +1,4 @@
-name: /take Command
+name: Issue Commands
 
 on:
   issue_comment:
@@ -56,4 +56,43 @@ jobs:
               repo: context.repo.repo,
               issue_number: issue.number,
               body: `@${commenter} You've been assigned to this issue. Welcome aboard! 🎉\n\nPlease read our [contributing guide](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) before submitting a PR.`
+            });
+
+  drop:
+    if: >-
+      github.event.issue.pull_request == null &&
+      github.event.comment.body == '/drop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unassign commenter
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const commenter = context.payload.comment.user.login;
+
+            const isAssigned = issue.assignees.some(a => a.login === commenter);
+
+            if (!isAssigned) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `@${commenter} You are not currently assigned to this issue.`
+              });
+              return;
+            }
+
+            await github.rest.issues.removeAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [commenter]
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `@${commenter} You've been unassigned from this issue. The issue is now available for others to pick up.`
             });


### PR DESCRIPTION
## Purpose / Description

Adds `/take` and `/drop` slash commands that contributors can use in issue comments to self-assign or unassign from issues. This is a common pattern in open-source repos that streamlines community contribution.

## Fixes
* Fixes #695

## Approach

A single GitHub Actions workflow (`take-command.yml`) triggers on `issue_comment` events and handles both commands:

- **`/take`** — validates the issue has `good first issue` or `help wanted` labels and is unassigned, then assigns the commenter and posts a welcome message linking the contributing guide.
- **`/drop`** — validates the commenter is currently assigned, then removes them and posts a confirmation.

Both commands only work on issues (not PRs) and provide clear feedback when preconditions aren't met.

## How Has This Been Tested?

- Verified workflow YAML syntax is valid
- Linting passes (`make lint`)
- Reviewed logic paths: eligible + unassigned, already assigned, ineligible labels, drop when not assigned
- Workflow uses `actions/github-script@v7` which is well-established for this pattern

## Learning (optional, can help others)

- GitHub Actions `issue_comment` trigger only fires on issue/PR comments; the `github.event.issue.pull_request == null` check filters to issues only
- `actions/github-script` provides direct access to Octokit for fine-grained GitHub API calls within a workflow

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)