### PR TITLE
fix(kiro): stabilize agent credit tracking and display

### DIFF
--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -161,6 +161,33 @@ def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> 
     return "updated" if existed else "created"
 
 
+def _rewrite_kiro_hooks(content: dict) -> dict:
+    """Rewrite Kiro hook commands to use the current Python interpreter.
+
+    The server generates commands with bare 'python3' which won't find
+    observal_cli when installed in a project-local virtual environment.
+    """
+    hooks = content.get("hooks")
+    agent_name = content.get("name")
+    if not hooks or not agent_name:
+        return content
+
+    from observal_cli.ide_specs.kiro_hooks_spec import build_kiro_hooks
+
+    cfg = config.get_or_exit()
+    hooks_url = f"{cfg['server_url'].rstrip('/')}/api/v1/telemetry/hooks"
+    desired_hooks = build_kiro_hooks(hooks_url, agent_name)
+
+    # Replace only Observal hooks, preserve any user-added hooks
+    for event, desired_entries in desired_hooks.items():
+        existing = hooks.get(event, [])
+        cleaned = [h for h in existing if "observal_cli" not in h.get("command", "")]
+        hooks[event] = cleaned + desired_entries
+
+    content["hooks"] = hooks
+    return content
+
+
 def _resolve_path(raw_path: str, target_dir: Path, *, allow_home: bool = False) -> Path:
     """Resolve a path from the config snippet relative to *target_dir*.
 
@@ -340,6 +367,10 @@ def register_pull(app: typer.Typer):
         # ── agent_file (Kiro) ───────────────────────────────
         agent_file = snippet.get("agent_file")
         if agent_file:
+            # Rewrite hook commands to use the current Python interpreter
+            # so they work regardless of which directory Kiro is launched from.
+            if isinstance(agent_file.get("content"), dict):
+                agent_file["content"] = _rewrite_kiro_hooks(agent_file["content"])
             p = _resolve_path(agent_file["path"], target_dir, allow_home=is_user_scope)
             if dry_run:
                 written.append((str(p), "would write"))

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -186,6 +186,18 @@ def main():
             else:
                 payload["session_id"] = f"kiro-{os.getppid()}"
 
+    # Persist session_id so the stop hook (which may not receive it from Kiro)
+    # can reuse it and land credits on the same session.
+    try:
+        session_file = Path.home() / ".observal" / ".kiro-session"
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text(json.dumps({
+            "session_id": payload["session_id"],
+            "cwd": payload.get("cwd", ""),
+        }))
+    except Exception:
+        pass
+
     # Inject user_id and user_name from Observal config if not already present
     if not payload.get("user_id") or not payload.get("user_name"):
         try:

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -16,12 +16,31 @@ Usage (in a Kiro agent hook):
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 from observal_cli.hooks._kiro_utils import _find_kiro_cli_pid, _resolve_hooks_url
+
+_DEBUG = os.environ.get("OBSERVAL_DEBUG") == "1"
+_LOG_PATH = Path.home() / ".observal" / "hook-debug.log"
+
+logger = logging.getLogger(__name__)
+
+
+def _debug(msg: str) -> None:
+    """Write debug message to log file when OBSERVAL_DEBUG=1."""
+    if not _DEBUG:
+        return
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with _LOG_PATH.open("a") as f:
+            f.write(f"[kiro_stop_hook] {msg}\n")
+    except Exception:
+        pass
 
 
 def _get_kiro_db() -> Path | None:
@@ -45,43 +64,58 @@ def _get_kiro_db() -> Path | None:
     return None
 
 
+def _read_conversation(kiro_db: Path, cwd: str) -> tuple[str, dict] | None:
+    """Read the most recent conversation for *cwd* from Kiro's SQLite DB."""
+    conn = sqlite3.connect(f"file:{kiro_db}?mode=ro", uri=True)
+    cur = conn.cursor()
+    if cwd:
+        cur.execute(
+            "SELECT conversation_id, value FROM conversations_v2 WHERE key = ? ORDER BY updated_at DESC LIMIT 1",
+            (cwd,),
+        )
+    else:
+        cur.execute("SELECT conversation_id, value FROM conversations_v2 ORDER BY updated_at DESC LIMIT 1")
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        return None
+    conversation_id, value_str = row
+    return conversation_id, json.loads(value_str)
+
+
 def _enrich(payload: dict) -> dict:
     """Read the Kiro SQLite DB and merge session-level stats into *payload*."""
     kiro_db = _get_kiro_db()
     if not kiro_db:
+        _debug("Kiro DB not found")
         return payload
 
     cwd = payload.get("cwd", "")
+    _debug(f"cwd={cwd}, db={kiro_db}")
 
     try:
-        conn = sqlite3.connect(f"file:{kiro_db}?mode=ro", uri=True)
-        cur = conn.cursor()
+        result = _read_conversation(kiro_db, cwd)
 
