### PR TITLE
fix(api): derive device auth verification URL from request headers

### DIFF
--- a/observal-server/api/routes/device_auth.py
+++ b/observal-server/api/routes/device_auth.py
@@ -55,6 +55,20 @@ def _normalize_user_code(code: str) -> str:
     return code.replace("-", "").upper()
 
 
+def _resolve_frontend_url(request: Request) -> str:
+    """Derive the frontend base URL from the request when FRONTEND_URL is not configured."""
+    configured = settings.FRONTEND_URL
+    if configured and configured != "http://localhost:3000":
+        return configured.rstrip("/")
+    # Infer from proxy headers (nginx forwards X-Forwarded-Proto + Host)
+    scheme = request.headers.get("x-forwarded-proto", "http")
+    host = request.headers.get("host") or request.headers.get("x-forwarded-host")
+    if host:
+        return f"{scheme}://{host}".rstrip("/")
+    # Last resort: request base URL
+    return str(request.base_url).rstrip("/")
+
+
 @router.post("/authorize", response_model=DeviceAuthResponse)
 @limiter.limit("5/minute")
 async def device_authorize(request: Request, req: DeviceAuthRequest = None):
@@ -81,11 +95,13 @@ async def device_authorize(request: Request, req: DeviceAuthRequest = None):
         logger.error("Redis unavailable during device authorize: %s", e)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
 
+    frontend_url = _resolve_frontend_url(request)
+
     return DeviceAuthResponse(
         device_code=device_code,
         user_code=user_code,
-        verification_uri=f"{settings.FRONTEND_URL}/device",
-        verification_uri_complete=f"{settings.FRONTEND_URL}/device?code={user_code}",
+        verification_uri=f"{frontend_url}/device",
+        verification_uri_complete=f"{frontend_url}/device?code={user_code}",
         expires_in=_DEVICE_AUTH_TTL,
         interval=5,
     )


### PR DESCRIPTION
## Purpose / Description
Browser login via `observal auth login` → "Sign in via browser" fails on remote deployments. The device auth endpoint always returns `http://localhost:3000/device` as the verification URI because `FRONTEND_URL` defaults to localhost.

## Fixes
* Fixes #730

## Approach
When `FRONTEND_URL` is still the default (`http://localhost:3000`), derive the frontend URL from request headers that nginx already forwards:
- `X-Forwarded-Proto` → scheme (https)
- `Host` → domain (dev.observal.io)

Result: `https://dev.observal.io/device?code=XXXX-XXXX`

If `FRONTEND_URL` is explicitly configured, it's used as-is (existing behavior preserved).

## How Has This Been Tested?

Verified nginx.production.conf already sends `X-Forwarded-Proto` and `Host` headers. The logic is straightforward header concatenation with a single fallback chain.

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)