### PR TITLE
fix: replace dangerous alembic stamp-head fallback with smart migration script

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -25,6 +25,7 @@ COPY --from=builder --chown=appuser:appgroup /app/.venv /app/.venv
 COPY --chown=appuser:appgroup observal-server/ .
 COPY --chown=appuser:appgroup ee/ ./ee/
 COPY --chown=appuser:appgroup docker/entrypoint.sh /app/entrypoint.sh
+COPY --chown=appuser:appgroup docker/migrate.py /app/migrate.py
 RUN sed -i 's/\r$//' /app/entrypoint.sh
 
 USER appuser

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,25 +1,8 @@
 #!/bin/bash
 set -e
 
-echo "Ensuring base schema exists..."
-/app/.venv/bin/python -c "
-import asyncio
-from database import engine
-from models import Base
-
-async def init():
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    await engine.dispose()
-
-asyncio.run(init())
-"
-
-echo "Running database migrations..."
-/app/.venv/bin/python -m alembic upgrade head || {
-    echo "Migrations failed — stamping head and retrying..."
-    /app/.venv/bin/python -m alembic stamp head
-}
+echo "Running database migration..."
+/app/.venv/bin/python /app/migrate.py
 
 echo "Ensuring ClickHouse database exists..."
 # Parse credentials from CLICKHOUSE_URL using Python to handle special chars

