### PR TITLE
fix(agent): version-scoped columns, review flow, and model frontmatter

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -1360,18 +1360,24 @@ async def update_draft(
         agent.external_mcps = [m.model_dump() for m in req.external_mcps]
 
     if req.components is not None:
+        if not agent.latest_version:
+            raise HTTPException(status_code=400, detail="Agent has no version to update components on")
+        version_id = agent.latest_version.id
         old_comps = (
-            (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == version_id)))
+            .scalars()
+            .all()
         )
         for comp in old_comps:
             await db.delete(comp)
         for i, cref in enumerate(req.components):
             db.add(
                 AgentComponent(
-                    agent_id=agent.id,
+                    agent_version_id=version_id,
                     component_type=cref.component_type,
                     component_id=cref.component_id,
-                    version_ref="latest",
+                    component_name="",
+                    resolved_version="latest",
                     order_index=i,
                     config_override=cref.config_override,
                 )
@@ -1379,8 +1385,12 @@ async def update_draft(
 
     # Re-infer IDE features only when components or external_mcps changed
     if req.components is not None or req.external_mcps is not None:
+        if not agent.latest_version:
+            raise HTTPException(status_code=400, detail="Agent has no version to update features on")
         current_comps_draft = (
-            (await db.execute(select(AgentComponent).where(AgentComponent.agent_id == agent.id))).scalars().all()
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == agent.latest_version.id)))
+            .scalars()
+            .all()
         )
         skill_comp_ids = [c.component_id for c in current_comps_draft if c.component_type == "skill"]
         skill_listings_map_draft_update: dict = {}

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -554,8 +554,10 @@ async def approve_agent(
     pending_ver.rejection_reason = None
     pending_ver.reviewed_by = current_user.id
     pending_ver.reviewed_at = datetime.now(UTC)
+    await db.flush()
 
-    # Promote to latest if this version is newer than the current latest
+    # Promote to latest if this version is newer than the current latest.
+    # Flush first to break the circular dependency (Agent ↔ AgentVersion).
     from services.versioning import parse_semver
 
     current_latest = agent.latest_version

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -1,5 +1,6 @@
 import enum
 import uuid
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -524,10 +525,22 @@ async def approve_agent(
     agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
-    if agent.status != AgentStatus.pending:
+
+    # Find the newest pending version — it may not be latest_version yet
+    # (new versions are published as pending and only become latest on approval).
+    pending_ver = (
+        await db.execute(
+            select(AgentVersion)
+            .where(AgentVersion.agent_id == agent.id, AgentVersion.status == AgentStatus.pending)
+            .order_by(AgentVersion.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if not pending_ver:
         raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', not pending")
 
-    components_ready, blocking = await _check_agent_components_ready(agent.components, db)
+    components_ready, blocking = await _check_agent_components_ready(pending_ver.components, db)
     if not components_ready:
         raise HTTPException(
             status_code=422,
@@ -537,8 +550,20 @@ async def approve_agent(
             },
         )
 
-    agent.status = AgentStatus.approved
-    agent.rejection_reason = None
+    pending_ver.status = AgentStatus.approved
+    pending_ver.rejection_reason = None
+    pending_ver.reviewed_by = current_user.id
+    pending_ver.reviewed_at = datetime.now(UTC)
+
+    # Promote to latest if this version is newer than the current latest
+    from services.versioning import parse_semver
+
+    current_latest = agent.latest_version
+    new_parsed = parse_semver(pending_ver.version)
+    current_parsed = parse_semver(current_latest.version) if current_latest else None
+    if not current_latest or (new_parsed is not None and current_parsed is not None and new_parsed >= current_parsed):
+        agent.latest_version_id = pending_ver.id
+
     await db.commit()
     await audit(
         current_user,
@@ -547,7 +572,7 @@ async def approve_agent(
         resource_id=str(agent_id),
         resource_name=agent.name,
     )
-    return {"id": str(agent.id), "name": agent.name, "status": agent.status.value}
+    return {"id": str(agent.id), "name": agent.name, "status": "approved", "version": pending_ver.version}
 
 
 @router.post("/agents/{agent_id}/reject")
@@ -560,11 +585,24 @@ async def reject_agent(
     agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
-    if agent.status not in (AgentStatus.pending, AgentStatus.approved):
-        raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', cannot reject")
 
-    agent.status = AgentStatus.rejected
-    agent.rejection_reason = req.reason
+    # Find the newest pending version to reject
+    pending_ver = (
+        await db.execute(
+            select(AgentVersion)
+            .where(AgentVersion.agent_id == agent.id, AgentVersion.status == AgentStatus.pending)
+            .order_by(AgentVersion.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if not pending_ver:
+        raise HTTPException(status_code=400, detail="Agent has no pending version to reject")
+
+    pending_ver.status = AgentStatus.rejected
+    pending_ver.rejection_reason = req.reason
+    pending_ver.reviewed_by = current_user.id
+    pending_ver.reviewed_at = datetime.now(UTC)
     await db.commit()
     await audit(
         current_user,
@@ -574,7 +612,7 @@ async def reject_agent(
         resource_name=agent.name,
         detail=f"reason={req.reason}",
     )
-    return {"id": str(agent.id), "name": agent.name, "status": agent.status.value}
+    return {"id": str(agent.id), "name": agent.name, "status": "rejected", "version": pending_ver.version}
 
 
 # ---------------------------------------------------------------------------

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -18,17 +18,31 @@ from services.config_generator import (
 
 _SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-_DATE_SUFFIX = re.compile(r"-\d{8}$")
+_MODEL_SHORT_NAMES: dict[str, str] = {
+    "sonnet": "sonnet",
+    "opus": "opus",
+    "haiku": "haiku",
+}
 
 
 def _model_name_to_frontmatter(model_name: str) -> str:
-    """Strip the date suffix from a stored model_name, keeping the full model ID.
+    """Convert a stored model_name to a Claude Code frontmatter short name.
 
-    e.g. 'claude-sonnet-4-6-20250725' -> 'claude-sonnet-4-6'
+    Claude Code frontmatter accepts short names (sonnet, opus, haiku)
+    or full API model IDs (claude-sonnet-4-6-20250725). The intermediate
+    form (claude-sonnet-4-6) is NOT valid and causes API errors.
+
+    e.g. 'claude-sonnet-4-6-20250725' -> 'sonnet'
+         'claude-opus-4-6-20250725'   -> 'opus'
+         'gpt-4o'                     -> 'gpt-4o'  (passthrough)
     """
     if not model_name:
         return ""
-    return _DATE_SUFFIX.sub("", model_name)
+    lower = model_name.lower()
+    for keyword, short in _MODEL_SHORT_NAMES.items():
+        if keyword in lower:
+            return short
+    return model_name
 
 
 _FEATURE_LABELS: dict[str, str] = {

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -270,7 +270,7 @@ class TestGenerateClaudeCode:
         content = cfg["rules_file"]["content"]
         parts = content.split("---", 2)
         fm = yaml.safe_load(parts[1])
-        assert fm["model"] == "claude-sonnet-4-6"
+        assert fm["model"] == "sonnet"
 
     def test_model_fallback_from_agent_when_inherit(self):
         agent = _make_agent(model_name="claude-opus-4-6-20250725")
@@ -278,7 +278,7 @@ class TestGenerateClaudeCode:
         content = cfg["rules_file"]["content"]
         parts = content.split("---", 2)
         fm = yaml.safe_load(parts[1])
-        assert fm["model"] == "claude-opus-4-6"
+        assert fm["model"] == "opus"
 
     def test_explicit_model_option_overrides_agent(self):
         agent = _make_agent(model_name="claude-sonnet-4-6-20250725")
@@ -303,14 +303,14 @@ class TestGenerateClaudeCode:
 
 
 class TestModelNameToFrontmatter:
-    def test_strips_date_suffix(self):
-        assert _model_name_to_frontmatter("claude-sonnet-4-6-20250725") == "claude-sonnet-4-6"
+    def test_sonnet_with_date(self):
+        assert _model_name_to_frontmatter("claude-sonnet-4-6-20250725") == "sonnet"
 
-    def test_no_date_suffix_unchanged(self):
-        assert _model_name_to_frontmatter("claude-opus-4-6") == "claude-opus-4-6"
+    def test_opus_without_date(self):
+        assert _model_name_to_frontmatter("claude-opus-4-6") == "opus"
 
     def test_haiku_with_date(self):
-        assert _model_name_to_frontmatter("claude-haiku-4-5-20251001") == "claude-haiku-4-5"
+        assert _model_name_to_frontmatter("claude-haiku-4-5-20251001") == "haiku"
 
     def test_empty(self):
         assert _model_name_to_frontmatter("") == ""

--- a/tests/test_agent_review.py
+++ b/tests/test_agent_review.py
@@ -63,8 +63,22 @@ def _agent_mock(status=AgentStatus.pending, **extra):
     m.created_at = datetime.now(UTC)
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
+    m.latest_version = extra.get("latest_version")
     for k, v in extra.items():
         setattr(m, k, v)
+    return m
+
+
+def _version_mock(status=AgentStatus.pending, **extra):
+    """Return a MagicMock that looks like an AgentVersion ORM instance."""
+    m = MagicMock()
+    m.id = extra.get("id", uuid.uuid4())
+    m.version = extra.get("version", "1.0.0")
+    m.status = status
+    m.rejection_reason = None
+    m.components = extra.get("components", [])
+    m.reviewed_by = None
+    m.reviewed_at = None
     return m
 
 
@@ -75,11 +89,11 @@ def _empty_result():
     return r
 
 
-def _result_with_agent(agent):
-    """Return a mock result that yields the agent via scalar_one_or_none."""
+def _result_with(obj):
+    """Return a mock result that yields obj via scalar_one_or_none."""
     r = MagicMock()
-    r.scalar_one_or_none.return_value = agent
-    r.scalars.return_value.all.return_value = [agent]
+    r.scalar_one_or_none.return_value = obj
+    r.scalars.return_value.all.return_value = [obj] if obj else []
     return r
 
 
@@ -95,17 +109,17 @@ class TestAgentApprove:
     async def test_sets_status_to_active(self):
         """Approving a pending agent with all components ready sets status to active."""
         app, db, _ = _app_with()
+        pending_ver = _version_mock(status=AgentStatus.pending, components=[])
         agent = _agent_mock(status=AgentStatus.pending, components=[])
 
-        # First execute: select Agent -> returns agent
-        # The endpoint uses selectinload, so scalar_one_or_none is the path
-        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+        # 1st execute: select Agent; 2nd: select pending AgentVersion
+        db.execute = AsyncMock(side_effect=[_result_with(agent), _result_with(pending_ver)])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(f"/api/v1/review/agents/{agent.id}/approve")
 
         assert r.status_code == 200
-        assert agent.status == AgentStatus.approved
+        assert pending_ver.status == AgentStatus.approved
         assert r.json()["status"] == "approved"
         db.commit.assert_awaited_once()
 
@@ -117,16 +131,13 @@ class TestAgentApprove:
         comp = MagicMock()
         comp.component_type = "mcp"
         comp.component_id = uuid.uuid4()
+        pending_ver = _version_mock(status=AgentStatus.pending, components=[comp])
         agent = _agent_mock(status=AgentStatus.pending, components=[comp])
 
-        # First call: select Agent -> agent
-        # Second call: select component status -> component not approved
+        # Row returned by _check_agent_components_ready
         blocking_row = MagicMock()
         blocking_row.id = comp.component_id
         blocking_row.name = "unapproved-mcp"
-        blocking_row.status = MagicMock()
-        blocking_row.status.value = "pending"
-        # The status comparison != ListingStatus.approved should be truthy
         from models.mcp import ListingStatus
 
         blocking_row.status = ListingStatus.pending
@@ -134,7 +145,8 @@ class TestAgentApprove:
         component_result = MagicMock()
         component_result.all.return_value = [blocking_row]
 
-        db.execute = AsyncMock(side_effect=[_result_with_agent(agent), component_result])
+        # 1st: select Agent; 2nd: select pending AgentVersion; 3rd: component check
+        db.execute = AsyncMock(side_effect=[_result_with(agent), _result_with(pending_ver), component_result])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(f"/api/v1/review/agents/{agent.id}/approve")
@@ -145,8 +157,10 @@ class TestAgentApprove:
     async def test_response_includes_id_and_name(self):
         """Approval response includes agent id, name, and status."""
         app, db, _ = _app_with()
+        pending_ver = _version_mock(status=AgentStatus.pending, version="1.0.0", components=[])
         agent = _agent_mock(status=AgentStatus.pending, name="my-agent", components=[])
-        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        db.execute = AsyncMock(side_effect=[_result_with(agent), _result_with(pending_ver)])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(f"/api/v1/review/agents/{agent.id}/approve")
@@ -169,8 +183,11 @@ class TestAgentReject:
     async def test_sets_status_and_stores_reason(self):
         """Rejecting a pending agent stores the rejection reason."""
         app, db, _ = _app_with()
+        pending_ver = _version_mock(status=AgentStatus.pending)
         agent = _agent_mock(status=AgentStatus.pending)
-        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        # 1st: select Agent; 2nd: select pending AgentVersion
+        db.execute = AsyncMock(side_effect=[_result_with(agent), _result_with(pending_ver)])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(
@@ -179,17 +196,19 @@ class TestAgentReject:
             )
 
         assert r.status_code == 200
-        assert agent.status == AgentStatus.rejected
-        assert agent.rejection_reason == "missing documentation"
+        assert pending_ver.status == AgentStatus.rejected
+        assert pending_ver.rejection_reason == "missing documentation"
         assert r.json()["status"] == "rejected"
         db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_reject_active_agent(self):
-        """An active agent can also be rejected."""
+    async def test_reject_active_agent_with_pending_version(self):
+        """An approved agent can have a pending version rejected."""
         app, db, _ = _app_with()
+        pending_ver = _version_mock(status=AgentStatus.pending)
         agent = _agent_mock(status=AgentStatus.approved)
-        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        db.execute = AsyncMock(side_effect=[_result_with(agent), _result_with(pending_ver)])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(
@@ -198,14 +217,16 @@ class TestAgentReject:
             )
 
         assert r.status_code == 200
-        assert agent.status == AgentStatus.rejected
+        assert pending_ver.status == AgentStatus.rejected
 
     @pytest.mark.asyncio
-    async def test_reject_draft_agent_returns_400(self):
-        """Rejecting a draft agent is not allowed (status must be pending or active)."""
+    async def test_reject_returns_400_when_no_pending_version(self):
+        """Rejecting when there is no pending version returns 400."""
         app, db, _ = _app_with()
         agent = _agent_mock(status=AgentStatus.draft)
-        db.execute = AsyncMock(return_value=_result_with_agent(agent))
+
+        # 1st: select Agent; 2nd: select pending AgentVersion -> None
+        db.execute = AsyncMock(side_effect=[_result_with(agent), _result_with(None)])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.post(


### PR DESCRIPTION
## Summary
- **update_draft**: migrated to use `agent_version_id` / `resolved_version` (was referencing non-existent `agent_id` / `version_ref` columns — runtime crash)
- **approve/reject agent**: now queries for the pending `AgentVersion` directly instead of relying on `agent.status` (which delegates to `latest_version`, not the pending one)
- **model frontmatter**: maps stored model names to short names (`sonnet`, `opus`, `haiku`) instead of invalid intermediate form (`claude-sonnet-4-6`)

## Test plan
- [x] `update_draft` with components no longer 500s
- [x] Approve agent after publishing a new version no longer returns "Agent is 'approved', not pending"
- [x] `claude --agent <name>` launches with the correct model
- [x] All 106 config generator tests pass
- [x] All 50 review tests pass (8 agent-specific tests updated)