### PR TITLE
fix: move blocking git operations to thread and add crash recovery

### DIFF
--- a/observal-server/api/routes/component_source.py
+++ b/observal-server/api/routes/component_source.py
@@ -1,5 +1,6 @@
 """Component source CRUD and sync endpoints."""
 
+import asyncio
 import uuid
 from datetime import UTC, datetime
 
@@ -108,7 +109,7 @@ async def trigger_sync(
     source.sync_status = "syncing"
     await db.commit()
 
-    result = sync_source(source.url, source.component_type)
+    result = await asyncio.to_thread(sync_source, source.url, source.component_type)
 
     source.last_synced_at = datetime.now(UTC)
     if result.success:

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -106,6 +106,28 @@ async def lifespan(app: FastAPI):
     async with _session_factory() as db:
         await seed_demo_accounts(db)
 
+    # Reset any component sources stuck in "syncing" from a previous API server crash
+    try:
+        from models.component_source import ComponentSource
+
+        async with _session_factory() as db:
+            result = await db.execute(
+                update(ComponentSource)
+                .where(ComponentSource.sync_status == "syncing")
+                .values(
+                    sync_status="failed",
+                    sync_error="Server restarted during sync",
+                )
+            )
+            await db.commit()
+            if result.rowcount:
+                logger.warning(
+                    "Reset %d component source(s) stuck in 'syncing' state",
+                    result.rowcount,
+                )
+    except Exception:
+        logger.warning("Failed to reset stuck component sources", exc_info=True)
+
     # Register audit event bus handlers during startup
     if settings.DEPLOYMENT_MODE == "enterprise":
         try:

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -1,5 +1,7 @@
 """arq background worker for eval jobs and async tasks."""
 
+import asyncio
+
 import structlog
 from arq.cron import cron
 
@@ -73,7 +75,7 @@ async def sync_component_sources(ctx: dict):
             source.sync_status = "syncing"
             await db.commit()
 
-            sync_result = sync_source(source.url, source.component_type)
+            sync_result = await asyncio.to_thread(sync_source, source.url, source.component_type)
 
             source.last_synced_at = now
             source.sync_status = "success" if sync_result.success else "failed"
@@ -162,6 +164,32 @@ async def startup(ctx: dict):
     from services.insights import configure_insights
 
     configure_insights()
+
+    # Reset any component sources stuck in "syncing" from a previous crash
+    try:
+        from sqlalchemy import update
+
+        from database import async_session
+        from models.component_source import ComponentSource
+
+        async with async_session() as db:
+            result = await db.execute(
+                update(ComponentSource)
+                .where(ComponentSource.sync_status == "syncing")
+                .values(
+                    sync_status="failed",
+                    sync_error="Worker restarted during sync",
+                )
+            )
+            await db.commit()
+            if result.rowcount:
+                logger.warning(
+                    "Reset %d component source(s) stuck in 'syncing' state",
+                    result.rowcount,
+                )
+    except Exception:
+        logger.warning("Failed to reset stuck component sources", exc_info=True)
+
     logger.info("arq worker started")
 
 


### PR DESCRIPTION
`sync_source()` calls `subprocess.run()` which blocks the asyncio event loop for up to 120s, freezing all other arq jobs (alert evaluation, ClickHouse maintenance, eval scoring) and the FastAPI request handler.

Move the call to `asyncio.to_thread()` so the event loop stays free.

Also reset any component sources stuck in "syncing" state on both worker and API server startup, so a process crash during sync doesn't leave a source permanently stuck.

<!--- Please fill the necessary details below -->
## Purpose / Description
sync_source() calls subprocess.run() — blocking for up to 120s — from inside asyncio event loops in both the arq worker and the FastAPI request handler. During git clone/fetch, the event loop is frozen: all other arq jobs stall (alert evaluation every 60s, ClickHouse maintenance, eval scoring), and the API server blocks on admin-triggered syncs.

  If a process crashes between committing sync_status = "syncing" and the final status, the source is stuck permanently
  with no recovery.

## Fixes
Event loop blocking in worker sync_component_sources and REST trigger_sync and Permanently stuck "syncing" state after crash -> adds reset on both worker and API server startup

## Approach
1. Thread dispatch: sync_source() → await asyncio.to_thread(sync_source, ...) at both call sites. Only immutable strings cross the thread boundary. DB session stays in the event loop. sync_source is thread-safe: per-URL temp dirs, independent subprocesses, no shared state.
2. Crash recovery (worker): On startup, UPDATE component_sources SET sync_status = 'failed' WHERE sync_status = 'syncing'
3. Crash recovery (API server): Same reset in main.py lifespan, covering manual trigger only sources that the worker cron won't retry.

## How Has This Been Tested?
  - py_compile: all 3 files compile cleanly
  - Unit tests: 38/38 passed (tests/test_git_mirror.py)
  - Docker stack: rebuilt observal-api + observal-worker, worker started cleanly, API health OK
  (Postgres/ClickHouse/Redis all green)
  - Thread safety: verified no shared state, no DB access, per-URL isolation

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->