### PR TITLE
fix(api): resolve agent version approve CircularDependencyError

### DIFF
--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -359,6 +359,11 @@ async def _review_agent_version(
     if req.action == "approve":
         ver.status = AgentStatus.approved
         ver.rejection_reason = None
+        ver.reviewed_by = current_user.id
+        ver.reviewed_at = datetime.now(UTC)
+        # Flush version status change first to avoid CircularDependencyError
+        # between Agent.latest_version (ManyToOne) and Agent.versions (OneToMany)
+        await db.flush()
         # Update latest_version_id if this version is newer than (or equal to) the current latest
         current_latest = agent.latest_version
         new_parsed = parse_semver(ver.version)
@@ -370,9 +375,8 @@ async def _review_agent_version(
     else:
         ver.status = AgentStatus.rejected
         ver.rejection_reason = req.reason
-
-    ver.reviewed_by = current_user.id
-    ver.reviewed_at = datetime.now(UTC)
+        ver.reviewed_by = current_user.id
+        ver.reviewed_at = datetime.now(UTC)
 
     await db.commit()
 


### PR DESCRIPTION
## Purpose / Description
The agent version review endpoint (`POST /agents/:id/versions/:ver/review`) returns 500 when approving a version due to SQLAlchemy's `CircularDependencyError`. This prevents agents from ever reaching "approved" status, which in turn means "delete approved agent" never works since agents can't be approved.

## Fixes
* Approved agents delete doesn't work (root cause: approve itself was broken)

## Approach
Same fix as `4471a7d` (which fixed `review.py`) but applied to `agent_versions.py` which was missed.

Setting `agent.latest_version_id = ver.id` in the same flush as the version status change creates a cycle between `Agent.latest_version` (ManyToOne) and `Agent.versions` (OneToMany). Fix: flush the version changes first, then set the FK.

## How Has This Been Tested?
```bash
# Create agent → approve → delete (all return 200)
curl -X POST /agents/:id/versions/1.0.0/review -d '{"action":"approve"}'
# → {"version":"1.0.0","new_status":"approved"}

curl /agents/:id → status: "approved"

curl -X DELETE /agents/:id → {"deleted":"..."}
```

## Checklist
- [x] All commits are signed off (`git commit -s`)
- [x] Descriptive commit message
- [x] Self-reviewed