### PR TITLE
feat(eval): sessions by agent for claude

### DIFF
--- a/observal-server/api/routes/sessions.py
+++ b/observal-server/api/routes/sessions.py
@@ -869,6 +869,8 @@ async def get_session_efficiency(session_id: str, current_user: User = Depends(r
             "ServiceName AS service_name "
             "FROM otel_logs "
             "WHERE TraceId = {sid:String} "
+            "AND (LogAttributes['user.id'] = {uid:String} "
+            "     OR LogAttributes['user.id'] = {uemail:String}) "
             "ORDER BY Timestamp ASC",
             params,
         )
@@ -883,3 +885,42 @@ async def get_session_efficiency(session_id: str, current_user: User = Depends(r
     except Exception:
         logger.exception("Session efficiency analysis failed for %s", session_id)
         return {"error": "Analysis failed", "session_id": session_id}
+
+
+@router.post("/{session_id}/bind-agent")
+async def bind_session_agent(
+    session_id: str,
+    agent_name: str = Query(..., description="Agent name to bind to this session"),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Explicitly bind a session to an agent name.
+
+    Overrides any cached attribution.  Used when frontmatter hooks are
+    unavailable or when the wrong agent was initially attributed.
+    """
+    is_admin = _is_admin_user(current_user)
+    if not is_admin:
+        params = {"param_sid": session_id, "param_uid": str(current_user.id), "param_uemail": current_user.email}
+        ownership = await _ch_json(
+            "SELECT 1 FROM otel_logs "
+            "WHERE LogAttributes['session.id'] = {sid:String} "
+            "AND (LogAttributes['user.id'] = {uid:String} "
+            "     OR LogAttributes['user.id'] = {uemail:String}) "
+            "LIMIT 1",
+            params,
+        )
+        if not ownership:
+            return {"error": "Session not found or access denied"}
+
+    from redis.exceptions import RedisError
+
+    from services.redis import get_redis
+
+    try:
+        redis = get_redis()
+        await redis.set(f"session_agent:{session_id}", agent_name, ex=86400)
+    except RedisError:
+        return {"session_id": session_id, "agent_name": agent_name, "bound": False, "error": "Redis unavailable"}
+
+    await audit(current_user, "session.bind_agent", "session", resource_id=session_id, detail=f"Bound to {agent_name}")
+    return {"session_id": session_id, "agent_name": agent_name, "bound": True}

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -898,6 +898,27 @@ async def ingest_hook(request: Request):
     if body.get("permission_mode"):
         attrs["permission_mode"] = body["permission_mode"]
 
+    # ── Session-agent cache: propagate agent_name across all events in a session ──
+    # Uses body["agent_name"] (hook-injected) for writes to avoid caching subagent
+    # descriptions set by _extract_claude_code in attrs.  SETNX ensures the first
+    # attribution sticks for the session's lifetime.
+    if session_id and len(session_id) <= 256 and all(c.isalnum() or c in "-_" for c in session_id):
+        _body_agent = body.get("agent_name", "")
+        if _body_agent:
+            try:
+                _redis = get_redis()
+                await _redis.set(f"session_agent:{session_id}", _body_agent, nx=True, ex=86400)
+            except RedisError:
+                pass
+        elif not attrs.get("agent_name"):
+            try:
+                _redis = get_redis()
+                _cached = await _redis.get(f"session_agent:{session_id}")
+                if _cached:
+                    attrs["agent_name"] = _cached
+            except RedisError:
+                pass
+
     # ── Registered-agents-only gate ──
     # When enabled, drop unregistered agent spans entirely (no ClickHouse write).
     from services.agent_registry_cache import is_registered, is_toggle_enabled, resolve_user_org

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -50,16 +50,24 @@ _GENERIC_HOOK_EVENTS = [
 
 
 def _claude_code_hooks_frontmatter_lines(
-    hook_script: str, stop_script: str, custom_hooks: list[dict] | None = None
+    hook_script: str,
+    stop_script: str,
+    agent_name: str = "",
+    custom_hooks: list[dict] | None = None,
 ) -> list[str]:
     """Build the YAML lines for a hooks: section in Claude Code frontmatter.
 
     Returns a list of indented strings (no trailing newlines) ready to be
     appended to the frontmatter_lines list before the closing '---'.
 
+    agent_name: baked into hook commands so each agent's telemetry carries
+    its identity (mirrors Kiro's --agent-name pattern).
+
     custom_hooks: list of dicts with event, handler_type, handler_config
     from hook components attached to the agent.
     """
+    import re
+
     custom_hooks = custom_hooks or []
     custom_by_event: dict[str, list[dict]] = {}
     for h in custom_hooks:
@@ -67,13 +75,16 @@ def _claude_code_hooks_frontmatter_lines(
         if ev:
             custom_by_event.setdefault(ev, []).append(h)
 
+    agent_name = re.sub(r"[^a-zA-Z0-9_\-.]", "", agent_name)
+    agent_flag = f" --agent-name {agent_name}" if agent_name else ""
+
     lines = ["hooks:"]
     for event in _GENERIC_HOOK_EVENTS:
         lines += [
             f"  {event}:",
             "    - hooks:",
             "        - type: command",
-            f'          command: "{hook_script}"',
+            f'          command: "{hook_script}{agent_flag}"',
         ]
         for ch in custom_by_event.get(event, []):
             lines += _custom_hook_matcher_lines(ch)
@@ -82,10 +93,10 @@ def _claude_code_hooks_frontmatter_lines(
         "  Stop:",
         "    - hooks:",
         "        - type: command",
-        f'          command: "{hook_script}"',
+        f'          command: "{hook_script}{agent_flag}"',
         "    - hooks:",
         "        - type: command",
-        f'          command: "{stop_script}"',
+        f'          command: "{stop_script}{agent_flag}"',
     ]
     for ch in custom_by_event.get("Stop", []):
         lines += _custom_hook_matcher_lines(ch)
@@ -730,7 +741,12 @@ def generate_agent_config(
             for mcp_name in claude_mcps:
                 frontmatter_lines.append(f"  - {mcp_name}")
         frontmatter_lines.extend(
-            _claude_code_hooks_frontmatter_lines("observal-hook.sh", "observal-stop-hook.sh", custom_hooks=hook_configs)
+            _claude_code_hooks_frontmatter_lines(
+                "observal-hook.sh",
+                "observal-stop-hook.sh",
+                agent_name=safe_name,
+                custom_hooks=hook_configs,
+            )
         )
         frontmatter_lines.append("---")
         agent_content = "\n".join(frontmatter_lines) + "\n\n" + rules_content

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -933,7 +933,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "0.3.4"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -1080,9 +1080,10 @@ def _install_claude_code_hooks(server_url: str, api_key: str) -> list[str]:
     stop_script = _find_hook_script("observal-stop-hook.sh")
     cfg = config.load()
     user_id = cfg.get("user_id", "")
+    agent_name = cfg.get("agent_name", "")
 
     desired_hooks = get_desired_hooks(hook_script, stop_script, hooks_url, user_id)
-    desired_env = get_desired_env(server_url, api_key, user_id)
+    desired_env = get_desired_env(server_url, api_key, user_id, agent_name=agent_name)
 
     return settings_reconciler.reconcile(desired_hooks, desired_env)
 
@@ -1441,7 +1442,8 @@ def doctor_patch(
                         "(telemetry via agent frontmatter)[/dim]"
                     )
                     user_id = cfg.get("user_id", "")
-                    desired_env = get_desired_env(server_url, api_key, user_id)
+                    agent_name = cfg.get("agent_name", "")
+                    desired_env = get_desired_env(server_url, api_key, user_id, agent_name=agent_name)
                     changes = settings_reconciler.reconcile({}, desired_env, dry_run=dry_run)
                     # Warn if stale global hooks exist in settings.json
                     settings_path = Path.home() / ".claude" / "settings.json"
@@ -1476,7 +1478,8 @@ def doctor_patch(
                         stop_script = _find_hook_script("observal-stop-hook.sh")
                         user_id = cfg.get("user_id", "")
                         desired_hooks = get_desired_hooks(hook_script, stop_script, hooks_url, user_id)
-                        desired_env = get_desired_env(server_url, api_key, user_id)
+                        agent_name = cfg.get("agent_name", "")
+                        desired_env = get_desired_env(server_url, api_key, user_id, agent_name=agent_name)
                         changes = settings_reconciler.reconcile(desired_hooks, desired_env, dry_run=True)
                     else:
                         changes = _install_claude_code_hooks(server_url, api_key)

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -296,6 +296,7 @@ def _find_hook_script(name: str) -> str | None:
 @hook_app.command(name="sync")
 def hook_sync(
     dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show changes without applying"),
+    agent_name: str = typer.Option("", "--agent-name", help="Agent name for telemetry attribution (env var fallback)"),
 ):
     """Sync Claude Code hooks to the latest Observal spec.
 
@@ -316,8 +317,19 @@ def hook_sync(
     stop_script = _find_hook_script("observal-stop-hook.sh")
     user_id = cfg.get("user_id", "")
 
+    # Use explicit --agent-name, fall back to config, then auto-detect
+    if not agent_name:
+        agent_name = cfg.get("agent_name", "")
+    if not agent_name:
+        from observal_cli.client import get_registered_agent_names
+
+        agents = get_registered_agent_names()
+        if len(agents) == 1:
+            agent_name = next(iter(agents))
+            rprint(f"[dim]Auto-detected single agent: {agent_name}[/dim]")
+
     desired_hooks = get_desired_hooks(hook_script, stop_script, hooks_url, user_id)
-    desired_env = get_desired_env(server_url, access_token, user_id)
+    desired_env = get_desired_env(server_url, access_token, user_id, agent_name=agent_name)
 
     applied = settings_reconciler.get_applied_version()
     from observal_cli.ide_specs.claude_code_hooks_spec import HOOKS_SPEC_VERSION

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -25,19 +26,27 @@ def _resolve_hook_paths(content: str) -> str:
     Server-side config generator emits bare script names (observal-hook.sh)
     since it doesn't know the client's install path. This resolves them to
     the actual paths inside the installed package.
+
+    Uses regex anchored to quoted command context so matches like
+    ``"observal-hook.sh --agent-name foo"`` are resolved correctly,
+    but comments or prose mentioning the script name are not affected.
     """
     import shutil
 
     hooks_dir = Path(__file__).parent / "hooks"
     for name in _HOOK_SCRIPT_NAMES:
         local = hooks_dir / name
-        if local.is_file():
-            content = content.replace(f'"{name}"', f'"{local.resolve().as_posix()}"')
-        else:
+        path = local.resolve().as_posix()
+        if not local.is_file():
             # Fallback: check if it's on PATH
             found = shutil.which(name)
-            if found:
-                content = content.replace(f'"{name}"', f'"{Path(found).resolve().as_posix()}"')
+            if not found:
+                continue
+            path = Path(found).resolve().as_posix()
+        # Match script name inside quotes with optional trailing args, replace only the script name
+        pattern = rf'"{re.escape(name)}(?:\s+[^"]*)?'
+        replacement = f'"{path}'
+        content = re.sub(pattern, replacement, content)
     return content
 
 

--- a/observal_cli/hooks/observal-hook.sh
+++ b/observal_cli/hooks/observal-hook.sh
@@ -25,8 +25,30 @@ if [ -z "$OBSERVAL_HOOKS_URL" ]; then
 fi
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Parse --agent-name from arguments (set by per-agent frontmatter hooks)
+_agent_name=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --agent-name) _agent_name="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
 # Read payload from stdin into a variable so we can reuse it
 payload=$(cat)
+
+# Inject agent_name into the payload (frontmatter arg takes priority over env var)
+_effective_agent="${_agent_name:-$OBSERVAL_AGENT_NAME}"
+if [ -n "$_effective_agent" ]; then
+  payload=$(echo "$payload" | OBSERVAL_AGENT_NAME="$_effective_agent" "$_py" -c "
+import json,sys,os
+d=json.load(sys.stdin)
+a=os.environ.get('OBSERVAL_AGENT_NAME','')
+if a and not d.get('agent_name'):
+    d['agent_name']=a
+print(json.dumps(d))
+" 2>/dev/null || echo "$payload")
+fi
 
 # Try to send to server first
 if echo "$payload" | curl -sf --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \

--- a/observal_cli/hooks/observal-stop-hook.sh
+++ b/observal_cli/hooks/observal-stop-hook.sh
@@ -29,6 +29,16 @@ if [ -z "$OBSERVAL_HOOKS_URL" ]; then
 fi
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Parse --agent-name from arguments (set by per-agent frontmatter hooks)
+_agent_name=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --agent-name) _agent_name="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+_effective_agent="${_agent_name:-$OBSERVAL_AGENT_NAME}"
+
 # Read hook payload from stdin
 PAYLOAD=$(cat)
 
@@ -98,6 +108,7 @@ if [ -n "$THINK_FILES" ]; then
       --arg response "$THINK_TEXT" \
       --arg seq "$TSEQ" \
       --arg total "$THINK_TOTAL" \
+      --arg agent_name "${_effective_agent:-}" \
       '{
         hook_event_name: "Stop",
         session_id: $session_id,
@@ -105,7 +116,7 @@ if [ -n "$THINK_FILES" ]; then
         tool_response: $response,
         message_sequence: ($seq | tonumber),
         message_total: ($total | tonumber)
-      }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
+      } + (if $agent_name != "" then {agent_name: $agent_name} else {} end)' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
         ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
         ${OBSERVAL_USERNAME:+-H "X-Observal-Username: $OBSERVAL_USERNAME"} \
         -H "Content-Type: application/json" \
@@ -129,6 +140,7 @@ if [ -n "$MSG_FILES" ]; then
       --arg response "$MSG_TEXT" \
       --arg seq "$SEQ" \
       --arg total "$MSG_TOTAL" \
+      --arg agent_name "${_effective_agent:-}" \
       '{
         hook_event_name: "Stop",
         session_id: $session_id,
@@ -136,7 +148,7 @@ if [ -n "$MSG_FILES" ]; then
         tool_response: $response,
         message_sequence: ($seq | tonumber),
         message_total: ($total | tonumber)
-      }' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
+      } + (if $agent_name != "" then {agent_name: $agent_name} else {} end)' | curl -s --max-time 5 -X POST "$OBSERVAL_HOOKS_URL" \
         ${OBSERVAL_USER_ID:+-H "X-Observal-User-Id: $OBSERVAL_USER_ID"} \
         ${OBSERVAL_USERNAME:+-H "X-Observal-Username: $OBSERVAL_USERNAME"} \
         -H "Content-Type: application/json" \

--- a/observal_cli/ide_specs/claude_code_hooks_spec.py
+++ b/observal_cli/ide_specs/claude_code_hooks_spec.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 # Bump this when hook definitions change (new events, different scripts,
 # additional handlers, etc.).  Stored in ~/.observal/config.json so we
 # can detect when an upgrade is needed without re-reading all hooks.
-HOOKS_SPEC_VERSION = "6"
+HOOKS_SPEC_VERSION = "7"
 
 # Metadata key injected into every Observal matcher group.
 # Primary identification method — the reconciler checks this first.
@@ -105,6 +105,7 @@ def get_desired_env(
     hooks_token: str,
     user_id: str = "",
     user_name: str = "",
+    agent_name: str = "",
 ) -> dict[str, str]:
     """Return the desired Observal env vars for Claude Code settings."""
     env: dict[str, str] = {
@@ -122,6 +123,8 @@ def get_desired_env(
         env["OTEL_RESOURCE_ATTRIBUTES"] = f"user.id={user_id}"
     if user_name:
         env["OBSERVAL_USERNAME"] = user_name
+    if agent_name:
+        env["OBSERVAL_AGENT_NAME"] = agent_name
 
     return env
 
@@ -141,5 +144,6 @@ MANAGED_ENV_KEYS = frozenset(
         "OBSERVAL_HOOKS_SPEC_VERSION",
         "OBSERVAL_USER_ID",
         "OBSERVAL_USERNAME",
+        "OBSERVAL_AGENT_NAME",
     }
 )


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Needed to make sure claude sessions were taken into account for agent eval

## Fixes
* Fixes #743

## Approach
uses the agent specific .claude files, adding am agent-name field to check against for each session

## How Has This Been Tested?
full flow checked to see results in frontend with multiple concurrent agents

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->