### PR TITLE
fix(review): expand component content and read from pending version

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -948,6 +948,27 @@ async def install_agent(
         )
         hook_listings_map = {row.id: row for row in hook_rows}
 
+    # Pre-load prompt listings for template injection
+    prompt_comp_ids = [c.component_id for c in agent.components if c.component_type == "prompt"]
+    prompt_listings_map = {}
+    if prompt_comp_ids:
+        from sqlalchemy.orm import selectinload as _sel2
+
+        from models.prompt import PromptListing
+
+        prompt_rows = (
+            (
+                await db.execute(
+                    select(PromptListing)
+                    .options(_sel2(PromptListing.latest_version))
+                    .where(PromptListing.id.in_(prompt_comp_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        prompt_listings_map = {row.id: row for row in prompt_rows}
+
     # Resolve all component names for rules file content
     name_map = await _resolve_component_names(agent.components, db)
 
@@ -966,6 +987,7 @@ async def install_agent(
         skill_listings=skill_listings_map,
         hook_listings=hook_listings_map,
         otlp_http_url=endpoints["otlp_http"],
+        prompt_listings=prompt_listings_map,
     )
 
     # Capture agent.id before any DB operations that might expire the ORM

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -82,6 +82,15 @@ def _version_to_detail(ver: AgentVersion) -> dict:
             "inferred_supported_ides": ver.inferred_supported_ides,
         }
     )
+    d["components"] = [
+        {
+            "component_type": c.component_type,
+            "component_id": str(c.component_id),
+            "name": c.component_name or "",
+            "resolved_version": c.resolved_version or "",
+        }
+        for c in (ver.components or [])
+    ]
     return d
 
 
@@ -455,8 +464,41 @@ async def _get_version_diff(
     if not ver2:
         raise HTTPException(status_code=404, detail=f"Version {v2!r} not found")
 
-    # Build YAML diff text
-    def _structural_text(ver: AgentVersion) -> str:
+    # Build YAML diff text with resolved component details
+    async def _structural_text(ver: AgentVersion) -> str:
+        # Resolve component names and content from listings
+        comp_details = []
+        if ver.components:
+            from models.hook import HookListing
+            from models.mcp import McpListing
+            from models.prompt import PromptListing
+            from models.sandbox import SandboxListing
+            from models.skill import SkillListing
+
+            listing_models = {
+                "mcp": McpListing,
+                "skill": SkillListing,
+                "hook": HookListing,
+                "prompt": PromptListing,
+                "sandbox": SandboxListing,
+            }
+            for c in ver.components:
+                model = listing_models.get(c.component_type)
+                comp_entry: dict = {"type": c.component_type}
+                if model:
+                    listing = (await db.execute(select(model).where(model.id == c.component_id))).scalar_one_or_none()
+                    if listing:
+                        comp_entry["name"] = listing.name
+                        if c.component_type == "prompt":
+                            comp_entry["template"] = getattr(listing, "template", "") or ""
+                        else:
+                            comp_entry["description"] = getattr(listing, "description", "") or ""
+                    else:
+                        comp_entry["name"] = c.component_name or str(c.component_id)[:8]
+                else:
+                    comp_entry["name"] = c.component_name or str(c.component_id)[:8]
+                comp_details.append(comp_entry)
+
         data = {
             "description": ver.description,
             "prompt": ver.prompt,
@@ -464,11 +506,12 @@ async def _get_version_diff(
             "model_config_json": ver.model_config_json,
             "supported_ides": ver.supported_ides,
             "external_mcps": ver.external_mcps,
+            "components": comp_details,
         }
         return json.dumps(data, indent=2, default=str)
 
-    text1 = ver1.yaml_snapshot if ver1.yaml_snapshot is not None else _structural_text(ver1)
-    text2 = ver2.yaml_snapshot if ver2.yaml_snapshot is not None else _structural_text(ver2)
+    text1 = ver1.yaml_snapshot if ver1.yaml_snapshot is not None else await _structural_text(ver1)
+    text2 = ver2.yaml_snapshot if ver2.yaml_snapshot is not None else await _structural_text(ver2)
 
     yaml_diff = "\n".join(
         line.rstrip("\n")

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -169,26 +169,47 @@ async def _query_pending_components(db: AsyncSession, type_filter: str | None = 
     user_ids: set[uuid.UUID] = set()
     for listing_type, model in models_to_query.items():
         version_model = VERSION_MODELS[listing_type]
-        result = await db.execute(
-            select(model)
-            .join(version_model, model.latest_version_id == version_model.id)
+        # Find listings that have ANY pending version (not just latest_version_id).
+        # This ensures version updates appear in the queue after first approval.
+        pending_versions_stmt = (
+            select(version_model)
             .where(version_model.status == ListingStatus.pending)
-            .order_by(model.created_at.desc())
+            .order_by(version_model.released_at.desc())
         )
-        for r in result.scalars().all():
-            if r.latest_version and is_actively_editing(r.latest_version):
+        pending_versions = (await db.execute(pending_versions_stmt)).scalars().all()
+        if not pending_versions:
+            continue
+
+        # Group by listing_id, take newest pending version per listing
+        seen_listings: dict[uuid.UUID, object] = {}
+        for pv in pending_versions:
+            if pv.listing_id not in seen_listings and not is_actively_editing(pv):
+                seen_listings[pv.listing_id] = pv
+
+        if not seen_listings:
+            continue
+
+        # Load the listings
+        listings_result = await db.execute(select(model).where(model.id.in_(list(seen_listings.keys()))))
+        listings_map = {r.id: r for r in listings_result.scalars().all()}
+
+        for listing_id, pv in seen_listings.items():
+            r = listings_map.get(listing_id)
+            if not r:
                 continue
             user_ids.add(r.submitted_by)
             item: dict = {
                 "type": listing_type,
                 "id": str(r.id),
                 "name": r.name,
-                "description": getattr(r, "description", None) or "",
-                "version": getattr(r, "version", None) or "",
+                "description": getattr(pv, "description", None) or getattr(r, "description", None) or "",
+                "version": getattr(pv, "version", None) or "",
                 "owner": getattr(r, "owner", None) or "",
-                "status": r.status.value,
+                "status": pv.status.value,
                 "submitted_by": r.submitted_by,
-                "created_at": r.created_at.isoformat(),
+                "created_at": pv.created_at.isoformat()
+                if hasattr(pv, "created_at") and pv.created_at
+                else r.created_at.isoformat(),
                 "bundle_id": str(r.bundle_id) if isinstance(getattr(r, "bundle_id", None), uuid.UUID) else None,
             }
             # Include validation results for MCP listings
@@ -362,20 +383,32 @@ def _safe_serialize(val: object) -> object:
 
 
 def _serialize_listing_detail(listing_type: str, listing) -> dict:
+    # Find the pending version if one exists (for reviews, we want pending content)
+    pending_ver = None
+    if hasattr(listing, "versions"):
+        pending_ver = next(
+            (v for v in listing.versions if v.status == ListingStatus.pending),
+            None,
+        )
+    # Use the pending version for field resolution; fall back to listing properties
+    source = pending_ver if pending_ver else listing
+
     base = {
         "type": listing_type,
         "id": str(listing.id),
         "name": listing.name,
-        "description": getattr(listing, "description", None) or "",
-        "version": getattr(listing, "version", None) or "",
+        "description": getattr(source, "description", None) or "",
+        "version": getattr(source, "version", None) or "",
         "owner": getattr(listing, "owner", None) or "",
-        "status": listing.status.value,
+        "status": source.status.value if hasattr(source, "status") else listing.status.value,
         "submitted_by": str(listing.submitted_by),
         "created_at": listing.created_at.isoformat(),
         "updated_at": listing.updated_at.isoformat() if getattr(listing, "updated_at", None) else None,
     }
     for field in _DETAIL_FIELDS.get(listing_type, []):
-        val = getattr(listing, field, None)
+        val = getattr(source, field, None)
+        if val is None:
+            val = getattr(listing, field, None)
         base[field] = _safe_serialize(val)
     if listing_type == "mcp" and hasattr(listing, "validation_results"):
         base["mcp_validated"] = getattr(listing, "mcp_validated", False)
@@ -410,27 +443,34 @@ async def get_review(
         agent = (await db.execute(select(Agent).where(Agent.id == agent_uuid))).scalar_one_or_none()
         if not agent:
             raise HTTPException(status_code=404, detail="Listing not found")
-        components_ready, blocking = await _check_agent_components_ready(agent.components, db)
+        # Use the pending version for review (not latest_version which is the approved one)
+        pending_ver = next(
+            (v for v in agent.versions if v.status == AgentStatus.pending),
+            None,
+        )
+        ver = pending_ver or agent.latest_version
+        ver_components = ver.components if ver else agent.components
+        components_ready, blocking = await _check_agent_components_ready(ver_components, db)
         result = {
             "type": "agent",
             "id": str(agent.id),
             "name": agent.name,
-            "description": agent.description or "",
-            "version": agent.version or "",
+            "description": (ver.description if ver else "") or agent.description or "",
+            "version": (ver.version if ver else "") or agent.version or "",
             "owner": agent.owner or "",
-            "status": agent.status.value,
+            "status": (ver.status.value if ver else agent.status.value),
             "submitted_by": str(agent.created_by),
             "created_at": agent.created_at.isoformat() if agent.created_at else None,
             "updated_at": agent.updated_at.isoformat() if agent.updated_at else None,
-            "git_url": agent.git_url,
-            "prompt": agent.prompt,
-            "model_name": agent.model_name,
-            "model_config_json": agent.model_config_json,
-            "external_mcps": agent.external_mcps,
-            "supported_ides": agent.supported_ides,
-            "required_ide_features": agent.required_ide_features,
-            "rejection_reason": agent.rejection_reason,
-            "component_count": len(agent.components),
+            "git_url": getattr(agent, "git_url", None),
+            "prompt": (ver.prompt if ver else "") or "",
+            "model_name": (ver.model_name if ver else "") or "",
+            "model_config_json": (ver.model_config_json if ver else {}) or {},
+            "external_mcps": (ver.external_mcps if ver else []) or [],
+            "supported_ides": (ver.supported_ides if ver else []) or [],
+            "required_ide_features": (ver.required_ide_features if ver else []) or [],
+            "rejection_reason": ver.rejection_reason if ver else None,
+            "component_count": len(ver_components),
             "components_ready": components_ready,
             "component_blockers": blocking,
             "components": [
@@ -438,9 +478,30 @@ async def get_review(
                     "component_type": c.component_type,
                     "component_id": str(c.component_id),
                 }
-                for c in agent.components
+                for c in ver_components
             ],
         }
+
+        # Expand component details with resolved listing content
+        expanded_components = []
+        for c in ver_components:
+            comp_data = {
+                "component_type": c.component_type,
+                "component_id": str(c.component_id),
+                "name": getattr(c, "component_name", "") or "",
+            }
+            model = LISTING_MODELS.get(c.component_type)
+            if model:
+                listing = (await db.execute(select(model).where(model.id == c.component_id))).scalar_one_or_none()
+                if listing:
+                    comp_data["name"] = listing.name
+                    if c.component_type == "prompt":
+                        comp_data["template"] = getattr(listing, "template", "") or ""
+                        comp_data["category"] = getattr(listing, "category", "") or ""
+                    else:
+                        comp_data["description"] = getattr(listing, "description", "") or ""
+            expanded_components.append(comp_data)
+        result["components"] = expanded_components
 
     # Resolve submitted_by UUID to display name
     uid_str = result.get("submitted_by", "")
@@ -471,10 +532,31 @@ async def approve(
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    if listing.latest_version and is_actively_editing(listing.latest_version):
-        raise HTTPException(status_code=409, detail="Cannot approve: the owner is currently editing this item")
-    listing.status = ListingStatus.approved
-    listing.rejection_reason = None
+
+    # Find the pending version to approve (may not be latest_version)
+    pending_ver = None
+    if hasattr(listing, "versions"):
+        pending_ver = next(
+            (v for v in listing.versions if v.status == ListingStatus.pending),
+            None,
+        )
+
+    if pending_ver:
+        if is_actively_editing(pending_ver):
+            raise HTTPException(status_code=409, detail="Cannot approve: the owner is currently editing this item")
+        pending_ver.status = ListingStatus.approved
+        pending_ver.rejection_reason = None
+        pending_ver.reviewed_by = current_user.id
+        pending_ver.reviewed_at = datetime.now(UTC)
+        # Update latest_version_id to point to newly approved version
+        listing.latest_version_id = pending_ver.id
+    else:
+        # Fallback: legacy path for listings without versioning
+        if listing.latest_version and is_actively_editing(listing.latest_version):
+            raise HTTPException(status_code=409, detail="Cannot approve: the owner is currently editing this item")
+        listing.status = ListingStatus.approved
+        listing.rejection_reason = None
+
     await db.commit()
     await db.refresh(listing)
     await audit(
@@ -498,10 +580,29 @@ async def reject(
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
-    if listing.latest_version and is_actively_editing(listing.latest_version):
-        raise HTTPException(status_code=409, detail="Cannot reject: the owner is currently editing this item")
-    listing.status = ListingStatus.rejected
-    listing.rejection_reason = req.reason
+
+    # Find the pending version to reject (may not be latest_version)
+    pending_ver = None
+    if hasattr(listing, "versions"):
+        pending_ver = next(
+            (v for v in listing.versions if v.status == ListingStatus.pending),
+            None,
+        )
+
+    if pending_ver:
+        if is_actively_editing(pending_ver):
+            raise HTTPException(status_code=409, detail="Cannot reject: the owner is currently editing this item")
+        pending_ver.status = ListingStatus.rejected
+        pending_ver.rejection_reason = req.reason
+        pending_ver.reviewed_by = current_user.id
+        pending_ver.reviewed_at = datetime.now(UTC)
+    else:
+        # Fallback: legacy path for listings without versioning
+        if listing.latest_version and is_actively_editing(listing.latest_version):
+            raise HTTPException(status_code=409, detail="Cannot reject: the owner is currently editing this item")
+        listing.status = ListingStatus.rejected
+        listing.rejection_reason = req.reason
+
     await db.commit()
     await db.refresh(listing)
     await audit(

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -497,11 +497,15 @@ def _build_hook_configs(
     return hooks
 
 
-def _build_rules_content(agent: Agent, component_names: dict | None = None) -> str:
+def _build_rules_content(agent: Agent, component_names: dict | None = None, prompt_listings: dict | None = None) -> str:
     """Build markdown rules content from the agent and its components.
 
     Assembles the agent prompt (if any), description, and a summary of
     all bundled components so the rules file is never empty.
+
+    Args:
+        prompt_listings: optional {component_id: PromptListing} map. When provided,
+            prompt components inject their full template content instead of a bullet name.
     """
     sections: list[str] = []
 
@@ -529,10 +533,30 @@ def _build_rules_content(agent: Agent, component_names: dict | None = None) -> s
         comp_names = by_type.get(comp_type)
         if not comp_names:
             continue
-        lines = [f"## {heading}", ""]
-        for n in comp_names:
-            lines.append(f"- **{n}**")
-        sections.append("\n".join(lines))
+        if comp_type == "prompt" and prompt_listings:
+            # Inject full prompt template content instead of bullet names
+            lines = [f"## {heading}", ""]
+            for comp in agent.components:
+                if comp.component_type != "prompt":
+                    continue
+                listing = prompt_listings.get(comp.component_id)
+                if not listing:
+                    continue
+                pname = names.get(str(comp.component_id), str(comp.component_id)[:8])
+                template = getattr(listing, "template", "") or ""
+                if template:
+                    lines.append(f"### {pname}")
+                    lines.append("")
+                    lines.append(template)
+                    lines.append("")
+                else:
+                    lines.append(f"- **{pname}**")
+            sections.append("\n".join(lines))
+        else:
+            lines = [f"## {heading}", ""]
+            for n in comp_names:
+                lines.append(f"- **{n}**")
+            sections.append("\n".join(lines))
 
     return "\n\n".join(sections) if sections else f"# {agent.name}\n\n{agent.description or ''}"
 
@@ -549,6 +573,7 @@ def generate_agent_config(
     skill_listings: dict | None = None,
     hook_listings: dict | None = None,
     otlp_http_url: str = "",
+    prompt_listings: dict | None = None,
 ) -> dict:
     """Generate IDE-specific config for an agent.
 
@@ -559,11 +584,12 @@ def generate_agent_config(
         platform: client platform string (e.g. "win32", "darwin", "linux"). Empty = Unix default.
         skill_listings: optional {component_id: SkillListing} map pre-loaded by caller.
         hook_listings: optional {component_id: HookListing} map pre-loaded by caller.
+        prompt_listings: optional {component_id: PromptListing} map pre-loaded by caller.
     """
     safe_name = _sanitize_name(agent.name)
     effective_otlp_http = otlp_http_url or observal_url
     mcp_configs = _build_mcp_configs(agent, ide, effective_otlp_http, mcp_listings=mcp_listings, env_values=env_values)
-    rules_content = _build_rules_content(agent, component_names)
+    rules_content = _build_rules_content(agent, component_names, prompt_listings)
     skill_configs = _build_skill_configs(agent, skill_listings)
     hook_configs = _build_hook_configs(agent, hook_listings)
     options = options or {}

--- a/observal-server/tests/test_agent_config_gen_versioned.py
+++ b/observal-server/tests/test_agent_config_gen_versioned.py
@@ -176,3 +176,112 @@ class TestGenerateAllIdeConfigs:
             if path.endswith(".json"):
                 parsed = json.loads(content)
                 assert "name" in parsed
+
+
+# ── _build_rules_content prompt injection tests ──────────────────
+
+
+class TestBuildRulesContentPromptInjection:
+    """Tests for prompt template injection via prompt_listings parameter."""
+
+    def _make_agent_with_prompt_component(self, prompt_comp_id=None):
+        """Build a mock agent with one prompt component."""
+        comp_id = prompt_comp_id or uuid.uuid4()
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "my-agent"
+        agent.description = "An agent"
+        agent.prompt = ""
+
+        comp = MagicMock()
+        comp.component_id = comp_id
+        comp.component_type = "prompt"
+        agent.components = [comp]
+        agent.external_mcps = []
+        return agent, comp_id
+
+    def _make_prompt_listing(self, listing_id, name="Test Prompt", template="Do something useful."):
+        listing = MagicMock()
+        listing.id = listing_id
+        listing.name = name
+        listing.template = template
+        return listing
+
+    def test_prompt_template_injected_when_listings_provided(self):
+        from services.agent_config_generator import _build_rules_content
+
+        agent, comp_id = self._make_agent_with_prompt_component()
+        listing = self._make_prompt_listing(comp_id, name="Test", template="Do something useful.")
+        names = {str(comp_id): "Test"}
+
+        result = _build_rules_content(agent, component_names=names, prompt_listings={comp_id: listing})
+
+        assert "Do something useful." in result
+        assert "### Test" in result
+        # Should NOT produce bullet-point format
+        assert "- **Test**" not in result
+
+    def test_prompt_bullet_fallback_without_listings(self):
+        from services.agent_config_generator import _build_rules_content
+
+        agent, comp_id = self._make_agent_with_prompt_component()
+        names = {str(comp_id): "Test"}
+
+        result = _build_rules_content(agent, component_names=names, prompt_listings=None)
+
+        assert "- **Test**" in result
+        assert "Do something useful." not in result
+
+    def test_prompt_bullet_fallback_when_listing_has_empty_template(self):
+        from services.agent_config_generator import _build_rules_content
+
+        agent, comp_id = self._make_agent_with_prompt_component()
+        listing = self._make_prompt_listing(comp_id, name="Test", template="")
+        names = {str(comp_id): "Test"}
+
+        result = _build_rules_content(agent, component_names=names, prompt_listings={comp_id: listing})
+
+        assert "- **Test**" in result
+
+    def test_non_prompt_components_still_use_bullets(self):
+        from services.agent_config_generator import _build_rules_content
+
+        mcp_id = uuid.uuid4()
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.name = "my-agent"
+        agent.description = "desc"
+        agent.prompt = ""
+        mcp_comp = MagicMock()
+        mcp_comp.component_id = mcp_id
+        mcp_comp.component_type = "mcp"
+        agent.components = [mcp_comp]
+        agent.external_mcps = []
+
+        names = {str(mcp_id): "my-mcp"}
+
+        # Even with a prompt_listings dict, mcp components use bullets
+        result = _build_rules_content(agent, component_names=names, prompt_listings={})
+
+        assert "- **my-mcp**" in result
+
+    def test_generate_agent_config_accepts_prompt_listings(self):
+        """Ensure generate_agent_config passes prompt_listings through to rules content."""
+        from services.agent_config_generator import generate_agent_config
+
+        agent, comp_id = self._make_agent_with_prompt_component()
+        agent.prompt = ""
+        agent.required_ide_features = []
+        agent.model_name = ""
+        listing = self._make_prompt_listing(comp_id, name="Test", template="My prompt template content.")
+        names = {str(comp_id): "Test"}
+
+        result = generate_agent_config(
+            agent,
+            ide="claude-code",
+            prompt_listings={comp_id: listing},
+            component_names=names,
+        )
+
+        rules_content = result["rules_file"]["content"]
+        assert "My prompt template content." in rules_content

--- a/tests/test_review_queue.py
+++ b/tests/test_review_queue.py
@@ -59,8 +59,26 @@ def _listing_mock(status=ListingStatus.pending, **extra):
     m.submitted_by = uuid.uuid4()
     m.created_at = datetime.now(UTC)
     m.updated_at = datetime.now(UTC)
+    m.bundle_id = extra.get("bundle_id")
+    m.versions = extra.get("versions", [])
+    m.latest_version_id = extra.get("latest_version_id")
+    m.latest_version = extra.get("latest_version")
     for k, v in extra.items():
         setattr(m, k, v)
+    return m
+
+
+def _version_mock(listing_id, **extra):
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.listing_id = listing_id
+    m.status = extra.get("status", ListingStatus.pending)
+    m.description = extra.get("description", "A test description")
+    m.version = extra.get("version", "1.0.0")
+    m.created_at = extra.get("created_at", datetime.now(UTC))
+    m.is_editing = False
+    m.editing_since = None
+    m.editing_by = None
     return m
 
 
@@ -91,13 +109,18 @@ class TestListPending:
     async def test_response_includes_description_version_owner(self):
         """PR #174: list_pending must return description, version, owner fields."""
         app, db, _ = _app_with()
-        listing = _listing_mock(
-            description="My cool MCP server",
-            version="2.1.0",
-            owner="acme-corp",
-        )
-        # agents query (empty) + 5 listing types + user lookup
-        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        listing = _listing_mock(owner="acme-corp")
+        version = _version_mock(listing.id, description="My cool MCP server", version="2.1.0")
+        results = [
+            _empty_result(),  # agents: pending versions (empty → return early)
+            _result_with(version),  # mcp: pending versions
+            _result_with(listing),  # mcp: listings load
+            _empty_result(),  # skill: pending versions (empty → continue)
+            _empty_result(),  # hook: pending versions (empty → continue)
+            _empty_result(),  # prompt: pending versions (empty → continue)
+            _empty_result(),  # sandbox: pending versions (empty → continue)
+            _empty_result(),  # user lookup
+        ]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -116,7 +139,17 @@ class TestListPending:
         """Verify the full shape of each item in the list_pending response."""
         app, db, _ = _app_with()
         listing = _listing_mock()
-        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        version = _version_mock(listing.id)
+        results = [
+            _empty_result(),  # agents: pending versions (empty → return early)
+            _result_with(version),  # mcp: pending versions
+            _result_with(listing),  # mcp: listings load
+            _empty_result(),  # skill: pending versions (empty → continue)
+            _empty_result(),  # hook: pending versions (empty → continue)
+            _empty_result(),  # prompt: pending versions (empty → continue)
+            _empty_result(),  # sandbox: pending versions (empty → continue)
+            _empty_result(),  # user lookup
+        ]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -142,8 +175,19 @@ class TestListPending:
         """When a listing has no description attr, response should default to empty string."""
         app, db, _ = _app_with()
         listing = _listing_mock()
+        version = _version_mock(listing.id)
+        version.description = None
         listing.description = None
-        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        results = [
+            _empty_result(),  # agents: pending versions (empty → return early)
+            _result_with(version),  # mcp: pending versions
+            _result_with(listing),  # mcp: listings load
+            _empty_result(),  # skill: pending versions (empty → continue)
+            _empty_result(),  # hook: pending versions (empty → continue)
+            _empty_result(),  # prompt: pending versions (empty → continue)
+            _empty_result(),  # sandbox: pending versions (empty → continue)
+            _empty_result(),  # user lookup
+        ]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -156,8 +200,18 @@ class TestListPending:
         """When a listing has no version attr, response should default to empty string."""
         app, db, _ = _app_with()
         listing = _listing_mock()
-        listing.version = None
-        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        version = _version_mock(listing.id)
+        version.version = None
+        results = [
+            _empty_result(),  # agents: pending versions (empty → return early)
+            _result_with(version),  # mcp: pending versions
+            _result_with(listing),  # mcp: listings load
+            _empty_result(),  # skill: pending versions (empty → continue)
+            _empty_result(),  # hook: pending versions (empty → continue)
+            _empty_result(),  # prompt: pending versions (empty → continue)
+            _empty_result(),  # sandbox: pending versions (empty → continue)
+            _empty_result(),  # user lookup
+        ]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -170,8 +224,18 @@ class TestListPending:
         """When a listing has no owner attr, response should default to empty string."""
         app, db, _ = _app_with()
         listing = _listing_mock()
+        version = _version_mock(listing.id)
         listing.owner = None
-        results = [_empty_result()] + [_result_with(listing)] + [_empty_result() for _ in range(4)] + [_empty_result()]
+        results = [
+            _empty_result(),  # agents: pending versions (empty → return early)
+            _result_with(version),  # mcp: pending versions
+            _result_with(listing),  # mcp: listings load
+            _empty_result(),  # skill: pending versions (empty → continue)
+            _empty_result(),  # hook: pending versions (empty → continue)
+            _empty_result(),  # prompt: pending versions (empty → continue)
+            _empty_result(),  # sandbox: pending versions (empty → continue)
+            _empty_result(),  # user lookup
+        ]
         db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -184,15 +248,21 @@ class TestListPending:
         """The ?type= query param should only query that one listing type."""
         app, db, _ = _app_with()
         listing = _listing_mock()
-        # agents query (empty) + single type query + user lookup
-        db.execute = AsyncMock(side_effect=[_empty_result(), _result_with(listing), _empty_result()])
+        version = _version_mock(listing.id)
+        results = [
+            _empty_result(),  # agents: pending versions (empty → return early)
+            _result_with(version),  # mcp: pending versions
+            _result_with(listing),  # mcp: listings load
+            _empty_result(),  # user lookup
+        ]
+        db.execute = AsyncMock(side_effect=results)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             r = await ac.get("/api/v1/review?type=mcp")
 
         assert r.status_code == 200
-        # 1 agents query + 1 single type + 1 user lookup
-        assert db.execute.call_count == 3
+        # 1 agents query + 2 mcp queries (versions + listings) + 1 user lookup
+        assert db.execute.call_count == 4
         assert r.json()[0]["type"] == "mcp"
 
     @pytest.mark.asyncio
@@ -213,14 +283,18 @@ class TestListPending:
         """Listings from different model types all appear in a single response."""
         app, db, _ = _app_with()
         mcp_listing = _listing_mock(name="mcp-one")
+        mcp_version = _version_mock(mcp_listing.id)
         skill_listing = _listing_mock(name="skill-one")
+        skill_version = _version_mock(skill_listing.id)
         results = [
-            _empty_result(),  # agents query
-            _result_with(mcp_listing),
-            _result_with(skill_listing),
-            _empty_result(),
-            _empty_result(),
-            _empty_result(),
+            _empty_result(),  # agents: pending versions (empty → return early)
+            _result_with(mcp_version),  # mcp: pending versions
+            _result_with(mcp_listing),  # mcp: listings load
+            _result_with(skill_version),  # skill: pending versions
+            _result_with(skill_listing),  # skill: listings load
+            _empty_result(),  # hook: pending versions (empty → continue)
+            _empty_result(),  # prompt: pending versions (empty → continue)
+            _empty_result(),  # sandbox: pending versions (empty → continue)
             _empty_result(),  # user lookup
         ]
         db.execute = AsyncMock(side_effect=results)

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -363,11 +363,7 @@ export default function ReviewPage() {
 
   const handleItemClick = useCallback(
     (item: ReviewItem) => {
-      if (item.type === "agent") {
-        setDiffItem(item);
-      } else {
-        setSelectedItem(item);
-      }
+      setDiffItem(item);
     },
     [],
   );

--- a/web/src/components/review/review-detail-sheet.tsx
+++ b/web/src/components/review/review-detail-sheet.tsx
@@ -181,18 +181,30 @@ function AgentConfigSection({ detail }: { detail: ReviewItem }) {
           <dt className="text-xs font-medium text-muted-foreground">
             Components ({detail.components.length})
           </dt>
-          <dd className="mt-0.5 space-y-1">
+          <dd className="mt-0.5 space-y-2">
             {detail.components.map((c, i) => (
               <div
                 key={i}
-                className="text-xs flex items-center gap-2 px-2 py-1 rounded bg-muted"
+                className="text-xs rounded bg-muted overflow-hidden"
               >
-                <Badge variant="outline" className="text-[10px]">
-                  {c.component_type}
-                </Badge>
-                <span className="font-mono text-muted-foreground">
-                  {c.component_id.slice(0, 8)}
-                </span>
+                <div className="flex items-center gap-2 px-2 py-1">
+                  <Badge variant="outline" className="text-[10px]">
+                    {c.component_type}
+                  </Badge>
+                  <span className="font-medium">
+                    {(c as Record<string, string>).name || c.component_id.slice(0, 8)}
+                  </span>
+                </div>
+                {(c as Record<string, string>).template && (
+                  <pre className="px-3 pb-2 text-[11px] font-mono whitespace-pre-wrap break-words text-muted-foreground leading-relaxed">
+                    {(c as Record<string, string>).template}
+                  </pre>
+                )}
+                {(c as Record<string, string>).description && !(c as Record<string, string>).template && (
+                  <p className="px-3 pb-2 text-[11px] text-muted-foreground">
+                    {(c as Record<string, string>).description}
+                  </p>
+                )}
               </div>
             ))}
           </dd>

--- a/web/src/components/review/review-diff-sheet.tsx
+++ b/web/src/components/review/review-diff-sheet.tsx
@@ -22,8 +22,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { YamlDiffView } from "./yaml-diff-view";
-import { useAgentVersions, useVersionDiff, useAgentVersionDetail } from "@/hooks/use-api";
+import { useAgentVersions, useVersionDiff, useAgentVersionDetail, useComponentVersions, useComponentVersionDetail } from "@/hooks/use-api";
+import type { RegistryType } from "@/lib/api";
 import type { ReviewItem, ComponentChange } from "@/lib/types";
+
+function pluralizeType(type: string): string {
+  if (type === "agent") return "agents";
+  return `${type}s`;
+}
 
 function semverBumpType(from: string, to: string): "major" | "minor" | "patch" | null {
   const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
@@ -140,34 +146,97 @@ function DiffDialogBody({
   const [showRejectDialog, setShowRejectDialog] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
 
-  const { data: versionsData, isLoading: versionsLoading } = useAgentVersions(item.id);
+  const isAgent = item.type === "agent";
+  const registryType = !isAgent && item.type ? pluralizeType(item.type) as RegistryType : undefined;
+
+  // Agent versions
+  const { data: agentVersionsData, isLoading: agentVersionsLoading } = useAgentVersions(
+    isAgent ? item.id : undefined,
+  );
+
+  // Component versions
+  const { data: compVersionsData, isLoading: compVersionsLoading } = useComponentVersions(
+    registryType,
+    !isAgent ? item.id : undefined,
+  );
+
+  const versionsLoading = isAgent ? agentVersionsLoading : compVersionsLoading;
+  const versionsItems = isAgent ? agentVersionsData?.items : compVersionsData?.items;
 
   // Find the most recent approved version before the pending one.
   // Versions are returned newest-first (created_at DESC), so [0] is the most recent.
   const previousVersion = useMemo(() => {
-    if (!versionsData?.items || !item.version) return undefined;
-    const approved = versionsData.items.filter(
+    if (!versionsItems || !item.version) return undefined;
+    const approved = versionsItems.filter(
       (v) => v.status === "approved" && v.version !== item.version,
     );
     return approved[0]?.version;
-  }, [versionsData, item.version]);
+  }, [versionsItems, item.version]);
 
+  // Only agents have a server-side diff endpoint
   const { data: diffData, isLoading: diffLoading } = useVersionDiff(
-    item.id,
-    previousVersion,
-    item.version,
+    isAgent ? item.id : undefined,
+    isAgent ? previousVersion : undefined,
+    isAgent ? item.version : undefined,
   );
 
-  // Always fetch version detail for the left pane (prompt, model, components, yaml_snapshot)
-  const { data: versionDetail, isLoading: detailLoading } = useAgentVersionDetail(
-    item.id,
-    item.version ?? null,
+  // Agent version detail
+  const { data: agentDetail, isLoading: agentDetailLoading } = useAgentVersionDetail(
+    isAgent ? item.id : undefined,
+    isAgent ? (item.version ?? null) : null,
   );
+
+  // Component version detail
+  const { data: compDetail, isLoading: compDetailLoading } = useComponentVersionDetail(
+    registryType,
+    !isAgent ? item.id : undefined,
+    !isAgent ? (item.version ?? null) : null,
+  );
+
+  // Also fetch previous approved version detail for component diff
+  const { data: compPrevDetail } = useComponentVersionDetail(
+    registryType,
+    !isAgent ? item.id : undefined,
+    !isAgent ? (previousVersion ?? null) : null,
+  );
+
+  const detailLoading = isAgent ? agentDetailLoading : compDetailLoading;
 
   const bumpType = useMemo(() => {
     if (!previousVersion || !item.version) return null;
     return semverBumpType(previousVersion, item.version);
   }, [previousVersion, item.version]);
+
+  const componentDiff = useMemo(() => {
+    if (isAgent || !compDetail || !compPrevDetail || !previousVersion) return null;
+    const prev = JSON.stringify(compPrevDetail, null, 2);
+    const curr = JSON.stringify(compDetail, null, 2);
+    if (prev === curr) return "";
+    const prevLines = prev.split("\n");
+    const currLines = curr.split("\n");
+    const lines: string[] = [`--- v${previousVersion}`, `+++ v${item.version}`];
+    const hunks: string[] = [];
+    const maxLen = Math.max(prevLines.length, currLines.length);
+    let inHunk = false;
+    for (let i = 0; i < maxLen; i++) {
+      const pl = prevLines[i] ?? "";
+      const cl = currLines[i] ?? "";
+      if (pl !== cl) {
+        if (!inHunk) {
+          hunks.push(`@@ -${i + 1} +${i + 1} @@`);
+          inHunk = true;
+        }
+        if (pl) hunks.push(`-${pl}`);
+        if (cl) hunks.push(`+${cl}`);
+      } else {
+        if (inHunk) {
+          hunks.push(` ${cl}`);
+          inHunk = false;
+        }
+      }
+    }
+    return [...lines, ...hunks].join("\n");
+  }, [isAgent, compDetail, compPrevDetail, previousVersion, item.version]);
 
   const handleApprove = useCallback(() => {
     onApprove(item.id, item.type);
@@ -184,15 +253,19 @@ function DiffDialogBody({
 
   const disableApprove = item.components_ready === false;
 
-  const isLoading = versionsLoading || (!!previousVersion && diffLoading);
+  const isLoading = versionsLoading || detailLoading || (!!previousVersion && diffLoading);
 
-  const detail = versionDetail as Record<string, unknown> | undefined;
-  const yamlSnapshot = detail?.yaml_snapshot as string | null | undefined;
+  const detail = (isAgent ? agentDetail : compDetail) as Record<string, unknown> | undefined;
+  const yamlSnapshot = isAgent
+    ? (detail?.yaml_snapshot as string | null | undefined)
+    : detail
+      ? JSON.stringify(detail, null, 2)
+      : null;
   // Prefer version detail fields over the sparse review item fields
   const prompt = (detail?.prompt as string) || item.prompt || "";
   const modelName = (detail?.model_name as string) || item.model_name || "";
   const supportedIdes = (detail?.supported_ides as string[]) || item.supported_ides || [];
-  const components = (detail?.components as { component_type: string; component_id: string }[]) || item.components || [];
+  const components = (detail?.components as { component_type: string; component_id: string; name?: string; template?: string; description?: string; category?: string }[]) || item.components || [];
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -201,7 +274,7 @@ function DiffDialogBody({
         <DialogHeader className="space-y-1.5">
           <div className="flex items-center gap-2 flex-wrap">
             <Badge variant="outline" className="text-[10px]">
-              agent
+              {item.type}
             </Badge>
             {bumpType && (
               <Badge
@@ -321,6 +394,71 @@ function DiffDialogBody({
               </>
             )}
 
+            {/* Component-specific fields */}
+            {!isAgent && detail && (
+              <>
+                {(detail.template as string) && (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                        Template
+                      </h4>
+                      <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words bg-muted/40 rounded p-3 leading-relaxed max-h-64 overflow-y-auto">
+                        {detail.template as string}
+                      </pre>
+                    </div>
+                  </>
+                )}
+                {(detail.category as string) && (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                        Category
+                      </h4>
+                      <p className="text-xs font-medium">{detail.category as string}</p>
+                    </div>
+                  </>
+                )}
+                {(detail.event as string) && (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                        Event
+                      </h4>
+                      <p className="text-xs font-medium">{detail.event as string}</p>
+                    </div>
+                  </>
+                )}
+                {(detail.handler_type as string) && (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                        Handler
+                      </h4>
+                      <p className="text-xs font-medium">{detail.handler_type as string}</p>
+                    </div>
+                  </>
+                )}
+                {(detail.changelog as string) && (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                        Changelog
+                      </h4>
+                      <pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words bg-muted/40 rounded p-3 leading-relaxed max-h-32 overflow-y-auto">
+                        {detail.changelog as string}
+                      </pre>
+                    </div>
+                  </>
+                )}
+              </>
+            )}
+
             {/* Component changes (from diff) or component list */}
             {diffData?.component_changes?.length ? (
               <>
@@ -339,18 +477,30 @@ function DiffDialogBody({
                   <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
                     Components ({components.length})
                   </h4>
-                  <div className="space-y-1.5">
+                  <div className="space-y-2">
                     {components.map((c, i) => (
                       <div
                         key={i}
-                        className="flex items-center gap-2 text-xs py-1.5 px-2 rounded bg-muted/40"
+                        className="text-xs rounded bg-muted/40 overflow-hidden"
                       >
-                        <Badge variant="outline" className="text-[10px] shrink-0">
-                          {c.component_type}
-                        </Badge>
-                        <span className="text-muted-foreground font-[family-name:var(--font-mono)] truncate">
-                          {c.component_id}
-                        </span>
+                        <div className="flex items-center gap-2 py-1.5 px-2">
+                          <Badge variant="outline" className="text-[10px] shrink-0">
+                            {c.component_type}
+                          </Badge>
+                          <span className="font-medium truncate">
+                            {c.name || c.component_id}
+                          </span>
+                        </div>
+                        {c.template && (
+                          <pre className="px-3 pb-2 text-[11px] font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words text-muted-foreground leading-relaxed">
+                            {c.template}
+                          </pre>
+                        )}
+                        {c.description && !c.template && (
+                          <p className="px-3 pb-2 text-[11px] text-muted-foreground">
+                            {c.description}
+                          </p>
+                        )}
                       </div>
                     ))}
                   </div>
@@ -437,6 +587,12 @@ function DiffDialogBody({
                 </div>
               )}
             </div>
+          ) : componentDiff !== null ? (
+            <YamlDiffView
+              diff={componentDiff}
+              versionA={previousVersion ?? ""}
+              versionB={item.version ?? ""}
+            />
           ) : (
             <div className="flex items-center justify-center flex-1 text-sm text-muted-foreground">
               Unable to load diff.


### PR DESCRIPTION
## Purpose / Description

The review screen had two issues:
1. Agent details (prompt, model_name, description) were read from `agent.latest_version` (the approved version) instead of the pending version being reviewed — resulting in empty fields for first submissions
2. Components were displayed as bare UUIDs with no content — reviewers couldn't see what prompt templates or descriptions an agent would actually receive

## Fixes
* Fixes agent review showing empty prompt/model/description for pending versions
* Fixes component content not being visible in review screen

## Approach

**Prompt template injection (install route):**
- Added `prompt_listings` parameter to `_build_rules_content` and `generate_agent_config`
- Pre-loads PromptListing objects in the install route (same pattern as hooks/skills)
- Full prompt template text is now injected into generated rules files

<img width="1378" height="898" alt="image" src="https://github.com/user-attachments/assets/8c804631-43d8-4f68-acfa-ac3b17d0b7ea" />

**Review reads from pending version:**
- `get_review()` now finds the pending version from `agent.versions` and reads version-specific fields from it
- Falls back to `agent.latest_version` only when no pending version exists

**Component content expansion:**
- Review detail API resolves each component's listing from the DB
- Prompt components include `template` and `category`; others include `description`
- Version detail endpoint includes component names and resolved versions
- Structural text (for diff view) now includes components list
- Frontend review sheets render template/description content inline

## How Has This Been Tested?

- 19 unit tests pass (including 5 new tests for prompt template injection)
- Manual verification via API: review detail for "raja" agent now returns `{"template": "You finish all responses with +=+ as a signature"}` in the components array
- Docker containers rebuilt and API confirmed healthy

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)