### PR TITLE
fix(deploy): use persistent SSL config so merges stop breaking HTTPS

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,12 +26,19 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
 
-            cd docker
-            docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build --remove-orphans
+            # Use SSL override from outside repo so git reset never wipes it
+            SSL_OVERRIDE=~/observal-ssl/docker-compose.ssl.yml
+            if [ -f "$SSL_OVERRIDE" ]; then
+              DEV_OVERRIDE="$SSL_OVERRIDE"
+            else
+              DEV_OVERRIDE="docker/docker-compose.dev.yml"
+            fi
+
+            docker compose -f docker/docker-compose.yml -f "$DEV_OVERRIDE" up -d --build --remove-orphans
 
             echo "Waiting for API container to start..."
             for i in $(seq 1 60); do
-              if docker compose exec -T observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/livez')" 2>/dev/null; then
+              if docker compose -f docker/docker-compose.yml -f "$DEV_OVERRIDE" exec -T observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/livez')" 2>/dev/null; then
                 echo "API process is alive"
                 break
               fi
@@ -39,7 +46,7 @@ jobs:
               sleep 5
             done
 
-            docker compose -f docker-compose.yml -f docker-compose.dev.yml restart observal-lb
+            docker compose -f docker/docker-compose.yml -f "$DEV_OVERRIDE" restart observal-lb
             sleep 3
 
             for i in $(seq 1 30); do
@@ -52,5 +59,5 @@ jobs:
             done
 
             echo "API failed health check"
-            docker compose logs observal-api observal-init observal-lb observal-db observal-clickhouse --tail 20
+            docker compose -f docker/docker-compose.yml -f "$DEV_OVERRIDE" logs observal-api observal-init observal-lb observal-db observal-clickhouse --tail 20
             exit 1


### PR DESCRIPTION
## Purpose / Description
Every merge to main runs `git reset --hard origin/main` in the deploy workflow, which wipes the in-repo SSL/HTTPS nginx config. This causes dev.observal.io to lose HTTPS after every deploy.

## Fixes
* Fixes HTTPS breaking on dev.observal.io after every merge to main

## Approach
The deploy-dev workflow now checks for `~/observal-ssl/docker-compose.ssl.yml` on the server and uses it as the docker compose override instead of the in-repo `docker-compose.dev.yml`. Since the SSL config lives outside the repo, `git reset --hard` no longer wipes it.

## How Has This Been Tested?
Deployed to dev.observal.io and confirmed HTTPS stays up after a fresh `git reset --hard` and `docker compose up`.

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code