### PR TITLE
feat: custom branding (logo, wordmark, app name) in admin settings

### DIFF
--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -116,12 +116,76 @@ _ALLOWED_LOGO_MIMES = {
     "image/webp",
 }
 _MAX_LOGO_BYTES = 2 * 1024 * 1024
+_MAX_DATA_URL_LEN = 3 * 1024 * 1024  # base64 bloats ~33%, cap raw string
 _MAX_APP_NAME_LEN = 30
+
+# Magic byte signatures for allowed image formats
+_MAGIC_BYTES: dict[str, list[bytes]] = {
+    "image/png": [b"\x89PNG\r\n\x1a\n"],
+    "image/jpeg": [b"\xff\xd8\xff"],
+    "image/webp": [b"RIFF"],  # RIFF....WEBP
+    "image/x-icon": [b"\x00\x00\x01\x00", b"\x00\x00\x02\x00"],
+    "image/vnd.microsoft.icon": [b"\x00\x00\x01\x00", b"\x00\x00\x02\x00"],
+    # SVG is validated separately via _sanitize_svg
+}
+
+# SVG elements and attributes that can execute code or make external requests
+_SVG_DANGEROUS_TAGS = re.compile(
+    r"<[\s/]*(script|foreignObject|iframe|embed|object|applet|meta|link|style|handler|set|animate|animateTransform|animateMotion)\b",
+    re.IGNORECASE,
+)
+_SVG_EVENT_ATTRS = re.compile(r"\bon\w+\s*=", re.IGNORECASE)
+_SVG_JS_HREF = re.compile(r"(?:href|xlink:href)[\s=\"']*javascript:", re.IGNORECASE)
+_SVG_EXTERNAL_REF = re.compile(r"(?:href|xlink:href|src|url)[\s=\"']*(?:https?://|//|data:(?!image/))", re.IGNORECASE)
+_SVG_XML_DECL = re.compile(r"<!(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
+
+# Characters forbidden in the app name
+_UNSAFE_NAME_CHARS = re.compile("[\x00-\x1f\x7f\u200b-\u200f\u202a-\u202e\u2060-\u2064\ufeff]")
+
+
+def _validate_magic_bytes(raw: bytes, mime_type: str) -> None:
+    """Verify the file's actual bytes match the claimed MIME type."""
+    signatures = _MAGIC_BYTES.get(mime_type)
+    if signatures is None:
+        return  # SVG handled separately
+    if not any(raw.startswith(sig) for sig in signatures):
+        raise HTTPException(status_code=422, detail=f"File content does not match declared type {mime_type}")
+    if mime_type == "image/webp" and raw[8:12] != b"WEBP":
+        raise HTTPException(status_code=422, detail="File content does not match declared type image/webp")
+
+
+def _sanitize_svg(raw: bytes) -> bytes:
+    """Reject SVGs containing dangerous elements or attributes."""
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=422, detail="SVG contains invalid UTF-8")
+
+    if _SVG_XML_DECL.search(text):
+        raise HTTPException(status_code=422, detail="SVG must not contain DOCTYPE or ENTITY declarations")
+    if _SVG_DANGEROUS_TAGS.search(text):
+        raise HTTPException(
+            status_code=422, detail="SVG contains forbidden elements (script, foreignObject, iframe, etc.)"
+        )
+    if _SVG_EVENT_ATTRS.search(text):
+        raise HTTPException(
+            status_code=422, detail="SVG contains forbidden event handler attributes (onclick, onload, etc.)"
+        )
+    if _SVG_JS_HREF.search(text):
+        raise HTTPException(status_code=422, detail="SVG contains javascript: URLs")
+    if _SVG_EXTERNAL_REF.search(text):
+        raise HTTPException(status_code=422, detail="SVG contains external resource references")
+
+    return raw
 
 
 def _validate_branding_logo(value: str) -> None:
     if not value:
         return
+
+    if len(value) > _MAX_DATA_URL_LEN:
+        raise HTTPException(status_code=422, detail="Image data too large")
+
     match = re.match(r"^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", value, re.DOTALL)
     if not match:
         raise HTTPException(status_code=422, detail="Logo must be a base64 data URL (data:image/...;base64,...)")
