### PR TITLE
chore(deps): automerge minor+patch Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,8 +30,10 @@
       "groupName": "pre-commit hooks (minor/patch)"
     },
     {
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
## Purpose / Description
Renovate bot opens PRs for dependency updates weekly, but they pile up requiring manual merge. This enables automatic merging for non-breaking (minor + patch) updates once CI passes, reducing manual toil while keeping major (breaking) updates gated on human review.

## Fixes
* Fixes #720

## Approach
- Expanded the existing `automerge` rule from `patch`-only to `minor + patch`
- Added `automergeType: "pr"` to ensure updates still go through the normal PR + CI flow (not direct branch push)
- Added `platformAutomerge: true` to use GitHub's native auto-merge, which waits for all required status checks to pass before merging

Only Renovate's own PRs are affected — this config is exclusively read by the Renovate bot and has no effect on human-authored PRs.

## How Has This Been Tested?

- Verified the JSON schema is valid against `https://docs.renovatebot.com/renovate-schema.json`
- Lint passes (`make lint`)
- Behavior will be observable on the next Renovate run (Saturday schedule)

## Learning (optional, can help others)
- [Renovate automerge docs](https://docs.renovatebot.com/configuration-options/#automerge)
- `platformAutomerge` leverages GitHub's native auto-merge feature, which respects branch protection and required checks

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)