### PR TITLE
fix(web): layout does not scale with monitor size

### DIFF
--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -536,7 +536,7 @@ export default function AgentDetailPage({
         }
       />
 
-      <div className="p-6 lg:p-8 max-w-[1200px]">
+      <div className="p-6 lg:p-8 w-full">
         {isLoading ? (
           <DetailSkeleton />
         ) : isError ? (

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -221,7 +221,7 @@ const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<"main
   ({ className, ...props }, ref) => (
     <main
       ref={ref}
-      className={cn("relative flex w-full flex-1 flex-col overflow-y-auto bg-background [scrollbar-gutter:stable]", className)}
+      className={cn("relative flex min-w-0 w-full flex-1 flex-col overflow-y-auto bg-background [scrollbar-gutter:stable]", className)}
       {...props}
     />
   ),


### PR DESCRIPTION
## Purpose / Description

The frontend UI does not properly scale or adapt to different monitor/screen sizes. The agent detail page had a hardcoded `max-w-[1200px]` that capped content width, and the `SidebarInset` was missing `min-w-0` causing flex children to refuse to shrink below their content's intrinsic width.

## Fixes
* Fixes #700

## Approach

1. Remove `max-w-[1200px]` from agent detail page container — same pattern as commit `6ee1f68` which stripped `max-w` from 13 other pages (this one was missed)
2. Add `min-w-0` to `SidebarInset` component — without it, CSS flex items default to `min-width: auto` which prevents shrinking below content width on narrow viewports

## How Has This Been Tested?

- Opened agent detail page on wide viewport (>1400px) — content fills available space
- Resized browser to narrow width — content shrinks without horizontal overflow
- Verified sidebar collapse/expand still works correctly
- Checked other pages (components, review, dashboard) still render properly

## Learning (optional, can help others)

CSS flexbox items have \`min-width: auto\` by default, meaning they won't shrink smaller than their content. Adding \`min-w-0\` overrides this so \`flex-1\` children actually shrink when the parent is narrower than the content's intrinsic width.

## Checklist

- [x] All commits are signed off (\`git commit -s\`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)