### PR TITLE
Unified eval categories in the UI

### DIFF
--- a/observal-server/api/routes/eval.py
+++ b/observal-server/api/routes/eval.py
@@ -529,3 +529,84 @@ async def scorecard_penalties(
     penalties = raw.get("penalties", [])
     await audit(current_user, "eval.scorecard.penalties", resource_type="scorecard", resource_id=str(sc.id))
     return penalties
+
+
+@router.get("/agents/{agent_id}/sessions", response_model=list[dict])
+async def list_agent_evaluated_sessions(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Get list of sessions where this agent was actually used (from telemetry), not from scorecards.
+
+    This avoids the trace_id mapping problem where eval creates synthetic trace_ids that don't
+    exist in ClickHouse telemetry.
+    """
+    agent = await resolve_prefix_id(Agent, agent_id, db)
+
+    _log.info("list_agent_evaluated_sessions_start", agent_id=str(agent.id), agent_name=agent.name)
+
+    # Org-scope check: verify agent belongs to user's org
+    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
+        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+
+    # Query ClickHouse directly for sessions where this agent was used
+    # Uses strict agent_name matching (works for Kiro and any IDE that sets agent_name)
+    # No heuristics = zero false positives
+    sql = (
+        "SELECT DISTINCT "
+        "LogAttributes['session.id'] AS session_id, "
+        "min(Timestamp) AS start_time, "
+        "max(Timestamp) AS end_time, "
+        "count() AS event_count, "
+        "any(LogAttributes['tool_input']) AS first_prompt, "
+        "any(ServiceName) AS service_name "
+        "FROM otel_logs "
+        "WHERE LogAttributes['agent_name'] = {agent_name:String} "
+        "AND LogAttributes['session.id'] != '' "
+        "GROUP BY session_id "
+        "ORDER BY start_time DESC "
+        "LIMIT 50"
+    )
+
+    session_map: dict[str, dict] = {}
+
+    try:
+        ch_result = await _query(f"{sql} FORMAT JSON", {"param_agent_name": agent.name})
+        _log.info("clickhouse_query_result", status_code=ch_result.status_code, agent_name=agent.name)
+        if ch_result.status_code == 200:
+            data = ch_result.json().get("data", [])
+            _log.info("clickhouse_data", row_count=len(data), agent_name=agent.name)
+            for row in data:
+                sid = row.get("session_id")
+                # Only include sessions with actual events
+                event_count = row.get("event_count", 0)
+                if sid and event_count > 0:
+                    session_map[sid] = {
+                        "session_id": sid,
+                        "trace_id": sid,  # Use session_id as trace_id for consistency
+                        "evaluated_at": row.get("end_time", row.get("start_time")),  # Use session end time
+                        "start_time": row.get("start_time"),
+                        "end_time": row.get("end_time"),
+                        "event_count": event_count,
+                        "first_prompt": (row.get("first_prompt") or "")[:100],
+                        "service_name": row.get("service_name"),
+                    }
+    except Exception as e:
+        _log.warning("failed_to_fetch_agent_sessions", agent_name=agent.name, error=str(e))
+        return []
+
+    # Convert to list
+    valid_sessions = list(session_map.values())
+
+    _log.info("list_agent_evaluated_sessions_complete", agent_name=agent.name, session_count=len(valid_sessions))
+
+    await audit(
+        current_user,
+        "eval.agent.sessions.list",
+        resource_type="agent",
+        resource_id=str(agent.id),
+        resource_name=agent.name,
+    )
+
+    return valid_sessions

--- a/observal-server/api/routes/sessions.py
+++ b/observal-server/api/routes/sessions.py
@@ -824,6 +824,9 @@ async def get_session(session_id: str, current_user: User = Depends(require_role
 @router.get("/{session_id}/efficiency")
 async def get_session_efficiency(session_id: str, current_user: User = Depends(require_role(UserRole.user))):
     """Run kernel efficiency analysis on a session's hook events."""
+    if not session_id or not session_id.strip():
+        return {"error": "No session ID provided"}
+
     is_admin = _is_admin_user(current_user)
     params: dict[str, str] = {"param_sid": session_id}
 
@@ -841,6 +844,7 @@ async def get_session_efficiency(session_id: str, current_user: User = Depends(r
         if not ownership:
             return {"error": "Session not found or access denied"}
 
+    # Try querying by session.id first
     events = await _ch_json(
         "SELECT "
         "Timestamp AS timestamp, "
@@ -853,6 +857,21 @@ async def get_session_efficiency(session_id: str, current_user: User = Depends(r
         "ORDER BY Timestamp ASC",
         params,
     )
+
+    # If no events found, try querying by TraceId (for evaluation traces)
+    if not events:
+        events = await _ch_json(
+            "SELECT "
+            "Timestamp AS timestamp, "
+            "LogAttributes['event.name'] AS event_name, "
+            "Body AS body, "
+            "LogAttributes AS attributes, "
+            "ServiceName AS service_name "
+            "FROM otel_logs "
+            "WHERE TraceId = {sid:String} "
+            "ORDER BY Timestamp ASC",
+            params,
+        )
 
     if not events:
         return {"error": "No events found for session", "session_id": session_id}

--- a/observal-server/services/hook_materializer.py
+++ b/observal-server/services/hook_materializer.py
@@ -576,7 +576,24 @@ def build_agent_eval_context(
 
 def _normalize_event_name(name: str) -> str:
     """Normalize event names to a consistent form."""
-    if name.startswith("hook_") or name in (
+    # Normalize hook_ prefixed names (handle both lowercase and camelCase)
+    if name.startswith("hook_"):
+        # Map lowercase hook events to camelCase
+        hook_mapping = {
+            "hook_pretooluse": "hook_PreToolUse",
+            "hook_posttooluse": "hook_PostToolUse",
+            "hook_posttoolusefailure": "hook_PostToolUseFailure",
+            "hook_userpromptsubmit": "hook_UserPromptSubmit",
+            "hook_assistant_response": "hook_AssistantResponse",
+            "hook_sessionstart": "hook_SessionStart",
+            "hook_subagentstart": "hook_SubagentStart",
+            "hook_subagentstop": "hook_SubagentStop",
+            "hook_stop": "hook_Stop",
+        }
+        normalized = hook_mapping.get(name.lower(), name)
+        return normalized
+
+    if name in (
         "PreToolUse",
         "PostToolUse",
         "UserPromptSubmit",
@@ -584,6 +601,8 @@ def _normalize_event_name(name: str) -> str:
         "SessionStart",
     ):
         return name
+
+    # Non-hook event mapping
     mapping = {
         "preToolUse": "PreToolUse",
         "postToolUse": "PostToolUse",

--- a/web/src/app/(admin)/eval/[agentId]/page.tsx
+++ b/web/src/app/(admin)/eval/[agentId]/page.tsx
@@ -1,23 +1,32 @@
 "use client";
 
-import { use } from "react";
-import { FlaskConical } from "lucide-react";
-import { useEvalScorecards, useEvalAggregate, useRegistryItem, useEvalRun, useEvalPenalties } from "@/hooks/use-api";
+import { use, useState, useEffect } from "react";
+import { FlaskConical, Zap } from "lucide-react";
+import { useEvalScorecards, useEvalAggregate, useRegistryItem, useEvalRun, useEvalPenalties, useAgentEvaluatedSessions, useSessionEfficiency } from "@/hooks/use-api";
 import type { RegistryItem, Scorecard } from "@/lib/types";
 import { AgentAggregateChart } from "@/components/dashboard/agent-aggregate-chart";
 import { DimensionRadar } from "@/components/dashboard/dimension-radar";
 import { PenaltyAccordion } from "@/components/dashboard/penalty-accordion";
+import { EfficiencyMetrics } from "@/components/dashboard/efficiency-metrics";
+import { SessionDAG } from "@/components/dashboard/session-dag";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { PageHeader } from "@/components/layouts/page-header";
-import { TableSkeleton, ChartSkeleton } from "@/components/shared/skeleton-layouts";
+import { TableSkeleton, ChartSkeleton, DetailSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { ScoreOverview } from "@/components/dashboard/score-overview";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 function gradeColor(grade: string | undefined): string {
   if (!grade) return "text-muted-foreground";
@@ -28,21 +37,22 @@ function gradeColor(grade: string | undefined): string {
   return "text-destructive";
 }
 
-function _gradeBg(grade: string | undefined): string {
-  if (!grade) return "bg-muted";
-  const g = grade.toUpperCase();
-  if (g.startsWith("A")) return "bg-success/10";
-  if (g.startsWith("B")) return "bg-info/10";
-  if (g.startsWith("C")) return "bg-warning/10";
-  return "bg-destructive/10";
-}
 
 export default function EvalDetailPage({ params }: { params: Promise<{ agentId: string }> }) {
   const { agentId } = use(params);
   const { data: agent } = useRegistryItem("agents", agentId);
   const { data: scorecards, isLoading, isError, error, refetch } = useEvalScorecards(agentId);
   const { data: aggregate, isLoading: aggLoading } = useEvalAggregate(agentId);
+  const { data: evaluatedSessions, isLoading: sessionsLoading } = useAgentEvaluatedSessions(agentId);
   const runEval = useEvalRun();
+
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+
+  // Auto-select first session when sessions load (using derived state to avoid effect)
+  const defaultSessionId = evaluatedSessions?.[0]?.session_id ?? null;
+  const activeSessionId = selectedSessionId ?? defaultSessionId;
+
+  const { data: efficiency, isLoading: effLoading } = useSessionEfficiency(activeSessionId ?? undefined);
 
   const a = agent as RegistryItem | undefined;
   const cards = scorecards ?? [];
@@ -72,149 +82,279 @@ export default function EvalDetailPage({ params }: { params: Promise<{ agentId: 
         }
       />
       <div className="p-6 w-full mx-auto space-y-6">
-        {/* 2-column layout */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Left: 2/3 — Chart + History */}
-          <div className="lg:col-span-2 space-y-6">
-            {/* Aggregate Chart */}
-            {aggLoading ? (
-              <ChartSkeleton />
-            ) : aggregate ? (
-              <section className="animate-in">
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-                  Score Over Time
-                </h3>
-                <div className="rounded-md border border-border p-4">
-                  <AgentAggregateChart data={aggregate} />
-                </div>
-              </section>
-            ) : null}
+        <Tabs defaultValue="evaluation" className="animate-in">
+          <TabsList>
+            <TabsTrigger value="evaluation">Evaluation</TabsTrigger>
+            <TabsTrigger value="history">History</TabsTrigger>
+          </TabsList>
 
-            {/* Scorecard History */}
-            <section className="animate-in stagger-2">
-              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-                Scorecard History
-              </h3>
-              {isLoading ? (
-                <TableSkeleton rows={5} cols={5} />
-              ) : isError ? (
-                <ErrorState message={error?.message} onRetry={() => refetch()} />
-              ) : cards.length === 0 ? (
-                <EmptyState
-                  icon={FlaskConical}
-                  title="No scorecards yet"
-                  description="Run an eval to generate scores for this agent."
-                  onAction={() => runEval.mutate({ agentId })}
-                  actionLabel="Run Eval"
-                />
-              ) : (
-                <div className="overflow-x-auto rounded-md border border-border">
-                  <Table>
-                    <TableHeader>
-                      <TableRow className="hover:bg-transparent">
-                        <TableHead className="h-8 text-xs">Date</TableHead>
-                        <TableHead className="h-8 text-xs">Version</TableHead>
-                        <TableHead className="h-8 text-xs">Score</TableHead>
-                        <TableHead className="h-8 text-xs">Grade</TableHead>
-                        <TableHead className="h-8 text-xs text-right">Penalties</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {cards.map((sc: Scorecard) => (
-                        <TableRow key={sc.id}>
-                          <TableCell className="py-1.5 text-xs tabular-nums">
-                            {sc.created_at ? new Date(sc.created_at).toLocaleDateString() : "-"}
-                          </TableCell>
-                          <TableCell className="py-1.5 text-xs text-muted-foreground font-[family-name:var(--font-mono)]">
-                            {sc.version ? `v${sc.version}` : "-"}
-                          </TableCell>
-                          <TableCell className="py-1.5 text-xs font-[family-name:var(--font-mono)] tabular-nums">
-                            {sc.display_score?.toFixed(1) ?? sc.overall_score?.toFixed(1) ?? "-"}
-                          </TableCell>
-                          <TableCell className="py-1.5">
-                            <Badge variant="outline" className={`text-[10px] px-1.5 py-0 ${gradeColor(sc.grade ?? sc.overall_grade)}`}>
-                              {sc.grade ?? sc.overall_grade ?? "-"}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className="py-1.5 text-xs text-muted-foreground text-right tabular-nums">
-                            {sc.penalty_count ?? 0}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
+          {/* Evaluation Tab - Merged Correctness & Efficiency */}
+          <TabsContent value="evaluation" className="mt-6">
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+              {/* LEFT SECTION: CORRECTNESS */}
+              <div className="rounded-lg border border-border bg-card">
+                <div className="border-b border-border px-5 py-3 flex items-center gap-2">
+                  <FlaskConical className="h-4 w-4 text-muted-foreground" />
+                  <h2 className="text-sm font-semibold">Correctness</h2>
                 </div>
-              )}
-            </section>
-          </div>
+                <div className="p-5 space-y-6">
+                  {/* Latest Evaluation */}
+                  {latest ? (
+                    <section className="animate-in">
+                      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                        Latest Evaluation
+                      </h3>
+                      <div className="rounded-md border border-border p-4">
+                        <ScoreOverview
+                          displayScore={latest.display_score ?? 0}
+                          grade={latest.grade ?? "-"}
+                          dimensionScores={latest.dimension_scores ?? {}}
+                          penaltyCount={latest.penalty_count}
+                        />
+                        {latest.version && (
+                          <p className="text-xs text-muted-foreground mt-3 pt-3 border-t border-border">
+                            Version: <span className="font-[family-name:var(--font-mono)]">v{latest.version}</span>
+                          </p>
+                        )}
+                      </div>
+                    </section>
+                  ) : (
+                    <EmptyState
+                      icon={FlaskConical}
+                      title="No evaluation yet"
+                      description="Run an eval to see correctness scores."
+                      onAction={() => runEval.mutate({ agentId })}
+                      actionLabel="Run Eval"
+                    />
+                  )}
 
-          {/* Right: 1/3 — Score Summary */}
-          <div className="space-y-6">
-            {/* Score Overview with Dimension Breakdown */}
-            {latest && (
-              <section className="animate-in stagger-1">
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-                  Current Score
-                </h3>
-                <div className="rounded-md border border-border p-5">
-                  <ScoreOverview
-                    displayScore={latest.display_score ?? 0}
-                    grade={latest.grade ?? "-"}
-                    dimensionScores={latest.dimension_scores ?? {}}
-                    penaltyCount={latest.penalty_count}
-                  />
-                  {latest.version && (
-                    <p className="text-xs text-muted-foreground mt-3 pt-3 border-t border-border">
-                      Version: <span className="font-[family-name:var(--font-mono)]">v{latest.version}</span>
-                    </p>
+                  {/* Dimension Radar */}
+                  {latest?.dimension_scores && (
+                    <section className="animate-in stagger-1">
+                      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                        Dimension Radar
+                      </h3>
+                      <div className="rounded-md border border-border p-3">
+                        <DimensionRadar dimensionScores={latest.dimension_scores} />
+                      </div>
+                    </section>
+                  )}
+
+                  {/* Recommendations */}
+                  {latest && (latest.scoring_recommendations ?? []).length > 0 && (
+                    <section className="animate-in stagger-2">
+                      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                        Recommendations
+                      </h3>
+                      <ul className="space-y-2">
+                        {(latest.scoring_recommendations ?? []).map((r: string, i: number) => (
+                          <li key={i} className="flex gap-2 text-xs text-muted-foreground">
+                            <span className="text-foreground shrink-0">-</span>
+                            <span>{r}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  )}
+
+                  {/* Penalties */}
+                  {latestPenalties && latestPenalties.length > 0 && (
+                    <section className="animate-in stagger-3">
+                      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                        Penalties ({latestPenalties.length})
+                      </h3>
+                      <PenaltyAccordion penalties={latestPenalties} />
+                    </section>
                   )}
                 </div>
-              </section>
-            )}
+              </div>
 
-            {/* Dimension Radar */}
-            {latest?.dimension_scores && (
+              {/* RIGHT SECTION: EFFICIENCY */}
+              <div className="rounded-lg border border-border bg-card">
+                <div className="border-b border-border px-5 py-3 flex items-center gap-2">
+                  <Zap className="h-4 w-4 text-muted-foreground" />
+                  <h2 className="text-sm font-semibold">Efficiency</h2>
+                </div>
+                <div className="p-5 space-y-6">
+                  {/* Session Selector */}
+                  <div className="space-y-3">
+                    <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                      Evaluated Session
+                    </h3>
+                    {sessionsLoading ? (
+                      <div className="h-9 w-full animate-pulse bg-muted rounded-md" />
+                    ) : evaluatedSessions && evaluatedSessions.length > 0 ? (
+                      <Select value={activeSessionId ?? ""} onValueChange={setSelectedSessionId}>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select a session to view efficiency" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {evaluatedSessions.map((session) => {
+                            const startTime = session.start_time ? new Date(session.start_time) : null;
+                            const firstPrompt = session.first_prompt || "";
+                            const promptPreview = firstPrompt.slice(0, 60);
+
+                            return (
+                              <SelectItem key={session.session_id} value={session.session_id}>
+                                <div className="flex flex-col gap-0.5 py-1">
+                                  <div className="flex items-center gap-2">
+                                    <span className="font-mono text-xs text-foreground">
+                                      {session.session_id.slice(0, 12)}...
+                                    </span>
+                                    {startTime && (
+                                      <span className="text-muted-foreground text-xs">
+                                        {startTime.toLocaleDateString()} {startTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                      </span>
+                                    )}
+                                    {session.event_count && session.event_count > 0 && (
+                                      <span className="text-muted-foreground text-[10px]">
+                                        ({session.event_count} events)
+                                      </span>
+                                    )}
+                                  </div>
+                                  {promptPreview && (
+                                    <span className="text-muted-foreground text-[11px] italic">
+                                      &ldquo;{promptPreview}{firstPrompt.length > 60 ? "..." : ""}&rdquo;
+                                    </span>
+                                  )}
+                                </div>
+                              </SelectItem>
+                            );
+                          })}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <EmptyState
+                        icon={Zap}
+                        title="No evaluated sessions"
+                        description="Run an eval to see efficiency metrics."
+                        onAction={() => runEval.mutate({ agentId })}
+                        actionLabel="Run Eval"
+                      />
+                    )}
+                  </div>
+
+                  {/* Efficiency Content */}
+                  {activeSessionId && (
+                    <>
+                      {effLoading ? (
+                        <DetailSkeleton />
+                      ) : efficiency && !efficiency.error ? (
+                        <div className="space-y-6">
+                          {/* Efficiency Metrics */}
+                          <section className="animate-in">
+                            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                              Metrics
+                            </h3>
+                            <EfficiencyMetrics data={efficiency} />
+                          </section>
+
+                          {/* Session DAG */}
+                          <section className="animate-in stagger-1">
+                            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                              Session DAG
+                            </h3>
+                            {efficiency.dag ? (
+                              <SessionDAG dag={efficiency.dag} />
+                            ) : (
+                              <EmptyState
+                                icon={Zap}
+                                title="No DAG data"
+                                description="DAG visualization is not available for this session."
+                              />
+                            )}
+                          </section>
+                        </div>
+                      ) : (
+                        <EmptyState
+                          icon={Zap}
+                          title="No efficiency data"
+                          description={efficiency?.error || "Efficiency metrics are not available for this session yet."}
+                        />
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+
+          {/* History Tab */}
+          <TabsContent value="history" className="mt-6">
+            <div className="space-y-6">
+              {/* Aggregate Chart */}
+              {aggLoading ? (
+                <ChartSkeleton />
+              ) : aggregate ? (
+                <section className="animate-in">
+                  <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                    Score Over Time
+                  </h3>
+                  <div className="rounded-md border border-border p-4">
+                    <AgentAggregateChart data={aggregate} />
+                  </div>
+                </section>
+              ) : null}
+
+              {/* Scorecard History */}
               <section className="animate-in stagger-2">
                 <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-                  Dimension Radar
+                  Scorecard History
                 </h3>
-                <div className="rounded-md border border-border p-2">
-                  <DimensionRadar dimensionScores={latest.dimension_scores} />
-                </div>
+                {isLoading ? (
+                  <TableSkeleton rows={5} cols={5} />
+                ) : isError ? (
+                  <ErrorState message={error?.message} onRetry={() => refetch()} />
+                ) : cards.length === 0 ? (
+                  <EmptyState
+                    icon={FlaskConical}
+                    title="No scorecards yet"
+                    description="Run an eval to generate scores for this agent."
+                    onAction={() => runEval.mutate({ agentId })}
+                    actionLabel="Run Eval"
+                  />
+                ) : (
+                  <div className="overflow-x-auto rounded-md border border-border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow className="hover:bg-transparent">
+                          <TableHead className="h-8 text-xs">Date</TableHead>
+                          <TableHead className="h-8 text-xs">Version</TableHead>
+                          <TableHead className="h-8 text-xs">Score</TableHead>
+                          <TableHead className="h-8 text-xs">Grade</TableHead>
+                          <TableHead className="h-8 text-xs text-right">Penalties</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {cards.map((sc: Scorecard) => (
+                          <TableRow key={sc.id}>
+                            <TableCell className="py-1.5 text-xs tabular-nums">
+                              {sc.created_at ? new Date(sc.created_at).toLocaleDateString() : "-"}
+                            </TableCell>
+                            <TableCell className="py-1.5 text-xs text-muted-foreground font-[family-name:var(--font-mono)]">
+                              {sc.version ? `v${sc.version}` : "-"}
+                            </TableCell>
+                            <TableCell className="py-1.5 text-xs font-[family-name:var(--font-mono)] tabular-nums">
+                              {sc.display_score?.toFixed(1) ?? sc.overall_score?.toFixed(1) ?? "-"}
+                            </TableCell>
+                            <TableCell className="py-1.5">
+                              <Badge variant="outline" className={`text-[10px] px-1.5 py-0 ${gradeColor(sc.grade ?? sc.overall_grade)}`}>
+                                {sc.grade ?? sc.overall_grade ?? "-"}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="py-1.5 text-xs text-muted-foreground text-right tabular-nums">
+                              {sc.penalty_count ?? 0}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
               </section>
-            )}
-
-            {/* Recommendations */}
-            {latest && (latest.scoring_recommendations ?? []).length > 0 && (
-              <section className="animate-in stagger-3">
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-                  Recommendations
-                </h3>
-                <ul className="space-y-2">
-                  {(latest.scoring_recommendations ?? []).map((r: string, i: number) => (
-                    <li key={i} className="flex gap-2 text-xs text-muted-foreground">
-                      <span className="text-foreground shrink-0">-</span>
-                      <span>{r}</span>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            )}
-          </div>
-        </div>
-
-        {/* Penalties */}
-        {latestPenalties && latestPenalties.length > 0 && (
-          <>
-            <Separator />
-            <section className="animate-in stagger-4">
-              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-                Penalties ({latestPenalties.length})
-              </h3>
-              <PenaltyAccordion penalties={latestPenalties} />
-            </section>
-          </>
-        )}
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
     </>
   );

--- a/web/src/app/(user)/traces/[id]/page.tsx
+++ b/web/src/app/(user)/traces/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useState, useCallback, useMemo, createElement } from "react";
-import { useSessionDetail, useSessionSubscription, useSessionEfficiency } from "@/hooks/use-api";
+import { useSessionDetail, useSessionSubscription } from "@/hooks/use-api";
 import type { SessionData, RawSessionEvent } from "@/lib/types";
 import {
   FileText,
@@ -40,8 +40,6 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { EfficiencyMetrics } from "@/components/dashboard/efficiency-metrics";
-import { SessionDAG } from "@/components/dashboard/session-dag";
 
 /* ── Helpers ─────────────────────────────────────────────── */
 
@@ -1593,7 +1591,6 @@ function SessionInfoTab({ events, sessionId, serviceName }: { events: RawSession
 export default function TraceDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { data, isLoading, isError, error, refetch } = useSessionDetail(id);
-  const { data: efficiency, isLoading: effLoading } = useSessionEfficiency(id);
   useSessionSubscription();
 
   const session = data as SessionData;
@@ -1720,7 +1717,6 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
               <Tabs defaultValue="traces" className="animate-in stagger-1">
                 <TabsList>
                   <TabsTrigger value="traces">Traces</TabsTrigger>
-                  <TabsTrigger value="efficiency">Efficiency</TabsTrigger>
                   <TabsTrigger value="info">Session Info</TabsTrigger>
                 </TabsList>
                 <TabsContent value="traces" className="space-y-2 mt-4">
@@ -1812,22 +1808,6 @@ export default function TraceDetailPage({ params }: { params: Promise<{ id: stri
                         );
                       })}
                     </div>
-                  )}
-                </TabsContent>
-                <TabsContent value="efficiency" className="mt-4">
-                  {effLoading ? (
-                    <DetailSkeleton />
-                  ) : efficiency && !efficiency.error ? (
-                    <div className="space-y-4">
-                      <EfficiencyMetrics data={efficiency} />
-                      {efficiency.dag && <SessionDAG dag={efficiency.dag} />}
-                    </div>
-                  ) : (
-                    <EmptyState
-                      icon={Zap}
-                      title="No efficiency data"
-                      description={efficiency?.error || "Efficiency metrics are not available for this session yet."}
-                    />
                   )}
                 </TabsContent>
                 <TabsContent value="info" className="mt-4">

--- a/web/src/components/dashboard/efficiency-metrics.tsx
+++ b/web/src/components/dashboard/efficiency-metrics.tsx
@@ -39,8 +39,11 @@ export function EfficiencyMetrics({ data }: { data: EfficiencyData }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const animatedRef = useRef(false);
 
+  // Check if there are no tool calls (rating is 0 and no meaningful metrics)
+  const hasNoToolCalls = rating === 0 && Object.values(data.efficiency_metrics).every(v => v === 0 || v === null);
+
   useEffect(() => {
-    if (animatedRef.current || !containerRef.current) return;
+    if (animatedRef.current || !containerRef.current || hasNoToolCalls) return;
     animatedRef.current = true;
 
     const scoreEl = containerRef.current.querySelector("[data-score-number]");
@@ -72,7 +75,7 @@ export function EfficiencyMetrics({ data }: { data: EfficiencyData }) {
 
     tl.to(rows, { opacity: 1, x: 0, duration: 0.5, stagger: 0.04 }, 0.3);
     tl.to(warnings, { opacity: 1, y: 0, duration: 0.4, stagger: 0.06 }, "-=0.2");
-  }, [rating]);
+  }, [rating, hasNoToolCalls]);
 
   const entries = Object.entries(data.interpretation);
 
@@ -107,87 +110,90 @@ export function EfficiencyMetrics({ data }: { data: EfficiencyData }) {
           }}
         >
           {/* Hero score section */}
-          <div className="px-5 pt-5 pb-4">
-            <div className="flex items-end gap-4">
-              <div className="flex items-baseline gap-1">
-                <span
-                  data-score-number
-                  className="text-5xl font-black tabular-nums leading-none"
-                  style={{ color, textShadow: `0 0 40px ${color}40` }}
-                >
-                  0
-                </span>
-                <span className="text-lg font-medium" style={{ color: color + "80" }}>/100</span>
-              </div>
-              <div className="flex-1 pb-2">
-                <div
-                  className="h-2 rounded-full overflow-hidden"
-                  style={{ background: "rgba(100,116,139,0.08)" }}
-                >
+          {!hasNoToolCalls && (
+            <div className="px-5 pt-5 pb-4">
+              <div className="flex items-end gap-4">
+                <div className="flex items-baseline gap-1">
+                  <span
+                    data-score-number
+                    className="text-5xl font-black tabular-nums leading-none"
+                    style={{ color, textShadow: `0 0 40px ${color}40` }}
+                  >
+                    0
+                  </span>
+                  <span className="text-lg font-medium" style={{ color: color + "80" }}>/100</span>
+                </div>
+                <div className="flex-1 pb-2">
                   <div
-                    data-bar-fill
-                    className="h-full rounded-full"
-                    style={{
-                      background: `linear-gradient(90deg, ${color}cc, ${color})`,
-                      boxShadow: `0 0 12px ${color}50`,
-                      width: "0%",
-                    }}
-                  />
+                    className="h-2 rounded-full overflow-hidden"
+                    style={{ background: "rgba(100,116,139,0.08)" }}
+                  >
+                    <div
+                      data-bar-fill
+                      className="h-full rounded-full"
+                      style={{
+                        background: `linear-gradient(90deg, ${color}cc, ${color})`,
+                        boxShadow: `0 0 12px ${color}50`,
+                        width: "0%",
+                      }}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          )}
 
           {/* Metrics grid */}
-          <div className="px-4 pb-4 space-y-1">
-            {entries.map(([key, label]) => {
-              const meta = METRIC_LABELS[key] || { label: key, description: "" };
-              const rawValue = data.efficiency_metrics[key];
-              const displayValue = rawValue === null || rawValue === undefined
-                ? "—"
-                : typeof rawValue === "number" && !Number.isInteger(rawValue)
-                  ? rawValue.toFixed(2)
-                  : String(rawValue);
-              const style = interpretStyle(label);
+          {entries.length > 0 && (
+            <div className="px-4 pb-4 space-y-1">
+              {entries.map(([key, label]) => {
+                const meta = METRIC_LABELS[key] || { label: key, description: "" };
+                const rawValue = data.efficiency_metrics[key];
+                const displayValue = rawValue === null || rawValue === undefined
+                  ? "—"
+                  : typeof rawValue === "number" && !Number.isInteger(rawValue)
+                    ? rawValue.toFixed(2)
+                    : String(rawValue);
+                const style = interpretStyle(label);
 
-              return (
-                <div
-                  key={key}
-                  data-metric-row
-                  className="flex items-center justify-between py-2 px-3 rounded-lg group"
-                  style={{ background: "rgba(100,116,139,0.03)" }}
-                >
-                  <div className="flex flex-col min-w-0 mr-3">
-                    <span className="text-[12px] font-medium" style={{ color: "rgba(226,232,240,0.8)" }}>
-                      {meta.label}
-                    </span>
-                    <span className="text-[10px]" style={{ color: "rgba(148,163,184,0.4)" }}>
-                      {meta.description}
-                    </span>
+                return (
+                  <div
+                    key={key}
+                    data-metric-row
+                    className="flex items-center justify-between py-2 px-3 rounded-lg group"
+                    style={{ background: "rgba(100,116,139,0.03)" }}
+                  >
+                    <div className="flex flex-col min-w-0 mr-3">
+                      <span className="text-[12px] font-medium" style={{ color: "rgba(226,232,240,0.8)" }}>
+                        {meta.label}
+                      </span>
+                      <span className="text-[10px]" style={{ color: "rgba(148,163,184,0.4)" }}>
+                        {meta.description}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2.5 shrink-0">
+                      <span
+                        className="text-xs font-mono font-bold tabular-nums"
+                        style={{ color: "rgba(226,232,240,0.7)" }}
+                      >
+                        {displayValue}
+                      </span>
+                      <span
+                        className="text-[10px] font-semibold px-2 py-0.5 rounded-md whitespace-nowrap"
+                        style={{ color: style.color, background: style.bg, border: `1px solid ${style.border}` }}
+                      >
+                        {label.split("(")[0].trim()}
+                      </span>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2.5 shrink-0">
-                    <span
-                      className="text-xs font-mono font-bold tabular-nums"
-                      style={{ color: "rgba(226,232,240,0.7)" }}
-                    >
-                      {displayValue}
-                    </span>
-                    <span
-                      className="text-[10px] font-semibold px-2 py-0.5 rounded-md whitespace-nowrap"
-                      style={{ color: style.color, background: style.bg, border: `1px solid ${style.border}` }}
-                    >
-                      {label.split("(")[0].trim()}
-                    </span>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+                );
+              })}
+            </div>
+          )}
 
           {/* Warnings */}
           {data.warnings.length > 0 && (
-            <div className="px-4 pb-4 space-y-1.5">
-              <div className="h-px" style={{ background: "rgba(245,158,11,0.1)" }} />
+            <div className="p-4 space-y-1.5">
               {data.warnings.map((w, i) => (
                 <div
                   key={i}

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -216,6 +216,14 @@ export function useEvalScorecards(
   });
 }
 
+export function useAgentEvaluatedSessions(agentId: string | undefined) {
+  return useQuery({
+    queryKey: ["eval", "agent-sessions", agentId],
+    enabled: !!agentId,
+    queryFn: () => eval_.agentSessions(agentId!),
+  });
+}
+
 export function useEvalCompare(
   agentId: string | undefined,
   params: Record<string, string>,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -424,6 +424,17 @@ export const eval_ = {
   },
   penalties: (scorecardId: string) =>
     get<TracePenalty[]>(`/eval/scorecards/${scorecardId}/penalties`),
+  agentSessions: (agentId: string) =>
+    get<Array<{
+      session_id: string;
+      trace_id: string;
+      evaluated_at: string;
+      start_time?: string;
+      end_time?: string;
+      event_count?: number;
+      first_prompt?: string;
+      service_name?: string;
+    }>>(`/eval/agents/${agentId}/sessions`),
 };
 
 // ── Admin ───────────────────────────────────────────────────────────


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Two sets of evals show up in different places

## Fixes
* Fixes #<!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
Moves them to exist together by agent, adds session identification by agent so DAG and efficiency metrics are still viewed per session 
Session filtering works for Kiro, separate PR needed for Claude Code

## How Has This Been Tested?
Checked new agents, concurrent running, etc

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->