-        # Find the most recent conversation for this cwd
-        if cwd:
-            cur.execute(
-                "SELECT conversation_id, value FROM conversations_v2 WHERE key = ? ORDER BY updated_at DESC LIMIT 1",
-                (cwd,),
-            )
-        else:
-            cur.execute("SELECT conversation_id, value FROM conversations_v2 ORDER BY updated_at DESC LIMIT 1")
+        # Kiro may not have committed the conversation to SQLite yet when the
+        # stop hook fires. Retry with increasing delays.
+        if not result:
+            for delay in (0.5, 1.0, 1.5):
+                _debug(f"No conversation found for cwd, retrying after {delay}s...")
+                time.sleep(delay)
+                result = _read_conversation(kiro_db, cwd)
+                if result:
+                    break
 
-        row = cur.fetchone()
-        conn.close()
-
-        if not row:
+        if not result:
+            _debug("No conversation found for cwd after retries")
             return payload
 
-        conversation_id, value_str = row
-        conv = json.loads(value_str)
+        conversation_id, conv = result
 
-        # Include the real conversation_id for cross-session linking.
-        # The $PPID-based session_id (injected via sed before this script) groups
-        # events within a single kiro-cli run. The conversation_id persists across
-        # resumed sessions — the dashboard can use it to link related sessions.
         if conversation_id:
             payload["conversation_id"] = conversation_id
-    except Exception:
+    except Exception as e:
+        _debug(f"DB read error: {e}")
         return payload
 
     # --- Extract model info ---
@@ -117,9 +151,24 @@ def _enrich(payload: dict) -> dict:
     # --- Credit usage ---
     utm = conv.get("user_turn_metadata", {})
     usage_info = utm.get("usage_info", [])
-    total_credits = 0.0
-    for u in usage_info:
-        total_credits += u.get("value", 0.0)
+
+    # Kiro writes usage_info asynchronously — if empty on first read but we
+    # have history entries, retry after a short delay.
+    if not usage_info and history:
+        _debug("usage_info empty, retrying after 500ms...")
+        time.sleep(0.5)
+        try:
+            result2 = _read_conversation(kiro_db, cwd)
+            if result2:
+                conv2 = result2[1]
+                utm = conv2.get("user_turn_metadata", {})
+                usage_info = utm.get("usage_info", [])
+                _debug(f"Retry result: {len(usage_info)} usage_info items")
+        except Exception:
+            pass
+
+    total_credits = sum(u.get("value", 0.0) for u in usage_info) if usage_info else None
+    _debug(f"credits={total_credits}, turn_count={turn_count}, usage_items={len(usage_info)}")
 
     # --- Resolve the actual model used ---
     # If model_id is "auto", try to use per-turn model_ids
@@ -134,7 +183,8 @@ def _enrich(payload: dict) -> dict:
     if resolved_model and not payload.get("model"):
         payload["model"] = resolved_model
     payload["turn_count"] = str(turn_count)
-    payload["credits"] = f"{total_credits:.6f}"
+    if total_credits is not None:
+        payload["credits"] = f"{total_credits:.6f}"
 
     if tools_used:
         # Deduplicate while preserving order
@@ -175,7 +225,24 @@ def main():
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
+    _debug(f"payload keys: {list(payload.keys())}")
+    _debug(f"payload: {json.dumps(payload)[:2000]}")
+
     payload.setdefault("service_name", "kiro")
+
+    if not payload.get("session_id"):
+        # Kiro 2.x sends session_id on agentSpawn/userPromptSubmit but NOT on
+        # stop events. Read the session_id persisted by the non-stop hook so
+        # credits land on the same session the user sees in the UI.
+        session_file = Path.home() / ".observal" / ".kiro-session"
+        try:
+            if session_file.exists():
+                cached = json.loads(session_file.read_text())
+                if cached.get("session_id"):
+                    payload["session_id"] = cached["session_id"]
+                    _debug(f"Reused persisted session_id: {cached['session_id']}")
+        except Exception:
+            pass
 
     if not payload.get("session_id"):
         env_pid = os.environ.get("KIRO_CLI_PID")

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -325,6 +326,37 @@ class TestPullKiro:
         data = json.loads(agent.read_text())
         assert data["name"] == "my-agent"
         assert data["tools"] == ["search"]
