### PR TITLE
feat: registry owner edit/delete for pending submissions (#663)

### DIFF
--- a/observal-server/alembic/versions/0023_add_editing_lock_columns.py
+++ b/observal-server/alembic/versions/0023_add_editing_lock_columns.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "0023"

--- a/observal-server/alembic/versions/0023_add_editing_lock_columns.py
+++ b/observal-server/alembic/versions/0023_add_editing_lock_columns.py
@@ -1,0 +1,43 @@
+"""Add editing lock columns to all version tables.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-05-01
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0023"
+down_revision: Union[str, Sequence[str], None] = "0022"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+VERSION_TABLES = [
+    "mcp_versions",
+    "skill_versions",
+    "hook_versions",
+    "prompt_versions",
+    "sandbox_versions",
+    "agent_versions",
+]
+
+
+def upgrade() -> None:
+    for table in VERSION_TABLES:
+        op.add_column(table, sa.Column("is_editing", sa.Boolean(), server_default=sa.text("false"), nullable=False))
+        op.add_column(table, sa.Column("editing_since", sa.DateTime(timezone=True), nullable=True))
+        op.add_column(
+            table,
+            sa.Column("editing_by", sa.UUID(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    for table in VERSION_TABLES:
+        op.drop_column(table, "editing_by")
+        op.drop_column(table, "editing_since")
+        op.drop_column(table, "is_editing")

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -1402,11 +1402,7 @@ async def update_draft(
         version.inferred_supported_ides = compute_supported_ides(version.required_ide_features)
 
     # Don't allow saving over another user's active lock
-    if (
-        version.is_editing
-        and version.editing_by != current_user.id
-        and not _is_lock_expired(version.editing_since)
-    ):
+    if version.is_editing and version.editing_by != current_user.id and not _is_lock_expired(version.editing_since):
         raise HTTPException(
             status_code=409,
             detail="This item is currently being edited by another user. Please try again later.",
@@ -1450,9 +1446,7 @@ async def start_edit_agent(
         raise HTTPException(status_code=400, detail=f"Cannot edit: agent version is '{version.status.value}'")
     # Re-fetch with row-level lock to prevent TOCTOU race
     version = (
-        await db.execute(
-            select(AgentVersion).where(AgentVersion.id == version.id).with_for_update()
-        )
+        await db.execute(select(AgentVersion).where(AgentVersion.id == version.id).with_for_update())
     ).scalar_one()
     acquire_edit_lock(version, current_user.id)
     await db.commit()

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -47,7 +47,7 @@ from schemas.agent import (
 )
 from services.agent_config_generator import generate_agent_config
 from services.audit_helpers import audit
-from services.editing_lock import acquire_edit_lock, release_edit_lock
+from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 from services.ide_feature_inference import compute_supported_ides, infer_required_features
 from services.registry_telemetry import emit_registry_event
 
@@ -1401,6 +1401,16 @@ async def update_draft(
         )
         version.inferred_supported_ides = compute_supported_ides(version.required_ide_features)
 
+    # Don't allow saving over another user's active lock
+    if (
+        version.is_editing
+        and version.editing_by != current_user.id
+        and not _is_lock_expired(version.editing_since)
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="This item is currently being edited by another user. Please try again later.",
+        )
     release_edit_lock(version, current_user.id, force=True)
     await db.flush()
 
@@ -1438,6 +1448,12 @@ async def start_edit_agent(
         raise HTTPException(status_code=400, detail="Agent has no version")
     if version.status not in (AgentStatus.pending, AgentStatus.draft, AgentStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: agent version is '{version.status.value}'")
+    # Re-fetch with row-level lock to prevent TOCTOU race
+    version = (
+        await db.execute(
+            select(AgentVersion).where(AgentVersion.id == version.id).with_for_update()
+        )
+    ).scalar_one()
     acquire_edit_lock(version, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -47,6 +47,7 @@ from schemas.agent import (
 )
 from services.agent_config_generator import generate_agent_config
 from services.audit_helpers import audit
+from services.editing_lock import acquire_edit_lock, release_edit_lock
 from services.ide_feature_inference import compute_supported_ides, infer_required_features
 from services.registry_telemetry import emit_registry_event
 
@@ -1400,6 +1401,7 @@ async def update_draft(
         )
         version.inferred_supported_ides = compute_supported_ides(version.required_ide_features)
 
+    release_edit_lock(version, current_user.id, force=True)
     await db.flush()
 
     for field in ("name", "owner"):
@@ -1417,6 +1419,48 @@ async def update_draft(
         action = "agent.draft.update"
     await audit(current_user, action, resource_type="agent", resource_id=str(agent.id), resource_name=agent.name)
     return _agent_to_response(agent, created_by_email=current_user.email, created_by_username=current_user.username)
+
+
+@router.post("/{agent_id}/start-edit")
+async def start_edit_agent(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    perm = get_effective_agent_permission(agent, current_user)
+    if perm not in ("owner", "edit"):
+        raise HTTPException(status_code=403, detail="Not the agent owner or editor")
+    version = agent.latest_version
+    if not version:
+        raise HTTPException(status_code=400, detail="Agent has no version")
+    if version.status not in (AgentStatus.pending, AgentStatus.draft, AgentStatus.rejected):
+        raise HTTPException(status_code=400, detail=f"Cannot edit: agent version is '{version.status.value}'")
+    acquire_edit_lock(version, current_user.id)
+    await db.commit()
+    return {"status": "locked"}
+
+
+@router.post("/{agent_id}/cancel-edit")
+async def cancel_edit_agent(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    perm = get_effective_agent_permission(agent, current_user)
+    if perm not in ("owner", "edit"):
+        raise HTTPException(status_code=403, detail="Not the agent owner or editor")
+    version = agent.latest_version
+    if not version:
+        raise HTTPException(status_code=400, detail="Agent has no version")
+    release_edit_lock(version, current_user.id)
+    await db.commit()
+    return {"status": "unlocked"}
 
 
 @router.post("/{agent_id}/submit", response_model=AgentResponse)

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -1339,30 +1339,23 @@ async def update_draft(
     perm = get_effective_agent_permission(agent, current_user)
     if perm not in ("owner", "edit"):
         raise HTTPException(status_code=403, detail="Not the agent owner or editor")
-    if agent.status not in (AgentStatus.draft, AgentStatus.rejected):
-        raise HTTPException(status_code=400, detail="Agent is not a draft")
+    if agent.status not in (AgentStatus.draft, AgentStatus.rejected, AgentStatus.pending):
+        raise HTTPException(status_code=400, detail="Only draft, rejected, or pending agents can be edited")
 
-    for field in (
-        "name",
-        "version",
-        "description",
-        "owner",
-        "prompt",
-        "model_name",
-        "model_config_json",
-        "supported_ides",
-    ):
+    version = agent.latest_version
+    if not version:
+        raise HTTPException(status_code=400, detail="Agent has no version to update")
+
+    for field in ("version", "description", "prompt", "model_name", "model_config_json", "supported_ides"):
         val = getattr(req, field)
         if val is not None:
-            setattr(agent, field, val)
+            setattr(version, field, val)
 
     if req.external_mcps is not None:
-        agent.external_mcps = [m.model_dump() for m in req.external_mcps]
+        version.external_mcps = [m.model_dump() for m in req.external_mcps]
 
     if req.components is not None:
-        if not agent.latest_version:
-            raise HTTPException(status_code=400, detail="Agent has no version to update components on")
-        version_id = agent.latest_version.id
+        version_id = version.id
         old_comps = (
             (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == version_id)))
             .scalars()
@@ -1388,7 +1381,7 @@ async def update_draft(
         if not agent.latest_version:
             raise HTTPException(status_code=400, detail="Agent has no version to update features on")
         current_comps_draft = (
-            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == agent.latest_version.id)))
+            (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == version.id)))
             .scalars()
             .all()
         )
@@ -1400,18 +1393,29 @@ async def update_draft(
 
         class _DraftUpdateProxy:
             components = current_comps_draft
-            external_mcps = agent.external_mcps
+            external_mcps = version.external_mcps
 
-        agent.required_ide_features = infer_required_features(
+        version.required_ide_features = infer_required_features(
             _DraftUpdateProxy(), skill_listings=skill_listings_map_draft_update
         )
-        agent.inferred_supported_ides = compute_supported_ides(agent.required_ide_features)
+        version.inferred_supported_ides = compute_supported_ides(version.required_ide_features)
+
+    await db.flush()
+
+    for field in ("name", "owner"):
+        val = getattr(req, field)
+        if val is not None:
+            setattr(agent, field, val)
 
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
-    await audit(
-        current_user, "agent.draft.update", resource_type="agent", resource_id=str(agent.id), resource_name=agent.name
-    )
+    if agent.status == AgentStatus.pending:
+        action = "agent.pending.update"
+    elif agent.status == AgentStatus.rejected:
+        action = "agent.rejected.update"
+    else:
+        action = "agent.draft.update"
+    await audit(current_user, action, resource_type="agent", resource_id=str(agent.id), resource_name=agent.name)
     return _agent_to_response(agent, created_by_email=current_user.email, created_by_username=current_user.username)
 
 

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -20,6 +20,7 @@ from schemas.hook import (
     HookUpdateRequest,
 )
 from services.audit_helpers import audit
+from services.editing_lock import acquire_edit_lock, release_edit_lock
 
 router = APIRouter(prefix="/api/v1/hooks", tags=["hooks"])
 
@@ -256,6 +257,7 @@ async def update_hook_draft(
         if val is not None:
             setattr(ver, field, val)
 
+    release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
     for field in ("name", "owner"):
@@ -273,6 +275,46 @@ async def update_hook_draft(
         action = "hook.draft.update"
     await audit(current_user, action, resource_type="hook", resource_id=str(listing.id), resource_name=listing.name)
     return HookListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/start-edit")
+async def start_edit_hook(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(HookListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
+        raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    acquire_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "locked"}
+
+
+@router.post("/{listing_id}/cancel-edit")
+async def cancel_edit_hook(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(HookListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    release_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "unlocked"}
 
 
 @router.post("/{listing_id}/submit", response_model=HookListingResponse)

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -230,14 +230,16 @@ async def update_hook_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
-        raise HTTPException(status_code=400, detail="Listing is not a draft")
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
+        raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version to update")
 
     for field in (
-        "name",
         "version",
         "description",
-        "owner",
         "event",
         "execution_mode",
         "priority",
@@ -252,13 +254,24 @@ async def update_hook_draft(
     ):
         val = getattr(req, field)
         if val is not None:
+            setattr(ver, field, val)
+
+    await db.flush()
+
+    for field in ("name", "owner"):
+        val = getattr(req, field)
+        if val is not None:
             setattr(listing, field, val)
 
     await db.commit()
     await db.refresh(listing)
-    await audit(
-        current_user, "hook.draft.update", resource_type="hook", resource_id=str(listing.id), resource_name=listing.name
-    )
+    if listing.status == ListingStatus.pending:
+        action = "hook.pending.update"
+    elif listing.status == ListingStatus.rejected:
+        action = "hook.rejected.update"
+    else:
+        action = "hook.draft.update"
+    await audit(current_user, action, resource_type="hook", resource_id=str(listing.id), resource_name=listing.name)
     return HookListingResponse.model_validate(listing)
 
 

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -20,7 +20,7 @@ from schemas.hook import (
     HookUpdateRequest,
 )
 from services.audit_helpers import audit
-from services.editing_lock import acquire_edit_lock, release_edit_lock
+from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 
 router = APIRouter(prefix="/api/v1/hooks", tags=["hooks"])
 
@@ -257,6 +257,16 @@ async def update_hook_draft(
         if val is not None:
             setattr(ver, field, val)
 
+    # Don't allow saving over another user's active lock
+    if (
+        ver.is_editing
+        and ver.editing_by != current_user.id
+        and not _is_lock_expired(ver.editing_since)
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="This item is currently being edited by another user. Please try again later.",
+        )
     release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
@@ -293,6 +303,12 @@ async def start_edit_hook(
         raise HTTPException(status_code=400, detail="Listing has no version")
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    # Re-fetch with row-level lock to prevent TOCTOU race
+    ver = (
+        await db.execute(
+            select(HookVersion).where(HookVersion.id == ver.id).with_for_update()
+        )
+    ).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -258,11 +258,7 @@ async def update_hook_draft(
             setattr(ver, field, val)
 
     # Don't allow saving over another user's active lock
-    if (
-        ver.is_editing
-        and ver.editing_by != current_user.id
-        and not _is_lock_expired(ver.editing_since)
-    ):
+    if ver.is_editing and ver.editing_by != current_user.id and not _is_lock_expired(ver.editing_since):
         raise HTTPException(
             status_code=409,
             detail="This item is currently being edited by another user. Please try again later.",
@@ -304,11 +300,7 @@ async def start_edit_hook(
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
     # Re-fetch with row-level lock to prevent TOCTOU race
-    ver = (
-        await db.execute(
-            select(HookVersion).where(HookVersion.id == ver.id).with_for_update()
-        )
-    ).scalar_one()
+    ver = (await db.execute(select(HookVersion).where(HookVersion.id == ver.id).with_for_update())).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -368,11 +368,7 @@ async def update_mcp_draft(
         ver.environment_variables = [ev.model_dump() for ev in req.environment_variables]
 
     # Don't allow saving over another user's active lock
-    if (
-        ver.is_editing
-        and ver.editing_by != current_user.id
-        and not _is_lock_expired(ver.editing_since)
-    ):
+    if ver.is_editing and ver.editing_by != current_user.id and not _is_lock_expired(ver.editing_since):
         raise HTTPException(
             status_code=409,
             detail="This item is currently being edited by another user. Please try again later.",
@@ -414,11 +410,7 @@ async def start_edit_mcp(
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
     # Re-fetch with row-level lock to prevent TOCTOU race
-    ver = (
-        await db.execute(
-            select(McpVersion).where(McpVersion.id == ver.id).with_for_update()
-        )
-    ).scalar_one()
+    ver = (await db.execute(select(McpVersion).where(McpVersion.id == ver.id).with_for_update())).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -334,16 +334,16 @@ async def update_mcp_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
-        raise HTTPException(status_code=400, detail="Listing is not a draft")
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
+        raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version to update")
 
     for field in (
-        "name",
         "version",
         "description",
-        "category",
-        "owner",
-        "git_url",
         "framework",
         "docker_image",
         "command",
@@ -357,18 +357,31 @@ async def update_mcp_draft(
     ):
         val = getattr(req, field)
         if val is not None:
-            setattr(listing, field, val)
+            setattr(ver, field, val)
 
+    if req.git_url is not None:
+        ver.source_url = req.git_url
     if req.headers is not None:
-        listing.headers = [h.model_dump() for h in req.headers]
+        ver.headers = [h.model_dump() for h in req.headers]
     if req.environment_variables is not None:
-        listing.environment_variables = [ev.model_dump() for ev in req.environment_variables]
+        ver.environment_variables = [ev.model_dump() for ev in req.environment_variables]
+
+    await db.flush()
+
+    for field in ("name", "category", "owner"):
+        val = getattr(req, field)
+        if val is not None:
+            setattr(listing, field, val)
 
     await db.commit()
     await db.refresh(listing)
-    await audit(
-        current_user, "mcp.draft.update", resource_type="mcp", resource_id=str(listing.id), resource_name=listing.name
-    )
+    if listing.status == ListingStatus.pending:
+        action = "mcp.pending.update"
+    elif listing.status == ListingStatus.rejected:
+        action = "mcp.rejected.update"
+    else:
+        action = "mcp.draft.update"
+    await audit(current_user, action, resource_type="mcp", resource_id=str(listing.id), resource_name=listing.name)
     return McpListingResponse.model_validate(listing)
 
 

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -25,6 +25,7 @@ from schemas.mcp import (
 )
 from services.audit_helpers import audit
 from services.config_generator import generate_config
+from services.editing_lock import acquire_edit_lock, release_edit_lock
 from services.mcp_validator import analyze_repo, run_validation
 
 router = APIRouter(prefix="/api/v1/mcps", tags=["mcp"])
@@ -366,6 +367,7 @@ async def update_mcp_draft(
     if req.environment_variables is not None:
         ver.environment_variables = [ev.model_dump() for ev in req.environment_variables]
 
+    release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
     for field in ("name", "category", "owner"):
@@ -383,6 +385,46 @@ async def update_mcp_draft(
         action = "mcp.draft.update"
     await audit(current_user, action, resource_type="mcp", resource_id=str(listing.id), resource_name=listing.name)
     return McpListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/start-edit")
+async def start_edit_mcp(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(McpListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
+        raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    acquire_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "locked"}
+
+
+@router.post("/{listing_id}/cancel-edit")
+async def cancel_edit_mcp(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(McpListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    release_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "unlocked"}
 
 
 @router.post("/{listing_id}/submit", response_model=McpListingResponse)

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -25,7 +25,7 @@ from schemas.mcp import (
 )
 from services.audit_helpers import audit
 from services.config_generator import generate_config
-from services.editing_lock import acquire_edit_lock, release_edit_lock
+from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 from services.mcp_validator import analyze_repo, run_validation
 
 router = APIRouter(prefix="/api/v1/mcps", tags=["mcp"])
@@ -367,6 +367,16 @@ async def update_mcp_draft(
     if req.environment_variables is not None:
         ver.environment_variables = [ev.model_dump() for ev in req.environment_variables]
 
+    # Don't allow saving over another user's active lock
+    if (
+        ver.is_editing
+        and ver.editing_by != current_user.id
+        and not _is_lock_expired(ver.editing_since)
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="This item is currently being edited by another user. Please try again later.",
+        )
     release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
@@ -403,6 +413,12 @@ async def start_edit_mcp(
         raise HTTPException(status_code=400, detail="Listing has no version")
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    # Re-fetch with row-level lock to prevent TOCTOU race
+    ver = (
+        await db.execute(
+            select(McpVersion).where(McpVersion.id == ver.id).with_for_update()
+        )
+    ).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -22,7 +22,7 @@ from schemas.prompt import (
     PromptUpdateRequest,
 )
 from services.audit_helpers import audit
-from services.editing_lock import acquire_edit_lock, release_edit_lock
+from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 
 router = APIRouter(prefix="/api/v1/prompts", tags=["prompts"])
 
@@ -300,6 +300,16 @@ async def update_prompt_draft(
         if val is not None:
             setattr(ver, field, val)
 
+    # Don't allow saving over another user's active lock
+    if (
+        ver.is_editing
+        and ver.editing_by != current_user.id
+        and not _is_lock_expired(ver.editing_since)
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="This item is currently being edited by another user. Please try again later.",
+        )
     release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
@@ -342,6 +352,12 @@ async def start_edit_prompt(
         raise HTTPException(status_code=400, detail="Listing has no version")
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    # Re-fetch with row-level lock to prevent TOCTOU race
+    ver = (
+        await db.execute(
+            select(PromptVersion).where(PromptVersion.id == ver.id).with_for_update()
+        )
+    ).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -301,11 +301,7 @@ async def update_prompt_draft(
             setattr(ver, field, val)
 
     # Don't allow saving over another user's active lock
-    if (
-        ver.is_editing
-        and ver.editing_by != current_user.id
-        and not _is_lock_expired(ver.editing_since)
-    ):
+    if ver.is_editing and ver.editing_by != current_user.id and not _is_lock_expired(ver.editing_since):
         raise HTTPException(
             status_code=409,
             detail="This item is currently being edited by another user. Please try again later.",
@@ -353,11 +349,7 @@ async def start_edit_prompt(
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
     # Re-fetch with row-level lock to prevent TOCTOU race
-    ver = (
-        await db.execute(
-            select(PromptVersion).where(PromptVersion.id == ver.id).with_for_update()
-        )
-    ).scalar_one()
+    ver = (await db.execute(select(PromptVersion).where(PromptVersion.id == ver.id).with_for_update())).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -278,14 +278,16 @@ async def update_prompt_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
-        raise HTTPException(status_code=400, detail="Listing is not a draft")
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
+        raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version to update")
 
     for field in (
-        "name",
         "version",
         "description",
-        "owner",
         "category",
         "template",
         "variables",
@@ -295,13 +297,26 @@ async def update_prompt_draft(
     ):
         val = getattr(req, field)
         if val is not None:
+            setattr(ver, field, val)
+
+    await db.flush()
+
+    for field in ("name", "owner"):
+        val = getattr(req, field)
+        if val is not None:
             setattr(listing, field, val)
 
     await db.commit()
     await db.refresh(listing)
+    if listing.status == ListingStatus.pending:
+        action = "prompt.pending.update"
+    elif listing.status == ListingStatus.rejected:
+        action = "prompt.rejected.update"
+    else:
+        action = "prompt.draft.update"
     await audit(
         current_user,
-        "prompt.draft.update",
+        action,
         resource_type="prompt",
         resource_id=str(listing.id),
         resource_name=listing.name,

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -22,6 +22,7 @@ from schemas.prompt import (
     PromptUpdateRequest,
 )
 from services.audit_helpers import audit
+from services.editing_lock import acquire_edit_lock, release_edit_lock
 
 router = APIRouter(prefix="/api/v1/prompts", tags=["prompts"])
 
@@ -299,6 +300,7 @@ async def update_prompt_draft(
         if val is not None:
             setattr(ver, field, val)
 
+    release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
     for field in ("name", "owner"):
@@ -322,6 +324,46 @@ async def update_prompt_draft(
         resource_name=listing.name,
     )
     return PromptListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/start-edit")
+async def start_edit_prompt(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(PromptListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
+        raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    acquire_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "locked"}
+
+
+@router.post("/{listing_id}/cancel-edit")
+async def cancel_edit_prompt(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(PromptListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    release_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "unlocked"}
 
 
 @router.post("/{listing_id}/submit", response_model=PromptListingResponse)

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -19,6 +19,7 @@ from models.skill import SkillListing, SkillVersion
 from models.user import User, UserRole
 from schemas.mcp import ReviewActionRequest
 from services.audit_helpers import audit
+from services.editing_lock import is_actively_editing
 
 router = APIRouter(prefix="/api/v1/review", tags=["review"])
 
@@ -117,10 +118,11 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
     if not pending_versions:
         return []
 
-    # Group by agent_id, take the newest pending version per agent
+    # Group by agent_id, take the newest pending version per agent.
+    # Skip versions that are actively being edited by their owner.
     seen_agents: dict[uuid.UUID, AgentVersion] = {}
     for v in pending_versions:
-        if v.agent_id not in seen_agents:
+        if v.agent_id not in seen_agents and not is_actively_editing(v):
             seen_agents[v.agent_id] = v
 
     # Load the agents
@@ -174,6 +176,8 @@ async def _query_pending_components(db: AsyncSession, type_filter: str | None = 
             .order_by(model.created_at.desc())
         )
         for r in result.scalars().all():
+            if r.latest_version and is_actively_editing(r.latest_version):
+                continue
             user_ids.add(r.submitted_by)
             item: dict = {
                 "type": listing_type,
@@ -467,6 +471,8 @@ async def approve(
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.latest_version and is_actively_editing(listing.latest_version):
+        raise HTTPException(status_code=409, detail="Cannot approve: the owner is currently editing this item")
     listing.status = ListingStatus.approved
     listing.rejection_reason = None
     await db.commit()
@@ -492,6 +498,8 @@ async def reject(
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.latest_version and is_actively_editing(listing.latest_version):
+        raise HTTPException(status_code=409, detail="Cannot reject: the owner is currently editing this item")
     listing.status = ListingStatus.rejected
     listing.rejection_reason = req.reason
     await db.commit()
@@ -522,25 +530,33 @@ async def approve_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
+    from services.versioning import parse_semver
+
     agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    # Find the newest pending version — it may not be latest_version yet
-    # (new versions are published as pending and only become latest on approval).
-    pending_ver = (
-        await db.execute(
-            select(AgentVersion)
-            .where(AgentVersion.agent_id == agent.id, AgentVersion.status == AgentStatus.pending)
-            .order_by(AgentVersion.created_at.desc())
-            .limit(1)
+    pending_versions = (
+        (
+            await db.execute(
+                select(AgentVersion)
+                .where(AgentVersion.agent_id == agent.id, AgentVersion.status == AgentStatus.pending)
+                .order_by(AgentVersion.created_at.desc())
+            )
         )
-    ).scalar_one_or_none()
+        .scalars()
+        .all()
+    )
 
-    if not pending_ver:
-        raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', not pending")
+    if not pending_versions:
+        raise HTTPException(status_code=400, detail=f"Agent has no pending versions (latest is '{agent.status.value}')")
 
-    components_ready, blocking = await _check_agent_components_ready(pending_ver.components, db)
+    for pv in pending_versions:
+        if is_actively_editing(pv):
+            raise HTTPException(status_code=409, detail="Cannot approve: the owner is currently editing this agent")
+
+    newest_pending = pending_versions[0]
+    components_ready, blocking = await _check_agent_components_ready(newest_pending.components, db)
     if not components_ready:
         raise HTTPException(
             status_code=422,
@@ -550,21 +566,21 @@ async def approve_agent(
             },
         )
 
-    pending_ver.status = AgentStatus.approved
-    pending_ver.rejection_reason = None
-    pending_ver.reviewed_by = current_user.id
-    pending_ver.reviewed_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    for pv in pending_versions:
+        pv.status = AgentStatus.approved
+        pv.rejection_reason = None
+        pv.reviewed_by = current_user.id
+        pv.reviewed_at = now
+
+    # Flush version changes first to avoid CircularDependencyError
     await db.flush()
 
-    # Promote to latest if this version is newer than the current latest.
-    # Flush first to break the circular dependency (Agent ↔ AgentVersion).
-    from services.versioning import parse_semver
-
     current_latest = agent.latest_version
-    new_parsed = parse_semver(pending_ver.version)
+    new_parsed = parse_semver(newest_pending.version)
     current_parsed = parse_semver(current_latest.version) if current_latest else None
     if not current_latest or (new_parsed is not None and current_parsed is not None and new_parsed >= current_parsed):
-        agent.latest_version_id = pending_ver.id
+        agent.latest_version_id = newest_pending.id
 
     await db.commit()
     await audit(
@@ -574,7 +590,7 @@ async def approve_agent(
         resource_id=str(agent_id),
         resource_name=agent.name,
     )
-    return {"id": str(agent.id), "name": agent.name, "status": "approved", "version": pending_ver.version}
+    return {"id": str(agent.id), "name": agent.name, "status": "approved", "version": newest_pending.version}
 
 
 @router.post("/agents/{agent_id}/reject")
@@ -588,23 +604,35 @@ async def reject_agent(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    # Find the newest pending version to reject
-    pending_ver = (
-        await db.execute(
-            select(AgentVersion)
-            .where(AgentVersion.agent_id == agent.id, AgentVersion.status == AgentStatus.pending)
-            .order_by(AgentVersion.created_at.desc())
-            .limit(1)
+    pending_versions = (
+        (
+            await db.execute(
+                select(AgentVersion)
+                .where(AgentVersion.agent_id == agent.id, AgentVersion.status == AgentStatus.pending)
+                .order_by(AgentVersion.created_at.desc())
+            )
         )
-    ).scalar_one_or_none()
+        .scalars()
+        .all()
+    )
 
-    if not pending_ver:
-        raise HTTPException(status_code=400, detail="Agent has no pending version to reject")
+    if not pending_versions:
+        if agent.status not in (AgentStatus.pending, AgentStatus.approved):
+            raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', cannot reject")
+        agent.status = AgentStatus.rejected
+        agent.rejection_reason = req.reason
+    else:
+        for pv in pending_versions:
+            if is_actively_editing(pv):
+                raise HTTPException(status_code=409, detail="Cannot reject: the owner is currently editing this agent")
+        now = datetime.now(UTC)
+        for pv in pending_versions:
+            pv.status = AgentStatus.rejected
+            pv.rejection_reason = req.reason
+            pv.reviewed_by = current_user.id
+            pv.reviewed_at = now
+        await db.flush()
 
-    pending_ver.status = AgentStatus.rejected
-    pending_ver.rejection_reason = req.reason
-    pending_ver.reviewed_by = current_user.id
-    pending_ver.reviewed_at = datetime.now(UTC)
     await db.commit()
     await audit(
         current_user,
@@ -636,6 +664,11 @@ async def approve_bundle(
     for model in LISTING_MODELS.values():
         result = await db.execute(select(model).where(model.bundle_id == bundle_id))
         for listing in result.scalars().all():
+            if listing.latest_version and is_actively_editing(listing.latest_version):
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Cannot approve: '{listing.name}' is currently being edited by its owner",
+                )
             listing.status = ListingStatus.approved
             listing.rejection_reason = None
             count += 1
@@ -667,6 +700,11 @@ async def reject_bundle(
     for model in LISTING_MODELS.values():
         result = await db.execute(select(model).where(model.bundle_id == bundle_id))
         for listing in result.scalars().all():
+            if listing.latest_version and is_actively_editing(listing.latest_version):
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Cannot reject: '{listing.name}' is currently being edited by its owner",
+                )
             listing.status = ListingStatus.rejected
             listing.rejection_reason = req.reason
             count += 1

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -567,9 +567,14 @@ async def approve_agent(
         )
 
     now = datetime.now(UTC)
-    for pv in pending_versions:
-        pv.status = AgentStatus.approved
-        pv.rejection_reason = None
+    # Approve only the newest pending version; mark older ones as superseded
+    newest_pending.status = AgentStatus.approved
+    newest_pending.rejection_reason = None
+    newest_pending.reviewed_by = current_user.id
+    newest_pending.reviewed_at = now
+    for pv in pending_versions[1:]:
+        pv.status = AgentStatus.rejected
+        pv.rejection_reason = "Superseded by newer version"
         pv.reviewed_by = current_user.id
         pv.reviewed_at = now
 
@@ -617,10 +622,7 @@ async def reject_agent(
     )
 
     if not pending_versions:
-        if agent.status not in (AgentStatus.pending, AgentStatus.approved):
-            raise HTTPException(status_code=400, detail=f"Agent is '{agent.status.value}', cannot reject")
-        agent.status = AgentStatus.rejected
-        agent.rejection_reason = req.reason
+        raise HTTPException(status_code=400, detail=f"Agent has no pending versions (latest is '{agent.status.value}')")
     else:
         for pv in pending_versions:
             if is_actively_editing(pv):

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -642,7 +642,8 @@ async def reject_agent(
         resource_name=agent.name,
         detail=f"reason={req.reason}",
     )
-    return {"id": str(agent.id), "name": agent.name, "status": "rejected", "version": pending_ver.version}
+    rejected_version = pending_versions[0].version if pending_versions else ""
+    return {"id": str(agent.id), "name": agent.name, "status": "rejected", "version": rejected_version}
 
 
 # ---------------------------------------------------------------------------

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -20,7 +20,7 @@ from schemas.sandbox import (
     SandboxUpdateRequest,
 )
 from services.audit_helpers import audit
-from services.editing_lock import acquire_edit_lock, release_edit_lock
+from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 
 router = APIRouter(prefix="/api/v1/sandboxes", tags=["sandboxes"])
 
@@ -266,6 +266,16 @@ async def update_sandbox_draft(
         if val is not None:
             setattr(ver, field, val)
 
+    # Don't allow saving over another user's active lock
+    if (
+        ver.is_editing
+        and ver.editing_by != current_user.id
+        and not _is_lock_expired(ver.editing_since)
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="This item is currently being edited by another user. Please try again later.",
+        )
     release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
@@ -308,6 +318,12 @@ async def start_edit_sandbox(
         raise HTTPException(status_code=400, detail="Listing has no version")
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    # Re-fetch with row-level lock to prevent TOCTOU race
+    ver = (
+        await db.execute(
+            select(SandboxVersion).where(SandboxVersion.id == ver.id).with_for_update()
+        )
+    ).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -20,6 +20,7 @@ from schemas.sandbox import (
     SandboxUpdateRequest,
 )
 from services.audit_helpers import audit
+from services.editing_lock import acquire_edit_lock, release_edit_lock
 
 router = APIRouter(prefix="/api/v1/sandboxes", tags=["sandboxes"])
 
@@ -265,6 +266,7 @@ async def update_sandbox_draft(
         if val is not None:
             setattr(ver, field, val)
 
+    release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
     for field in ("name", "owner"):
@@ -288,6 +290,46 @@ async def update_sandbox_draft(
         resource_name=listing.name,
     )
     return SandboxListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/start-edit")
+async def start_edit_sandbox(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(SandboxListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
+        raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    acquire_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "locked"}
+
+
+@router.post("/{listing_id}/cancel-edit")
+async def cancel_edit_sandbox(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(SandboxListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    release_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "unlocked"}
 
 
 @router.post("/{listing_id}/submit", response_model=SandboxListingResponse)

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -241,14 +241,16 @@ async def update_sandbox_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
-        raise HTTPException(status_code=400, detail="Listing is not a draft")
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
+        raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version to update")
 
     for field in (
-        "name",
         "version",
         "description",
-        "owner",
         "runtime_type",
         "image",
         "dockerfile_url",
@@ -261,13 +263,26 @@ async def update_sandbox_draft(
     ):
         val = getattr(req, field)
         if val is not None:
+            setattr(ver, field, val)
+
+    await db.flush()
+
+    for field in ("name", "owner"):
+        val = getattr(req, field)
+        if val is not None:
             setattr(listing, field, val)
 
     await db.commit()
     await db.refresh(listing)
+    if listing.status == ListingStatus.pending:
+        action = "sandbox.pending.update"
+    elif listing.status == ListingStatus.rejected:
+        action = "sandbox.rejected.update"
+    else:
+        action = "sandbox.draft.update"
     await audit(
         current_user,
-        "sandbox.draft.update",
+        action,
         resource_type="sandbox",
         resource_id=str(listing.id),
         resource_name=listing.name,

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -267,11 +267,7 @@ async def update_sandbox_draft(
             setattr(ver, field, val)
 
     # Don't allow saving over another user's active lock
-    if (
-        ver.is_editing
-        and ver.editing_by != current_user.id
-        and not _is_lock_expired(ver.editing_since)
-    ):
+    if ver.is_editing and ver.editing_by != current_user.id and not _is_lock_expired(ver.editing_since):
         raise HTTPException(
             status_code=409,
             detail="This item is currently being edited by another user. Please try again later.",
@@ -319,11 +315,7 @@ async def start_edit_sandbox(
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
     # Re-fetch with row-level lock to prevent TOCTOU race
-    ver = (
-        await db.execute(
-            select(SandboxVersion).where(SandboxVersion.id == ver.id).with_for_update()
-        )
-    ).scalar_one()
+    ver = (await db.execute(select(SandboxVersion).where(SandboxVersion.id == ver.id).with_for_update())).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -238,14 +238,16 @@ async def update_skill_draft(
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing.submitted_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not the listing owner")
-    if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
-        raise HTTPException(status_code=400, detail="Listing is not a draft")
+    if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
+        raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version to update")
 
     for field in (
-        "name",
         "version",
         "description",
-        "owner",
         "skill_path",
         "target_agents",
         "task_type",
@@ -261,13 +263,26 @@ async def update_skill_draft(
     ):
         val = getattr(req, field)
         if val is not None:
+            setattr(ver, field, val)
+
+    await db.flush()
+
+    for field in ("name", "owner"):
+        val = getattr(req, field)
+        if val is not None:
             setattr(listing, field, val)
 
     await db.commit()
     await db.refresh(listing)
+    if listing.status == ListingStatus.pending:
+        action = "skill.pending.update"
+    elif listing.status == ListingStatus.rejected:
+        action = "skill.rejected.update"
+    else:
+        action = "skill.draft.update"
     await audit(
         current_user,
-        "skill.draft.update",
+        action,
         resource_type="skill",
         resource_id=str(listing.id),
         resource_name=listing.name,

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -20,7 +20,7 @@ from schemas.skill import (
     SkillUpdateRequest,
 )
 from services.audit_helpers import audit
-from services.editing_lock import acquire_edit_lock, release_edit_lock
+from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 
 router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
 
@@ -266,6 +266,16 @@ async def update_skill_draft(
         if val is not None:
             setattr(ver, field, val)
 
+    # Don't allow saving over another user's active lock
+    if (
+        ver.is_editing
+        and ver.editing_by != current_user.id
+        and not _is_lock_expired(ver.editing_since)
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="This item is currently being edited by another user. Please try again later.",
+        )
     release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
@@ -308,6 +318,12 @@ async def start_edit_skill(
         raise HTTPException(status_code=400, detail="Listing has no version")
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    # Re-fetch with row-level lock to prevent TOCTOU race
+    ver = (
+        await db.execute(
+            select(SkillVersion).where(SkillVersion.id == ver.id).with_for_update()
+        )
+    ).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -267,11 +267,7 @@ async def update_skill_draft(
             setattr(ver, field, val)
 
     # Don't allow saving over another user's active lock
-    if (
-        ver.is_editing
-        and ver.editing_by != current_user.id
-        and not _is_lock_expired(ver.editing_since)
-    ):
+    if ver.is_editing and ver.editing_by != current_user.id and not _is_lock_expired(ver.editing_since):
         raise HTTPException(
             status_code=409,
             detail="This item is currently being edited by another user. Please try again later.",
@@ -319,11 +315,7 @@ async def start_edit_skill(
     if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
     # Re-fetch with row-level lock to prevent TOCTOU race
-    ver = (
-        await db.execute(
-            select(SkillVersion).where(SkillVersion.id == ver.id).with_for_update()
-        )
-    ).scalar_one()
+    ver = (await db.execute(select(SkillVersion).where(SkillVersion.id == ver.id).with_for_update())).scalar_one()
     acquire_edit_lock(ver, current_user.id)
     await db.commit()
     return {"status": "locked"}

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -20,6 +20,7 @@ from schemas.skill import (
     SkillUpdateRequest,
 )
 from services.audit_helpers import audit
+from services.editing_lock import acquire_edit_lock, release_edit_lock
 
 router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
 
@@ -265,6 +266,7 @@ async def update_skill_draft(
         if val is not None:
             setattr(ver, field, val)
 
+    release_edit_lock(ver, current_user.id, force=True)
     await db.flush()
 
     for field in ("name", "owner"):
@@ -288,6 +290,46 @@ async def update_skill_draft(
         resource_name=listing.name,
     )
     return SkillListingResponse.model_validate(listing)
+
+
+@router.post("/{listing_id}/start-edit")
+async def start_edit_skill(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(SkillListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    if ver.status not in (ListingStatus.pending, ListingStatus.draft, ListingStatus.rejected):
+        raise HTTPException(status_code=400, detail=f"Cannot edit: listing is '{ver.status.value}'")
+    acquire_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "locked"}
+
+
+@router.post("/{listing_id}/cancel-edit")
+async def cancel_edit_skill(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    listing = await resolve_listing(SkillListing, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if listing.submitted_by != current_user.id:
+        raise HTTPException(status_code=403, detail="Not the listing owner")
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    release_edit_lock(ver, current_user.id)
+    await db.commit()
+    return {"status": "unlocked"}
 
 
 @router.post("/{listing_id}/submit", response_model=SkillListingResponse)

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -69,6 +69,9 @@ class AgentVersion(Base):
     reviewed_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    is_editing: Mapped[bool] = mapped_column(Boolean, default=False)
+    editing_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    editing_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
 
     agent: Mapped["Agent"] = relationship(back_populates="versions", foreign_keys=[agent_id])
     components: Mapped[list["AgentComponent"]] = relationship(

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -131,8 +131,9 @@ class Agent(Base):
 
     @version.setter
     def version(self, value: str) -> None:
-        if self.latest_version:
-            self.latest_version.version = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set version")
+        self.latest_version.version = value
 
     @property
     def description(self) -> str:
@@ -140,8 +141,9 @@ class Agent(Base):
 
     @description.setter
     def description(self, value: str) -> None:
-        if self.latest_version:
-            self.latest_version.description = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set description")
+        self.latest_version.description = value
 
     @property
     def prompt(self) -> str:
@@ -149,8 +151,9 @@ class Agent(Base):
 
     @prompt.setter
     def prompt(self, value: str) -> None:
-        if self.latest_version:
-            self.latest_version.prompt = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set prompt")
+        self.latest_version.prompt = value
 
     @property
     def model_name(self) -> str:
@@ -158,8 +161,9 @@ class Agent(Base):
 
     @model_name.setter
     def model_name(self, value: str) -> None:
-        if self.latest_version:
-            self.latest_version.model_name = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set model_name")
+        self.latest_version.model_name = value
 
     @property
     def model_config_json(self) -> dict:
@@ -167,8 +171,9 @@ class Agent(Base):
 
     @model_config_json.setter
     def model_config_json(self, value: dict) -> None:
-        if self.latest_version:
-            self.latest_version.model_config_json = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set model_config_json")
+        self.latest_version.model_config_json = value
 
     @property
     def external_mcps(self) -> list:
@@ -176,8 +181,9 @@ class Agent(Base):
 
     @external_mcps.setter
     def external_mcps(self, value: list) -> None:
-        if self.latest_version:
-            self.latest_version.external_mcps = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set external_mcps")
+        self.latest_version.external_mcps = value
 
     @property
     def supported_ides(self) -> list:
@@ -185,8 +191,9 @@ class Agent(Base):
 
     @supported_ides.setter
     def supported_ides(self, value: list) -> None:
-        if self.latest_version:
-            self.latest_version.supported_ides = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set supported_ides")
+        self.latest_version.supported_ides = value
 
     @property
     def required_ide_features(self) -> list:
@@ -194,8 +201,9 @@ class Agent(Base):
 
     @required_ide_features.setter
     def required_ide_features(self, value: list) -> None:
-        if self.latest_version:
-            self.latest_version.required_ide_features = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set required_ide_features")
+        self.latest_version.required_ide_features = value
 
     @property
     def inferred_supported_ides(self) -> list:
@@ -203,8 +211,9 @@ class Agent(Base):
 
     @inferred_supported_ides.setter
     def inferred_supported_ides(self, value: list) -> None:
-        if self.latest_version:
-            self.latest_version.inferred_supported_ides = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set inferred_supported_ides")
+        self.latest_version.inferred_supported_ides = value
 
     @property
     def status(self) -> "AgentStatus":
@@ -212,8 +221,9 @@ class Agent(Base):
 
     @status.setter
     def status(self, value: "AgentStatus") -> None:
-        if self.latest_version:
-            self.latest_version.status = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set status")
+        self.latest_version.status = value
 
     @property
     def rejection_reason(self) -> str | None:
@@ -221,8 +231,9 @@ class Agent(Base):
 
     @rejection_reason.setter
     def rejection_reason(self, value: str | None) -> None:
-        if self.latest_version:
-            self.latest_version.rejection_reason = value
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set rejection_reason")
+        self.latest_version.rejection_reason = value
 
     @property
     def download_count(self) -> int:

--- a/observal-server/models/hook.py
+++ b/observal-server/models/hook.py
@@ -56,9 +56,21 @@ class HookListing(Base):
     def version(self) -> str:
         return self.latest_version.version if self.latest_version else "0.0.0"
 
+    @version.setter
+    def version(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set version")
+        self.latest_version.version = value
+
     @property
     def description(self) -> str:
         return self.latest_version.description if self.latest_version else ""
+
+    @description.setter
+    def description(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set description")
+        self.latest_version.description = value
 
     @property
     def status(self) -> ListingStatus:
@@ -87,6 +99,12 @@ class HookListing(Base):
     @property
     def supported_ides(self) -> list:
         return self.latest_version.supported_ides if self.latest_version else []
+
+    @supported_ides.setter
+    def supported_ides(self, value: list) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set supported_ides")
+        self.latest_version.supported_ides = value
 
     @property
     def event(self) -> str:

--- a/observal-server/models/hook.py
+++ b/observal-server/models/hook.py
@@ -251,5 +251,8 @@ class HookVersion(Base):
     scope: Mapped[str] = mapped_column(String(20), default="agent")
     tool_filter: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     file_pattern: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    is_editing: Mapped[bool] = mapped_column(Boolean, default=False)
+    editing_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    editing_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
 
     listing: Mapped[HookListing] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -328,5 +328,8 @@ class McpVersion(Base):
     reviewed_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    is_editing: Mapped[bool] = mapped_column(Boolean, default=False)
+    editing_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    editing_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
 
     listing: Mapped[McpListing] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -71,9 +71,21 @@ class McpListing(Base):
     def version(self) -> str:
         return self.latest_version.version if self.latest_version else "0.0.0"
 
+    @version.setter
+    def version(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set version")
+        self.latest_version.version = value
+
     @property
     def description(self) -> str:
         return self.latest_version.description if self.latest_version else ""
+
+    @description.setter
+    def description(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set description")
+        self.latest_version.description = value
 
     @property
     def status(self) -> ListingStatus:
@@ -103,9 +115,21 @@ class McpListing(Base):
     def supported_ides(self) -> list:
         return self.latest_version.supported_ides if self.latest_version else []
 
+    @supported_ides.setter
+    def supported_ides(self, value: list) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set supported_ides")
+        self.latest_version.supported_ides = value
+
     @property
     def changelog(self) -> str | None:
         return self.latest_version.changelog if self.latest_version else None
+
+    @changelog.setter
+    def changelog(self, value: str | None) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set changelog")
+        self.latest_version.changelog = value
 
     @property
     def transport(self) -> str | None:

--- a/observal-server/models/prompt.py
+++ b/observal-server/models/prompt.py
@@ -54,9 +54,21 @@ class PromptListing(Base):
     def version(self) -> str:
         return self.latest_version.version if self.latest_version else "0.0.0"
 
+    @version.setter
+    def version(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set version")
+        self.latest_version.version = value
+
     @property
     def description(self) -> str:
         return self.latest_version.description if self.latest_version else ""
+
+    @description.setter
+    def description(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set description")
+        self.latest_version.description = value
 
     @property
     def status(self) -> ListingStatus:
@@ -85,6 +97,12 @@ class PromptListing(Base):
     @property
     def supported_ides(self) -> list:
         return self.latest_version.supported_ides if self.latest_version else []
+
+    @supported_ides.setter
+    def supported_ides(self, value: list) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set supported_ides")
+        self.latest_version.supported_ides = value
 
     @property
     def category(self) -> str:

--- a/observal-server/models/prompt.py
+++ b/observal-server/models/prompt.py
@@ -194,5 +194,8 @@ class PromptVersion(Base):
     variables: Mapped[list] = mapped_column(JSON, default=list)
     model_hints: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     tags: Mapped[list] = mapped_column(JSON, default=list)
+    is_editing: Mapped[bool] = mapped_column(Boolean, default=False)
+    editing_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    editing_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
 
     listing: Mapped[PromptListing] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/sandbox.py
+++ b/observal-server/models/sandbox.py
@@ -54,9 +54,21 @@ class SandboxListing(Base):
     def version(self) -> str:
         return self.latest_version.version if self.latest_version else "0.0.0"
 
+    @version.setter
+    def version(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set version")
+        self.latest_version.version = value
+
     @property
     def description(self) -> str:
         return self.latest_version.description if self.latest_version else ""
+
+    @description.setter
+    def description(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set description")
+        self.latest_version.description = value
 
     @property
     def status(self) -> ListingStatus:
@@ -85,6 +97,12 @@ class SandboxListing(Base):
     @property
     def supported_ides(self) -> list:
         return self.latest_version.supported_ides if self.latest_version else []
+
+    @supported_ides.setter
+    def supported_ides(self, value: list) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set supported_ides")
+        self.latest_version.supported_ides = value
 
     @property
     def git_url(self) -> str | None:

--- a/observal-server/models/sandbox.py
+++ b/observal-server/models/sandbox.py
@@ -250,5 +250,8 @@ class SandboxVersion(Base):
     allowed_mounts: Mapped[list] = mapped_column(JSON, default=list)
     env_vars: Mapped[dict] = mapped_column(JSON, default=dict)
     entrypoint: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    is_editing: Mapped[bool] = mapped_column(Boolean, default=False)
+    editing_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    editing_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
 
     listing: Mapped[SandboxListing] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/skill.py
+++ b/observal-server/models/skill.py
@@ -262,5 +262,8 @@ class SkillVersion(Base):
     power_md: Mapped[str | None] = mapped_column(Text, nullable=True)
     mcp_server_config: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     activation_keywords: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    is_editing: Mapped[bool] = mapped_column(Boolean, default=False)
+    editing_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    editing_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
 
     listing: Mapped[SkillListing] = relationship(back_populates="versions", foreign_keys=[listing_id])

--- a/observal-server/models/skill.py
+++ b/observal-server/models/skill.py
@@ -56,9 +56,21 @@ class SkillListing(Base):
     def version(self) -> str:
         return self.latest_version.version if self.latest_version else "0.0.0"
 
+    @version.setter
+    def version(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set version")
+        self.latest_version.version = value
+
     @property
     def description(self) -> str:
         return self.latest_version.description if self.latest_version else ""
+
+    @description.setter
+    def description(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set description")
+        self.latest_version.description = value
 
     @property
     def status(self) -> ListingStatus:
@@ -87,6 +99,12 @@ class SkillListing(Base):
     @property
     def supported_ides(self) -> list:
         return self.latest_version.supported_ides if self.latest_version else []
+
+    @supported_ides.setter
+    def supported_ides(self, value: list) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set supported_ides")
+        self.latest_version.supported_ides = value
 
     @property
     def skill_path(self) -> str:

--- a/observal-server/services/editing_lock.py
+++ b/observal-server/services/editing_lock.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException
+
+if TYPE_CHECKING:
+    import uuid
+
+LOCK_TTL_MINUTES = 30
+
+
+def _is_lock_expired(editing_since: datetime | None) -> bool:
+    if not editing_since:
+        return True
+    return datetime.now(UTC) - editing_since > timedelta(minutes=LOCK_TTL_MINUTES)
+
+
+def acquire_edit_lock(
+    version,
+    user_id: uuid.UUID,
+) -> None:
+    """Set is_editing on a version row. Raises 409 if already locked by another user."""
+    if version.is_editing and not _is_lock_expired(version.editing_since) and version.editing_by != user_id:
+        raise HTTPException(
+            status_code=409,
+            detail="This item is currently being edited by another user. Please try again later.",
+        )
+    version.is_editing = True
+    version.editing_since = datetime.now(UTC)
+    version.editing_by = user_id
+
+
+def release_edit_lock(
+    version,
+    user_id: uuid.UUID,
+    *,
+    force: bool = False,
+) -> None:
+    """Clear is_editing on a version row. Only the lock holder (or force) can release."""
+    if not version.is_editing:
+        return
+    if not force and version.editing_by != user_id:
+        raise HTTPException(status_code=403, detail="You do not hold the edit lock on this item")
+    version.is_editing = False
+    version.editing_since = None
+    version.editing_by = None
+
+
+def is_actively_editing(version) -> bool:
+    """Return True if the version is locked and the lock has not expired."""
+    return bool(
+        version.is_editing
+        and version.editing_by is not None
+        and not _is_lock_expired(version.editing_since)
+    )

--- a/observal-server/services/editing_lock.py
+++ b/observal-server/services/editing_lock.py
@@ -50,8 +50,12 @@ def release_edit_lock(
 
 def is_actively_editing(version) -> bool:
     """Return True if the version is locked and the lock has not expired."""
-    return bool(
-        version.is_editing
-        and version.editing_by is not None
-        and not _is_lock_expired(version.editing_since)
-    )
+    if not getattr(version, "is_editing", False):
+        return False
+    editing_by = getattr(version, "editing_by", None)
+    if editing_by is None:
+        return False
+    editing_since = getattr(version, "editing_since", None)
+    if not isinstance(editing_since, datetime):
+        return False
+    return not _is_lock_expired(editing_since)

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -170,6 +170,47 @@ def hook_install(
     console.print_json(_json.dumps(snippet, indent=2))
 
 
+@hook_app.command(name="edit")
+def hook_edit(
+    hook_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Load updates from JSON file"),
+    name: str | None = typer.Option(None, "--name", "-n", help="New listing name"),
+    description: str | None = typer.Option(None, "--description", "-d", help="New description"),
+    version: str | None = typer.Option(None, "--version", "-v", help="New version string"),
+    event: str | None = typer.Option(None, "--event", "-e", help="New event type"),
+):
+    """Edit a draft, rejected, or pending hook submission."""
+    resolved = config.resolve_alias(hook_id)
+    if from_file:
+        try:
+            with open(from_file) as f:
+                updates = _json.load(f)
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON in {from_file}:[/red] {e}")
+            raise typer.Exit(code=1)
+        except FileNotFoundError:
+            rprint(f"[red]File not found:[/red] {from_file}")
+            raise typer.Exit(code=1)
+    else:
+        updates = {}
+        if name is not None:
+            updates["name"] = name
+        if description is not None:
+            updates["description"] = description
+        if version is not None:
+            updates["version"] = version
+        if event is not None:
+            updates["event"] = event
+
+    if not updates:
+        rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
+        raise typer.Exit(code=1)
+
+    with spinner("Saving changes..."):
+        result = client.put(f"/api/v1/hooks/{resolved}/draft", updates)
+    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+
+
 @hook_app.command(name="delete")
 def hook_delete(
     hook_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -208,8 +208,10 @@ def hook_edit(
 
     try:
         client.post(f"/api/v1/hooks/{resolved}/start-edit")
-    except Exception:
-        pass
+    except Exception as exc:
+        if "409" in str(exc) or "currently being edited" in str(exc):
+            rprint(f"[red]✗ Cannot edit:[/red] {exc}")
+            raise typer.Exit(code=1)
     try:
         with spinner("Saving changes..."):
             result = client.put(f"/api/v1/hooks/{resolved}/draft", updates)

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -206,9 +206,21 @@ def hook_edit(
         rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
         raise typer.Exit(code=1)
 
-    with spinner("Saving changes..."):
-        result = client.put(f"/api/v1/hooks/{resolved}/draft", updates)
-    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    try:
+        client.post(f"/api/v1/hooks/{resolved}/start-edit")
+    except Exception:
+        pass
+    try:
+        with spinner("Saving changes..."):
+            result = client.put(f"/api/v1/hooks/{resolved}/draft", updates)
+        rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    except Exception as exc:
+        try:
+            client.post(f"/api/v1/hooks/{resolved}/cancel-edit")
+        except Exception:
+            pass
+        rprint(f"[red]Failed to update:[/red] {exc}")
+        raise typer.Exit(code=1)
 
 
 @hook_app.command(name="delete")

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1058,6 +1058,56 @@ def install(
     _install_impl(mcp_id, ide, raw)
 
 
+@mcp_app.command(name="edit")
+def edit_mcp(
+    mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Load updates from JSON file"),
+    name: str | None = typer.Option(None, "--name", "-n", help="New listing name"),
+    description: str | None = typer.Option(None, "--description", "-d", help="New description"),
+    category: str | None = typer.Option(None, "--category", "-c", help="New category"),
+    version: str | None = typer.Option(None, "--version", "-v", help="New version string"),
+    git_url: str | None = typer.Option(None, "--git-url", help="New git URL"),
+    command: str | None = typer.Option(None, "--command", help="New command"),
+    url: str | None = typer.Option(None, "--url", help="New URL"),
+):
+    """Edit a draft, rejected, or pending MCP server submission."""
+    resolved = config.resolve_alias(mcp_id)
+    if from_file:
+        try:
+            with open(from_file) as f:
+                updates = json.load(f)
+        except json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON in {from_file}:[/red] {e}")
+            raise typer.Exit(code=1)
+        except FileNotFoundError:
+            rprint(f"[red]File not found:[/red] {from_file}")
+            raise typer.Exit(code=1)
+    else:
+        updates = {}
+        if name is not None:
+            updates["name"] = name
+        if description is not None:
+            updates["description"] = description
+        if category is not None:
+            updates["category"] = category
+        if version is not None:
+            updates["version"] = version
+        if git_url is not None:
+            updates["git_url"] = git_url
+        if command is not None:
+            updates["command"] = command
+        if url is not None:
+            updates["url"] = url
+
+    if not updates:
+        rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
+        raise typer.Exit(code=1)
+
+    with spinner("Saving changes..."):
+        result = client.put(f"/api/v1/mcps/{resolved}/draft", updates)
+    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+
+
 @mcp_app.command(name="delete")
 def delete_mcp(
     mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1103,9 +1103,21 @@ def edit_mcp(
         rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
         raise typer.Exit(code=1)
 
-    with spinner("Saving changes..."):
-        result = client.put(f"/api/v1/mcps/{resolved}/draft", updates)
-    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    try:
+        client.post(f"/api/v1/mcps/{resolved}/start-edit")
+    except Exception:
+        pass
+    try:
+        with spinner("Saving changes..."):
+            result = client.put(f"/api/v1/mcps/{resolved}/draft", updates)
+        rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    except Exception as exc:
+        try:
+            client.post(f"/api/v1/mcps/{resolved}/cancel-edit")
+        except Exception:
+            pass
+        rprint(f"[red]Failed to update:[/red] {exc}")
+        raise typer.Exit(code=1)
 
 
 @mcp_app.command(name="delete")

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1105,8 +1105,10 @@ def edit_mcp(
 
     try:
         client.post(f"/api/v1/mcps/{resolved}/start-edit")
-    except Exception:
-        pass
+    except Exception as exc:
+        if "409" in str(exc) or "currently being edited" in str(exc):
+            rprint(f"[red]✗ Cannot edit:[/red] {exc}")
+            raise typer.Exit(code=1)
     try:
         with spinner("Saving changes..."):
             result = client.put(f"/api/v1/mcps/{resolved}/draft", updates)

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -228,8 +228,10 @@ def prompt_edit(
 
     try:
         client.post(f"/api/v1/prompts/{resolved}/start-edit")
-    except Exception:
-        pass
+    except Exception as exc:
+        if "409" in str(exc) or "currently being edited" in str(exc):
+            rprint(f"[red]✗ Cannot edit:[/red] {exc}")
+            raise typer.Exit(code=1)
     try:
         with spinner("Saving changes..."):
             result = client.put(f"/api/v1/prompts/{resolved}/draft", updates)

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -187,6 +187,50 @@ def prompt_install(
     console.print_json(_json.dumps(snippet, indent=2))
 
 
+@prompt_app.command(name="edit")
+def prompt_edit(
+    prompt_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Load updates from JSON file"),
+    name: str | None = typer.Option(None, "--name", "-n", help="New listing name"),
+    description: str | None = typer.Option(None, "--description", "-d", help="New description"),
+    version: str | None = typer.Option(None, "--version", "-v", help="New version string"),
+    category: str | None = typer.Option(None, "--category", "-c", help="New category"),
+    template: str | None = typer.Option(None, "--template", "-t", help="New template text"),
+):
+    """Edit a draft, rejected, or pending prompt submission."""
+    resolved = config.resolve_alias(prompt_id)
+    if from_file:
+        try:
+            with open(from_file) as f:
+                updates = _json.load(f)
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON in {from_file}:[/red] {e}")
+            raise typer.Exit(code=1)
+        except FileNotFoundError:
+            rprint(f"[red]File not found:[/red] {from_file}")
+            raise typer.Exit(code=1)
+    else:
+        updates = {}
+        if name is not None:
+            updates["name"] = name
+        if description is not None:
+            updates["description"] = description
+        if version is not None:
+            updates["version"] = version
+        if category is not None:
+            updates["category"] = category
+        if template is not None:
+            updates["template"] = template
+
+    if not updates:
+        rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
+        raise typer.Exit(code=1)
+
+    with spinner("Saving changes..."):
+        result = client.put(f"/api/v1/prompts/{resolved}/draft", updates)
+    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+
+
 @prompt_app.command(name="delete")
 def prompt_delete(
     prompt_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -226,9 +226,21 @@ def prompt_edit(
         rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
         raise typer.Exit(code=1)
 
-    with spinner("Saving changes..."):
-        result = client.put(f"/api/v1/prompts/{resolved}/draft", updates)
-    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    try:
+        client.post(f"/api/v1/prompts/{resolved}/start-edit")
+    except Exception:
+        pass
+    try:
+        with spinner("Saving changes..."):
+            result = client.put(f"/api/v1/prompts/{resolved}/draft", updates)
+        rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    except Exception as exc:
+        try:
+            client.post(f"/api/v1/prompts/{resolved}/cancel-edit")
+        except Exception:
+            pass
+        rprint(f"[red]Failed to update:[/red] {exc}")
+        raise typer.Exit(code=1)
 
 
 @prompt_app.command(name="delete")

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -206,8 +206,10 @@ def sandbox_edit(
 
     try:
         client.post(f"/api/v1/sandboxes/{resolved}/start-edit")
-    except Exception:
-        pass
+    except Exception as exc:
+        if "409" in str(exc) or "currently being edited" in str(exc):
+            rprint(f"[red]✗ Cannot edit:[/red] {exc}")
+            raise typer.Exit(code=1)
     try:
         with spinner("Saving changes..."):
             result = client.put(f"/api/v1/sandboxes/{resolved}/draft", updates)

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -165,6 +165,50 @@ def sandbox_install(
     console.print_json(_json.dumps(snippet, indent=2))
 
 
+@sandbox_app.command(name="edit")
+def sandbox_edit(
+    sandbox_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Load updates from JSON file"),
+    name: str | None = typer.Option(None, "--name", "-n", help="New listing name"),
+    description: str | None = typer.Option(None, "--description", "-d", help="New description"),
+    version: str | None = typer.Option(None, "--version", "-v", help="New version string"),
+    runtime_type: str | None = typer.Option(None, "--runtime-type", "-r", help="New runtime type"),
+    image: str | None = typer.Option(None, "--image", "-i", help="New container image"),
+):
+    """Edit a draft, rejected, or pending sandbox submission."""
+    resolved = config.resolve_alias(sandbox_id)
+    if from_file:
+        try:
+            with open(from_file) as f:
+                updates = _json.load(f)
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON in {from_file}:[/red] {e}")
+            raise typer.Exit(code=1)
+        except FileNotFoundError:
+            rprint(f"[red]File not found:[/red] {from_file}")
+            raise typer.Exit(code=1)
+    else:
+        updates = {}
+        if name is not None:
+            updates["name"] = name
+        if description is not None:
+            updates["description"] = description
+        if version is not None:
+            updates["version"] = version
+        if runtime_type is not None:
+            updates["runtime_type"] = runtime_type
+        if image is not None:
+            updates["image"] = image
+
+    if not updates:
+        rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
+        raise typer.Exit(code=1)
+
+    with spinner("Saving changes..."):
+        result = client.put(f"/api/v1/sandboxes/{resolved}/draft", updates)
+    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+
+
 @sandbox_app.command(name="delete")
 def sandbox_delete(
     sandbox_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -204,9 +204,21 @@ def sandbox_edit(
         rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
         raise typer.Exit(code=1)
 
-    with spinner("Saving changes..."):
-        result = client.put(f"/api/v1/sandboxes/{resolved}/draft", updates)
-    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    try:
+        client.post(f"/api/v1/sandboxes/{resolved}/start-edit")
+    except Exception:
+        pass
+    try:
+        with spinner("Saving changes..."):
+            result = client.put(f"/api/v1/sandboxes/{resolved}/draft", updates)
+        rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    except Exception as exc:
+        try:
+            client.post(f"/api/v1/sandboxes/{resolved}/cancel-edit")
+        except Exception:
+            pass
+        rprint(f"[red]Failed to update:[/red] {exc}")
+        raise typer.Exit(code=1)
 
 
 @sandbox_app.command(name="delete")

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -189,6 +189,47 @@ def skill_install(
     console.print_json(_json.dumps(snippet, indent=2))
 
 
+@skill_app.command(name="edit")
+def skill_edit(
+    skill_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Load updates from JSON file"),
+    name: str | None = typer.Option(None, "--name", "-n", help="New listing name"),
+    description: str | None = typer.Option(None, "--description", "-d", help="New description"),
+    version: str | None = typer.Option(None, "--version", "-v", help="New version string"),
+    task_type: str | None = typer.Option(None, "--task-type", "-t", help="New task type"),
+):
+    """Edit a draft, rejected, or pending skill submission."""
+    resolved = config.resolve_alias(skill_id)
+    if from_file:
+        try:
+            with open(from_file) as f:
+                updates = _json.load(f)
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON in {from_file}:[/red] {e}")
+            raise typer.Exit(code=1)
+        except FileNotFoundError:
+            rprint(f"[red]File not found:[/red] {from_file}")
+            raise typer.Exit(code=1)
+    else:
+        updates = {}
+        if name is not None:
+            updates["name"] = name
+        if description is not None:
+            updates["description"] = description
+        if version is not None:
+            updates["version"] = version
+        if task_type is not None:
+            updates["task_type"] = task_type
+
+    if not updates:
+        rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
+        raise typer.Exit(code=1)
+
+    with spinner("Saving changes..."):
+        result = client.put(f"/api/v1/skills/{resolved}/draft", updates)
+    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+
+
 @skill_app.command(name="delete")
 def skill_delete(
     skill_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -225,9 +225,21 @@ def skill_edit(
         rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
         raise typer.Exit(code=1)
 
-    with spinner("Saving changes..."):
-        result = client.put(f"/api/v1/skills/{resolved}/draft", updates)
-    rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    try:
+        client.post(f"/api/v1/skills/{resolved}/start-edit")
+    except Exception:
+        pass
+    try:
+        with spinner("Saving changes..."):
+            result = client.put(f"/api/v1/skills/{resolved}/draft", updates)
+        rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+    except Exception as exc:
+        try:
+            client.post(f"/api/v1/skills/{resolved}/cancel-edit")
+        except Exception:
+            pass
+        rprint(f"[red]Failed to update:[/red] {exc}")
+        raise typer.Exit(code=1)
 
 
 @skill_app.command(name="delete")

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -227,8 +227,10 @@ def skill_edit(
 
     try:
         client.post(f"/api/v1/skills/{resolved}/start-edit")
-    except Exception:
-        pass
+    except Exception as exc:
+        if "409" in str(exc) or "currently being edited" in str(exc):
+            rprint(f"[red]✗ Cannot edit:[/red] {exc}")
+            raise typer.Exit(code=1)
     try:
         with spinner("Saving changes..."):
             result = client.put(f"/api/v1/skills/{resolved}/draft", updates)

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -77,6 +77,10 @@ def _agent_mock(status=AgentStatus.draft, created_by=None, **extra):
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
     m.goal_template = extra.get("goal_template")
+    # Edit-lock fields on the latest_version mock
+    m.latest_version.is_editing = False
+    m.latest_version.editing_by = None
+    m.latest_version.editing_since = None
     # Make __table__.columns iterable for _agent_to_response
     col_keys = [
         "id",

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -221,10 +221,10 @@ class TestDraftUpdate:
     @pytest.mark.asyncio
     @patch("api.routes.agent._load_agent")
     async def test_rejects_update_on_non_draft(self, mock_load):
-        """Updating a non-draft agent returns 400."""
+        """Updating an approved agent returns 400."""
         user = _user()
         app, db, _ = _app_with(user=user)
-        agent = _agent_mock(status=AgentStatus.pending, created_by=user.id)
+        agent = _agent_mock(status=AgentStatus.approved, created_by=user.id)
         mock_load.return_value = agent
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -507,7 +507,8 @@ export default function AgentDetailPage({
   const versionRequiredFeatures = (vd?.required_ide_features as string[]) ?? a?.required_ide_features;
   const versionInferredIdes = (vd?.inferred_supported_ides as string[]) ?? a?.inferred_supported_ides;
   const canDelete = isAdmin || (whoami?.id && a?.created_by && whoami.id === String(a.created_by));
-  const canEdit = isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit";
+  const agentStatus = a?.status as string | undefined;
+  const canEdit = (isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit") && agentStatus === "approved";
   const components: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];
   const goalTemplate = a?.goal_template;
   const agentName = a?.name ?? id.slice(0, 8);

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -508,7 +508,7 @@ export default function AgentDetailPage({
   const versionInferredIdes = (vd?.inferred_supported_ides as string[]) ?? a?.inferred_supported_ides;
   const canDelete = isAdmin || (whoami?.id && a?.created_by && whoami.id === String(a.created_by));
   const agentStatus = a?.status as string | undefined;
-  const canEdit = (isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit") && agentStatus === "approved";
+  const canEdit = (isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit") && ["approved", "pending", "draft", "rejected"].includes(agentStatus ?? "");
   const components: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];
   const goalTemplate = a?.goal_template;
   const agentName = a?.name ?? id.slice(0, 8);

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -33,7 +33,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { PageHeader } from "@/components/layouts/page-header";
-import { useRegistryList, useRegistryItem, useAgentValidation, useWhoami, useSaveDraft, useUpdateDraft } from "@/hooks/use-api";
+import { useRegistryList, useRegistryItem, useAgentValidation, useWhoami, useSaveDraft, useUpdateDraft, useStartEdit } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import { registry, type RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
@@ -444,6 +444,41 @@ function AgentBuilderInner() {
       if (loaded.length > 0) setCustomPrompts(loaded);
     }
   }, [existingAgent, draftParam]);
+
+  // Edit lock for pending agents — acquire on mount, release on unmount
+  const agentIdParam = editId ?? draftParam;
+  const startEdit = useStartEdit("agents");
+  const editLockAcquiredRef = useRef(false);
+
+  useEffect(() => {
+    if (!agentIdParam || !existingAgent) return;
+    if ((existingAgent as Record<string, unknown>).status !== "pending") return;
+    if (editLockAcquiredRef.current) return;
+    editLockAcquiredRef.current = true;
+
+    startEdit.mutate(agentIdParam, {
+      onError: () => { editLockAcquiredRef.current = false; },
+    });
+
+    const releaseLock = () => {
+      const token = localStorage.getItem("observal_access_token");
+      fetch(`/api/v1/agents/${agentIdParam}/cancel-edit`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        keepalive: true,
+      });
+    };
+
+    window.addEventListener("beforeunload", releaseLock);
+    return () => {
+      window.removeEventListener("beforeunload", releaseLock);
+      releaseLock();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentIdParam, existingAgent]);
 
   // Compute selected IDs for quick lookup
   const selectedIds = useMemo(() => {

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -744,8 +744,11 @@ function AgentBuilderInner() {
       const body = buildRequestBody();
       if (draftId) {
         await updateDraft.mutateAsync({ id: draftId, body });
-        await registry.submitDraft(draftId);
-        toast.success("Agent resubmitted for review.");
+        const agentStatus = existingAgent?.status;
+        if (agentStatus && agentStatus !== "pending") {
+          await registry.submitDraft(draftId);
+        }
+        toast.success(!agentStatus || agentStatus === "pending" ? "Changes saved." : "Agent resubmitted for review.");
         router.push(`/agents/${draftId}`);
       } else {
         const created = await registry.create("agents", body);
@@ -1230,7 +1233,7 @@ function AgentBuilderInner() {
                 ) : (
                   <ArrowRight className="mr-2 h-4 w-4" />
                 )}
-                {isEditMode ? "Update Agent" : "Submit for Review"}
+                {isEditMode ? "Update Agent" : existingAgent?.status === "pending" ? "Save Changes" : "Submit for Review"}
               </Button>
             </div>
           </div>

--- a/web/src/app/(registry)/agents/page.tsx
+++ b/web/src/app/(registry)/agents/page.tsx
@@ -427,7 +427,7 @@ function AgentListContent() {
   const qc = useQueryClient();
 
   const drafts = useMemo(() => {
-    return (myAgents ?? []).filter((a) => a.status === "draft" || a.status === "rejected");
+    return (myAgents ?? []).filter((a) => a.status === "draft" || a.status === "rejected" || a.status === "pending");
   }, [myAgents]);
 
   const { filtered, pendingCount } = useMemo(() => {
@@ -529,7 +529,7 @@ function AgentListContent() {
               ) : (
                 <ChevronRight className="h-4 w-4 text-muted-foreground" />
               )}
-              My Drafts & Rejected
+              My Submissions
               <span className="ml-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
                 {drafts.length}
               </span>
@@ -541,7 +541,9 @@ function AgentListContent() {
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <p className="truncate text-sm font-medium">{draft.name}</p>
-                        {draft.status === "rejected" && <StatusBadge status="rejected" />}
+                        {(draft.status === "rejected" || draft.status === "pending") && (
+                          <StatusBadge status={draft.status} />
+                        )}
                       </div>
                       {draft.status === "rejected" && draft.rejection_reason && (
                         <p className="text-xs text-destructive mt-0.5">
@@ -569,16 +571,18 @@ function AgentListContent() {
                         <FileEdit className="mr-1 h-3 w-3" />
                         Edit
                       </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-7 text-xs"
-                        disabled={submitDraft.isPending}
-                        onClick={() => submitDraft.mutate(draft.id)}
-                      >
-                        <Send className="mr-1 h-3 w-3" />
-                        {draft.status === "rejected" ? "Resubmit" : "Submit for Review"}
-                      </Button>
+                      {(draft.status === "draft" || draft.status === "rejected") && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs"
+                          disabled={submitDraft.isPending}
+                          onClick={() => submitDraft.mutate(draft.id)}
+                        >
+                          <Send className="mr-1 h-3 w-3" />
+                          {draft.status === "rejected" ? "Resubmit" : "Submit for Review"}
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="sm"

--- a/web/src/app/(registry)/components/page.tsx
+++ b/web/src/app/(registry)/components/page.tsx
@@ -26,6 +26,8 @@ import {
   useComponentSubmitDraft,
   useComponentUpdateDraft,
   useComponentDelete,
+  useStartEdit,
+  useCancelEdit,
 } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import type { RegistryType } from "@/lib/api";
@@ -187,6 +189,33 @@ export default function ComponentsPage() {
   const submitDraftMutation = useComponentSubmitDraft(activeType);
   const updateDraftMutation = useComponentUpdateDraft(activeType);
   const deleteMutation = useComponentDelete(activeType);
+  const startEditMutation = useStartEdit(activeType);
+  const cancelEditMutation = useCancelEdit(activeType);
+
+  const editItemRef = useRef(editItem);
+  editItemRef.current = editItem;
+  const activeTypeRef = useRef(activeType);
+  activeTypeRef.current = activeType;
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      const item = editItemRef.current;
+      if (item?.status === "pending") {
+        const type = activeTypeRef.current;
+        const token = localStorage.getItem("observal_access_token");
+        fetch(`/api/v1/${type}/${item.id}/cancel-edit`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          keepalive: true,
+        });
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []);
 
   const items = useMemo(() => data ?? [], [data]);
 
@@ -402,7 +431,16 @@ export default function ComponentsPage() {
                         variant="outline"
                         size="sm"
                         className="h-7 text-xs"
-                        onClick={() => { setEditItem(item); setSubmitOpen(true); }}
+                        disabled={startEditMutation.isPending}
+                        onClick={() => {
+                          if (item.status === "pending") {
+                            startEditMutation.mutate(item.id, {
+                              onSuccess: () => { setEditItem(item); setSubmitOpen(true); },
+                            });
+                          } else {
+                            setEditItem(item); setSubmitOpen(true);
+                          }
+                        }}
                       >
                         <FileEdit className="h-3 w-3 mr-1" />
                         Edit
@@ -440,7 +478,13 @@ export default function ComponentsPage() {
       <SubmitComponentDialog
         key={editItem?.id ?? "new"}
         open={submitOpen}
-        onOpenChange={(v) => { setSubmitOpen(v); if (!v) setEditItem(null); }}
+        onOpenChange={(v) => {
+          if (!v && editItem?.status === "pending") {
+            cancelEditMutation.mutate(editItem.id);
+          }
+          setSubmitOpen(v);
+          if (!v) setEditItem(null);
+        }}
         type={activeType}
         editItem={editItem as Record<string, unknown> | null}
         onSubmit={(body) => {

--- a/web/src/app/(registry)/components/page.tsx
+++ b/web/src/app/(registry)/components/page.tsx
@@ -397,28 +397,28 @@ export default function ComponentsPage() {
                     </div>
                   </div>
                   <div className="flex items-center gap-1.5 shrink-0">
+                    {(item.status === "draft" || item.status === "rejected" || item.status === "pending") && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => { setEditItem(item); setSubmitOpen(true); }}
+                      >
+                        <FileEdit className="h-3 w-3 mr-1" />
+                        Edit
+                      </Button>
+                    )}
                     {(item.status === "draft" || item.status === "rejected") && (
-                      <>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="h-7 text-xs"
-                          onClick={() => { setEditItem(item); setSubmitOpen(true); }}
-                        >
-                          <FileEdit className="h-3 w-3 mr-1" />
-                          Edit
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="h-7 text-xs"
-                          onClick={() => submitDraftMutation.mutate(item.id)}
-                          disabled={submitDraftMutation.isPending}
-                        >
-                          <Send className="h-3 w-3 mr-1" />
-                          {item.status === "rejected" ? "Resubmit" : "Submit"}
-                        </Button>
-                      </>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => submitDraftMutation.mutate(item.id)}
+                        disabled={submitDraftMutation.isPending}
+                      >
+                        <Send className="h-3 w-3 mr-1" />
+                        {item.status === "rejected" ? "Resubmit" : "Submit"}
+                      </Button>
                     )}
                     <Button
                       variant="ghost"
@@ -445,9 +445,15 @@ export default function ComponentsPage() {
         editItem={editItem as Record<string, unknown> | null}
         onSubmit={(body) => {
           if (editItem) {
-            submitDraftMutation.mutate(editItem.id, {
-              onSuccess: () => { setSubmitOpen(false); setEditItem(null); },
-            });
+            if (editItem.status === "pending") {
+              updateDraftMutation.mutate({ id: editItem.id, body }, {
+                onSuccess: () => { setSubmitOpen(false); setEditItem(null); },
+              });
+            } else {
+              submitDraftMutation.mutate(editItem.id, {
+                onSuccess: () => { setSubmitOpen(false); setEditItem(null); },
+              });
+            }
           } else {
             submitMutation.mutate(body, {
               onSuccess: () => setSubmitOpen(false),

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -185,6 +185,7 @@ export function SubmitComponentDialog({
   }
 
   const isEditMode = !!editItem;
+  const isPendingEdit = isEditMode && d?.status === "pending";
 
   function buildBody(): Record<string, unknown> {
     const base: Record<string, unknown> = {
@@ -757,30 +758,47 @@ export function SubmitComponentDialog({
           <div className="flex justify-end gap-2 pt-2">
             {isEditMode ? (
               <>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    if (!name) { toast.error("Name is required"); return; }
-                    onUpdateDraft?.((editItem as Record<string, unknown>).id as string, buildBody());
-                  }}
-                  disabled={busy || !name}
-                >
-                  {isSavingDraft && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
-                  Save Changes
-                </Button>
-                <Button
-                  onClick={() => {
-                    const err = validateForSubmit();
-                    if (err) { toast.error(err); return; }
-                    onUpdateDraft?.((editItem as Record<string, unknown>).id as string, buildBody());
-                    onSubmit(buildBody());
-                  }}
-                  disabled={busy || !!submitError}
-                  title={submitError ?? undefined}
-                >
-                  {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
-                  Save & Resubmit
-                </Button>
+                {isPendingEdit ? (
+                  <Button
+                    onClick={() => {
+                      const err = validateForSubmit();
+                      if (err) { toast.error(err); return; }
+                      onUpdateDraft?.((editItem as Record<string, unknown>).id as string, buildBody());
+                    }}
+                    disabled={busy || !!submitError}
+                    title={submitError ?? undefined}
+                  >
+                    {isSavingDraft && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+                    Save Changes
+                  </Button>
+                ) : (
+                  <>
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        if (!name) { toast.error("Name is required"); return; }
+                        onUpdateDraft?.((editItem as Record<string, unknown>).id as string, buildBody());
+                      }}
+                      disabled={busy || !name}
+                    >
+                      {isSavingDraft && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+                      Save Changes
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        const err = validateForSubmit();
+                        if (err) { toast.error(err); return; }
+                        onUpdateDraft?.((editItem as Record<string, unknown>).id as string, buildBody());
+                        onSubmit(buildBody());
+                      }}
+                      disabled={busy || !!submitError}
+                      title={submitError ?? undefined}
+                    >
+                      {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+                      Save & Resubmit
+                    </Button>
+                  </>
+                )}
               </>
             ) : (
               <>

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -694,6 +694,32 @@ export function useComponentSubmitDraft(type: RegistryType) {
   });
 }
 
+export function useStartEdit(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.startEdit(id, type),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["review"] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to start editing");
+    },
+  });
+}
+
+export function useCancelEdit(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.cancelEdit(id, type),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["review"] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to cancel editing");
+    },
+  });
+}
+
 export function useComponentDelete(type: RegistryType) {
   const qc = useQueryClient();
   return useMutation({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -177,7 +177,16 @@ async function request<T = unknown>(
     }
 
     const text = await response.text().catch(() => response.statusText);
-    throw new Error(`${response.status}: ${text}`);
+    let detail = text;
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed.detail) detail = typeof parsed.detail === "string" ? parsed.detail : JSON.stringify(parsed.detail);
+    } catch {
+      // not JSON — use raw text
+    }
+    const err = new Error(detail);
+    (err as Error & { status: number }).status = response.status;
+    throw err;
   }
 
   if (response.status === 204) return undefined as T;
@@ -294,6 +303,10 @@ export const registry = {
     post<ComponentVersionDetail>(`/${type}/${listingId}/versions`, body),
   componentVersionSuggestions: (type: RegistryType, listingId: string) =>
     get<VersionSuggestions>(`/${type}/${listingId}/version-suggestions`),
+  startEdit: (id: string, type?: RegistryType) =>
+    post<{ status: string }>(`/${type ?? "agents"}/${id}/start-edit`),
+  cancelEdit: (id: string, type?: RegistryType) =>
+    post<{ status: string }>(`/${type ?? "agents"}/${id}/cancel-edit`),
 };
 
 // ── Review ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Allow registry item owners to edit their submissions in the review queue

### New Features

**Edit own submissions**
- Owners can now click **Edit** on any pending, draft, or rejected listing to modify it
- Opens the builder pre-filled with current data — no need to resubmit from scratch
- Works for all 6 component types: agents, MCP servers, hooks, skills, prompts, sandboxes

**Edit locking**
- Clicking Edit acquires a time-limited lock (30 minutes) so reviewers can't approve/reject mid-edit
- Lock auto-expires if the owner forgets to save or cancel
- Review queue shows lock status in real time

**CLI commands**
- New `edit` subcommand for `observal mcp`, `hook`, `skill`, `prompt`, `sandbox`

### UI changes

- Edit button appears on owner's own pending/draft/rejected listings in the registry
- Toast notifications (Sonner) replace browser `alert()` popups
- Review queue auto-refreshes when a lock is acquired or released
- All state updates reflect immediately on page reload

### How it works

- New DB columns (`is_editing`, `editing_by`, `editing_since`) on all 6 version tables via migration 0023
- `start-edit` / `cancel-edit` / `update-draft` API endpoints for each component type
- Reviewers get a **409** if they try to approve or reject a listing that's currently being edited
- Central `editing_lock.py` service handles lock acquire, release, expiry, and conflict detection

Closes #663