### PR TITLE
fix(db): resolve duplicate Alembic revision 0023 causing deploy failure

### DIFF
--- a/observal-server/alembic/versions/0024_add_registered_agents_only.py
+++ b/observal-server/alembic/versions/0024_add_registered_agents_only.py
@@ -3,8 +3,8 @@
 When enabled, only registered (active) agents are traced.
 Unregistered agent telemetry is stored as metadata-only (no content).
 
-Revision ID: 0023
-Revises: 0022
+Revision ID: 0024
+Revises: 0023
 Create Date: 2026-05-01 00:00:00.000000
 
 """
@@ -15,8 +15,8 @@ from typing import Union
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0023"
-down_revision: Union[str, Sequence[str], None] = "0022"
+revision: str = "0024"
+down_revision: Union[str, Sequence[str], None] = "0023"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Purpose / Description
The EC2 deploy fails with `observal-init` exit code 255 because two Alembic migrations share revision ID `0023` with the same `down_revision = "0022"`, creating multiple heads in the dependency graph. `alembic upgrade head` cannot resolve which head to target and errors out.

## Fixes
* Fixes #670

## Approach
Renumber `0023_add_registered_agents_only.py` → `0024_add_registered_agents_only.py` and update its internal `revision` to `"0024"` and `down_revision` to `"0023"`. This restores a linear chain: `0022 → 0023 (editing lock) → 0024 (registered_agents_only)`.

## How Has This Been Tested?

Verified via Alembic's `ScriptDirectory.get_heads()` that only a single head (`0024`) exists after the fix:
```
Heads: ['0024']
Number of heads: 1
```

Also verified the chain is correct:
```
0024 down_revision: 0023
0023 down_revision: 0022
0022 down_revision: 0021
```

## Learning (optional, can help others)
When two Alembic migrations are authored concurrently with the same revision ID and down_revision, Alembic creates a branching dependency graph ("multiple heads"). `alembic upgrade head` refuses to run because "head" is ambiguous. The fix is to serialize them into a linear chain.

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)