--- a/docker/migrate.py
+++ b/docker/migrate.py
@@ -1,0 +1,175 @@
+"""Smart database migration script for Observal.
+
+Detects the current database state and applies the correct migration strategy:
+- Empty DB: create_all + stamp head (fresh install)
+- Managed DB (has alembic_version): alembic upgrade head (fail hard on error)
+- Unmanaged DB (tables exist, no alembic_version): create_all + sync missing columns + stamp head
+
+Never silently stamps head after a failure. Exits non-zero on any error.
+"""
+
+import asyncio
+import subprocess
+import sys
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from config import settings
+from models import Base
+
+
+def detect_state_sync(conn) -> str:
+    """Detect the current database state (runs inside run_sync).
+
+    Returns:
+        "empty" - no application tables exist
+        "managed" - alembic_version table exists (previously migrated)
+        "unmanaged" - application tables exist but no alembic_version
+    """
+    result = conn.execute(
+        text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = 'alembic_version'"
+        )
+    )
+    if result.scalar() is not None:
+        return "managed"
+
+    result = conn.execute(
+        text(
+            "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_type = 'BASE TABLE'"
+        )
+    )
+    table_count = result.scalar() or 0
+    return "unmanaged" if table_count > 0 else "empty"
+
+
+def sync_missing_columns(conn) -> int:
+    """Compare model-defined columns against live DB and add missing ones.
+
+    Uses ALTER TABLE ... ADD COLUMN IF NOT EXISTS for safety.
+    Returns the number of columns added.
+    """
+    insp = inspect(conn)
+    dialect = conn.engine.dialect
+    added = 0
+
+    for table_name, table in Base.metadata.tables.items():
+        if not insp.has_table(table_name):
+            continue
+
+        live_columns = {col["name"] for col in insp.get_columns(table_name)}
+
+        for column in table.columns:
+            if column.name in live_columns:
+                continue
+
+            col_type = column.type.compile(dialect=dialect)
+            nullable = "" if column.nullable else " NOT NULL"
+            default = ""
+            if column.server_default is not None:
+                default_text = column.server_default.arg
+                if hasattr(default_text, "text"):
+                    default = f" DEFAULT {default_text.text}"
+                else:
+                    default = f" DEFAULT {default_text}"
+
+            # NOT NULL columns without a default can't be added to non-empty tables,
+            # so we add them as nullable in that case.
+            ddl = (
+                f"ALTER TABLE {table_name} "
+                f"ADD COLUMN IF NOT EXISTS \"{column.name}\" {col_type}{nullable}{default}"
+            )
+            print(f"  Adding missing column: {table_name}.{column.name} ({col_type})")
+            try:
+                conn.execute(text(ddl))
+                added += 1
+            except Exception:
+                # Retry as nullable if NOT NULL constraint fails
+                ddl_nullable = (
+                    f"ALTER TABLE {table_name} "
+                    f"ADD COLUMN IF NOT EXISTS \"{column.name}\" {col_type}{default}"
+                )
+                try:
+                    conn.execute(text(ddl_nullable))
+                    added += 1
+                except Exception as e2:
+                    print(f"  WARNING: Could not add {table_name}.{column.name}: {e2}")
+
+    return added
+
+
+def run_alembic(command: list[str]) -> int:
+    """Run an alembic command and return the exit code."""
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic"] + command,
+        capture_output=False,
+    )
+    return result.returncode
+
+
+async def main():
+    async_engine = create_async_engine(settings.DATABASE_URL)
+
+    # Step 1: Detect state
+    async with async_engine.connect() as conn:
+        state = await conn.run_sync(detect_state_sync)
+
+    if state == "empty":
+        print("[migrate] Empty database detected — fresh install")
+        print("[migrate] Creating tables from models...")
+        async with async_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        print("[migrate] Stamping alembic head...")
+        rc = run_alembic(["stamp", "head"])
+        if rc != 0:
+            print("[migrate] ERROR: Failed to stamp head", file=sys.stderr)
+            sys.exit(1)
+        print("[migrate] Fresh install complete ✓")
+
+    elif state == "managed":
+        print("[migrate] Managed database detected — running migrations")
+        rc = run_alembic(["upgrade", "head"])
+        if rc != 0:
+            print(
+                "[migrate] ERROR: Migrations failed. "
+                "Do NOT use 'alembic stamp head' to work around this. "
+                "Investigate the error above and fix the migration.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print("[migrate] Migrations complete ✓")
+
+    else:
+        print("[migrate] Unmanaged database detected — reconciling schema")
+        print("[migrate] Running create_all for missing tables...")
+        async with async_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        print("[migrate] Checking for missing columns...")
+        # Use a synchronous engine for inspect() — it doesn't support async
+        sync_url = settings.DATABASE_URL.replace("+asyncpg", "")
+        sync_engine = create_engine(sync_url)
+        with sync_engine.begin() as sync_conn:
+            added = sync_missing_columns(sync_conn)
+        sync_engine.dispose()
+
+        if added:
+            print(f"[migrate] Added {added} missing column(s)")
+        else:
+            print("[migrate] Schema is up to date")
+
+        print("[migrate] Stamping alembic head...")
+        rc = run_alembic(["stamp", "head"])
+        if rc != 0:
+            print("[migrate] ERROR: Failed to stamp head", file=sys.stderr)
+            sys.exit(1)
+        print("[migrate] Schema reconciliation complete ✓")
+
+    await async_engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -58,32 +58,11 @@ from services.redis import close as close_redis
 setup_logging()
 
 
-async def _ensure_columns(conn):
-    """Add columns that may be missing on existing databases."""
-    from sqlalchemy import text
-
-    stmts = [
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255)",
-        "ALTER TABLE mcp_listings ADD COLUMN IF NOT EXISTS environment_variables JSONB",
-    ]
-    for stmt in stmts:
-        try:
-            await conn.execute(text(stmt))
-        except Exception:
-            pass  # column already exists or DB doesn't support IF NOT EXISTS
-
-    try:
-        await conn.execute(text("ALTER TABLE users ADD COLUMN IF NOT EXISTS is_demo BOOLEAN DEFAULT false"))
-    except Exception:
-        pass
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     if not settings.SKIP_DDL_ON_STARTUP:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-            await _ensure_columns(conn)
         await init_clickhouse()
     await init_cache()
     # Initialize asymmetric key manager for JWT signing