+
+    def test_rewrites_hook_python_path(self, tmp_path: Path):
+        """Hook commands should use sys.executable, not bare python3."""
+        snippet = {
+            "config_snippet": {
+                "agent_file": {
+                    "path": "~/.kiro/agents/my-agent.json",
+                    "content": {
+                        "name": "my-agent",
+                        "tools": ["search"],
+                        "hooks": {
+                            "agentSpawn": [{"command": "python3 -m observal_cli.hooks.kiro_hook --url http://localhost:8000/api/v1/telemetry/hooks --agent-name my-agent"}],
+                            "stop": [{"command": "python3 -m observal_cli.hooks.kiro_stop_hook --url http://localhost:8000/api/v1/telemetry/hooks --agent-name my-agent"}],
+                        },
+                    },
+                }
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(
+                cli_app, ["agent", "pull", "abc123", "--ide", "kiro", "--dir", str(tmp_path), "--no-prompt"]
+            )
+
+        assert result.exit_code == 0, result.output
+        agent = tmp_path / ".kiro" / "agents" / "my-agent.json"
+        data = json.loads(agent.read_text())
+        # All hook commands should use sys.executable, not bare python3
+        for event, entries in data["hooks"].items():
+            for h in entries:
+                assert sys.executable in h["command"], f"{event} hook missing sys.executable: {h['command']}"
+                assert not h["command"].startswith("python3 ")
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/web/src/app/(user)/traces/[id]/page.tsx
+++ b/web/src/app/(user)/traces/[id]/page.tsx
@@ -1293,7 +1293,7 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawSessionEv
       {stats.isKiro ? (
         <div className="space-y-1">
           <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Credits</p>
-          <p className="text-lg font-semibold tabular-nums text-orange-500">{formatCredits(stats.credits)}</p>
+          <p className="text-lg font-semibold tabular-nums text-orange-500">{stats.credits > 0 ? formatCredits(stats.credits) : "—"}</p>
         </div>
       ) : !stats.isCopilotCli ? (
         <>

--- a/web/src/app/(user)/traces/page.tsx
+++ b/web/src/app/(user)/traces/page.tsx
@@ -73,11 +73,11 @@ function fmtTokens(n: number | string | undefined): string {
   return `${num}`;
 }
 
-function fmtCredits(c: string | undefined): string {
-  if (!c) return "0.00";
+function fmtCredits(c: string | undefined): string | null {
+  if (!c) return null;
   const num = parseFloat(c);
-  if (isNaN(num)) return "0.00";
-  return num < 0.01 && num > 0 ? num.toFixed(4) : num.toFixed(2);
+  if (isNaN(num) || num <= 0) return null;
+  return num < 0.01 ? num.toFixed(4) : num.toFixed(2);
 }
 
 function fmtDuration(first?: string, last?: string): string {
@@ -184,9 +184,18 @@ const columns: ColumnDef<Session>[] = [
         );
       }
       if (isKiroSession(r)) {
+        const credits = fmtCredits(r.credits);
+        if (credits) {
+          return (
+            <span className="text-[13px] font-mono tabular-nums text-orange-400">
+              {credits} cr
+            </span>
+          );
+        }
+        const count = r.prompt_count ?? 0;
         return (
-          <span className="text-[13px] font-mono tabular-nums text-orange-400">
-            {fmtCredits(r.credits)} cr
+          <span className="text-[13px] text-muted-foreground">
+            {count} prompt{count !== 1 ? "s" : ""}
           </span>
         );
       }


### PR DESCRIPTION
## Purpose / Description

Kiro 2.x changed its hook behavior: `session_id` is sent on non-stop events (agentSpawn, userPromptSubmit) but NOT on stop events. This caused credits to land on a ghost session. Additionally, Kiro 2.2.0 no longer writes conversation data to its local SQLite database, breaking the credit enrichment strategy entirely.

This PR stabilizes Kiro agent telemetry so traces always show useful data regardless of where the agent is called from.

## Fixes
* Fixes #693

## Approach

1. **Session ID persistence** — The non-stop hook (`kiro_hook.py`) persists the session_id to `~/.observal/.kiro-session`. The stop hook reads it back, ensuring credits land on the correct session.

2. **Frontend fallback** — When credits aren't available (Kiro 2.2.0 doesn't write to SQLite), show prompt count ("N prompts") instead of "—" in the Tokens column. Credits display correctly when available from older Kiro versions.

3. **Hook python path rewriting** — `cmd_pull.py` rewrites bare `python3` in Kiro hook commands to `sys.executable`, ensuring hooks work with `uv`-based installs.

4. **Debug diagnostics** — When `OBSERVAL_DEBUG=1`, the stop hook dumps the full payload to `~/.observal/hook-debug.log` for future investigation of what Kiro 2.2.0 sends natively.

## How Has This Been Tested?

- `uv run pytest tests/test_pull_and_agent_cli.py` — 39 tests pass
- TypeScript compilation passes (`tsc --noEmit`)
- Manual E2E: run Kiro agent from outside repo directory, verify traces appear with prompt count in frontend
- Debug logging verified via `OBSERVAL_DEBUG=1`

## Learning (optional)

Kiro CLI 2.2.0 no longer populates the `conversations_v2` SQLite table during or after agent sessions (last entry is from April 25). The enrichment strategy that reads credits from SQLite is broken for 2.x. Future work: parse native Kiro hook payload fields if/when they add credit data.

## Checklist

- [x] All commits are signed off per the DCO
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: frontend now shows "N prompts" instead of "—" for Kiro sessions without credit data