@@ -140,12 +204,21 @@ def _validate_branding_logo(value: str) -> None:
         max_mb = _MAX_LOGO_BYTES // (1024 * 1024)
         raise HTTPException(status_code=422, detail=f"Logo too large ({size_mb}MB). Maximum: {max_mb}MB")
 
+    if mime_type == "image/svg+xml":
+        _sanitize_svg(raw)
+    else:
+        _validate_magic_bytes(raw, mime_type)
+
 
 def _validate_branding_app_name(value: str) -> None:
     if len(value) > _MAX_APP_NAME_LEN:
         raise HTTPException(
             status_code=422, detail=f"App name too long ({len(value)} chars). Maximum: {_MAX_APP_NAME_LEN}"
         )
+    if _UNSAFE_NAME_CHARS.search(value):
+        raise HTTPException(status_code=422, detail="App name contains forbidden control or invisible characters")
+    if "<" in value and ">" in value:
+        raise HTTPException(status_code=422, detail="App name must not contain HTML tags")
 
 
 # ── Enterprise Settings ──────────────────────────────────

--- a/observal-server/api/routes/admin.py
+++ b/observal-server/api/routes/admin.py
@@ -1,6 +1,8 @@
+import base64
 import hashlib
 import json
 import logging
+import re
 import secrets
 import uuid
 
@@ -103,6 +105,49 @@ async def diagnostics(
     return diag
 
 
+# ── Branding Validation ──────────────────────────────────
+
+_ALLOWED_LOGO_MIMES = {
+    "image/png",
+    "image/svg+xml",
+    "image/x-icon",
+    "image/vnd.microsoft.icon",
+    "image/jpeg",
+    "image/webp",
+}
+_MAX_LOGO_BYTES = 2 * 1024 * 1024
+_MAX_APP_NAME_LEN = 30
+
+
+def _validate_branding_logo(value: str) -> None:
+    if not value:
+        return
+    match = re.match(r"^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", value, re.DOTALL)
+    if not match:
+        raise HTTPException(status_code=422, detail="Logo must be a base64 data URL (data:image/...;base64,...)")
+    mime_type = match.group(1)
+    b64_data = match.group(2)
+    if mime_type not in _ALLOWED_LOGO_MIMES:
+        raise HTTPException(
+            status_code=422, detail=f"Unsupported image type: {mime_type}. Allowed: PNG, SVG, ICO, JPEG, WEBP"
+        )
+    try:
+        raw = base64.b64decode(b64_data)
+    except Exception:
+        raise HTTPException(status_code=422, detail="Invalid base64 data")
+    if len(raw) > _MAX_LOGO_BYTES:
+        size_mb = round(len(raw) / (1024 * 1024), 1)
+        max_mb = _MAX_LOGO_BYTES // (1024 * 1024)
+        raise HTTPException(status_code=422, detail=f"Logo too large ({size_mb}MB). Maximum: {max_mb}MB")
+
+
+def _validate_branding_app_name(value: str) -> None:
+    if len(value) > _MAX_APP_NAME_LEN:
+        raise HTTPException(
+            status_code=422, detail=f"App name too long ({len(value)} chars). Maximum: {_MAX_APP_NAME_LEN}"
+        )
+
+
 # ── Enterprise Settings ──────────────────────────────────
 
 
@@ -138,6 +183,11 @@ async def upsert_setting(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
+    if key in ("branding.logo", "branding.wordmark"):
+        _validate_branding_logo(req.value)
+    elif key == "branding.app_name":
+        _validate_branding_app_name(req.value)
+
     result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key == key))
     cfg = result.scalar_one_or_none()
     if cfg:

--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 
 from api.deps import get_db
 from config import settings
+from models.enterprise_config import EnterpriseConfig
 
 router = APIRouter(prefix="/api/v1/config", tags=["config"])
 
@@ -68,10 +69,32 @@ async def get_public_config(db=Depends(get_db)):
         except Exception:
             pass
 