--- a/tests/test_docker_migrate.py
+++ b/tests/test_docker_migrate.py
@@ -1,0 +1,497 @@
+"""Tests for docker/migrate.py — smart database migration script."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add docker/ to path so we can import migrate
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "docker"))
+import migrate
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+class AsyncCM:
+    """Async context manager mock."""
+    def __init__(self, value):
+        self.value = value
+    async def __aenter__(self):
+        return self.value
+    async def __aexit__(self, *args):
+        pass
+
+
+class AsyncConnMock:
+    """Mock async connection where run_sync returns a coroutine."""
+    def __init__(self, sync_return=None):
+        self._sync_return = sync_return
+        self.run_sync_calls = []
+
+    async def run_sync(self, fn):
+        self.run_sync_calls.append(fn)
+        if self._sync_return is not None:
+            return self._sync_return
+        return fn(MagicMock())
+
+
+async def _coro(val):
+    return val
+
+
+def make_mock_conn(state="empty"):
+    """Create a mock connection that returns the given state from detect_state_sync."""
+    conn = MagicMock()
+    if state == "managed":
+        r1 = MagicMock(); r1.scalar.return_value = 1
+        conn.execute.side_effect = [r1]
+    elif state == "unmanaged":
+        r1 = MagicMock(); r1.scalar.return_value = None
+        r2 = MagicMock(); r2.scalar.return_value = 5
+        conn.execute.side_effect = [r1, r2]
+    else:  # empty
+        r1 = MagicMock(); r1.scalar.return_value = None
+        r2 = MagicMock(); r2.scalar.return_value = 0
+        conn.execute.side_effect = [r1, r2]
+    return conn
+
+
+# ── detect_state_sync tests ──────────────────────────────────────────
+
+class TestDetectState:
+    def test_empty_database(self):
+        conn = make_mock_conn("empty")
+        assert migrate.detect_state_sync(conn) == "empty"
+
+    def test_managed_database(self):
+        conn = make_mock_conn("managed")
+        assert migrate.detect_state_sync(conn) == "managed"
+
+    def test_unmanaged_database(self):
+        conn = make_mock_conn("unmanaged")
+        assert migrate.detect_state_sync(conn) == "unmanaged"
+
+    def test_null_table_count_treated_as_empty(self):
+        """Edge case: COUNT returns NULL (shouldn't happen but defensive)."""
+        conn = MagicMock()
+        r1 = MagicMock(); r1.scalar.return_value = None
+        r2 = MagicMock(); r2.scalar.return_value = None
+        conn.execute.side_effect = [r1, r2]
+        assert migrate.detect_state_sync(conn) == "empty"
+
+    def test_db_error_propagates(self):
+        """Adversarial: DB connection error should propagate, not be swallowed."""
+        conn = MagicMock()
+        conn.execute.side_effect = Exception("connection refused")
+        with pytest.raises(Exception, match="connection refused"):
+            migrate.detect_state_sync(conn)
+
+    def test_single_table_is_unmanaged(self):
+        """Edge case: just 1 table (not alembic_version) → unmanaged."""
+        conn = MagicMock()
+        r1 = MagicMock(); r1.scalar.return_value = None
+        r2 = MagicMock(); r2.scalar.return_value = 1
+        conn.execute.side_effect = [r1, r2]
+        assert migrate.detect_state_sync(conn) == "unmanaged"
+
+
+# ── sync_missing_columns tests ───────────────────────────────────────
+
+class TestSyncMissingColumns:
+    def _make_conn_and_insp(self, live_columns, table_exists=True):
+        conn = MagicMock()
+        conn.engine = MagicMock()
+        conn.engine.dialect = MagicMock()
+        insp = MagicMock()
+        insp.has_table.return_value = table_exists
+        insp.get_columns.return_value = [{"name": c} for c in live_columns]
+        return conn, insp
+
+    def _make_model_col(self, name, col_type="JSONB", nullable=True, default=None):
+        col = MagicMock()
+        col.name = name
+        col.type = MagicMock()
+        col.type.compile.return_value = col_type
+        col.nullable = nullable
+        col.server_default = default
+        return col
+
+    def test_no_missing_columns(self):
+        conn, insp = self._make_conn_and_insp(["id", "name"])
+        col1 = self._make_model_col("id")
+        col2 = self._make_model_col("name")
+        table = MagicMock(); table.columns = [col1, col2]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                assert migrate.sync_missing_columns(conn) == 0
+        conn.execute.assert_not_called()
+
+    def test_adds_missing_nullable_column(self):
+        conn, insp = self._make_conn_and_insp(["id"])
+        col_missing = self._make_model_col("gaming_flags", "JSONB", nullable=True)
+        table = MagicMock(); table.columns = [self._make_model_col("id"), col_missing]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"agent_versions": table}
+                assert migrate.sync_missing_columns(conn) == 1
+        sql_text = conn.execute.call_args[0][0].text
+        assert "ADD COLUMN IF NOT EXISTS" in sql_text
+        assert "gaming_flags" in sql_text
+        assert "JSONB" in sql_text
+
+    def test_adds_column_with_server_default(self):
+        default = MagicMock()
+        default.arg = MagicMock()
+        default.arg.text = "'false'"
+        col = self._make_model_col("is_editing", "BOOLEAN", nullable=False, default=default)
+        conn, insp = self._make_conn_and_insp(["id"])
+        table = MagicMock(); table.columns = [self._make_model_col("id"), col]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                assert migrate.sync_missing_columns(conn) == 1
+        sql_text = conn.execute.call_args[0][0].text
+        assert "DEFAULT 'false'" in sql_text
+
+    def test_skips_nonexistent_table(self):
+        conn, insp = self._make_conn_and_insp([], table_exists=False)
+        table = MagicMock(); table.columns = [self._make_model_col("id")]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"ghost": table}
+                assert migrate.sync_missing_columns(conn) == 0
+        insp.get_columns.assert_not_called()
+
+    def test_not_null_fallback_to_nullable(self):
+        """NOT NULL without default on non-empty table → retry as nullable."""
+        conn, insp = self._make_conn_and_insp(["id"])
+        col = self._make_model_col("required", "VARCHAR(255)", nullable=False)
+        table = MagicMock(); table.columns = [self._make_model_col("id"), col]
+        conn.execute.side_effect = [Exception("null value in column"), None]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                assert migrate.sync_missing_columns(conn) == 1
+        assert conn.execute.call_count == 2
+
+    def test_multiple_missing_columns(self):
+        conn, insp = self._make_conn_and_insp(["id"])
+        col_a = self._make_model_col("col_a", "TEXT")
+        col_b = self._make_model_col("col_b", "INTEGER")
+        table = MagicMock(); table.columns = [self._make_model_col("id"), col_a, col_b]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                assert migrate.sync_missing_columns(conn) == 2
+
+    def test_column_with_special_characters_quoted(self):
+        """Column names are quoted to handle reserved words."""
+        conn, insp = self._make_conn_and_insp([])
+        col = self._make_model_col("order", "INTEGER")
+        table = MagicMock(); table.columns = [col]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                migrate.sync_missing_columns(conn)
+        sql_text = conn.execute.call_args[0][0].text
+        assert '"order"' in sql_text
+
+    def test_both_retries_fail_warns_but_continues(self):
+        """If both attempts fail, warn and continue without crashing."""
+        conn, insp = self._make_conn_and_insp(["id"])
+        col = self._make_model_col("broken", "BADTYPE", nullable=False)
+        table = MagicMock(); table.columns = [self._make_model_col("id"), col]
+        conn.execute.side_effect = [Exception("type error"), Exception("still broken")]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                assert migrate.sync_missing_columns(conn) == 0
+
+    def test_server_default_without_text_attr(self):
+        """Edge case: server_default.arg is a plain string, not a text clause."""
+        default = MagicMock(spec=[])
+        default.arg = "42"
+        col = self._make_model_col("priority", "INTEGER", nullable=False, default=default)
+        conn, insp = self._make_conn_and_insp([])
+        table = MagicMock(); table.columns = [col]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                migrate.sync_missing_columns(conn)
+        sql_text = conn.execute.call_args[0][0].text
+        assert "DEFAULT 42" in sql_text
+
+
+# ── run_alembic tests ────────────────────────────────────────────────
+
+class TestRunAlembic:
+    def test_returns_zero_on_success(self):
+        with patch("migrate.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert migrate.run_alembic(["stamp", "head"]) == 0
+
+    def test_returns_nonzero_on_failure(self):
+        with patch("migrate.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            assert migrate.run_alembic(["upgrade", "head"]) == 1
+
+    def test_passes_correct_args(self):
+        with patch("migrate.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            migrate.run_alembic(["upgrade", "head"])
+            args = mock_run.call_args[0][0]
+            assert args[-2:] == ["upgrade", "head"]
+            assert "alembic" in args[-3]
+
+    def test_subprocess_exception_propagates(self):
+        """Adversarial: subprocess crashes → exception propagates."""
+        with patch("migrate.subprocess.run", side_effect=OSError("no such file")):
+            with pytest.raises(OSError, match="no such file"):
+                migrate.run_alembic(["upgrade", "head"])
+
+
+# ── main() integration tests ─────────────────────────────────────────
+
+class TestMainFlow:
+    def _setup_engine(self, state):
+        mock_engine = MagicMock()
+        detect_conn = AsyncConnMock(sync_return=state)
+        begin_conn = AsyncConnMock()
+        mock_engine.connect.return_value = AsyncCM(detect_conn)
+        mock_engine.begin.return_value = AsyncCM(begin_conn)
+        mock_engine.dispose = lambda: _coro(None)
+        return mock_engine
+
+    @pytest.mark.asyncio
+    async def test_empty_creates_and_stamps(self):
+        with patch("migrate.create_async_engine") as mock_aef:
+            mock_aef.return_value = self._setup_engine("empty")
+            with patch("migrate.settings") as ms:
+                ms.DATABASE_URL = "postgresql+asyncpg://x/y"
+                with patch("migrate.Base") as mb:
+                    mb.metadata.create_all = MagicMock()
+                    with patch("migrate.run_alembic", return_value=0) as mock_alembic:
+                        await migrate.main()
+                        mock_alembic.assert_called_once_with(["stamp", "head"])
+                        mb.metadata.create_all.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_managed_upgrades(self):
+        with patch("migrate.create_async_engine") as mock_aef:
+            mock_aef.return_value = self._setup_engine("managed")
+            with patch("migrate.settings") as ms:
+                ms.DATABASE_URL = "postgresql+asyncpg://x/y"
+                with patch("migrate.run_alembic", return_value=0) as mock_alembic:
+                    await migrate.main()
+                    mock_alembic.assert_called_once_with(["upgrade", "head"])
+
+    @pytest.mark.asyncio
+    async def test_managed_failure_exits_nonzero(self):
+        with patch("migrate.create_async_engine") as mock_aef:
+            mock_aef.return_value = self._setup_engine("managed")
+            with patch("migrate.settings") as ms:
+                ms.DATABASE_URL = "postgresql+asyncpg://x/y"
+                with patch("migrate.run_alembic", return_value=1):
+                    with pytest.raises(SystemExit) as exc:
+                        await migrate.main()
+                    assert exc.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_unmanaged_syncs_and_stamps(self):
+        with patch("migrate.create_async_engine") as mock_aef:
+            mock_aef.return_value = self._setup_engine("unmanaged")
+            with patch("migrate.settings") as ms:
+                ms.DATABASE_URL = "postgresql+asyncpg://x/y"
+                mock_sync_engine = MagicMock()
+                mock_sync_conn = MagicMock()
+                mock_sync_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_sync_conn)
+                mock_sync_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+                with patch("migrate.create_engine", return_value=mock_sync_engine):
+                    with patch("migrate.sync_missing_columns", return_value=3) as mock_sync:
+                        with patch("migrate.run_alembic", return_value=0) as mock_alembic:
+                            with patch("migrate.Base") as mb:
+                                mb.metadata.create_all = MagicMock()
+                                await migrate.main()
+                                mock_sync.assert_called_once()
+                                mock_alembic.assert_called_once_with(["stamp", "head"])
+
+    @pytest.mark.asyncio
+    async def test_unmanaged_stamp_failure_exits(self):
+        """Adversarial: stamp fails after sync → exit 1."""
+        with patch("migrate.create_async_engine") as mock_aef:
+            mock_aef.return_value = self._setup_engine("unmanaged")
+            with patch("migrate.settings") as ms:
+                ms.DATABASE_URL = "postgresql+asyncpg://x/y"
+                mock_sync_engine = MagicMock()
+                mock_sync_conn = MagicMock()
+                mock_sync_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_sync_conn)
+                mock_sync_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+                with patch("migrate.create_engine", return_value=mock_sync_engine):
+                    with patch("migrate.sync_missing_columns", return_value=0):
+                        with patch("migrate.run_alembic", return_value=1):
+                            with patch("migrate.Base") as mb:
+                                mb.metadata.create_all = MagicMock()
+                                with pytest.raises(SystemExit) as exc:
+                                    await migrate.main()
+                                assert exc.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_stamp_failure_exits(self):
+        """Adversarial: fresh install but stamp fails → exit 1."""
+        with patch("migrate.create_async_engine") as mock_aef:
+            mock_aef.return_value = self._setup_engine("empty")
+            with patch("migrate.settings") as ms:
+                ms.DATABASE_URL = "postgresql+asyncpg://x/y"
+                with patch("migrate.Base") as mb:
+                    mb.metadata.create_all = MagicMock()
+                    with patch("migrate.run_alembic", return_value=1):
+                        with pytest.raises(SystemExit) as exc:
+                            await migrate.main()
+                        assert exc.value.code == 1
+
+
+# ── Adversarial / edge case tests ────────────────────────────────────
+
+class TestAdversarial:
+    def test_sql_injection_in_column_name_is_quoted(self):
+        """Column names are quoted, preventing SQL injection via model definitions."""
+        conn = MagicMock()
+        conn.engine = MagicMock()
+        conn.engine.dialect = MagicMock()
+
+        insp = MagicMock()
+        insp.has_table.return_value = True
+        insp.get_columns.return_value = []
+
+        col = MagicMock()
+        col.name = "x; DROP TABLE users; --"
+        col.type = MagicMock()
+        col.type.compile.return_value = "TEXT"
+        col.nullable = True
+        col.server_default = None
+        table = MagicMock(); table.columns = [col]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                migrate.sync_missing_columns(conn)
+
+        sql_text = conn.execute.call_args[0][0].text
+        # The malicious name is quoted, not executed as separate SQL
+        assert '"x; DROP TABLE users; --"' in sql_text
+
+    def test_empty_table_metadata(self):
+        """Edge case: Base.metadata.tables is empty → no-op."""
+        conn = MagicMock()
+        conn.engine = MagicMock()
+
+        with patch("migrate.inspect") as mock_insp:
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {}
+                result = migrate.sync_missing_columns(conn)
+        assert result == 0
+
+    def test_large_number_of_tables(self):
+        """Stress: many tables with many columns — should not crash."""
+        conn = MagicMock()
+        conn.engine = MagicMock()
+        conn.engine.dialect = MagicMock()
+
+        insp = MagicMock()
+        insp.has_table.return_value = True
+        insp.get_columns.return_value = [{"name": "id"}]
+
+        tables = {}
+        for i in range(50):
+            cols = []
+            id_col = MagicMock(); id_col.name = "id"
+            cols.append(id_col)
+            for j in range(10):
+                c = MagicMock()
+                c.name = f"col_{j}"
+                c.type = MagicMock()
+                c.type.compile.return_value = "TEXT"
+                c.nullable = True
+                c.server_default = None
+                cols.append(c)
+            t = MagicMock(); t.columns = cols
+            tables[f"table_{i}"] = t
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = tables
+                result = migrate.sync_missing_columns(conn)
+        # 50 tables × 10 missing columns each = 500
+        assert result == 500
+
+    def test_concurrent_column_add_is_idempotent(self):
+        """IF NOT EXISTS makes concurrent adds safe."""
+        conn = MagicMock()
+        conn.engine = MagicMock()
+        conn.engine.dialect = MagicMock()
+
+        insp = MagicMock()
+        insp.has_table.return_value = True
+        insp.get_columns.return_value = []
+
+        col = MagicMock()
+        col.name = "new_col"
+        col.type = MagicMock()
+        col.type.compile.return_value = "TEXT"
+        col.nullable = True
+        col.server_default = None
+        table = MagicMock(); table.columns = [col]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": table}
+                migrate.sync_missing_columns(conn)
+        sql_text = conn.execute.call_args[0][0].text
+        assert "IF NOT EXISTS" in sql_text
+
+    def test_table_name_with_special_chars(self):
+        """Edge case: table name with unusual characters."""
+        conn = MagicMock()
+        conn.engine = MagicMock()
+        conn.engine.dialect = MagicMock()
+
+        insp = MagicMock()
+        insp.has_table.return_value = True
+        insp.get_columns.return_value = []
+
+        col = MagicMock()
+        col.name = "val"
+        col.type = MagicMock()
+        col.type.compile.return_value = "TEXT"
+        col.nullable = True
+        col.server_default = None
+        table = MagicMock(); table.columns = [col]
+
+        with patch("migrate.inspect", return_value=insp):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"my-table_v2": table}
+                migrate.sync_missing_columns(conn)
+        sql_text = conn.execute.call_args[0][0].text
+        assert "my-table_v2" in sql_text
+
+    def test_inspect_raises_does_not_swallow(self):
+        """Adversarial: inspect() failure propagates."""
+        conn = MagicMock()
+        conn.engine = MagicMock()
+
+        with patch("migrate.inspect", side_effect=RuntimeError("inspect failed")):
+            with patch("migrate.Base") as mock_base:
+                mock_base.metadata.tables = {"t": MagicMock()}
+                with pytest.raises(RuntimeError, match="inspect failed"):
+                    migrate.sync_missing_columns(conn)


