### PR TITLE
Fix/kiro hooks and credits

### DIFF
--- a/observal-server/api/routes/sessions.py
+++ b/observal-server/api/routes/sessions.py
@@ -240,7 +240,7 @@ async def _list_sessions_query(
         "groupUniqArrayIf(LogAttributes['user.id'], LogAttributes['user.id'] != '') AS user_ids, "
         "anyIf(LogAttributes['user.name'], LogAttributes['user.name'] != '') AS user_name, "
         "anyIf(LogAttributes['terminal.type'], LogAttributes['terminal.type'] != '') AS terminal_type, "
-        "anyIf(LogAttributes['credits'], LogAttributes['credits'] != '') AS credits, "
+        "sumIf(toFloat64OrZero(LogAttributes['credits']), LogAttributes['credits'] != '') AS credits, "
         "anyIf(LogAttributes['tools_used'], LogAttributes['tools_used'] != '') AS tools_used, "
         "multiIf("
         "  any(ServiceName) IN ('kiro', 'kiro-cli'), 'kiro',"

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -161,6 +161,33 @@ def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> 
     return "updated" if existed else "created"
 
 
+def _rewrite_kiro_hooks(content: dict) -> dict:
+    """Rewrite Kiro hook commands to use the current Python interpreter.
+
+    The server generates commands with bare 'python3' which won't find
+    observal_cli when installed in a project-local virtual environment.
+    """
+    hooks = content.get("hooks")
+    agent_name = content.get("name")
+    if not hooks or not agent_name:
+        return content
+
+    from observal_cli.ide_specs.kiro_hooks_spec import build_kiro_hooks
+
+    cfg = config.get_or_exit()
+    hooks_url = f"{cfg['server_url'].rstrip('/')}/api/v1/telemetry/hooks"
+    desired_hooks = build_kiro_hooks(hooks_url, agent_name)
+
+    # Replace only Observal hooks, preserve any user-added hooks
+    for event, desired_entries in desired_hooks.items():
+        existing = hooks.get(event, [])
+        cleaned = [h for h in existing if "observal_cli" not in h.get("command", "")]
+        hooks[event] = cleaned + desired_entries
+
+    content["hooks"] = hooks
+    return content
+
+
 def _resolve_path(raw_path: str, target_dir: Path, *, allow_home: bool = False) -> Path:
     """Resolve a path from the config snippet relative to *target_dir*.
 
@@ -340,6 +367,10 @@ def register_pull(app: typer.Typer):
         # ── agent_file (Kiro) ───────────────────────────────
         agent_file = snippet.get("agent_file")
         if agent_file:
+            # Rewrite hook commands to use the current Python interpreter
+            # so they work regardless of which directory Kiro is launched from.
+            if isinstance(agent_file.get("content"), dict):
+                agent_file["content"] = _rewrite_kiro_hooks(agent_file["content"])
             p = _resolve_path(agent_file["path"], target_dir, allow_home=is_user_scope)
             if dry_run:
                 written.append((str(p), "would write"))

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -131,7 +131,9 @@ def _auto_inject_hooks(url: str):
             else:
                 _py = f"PYTHONPATH={_pkg_root} {sys.executable}"
                 cmd = f"KIRO_CLI_PID=$PPID {_py} -m observal_cli.hooks.kiro_hook --url {url} --agent-name {name}"
-                stop_cmd = f"KIRO_CLI_PID=$PPID {_py} -m observal_cli.hooks.kiro_stop_hook --url {url} --agent-name {name}"
+                stop_cmd = (
+                    f"KIRO_CLI_PID=$PPID {_py} -m observal_cli.hooks.kiro_stop_hook --url {url} --agent-name {name}"
+                )
             desired = {
                 "agentSpawn": [{"command": cmd}],
                 "userPromptSubmit": [{"command": cmd}],
@@ -194,10 +196,14 @@ def main():
     try:
         session_file = Path.home() / ".observal" / ".kiro-session"
         session_file.parent.mkdir(parents=True, exist_ok=True)
-        session_file.write_text(json.dumps({
-            "session_id": payload["session_id"],
-            "cwd": payload.get("cwd", ""),
-        }))
+        session_file.write_text(
+            json.dumps(
+                {
+                    "session_id": payload["session_id"],
+                    "cwd": payload.get("cwd", ""),
+                }
+            )
+        )
     except Exception:
         pass
 

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -123,12 +123,15 @@ def _auto_inject_hooks(url: str):
             data = json.loads(af.read_text())
             hooks = data.get("hooks", {})
             name = data.get("name") or af.stem
+            _pkg_root = str(Path(__file__).resolve().parent.parent.parent)
             if sys.platform == "win32":
-                cmd = f"{sys.executable} -m observal_cli.hooks.kiro_hook --url {url} --agent-name {name}"
-                stop_cmd = f"{sys.executable} -m observal_cli.hooks.kiro_stop_hook --url {url} --agent-name {name}"
+                _py = f'set "PYTHONPATH={_pkg_root}" && {sys.executable}'
+                cmd = f"{_py} -m observal_cli.hooks.kiro_hook --url {url} --agent-name {name}"
+                stop_cmd = f"{_py} -m observal_cli.hooks.kiro_stop_hook --url {url} --agent-name {name}"
             else:
-                cmd = f"KIRO_CLI_PID=$PPID {sys.executable} -m observal_cli.hooks.kiro_hook --url {url} --agent-name {name}"
-                stop_cmd = f"KIRO_CLI_PID=$PPID {sys.executable} -m observal_cli.hooks.kiro_stop_hook --url {url} --agent-name {name}"
+                _py = f"PYTHONPATH={_pkg_root} {sys.executable}"
+                cmd = f"KIRO_CLI_PID=$PPID {_py} -m observal_cli.hooks.kiro_hook --url {url} --agent-name {name}"
+                stop_cmd = f"KIRO_CLI_PID=$PPID {_py} -m observal_cli.hooks.kiro_stop_hook --url {url} --agent-name {name}"
             desired = {
                 "agentSpawn": [{"command": cmd}],
                 "userPromptSubmit": [{"command": cmd}],

--- a/observal_cli/hooks/kiro_hook.py
+++ b/observal_cli/hooks/kiro_hook.py
@@ -186,6 +186,18 @@ def main():
             else:
                 payload["session_id"] = f"kiro-{os.getppid()}"
 
+    # Persist session_id so the stop hook (which may not receive it from Kiro)
+    # can reuse it and land credits on the same session.
+    try:
+        session_file = Path.home() / ".observal" / ".kiro-session"
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text(json.dumps({
+            "session_id": payload["session_id"],
+            "cwd": payload.get("cwd", ""),
+        }))
+    except Exception:
+        pass
+
     # Inject user_id and user_name from Observal config if not already present
     if not payload.get("user_id") or not payload.get("user_name"):
         try:

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -83,119 +83,154 @@ def _read_conversation(kiro_db: Path, cwd: str) -> tuple[str, dict] | None:
     return conversation_id, json.loads(value_str)
 
 
+def _read_session_file(session_id: str, retries: tuple = (0.5, 1.0, 2.0)) -> dict | None:
+    """Read a Kiro session JSON file by session_id, retrying if not yet written."""
+    candidates = [session_id]
+    for prefix in ("kiro-cli-", "kiro-"):
+        if session_id.startswith(prefix):
+            candidates.append(session_id[len(prefix):])
+
+    sessions_dir = Path.home() / ".kiro" / "sessions" / "cli"
+    if not sessions_dir.is_dir():
+        return None
+
+    for attempt, delay in enumerate((-1,) + retries):
+        if delay >= 0:
+            time.sleep(delay)
+        for sid in candidates:
+            p = sessions_dir / f"{sid}.json"
+            if p.exists():
+                try:
+                    return json.loads(p.read_text())
+                except Exception:
+                    return None
+
+    return None
+
+
 def _enrich(payload: dict) -> dict:
-    """Read the Kiro SQLite DB and merge session-level stats into *payload*."""
-    kiro_db = _get_kiro_db()
-    if not kiro_db:
-        _debug("Kiro DB not found")
-        return payload
-
+    """Read the Kiro session file and merge session-level stats into *payload*."""
+    session_id = payload.get("session_id", "")
     cwd = payload.get("cwd", "")
-    _debug(f"cwd={cwd}, db={kiro_db}")
+    _debug(f"session_id={session_id}, cwd={cwd}")
 
-    try:
-        result = _read_conversation(kiro_db, cwd)
+    session = None
 
-        # Kiro may not have committed the conversation to SQLite yet when the
-        # stop hook fires. Retry with increasing delays.
-        if not result:
-            for delay in (0.5, 1.0, 1.5):
-                _debug(f"No conversation found for cwd, retrying after {delay}s...")
-                time.sleep(delay)
+    # Try reading from session file first (Kiro 2.2+)
+    if session_id:
+        session = _read_session_file(session_id)
+
+    # Fall back to most recent session matching cwd
+    if not session:
+        sessions_dir = Path.home() / ".kiro" / "sessions" / "cli"
+        if sessions_dir.is_dir() and cwd:
+            matches = [
+                f for f in sessions_dir.glob("*.json")
+                if json.loads(f.read_text()).get("cwd") == cwd
+            ] if False else []  # avoid double-parse; use stat-based sort below
+            try:
+                candidates = sorted(sessions_dir.glob("*.json"), key=lambda f: f.stat().st_mtime, reverse=True)
+                for f in candidates[:10]:
+                    try:
+                        data = json.loads(f.read_text())
+                        if data.get("cwd") == cwd:
+                            session = data
+                            break
+                    except Exception:
+                        continue
+            except Exception:
+                pass
+
+    if not session:
+        # Last resort: try SQLite (Kiro < 2.2)
+        kiro_db = _get_kiro_db()
+        if kiro_db:
+            try:
                 result = _read_conversation(kiro_db, cwd)
+                if not result:
+                    for delay in (0.5, 1.0, 1.5):
+                        time.sleep(delay)
+                        result = _read_conversation(kiro_db, cwd)
+                        if result:
+                            break
                 if result:
-                    break
-
-        if not result:
-            _debug("No conversation found for cwd after retries")
-            return payload
-
-        conversation_id, conv = result
-
-        if conversation_id:
-            payload["conversation_id"] = conversation_id
-    except Exception as e:
-        _debug(f"DB read error: {e}")
+                    conversation_id, conv = result
+                    if conversation_id:
+                        payload["conversation_id"] = conversation_id
+                    utm = conv.get("user_turn_metadata", {})
+                    usage_info = utm.get("usage_info", [])
+                    total_credits = sum(u.get("value", 0.0) for u in usage_info) if usage_info else None
+                    if total_credits is not None:
+                        payload["credits"] = f"{total_credits:.6f}"
+                    model_id = conv.get("model_info", {}).get("model_id", "")
+                    if model_id and not payload.get("model"):
+                        payload["model"] = model_id
+            except Exception as e:
+                _debug(f"SQLite fallback error: {e}")
         return payload
 
-    # --- Extract model info ---
-    model_info = conv.get("model_info", {})
-    model_id = model_info.get("model_id", "")
+    # --- Extract from session file ---
+    conv_meta = session.get("session_state", {}).get("conversation_metadata", {})
+    turn_metadatas = conv_meta.get("user_turn_metadatas", [])
 
-    # --- Aggregate per-turn metadata ---
-    history = conv.get("history", [])
-    total_input_chars = 0
-    total_output_chars = 0
-    turn_count = 0
-    models_used: set[str] = set()
+    def _has_credits(turns: list) -> bool:
+        return any(t.get("metering_usage") for t in turns)
+
+    # Kiro writes metering_usage asynchronously after the stop hook fires.
+    # Poll with increasing delays up to ~15s total.
+    if not _has_credits(turn_metadatas):
+        for delay in (2.0, 3.0, 4.0, 6.0):
+            _debug(f"metering_usage empty, retrying after {delay}s...")
+            time.sleep(delay)
+            fresh = _read_session_file(session_id) if session_id else None
+            if fresh:
+                session = fresh
+                conv_meta = session.get("session_state", {}).get("conversation_metadata", {})
+                turn_metadatas = conv_meta.get("user_turn_metadatas", [])
+            if _has_credits(turn_metadatas):
+                _debug(f"metering_usage found after retry")
+                break
+
+    turn_count = len(turn_metadatas)
+    # Only report the latest turn's credits — the stop hook fires after every
+    # prompt, so sending the cumulative total causes double-counting on the server.
+    latest_turn = turn_metadatas[-1] if turn_metadatas else {}
+    total_credits = sum(
+        u.get("value", 0.0)
+        for u in latest_turn.get("metering_usage", [])
+        if u.get("unit") == "credit"
+    )
+    models_used = {
+        t.get("model_id", "") for t in turn_metadatas if t.get("model_id", "")
+    }
     tools_used: list[str] = []
-    max_context_pct = 0.0
+    for t in turn_metadatas:
+        for tool in t.get("builtin_tool_uses_detail", []):
+            name = tool.get("name", "")
+            if name:
+                tools_used.append(name)
 
-    for entry in history:
-        rm = entry.get("request_metadata")
-        if not rm:
-            continue
-        turn_count += 1
-        total_input_chars += rm.get("user_prompt_length", 0)
-        total_output_chars += rm.get("response_size", 0)
-        mid = rm.get("model_id", "")
-        if mid:
-            models_used.add(mid)
-        ctx_pct = rm.get("context_usage_percentage", 0.0)
-        if ctx_pct > max_context_pct:
-            max_context_pct = ctx_pct
-        for tool_pair in rm.get("tool_use_ids_and_names", []):
-            if isinstance(tool_pair, list) and len(tool_pair) >= 2:
-                tools_used.append(tool_pair[1])
-
-    # --- Credit usage ---
-    utm = conv.get("user_turn_metadata", {})
-    usage_info = utm.get("usage_info", [])
-
-    # Kiro writes usage_info asynchronously — if empty on first read but we
-    # have history entries, retry after a short delay.
-    if not usage_info and history:
-        _debug("usage_info empty, retrying after 500ms...")
-        time.sleep(0.5)
-        try:
-            result2 = _read_conversation(kiro_db, cwd)
-            if result2:
-                conv2 = result2[1]
-                utm = conv2.get("user_turn_metadata", {})
-                usage_info = utm.get("usage_info", [])
-                _debug(f"Retry result: {len(usage_info)} usage_info items")
-        except Exception:
-            pass
-
-    total_credits = sum(u.get("value", 0.0) for u in usage_info) if usage_info else None
-    _debug(f"credits={total_credits}, turn_count={turn_count}, usage_items={len(usage_info)}")
-
-    # --- Resolve the actual model used ---
-    # If model_id is "auto", try to use per-turn model_ids
+    model_id = session.get("session_state", {}).get("rts_model_state", {}).get("model_info", {}).get("model_id", "")
     resolved_model = model_id
-    if model_id == "auto" and models_used - {"auto"}:
-        # Use the most common non-auto model
-        non_auto = [m for m in models_used if m != "auto"]
-        if non_auto:
-            resolved_model = non_auto[0]
+    if model_id == "auto" and models_used - {"auto", ""}:
+        resolved_model = next(m for m in models_used if m not in ("auto", ""))
 
-    # --- Merge into payload ---
+    conv_id = session.get("session_id", "")
+    if conv_id and not payload.get("conversation_id"):
+        payload["conversation_id"] = conv_id
+
     if resolved_model and not payload.get("model"):
         payload["model"] = resolved_model
     payload["turn_count"] = str(turn_count)
-    if total_credits is not None:
+    if total_credits:
         payload["credits"] = f"{total_credits:.6f}"
 
     if tools_used:
-        # Deduplicate while preserving order
         seen: set[str] = set()
-        unique_tools = []
-        for t in tools_used:
-            if t not in seen:
-                unique_tools.append(t)
-                seen.add(t)
+        unique_tools = [t for t in tools_used if not (t in seen or seen.add(t))]  # type: ignore[func-returns-value]
         payload["tools_used"] = ",".join(unique_tools[:20])
 
+    _debug(f"credits={total_credits}, turn_count={turn_count}")
     return payload
 
 
@@ -274,22 +309,28 @@ def main():
     if model:
         payload.setdefault("model", model)
 
-    # Enrich with SQLite data
-    payload = _enrich(payload)
-
-    # POST to Observal
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=5):
+    def _post(p: dict) -> None:
+        d = json.dumps(p).encode("utf-8")
+        r = urllib.request.Request(url, data=d, headers={"Content-Type": "application/json"}, method="POST")
+        try:
+            with urllib.request.urlopen(r, timeout=5):
+                pass
+        except Exception:
             pass
-    except Exception:
-        pass
+
+    # POST the stop event immediately so the server records the correct
+    # timestamp/duration, then fork a background child to enrich with
+    # credits and POST an update.
+    _post(payload)
+
+    if sys.platform != "win32":
+        pid = os.fork()
+        if pid != 0:
+            sys.exit(0)
+        os.setsid()
+
+    payload = _enrich(payload)
+    _post(payload)
 
 
 if __name__ == "__main__":

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -16,12 +16,31 @@ Usage (in a Kiro agent hook):
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 from observal_cli.hooks._kiro_utils import _find_kiro_cli_pid, _resolve_hooks_url
+
+_DEBUG = os.environ.get("OBSERVAL_DEBUG") == "1"
+_LOG_PATH = Path.home() / ".observal" / "hook-debug.log"
+
+logger = logging.getLogger(__name__)
+
+
+def _debug(msg: str) -> None:
+    """Write debug message to log file when OBSERVAL_DEBUG=1."""
+    if not _DEBUG:
+        return
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with _LOG_PATH.open("a") as f:
+            f.write(f"[kiro_stop_hook] {msg}\n")
+    except Exception:
+        pass
 
 
 def _get_kiro_db() -> Path | None:
@@ -45,43 +64,58 @@ def _get_kiro_db() -> Path | None:
     return None
 
 
+def _read_conversation(kiro_db: Path, cwd: str) -> tuple[str, dict] | None:
+    """Read the most recent conversation for *cwd* from Kiro's SQLite DB."""
+    conn = sqlite3.connect(f"file:{kiro_db}?mode=ro", uri=True)
+    cur = conn.cursor()
+    if cwd:
+        cur.execute(
+            "SELECT conversation_id, value FROM conversations_v2 WHERE key = ? ORDER BY updated_at DESC LIMIT 1",
+            (cwd,),
+        )
+    else:
+        cur.execute("SELECT conversation_id, value FROM conversations_v2 ORDER BY updated_at DESC LIMIT 1")
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        return None
+    conversation_id, value_str = row
+    return conversation_id, json.loads(value_str)
+
+
 def _enrich(payload: dict) -> dict:
     """Read the Kiro SQLite DB and merge session-level stats into *payload*."""
     kiro_db = _get_kiro_db()
     if not kiro_db:
+        _debug("Kiro DB not found")
         return payload
 
     cwd = payload.get("cwd", "")
+    _debug(f"cwd={cwd}, db={kiro_db}")
 
     try:
-        conn = sqlite3.connect(f"file:{kiro_db}?mode=ro", uri=True)
-        cur = conn.cursor()
+        result = _read_conversation(kiro_db, cwd)
 
-        # Find the most recent conversation for this cwd
-        if cwd:
-            cur.execute(
-                "SELECT conversation_id, value FROM conversations_v2 WHERE key = ? ORDER BY updated_at DESC LIMIT 1",
-                (cwd,),
-            )
-        else:
-            cur.execute("SELECT conversation_id, value FROM conversations_v2 ORDER BY updated_at DESC LIMIT 1")
+        # Kiro may not have committed the conversation to SQLite yet when the
+        # stop hook fires. Retry with increasing delays.
+        if not result:
+            for delay in (0.5, 1.0, 1.5):
+                _debug(f"No conversation found for cwd, retrying after {delay}s...")
+                time.sleep(delay)
+                result = _read_conversation(kiro_db, cwd)
+                if result:
+                    break
 
-        row = cur.fetchone()
-        conn.close()
-
-        if not row:
+        if not result:
+            _debug("No conversation found for cwd after retries")
             return payload
 
-        conversation_id, value_str = row
-        conv = json.loads(value_str)
+        conversation_id, conv = result
 
-        # Include the real conversation_id for cross-session linking.
-        # The $PPID-based session_id (injected via sed before this script) groups
-        # events within a single kiro-cli run. The conversation_id persists across
-        # resumed sessions — the dashboard can use it to link related sessions.
         if conversation_id:
             payload["conversation_id"] = conversation_id
-    except Exception:
+    except Exception as e:
+        _debug(f"DB read error: {e}")
         return payload
 
     # --- Extract model info ---
@@ -117,9 +151,24 @@ def _enrich(payload: dict) -> dict:
     # --- Credit usage ---
     utm = conv.get("user_turn_metadata", {})
     usage_info = utm.get("usage_info", [])
-    total_credits = 0.0
-    for u in usage_info:
-        total_credits += u.get("value", 0.0)
+
+    # Kiro writes usage_info asynchronously — if empty on first read but we
+    # have history entries, retry after a short delay.
+    if not usage_info and history:
+        _debug("usage_info empty, retrying after 500ms...")
+        time.sleep(0.5)
+        try:
+            result2 = _read_conversation(kiro_db, cwd)
+            if result2:
+                conv2 = result2[1]
+                utm = conv2.get("user_turn_metadata", {})
+                usage_info = utm.get("usage_info", [])
+                _debug(f"Retry result: {len(usage_info)} usage_info items")
+        except Exception:
+            pass
+
+    total_credits = sum(u.get("value", 0.0) for u in usage_info) if usage_info else None
+    _debug(f"credits={total_credits}, turn_count={turn_count}, usage_items={len(usage_info)}")
 
     # --- Resolve the actual model used ---
     # If model_id is "auto", try to use per-turn model_ids
@@ -134,7 +183,8 @@ def _enrich(payload: dict) -> dict:
     if resolved_model and not payload.get("model"):
         payload["model"] = resolved_model
     payload["turn_count"] = str(turn_count)
-    payload["credits"] = f"{total_credits:.6f}"
+    if total_credits is not None:
+        payload["credits"] = f"{total_credits:.6f}"
 
     if tools_used:
         # Deduplicate while preserving order
@@ -175,7 +225,24 @@ def main():
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
+    _debug(f"payload keys: {list(payload.keys())}")
+    _debug(f"payload: {json.dumps(payload)[:2000]}")
+
     payload.setdefault("service_name", "kiro")
+
+    if not payload.get("session_id"):
+        # Kiro 2.x sends session_id on agentSpawn/userPromptSubmit but NOT on
+        # stop events. Read the session_id persisted by the non-stop hook so
+        # credits land on the same session the user sees in the UI.
+        session_file = Path.home() / ".observal" / ".kiro-session"
+        try:
+            if session_file.exists():
+                cached = json.loads(session_file.read_text())
+                if cached.get("session_id"):
+                    payload["session_id"] = cached["session_id"]
+                    _debug(f"Reused persisted session_id: {cached['session_id']}")
+        except Exception:
+            pass
 
     if not payload.get("session_id"):
         env_pid = os.environ.get("KIRO_CLI_PID")

--- a/observal_cli/hooks/kiro_stop_hook.py
+++ b/observal_cli/hooks/kiro_stop_hook.py
@@ -88,13 +88,13 @@ def _read_session_file(session_id: str, retries: tuple = (0.5, 1.0, 2.0)) -> dic
     candidates = [session_id]
     for prefix in ("kiro-cli-", "kiro-"):
         if session_id.startswith(prefix):
-            candidates.append(session_id[len(prefix):])
+            candidates.append(session_id[len(prefix) :])
 
     sessions_dir = Path.home() / ".kiro" / "sessions" / "cli"
     if not sessions_dir.is_dir():
         return None
 
-    for attempt, delay in enumerate((-1,) + retries):
+    for _attempt, delay in enumerate((-1, *retries)):
         if delay >= 0:
             time.sleep(delay)
         for sid in candidates:
@@ -124,10 +124,6 @@ def _enrich(payload: dict) -> dict:
     if not session:
         sessions_dir = Path.home() / ".kiro" / "sessions" / "cli"
         if sessions_dir.is_dir() and cwd:
-            matches = [
-                f for f in sessions_dir.glob("*.json")
-                if json.loads(f.read_text()).get("cwd") == cwd
-            ] if False else []  # avoid double-parse; use stat-based sort below
             try:
                 candidates = sorted(sessions_dir.glob("*.json"), key=lambda f: f.stat().st_mtime, reverse=True)
                 for f in candidates[:10]:
@@ -188,21 +184,15 @@ def _enrich(payload: dict) -> dict:
                 conv_meta = session.get("session_state", {}).get("conversation_metadata", {})
                 turn_metadatas = conv_meta.get("user_turn_metadatas", [])
             if _has_credits(turn_metadatas):
-                _debug(f"metering_usage found after retry")
+                _debug("metering_usage found after retry")
                 break
 
     turn_count = len(turn_metadatas)
     # Only report the latest turn's credits — the stop hook fires after every
     # prompt, so sending the cumulative total causes double-counting on the server.
     latest_turn = turn_metadatas[-1] if turn_metadatas else {}
-    total_credits = sum(
-        u.get("value", 0.0)
-        for u in latest_turn.get("metering_usage", [])
-        if u.get("unit") == "credit"
-    )
-    models_used = {
-        t.get("model_id", "") for t in turn_metadatas if t.get("model_id", "")
-    }
+    total_credits = sum(u.get("value", 0.0) for u in latest_turn.get("metering_usage", []) if u.get("unit") == "credit")
+    models_used = {t.get("model_id", "") for t in turn_metadatas if t.get("model_id", "")}
     tools_used: list[str] = []
     for t in turn_metadatas:
         for tool in t.get("builtin_tool_uses_detail", []):

--- a/observal_cli/ide_specs/kiro_hooks_spec.py
+++ b/observal_cli/ide_specs/kiro_hooks_spec.py
@@ -19,6 +19,7 @@ def _python_cmd() -> str:
     """Return '{python}' or 'PYTHONPATH=... {python}' so observal_cli is always importable."""
     try:
         import importlib.util
+
         if importlib.util.find_spec("observal_cli") is not None:
             return sys.executable
     except Exception:

--- a/observal_cli/ide_specs/kiro_hooks_spec.py
+++ b/observal_cli/ide_specs/kiro_hooks_spec.py
@@ -7,8 +7,25 @@ Kiro has no global hooks -- hooks must be injected per-agent into
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 KIRO_HOOK_EVENTS = ("agentSpawn", "userPromptSubmit", "preToolUse", "postToolUse", "stop")
+
+# Parent of the observal_cli package directory
+_PKG_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+
+
+def _python_cmd() -> str:
+    """Return '{python}' or 'PYTHONPATH=... {python}' so observal_cli is always importable."""
+    try:
+        import importlib.util
+        if importlib.util.find_spec("observal_cli") is not None:
+            return sys.executable
+    except Exception:
+        pass
+    if sys.platform == "win32":
+        return f'set "PYTHONPATH={_PKG_ROOT}" && {sys.executable}'
+    return f"PYTHONPATH={_PKG_ROOT} {sys.executable}"
 
 
 def build_kiro_hook_cmd(hooks_url: str, agent_name: str, model: str = "") -> str:
@@ -16,7 +33,7 @@ def build_kiro_hook_cmd(hooks_url: str, agent_name: str, model: str = "") -> str
     args = f"--url {hooks_url} --agent-name {agent_name}"
     if model:
         args += f" --model {model}"
-    return f"{sys.executable} -m observal_cli.hooks.kiro_hook {args}"
+    return f"{_python_cmd()} -m observal_cli.hooks.kiro_hook {args}"
 
 
 def build_kiro_stop_cmd(hooks_url: str, agent_name: str, model: str = "") -> str:
@@ -24,7 +41,7 @@ def build_kiro_stop_cmd(hooks_url: str, agent_name: str, model: str = "") -> str
     args = f"--url {hooks_url} --agent-name {agent_name}"
     if model:
         args += f" --model {model}"
-    return f"{sys.executable} -m observal_cli.hooks.kiro_stop_hook {args}"
+    return f"{_python_cmd()} -m observal_cli.hooks.kiro_stop_hook {args}"
 
 
 def build_kiro_hooks(hooks_url: str, agent_name: str, model: str = "") -> dict:

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -337,8 +337,16 @@ class TestPullKiro:
                         "name": "my-agent",
                         "tools": ["search"],
                         "hooks": {
-                            "agentSpawn": [{"command": "python3 -m observal_cli.hooks.kiro_hook --url http://localhost:8000/api/v1/telemetry/hooks --agent-name my-agent"}],
-                            "stop": [{"command": "python3 -m observal_cli.hooks.kiro_stop_hook --url http://localhost:8000/api/v1/telemetry/hooks --agent-name my-agent"}],
+                            "agentSpawn": [
+                                {
+                                    "command": "python3 -m observal_cli.hooks.kiro_hook --url http://localhost:8000/api/v1/telemetry/hooks --agent-name my-agent"
+                                }
+                            ],
+                            "stop": [
+                                {
+                                    "command": "python3 -m observal_cli.hooks.kiro_stop_hook --url http://localhost:8000/api/v1/telemetry/hooks --agent-name my-agent"
+                                }
+                            ],
                         },
                     },
                 }

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -325,6 +326,37 @@ class TestPullKiro:
         data = json.loads(agent.read_text())
         assert data["name"] == "my-agent"
         assert data["tools"] == ["search"]
