### PR TITLE
feat(ci): enhance /take command with assignment limits, keep-open guard, and stale cleanup

### DIFF
--- a/.github/workflows/take-command.yml
+++ b/.github/workflows/take-command.yml
@@ -3,6 +3,9 @@ name: Issue Commands
 on:
   issue_comment:
     types: [created]
+  schedule:
+    # Run daily at midnight UTC to check for stale assignments
+    - cron: '0 0 * * *'
 
 permissions:
   issues: write
@@ -10,6 +13,7 @@ permissions:
 jobs:
   take:
     if: >-
+      github.event_name == 'issue_comment' &&
       github.event.issue.pull_request == null &&
       github.event.comment.body == '/take'
     runs-on: ubuntu-latest
@@ -22,6 +26,18 @@ jobs:
             const commenter = context.payload.comment.user.login;
 
             const labels = issue.labels.map(l => l.name.toLowerCase());
+
+            // Block assignment on issues tagged "keep open"
+            if (labels.includes('keep open')) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `@${commenter} This issue is marked as **keep open** and is not available for assignment. Anyone is welcome to work on it and submit a PR without being assigned.`
+              });
+              return;
+            }
+
             const eligible = labels.includes('good first issue') || labels.includes('help wanted');
 
             if (!eligible) {
@@ -34,12 +50,33 @@ jobs:
               return;
             }
 
-            if (issue.assignees.length > 0) {
+            // Check if the contributor already has 2 or more open assigned issues
+            const { data: assignedIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignee: commenter,
+              state: 'open',
+              per_page: 3
+            });
+
+            if (assignedIssues.length >= 2) {
+              // Minimise noise — notify the contributor without cluttering the issue thread
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `@${commenter} This issue is already assigned to @${issue.assignees[0].login}.`
+                body: `> **Note to @${commenter}:** You already have ${assignedIssues.length} open issues assigned to you. Please complete or \`/drop\` an existing issue before taking a new one.\n>\n> Your current assignments:\n${assignedIssues.slice(0, 2).map(i => `> - #${i.number} — ${i.title}`).join('\n')}`
+              });
+              return;
+            }
+
+            if (issue.assignees.length > 0) {
+              const currentAssignee = issue.assignees[0].login;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `@${commenter} This issue is already being worked on by @${currentAssignee}. If there has been no activity for a while, a maintainer may reassign it. You can also check other open issues labeled \`good first issue\` or \`help wanted\`.`
               });
               return;
             }
@@ -60,6 +97,7 @@ jobs:
 
   drop:
     if: >-
+      github.event_name == 'issue_comment' &&
       github.event.issue.pull_request == null &&
       github.event.comment.body == '/drop'
     runs-on: ubuntu-latest
@@ -96,3 +134,74 @@ jobs:
               issue_number: issue.number,
               body: `@${commenter} You've been unassigned from this issue. The issue is now available for others to pick up.`
             });
+
+  stale-assignments:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unassign stale issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const STALE_DAYS = 30;
+            const now = new Date();
+
+            // Fetch open issues that have assignees and qualifying labels
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const assigned = issues.filter(i =>
+              !i.pull_request &&
+              i.assignees.length > 0 &&
+              i.labels.some(l => {
+                const name = l.name.toLowerCase();
+                return name === 'good first issue' || name === 'help wanted';
+              })
+            );
+
+            for (const issue of assigned) {
+              // Get the most recent activity (comments, events) on the issue
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 1,
+                direction: 'desc'
+              });
+
+              const { data: events } = await github.rest.issues.listEvents({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 1
+              });
+
+              // Find the latest activity timestamp
+              const lastCommentDate = comments.length > 0 ? new Date(comments[0].created_at) : new Date(0);
+              const lastEventDate = events.length > 0 ? new Date(events[events.length - 1].created_at) : new Date(0);
+              const lastActivity = new Date(Math.max(lastCommentDate, lastEventDate, new Date(issue.updated_at)));
+
+              const daysSinceActivity = (now - lastActivity) / (1000 * 60 * 60 * 24);
+
+              if (daysSinceActivity >= STALE_DAYS) {
+                const assignee = issue.assignees[0].login;
+
+                await github.rest.issues.removeAssignees({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  assignees: issue.assignees.map(a => a.login)
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `@${assignee} This issue has been unassigned due to ${STALE_DAYS} days of inactivity. No worries — if you'd like to continue working on it, just comment \`/take\` again. Otherwise, the issue is now available for other contributors.`
+                });
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,22 @@ To develop or test enterprise features locally, set `DEPLOYMENT_MODE=enterprise`
 Before starting work, check the [open issues](https://github.com/BlazeUp-AI/Observal/issues) to see what needs attention.
 
 - Look for issues labelled **good first issue** if you are new to the project.
-- Comment on an issue to let others know you are working on it before you start.
 - For larger features or architectural changes, open an issue to discuss your approach before writing code. This avoids wasted effort if the direction needs adjustment.
+
+### Claiming Issues with `/take` and `/drop`
+
+Instead of commenting manually, you can use slash commands to self-assign issues:
+
+- **`/take`** — Comment `/take` on any issue labeled `good first issue` or `help wanted` to assign it to yourself. The bot will confirm the assignment and link you to this contributing guide.
+- **`/drop`** — Comment `/drop` on an issue you are assigned to if you can no longer work on it. This frees the issue for other contributors.
+
+**Rules:**
+
+- `/take` only works on issues labeled `good first issue` or `help wanted`.
+- Issues labeled `keep open` cannot be assigned — anyone can submit a PR for those without claiming them.
+- You can have at most **2 open issues** assigned to you at a time. If you try to take a third, the bot will list your current assignments so you can decide which to `/drop`.
+- If an issue is already assigned, `/take` will let you know who is working on it and suggest other available issues.
+- **Stale assignment cleanup:** Issues with no activity for 30 days are automatically unassigned. If you need more time, just post a comment with a progress update to reset the timer. You can always `/take` the issue again afterwards.
 
 ## Making Changes
 


### PR DESCRIPTION
## Purpose

Builds on #696 to add safeguards and documentation for the `/take` and `/drop` issue commands.

Fixes #695

## Commands

- `/take` — Contributors comment `/take` on an issue to self-assign it. The bot validates eligibility and assigns them with a welcome message linking the contributing guide.
- `/drop` — Contributors comment `/drop` to unassign themselves from an issue, freeing it up for others.

## Conditions

- `/take` only works on issues labeled `good first issue` or `help wanted`
- Issues labeled `keep open` cannot be assigned — the bot responds saying anyone can work on it and submit a PR without being assigned
- Contributors are limited to 2 assigned issues at a time — if they try to take a third, the bot lists their current assignments and asks them to `/drop` one first
- If an issue is already assigned, the bot names the current assignee and suggests checking other available issues
- Issues with no activity for 30 days are automatically unassigned via a daily cron job — the previous assignee can `/take` it again if they want

## Documentation

- Added "Claiming Issues with `/take` and `/drop`" section to `CONTRIBUTING.md` covering both commands and all rules above


