### PR TITLE
fix(api): only infer frontend URL behind TLS proxy, not local nginx

### DIFF
--- a/observal-server/api/routes/device_auth.py
+++ b/observal-server/api/routes/device_auth.py
@@ -60,13 +60,14 @@ def _resolve_frontend_url(request: Request) -> str:
     configured = settings.FRONTEND_URL
     if configured and configured != "http://localhost:3000":
         return configured.rstrip("/")
-    # Infer from proxy headers (nginx forwards X-Forwarded-Proto + Host)
-    scheme = request.headers.get("x-forwarded-proto", "http")
-    host = request.headers.get("host") or request.headers.get("x-forwarded-host")
-    if host:
-        return f"{scheme}://{host}".rstrip("/")
-    # Last resort: request base URL
-    return str(request.base_url).rstrip("/")
+    # Only infer from headers when behind a TLS-terminating proxy (https)
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    if forwarded_proto == "https":
+        host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+        if host:
+            return f"https://{host}".rstrip("/")
+    # Local dev: use the configured default (localhost:3000 = frontend dev server)
+    return configured.rstrip("/")
 
 
 @router.post("/authorize", response_model=DeviceAuthResponse)


### PR DESCRIPTION
## Purpose / Description
PR #729 introduced a regression: the device auth endpoint used the `Host` header (`localhost:8000`) when local dev nginx sent `X-Forwarded-Proto: http`, resulting in `verification_uri: http://localhost:8000/device` instead of `http://localhost:3000/device`.

## Fixes
* Fixes #730

## Approach
Only override the configured `FRONTEND_URL` when `X-Forwarded-Proto` is specifically `"https"` — meaning we're behind a TLS-terminating reverse proxy (production/staging). In local dev, nginx sends `X-Forwarded-Proto: http`, so we now fall through to the configured default (`http://localhost:3000`).

| Environment | X-Forwarded-Proto | Result |
|---|---|---|
| Local dev (nginx → API) | `http` | `http://localhost:3000` (default) |
| Production (TLS nginx → API) | `https` | `https://dev.observal.io` (from Host header) |
| Direct to API (no proxy) | absent | `http://localhost:3000` (default) |

## How Has This Been Tested?

```bash
$ curl -s http://localhost:8000/api/v1/auth/device/authorize -X POST -H "Content-Type: application/json" -d '{}'
{"verification_uri": "http://localhost:3000/device", ...}
```

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)