### PR DESCRIPTION
The entrypoint.sh previously ran 'alembic stamp head' when migrations failed, silently marking all migrations as applied without running them. This left the database with missing columns (e.g. gaming_flags on agent_versions) when users started the stack without a .env file first.

Replace with docker/migrate.py that detects the database state:
- Empty DB: create_all + stamp head (fresh install)
- Managed DB: alembic upgrade head, fail hard on error (never stamp)
- Unmanaged DB: create_all + sync missing columns via inspect() + stamp

The sync_missing_columns() function uses SQLAlchemy inspect() to diff model-defined columns against the live DB and issues ALTER TABLE ADD COLUMN IF NOT EXISTS for any gaps before stamping.

Also removes the _ensure_columns hack from main.py since schema reconciliation is now fully handled by the init container.

<!--- Please fill the necessary details below -->
## Purpose / Description
The Docker init container's entrypoint.sh uses alembic stamp head as a fallback when migrations fail. This silently
marks all migrations as applied without actually running them, leaving the database with missing columns. This causes
500 errors across all API endpoints (agents, review, evals, insights).

The issue is triggered when a user starts the stack without a .env file first (or with incorrect DB credentials), then
adds the correct .env and rebuilds. The Base.metadata.create_all creates tables from the current models, Alembic
migrations fail (because they assume incremental state), and the fallback stamp head marks everything as done, but
columns added by later migrations (e.g., gaming_flags on agent_versions from migration 0028) are never created.

