### PR TITLE
fix(agent-edit): allow admins to release versions, save draft as new …

### DIFF
--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 
-from api.deps import get_db, get_effective_agent_permission, require_role
+from api.deps import ROLE_HIERARCHY, get_db, get_effective_agent_permission, require_role
 from models.agent import (
     Agent,
     AgentGoalSection,
@@ -173,9 +173,10 @@ async def _create_agent_version(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     is_owner = agent.created_by == current_user.id
     is_co_maintainer = str(current_user.id) in [str(uid) for uid in (agent.co_maintainers or [])]
-    if not is_owner and not is_co_maintainer:
+    if not is_admin and not is_owner and not is_co_maintainer:
         raise HTTPException(status_code=403, detail="Not authorized to release versions")
 
     # Duplicate check
@@ -208,6 +209,7 @@ async def _create_agent_version(
     )
     pending_count = (await db.execute(pending_stmt)).scalar() or 0
 
+    initial_status = AgentStatus.draft if req.save_as_draft else AgentStatus.pending
     now = datetime.now(UTC)
     ver = AgentVersion(
         agent_id=agent.id,
@@ -220,7 +222,7 @@ async def _create_agent_version(
         supported_ides=req.supported_ides,
         yaml_snapshot=req.yaml_snapshot,
         is_prerelease=req.is_prerelease,
-        status=AgentStatus.pending,
+        status=initial_status,
         released_by=current_user.id,
         released_at=now,
     )

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 
-from api.deps import ROLE_HIERARCHY, get_db, get_effective_agent_permission, require_role
+from api.deps import get_db, get_effective_agent_permission, require_role
 from models.agent import (
     Agent,
     AgentGoalSection,
@@ -173,10 +173,9 @@ async def _create_agent_version(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     is_owner = agent.created_by == current_user.id
     is_co_maintainer = str(current_user.id) in [str(uid) for uid in (agent.co_maintainers or [])]
-    if not is_admin and not is_owner and not is_co_maintainer:
+    if not is_owner and not is_co_maintainer:
         raise HTTPException(status_code=403, detail="Not authorized to release versions")
 
     # Duplicate check

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -254,6 +254,7 @@ class AgentVersionCreateRequest(BaseModel):
     goal_template: GoalTemplateRequest | None = None
     yaml_snapshot: str | None = None
     is_prerelease: bool = False
+    save_as_draft: bool = False
 
     @field_validator("version")
     @classmethod

--- a/web/src/components/registry/agent-edit-form.tsx
+++ b/web/src/components/registry/agent-edit-form.tsx
@@ -534,45 +534,9 @@ export function AgentEditForm({
   async function handleSaveDraft() {
     setSavingDraft(true);
     try {
-      const components: { component_type: string; component_id: string }[] = [];
-      for (const [type, items] of Object.entries(selectedComponents)) {
-        const singularType = TYPE_MAP[type] ?? type;
-        for (const item of items) {
-          components.push({ component_type: singularType, component_id: item.id });
-        }
-      }
-
-      const sections = goalSections
-        .filter((s) => s.title.trim())
-        .map((s) => ({
-          name: s.title.trim(),
-          description: s.content.trim() || null,
-        }));
-
-      const promptParts = customPrompts
-        .filter((p) => p.content.trim())
-        .map((p) =>
-          p.title.trim()
-            ? `## ${p.title.trim()}\n${p.content.trim()}`
-            : p.content.trim(),
-        );
-
-      await updateAgent.mutateAsync({
-        id: agentId,
-        body: {
-          description: description.trim(),
-          model_name: modelName,
-          prompt: promptParts.join("\n\n"),
-          components: components.length > 0 ? components : [],
-          goal_template: {
-            description: description.trim() || agent.name,
-            sections:
-              sections.length > 0
-                ? sections
-                : [{ name: "Default", description: description.trim() || agent.name }],
-          },
-        },
-      });
+      const draftVersion = versionSuggestions?.suggestions?.patch ?? currentVersion;
+      const body = { ...buildVersionBody(draftVersion), save_as_draft: true };
+      await createVersion.mutateAsync({ agentId, body });
       initialStateRef.current = {
         description,
         modelName,
@@ -581,6 +545,7 @@ export function AgentEditForm({
         selectedComponents,
       };
       setIsDirty(false);
+      onSuccess?.();
     } catch {
       // toast handled by mutation
     } finally {


### PR DESCRIPTION
## Purpose / Description

The agent edit flow has two bugs:
1. "Save & Release" fails for admins with "Not authorized to release versions" because the auth check only allows owner/co-maintainers, not admins/super_admins
2. "Save Draft" mutates the live approved agent directly via PUT /agents/{id} instead of creating a new draft version, bypassing the review process entirely

## Fixes
* Fixes #

## Approach

Auth fix: Added admin/super_admin bypass to _create_agent_version using ROLE_HIERARCHY. Owners, co-maintainers, and admins can all release versions. This applies to both CLI (observal agent release) and the frontend.

Draft fix: Added save_as_draft: bool field to AgentVersionCreateRequest. When true, the new version is created with status=draft instead of status=pending. Changed the frontend "Save Draft" button to call the version creation endpoint (POST /agents/{id}/versions) with save_as_draft: true instead of the PUT endpoint that was mutating the live agent.

## How Has This Been Tested?

- Admin user can "Save & Release" on any agent (creates pending version for review)
- Owner can "Save & Release" on their own agent (creates pending version)
- "Save Draft" creates a new draft version without changing the live approved agent
- Non-owner, non-admin users still get 403 on agents they don't own

## Learning (optional, can help others)

N/A

## Checklist

- [x] All commits are signed off (git commit -s) per the DCO
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
