### PR TITLE
fix(auth): raise 401 for expired tokens in optional_current_user

### DIFF
--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -114,13 +114,19 @@ async def optional_current_user(
     authorization: str | None = Header(None),
     db: AsyncSession = Depends(get_db),
 ) -> User | None:
-    """Return the authenticated user when a valid token is present, else None."""
+    """Return the authenticated user when a valid token is present, else None.
+
+    Raises HTTP 401 if a Bearer token is present but invalid/expired —
+    this distinguishes 'no credentials' from 'bad credentials'.
+    """
     if not authorization or not authorization.startswith("Bearer "):
         return None
     token = authorization.removeprefix("Bearer ").strip()
     user = await _authenticate_via_jwt(token, db)
-    if user and user.auth_provider == "deactivated":
-        return None
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    if user.auth_provider == "deactivated":
+        raise HTTPException(status_code=401, detail="Account deactivated")
     return user
 
 

--- a/observal-server/tests/test_multi_tenancy.py
+++ b/observal-server/tests/test_multi_tenancy.py
@@ -126,10 +126,31 @@ class TestOptionalCurrentUser:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_for_invalid_token(self):
+    async def test_raises_401_for_invalid_token(self):
         mock_db = AsyncMock()
-        result = await optional_current_user(authorization="Bearer invalid-token", db=mock_db)
-        assert result is None
+        with pytest.raises(HTTPException) as exc_info:
+            await optional_current_user(authorization="Bearer invalid-token", db=mock_db)
+        assert exc_info.value.status_code == 401
+        assert "Invalid or expired" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_raises_401_for_deactivated_user(self):
+        from services.jwt_service import create_access_token
+
+        org = _make_org()
+        user = _make_user(org=org)
+        user.auth_provider = "deactivated"
+        token, _ = create_access_token(user.id, user.role)
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = (user, False)
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        with pytest.raises(HTTPException) as exc_info:
+            await optional_current_user(authorization=f"Bearer {token}", db=mock_db)
+        assert exc_info.value.status_code == 401
+        assert "deactivated" in exc_info.value.detail
 
     @pytest.mark.asyncio
     async def test_returns_user_with_valid_token(self):

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -37,7 +37,10 @@ def _handle_error(e: httpx.HTTPStatusError, path: str = ""):
         rprint("[dim]  Run [bold]observal auth login[/bold] to re-authenticate.[/dim]")
     elif code == 403:
         rprint(f"[red]Permission denied{path_info}.[/red]")
-        rprint("[dim]  This action requires a higher role (admin or super_admin).[/dim]")
+        if detail:
+            rprint(f"[dim]  {detail}[/dim]")
+        else:
+            rprint("[dim]  You do not have permission to perform this action.[/dim]")
     elif code == 404:
         rprint(f"[red]Not found{path_info}.[/red]")
         # Extract component type from API path (e.g. /api/v1/hooks/abc -> hook)


### PR DESCRIPTION
## Purpose / Description

Admin users get a misleading `Permission denied ... requires a higher role (admin or super_admin)` error when running `observal agent pull` on private agents. The root cause is that `optional_current_user` silently returns `None` for expired/invalid tokens instead of raising 401, causing the RBAC logic to treat the request as anonymous. This prevents the CLI's token auto-refresh mechanism from triggering.

## Fixes
* Fixes #701

## Approach

1. **Server (`optional_current_user` in `deps.py`)**: When a Bearer token IS present but authentication fails (expired, revoked, malformed), raise HTTP 401 instead of returning `None`. Only return `None` when no Authorization header is provided at all. This preserves public agent access for unauthenticated users while properly surfacing auth failures.

2. **CLI (`client.py` 403 handler)**: Display the actual server error detail instead of the hardcoded "requires a higher role" message. The `detail` variable is already parsed from the JSON response — we just need to use it.

## How Has This Been Tested?

- Updated `test_raises_401_for_invalid_token` — confirms expired/invalid tokens raise 401
- Added `test_raises_401_for_deactivated_user` — confirms deactivated accounts raise 401
- Existing `test_returns_none_without_auth` still passes — no auth header returns None
- Full test suite: `make lint` passes, 32/33 multi-tenancy tests pass (1 pre-existing Redis event loop failure)

## Learning (optional, can help others)

The `optional_current_user` pattern should distinguish between "no credentials provided" (`None`) and "bad credentials provided" (401). Conflating these two states causes downstream permission checks to misclassify auth failures as access-denied errors, breaking token refresh flows.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)