+    branding_logo = None
+    branding_app_name = None
+    branding_wordmark = None
+    try:
+        result = await db.execute(
+            select(EnterpriseConfig).where(
+                EnterpriseConfig.key.in_(["branding.logo", "branding.app_name", "branding.wordmark"])
+            )
+        )
+        for cfg in result.scalars().all():
+            if cfg.key == "branding.logo" and cfg.value:
+                branding_logo = cfg.value
+            elif cfg.key == "branding.app_name" and cfg.value:
+                branding_app_name = cfg.value
+            elif cfg.key == "branding.wordmark" and cfg.value:
+                branding_wordmark = cfg.value
+    except Exception:
+        pass
+
     return {
         "deployment_mode": settings.DEPLOYMENT_MODE,
         "sso_enabled": bool(settings.OAUTH_CLIENT_ID),
         "sso_only": settings.SSO_ONLY,
         "saml_enabled": saml_enabled,
         "eval_configured": bool(settings.EVAL_MODEL_NAME),
+        "branding_logo": branding_logo,
+        "branding_app_name": branding_app_name,
+        "branding_wordmark": branding_wordmark,
     }

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
-import { Settings, Plus, Pencil, Trash2, Save, X, Loader2, Info, Database, Activity, BookOpen, Shield, HelpCircle, Eye } from "lucide-react";
+import { useState, useCallback, useEffect, useRef } from "react";
+import { Settings, Plus, Pencil, Trash2, Save, X, Loader2, Info, Database, Activity, BookOpen, Shield, HelpCircle, Eye, Upload, RotateCcw, Palette } from "lucide-react";
 import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAdminSettings } from "@/hooks/use-api";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 import { useRoleGuard, hasMinRole } from "@/hooks/use-role-guard";
@@ -109,6 +110,9 @@ function SettingRow({
   );
 }
 