+
+    def test_rewrites_hook_python_path(self, tmp_path: Path):
+        """Hook commands should use sys.executable, not bare python3."""
+        snippet = {
+            "config_snippet": {
+                "agent_file": {
+                    "path": "~/.kiro/agents/my-agent.json",
+                    "content": {
+                        "name": "my-agent",
+                        "tools": ["search"],
+                        "hooks": {
+                            "agentSpawn": [{"command": "python3 -m observal_cli.hooks.kiro_hook --url http://localhost:8000/api/v1/telemetry/hooks --agent-name my-agent"}],
+                            "stop": [{"command": "python3 -m observal_cli.hooks.kiro_stop_hook --url http://localhost:8000/api/v1/telemetry/hooks --agent-name my-agent"}],
+                        },
+                    },
+                }
+            }
+        }
+        with _patch_config(), _patch_get_agent(), _patch_post(snippet):
+            result = runner.invoke(
+                cli_app, ["agent", "pull", "abc123", "--ide", "kiro", "--dir", str(tmp_path), "--no-prompt"]
+            )
+
+        assert result.exit_code == 0, result.output
+        agent = tmp_path / ".kiro" / "agents" / "my-agent.json"
+        data = json.loads(agent.read_text())
+        # All hook commands should use sys.executable, not bare python3
+        for event, entries in data["hooks"].items():
+            for h in entries:
+                assert sys.executable in h["command"], f"{event} hook missing sys.executable: {h['command']}"
+                assert not h["command"].startswith("python3 ")
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/web/src/app/(user)/traces/[id]/page.tsx
+++ b/web/src/app/(user)/traces/[id]/page.tsx
@@ -1293,7 +1293,7 @@ function SessionStats({ events, sessionId, serviceName }: { events: RawSessionEv
       {stats.isKiro ? (
         <div className="space-y-1">
           <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Credits</p>
-          <p className="text-lg font-semibold tabular-nums text-orange-500">{formatCredits(stats.credits)}</p>
+          <p className="text-lg font-semibold tabular-nums text-orange-500">{stats.credits > 0 ? formatCredits(stats.credits) : "—"}</p>
         </div>
       ) : !stats.isCopilotCli ? (
         <>

--- a/web/src/app/(user)/traces/page.tsx
+++ b/web/src/app/(user)/traces/page.tsx
@@ -73,11 +73,11 @@ function fmtTokens(n: number | string | undefined): string {
   return `${num}`;
 }
 
-function fmtCredits(c: string | undefined): string {
-  if (!c) return "0.00";
+function fmtCredits(c: string | undefined): string | null {
+  if (!c) return null;
   const num = parseFloat(c);
-  if (isNaN(num)) return "0.00";
-  return num < 0.01 && num > 0 ? num.toFixed(4) : num.toFixed(2);
+  if (isNaN(num) || num <= 0) return null;
+  return num < 0.01 ? num.toFixed(4) : num.toFixed(2);
 }
 
 function fmtDuration(first?: string, last?: string): string {
@@ -184,9 +184,18 @@ const columns: ColumnDef<Session>[] = [
         );
       }
       if (isKiroSession(r)) {
+        const credits = fmtCredits(r.credits);
+        if (credits) {
+          return (
+            <span className="text-[13px] font-mono tabular-nums text-orange-400">
+              {credits} cr
+            </span>
+          );
+        }
+        const count = r.prompt_count ?? 0;
         return (
-          <span className="text-[13px] font-mono tabular-nums text-orange-400">
-            {fmtCredits(r.credits)} cr
+          <span className="text-[13px] text-muted-foreground">
+            {count} prompt{count !== 1 ? "s" : ""}
           </span>
         );
       }


### PR DESCRIPTION
**fix(kiro): stabilize hook paths, credit tracking, and session list aggregation**
  
  
  ## Fixes
  - Fixes #693
  
  ## Changes
  
  ### Hook path resolution
  - Hooks used bare `python3` which can't find `observal_cli` when Kiro runs outside the repo
  directory
  - Added `PYTHONPATH` injection so hooks work from any working directory
  
  ### Credit tracking (Kiro 2.2+)
  - Kiro 2.2 no longer writes conversation data to SQLite
  - Reads `metering_usage` from `~/.kiro/sessions/cli/<session_id>.json` instead
  - Forks a background process to wait for async credit writes without blocking Kiro
  - Sends per-turn credits (not cumulative) to avoid double-counting
  
  ### Session list credits
  - Sessions list used `anyIf` (picks one arbitrary credit value) instead of summing
  - Changed to `sumIf` so list view matches detail view
  
  ## Testing
  - Verified hooks fire from directories outside the Observal repo
  - Verified credits appear in Observal UI after session ends
  - Verified per-turn credit amounts are correct