### PR TITLE
fix(auth): block deactivated users at token refresh and harmonize status codes

### DIFF
--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -126,7 +126,7 @@ async def optional_current_user(
     if not user:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
     if user.auth_provider == "deactivated":
-        raise HTTPException(status_code=401, detail="Account deactivated")
+        raise HTTPException(status_code=403, detail="Account deactivated")
     return user
 
 

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -549,6 +549,8 @@ async def refresh_token(request: Request, req: RefreshRequest, db: AsyncSession 
     user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=401, detail="User no longer exists")
+    if user.auth_provider == "deactivated":
+        raise HTTPException(status_code=401, detail="Account deactivated")
 
     # Issue new token pair
     groups = payload.get("groups", [])

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -189,6 +189,20 @@ async function request<T = unknown>(
       throw new Error("Session expired");
     }
 
+    // Handle deactivated accounts (403 from auth checks)
+    if (response.status === 403) {
+      const text = await response.text().catch(() => "");
+      let detail = "";
+      try { detail = JSON.parse(text).detail || ""; } catch {}
+      if (detail === "Account deactivated") {
+        clearSession();
+        if (typeof window !== "undefined") {
+          window.location.href = "/login?reason=account_deactivated";
+        }
+        throw new Error("Account deactivated");
+      }
+    }
+
     const text = await response.text().catch(() => response.statusText);
     let detail = text;
     try {


### PR DESCRIPTION
## Purpose / Description
Token refresh endpoint issued fresh tokens to deactivated users because it only checked user existence, not `auth_provider` status. `optional_current_user` returned 401 for deactivated users while `get_current_user` returned 403 -- inconsistent semantics and no frontend recovery path for 403.

## Fixes
* Fixes token refresh issuing valid JWTs to deactivated users
* Fixes inconsistent HTTP status codes (401 vs 403) for deactivated users across auth dependencies
* Fixes missing frontend recovery when a deactivated user hits a 403 endpoint

## Approach
1. **`auth.py`** -- Add `auth_provider == "deactivated"` check to `POST /api/v1/auth/token/refresh`. Returns 401 so the frontend's existing `_tryRefreshToken` -> `clearSession` -> redirect flow triggers automatically.
2. **`deps.py`** -- Change `optional_current_user` deactivated status from 401 to 403, matching `get_current_user`. 403 is semantically correct: the JWT is valid, the user is authenticated, but not permitted.
3. **`api.ts`** -- Add a 403 handler that checks for `"Account deactivated"` detail, calls `clearSession()`, and redirects to `/login?reason=account_deactivated`. Other 403s (e.g. permission denied) pass through to generic error handling unchanged.

## How Has This Been Tested?
- Ruff lint: all checks passed
- py_compile: all 3 files compile cleanly
- Verified 403 handler placement in api.ts (between 401 handler and generic error handler)
- No existing tests assert the old 401 behavior from `optional_current_user` for deactivated users

## Learning
SCIM deactivation sets `auth_provider = "deactivated"` but the token lifecycle never consulted this field. The deactivation was effective at request time (checked in `get_current_user`/`optional_current_user`) but the refresh endpoint was an unguarded backdoor.

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->