+const ALLOWED_LOGO_TYPES = ["image/png", "image/svg+xml", "image/x-icon", "image/vnd.microsoft.icon", "image/jpeg", "image/webp"];
+const MAX_LOGO_SIZE = 2 * 1024 * 1024;
+
 interface SettingDef {
   key: string;
   description: string;
@@ -184,8 +188,9 @@ const ALL_DEFAULT_SETTINGS = SETTING_SECTIONS.flatMap((s) => s.settings);
 
 export default function SettingsPage() {
   const { ready } = useRoleGuard("admin");
+  const queryClient = useQueryClient();
   const { data: settings, isLoading, isError, error, refetch } = useAdminSettings();
-  const { deploymentMode, ssoEnabled, samlEnabled, evalConfigured } = useDeploymentConfig();
+  const { deploymentMode, ssoEnabled, samlEnabled, evalConfigured, brandingLogo, brandingAppName, brandingWordmark } = useDeploymentConfig();
   const [addingKey, setAddingKey] = useState("");
   const [addingValue, setAddingValue] = useState("");
   const [showAdd, setShowAdd] = useState(false);
@@ -197,6 +202,16 @@ export default function SettingsPage() {
   const [registeredAgentsOnly, setRegisteredAgentsOnly] = useState(false);
   const [registeredAgentsOnlyLoading, setRegisteredAgentsOnlyLoading] = useState(true);
   const [registeredAgentsOnlyToggling, setRegisteredAgentsOnlyToggling] = useState(false);
+  const [logoOverride, setLogoOverride] = useState<string | null | undefined>(undefined);
+  const [wordmarkOverride, setWordmarkOverride] = useState<string | null | undefined>(undefined);
+  const [appNameOverride, setAppNameOverride] = useState<string | undefined>(undefined);
+  const [brandingSaving, setBrandingSaving] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const wordmarkInputRef = useRef<HTMLInputElement>(null);
+
+  const logoPreview = logoOverride !== undefined ? logoOverride : brandingLogo;
+  const wordmarkPreview = wordmarkOverride !== undefined ? wordmarkOverride : brandingWordmark;
+  const appNameDraft = appNameOverride !== undefined ? appNameOverride : (brandingAppName || "");
 
   useEffect(() => {
     admin.getTracePrivacy()
@@ -238,6 +253,65 @@ export default function SettingsPage() {
       setRegisteredAgentsOnlyToggling(false);
     }
   }, []);
+
+  const handleImageFile = useCallback((file: File, setter: (v: string) => void) => {
+    if (!ALLOWED_LOGO_TYPES.includes(file.type)) {
+      toast.error("Unsupported file type. Use PNG, SVG, ICO, JPEG, or WEBP.");
+      return;
+    }
+    if (file.size > MAX_LOGO_SIZE) {
+      toast.error(`File too large (${Math.round(file.size / 1024)}KB). Maximum: 2MB.`);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => setter(reader.result as string);
+    reader.readAsDataURL(file);
+  }, []);
+
+  const handleSaveBranding = useCallback(async () => {
+    setBrandingSaving(true);
+    try {
+      if (logoPreview !== brandingLogo) {
+        await admin.updateSetting("branding.logo", { value: logoPreview || "" });
+      }
+      if (wordmarkPreview !== brandingWordmark) {
+        await admin.updateSetting("branding.wordmark", { value: wordmarkPreview || "" });
+      }
+      const trimmedName = appNameDraft.trim();
+      if (trimmedName !== (brandingAppName || "")) {
+        await admin.updateSetting("branding.app_name", { value: trimmedName });
+      }
+      setLogoOverride(undefined);
+      setWordmarkOverride(undefined);
+      setAppNameOverride(undefined);
+      queryClient.invalidateQueries({ queryKey: ["config", "public"] });
+      toast.success("Branding updated");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save branding");
+    } finally {
+      setBrandingSaving(false);
+    }
+  }, [logoPreview, brandingLogo, wordmarkPreview, brandingWordmark, appNameDraft, brandingAppName, queryClient]);
+
+  const handleResetBranding = useCallback(async () => {
+    setBrandingSaving(true);
+    try {
+      await admin.updateSetting("branding.logo", { value: "" });
+      await admin.updateSetting("branding.wordmark", { value: "" });
+      await admin.updateSetting("branding.app_name", { value: "" });
+      setLogoOverride(undefined);
+      setWordmarkOverride(undefined);
+      setAppNameOverride(undefined);
+      queryClient.invalidateQueries({ queryKey: ["config", "public"] });
+      toast.success("Branding reset to defaults");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to reset branding");
+    } finally {
+      setBrandingSaving(false);
+    }
+  }, [queryClient]);
+
+  const hasBrandingChanges = logoPreview !== brandingLogo || wordmarkPreview !== brandingWordmark || appNameDraft.trim() !== (brandingAppName || "");
 
   const entries: { key: string; value: string }[] = Array.isArray(settings)
     ? settings.map((s: AdminSetting) => ({ key: s.key, value: s.value }))
@@ -342,6 +416,106 @@ export default function SettingsPage() {
               <span>Enterprise mode is active. Self-registration and password login are disabled.</span>
             </div>
           )}
+        </section>
+
+        {/* Branding */}
+        <section className="animate-in">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-1.5">
+            <Palette className="h-3.5 w-3.5" />
+            Branding
+          </h3>
+          <div className="rounded-md border border-border bg-card px-4 py-3 space-y-3">
+            <p className="text-xs text-muted-foreground">
+              PNG, SVG, ICO, JPEG, or WEBP. Max 2MB. Transparent images recommended for theme compatibility.
+            </p>
+            <div className="flex flex-wrap gap-4">
+              {/* Logo icon */}
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium">Icon</p>
+                <div
+                  className="w-12 h-12 rounded border-2 border-dashed border-border flex items-center justify-center cursor-pointer hover:border-primary/50 transition-colors bg-muted/30"
+                  onClick={() => fileInputRef.current?.click()}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => { e.preventDefault(); const f = e.dataTransfer.files[0]; if (f) handleImageFile(f, setLogoOverride); }}
+                >
+                  {logoPreview ? (
+                    <img src={logoPreview} alt="Icon" className="w-8 h-8 object-contain" />
+                  ) : (
+                    <Upload className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </div>
+                <input ref={fileInputRef} type="file" accept="image/png,image/svg+xml,image/x-icon,image/jpeg,image/webp" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; if (f) handleImageFile(f, setLogoOverride); e.target.value = ""; }} />
+                <div className="flex gap-1">
+                  <Button variant="ghost" size="sm" className="h-6 text-[11px] px-1.5" onClick={() => fileInputRef.current?.click()}>Upload</Button>
+                  {logoPreview && <Button variant="ghost" size="sm" className="h-6 text-[11px] px-1.5 text-muted-foreground" onClick={() => setLogoOverride(null)}>Remove</Button>}
+                </div>
+              </div>
+              {/* Wordmark */}
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium">Wordmark <span className="text-muted-foreground font-normal">(optional, replaces text)</span></p>
+                <div
+                  className="w-28 h-12 rounded border-2 border-dashed border-border flex items-center justify-center cursor-pointer hover:border-primary/50 transition-colors bg-muted/30"
+                  onClick={() => wordmarkInputRef.current?.click()}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => { e.preventDefault(); const f = e.dataTransfer.files[0]; if (f) handleImageFile(f, setWordmarkOverride); }}
+                >
+                  {wordmarkPreview ? (
+                    <img src={wordmarkPreview} alt="Wordmark" className="h-6 max-w-24 object-contain" />
+                  ) : (
+                    <Upload className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </div>
+                <input ref={wordmarkInputRef} type="file" accept="image/png,image/svg+xml,image/x-icon,image/jpeg,image/webp" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; if (f) handleImageFile(f, setWordmarkOverride); e.target.value = ""; }} />
+                <div className="flex gap-1">
+                  <Button variant="ghost" size="sm" className="h-6 text-[11px] px-1.5" onClick={() => wordmarkInputRef.current?.click()}>Upload</Button>
+                  {wordmarkPreview && <Button variant="ghost" size="sm" className="h-6 text-[11px] px-1.5 text-muted-foreground" onClick={() => setWordmarkOverride(null)}>Remove</Button>}
+                </div>
+              </div>
+              {/* App name (text fallback) */}
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium">App Name <span className="text-muted-foreground font-normal">(used when no wordmark)</span></p>
+                <Input
+                  value={appNameDraft}
+                  onChange={(e) => setAppNameOverride(e.target.value)}
+                  placeholder="Observal"
+                  maxLength={30}
+                  className="h-8 text-sm w-48"
+                />
+                <p className="text-[11px] text-muted-foreground">{appNameDraft.length}/30</p>
+              </div>
+            </div>
+            {/* Preview + actions */}
+            <div className="flex items-center gap-4 pt-1 border-t border-border">
+              <div className="rounded bg-sidebar px-3 py-2 inline-flex items-center gap-2">
+                <div className="flex size-8 shrink-0 items-center justify-center">
+                  {logoPreview ? (
+                    <img src={logoPreview} alt="" className="w-5 h-5 object-contain" />
+                  ) : (
+                    <img src="/favicon.ico" alt="" className="w-5 h-5" />
+                  )}
+                </div>
+                {wordmarkPreview ? (
+                  <img src={wordmarkPreview} alt="" className="h-4 max-w-35 object-contain object-left" />
+                ) : (
+                  <span className="text-sm font-semibold tracking-tight font-display text-sidebar-foreground truncate max-w-35">
+                    {appNameDraft.trim() || "Observal"}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <Button size="sm" className="h-7 text-xs" onClick={handleSaveBranding} disabled={brandingSaving || !hasBrandingChanges}>
+                  {brandingSaving ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <Save className="mr-1 h-3 w-3" />}
+                  Save
+                </Button>
+                {(brandingLogo || brandingAppName || brandingWordmark) && (
+                  <Button size="sm" variant="outline" className="h-7 text-xs" onClick={handleResetBranding} disabled={brandingSaving}>
+                    <RotateCcw className="mr-1 h-3 w-3" />
+                    Reset
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
         </section>
 
         {/* Trace Privacy */}

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -313,9 +313,10 @@ export default function SettingsPage() {
 
   const hasBrandingChanges = logoPreview !== brandingLogo || wordmarkPreview !== brandingWordmark || appNameDraft.trim() !== (brandingAppName || "");
 
-  const entries: { key: string; value: string }[] = Array.isArray(settings)
+  const entries: { key: string; value: string }[] = (Array.isArray(settings)
     ? settings.map((s: AdminSetting) => ({ key: s.key, value: s.value }))
-    : Object.entries(settings ?? {}).map(([k, v]) => ({ key: k, value: String(v) }));
+    : Object.entries(settings ?? {}).map(([k, v]) => ({ key: k, value: String(v) }))
+  ).filter((e) => !e.key.startsWith("branding."));
 
   const existingKeys = new Set(entries.map((e) => e.key));
   const missingSections = SETTING_SECTIONS

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { makeQueryClient } from "@/lib/query-client";
+import { DynamicTitle } from "@/components/dynamic-title";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(makeQueryClient);
@@ -19,6 +20,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       >
         {children}
       </ThemeProvider>
+      <DynamicTitle />
     </QueryClientProvider>
   );
 }

--- a/web/src/components/dynamic-title.tsx
+++ b/web/src/components/dynamic-title.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { useDeploymentConfig } from "@/hooks/use-deployment-config";
+
+export function DynamicTitle() {
+  const { brandingAppName } = useDeploymentConfig();
+
+  useEffect(() => {
+    document.title = brandingAppName || "Observal";
+  }, [brandingAppName]);
+
+  return null;
+}

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -91,7 +91,7 @@ export function RegistrySidebar() {
   const snap = useSyncExternalStore(storeSub, getAuthSnap, getServerSnap);
   const [token, role, userName, userEmail] = snap.split("|");
   const isAuthenticated = !!token;
-  const { deploymentMode } = useDeploymentConfig();
+  const { deploymentMode, brandingLogo, brandingAppName, brandingWordmark } = useDeploymentConfig();
 
   function isActive(href: string) {
     if (href === "/") return pathname === "/";
@@ -132,12 +132,20 @@ export function RegistrySidebar() {
             <SidebarMenuButton size="lg" asChild>
               <Link href="/">
                 <div className="flex size-8 shrink-0 items-center justify-center">
-                  <Image src="/favicon.ico" alt="" width={20} height={20} />
+                  {brandingLogo ? (
+                    <img src={brandingLogo} alt="" width={20} height={20} className="object-contain" />
+                  ) : (
+                    <Image src="/favicon.ico" alt="" width={20} height={20} />
+                  )}
                 </div>
                 <div className="flex flex-col gap-0.5 leading-none">
-                  <span className="text-base font-semibold tracking-tight font-[family-name:var(--font-display)]">
-                    Observal
-                  </span>
+                  {brandingWordmark ? (
+                    <img src={brandingWordmark} alt={brandingAppName || "Observal"} className="h-5 max-w-35 object-contain object-left" />
+                  ) : (
+                    <span className="text-base font-semibold tracking-tight font-display truncate max-w-35">
+                      {brandingAppName || "Observal"}
+                    </span>
+                  )}
                 </div>
               </Link>
             </SidebarMenuButton>

--- a/web/src/hooks/use-deployment-config.ts
+++ b/web/src/hooks/use-deployment-config.ts
@@ -17,6 +17,9 @@ export function useDeploymentConfig() {
     ssoOnly: data?.sso_only ?? false,
     samlEnabled: data?.saml_enabled ?? false,
     evalConfigured: data?.eval_configured ?? false,
+    brandingLogo: data?.branding_logo ?? null,
+    brandingAppName: data?.branding_app_name ?? null,
+    brandingWordmark: data?.branding_wordmark ?? null,
     loading: isLoading,
   };
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -468,6 +468,9 @@ export type PublicConfig = {
   sso_only: boolean;
   saml_enabled: boolean;
   eval_configured: boolean;
+  branding_logo: string | null;
+  branding_app_name: string | null;
+  branding_wordmark: string | null;
 };
 
 export const config = {


### PR DESCRIPTION
## Summary

Adds custom branding to Observal — admins can replace the sidebar logo, app name, and optionally upload a wordmark image. Changes are visible to **all users** on the server.

Closes #721
feature suggested by @dhanpraja231 

## What's included

- **Icon upload** — replaces the telescope favicon in the sidebar
- **Wordmark upload** (optional) — replaces the "Observal" text with an image (for companies with logo-style names)
- **App name text input** — fallback when no wordmark is set, max 30 chars
- **Live preview** — shows exactly how it looks on the dark sidebar before saving
- **Dynamic page title** — browser tab updates to match the custom app name
- **Reset to default** — one-click revert to Observal branding
- **Backend validation** — file type (PNG, SVG, ICO, JPEG, WEBP), size (max 2MB), and name length enforced
<img width="2827" height="1524" alt="image" src="https://github.com/user-attachments/assets/519f54f3-c217-4b7d-915e-c98a2be56908" />


## Access

- Available to **admin** and **super_admin** roles only
- Works in both **local** and **enterprise** deployment modes
- Stored in the existing `enterprise_config` table — no migrations needed

## Tested

- Uploaded logo and wordmark, saved, verified sidebar updated for all users on the same server
- Reset to default works correctly
- Invalid file types and oversized files are rejected with clear error messages
- Browser tab title updates dynamically
- Falls back to Observal defaults when no branding is configured