## Fixes
Fixes the 500 errors caused by missing agent_versions.gaming_flags column after rebuild and the dangerous alembic stamp head fallback that silently hides migration failures.

## Approach
Replace the fragile bash migration logic in entrypoint.sh with a Python script (docker/migrate.py) that detects the
database state and applies the correct strategy:

1. Empty DB (no tables): create_all + stamp head -> fresh install, models are source of truth.
2. Managed DB (has alembic_version): alembic upgrade head -> fail hard on error, never stamp.
3. Unmanaged DB (tables exist, no alembic_version): create_all for missing tables + sync_missing_columns() using
SQLAlchemy inspect() to diff model columns vs live DB and issue ALTER TABLE ADD COLUMN IF NOT EXISTS for any gaps, then
stamp head.

Also removes the _ensure_columns hack from main.py since schema reconciliation is now fully handled by the init
container.

## How Has This Been Tested?

Unit tests (31 tests in tests/test_docker_migrate.py):

bash
cd observal-server && uv run --with pytest --with pytest-asyncio pytest ../tests/test_docker_migrate.py -v


Tests cover:
- detect_state_sync() — all three states + edge cases (NULL count, DB errors propagating, single-table detection)
- sync_missing_columns() — no-op when schema matches, adds nullable columns, handles server defaults, NOT NULL fallback
to nullable, multiple missing columns, skips nonexistent tables, warns on unrecoverable failures
- run_alembic() — exit code passthrough, subprocess errors propagate
- main() flow — all three paths succeed, all failure paths exit non-zero
- Adversarial inputs — SQL injection in column names (quoted), empty metadata, 500-column stress test, inspect()
failures propagate

Full test suite:

bash
cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis pytest ../tests/ -q --ignore=../tests/test_migrate_telemetry.py


Result: 2035 passed, 3 pre-existing failures (unrelated), 0 new failures.

Test configuration: Python 3.12, pytest 9.0.3, pytest-asyncio 1.3.0, all tests mock external services (no Docker needed)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->