### PR TITLE
fix(dashboard): read telemetry from active tables instead of empty legacy tables

### DIFF
--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -197,15 +197,11 @@ async def overview_stats(
 
     days = _range_days(range_)
     tool_rows = await _ch_json(
-        "SELECT count() as cnt FROM spans "
-        "WHERE start_time > now() - INTERVAL {days:UInt32} DAY "
-        "AND is_deleted = 0",
+        "SELECT count() as cnt FROM spans WHERE start_time > now() - INTERVAL {days:UInt32} DAY AND is_deleted = 0",
         {"param_days": str(days)},
     )
     agent_rows = await _ch_json(
-        "SELECT count() as cnt FROM traces "
-        "WHERE start_time > now() - INTERVAL {days:UInt32} DAY "
-        "AND is_deleted = 0",
+        "SELECT count() as cnt FROM traces WHERE start_time > now() - INTERVAL {days:UInt32} DAY AND is_deleted = 0",
         {"param_days": str(days)},
     )
 

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -90,7 +90,7 @@ async def mcp_metrics(
         "quantile(0.5)(latency_ms) as p50, "
         "quantile(0.9)(latency_ms) as p90, "
         "quantile(0.99)(latency_ms) as p99 "
-        "FROM mcp_tool_calls WHERE mcp_server_id = {sid:String}",
+        "FROM spans WHERE mcp_id = {sid:String} AND is_deleted = 0",
         {"param_sid": str(listing_id)},
     )
     r = rows[0] if rows else {}
@@ -128,15 +128,12 @@ async def agent_metrics(
     rows = await _ch_json(
         "SELECT "
         "count() as total, "
-        "countIf(user_action='accepted') as accepted, "
-        "round(avg(tool_calls),1) as avg_tools, "
         "round(avg(latency_ms),1) as avg_latency "
-        "FROM agent_interactions WHERE agent_id = {aid:String}",
+        "FROM spans WHERE agent_id = {aid:String} AND is_deleted = 0",
         {"param_aid": str(agent_id)},
     )
     r = rows[0] if rows else {}
     total = int(r.get("total", 0))
-    accepted = int(r.get("accepted", 0))
 
     # Fetch recent scorecards for dimension breakdown
     sc_result = await db.execute(
@@ -165,8 +162,8 @@ async def agent_metrics(
         agent_id=agent_id,
         total_interactions=total,
         total_downloads=dl_count,
-        acceptance_rate=round(accepted / total, 4) if total else 0,
-        avg_tool_calls=float(r.get("avg_tools", 0)),
+        acceptance_rate=None,
+        avg_tool_calls=None,
         avg_latency_ms=float(r.get("avg_latency", 0)),
         dimension_averages=dimension_averages,
         weakest_dimension=weakest_dimension,
@@ -200,11 +197,15 @@ async def overview_stats(
 
     days = _range_days(range_)
     tool_rows = await _ch_json(
-        "SELECT count() as cnt FROM mcp_tool_calls WHERE timestamp > now() - INTERVAL {days:UInt32} DAY",
+        "SELECT count() as cnt FROM spans "
+        "WHERE start_time > now() - INTERVAL {days:UInt32} DAY "
+        "AND is_deleted = 0",
         {"param_days": str(days)},
     )
     agent_rows = await _ch_json(
-        "SELECT count() as cnt FROM agent_interactions WHERE timestamp > now() - INTERVAL {days:UInt32} DAY",
+        "SELECT count() as cnt FROM traces "
+        "WHERE start_time > now() - INTERVAL {days:UInt32} DAY "
+        "AND is_deleted = 0",
         {"param_days": str(days)},
     )
 

--- a/observal-server/schemas/dashboard.py
+++ b/observal-server/schemas/dashboard.py
@@ -19,8 +19,8 @@ class AgentMetrics(BaseModel):
     agent_id: uuid.UUID
     total_interactions: int
     total_downloads: int
-    acceptance_rate: float
-    avg_tool_calls: float
+    acceptance_rate: float | None = None
+    avg_tool_calls: float | None = None
     avg_latency_ms: float
     # New structured scoring fields
     dimension_averages: dict | None = None

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -465,7 +465,6 @@ async def init_clickhouse():
         logger.info("ClickHouse data retention disabled (DATA_RETENTION_DAYS=0)")
 
 
-
 def _now_ms() -> str:
     """Current UTC timestamp as ISO string with millisecond precision."""
     return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]

--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -465,58 +465,6 @@ async def init_clickhouse():
         logger.info("ClickHouse data retention disabled (DATA_RETENTION_DAYS=0)")
 
 
-async def insert_tool_call(event: dict):
-    sql = """INSERT INTO mcp_tool_calls
-        (event_id, timestamp, mcp_server_id, tool_name, input_params, response, latency_ms, status, user_action, session_id, user_id, ide)
-        VALUES
-        ({event_id:String}, {ts:String}, {mcp_server_id:String}, {tool_name:String}, {input_params:String}, {response:String}, {latency_ms:UInt32}, {status:String}, {user_action:String}, {session_id:String}, {user_id:String}, {ide:String})"""
-    params = {
-        "param_event_id": event["event_id"],
-        "param_ts": event["timestamp"],
-        "param_mcp_server_id": event.get("mcp_server_id", ""),
-        "param_tool_name": event.get("tool_name", ""),
-        "param_input_params": event.get("input_params", ""),
-        "param_response": event.get("response", ""),
-        "param_latency_ms": str(event.get("latency_ms", 0)),
-        "param_status": event.get("status", ""),
-        "param_user_action": event.get("user_action", ""),
-        "param_session_id": event.get("session_id", ""),
-        "param_user_id": event.get("user_id", ""),
-        "param_ide": event.get("ide", ""),
-    }
-    try:
-        r = await _query(sql, params)
-        r.raise_for_status()
-        await _invalidate_cache()
-    except Exception as e:
-        logger.error("clickhouse_insert_tool_call_failed", error=str(e))
-        raise
-
-
-async def insert_agent_interaction(event: dict):
-    sql = """INSERT INTO agent_interactions
-        (event_id, timestamp, agent_id, session_id, tool_calls, user_action, latency_ms, user_id, ide)
-        VALUES
-        ({event_id:String}, {ts:String}, {agent_id:String}, {session_id:String}, {tool_calls:UInt32}, {user_action:String}, {latency_ms:UInt32}, {user_id:String}, {ide:String})"""
-    params = {
-        "param_event_id": event["event_id"],
-        "param_ts": event["timestamp"],
-        "param_agent_id": event.get("agent_id", ""),
-        "param_session_id": event.get("session_id", ""),
-        "param_tool_calls": str(event.get("tool_calls", 0)),
-        "param_user_action": event.get("user_action", ""),
-        "param_latency_ms": str(event.get("latency_ms", 0)),
-        "param_user_id": event.get("user_id", ""),
-        "param_ide": event.get("ide", ""),
-    }
-    try:
-        r = await _query(sql, params)
-        r.raise_for_status()
-        await _invalidate_cache()
-    except Exception as e:
-        logger.error("clickhouse_insert_agent_interaction_failed", error=str(e))
-        raise
-
 
 def _now_ms() -> str:
     """Current UTC timestamp as ISO string with millisecond precision."""
@@ -758,30 +706,36 @@ async def insert_otel_logs(rows: list[dict]):
 
 
 async def query_recent_events(minutes: int = 60) -> dict:
-    """Get event counts from the last N minutes."""
+    """Get event counts from the last N minutes from the active telemetry tables."""
     minutes = int(minutes)
     tool_count = 0
     agent_count = 0
 
     try:
         r = await _query(
-            "SELECT count() as cnt FROM mcp_tool_calls WHERE timestamp > now() - INTERVAL {minutes:UInt32} MINUTE FORMAT JSON",
+            "SELECT count() as cnt FROM spans "
+            "WHERE start_time > now() - INTERVAL {minutes:UInt32} MINUTE "
+            "AND is_deleted = 0 "
+            "FORMAT JSON",
             {"param_minutes": str(minutes)},
         )
         if r.status_code == 200:
             tool_count = int(r.json().get("data", [{}])[0].get("cnt", 0))
     except Exception as e:
-        logger.warning("clickhouse_query_tool_calls_failed", error=str(e))
+        logger.warning("clickhouse_query_spans_failed", error=str(e))
 
     try:
         r = await _query(
-            "SELECT count() as cnt FROM agent_interactions WHERE timestamp > now() - INTERVAL {minutes:UInt32} MINUTE FORMAT JSON",
+            "SELECT count() as cnt FROM traces "
+            "WHERE start_time > now() - INTERVAL {minutes:UInt32} MINUTE "
+            "AND is_deleted = 0 "
+            "FORMAT JSON",
             {"param_minutes": str(minutes)},
         )
         if r.status_code == 200:
             agent_count = int(r.json().get("data", [{}])[0].get("cnt", 0))
     except Exception as e:
-        logger.warning("clickhouse_query_agent_interactions_failed", error=str(e))
+        logger.warning("clickhouse_query_traces_failed", error=str(e))
 
     return {"tool_call_events": tool_count, "agent_interaction_events": agent_count}
 


### PR DESCRIPTION
## Purpose / Description
Dashboard overview, telemetry status, MCP metrics, and agent metrics queried `mcp_tool_calls` and `agent_interactions` -- legacy tables that nothing writes to since the telemetry ingest pipeline migrated to `traces`, `spans`, and `scores`. All four endpoints silently returned zero or empty data.

Verified against live ClickHouse: `mcp_tool_calls` = 0 rows, `agent_interactions` = 0 rows, while `spans` = 1638 rows, `traces` = 31 rows.

## Fixes
* Fixes telemetry status endpoint (`GET /api/v1/telemetry/status`) always returning zeros
* Fixes dashboard overview stats (`total_tool_calls`, `total_agent_interactions`) always returning zeros
* Fixes MCP metrics page always showing empty data
* Fixes agent metrics page always showing empty data
* Removes dead `insert_tool_call` and `insert_agent_interaction` functions

## Approach
1. **`clickhouse.py`** -- Rewrite `query_recent_events` to count from `spans` and `traces` instead of legacy tables. Delete `insert_tool_call` and `insert_agent_interaction` (zero call sites).
2. **`dashboard.py`** -- Update `overview/stats`, `mcp_metrics`, and `agent_metrics` to query `spans` and `traces`. All latency/status aggregations map directly. Two fields (`acceptance_rate`, `avg_tool_calls`) have no equivalent columns in the new schema -- set to `None`.
3. **`schemas/dashboard.py`** -- Make `AgentMetrics.acceptance_rate` and `avg_tool_calls` Optional since the new schema cannot compute them.

## How Has This Been Tested?
- Ruff lint: all checks passed
- py_compile: all 3 files compile cleanly
- ClickHouse query verification: ran the new SQL directly against live ClickHouse -- `tool_count` = 1610, `agent_count` = 21, `total_tool_calls` = 1638, `total_agent_interactions` = 31 (old queries returned 0 for all)
- Docker: rebuilt `observal-api` container, startup clean

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->