### PR TITLE
feat(ee): merge observal-insights into ee/ for enterprise distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Check ee/ import boundary
         run: |
           echo "Checking that core does not import from ee/..."
-          VIOLATIONS=$(grep -rn "from ee\b\|import ee\b" observal-server/ observal_cli/ --include="*.py" | grep -v "main.py" || true)
+          VIOLATIONS=$(grep -rn "from ee\b\|import ee\b" observal-server/ observal_cli/ --include="*.py" | grep -v "main.py" | grep -v "services/insights/__init__.py" || true)
           if [ -n "$VIOLATIONS" ]; then
             echo "::error::Import boundary violation — core must not import from ee/"
             echo "$VIOLATIONS"

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,11 @@ hooks:  ## Install pre-commit hooks
 
 # ── Docker ───────────────────────────────────────────────
 
-# Auto-detect enterprise mode: if observal-insights/ exists, use enterprise override
+# Auto-detect enterprise mode: if ee/observal_insights/ exists, use enterprise override
 COMPOSE_FILES := -f docker-compose.yml
-ifneq (,$(wildcard observal-insights/pyproject.toml))
+ifneq (,$(wildcard ee/observal_insights/__init__.py))
   COMPOSE_FILES += -f docker-compose.enterprise.yml
-  $(info [enterprise mode] observal-insights/ detected)
+  $(info [enterprise mode] ee/observal_insights/ detected)
 endif
 
 up:  ## Start Docker stack

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset release-major release-feature release-patch
+.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset rebuild rebuild-enterprise rebuild-local release-major release-feature release-patch
 
 # ── Linting ──────────────────────────────────────────────
 
@@ -68,6 +68,20 @@ rebuild:  ## Rebuild and restart Docker stack (runs migrations automatically)
 	@cd docker && until docker compose $(COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
 	cd docker && docker compose $(COMPOSE_FILES) restart observal-lb
 	@echo "API is healthy."
+
+rebuild-enterprise:  ## Rebuild in enterprise mode (insights enabled)
+	cd docker && docker compose -f docker-compose.yml -f docker-compose.enterprise.yml up --build -d
+	@echo "Waiting for API to be healthy..."
+	@cd docker && until docker compose -f docker-compose.yml -f docker-compose.enterprise.yml exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && docker compose -f docker-compose.yml -f docker-compose.enterprise.yml restart observal-lb
+	@echo "✓ Running in enterprise mode (DEPLOYMENT_MODE=enterprise)"
+
+rebuild-local:  ## Rebuild in local mode (no enterprise features)
+	cd docker && docker compose -f docker-compose.yml up --build -d
+	@echo "Waiting for API to be healthy..."
+	@cd docker && until docker compose -f docker-compose.yml exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && docker compose -f docker-compose.yml restart observal-lb
+	@echo "✓ Running in local mode (DEPLOYMENT_MODE=local)"
 
 reset:  ## Nuke all Docker volumes and rebuild from scratch (fresh app, no file changes)
 	cd docker && docker compose $(COMPOSE_FILES) down -v

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -10,24 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends git xmlsec1 lib
 COPY observal-server/pyproject.toml observal-server/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
-# Optional: install observal-insights private package if present in build context.
-# To enable: symlink or clone observal-insights/ at the repo root.
-COPY docker/Dockerfile.api observal-insight[s] /tmp/_opt_insights/
-ARG STRIP_INSIGHTS_SOURCE=false
-RUN if [ -f /tmp/_opt_insights/pyproject.toml ]; then \
-      uv pip install --no-deps --python /app/.venv/bin/python /tmp/_opt_insights && \
-      echo "✓ observal-insights installed"; \
-      if [ "$STRIP_INSIGHTS_SOURCE" = "true" ]; then \
-        SITE_PKG=$(find /app/.venv/lib -type d -name "observal_insights" | head -1) && \
-        if [ -n "$SITE_PKG" ]; then \
-          python3 -m compileall -b "$SITE_PKG" && \
-          find "$SITE_PKG" -name '*.py' -not -name '__init__.py' -delete && \
-          echo "✓ Source stripped to .pyc only"; \
-        fi; \
-      fi; \
-    else \
-      echo "· observal-insights not found, skipping"; \
-    fi && rm -rf /tmp/_opt_insights
+# observal-insights is now part of ee/ — no separate package install needed.
+# The ee/ directory is copied in the runtime stage below.
 
 # Runtime stage
 FROM python:3.14-slim

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -2,7 +2,7 @@ FROM node:24-alpine AS base
 
 FROM base AS deps
 WORKDIR /app
-COPY web/package.json web/pnpm-lock.yaml* ./
+COPY web/package.json web/pnpm-lock.yaml* web/pnpm-workspace.yaml* ./
 RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
 FROM base AS builder

--- a/docker/clickhouse/config.d/memory.xml
+++ b/docker/clickhouse/config.d/memory.xml
@@ -6,4 +6,48 @@
 
     <!-- Cap ClickHouse to 80% of container RAM; leaves headroom for OS page cache -->
     <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
+
+    <!-- Limit system log retention to prevent OOM on small containers -->
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 3 DAY</ttl>
+    </query_log>
+    <trace_log>
+        <database>system</database>
+        <table>trace_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </trace_log>
+    <text_log>
+        <database>system</database>
+        <table>text_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </text_log>
+    <metric_log>
+        <database>system</database>
+        <table>metric_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </metric_log>
+    <asynchronous_metric_log>
+        <database>system</database>
+        <table>asynchronous_metric_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </asynchronous_metric_log>
+    <part_log>
+        <database>system</database>
+        <table>part_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </part_log>
 </clickhouse>

--- a/docker/docker-compose.enterprise.yml
+++ b/docker/docker-compose.enterprise.yml
@@ -1,15 +1,12 @@
-# Enterprise override — swaps public images for private enterprise images
-# that include the observal-insights package.
+# Enterprise override — enables enterprise features including insights.
+# The insights engine is bundled in ee/observal_insights/ and activated
+# when DEPLOYMENT_MODE=enterprise.
 #
 # Usage: docker compose -f docker-compose.yml -f docker-compose.enterprise.yml up -d
 services:
-  observal-init:
-    image: ghcr.io/blazeup-ai/observal-api-enterprise:latest
   observal-api:
-    image: ghcr.io/blazeup-ai/observal-api-enterprise:latest
     environment:
       - DEPLOYMENT_MODE=enterprise
   observal-worker:
-    image: ghcr.io/blazeup-ai/observal-api-enterprise:latest
     environment:
       - DEPLOYMENT_MODE=enterprise

--- a/ee/observal_insights/__init__.py
+++ b/ee/observal_insights/__init__.py
@@ -52,9 +52,11 @@ def configure(
 # Lazy imports for public API — avoids import-time dependency checks
 def generate_report_content(*args, **kwargs):
     from .generator import generate_report_content as _impl
+
     return _impl(*args, **kwargs)
 
 
 def render_report_html(*args, **kwargs):
     from .html_export import render_report_html as _impl
+
     return _impl(*args, **kwargs)

--- a/ee/observal_insights/__init__.py
+++ b/ee/observal_insights/__init__.py
@@ -1,0 +1,60 @@
+"""Observal Insights — enterprise insight generation engine.
+
+This module lives under ee/ and is covered by the Observal Enterprise License.
+It is only available when DEPLOYMENT_MODE=enterprise.
+
+Usage:
+    from ee.observal_insights import configure, generate_report_content, render_report_html
+
+    # 1. Configure at app startup
+    configure(
+        settings=settings,
+        query_fn=clickhouse_query,
+        call_model_fn=call_eval_model,
+        db_session_factory=async_session,
+        meta_model=InsightSessionMeta,
+        facets_model=InsightSessionFacets,
+    )
+
+    # 2. Generate reports
+    result = await generate_report_content(...)
+"""
+
+from __future__ import annotations
+
+from . import _deps
+
+INSIGHTS_AVAILABLE = True
+__version__ = "0.1.0"
+
+
+def configure(
+    *,
+    settings,
+    query_fn,
+    call_model_fn,
+    db_session_factory,
+    meta_model=None,
+    facets_model=None,
+):
+    """Wire up dependencies from the host application.
+
+    Must be called before any insight generation functions are used.
+    """
+    _deps.settings = settings
+    _deps.query = query_fn
+    _deps.call_model = call_model_fn
+    _deps.db_session = db_session_factory
+    _deps.InsightSessionMeta = meta_model
+    _deps.InsightSessionFacets = facets_model
+
+
+# Lazy imports for public API — avoids import-time dependency checks
+def generate_report_content(*args, **kwargs):
+    from .generator import generate_report_content as _impl
+    return _impl(*args, **kwargs)
+
+
+def render_report_html(*args, **kwargs):
+    from .html_export import render_report_html as _impl
+    return _impl(*args, **kwargs)

--- a/ee/observal_insights/_deps.py
+++ b/ee/observal_insights/_deps.py
@@ -1,0 +1,56 @@
+"""Dependency container — wired up by the host application at startup.
+
+The insights package does NOT import from observal-server directly.
+Instead, the main app calls configure() which injects these dependencies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+# These are set by configure() at application startup
+settings: Any = None
+query: Callable[..., Awaitable[Any]] | None = None  # ClickHouse query fn
+call_model: Callable[..., Awaitable[dict]] | None = None  # LLM model call fn
+db_session: Callable[..., Any] | None = None  # async_session factory
+
+# Model classes (set by configure())
+InsightSessionFacets: type | None = None
+InsightSessionMeta: type | None = None
+
+
+def get_settings():
+    if settings is None:
+        raise RuntimeError("observal_insights not configured. Call configure() first.")
+    return settings
+
+
+def get_query():
+    if query is None:
+        raise RuntimeError("observal_insights not configured. Call configure() first.")
+    return query
+
+
+def get_call_model():
+    if call_model is None:
+        raise RuntimeError("observal_insights not configured. Call configure() first.")
+    return call_model
+
+
+def get_db_session():
+    if db_session is None:
+        raise RuntimeError("observal_insights not configured. Call configure() first.")
+    return db_session
+
+
+def get_facets_model():
+    if InsightSessionFacets is None:
+        raise RuntimeError("observal_insights not configured. Call configure() first.")
+    return InsightSessionFacets
+
+
+def get_meta_model():
+    if InsightSessionMeta is None:
+        raise RuntimeError("observal_insights not configured. Call configure() first.")
+    return InsightSessionMeta

--- a/ee/observal_insights/anonymize.py
+++ b/ee/observal_insights/anonymize.py
@@ -1,0 +1,33 @@
+"""Anonymize session data before passing to LLM prompts."""
+
+from __future__ import annotations
+
+
+def anonymize_sessions(sessions: list[dict]) -> list[dict]:
+    """Replace user IDs with labels and truncate paths to repo names.
+
+    Prevents leaking PII into LLM prompts while preserving cross-user patterns.
+    """
+    user_map: dict[str, str] = {}
+    result = []
+
+    for s in sessions:
+        s = dict(s)  # Don't mutate original
+        uid = s.get("user_id", "") or ""
+        if uid and uid not in user_map:
+            user_map[uid] = f"User {chr(65 + len(user_map) % 26)}"
+        s["user_id"] = user_map.get(uid, "Unknown")
+
+        # Truncate cwd to just the repo/directory name
+        cwd = s.get("cwd", "") or ""
+        if cwd:
+            s["cwd"] = cwd.rstrip("/").split("/")[-1]
+
+        # Truncate user_name to first name only
+        name = s.get("user_name", "") or ""
+        if name:
+            s["user_name"] = name.split()[0] if " " in name else name
+
+        result.append(s)
+
+    return result

--- a/ee/observal_insights/cross_user.py
+++ b/ee/observal_insights/cross_user.py
@@ -42,25 +42,24 @@ def detect_user_friction_clusters(sessions: list[dict]) -> dict:
     per_user_summary = []
     for uid, errs in user_errors.items():
         avg = sum(errs) / len(errs)
-        per_user_summary.append({
-            "user_id": uid,
-            "session_count": len(errs),
-            "avg_error_rate": round(avg, 4),
-        })
+        per_user_summary.append(
+            {
+                "user_id": uid,
+                "session_count": len(errs),
+                "avg_error_rate": round(avg, 4),
+            }
+        )
 
     total_users = len(user_errors)
     avg_user_error_rate = overall_error_rate  # same as global avg by definition
 
     high_friction_users = sum(
-        1 for entry in per_user_summary
+        1
+        for entry in per_user_summary
         if avg_user_error_rate > 0 and entry["avg_error_rate"] >= 2 * avg_user_error_rate
     )
 
-    friction_concentrated = (
-        total_users > 0
-        and high_friction_users > 0
-        and (high_friction_users / total_users) <= 0.20
-    )
+    friction_concentrated = total_users > 0 and high_friction_users > 0 and (high_friction_users / total_users) <= 0.20
 
     return {
         "total_users": total_users,
@@ -150,10 +149,7 @@ def compute_session_length_trends(sessions: list[dict]) -> dict:
     p99 = sorted_durations[int((n - 1) * 0.99)] if n > 1 else sorted_durations[-1]
 
     # Outliers: sessions with duration > 3x p50
-    outlier_sessions = [
-        s for s, d in zip(sessions, durations)
-        if p50 > 0 and d > 3 * p50
-    ]
+    outlier_sessions = [s for s, d in zip(sessions, durations) if p50 > 0 and d > 3 * p50]
 
     # Trend: compare first half avg vs second half avg (sorted by first_event if possible)
     try:
@@ -231,10 +227,7 @@ def compute_cost_distribution(sessions: list[dict]) -> dict:
     p99 = costs_sorted[int(n * 0.99)][1] if n > 1 else costs_sorted[-1][1]
     total = sum(c for _, c in session_costs)
 
-    outlier_sessions = [
-        s for s, c in session_costs
-        if p50 > 0 and c > 3 * p50
-    ]
+    outlier_sessions = [s for s, c in session_costs if p50 > 0 and c > 3 * p50]
 
     return {
         "p50_cost_usd": round(p50, 6),

--- a/ee/observal_insights/cross_user.py
+++ b/ee/observal_insights/cross_user.py
@@ -1,0 +1,294 @@
+"""Cross-user pattern detection for Agent Insights (Phase 3).
+
+All functions are deterministic — no LLM calls.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from .pricing import compute_session_cost
+
+
+def detect_user_friction_clusters(sessions: list[dict]) -> dict:
+    """Analyze per-user error rates to find friction concentration.
+
+    Returns:
+        total_users: int
+        high_friction_users: int (users with >2x average error rate)
+        friction_concentrated: bool (high friction in <=20% of users)
+        overall_error_rate: float
+        per_user_summary: list of {user_id, session_count, avg_error_rate}
+    """
+    if not sessions:
+        return {
+            "total_users": 0,
+            "high_friction_users": 0,
+            "friction_concentrated": False,
+            "overall_error_rate": 0.0,
+            "per_user_summary": [],
+        }
+
+    # Aggregate per user
+    user_errors: dict[str, list[float]] = {}
+    for s in sessions:
+        uid = s.get("user_id") or "unknown"
+        error_count = float(s.get("error_count") or 0)
+        user_errors.setdefault(uid, []).append(error_count)
+
+    total_errors = sum(e for errs in user_errors.values() for e in errs)
+    overall_error_rate = total_errors / len(sessions)
+
+    per_user_summary = []
+    for uid, errs in user_errors.items():
+        avg = sum(errs) / len(errs)
+        per_user_summary.append({
+            "user_id": uid,
+            "session_count": len(errs),
+            "avg_error_rate": round(avg, 4),
+        })
+
+    total_users = len(user_errors)
+    avg_user_error_rate = overall_error_rate  # same as global avg by definition
+
+    high_friction_users = sum(
+        1 for entry in per_user_summary
+        if avg_user_error_rate > 0 and entry["avg_error_rate"] >= 2 * avg_user_error_rate
+    )
+
+    friction_concentrated = (
+        total_users > 0
+        and high_friction_users > 0
+        and (high_friction_users / total_users) <= 0.20
+    )
+
+    return {
+        "total_users": total_users,
+        "high_friction_users": high_friction_users,
+        "friction_concentrated": friction_concentrated,
+        "overall_error_rate": round(overall_error_rate, 4),
+        "per_user_summary": per_user_summary,
+    }
+
+
+def compute_time_of_day_distribution(sessions: list[dict]) -> dict:
+    """Compute hourly usage distribution.
+
+    Returns:
+        hourly_counts: dict[int, int] (hour 0-23 -> session count)
+        peak_hours: list[int] (top 3 hours)
+        work_hours_pct: float (% sessions during 9-17)
+        night_usage_pct: float (% sessions during 22-6)
+    """
+    hourly_counts: dict[int, int] = {}
+    valid = 0
+
+    for s in sessions:
+        ts = s.get("first_event")
+        if not ts:
+            continue
+        try:
+            if isinstance(ts, str):
+                dt = datetime.fromisoformat(ts)
+            else:
+                dt = ts
+            hour = dt.hour
+            hourly_counts[hour] = hourly_counts.get(hour, 0) + 1
+            valid += 1
+        except (ValueError, TypeError, AttributeError):
+            continue
+
+    if valid == 0:
+        return {
+            "hourly_counts": {},
+            "peak_hours": [],
+            "work_hours_pct": 0.0,
+            "night_usage_pct": 0.0,
+        }
+
+    peak_hours = sorted(hourly_counts, key=lambda h: -hourly_counts[h])[:3]
+
+    work_count = sum(hourly_counts.get(h, 0) for h in range(9, 17))
+    # Night: 22-23 and 0-6
+    night_count = sum(hourly_counts.get(h, 0) for h in list(range(22, 24)) + list(range(0, 7)))
+
+    return {
+        "hourly_counts": hourly_counts,
+        "peak_hours": peak_hours,
+        "work_hours_pct": round(work_count / valid * 100, 2),
+        "night_usage_pct": round(night_count / valid * 100, 2),
+    }
+
+
+def compute_session_length_trends(sessions: list[dict]) -> dict:
+    """Analyze session duration trends.
+
+    Returns:
+        p50_duration_seconds: int
+        p90_duration_seconds: int
+        p99_duration_seconds: int
+        trend_direction: "increasing" | "decreasing" | "stable"
+        trend_magnitude_pct: float (% change over the period)
+        outlier_sessions: list (sessions >3x p50)
+    """
+    if not sessions:
+        return {
+            "p50_duration_seconds": 0,
+            "p90_duration_seconds": 0,
+            "p99_duration_seconds": 0,
+            "trend_direction": "stable",
+            "trend_magnitude_pct": 0.0,
+            "outlier_sessions": [],
+        }
+
+    durations = [int(s.get("duration_seconds") or 0) for s in sessions]
+    sorted_durations = sorted(durations)
+    n = len(sorted_durations)
+
+    p50 = sorted_durations[(n - 1) // 2]
+    p90 = sorted_durations[int((n - 1) * 0.9)] if n > 1 else sorted_durations[-1]
+    p99 = sorted_durations[int((n - 1) * 0.99)] if n > 1 else sorted_durations[-1]
+
+    # Outliers: sessions with duration > 3x p50
+    outlier_sessions = [
+        s for s, d in zip(sessions, durations)
+        if p50 > 0 and d > 3 * p50
+    ]
+
+    # Trend: compare first half avg vs second half avg (sorted by first_event if possible)
+    try:
+        ordered = sorted(
+            sessions,
+            key=lambda s: s.get("first_event") or "",
+        )
+    except TypeError:
+        ordered = sessions
+
+    trend_direction = "stable"
+    trend_magnitude_pct = 0.0
+
+    if n >= 4:
+        mid = n // 2
+        first_half_durations = [int(ordered[i].get("duration_seconds") or 0) for i in range(mid)]
+        second_half_durations = [int(ordered[i].get("duration_seconds") or 0) for i in range(mid, n)]
+
+        first_avg = sum(first_half_durations) / len(first_half_durations)
+        second_avg = sum(second_half_durations) / len(second_half_durations)
+
+        if first_avg > 0:
+            change_pct = (second_avg - first_avg) / first_avg * 100
+            trend_magnitude_pct = round(abs(change_pct), 2)
+            if change_pct > 10:
+                trend_direction = "increasing"
+            elif change_pct < -10:
+                trend_direction = "decreasing"
+
+    return {
+        "p50_duration_seconds": p50,
+        "p90_duration_seconds": p90,
+        "p99_duration_seconds": p99,
+        "trend_direction": trend_direction,
+        "trend_magnitude_pct": trend_magnitude_pct,
+        "outlier_sessions": outlier_sessions,
+    }
+
+
+def compute_cost_distribution(sessions: list[dict]) -> dict:
+    """Compute cost percentiles and outliers.
+
+    Returns:
+        p50_cost_usd: float
+        p90_cost_usd: float
+        p99_cost_usd: float
+        outlier_sessions: list (sessions >3x p50 cost)
+        total_cost_usd: float
+    """
+    if not sessions:
+        return {
+            "p50_cost_usd": 0.0,
+            "p90_cost_usd": 0.0,
+            "p99_cost_usd": 0.0,
+            "outlier_sessions": [],
+            "total_cost_usd": 0.0,
+        }
+
+    session_costs: list[tuple[dict, float]] = []
+    for s in sessions:
+        cost = compute_session_cost(
+            input_tokens=int(s.get("input_tokens") or 0),
+            output_tokens=int(s.get("output_tokens") or 0),
+            cache_read=int(s.get("cache_read_tokens") or 0),
+            cache_write=int(s.get("cache_write_tokens") or 0),
+            model=s.get("model") or "",
+        )
+        session_costs.append((s, cost))
+
+    costs_sorted = sorted(session_costs, key=lambda x: x[1])
+    n = len(costs_sorted)
+
+    p50 = costs_sorted[n // 2][1]
+    p90 = costs_sorted[int(n * 0.9)][1] if n > 1 else costs_sorted[-1][1]
+    p99 = costs_sorted[int(n * 0.99)][1] if n > 1 else costs_sorted[-1][1]
+    total = sum(c for _, c in session_costs)
+
+    outlier_sessions = [
+        s for s, c in session_costs
+        if p50 > 0 and c > 3 * p50
+    ]
+
+    return {
+        "p50_cost_usd": round(p50, 6),
+        "p90_cost_usd": round(p90, 6),
+        "p99_cost_usd": round(p99, 6),
+        "outlier_sessions": outlier_sessions,
+        "total_cost_usd": round(total, 6),
+    }
+
+
+def compute_ide_distribution(sessions: list[dict]) -> dict:
+    """Group sessions by IDE/platform.
+
+    Returns:
+        distribution: dict[str, int] (ide_name -> session count)
+        primary_ide: str
+        multi_ide: bool (>1 IDE used)
+    """
+    distribution: dict[str, int] = {}
+
+    for s in sessions:
+        platform = s.get("platform") or "unknown"
+        distribution[platform] = distribution.get(platform, 0) + 1
+
+    if not distribution:
+        return {
+            "distribution": {},
+            "primary_ide": "",
+            "multi_ide": False,
+        }
+
+    primary_ide = max(distribution, key=distribution.__getitem__)
+    multi_ide = len(distribution) > 1
+
+    return {
+        "distribution": distribution,
+        "primary_ide": primary_ide,
+        "multi_ide": multi_ide,
+    }
+
+
+async def compute_cross_user_patterns(session_metas: dict[str, dict]) -> dict:
+    """Run all cross-user pattern detection and return combined results.
+
+    Input: dict of session_id -> session metadata (from session_cache.get_or_compute_metas)
+    Each session meta has fields: user_id, duration_seconds, error_count, tool_call_count,
+    input_tokens, output_tokens, model, platform, first_event (timestamp string), etc.
+    """
+    sessions = list(session_metas.values())
+
+    return {
+        "user_friction": detect_user_friction_clusters(sessions),
+        "time_of_day": compute_time_of_day_distribution(sessions),
+        "session_length": compute_session_length_trends(sessions),
+        "cost_distribution": compute_cost_distribution(sessions),
+        "ide_distribution": compute_ide_distribution(sessions),
+    }

--- a/ee/observal_insights/dedup.py
+++ b/ee/observal_insights/dedup.py
@@ -1,0 +1,115 @@
+"""Event deduplication — merge hook and OTLP records for the same action.
+
+Same session_id + same tool_name + timestamps within 2 seconds = same event.
+Merge strategy: take token fields from OTLP record, tool_input/tool_response from hook record.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def _parse_ts(ts_str: str | None) -> float:
+    """Parse an ISO-ish timestamp string to epoch seconds. Returns 0.0 on failure."""
+    if not ts_str:
+        return 0.0
+    for fmt in (
+        "%Y-%m-%d %H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%d %H:%M:%S",
+    ):
+        try:
+            return datetime.strptime(ts_str[:26], fmt).timestamp()
+        except (ValueError, TypeError):
+            continue
+    return 0.0
+
+
+def _make_dedup_key(event: dict) -> str:
+    """Generate dedup key from session_id + tool_name + 1-second time bucket."""
+    session_id = event.get("session_id") or ""
+    tool_name = event.get("tool_name") or ""
+    ts = _parse_ts(event.get("timestamp"))
+    bucket = int(ts)  # floor to whole second
+    return f"{session_id}|{tool_name}|{bucket}"
+
+
+def _merge_events(existing: dict, new: dict) -> dict:
+    """Merge two records for the same event, preferring richer data.
+
+    Merge rules:
+    - Token fields (input_tokens, output_tokens, cache_read, cache_creation):
+      prefer the non-zero value; OTLP typically carries these.
+    - tool_input, tool_response: prefer the non-empty value; hooks carry these.
+    - error: prefer whichever has it.
+    - model: prefer whichever has it.
+    - timestamp: keep the earlier one.
+    """
+    merged = dict(existing)
+
+    # Keep the earlier timestamp
+    ts_existing = _parse_ts(existing.get("timestamp"))
+    ts_new = _parse_ts(new.get("timestamp"))
+    if ts_new > 0 and (ts_existing == 0 or ts_new < ts_existing):
+        merged["timestamp"] = new["timestamp"]
+
+    # Token fields: prefer non-zero value (OTLP usually has these)
+    for field in ("input_tokens", "output_tokens", "cache_read", "cache_creation"):
+        existing_val = existing.get(field)
+        new_val = new.get(field)
+        if (new_val and not existing_val) or (new_val and existing_val == 0):
+            merged[field] = new_val
+
+    # tool_input / tool_response: prefer non-empty (hooks carry these)
+    for field in ("tool_input", "tool_response"):
+        if not existing.get(field) and new.get(field):
+            merged[field] = new[field]
+
+    # error: prefer whichever has it
+    if not existing.get("error") and new.get("error"):
+        merged["error"] = new["error"]
+
+    # model: prefer whichever has it
+    if not existing.get("model") and new.get("model"):
+        merged["model"] = new["model"]
+
+    return merged
+
+
+def dedupe_events(events: list[dict]) -> list[dict]:
+    """Deduplicate hook + OTLP events for the same action.
+
+    Dedup key: (session_id, tool_name, timestamp rounded to 1-second bucket)
+
+    Within the 2-second window events with the same key are merged.
+    Events that are more than 2 seconds apart are NOT merged even if they
+    share the same session_id and tool_name.
+
+    Returns: deduplicated event list, sorted by timestamp.
+    """
+    if not events:
+        return []
+
+    # Group events by their 1-second bucket key
+    buckets: dict[str, dict] = {}
+
+    for event in events:
+        key = _make_dedup_key(event)
+        if key not in buckets:
+            buckets[key] = dict(event)
+        else:
+            buckets[key] = _merge_events(buckets[key], event)
+
+    result = list(buckets.values())
+    result.sort(key=lambda e: _parse_ts(e.get("timestamp")))
+    return result
+
+
+def dedupe_session_events(session_id: str, events: list[dict]) -> list[dict]:
+    """Deduplicate events within a single session.
+
+    Filters to only events belonging to the given session_id, then deduplicates.
+    """
+    session_events = [e for e in events if e.get("session_id") == session_id]
+    return dedupe_events(session_events)

--- a/ee/observal_insights/enrichment.py
+++ b/ee/observal_insights/enrichment.py
@@ -1,0 +1,68 @@
+"""Session data enrichment for Agent Insights.
+
+When issue #735 (session file reconciliation) lands, this module will
+check for reconciled data (thinking blocks, full tool I/O, per-turn tokens)
+and merge it into session metadata for richer cost computation and
+facet extraction.
+
+Currently provides completeness scoring to indicate data quality.
+"""
+
+from __future__ import annotations
+
+
+def compute_completeness(meta: dict) -> float:
+    """Score how complete a session's metadata is (0.0-1.0).
+
+    Higher scores mean more data is available for accurate analysis.
+    When #735 lands, sessions with reconciled data will score > 0.9.
+    """
+    checks = [
+        ("input_tokens", 0.15),
+        ("output_tokens", 0.15),
+        ("model", 0.10),
+        ("stop_reason", 0.10),
+        ("tool_call_count", 0.15),
+        ("cache_read_tokens", 0.10),
+        ("cache_write_tokens", 0.05),
+        ("user_id", 0.05),
+        ("platform", 0.05),
+        ("duration_seconds", 0.10),
+    ]
+    score = 0.0
+    for field, weight in checks:
+        value = meta.get(field)
+        if value and str(value) not in ("0", "", "None"):
+            score += weight
+    return round(score, 3)
+
+
+def enrich_session_meta(meta: dict) -> dict:
+    """Enrich a session's metadata with derived fields.
+
+    Currently adds:
+    - completeness_score: data quality indicator
+    - has_errors: boolean convenience field
+    - is_substantive: whether session has enough activity for facet extraction
+
+    When #735 is available, this will also merge:
+    - per_turn_tokens: token breakdown per conversation turn
+    - thinking_blocks: agent reasoning content
+    - full_tool_io: complete tool input/output
+    - conversation_tree: full conversation structure
+    """
+    enriched = dict(meta)
+
+    enriched["completeness_score"] = compute_completeness(meta)
+    enriched["has_errors"] = int(meta.get("error_count", 0)) > 0
+    enriched["is_substantive"] = (
+        int(meta.get("tool_call_count", 0)) >= 3
+        and int(meta.get("duration_seconds", 0)) >= 60
+    )
+
+    return enriched
+
+
+def enrich_all_metas(metas: dict[str, dict]) -> dict[str, dict]:
+    """Enrich all session metadata in batch."""
+    return {sid: enrich_session_meta(meta) for sid, meta in metas.items()}

--- a/ee/observal_insights/enrichment.py
+++ b/ee/observal_insights/enrichment.py
@@ -55,10 +55,7 @@ def enrich_session_meta(meta: dict) -> dict:
 
     enriched["completeness_score"] = compute_completeness(meta)
     enriched["has_errors"] = int(meta.get("error_count", 0)) > 0
-    enriched["is_substantive"] = (
-        int(meta.get("tool_call_count", 0)) >= 3
-        and int(meta.get("duration_seconds", 0)) >= 60
-    )
+    enriched["is_substantive"] = int(meta.get("tool_call_count", 0)) >= 3 and int(meta.get("duration_seconds", 0)) >= 60
 
     return enriched
 

--- a/ee/observal_insights/facets.py
+++ b/ee/observal_insights/facets.py
@@ -142,11 +142,7 @@ async def store_facets(
     from sqlalchemy import select
 
     # Check if already exists (unique on agent_id + session_id)
-    stmt = (
-        select(FacetsModel)
-        .where(FacetsModel.agent_id == agent_id)
-        .where(FacetsModel.session_id == session_id)
-    )
+    stmt = select(FacetsModel).where(FacetsModel.agent_id == agent_id).where(FacetsModel.session_id == session_id)
     result = await db.execute(stmt)
     existing = result.scalar_one_or_none()
 

--- a/ee/observal_insights/facets.py
+++ b/ee/observal_insights/facets.py
@@ -141,21 +141,24 @@ async def store_facets(
 
     from sqlalchemy import select
 
-    # Check if already exists
-    stmt = select(FacetsModel).where(FacetsModel.session_id == session_id)
+    # Check if already exists (unique on agent_id + session_id)
+    stmt = (
+        select(FacetsModel)
+        .where(FacetsModel.agent_id == agent_id)
+        .where(FacetsModel.session_id == session_id)
+    )
     result = await db.execute(stmt)
     existing = result.scalar_one_or_none()
 
     if existing:
         existing.facets = facets
-        existing.updated_at = datetime.now(UTC)
+        existing.extracted_at = datetime.now(UTC)
     else:
         record = FacetsModel(
             session_id=session_id,
             agent_id=agent_id,
             facets=facets,
-            created_at=datetime.now(UTC),
-            updated_at=datetime.now(UTC),
+            extracted_at=datetime.now(UTC),
         )
         db.add(record)
 

--- a/ee/observal_insights/facets.py
+++ b/ee/observal_insights/facets.py
@@ -1,0 +1,272 @@
+"""Session facet extraction and caching for Agent Insights.
+
+Facets are structured metadata extracted from session transcripts via LLM analysis.
+They power the qualitative sections of insight reports (friction, tool usage patterns,
+user satisfaction signals).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+
+from ._deps import get_call_model, get_facets_model, get_settings
+
+logger = structlog.get_logger(__name__)
+
+FACET_EXTRACTION_PROMPT = """Analyze this AI coding agent session transcript and extract structured facets.
+
+## Session Metadata
+- Session ID: {session_id}
+- Duration: {duration_seconds}s
+- Tool calls: {tool_call_count}
+- Errors: {error_count}
+- Model: {model}
+
+## Transcript
+{transcript}
+
+Extract the following facets as a JSON object:
+{{
+  "task_type": "<one of: debugging | feature_implementation | refactoring | exploration | configuration | testing | documentation | code_review | unknown>",
+  "complexity": "<low | medium | high>",
+  "outcome": "<success | partial | failure | abandoned>",
+  "friction_points": [
+    {{"type": "<error_recovery | tool_failure | context_loss | misunderstanding | slow_response>", "description": "<brief description>"}}
+  ],
+  "tools_effective": ["<tool names that worked well>"],
+  "tools_problematic": ["<tool names that caused issues>"],
+  "user_satisfaction_signals": {{
+    "interruptions": <number of user interruptions>,
+    "retries": <number of retry attempts>,
+    "sentiment": "<positive | neutral | negative | unknown>"
+  }},
+  "notable_patterns": ["<any interesting patterns worth noting>"]
+}}
+
+Rules:
+- Base everything on the transcript evidence
+- If insufficient data, use "unknown" values
+- Maximum 3 friction points
+- Maximum 3 notable patterns"""
+
+
+async def extract_facets(
+    session_id: str,
+    transcript: str,
+    meta: dict,
+) -> dict:
+    """Extract structured facets from a session transcript using an LLM.
+
+    Args:
+        session_id: The session identifier.
+        transcript: Formatted session transcript text.
+        meta: Session metadata dict (duration_seconds, tool_call_count, etc.).
+
+    Returns:
+        Dict of extracted facets, or empty dict on failure.
+    """
+    if not transcript or len(transcript.strip()) < 50:
+        logger.debug("facets_skip_short_transcript", session_id=session_id)
+        return {}
+
+    call_model = get_call_model()
+    settings = get_settings()
+
+    model_override = getattr(settings, "INSIGHT_MODEL_FACETS", None) or None
+
+    prompt = FACET_EXTRACTION_PROMPT.format(
+        session_id=session_id,
+        duration_seconds=meta.get("duration_seconds", 0),
+        tool_call_count=meta.get("tool_call_count", 0),
+        error_count=meta.get("error_count", 0),
+        model=meta.get("model", "unknown"),
+        transcript=transcript,
+    )
+
+    try:
+        result = await call_model(prompt, model_override=model_override, max_tokens=4096)
+        if result and isinstance(result, dict):
+            return result
+        logger.warning("facets_empty_response", session_id=session_id)
+        return {}
+    except Exception as e:
+        logger.error("facets_extraction_failed", session_id=session_id, error=str(e))
+        return {}
+
+
+async def load_cached_facets(
+    session_id: str,
+    db,
+) -> dict | None:
+    """Load previously extracted facets from the database.
+
+    Args:
+        session_id: The session to look up.
+        db: An AsyncSession instance.
+
+    Returns:
+        Facets dict if cached, None otherwise.
+    """
+    FacetsModel = get_facets_model()
+
+    from sqlalchemy import select
+
+    stmt = select(FacetsModel).where(FacetsModel.session_id == session_id)
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+
+    if row is None:
+        return None
+
+    return row.facets if hasattr(row, "facets") else None
+
+
+async def store_facets(
+    session_id: str,
+    agent_id: str,
+    facets: dict,
+    db,
+) -> None:
+    """Persist extracted facets to the database.
+
+    Args:
+        session_id: The session identifier.
+        agent_id: The agent UUID (as string).
+        facets: The extracted facets dict.
+        db: An AsyncSession instance.
+    """
+    FacetsModel = get_facets_model()
+
+    from sqlalchemy import select
+
+    # Check if already exists
+    stmt = select(FacetsModel).where(FacetsModel.session_id == session_id)
+    result = await db.execute(stmt)
+    existing = result.scalar_one_or_none()
+
+    if existing:
+        existing.facets = facets
+        existing.updated_at = datetime.now(UTC)
+    else:
+        record = FacetsModel(
+            session_id=session_id,
+            agent_id=agent_id,
+            facets=facets,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        db.add(record)
+
+    await db.flush()
+
+
+async def extract_and_cache_facets(
+    session_id: str,
+    transcript: str,
+    meta: dict,
+    agent_id: str,
+    db,
+) -> dict:
+    """Extract facets for a session, using cache when available.
+
+    Checks the database first; if not cached, extracts via LLM and stores.
+
+    Args:
+        session_id: The session identifier.
+        transcript: Session transcript text.
+        meta: Session metadata dict.
+        agent_id: The agent UUID (as string).
+        db: An AsyncSession instance.
+
+    Returns:
+        Extracted facets dict.
+    """
+    # Check cache first
+    cached = await load_cached_facets(session_id, db)
+    if cached:
+        logger.debug("facets_cache_hit", session_id=session_id)
+        return cached
+
+    # Extract fresh
+    facets = await extract_facets(session_id, transcript, meta)
+    if facets:
+        await store_facets(session_id, agent_id, facets, db)
+        logger.debug("facets_extracted_and_cached", session_id=session_id)
+
+    return facets
+
+
+def aggregate_facets(all_facets: list[dict]) -> dict:
+    """Aggregate facets across multiple sessions into summary statistics.
+
+    Args:
+        all_facets: List of per-session facet dicts.
+
+    Returns:
+        Aggregated summary suitable for inclusion in the report data block.
+    """
+    if not all_facets:
+        return {}
+
+    task_types: dict[str, int] = {}
+    outcomes: dict[str, int] = {}
+    friction_types: dict[str, int] = {}
+    tools_effective: dict[str, int] = {}
+    tools_problematic: dict[str, int] = {}
+    total_interruptions = 0
+    total_retries = 0
+    sentiments: dict[str, int] = {}
+    complexities: dict[str, int] = {}
+
+    for f in all_facets:
+        if not f:
+            continue
+
+        # Task types
+        tt = f.get("task_type", "unknown")
+        task_types[tt] = task_types.get(tt, 0) + 1
+
+        # Complexity
+        cx = f.get("complexity", "unknown")
+        complexities[cx] = complexities.get(cx, 0) + 1
+
+        # Outcomes
+        oc = f.get("outcome", "unknown")
+        outcomes[oc] = outcomes.get(oc, 0) + 1
+
+        # Friction points
+        for fp in f.get("friction_points", []):
+            ft = fp.get("type", "unknown")
+            friction_types[ft] = friction_types.get(ft, 0) + 1
+
+        # Tools
+        for tool in f.get("tools_effective", []):
+            tools_effective[tool] = tools_effective.get(tool, 0) + 1
+        for tool in f.get("tools_problematic", []):
+            tools_problematic[tool] = tools_problematic.get(tool, 0) + 1
+
+        # Satisfaction signals
+        signals = f.get("user_satisfaction_signals", {})
+        total_interruptions += int(signals.get("interruptions", 0))
+        total_retries += int(signals.get("retries", 0))
+        sent = signals.get("sentiment", "unknown")
+        sentiments[sent] = sentiments.get(sent, 0) + 1
+
+    n = len(all_facets)
+    return {
+        "sessions_with_facets": n,
+        "task_types": sorted(task_types.items(), key=lambda x: -x[1]),
+        "complexity_distribution": complexities,
+        "outcomes": outcomes,
+        "friction_types": sorted(friction_types.items(), key=lambda x: -x[1]),
+        "tools_effective": sorted(tools_effective.items(), key=lambda x: -x[1])[:10],
+        "tools_problematic": sorted(tools_problematic.items(), key=lambda x: -x[1])[:10],
+        "satisfaction": {
+            "total_interruptions": total_interruptions,
+            "total_retries": total_retries,
+            "avg_interruptions_per_session": round(total_interruptions / n, 2) if n else 0,
+            "sentiment_distribution": sentiments,
+        },
+    }

--- a/ee/observal_insights/generator.py
+++ b/ee/observal_insights/generator.py
@@ -133,7 +133,14 @@ async def _run_pipeline(
         logger.warning("insight_no_sessions", agent_id=agent_id)
         return {
             "metrics": {},
-            "narrative": {"at_a_glance": {"health": "unknown", "whats_working": "No session data available.", "whats_hindering": "N/A", "quick_win": "N/A"}},
+            "narrative": {
+                "at_a_glance": {
+                    "health": "unknown",
+                    "whats_working": "No session data available.",
+                    "whats_hindering": "N/A",
+                    "quick_win": "N/A",
+                }
+            },
             "sessions_analyzed": 0,
             "models_used": [],
             "report_version": REPORT_VERSION,
@@ -155,10 +162,7 @@ async def _run_pipeline(
     cross_user_patterns = await compute_cross_user_patterns(enriched_metas)
 
     # -- Step 4: Build transcripts for substantive sessions --
-    substantive_sessions = [
-        (sid, meta) for sid, meta in enriched_metas.items()
-        if meta.get("is_substantive", False)
-    ]
+    substantive_sessions = [(sid, meta) for sid, meta in enriched_metas.items() if meta.get("is_substantive", False)]
     # Sort by duration descending, take top N
     substantive_sessions.sort(key=lambda x: int(x[1].get("duration_seconds", 0)), reverse=True)
     substantive_sessions = substantive_sessions[:MAX_TRANSCRIPT_SESSIONS]
@@ -226,9 +230,7 @@ async def _run_pipeline(
     )
 
     # Collect models used
-    models_used = list({
-        s.get("model", "") for s in enriched_sessions if s.get("model")
-    })
+    models_used = list({s.get("model", "") for s in enriched_sessions if s.get("model")})
 
     logger.info(
         "insight_generation_complete",
@@ -300,48 +302,56 @@ def _build_data_block(
     # Add MCP shim metrics if available (Claude Code + Observal shim only)
     mcp = metrics.get("mcp", {})
     if mcp and int(mcp.get("total_mcp_calls", 0)) > 0:
-        sections.extend([
-            "",
-            "## MCP Shim Metrics (precise latency + schema compliance)",
-            json.dumps(
-                {
-                    "mcp_latency": {
-                        "p50": mcp.get("latency_p50_ms", 0),
-                        "p95": mcp.get("latency_p95_ms", 0),
-                        "p99": mcp.get("latency_p99_ms", 0),
+        sections.extend(
+            [
+                "",
+                "## MCP Shim Metrics (precise latency + schema compliance)",
+                json.dumps(
+                    {
+                        "mcp_latency": {
+                            "p50": mcp.get("latency_p50_ms", 0),
+                            "p95": mcp.get("latency_p95_ms", 0),
+                            "p99": mcp.get("latency_p99_ms", 0),
+                        },
+                        "schema_violations": mcp.get("schema_violations", 0),
+                        "schema_violation_rate": mcp.get("schema_violation_rate", 0.0),
+                        "tools_available_count": mcp.get("tools_available_count", 0),
+                        "slowest_tools": mcp.get("slowest_tools", []),
+                        "error_tools": mcp.get("error_tools", []),
                     },
-                    "schema_violations": mcp.get("schema_violations", 0),
-                    "schema_violation_rate": mcp.get("schema_violation_rate", 0.0),
-                    "tools_available_count": mcp.get("tools_available_count", 0),
-                    "slowest_tools": mcp.get("slowest_tools", []),
-                    "error_tools": mcp.get("error_tools", []),
-                },
-                indent=2,
-            ),
-        ])
+                    indent=2,
+                ),
+            ]
+        )
 
     # Add facet summary if available
     if facet_summary:
-        sections.extend([
-            "",
-            "## Qualitative Facet Summary (from LLM analysis of individual sessions)",
-            json.dumps(facet_summary, indent=2),
-        ])
+        sections.extend(
+            [
+                "",
+                "## Qualitative Facet Summary (from LLM analysis of individual sessions)",
+                json.dumps(facet_summary, indent=2),
+            ]
+        )
 
     # Add cross-user patterns if available
     if cross_user_patterns:
-        sections.extend([
-            "",
-            "## Cross-User Patterns",
-            json.dumps(cross_user_patterns, indent=2),
-        ])
+        sections.extend(
+            [
+                "",
+                "## Cross-User Patterns",
+                json.dumps(cross_user_patterns, indent=2),
+            ]
+        )
 
     # Add regression flags if available
     if regressions:
-        sections.extend([
-            "",
-            "## Regression Flags (vs previous period)",
-            json.dumps(regressions, indent=2),
-        ])
+        sections.extend(
+            [
+                "",
+                "## Regression Flags (vs previous period)",
+                json.dumps(regressions, indent=2),
+            ]
+        )
 
     return "\n".join(sections)

--- a/ee/observal_insights/generator.py
+++ b/ee/observal_insights/generator.py
@@ -1,0 +1,347 @@
+"""Main report generation orchestrator for Agent Insights.
+
+This module coordinates the full insight generation pipeline:
+1. Fetch session metadata from ClickHouse (with caching)
+2. Enrich session metadata
+3. Build transcripts for substantive sessions
+4. Extract facets from transcripts (with caching)
+5. Compute quantitative metrics
+6. Detect regressions against previous period
+7. Generate narrative sections via LLM
+8. Return structured results for the host app to persist
+
+The host application (observal-server) is responsible for:
+- Loading the report/agent from PostgreSQL
+- Calling generate_report_content() with the necessary parameters
+- Persisting the results back to the database
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import structlog
+
+from ._deps import get_db_session, get_settings
+from .anonymize import anonymize_sessions
+from .cross_user import compute_cross_user_patterns
+from .enrichment import enrich_all_metas
+from .facets import aggregate_facets, extract_and_cache_facets
+from .metrics import compute_all_metrics
+from .regression import detect_regressions
+from .sections import generate_sections
+from .session_cache import get_session_metas
+from .transcript import build_session_transcript
+
+logger = structlog.get_logger(__name__)
+
+REPORT_VERSION = "2.0"
+
+# Maximum number of sessions to build transcripts for (most recent / most substantive)
+MAX_TRANSCRIPT_SESSIONS = 30
+# Maximum sessions to include in the LLM data block
+MAX_SESSIONS_IN_PROMPT = 75
+# Minimum tool calls for a session to be worth extracting facets from
+MIN_SUBSTANTIVE_TOOL_CALLS = 3
+
+
+async def generate_report_content(
+    agent_name: str,
+    agent_id: str,
+    period_start: str,
+    period_end: str,
+    previous_metrics: dict | None = None,
+    db=None,
+) -> dict:
+    """Generate a complete insight report for an agent over a time period.
+
+    This is the main entry point for the insight generation pipeline.
+
+    Args:
+        agent_name: Display name of the agent.
+        agent_id: The agent UUID (as string).
+        period_start: ISO timestamp for the reporting period start.
+        period_end: ISO timestamp for the reporting period end.
+        previous_metrics: Metrics dict from the previous report period (for regression detection).
+        db: Optional AsyncSession for caching. If None, a new session is created from _deps.
+
+    Returns:
+        Dict with keys:
+            - metrics: quantitative metrics dict
+            - narrative: structured narrative sections dict
+            - sessions_analyzed: number of sessions processed
+            - models_used: list of model names used in generation
+            - report_version: format version string
+            - regressions: list of detected regressions
+            - facets_summary: aggregated facets dict
+    """
+    settings = get_settings()
+
+    # Acquire a DB session if not provided
+    owns_session = False
+    if db is None:
+        session_factory = get_db_session()
+        db = session_factory()
+        owns_session = True
+
+    try:
+        return await _run_pipeline(
+            agent_name=agent_name,
+            agent_id=agent_id,
+            period_start=period_start,
+            period_end=period_end,
+            previous_metrics=previous_metrics,
+            db=db,
+            settings=settings,
+        )
+    finally:
+        if owns_session:
+            await db.close()
+
+
+async def _run_pipeline(
+    agent_name: str,
+    agent_id: str,
+    period_start: str,
+    period_end: str,
+    previous_metrics: dict | None,
+    db,
+    settings,
+) -> dict:
+    """Internal pipeline execution."""
+
+    logger.info(
+        "insight_generation_started",
+        agent_name=agent_name,
+        agent_id=agent_id,
+        period_start=period_start,
+        period_end=period_end,
+    )
+
+    # -- Step 1: Fetch session metadata --
+    session_metas = await get_session_metas(
+        agent_id=agent_id,
+        agent_name=agent_name,
+        period_start=period_start,
+        period_end=period_end,
+        db=db,
+        use_cache=True,
+    )
+
+    if not session_metas:
+        logger.warning("insight_no_sessions", agent_id=agent_id)
+        return {
+            "metrics": {},
+            "narrative": {"at_a_glance": {"health": "unknown", "whats_working": "No session data available.", "whats_hindering": "N/A", "quick_win": "N/A"}},
+            "sessions_analyzed": 0,
+            "models_used": [],
+            "report_version": REPORT_VERSION,
+            "regressions": [],
+            "facets_summary": {},
+        }
+
+    sessions = list(session_metas.values())
+    logger.info("insight_sessions_loaded", count=len(sessions))
+
+    # -- Step 2: Enrich session metadata --
+    enriched_metas = enrich_all_metas(session_metas)
+    enriched_sessions = list(enriched_metas.values())
+
+    # -- Step 3: Compute metrics --
+    metrics = await compute_all_metrics(agent_name, period_start, period_end)
+
+    # -- Step 3b: Cross-user pattern detection (deterministic) --
+    cross_user_patterns = await compute_cross_user_patterns(enriched_metas)
+
+    # -- Step 4: Build transcripts for substantive sessions --
+    substantive_sessions = [
+        (sid, meta) for sid, meta in enriched_metas.items()
+        if meta.get("is_substantive", False)
+    ]
+    # Sort by duration descending, take top N
+    substantive_sessions.sort(key=lambda x: int(x[1].get("duration_seconds", 0)), reverse=True)
+    substantive_sessions = substantive_sessions[:MAX_TRANSCRIPT_SESSIONS]
+
+    transcripts: dict[str, str] = {}
+    if substantive_sessions:
+        transcript_tasks = [
+            build_session_transcript(
+                session_id=sid,
+                start=meta.get("start_time", period_start),
+                end=meta.get("end_time", period_end),
+            )
+            for sid, meta in substantive_sessions
+        ]
+        transcript_results = await asyncio.gather(*transcript_tasks, return_exceptions=True)
+        for (sid, _), result in zip(substantive_sessions, transcript_results):
+            if isinstance(result, str) and result:
+                transcripts[sid] = result
+
+    logger.info("insight_transcripts_built", count=len(transcripts))
+
+    # -- Step 5: Extract facets from transcripts --
+    all_facets: list[dict] = []
+    if transcripts:
+        facet_tasks = [
+            extract_and_cache_facets(
+                session_id=sid,
+                transcript=transcript,
+                meta=enriched_metas.get(sid, {}),
+                agent_id=agent_id,
+                db=db,
+            )
+            for sid, transcript in transcripts.items()
+        ]
+        facet_results = await asyncio.gather(*facet_tasks, return_exceptions=True)
+        for result in facet_results:
+            if isinstance(result, dict) and result:
+                all_facets.append(result)
+
+    facets_summary = aggregate_facets(all_facets)
+    logger.info("insight_facets_extracted", count=len(all_facets))
+
+    # -- Step 6: Detect regressions --
+    regressions = []
+    if previous_metrics:
+        regressions = detect_regressions(metrics, previous_metrics)
+        logger.info("insight_regressions_detected", count=len(regressions))
+
+    # -- Step 7: Build data block for LLM narrative generation --
+    data_block = _build_data_block(
+        agent_name=agent_name,
+        metrics=metrics,
+        session_metas=enriched_metas,
+        facet_summary=facets_summary,
+        regressions=regressions,
+        period_start=period_start,
+        period_end=period_end,
+        cross_user_patterns=cross_user_patterns,
+    )
+
+    # -- Step 8: Generate narrative sections via LLM --
+    narrative = await generate_sections(
+        data_block=data_block,
+        previous_report=previous_metrics,
+    )
+
+    # Collect models used
+    models_used = list({
+        s.get("model", "") for s in enriched_sessions if s.get("model")
+    })
+
+    logger.info(
+        "insight_generation_complete",
+        agent_name=agent_name,
+        sessions_analyzed=len(sessions),
+        facets_extracted=len(all_facets),
+        regressions=len(regressions),
+    )
+
+    return {
+        "metrics": metrics,
+        "narrative": narrative,
+        "sessions_analyzed": len(sessions),
+        "models_used": models_used,
+        "report_version": REPORT_VERSION,
+        "regressions": regressions,
+        "facets_summary": facets_summary,
+    }
+
+
+def _build_data_block(
+    agent_name: str,
+    metrics: dict,
+    session_metas: dict[str, dict],
+    facet_summary: dict,
+    regressions: list[dict],
+    period_start: str,
+    period_end: str,
+    cross_user_patterns: dict | None = None,
+) -> str:
+    """Build the DATA_BLOCK string that gets passed to all section prompts."""
+    # Anonymize session data for LLM
+    meta_list = list(session_metas.values())[:MAX_SESSIONS_IN_PROMPT]
+    anonymized = anonymize_sessions(meta_list)
+
+    sections = [
+        f"## Agent: {agent_name}",
+        f"## Period: {period_start} to {period_end}",
+        f"## Sessions Analyzed: {len(session_metas)}",
+        "",
+        "## Metrics Overview",
+        json.dumps(metrics.get("overview", {}), indent=2),
+        "",
+        "## Token Usage",
+        json.dumps(metrics.get("tokens", {}), indent=2),
+        "",
+        "## Cost Analysis",
+        json.dumps(metrics.get("cost", {}), indent=2),
+        "",
+        "## Error Breakdown",
+        json.dumps(metrics.get("errors", {}), indent=2),
+        "",
+        "## Tool Error Categories",
+        json.dumps(metrics.get("tool_errors", {}), indent=2),
+        "",
+        "## Interruptions & Stop Reasons",
+        json.dumps(metrics.get("interruptions", {}), indent=2),
+        "",
+        "## Duration Stats",
+        json.dumps(metrics.get("duration", {}), indent=2),
+        "",
+        "## Top Tools",
+        json.dumps(metrics.get("tools", [])[:15], indent=2),
+        "",
+        "## Per-Session Data (sample)",
+        json.dumps(anonymized[:20], indent=2, default=str),
+    ]
+
+    # Add MCP shim metrics if available (Claude Code + Observal shim only)
+    mcp = metrics.get("mcp", {})
+    if mcp and int(mcp.get("total_mcp_calls", 0)) > 0:
+        sections.extend([
+            "",
+            "## MCP Shim Metrics (precise latency + schema compliance)",
+            json.dumps(
+                {
+                    "mcp_latency": {
+                        "p50": mcp.get("latency_p50_ms", 0),
+                        "p95": mcp.get("latency_p95_ms", 0),
+                        "p99": mcp.get("latency_p99_ms", 0),
+                    },
+                    "schema_violations": mcp.get("schema_violations", 0),
+                    "schema_violation_rate": mcp.get("schema_violation_rate", 0.0),
+                    "tools_available_count": mcp.get("tools_available_count", 0),
+                    "slowest_tools": mcp.get("slowest_tools", []),
+                    "error_tools": mcp.get("error_tools", []),
+                },
+                indent=2,
+            ),
+        ])
+
+    # Add facet summary if available
+    if facet_summary:
+        sections.extend([
+            "",
+            "## Qualitative Facet Summary (from LLM analysis of individual sessions)",
+            json.dumps(facet_summary, indent=2),
+        ])
+
+    # Add cross-user patterns if available
+    if cross_user_patterns:
+        sections.extend([
+            "",
+            "## Cross-User Patterns",
+            json.dumps(cross_user_patterns, indent=2),
+        ])
+
+    # Add regression flags if available
+    if regressions:
+        sections.extend([
+            "",
+            "## Regression Flags (vs previous period)",
+            json.dumps(regressions, indent=2),
+        ])
+
+    return "\n".join(sections)

--- a/ee/observal_insights/html_export.py
+++ b/ee/observal_insights/html_export.py
@@ -166,7 +166,7 @@ def render_report_html(report: dict) -> str:
                   <div class="tool-bar" style="width: {pct}%"></div>
                 </div>
                 <span class="tool-calls">{calls}</span>
-                <span class="tool-err" style="color: {'#dc2626' if err_rate > 5 else '#6b7280'}">{err_rate:.1f}%</span>
+                <span class="tool-err" style="color: {"#dc2626" if err_rate > 5 else "#6b7280"}">{err_rate:.1f}%</span>
               </div>"""
             tool_dist_html = f'<div class="tool-distribution"><h4>Tool Distribution</h4>{tool_rows}</div>'
 
@@ -306,11 +306,15 @@ def render_report_html(report: dict) -> str:
       <h2>User Experience</h2>
       <p class="narrative">{_esc(user_exp.get("narrative", ""))}</p>
       {f'<div class="signals"><h4>Signals</h4>{signals_html}</div>' if signals_html else ""}
-      {f'''<div class="satisfaction-indicators">
+      {
+            f'''<div class="satisfaction-indicators">
         <span>Completion: <strong>{_esc(str(indicators.get("completion_rate", "N/A")))}</strong></span>
         <span>Interruptions: <strong>{_esc(str(indicators.get("interruption_rate", "N/A")))}</strong></span>
         <span>Retries: <strong>{_esc(str(indicators.get("retry_patterns", "none")))}</strong></span>
-      </div>''' if indicators else ""}
+      </div>'''
+            if indicators
+            else ""
+        }
     </section>""")
 
     # ── Regression Detection ──
@@ -322,7 +326,9 @@ def render_report_html(report: dict) -> str:
                 if isinstance(ch, dict):
                     direction = ch.get("direction", "stable")
                     arrow = "\u2191" if direction == "improved" else "\u2193" if direction == "degraded" else "\u2192"
-                    color = "#16a34a" if direction == "improved" else "#dc2626" if direction == "degraded" else "#6b7280"
+                    color = (
+                        "#16a34a" if direction == "improved" else "#dc2626" if direction == "degraded" else "#6b7280"
+                    )
                     change_rows += f"""
               <tr>
                 <td>{_esc(ch.get("metric", ""))}</td>
@@ -354,7 +360,7 @@ def render_report_html(report: dict) -> str:
             <td><code>{_esc(t.get("name", t.get("tool", "")))}</code></td>
             <td>{invocations}</td>
             <td>{errs}</td>
-            <td style="color: {'#dc2626' if err_rate > 10 else '#6b7280'}">{err_rate:.1f}%</td>
+            <td style="color: {"#dc2626" if err_rate > 10 else "#6b7280"}">{err_rate:.1f}%</td>
           </tr>"""
         sections_html.append(f"""
     <section class="tools-table">

--- a/ee/observal_insights/html_export.py
+++ b/ee/observal_insights/html_export.py
@@ -1,0 +1,593 @@
+"""HTML export for insight reports — self-contained single-file report."""
+
+from __future__ import annotations
+
+import html
+from datetime import datetime
+
+
+def _esc(text: str | None) -> str:
+    """HTML-escape text."""
+    return html.escape(str(text)) if text else ""
+
+
+def _format_cost(val: float | None) -> str:
+    if val is None:
+        return "$0.00"
+    if val < 0.01:
+        return f"${val:.4f}"
+    return f"${val:.2f}"
+
+
+def _severity_color(severity: str) -> str:
+    return {"high": "#dc2626", "medium": "#d97706", "low": "#2563eb"}.get(severity, "#6b7280")
+
+
+def _priority_color(priority: str) -> str:
+    return {"high": "#dc2626", "medium": "#d97706", "low": "#16a34a"}.get(priority, "#6b7280")
+
+
+def _health_color(health: str) -> str:
+    return {"healthy": "#16a34a", "mixed": "#d97706", "concerning": "#dc2626"}.get(health, "#6b7280")
+
+
+def render_report_html(report: dict) -> str:
+    """Render a complete insight report as a self-contained HTML document.
+
+    Args:
+        report: Full report dict with keys: id, agent_id, status, period_start,
+                period_end, metrics, narrative, sessions_analyzed, etc.
+    """
+    metrics = report.get("metrics") or {}
+    narrative = report.get("narrative") or {}
+    agent_id = report.get("agent_id", "Unknown")
+    period_start = report.get("period_start", "")
+    period_end = report.get("period_end", "")
+    sessions_analyzed = report.get("sessions_analyzed", 0)
+    report_id = report.get("id", "")
+
+    # Format dates
+    if isinstance(period_start, datetime):
+        period_start = period_start.strftime("%Y-%m-%d")
+    elif isinstance(period_start, str) and "T" in period_start:
+        period_start = period_start.split("T")[0]
+
+    if isinstance(period_end, datetime):
+        period_end = period_end.strftime("%Y-%m-%d")
+    elif isinstance(period_end, str) and "T" in period_end:
+        period_end = period_end.split("T")[0]
+
+    # Extract sections
+    at_a_glance = narrative.get("at_a_glance", {})
+    usage_patterns = narrative.get("usage_patterns", {})
+    what_works = narrative.get("what_works", {})
+    friction = narrative.get("friction_analysis", {})
+    suggestions = narrative.get("suggestions", {})
+    token_opt = narrative.get("token_optimization", {})
+    user_exp = narrative.get("user_experience", {})
+    regression = narrative.get("regression_detection", {})
+    fun_ending = narrative.get("fun_ending", {})
+
+    # Metrics
+    overview = metrics.get("overview", {})
+    tokens = metrics.get("tokens", {})
+    cost = metrics.get("cost", {})
+    errors = metrics.get("errors", {})
+    duration = metrics.get("duration", {})
+    tools = metrics.get("tools", [])
+    tool_errors = metrics.get("tool_errors", {})
+
+    # Build HTML sections
+    sections_html = []
+
+    # ── At a Glance ──
+    if at_a_glance and isinstance(at_a_glance, dict):
+        health = at_a_glance.get("health", "mixed")
+        sections_html.append(f"""
+    <section class="at-a-glance">
+      <h2>At a Glance</h2>
+      <div class="health-badge" style="background: {_health_color(health)}; color: white; display: inline-block; padding: 4px 12px; border-radius: 12px; font-weight: 600; margin-bottom: 16px;">
+        {_esc(health).upper()}
+      </div>
+      <div class="glance-grid">
+        <div class="glance-card glance-good">
+          <h4>What's Working</h4>
+          <p>{_esc(at_a_glance.get("whats_working", ""))}</p>
+        </div>
+        <div class="glance-card glance-bad">
+          <h4>What's Hindering</h4>
+          <p>{_esc(at_a_glance.get("whats_hindering", ""))}</p>
+        </div>
+        <div class="glance-card glance-action">
+          <h4>Quick Win</h4>
+          <p>{_esc(at_a_glance.get("quick_win", ""))}</p>
+        </div>
+      </div>
+    </section>""")
+
+    # ── Key Metrics ──
+    sections_html.append(f"""
+    <section class="metrics-overview">
+      <h2>Key Metrics</h2>
+      <div class="metrics-grid">
+        <div class="metric-card">
+          <span class="metric-value">{overview.get("total_sessions", 0)}</span>
+          <span class="metric-label">Sessions</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-value">{overview.get("unique_users", overview.get("active_users", 0))}</span>
+          <span class="metric-label">Unique Users</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-value">{_format_cost(cost.get("total_cost_usd"))}</span>
+          <span class="metric-label">Total Cost</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-value">{_format_cost(cost.get("avg_cost_per_session"))}</span>
+          <span class="metric-label">Cost/Session</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-value">{round(float(cost.get("cache_efficiency_ratio", 0)) * 100, 1)}%</span>
+          <span class="metric-label">Cache Efficiency</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-value">{round(float(overview.get("avg_duration_seconds", duration.get("avg_duration_seconds", 0))) / 60, 1)}m</span>
+          <span class="metric-label">Avg Duration</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-value">{round(float(errors.get("error_rate", 0)) * 100, 1)}%</span>
+          <span class="metric-label">Error Rate</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-value">{int(tokens.get("total_tokens", 0)):,}</span>
+          <span class="metric-label">Total Tokens</span>
+        </div>
+      </div>
+    </section>""")
+
+    # ── Usage Patterns ──
+    if usage_patterns and isinstance(usage_patterns, dict):
+        usage_narrative = usage_patterns.get("narrative", "")
+        tool_dist = usage_patterns.get("tool_distribution", [])
+        session_profile = usage_patterns.get("session_profile", {})
+
+        tool_dist_html = ""
+        if tool_dist and isinstance(tool_dist, list):
+            max_calls = max((t.get("calls", 0) for t in tool_dist), default=1) or 1
+            tool_rows = ""
+            for t in tool_dist[:10]:
+                calls = t.get("calls", 0)
+                pct = (calls / max_calls) * 100
+                err_rate = t.get("error_rate", 0)
+                tool_rows += f"""
+              <div class="tool-row">
+                <span class="tool-name">{_esc(t.get("tool", ""))}</span>
+                <div class="tool-bar-container">
+                  <div class="tool-bar" style="width: {pct}%"></div>
+                </div>
+                <span class="tool-calls">{calls}</span>
+                <span class="tool-err" style="color: {'#dc2626' if err_rate > 5 else '#6b7280'}">{err_rate:.1f}%</span>
+              </div>"""
+            tool_dist_html = f'<div class="tool-distribution"><h4>Tool Distribution</h4>{tool_rows}</div>'
+
+        profile_html = ""
+        if session_profile and isinstance(session_profile, dict):
+            profile_html = f"""
+          <div class="session-profile">
+            <h4>Typical Session</h4>
+            <div class="profile-stats">
+              <span><strong>{session_profile.get("avg_duration_minutes", "?")}m</strong> duration</span>
+              <span><strong>{session_profile.get("avg_tool_calls", "?")}</strong> tool calls</span>
+              <span><strong>{session_profile.get("avg_prompts", "?")}</strong> prompts</span>
+              <span>Type: <strong>{_esc(session_profile.get("session_type", "?"))}</strong></span>
+            </div>
+          </div>"""
+
+        sections_html.append(f"""
+    <section class="usage-patterns">
+      <h2>Usage Patterns</h2>
+      <p class="narrative">{_esc(usage_narrative)}</p>
+      {tool_dist_html}
+      {profile_html}
+    </section>""")
+
+    # ── What Works ──
+    if what_works and isinstance(what_works, dict):
+        strengths = what_works.get("strengths", [])
+        if strengths and isinstance(strengths, list):
+            strength_cards = ""
+            for s in strengths:
+                if isinstance(s, dict):
+                    strength_cards += f"""
+              <div class="strength-card">
+                <h4>{_esc(s.get("title", ""))}</h4>
+                <p>{_esc(s.get("description", ""))}</p>
+              </div>"""
+            sections_html.append(f"""
+    <section class="what-works">
+      <h2>What Works Well</h2>
+      <p class="section-intro">{_esc(what_works.get("intro", ""))}</p>
+      <div class="strengths-grid">{strength_cards}</div>
+    </section>""")
+
+    # ── Friction Analysis ──
+    if friction and isinstance(friction, dict):
+        categories = friction.get("categories", [])
+        if categories and isinstance(categories, list):
+            friction_cards = ""
+            for c in categories:
+                if isinstance(c, dict):
+                    sev = c.get("severity", "low")
+                    friction_cards += f"""
+              <div class="friction-card" style="border-left: 4px solid {_severity_color(sev)}">
+                <div class="friction-header">
+                  <h4>{_esc(c.get("title", ""))}</h4>
+                  <span class="severity-badge" style="background: {_severity_color(sev)}; color: white;">{_esc(sev).upper()}</span>
+                </div>
+                <p>{_esc(c.get("description", ""))}</p>
+                <code class="evidence">{_esc(c.get("evidence", ""))}</code>
+                <p class="impact"><em>Impact: {_esc(c.get("impact", ""))}</em></p>
+              </div>"""
+            sections_html.append(f"""
+    <section class="friction-analysis">
+      <h2>Friction Analysis</h2>
+      <p class="section-intro">{_esc(friction.get("intro", ""))}</p>
+      <div class="friction-list">{friction_cards}</div>
+    </section>""")
+
+    # ── Suggestions ──
+    if suggestions and isinstance(suggestions, dict):
+        items = suggestions.get("items", [])
+        if items and isinstance(items, list):
+            suggestion_cards = ""
+            for idx, item in enumerate(items, 1):
+                if isinstance(item, dict):
+                    priority = item.get("priority", "medium")
+                    suggestion_cards += f"""
+              <div class="suggestion-card">
+                <div class="suggestion-header">
+                  <span class="suggestion-num">#{idx}</span>
+                  <h4>{_esc(item.get("title", ""))}</h4>
+                  <span class="priority-badge" style="background: {_priority_color(priority)}; color: white;">{_esc(priority).upper()}</span>
+                </div>
+                <div class="suggestion-action">
+                  <strong>Action:</strong> {_esc(item.get("action", ""))}
+                </div>
+                <p class="suggestion-why"><em>Why: {_esc(item.get("why", ""))}</em></p>
+              </div>"""
+            sections_html.append(f"""
+    <section class="suggestions">
+      <h2>Suggestions</h2>
+      <p class="section-intro">{_esc(suggestions.get("intro", ""))}</p>
+      <div class="suggestions-list">{suggestion_cards}</div>
+    </section>""")
+
+    # ── Token Optimization ──
+    if token_opt and isinstance(token_opt, dict):
+        tok_metrics = token_opt.get("metrics", {})
+        opportunities = token_opt.get("opportunities", [])
+        opp_html = ""
+        if opportunities and isinstance(opportunities, list):
+            for opp in opportunities:
+                if isinstance(opp, dict):
+                    opp_html += f"""
+              <div class="opportunity-card">
+                <h4>{_esc(opp.get("title", ""))}</h4>
+                <p>{_esc(opp.get("description", ""))}</p>
+                <span class="savings">{_esc(opp.get("estimated_savings", ""))}</span>
+              </div>"""
+        sections_html.append(f"""
+    <section class="token-optimization">
+      <h2>Cost & Token Optimization</h2>
+      <p class="narrative">{_esc(token_opt.get("summary", ""))}</p>
+      <div class="cost-metrics">
+        <div class="metric-card"><span class="metric-value">{_format_cost(tok_metrics.get("total_cost_usd"))}</span><span class="metric-label">Total Cost</span></div>
+        <div class="metric-card"><span class="metric-value">{_format_cost(tok_metrics.get("cost_per_session"))}</span><span class="metric-label">Per Session</span></div>
+        <div class="metric-card"><span class="metric-value">{round(float(tok_metrics.get("cache_efficiency_pct", 0)), 1)}%</span><span class="metric-label">Cache Efficiency</span></div>
+      </div>
+      {f'<div class="opportunities"><h4>Opportunities</h4>{opp_html}</div>' if opp_html else ""}
+    </section>""")
+
+    # ── User Experience ──
+    if user_exp and isinstance(user_exp, dict):
+        signals = user_exp.get("signals", [])
+        indicators = user_exp.get("satisfaction_indicators", {})
+        signals_html = ""
+        if signals and isinstance(signals, list):
+            for sig in signals:
+                if isinstance(sig, dict):
+                    signals_html += f"""
+              <div class="signal-row">
+                <span class="signal-obs">{_esc(sig.get("signal", ""))}</span>
+                <span class="signal-interp">{_esc(sig.get("interpretation", ""))}</span>
+              </div>"""
+        sections_html.append(f"""
+    <section class="user-experience">
+      <h2>User Experience</h2>
+      <p class="narrative">{_esc(user_exp.get("narrative", ""))}</p>
+      {f'<div class="signals"><h4>Signals</h4>{signals_html}</div>' if signals_html else ""}
+      {f'''<div class="satisfaction-indicators">
+        <span>Completion: <strong>{_esc(str(indicators.get("completion_rate", "N/A")))}</strong></span>
+        <span>Interruptions: <strong>{_esc(str(indicators.get("interruption_rate", "N/A")))}</strong></span>
+        <span>Retries: <strong>{_esc(str(indicators.get("retry_patterns", "none")))}</strong></span>
+      </div>''' if indicators else ""}
+    </section>""")
+
+    # ── Regression Detection ──
+    if regression and isinstance(regression, dict) and regression.get("has_previous_data"):
+        changes = regression.get("changes", [])
+        if changes and isinstance(changes, list):
+            change_rows = ""
+            for ch in changes:
+                if isinstance(ch, dict):
+                    direction = ch.get("direction", "stable")
+                    arrow = "\u2191" if direction == "improved" else "\u2193" if direction == "degraded" else "\u2192"
+                    color = "#16a34a" if direction == "improved" else "#dc2626" if direction == "degraded" else "#6b7280"
+                    change_rows += f"""
+              <tr>
+                <td>{_esc(ch.get("metric", ""))}</td>
+                <td style="color: {color}; font-weight: 600;">{arrow} {_esc(direction)}</td>
+                <td>{_esc(str(ch.get("previous_value", "")))}</td>
+                <td>{_esc(str(ch.get("current_value", "")))}</td>
+                <td>{ch.get("magnitude_pct", 0):.1f}%</td>
+                <td>{_esc(ch.get("significance", ""))}</td>
+              </tr>"""
+            sections_html.append(f"""
+    <section class="regression-detection">
+      <h2>Period-over-Period Changes</h2>
+      <p class="narrative">{_esc(regression.get("summary", ""))}</p>
+      <table class="changes-table">
+        <thead><tr><th>Metric</th><th>Direction</th><th>Previous</th><th>Current</th><th>Change</th><th>Significance</th></tr></thead>
+        <tbody>{change_rows}</tbody>
+      </table>
+    </section>""")
+
+    # ── Top Tools Table ──
+    if tools:
+        tool_rows = ""
+        for t in tools[:15]:
+            invocations = int(t.get("invocations", t.get("calls", 0)))
+            errs = int(t.get("errors", 0))
+            err_rate = (errs / invocations * 100) if invocations > 0 else 0
+            tool_rows += f"""
+          <tr>
+            <td><code>{_esc(t.get("name", t.get("tool", "")))}</code></td>
+            <td>{invocations}</td>
+            <td>{errs}</td>
+            <td style="color: {'#dc2626' if err_rate > 10 else '#6b7280'}">{err_rate:.1f}%</td>
+          </tr>"""
+        sections_html.append(f"""
+    <section class="tools-table">
+      <h2>Tool Usage</h2>
+      <table>
+        <thead><tr><th>Tool</th><th>Invocations</th><th>Errors</th><th>Error Rate</th></tr></thead>
+        <tbody>{tool_rows}</tbody>
+      </table>
+    </section>""")
+
+    # ── Error Categories ──
+    if tool_errors and tool_errors.get("categories"):
+        cats = tool_errors["categories"]
+        cat_rows = ""
+        for cat, count in sorted(cats.items(), key=lambda x: -x[1]):
+            cat_rows += f"<tr><td>{_esc(cat)}</td><td>{count}</td></tr>"
+        sections_html.append(f"""
+    <section class="error-categories">
+      <h2>Error Categories</h2>
+      <table>
+        <thead><tr><th>Category</th><th>Count</th></tr></thead>
+        <tbody>{cat_rows}</tbody>
+      </table>
+    </section>""")
+
+    # ── Fun Ending ──
+    if fun_ending and isinstance(fun_ending, dict) and fun_ending.get("headline"):
+        sections_html.append(f"""
+    <section class="fun-ending">
+      <div class="fun-card">
+        <h3>{_esc(fun_ending.get("headline", ""))}</h3>
+        <p>{_esc(fun_ending.get("detail", ""))}</p>
+      </div>
+    </section>""")
+
+    body_content = "\n".join(sections_html)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Insight Report \u2014 {_esc(period_start)} to {_esc(period_end)}</title>
+  <style>
+    :root {{
+      --bg: #f8fafc;
+      --card-bg: #ffffff;
+      --text: #1e293b;
+      --text-muted: #64748b;
+      --border: #e2e8f0;
+      --green: #16a34a;
+      --green-bg: #f0fdf4;
+      --red: #dc2626;
+      --red-bg: #fef2f2;
+      --amber: #d97706;
+      --amber-bg: #fffbeb;
+      --blue: #2563eb;
+      --blue-bg: #eff6ff;
+      --purple: #7c3aed;
+    }}
+    * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+    body {{
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      padding: 40px 20px;
+    }}
+    .container {{ max-width: 900px; margin: 0 auto; }}
+    header {{
+      text-align: center;
+      margin-bottom: 40px;
+      padding-bottom: 24px;
+      border-bottom: 2px solid var(--border);
+    }}
+    header h1 {{ font-size: 28px; margin-bottom: 8px; }}
+    header .subtitle {{ color: var(--text-muted); font-size: 14px; }}
+    section {{
+      background: var(--card-bg);
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 24px;
+      border: 1px solid var(--border);
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }}
+    section h2 {{
+      font-size: 20px;
+      margin-bottom: 16px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--border);
+    }}
+    .narrative {{ color: var(--text); margin-bottom: 16px; white-space: pre-wrap; }}
+    .section-intro {{ color: var(--text-muted); margin-bottom: 16px; font-style: italic; }}
+    .metrics-grid, .cost-metrics {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+    }}
+    .metric-card {{
+      background: var(--bg);
+      padding: 16px;
+      border-radius: 8px;
+      text-align: center;
+      border: 1px solid var(--border);
+    }}
+    .metric-value {{ display: block; font-size: 24px; font-weight: 700; color: var(--blue); }}
+    .metric-label {{ display: block; font-size: 12px; color: var(--text-muted); margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; }}
+    .glance-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; }}
+    .glance-card {{ padding: 16px; border-radius: 8px; }}
+    .glance-card h4 {{ font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }}
+    .glance-card p {{ font-size: 14px; }}
+    .glance-good {{ background: var(--green-bg); border: 1px solid #bbf7d0; }}
+    .glance-good h4 {{ color: var(--green); }}
+    .glance-bad {{ background: var(--red-bg); border: 1px solid #fecaca; }}
+    .glance-bad h4 {{ color: var(--red); }}
+    .glance-action {{ background: var(--blue-bg); border: 1px solid #bfdbfe; }}
+    .glance-action h4 {{ color: var(--blue); }}
+    .strengths-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; }}
+    .strength-card {{
+      background: var(--green-bg);
+      border: 1px solid #bbf7d0;
+      padding: 16px;
+      border-radius: 8px;
+    }}
+    .strength-card h4 {{ color: var(--green); margin-bottom: 8px; font-size: 14px; }}
+    .strength-card p {{ font-size: 13px; color: var(--text); }}
+    .friction-list {{ display: flex; flex-direction: column; gap: 12px; }}
+    .friction-card {{ padding: 16px; border-radius: 8px; background: var(--bg); }}
+    .friction-header {{ display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }}
+    .friction-header h4 {{ flex: 1; font-size: 15px; }}
+    .severity-badge, .priority-badge {{
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }}
+    .evidence {{
+      display: block;
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      margin: 8px 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }}
+    .impact {{ color: var(--text-muted); font-size: 13px; }}
+    .suggestions-list {{ display: flex; flex-direction: column; gap: 12px; }}
+    .suggestion-card {{
+      padding: 16px;
+      border-radius: 8px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+    }}
+    .suggestion-header {{ display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }}
+    .suggestion-num {{ font-size: 18px; font-weight: 700; color: var(--blue); min-width: 30px; }}
+    .suggestion-header h4 {{ flex: 1; font-size: 15px; }}
+    .suggestion-action {{ background: var(--card-bg); padding: 12px; border-radius: 6px; border: 1px solid var(--border); font-size: 13px; margin-bottom: 8px; }}
+    .suggestion-why {{ color: var(--text-muted); font-size: 13px; }}
+    table {{ width: 100%; border-collapse: collapse; font-size: 13px; }}
+    thead {{ background: var(--bg); }}
+    th, td {{ padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--border); }}
+    th {{ font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); }}
+    code {{ background: var(--bg); padding: 2px 6px; border-radius: 4px; font-size: 12px; }}
+    .tool-distribution {{ margin-top: 16px; }}
+    .tool-distribution h4 {{ margin-bottom: 12px; font-size: 14px; }}
+    .tool-row {{ display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }}
+    .tool-name {{ font-size: 12px; min-width: 100px; font-family: monospace; }}
+    .tool-bar-container {{ flex: 1; height: 20px; background: var(--bg); border-radius: 4px; overflow: hidden; }}
+    .tool-bar {{ height: 100%; background: var(--blue); border-radius: 4px; }}
+    .tool-calls {{ font-size: 12px; min-width: 40px; text-align: right; font-weight: 600; }}
+    .tool-err {{ font-size: 11px; min-width: 40px; text-align: right; }}
+    .session-profile {{ margin-top: 16px; }}
+    .session-profile h4 {{ margin-bottom: 8px; font-size: 14px; }}
+    .profile-stats {{ display: flex; gap: 20px; flex-wrap: wrap; font-size: 13px; }}
+    .signals {{ margin-top: 12px; }}
+    .signals h4 {{ margin-bottom: 8px; font-size: 14px; }}
+    .signal-row {{ display: flex; gap: 16px; padding: 8px 0; border-bottom: 1px solid var(--border); font-size: 13px; }}
+    .signal-obs {{ flex: 1; font-weight: 500; }}
+    .signal-interp {{ flex: 1; color: var(--text-muted); }}
+    .satisfaction-indicators {{ display: flex; gap: 20px; margin-top: 12px; font-size: 13px; }}
+    .opportunities {{ margin-top: 16px; }}
+    .opportunities h4 {{ margin-bottom: 12px; font-size: 14px; }}
+    .opportunity-card {{ background: var(--amber-bg); border: 1px solid #fde68a; padding: 12px; border-radius: 8px; margin-bottom: 8px; }}
+    .opportunity-card h4 {{ font-size: 13px; color: var(--amber); margin-bottom: 4px; }}
+    .opportunity-card p {{ font-size: 13px; }}
+    .savings {{ font-size: 12px; color: var(--green); font-weight: 600; }}
+    .changes-table th, .changes-table td {{ font-size: 12px; padding: 8px; }}
+    .fun-card {{
+      background: linear-gradient(135deg, #eff6ff, #f0fdf4);
+      padding: 24px;
+      border-radius: 8px;
+      text-align: center;
+    }}
+    .fun-card h3 {{ font-size: 18px; margin-bottom: 8px; color: var(--purple); }}
+    .fun-card p {{ color: var(--text-muted); font-size: 14px; }}
+    footer {{
+      text-align: center;
+      color: var(--text-muted);
+      font-size: 12px;
+      margin-top: 40px;
+      padding-top: 20px;
+      border-top: 1px solid var(--border);
+    }}
+    @media print {{
+      body {{ padding: 20px; }}
+      section {{ break-inside: avoid; box-shadow: none; }}
+    }}
+    @media (max-width: 640px) {{
+      .metrics-grid {{ grid-template-columns: repeat(2, 1fr); }}
+      .glance-grid {{ grid-template-columns: 1fr; }}
+      .strengths-grid {{ grid-template-columns: 1fr; }}
+    }}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Agent Insight Report</h1>
+      <p class="subtitle">
+        Period: {_esc(period_start)} to {_esc(period_end)} &middot;
+        {sessions_analyzed} sessions analyzed &middot;
+        Report ID: {_esc(str(report_id)[:8])}
+      </p>
+    </header>
+
+    {body_content}
+
+    <footer>
+      Generated by Observal &middot; {datetime.now().strftime("%Y-%m-%d %H:%M")}
+    </footer>
+  </div>
+</body>
+</html>"""

--- a/ee/observal_insights/metrics.py
+++ b/ee/observal_insights/metrics.py
@@ -1,0 +1,457 @@
+"""Deterministic metrics computation from ClickHouse telemetry."""
+
+import asyncio
+
+import structlog
+
+from ._deps import get_query
+from .pricing import compute_cost_summary
+
+logger = structlog.get_logger(__name__)
+
+# Subquery to find all session IDs belonging to an agent.
+# Matches sessions where either agent_type or agent_name equals the registry name.
+_SESSIONS_SUBQUERY = """
+    SELECT DISTINCT LogAttributes['session.id']
+    FROM otel_logs
+    WHERE (LogAttributes['agent_type'] = {aname:String}
+           OR LogAttributes['agent_name'] = {aname:String})
+      AND Timestamp >= {t_start:String}
+      AND Timestamp <= {t_end:String}
+      AND LogAttributes['session.id'] != ''
+"""
+
+
+async def get_session_overview(agent_name: str, start: str, end: str) -> dict:
+    """Count sessions and unique users for the agent in the time window."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            count(DISTINCT LogAttributes['session.id']) AS total_sessions,
+            count(DISTINCT LogAttributes['user.id']) AS unique_users,
+            min(Timestamp) AS first_session,
+            max(Timestamp) AS last_session
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        data = r.json().get("data", [])
+        return data[0] if data else {}
+    except Exception as e:
+        logger.error("insight_session_overview_failed", error=str(e))
+        return {}
+
+
+async def get_token_aggregates(agent_name: str, start: str, end: str) -> dict:
+    """Aggregate token counts from otel_logs for this agent's sessions."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            sum(toUInt64OrZero(LogAttributes['input_tokens'])) AS total_input_tokens,
+            sum(toUInt64OrZero(LogAttributes['output_tokens'])) AS total_output_tokens,
+            sum(toUInt64OrZero(LogAttributes['input_tokens'])) + sum(toUInt64OrZero(LogAttributes['output_tokens'])) AS total_tokens,
+            sum(toUInt64OrZero(LogAttributes['cache_read_tokens'])) AS total_cache_read_tokens,
+            sum(toUInt64OrZero(LogAttributes['cache_creation_tokens'])) AS total_cache_write_tokens
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        data = r.json().get("data", [])
+        return data[0] if data else {}
+    except Exception as e:
+        logger.error("insight_token_aggregates_failed", error=str(e))
+        return {}
+
+
+async def get_latency_and_duration(agent_name: str, start: str, end: str) -> dict:
+    """Compute session duration stats from otel_logs timestamps."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            count() AS session_count,
+            avg(duration_s) AS avg_duration_seconds,
+            quantile(0.5)(duration_s) AS p50_duration_seconds,
+            quantile(0.9)(duration_s) AS p90_duration_seconds
+        FROM (
+            SELECT
+                dateDiff('second', min(Timestamp), max(Timestamp)) AS duration_s
+            FROM otel_logs
+            WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+              AND Timestamp >= {{t_start:String}}
+              AND Timestamp <= {{t_end:String}}
+            GROUP BY LogAttributes['session.id']
+        )
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        data = r.json().get("data", [])
+        return data[0] if data else {}
+    except Exception as e:
+        logger.error("insight_latency_failed", error=str(e))
+        return {}
+
+
+async def get_error_breakdown(agent_name: str, start: str, end: str) -> dict:
+    """Get tool call success/error rates from otel_logs."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            count() AS total_events,
+            countIf(LogAttributes['event.name'] = 'hook_posttooluse') AS total_tool_calls,
+            countIf(LogAttributes['event.name'] = 'hook_stopfailure') AS failure_stops,
+            countIf(LogAttributes['error'] != '') AS error_events
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        data = r.json().get("data", [])
+        row = data[0] if data else {}
+        total = int(row.get("total_tool_calls", 0))
+        errors = int(row.get("error_events", 0))
+        row["error_rate"] = round(errors / total, 4) if total > 0 else 0
+        return row
+    except Exception as e:
+        logger.error("insight_error_breakdown_failed", error=str(e))
+        return {}
+
+
+async def get_tool_usage(agent_name: str, start: str, end: str) -> list[dict]:
+    """Get top tools by invocation count from otel_logs."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            LogAttributes['tool_name'] AS name,
+            count() AS invocations,
+            countIf(LogAttributes['error'] != '') AS errors
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+          AND LogAttributes['event.name'] IN ('hook_posttooluse', 'tool_result')
+          AND LogAttributes['tool_name'] != ''
+        GROUP BY name
+        ORDER BY invocations DESC
+        LIMIT 20
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        return r.json().get("data", [])
+    except Exception as e:
+        logger.error("insight_tool_usage_failed", error=str(e))
+        return []
+
+
+async def get_session_details(agent_name: str, start: str, end: str) -> list[dict]:
+    """Get per-session stats from otel_logs."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            LogAttributes['session.id'] AS session_id,
+            dateDiff('second', min(Timestamp), max(Timestamp)) AS duration_seconds,
+            greatest(
+                countIf(LogAttributes['event.name'] = 'user_prompt'),
+                countIf(LogAttributes['event.name'] = 'hook_userpromptsubmit')
+            ) AS prompt_count,
+            greatest(
+                countIf(LogAttributes['event.name'] = 'tool_result'),
+                countIf(LogAttributes['event.name'] = 'hook_posttooluse')
+            ) AS tool_call_count,
+            sum(toUInt64OrZero(LogAttributes['input_tokens'])) AS input_tokens,
+            sum(toUInt64OrZero(LogAttributes['output_tokens'])) AS output_tokens
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+        GROUP BY session_id
+        ORDER BY min(Timestamp) DESC
+        LIMIT 200
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        return r.json().get("data", [])
+    except Exception as e:
+        logger.error("insight_session_details_failed", error=str(e))
+        return []
+
+
+async def get_per_session_tokens(agent_name: str, start: str, end: str) -> list[dict]:
+    """Get per-session token breakdown with model name for cost computation."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            LogAttributes['session.id'] AS session_id,
+            sum(toUInt64OrZero(LogAttributes['input_tokens'])) AS input_tokens,
+            sum(toUInt64OrZero(LogAttributes['output_tokens'])) AS output_tokens,
+            sum(toUInt64OrZero(LogAttributes['cache_read_tokens'])) AS cache_read,
+            sum(toUInt64OrZero(LogAttributes['cache_creation_tokens'])) AS cache_write,
+            anyIf(LogAttributes['model'], LogAttributes['model'] != '') AS model
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+        GROUP BY session_id
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        return r.json().get("data", [])
+    except Exception as e:
+        logger.error("insight_per_session_tokens_failed", error=str(e))
+        return []
+
+
+def categorize_error(error_text: str) -> str:
+    """Categorize a tool error into a high-level bucket."""
+    lower = error_text.lower()
+    if "exit code" in lower:
+        return "command_failed"
+    if "rejected" in lower or "doesn't want" in lower or "denied" in lower:
+        return "user_rejected"
+    if "string to replace not found" in lower or "not unique" in lower:
+        return "edit_failed"
+    if "modified since read" in lower:
+        return "file_changed"
+    if "exceeds maximum" in lower or "too large" in lower:
+        return "file_too_large"
+    if "file not found" in lower or "does not exist" in lower or "no such file" in lower:
+        return "file_not_found"
+    if "timeout" in lower or "timed out" in lower:
+        return "timeout"
+    if "permission" in lower:
+        return "permission_denied"
+    return "other"
+
+
+async def get_tool_error_categories(agent_name: str, start: str, end: str) -> dict:
+    """Get tool errors with their text for categorization in Python."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            LogAttributes['tool_name'] AS tool_name,
+            LogAttributes['error'] AS error_text
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+          AND LogAttributes['error'] != ''
+        LIMIT 500
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        rows = r.json().get("data", [])
+
+        # Categorize errors
+        categories: dict[str, int] = {}
+        by_tool: dict[str, dict[str, int]] = {}
+        for row in rows:
+            cat = categorize_error(row.get("error_text", ""))
+            categories[cat] = categories.get(cat, 0) + 1
+            tool = row.get("tool_name", "unknown")
+            if tool not in by_tool:
+                by_tool[tool] = {}
+            by_tool[tool][cat] = by_tool[tool].get(cat, 0) + 1
+
+        return {
+            "total_categorized": len(rows),
+            "categories": categories,
+            "by_tool": by_tool,
+        }
+    except Exception as e:
+        logger.error("insight_tool_error_categories_failed", error=str(e))
+        return {"total_categorized": 0, "categories": {}, "by_tool": {}}
+
+
+async def get_interruption_metrics(agent_name: str, start: str, end: str) -> dict:
+    """Get stop reason counts and user interruption metrics."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            LogAttributes['stop_reason'] AS stop_reason,
+            count() AS cnt
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+          AND LogAttributes['stop_reason'] != ''
+        GROUP BY stop_reason
+        ORDER BY cnt DESC
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        rows = r.json().get("data", [])
+        stop_reasons = {row["stop_reason"]: int(row["cnt"]) for row in rows}
+        user_interruptions = stop_reasons.get("user_interrupt", 0) + stop_reasons.get("interrupted", 0)
+        return {
+            "stop_reasons": stop_reasons,
+            "user_interruptions": user_interruptions,
+            "total_stops": sum(stop_reasons.values()),
+        }
+    except Exception as e:
+        logger.error("insight_interruption_metrics_failed", error=str(e))
+        return {"stop_reasons": {}, "user_interruptions": 0, "total_stops": 0}
+
+
+async def get_reconciliation_data(agent_name: str, start: str, end: str) -> dict:
+    """Check if any sessions have reconciliation enrichment data."""
+    _query = get_query()
+    sql = f"""
+        SELECT
+            count(DISTINCT LogAttributes['session.id']) AS reconciled_sessions,
+            sum(toUInt64OrZero(LogAttributes['input_tokens'])) AS total_input,
+            sum(toUInt64OrZero(LogAttributes['output_tokens'])) AS total_output,
+            sum(toUInt64OrZero(LogAttributes['cache_read_tokens'])) AS cache_read,
+            sum(toUInt64OrZero(LogAttributes['cache_creation_tokens'])) AS cache_creation,
+            sum(toUInt64OrZero(LogAttributes['thinking_turns'])) AS thinking_turns,
+            sum(toUInt64OrZero(LogAttributes['tool_use_count'])) AS tool_uses
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] IN ({_SESSIONS_SUBQUERY})
+          AND LogAttributes['event.name'] = 'reconcile_enrichment'
+          AND Timestamp >= {{t_start:String}}
+          AND Timestamp <= {{t_end:String}}
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        data = r.json().get("data", [])
+        if data and int(data[0].get("reconciled_sessions", 0)) > 0:
+            row = data[0]
+            return {
+                "available": True,
+                "reconciled_sessions": int(row["reconciled_sessions"]),
+                "total_input_tokens": int(row["total_input"]),
+                "total_output_tokens": int(row["total_output"]),
+                "cache_read_tokens": int(row["cache_read"]),
+                "cache_creation_tokens": int(row["cache_creation"]),
+                "thinking_turns": int(row["thinking_turns"]),
+                "tool_uses": int(row["tool_uses"]),
+            }
+        return {"available": False}
+    except Exception as e:
+        logger.warning("reconciliation_data_query_failed", error=str(e))
+        return {"available": False}
+
+
+async def compute_all_metrics(agent_name: str, start: str, end: str) -> dict:
+    """Run all metric queries in parallel and return combined results."""
+    from .shim_enrichment import compute_mcp_metrics
+
+    (
+        overview,
+        tokens,
+        duration,
+        errors,
+        tools,
+        sessions,
+        per_session_tokens,
+        tool_errors,
+        interruptions,
+        mcp_metrics,
+    ) = await asyncio.gather(
+        get_session_overview(agent_name, start, end),
+        get_token_aggregates(agent_name, start, end),
+        get_latency_and_duration(agent_name, start, end),
+        get_error_breakdown(agent_name, start, end),
+        get_tool_usage(agent_name, start, end),
+        get_session_details(agent_name, start, end),
+        get_per_session_tokens(agent_name, start, end),
+        get_tool_error_categories(agent_name, start, end),
+        get_interruption_metrics(agent_name, start, end),
+        compute_mcp_metrics(agent_name, start, end),
+    )
+
+    # Compute cost summary from per-session token data
+    cost = compute_cost_summary(per_session_tokens)
+
+    # Check for reconciliation enrichment data
+    reconciliation = await get_reconciliation_data(agent_name, start, end)
+
+    return {
+        "overview": overview,
+        "tokens": tokens,
+        "duration": duration,
+        "errors": errors,
+        "tools": tools,
+        "sessions": sessions,
+        "cost": cost,
+        "tool_errors": tool_errors,
+        "interruptions": interruptions,
+        "reconciliation": reconciliation,
+        "mcp": mcp_metrics,
+    }

--- a/ee/observal_insights/narrative.py
+++ b/ee/observal_insights/narrative.py
@@ -1,0 +1,113 @@
+"""LLM narrative generation for Agent Insights reports (V1 fallback)."""
+
+import json
+
+import structlog
+
+from ._deps import get_call_model, get_settings
+
+logger = structlog.get_logger(__name__)
+
+INSIGHT_PROMPT = """You are an AI agent performance analyst. Given the following deterministic metrics about an AI coding agent's performance over a time window, generate an actionable insight report.
+
+## Agent: {agent_name}
+## Period: {period_start} to {period_end}
+## Sessions Analyzed: {session_count}
+
+## Raw Metrics
+
+### Session Overview
+{overview_json}
+
+### Token Usage (input + output + cache)
+{tokens_json}
+
+### Cost Analysis (USD)
+{cost_json}
+
+### Session Duration
+{duration_json}
+
+### Error Rates
+{errors_json}
+
+### Tool Error Categories
+{tool_errors_json}
+
+### Interruptions & Stop Reasons
+{interruptions_json}
+
+### Top Tools (by invocation count)
+{tools_json}
+
+### Per-Session Breakdown
+{sessions_json}
+
+## Instructions
+
+Analyze these metrics and produce a structured JSON report with exactly 4 sections:
+
+1. "at_a_glance": A 2-3 sentence executive summary. State the most important finding, whether things look healthy or concerning, and one specific number that stands out. Include cost if notable.
+
+2. "usage_patterns": 3-5 bullet points about how the agent is being used. Which tools dominate? What do session durations suggest? How many tokens are consumed? Comment on cache efficiency and cost patterns.
+
+3. "friction_analysis": 3-5 bullet points identifying where users encounter problems. Use the error categories (command_failed, edit_failed, user_rejected, etc.) to be specific. Note any high interrupt rates. Rank by severity.
+
+4. "suggestions": 3-5 concrete, actionable recommendations the agent author should implement. Be specific (e.g., "Add retry logic for tool X which fails 15% of the time", "Improve cache utilization — current efficiency is only 23%") not vague ("improve reliability"). Include cost optimization suggestions if relevant.
+
+Respond ONLY with valid JSON matching this exact structure:
+{{"at_a_glance": "<string>", "usage_patterns": ["<bullet>", ...], "friction_analysis": ["<bullet>", ...], "suggestions": ["<suggestion>", ...]}}"""
+
+
+async def generate_narrative(
+    agent_name: str,
+    metrics: dict,
+    period_start: str,
+    period_end: str,
+    session_count: int,
+) -> dict | None:
+    """Generate narrative sections from aggregated metrics via LLM.
+
+    Returns a dict with keys: at_a_glance, usage_patterns, friction_analysis, suggestions.
+    Returns None if no eval model is configured or on failure.
+    """
+    settings = get_settings()
+    eval_model = getattr(settings, "EVAL_MODEL_NAME", "") or ""
+    if not eval_model:
+        logger.info("insight_narrative_skipped", reason="no eval model configured")
+        return None
+
+    call_model = get_call_model()
+
+    prompt = INSIGHT_PROMPT.format(
+        agent_name=agent_name,
+        period_start=period_start,
+        period_end=period_end,
+        session_count=session_count,
+        overview_json=json.dumps(metrics.get("overview", {}), indent=2),
+        tokens_json=json.dumps(metrics.get("tokens", {}), indent=2),
+        cost_json=json.dumps(metrics.get("cost", {}), indent=2),
+        duration_json=json.dumps(metrics.get("duration", {}), indent=2),
+        errors_json=json.dumps(metrics.get("errors", {}), indent=2),
+        tool_errors_json=json.dumps(metrics.get("tool_errors", {}), indent=2),
+        interruptions_json=json.dumps(metrics.get("interruptions", {}), indent=2),
+        tools_json=json.dumps(metrics.get("tools", [])[:10], indent=2),
+        sessions_json=json.dumps(metrics.get("sessions", [])[:5], indent=2),
+    )
+
+    try:
+        result = await call_model(prompt)
+        if not result:
+            logger.warning("insight_narrative_empty_response")
+            return None
+
+        # Validate expected keys
+        expected_keys = {"at_a_glance", "usage_patterns", "friction_analysis", "suggestions"}
+        if not expected_keys.issubset(result.keys()):
+            logger.warning("insight_narrative_missing_keys", keys=list(result.keys()))
+            return result  # Return partial result anyway
+
+        return result
+    except Exception as e:
+        logger.error("insight_narrative_failed", error=str(e))
+        return None

--- a/ee/observal_insights/pricing.py
+++ b/ee/observal_insights/pricing.py
@@ -37,7 +37,7 @@ def get_pricing(model_name: str) -> dict[str, float]:
     normalized = model_name
     for prefix in ("us.", "eu.", "ap.", "us.anthropic.", "eu.anthropic.", "anthropic."):
         if normalized.startswith(prefix):
-            normalized = normalized[len(prefix):]
+            normalized = normalized[len(prefix) :]
             break
 
     # Strip Bedrock version suffixes like ":0", "-v1:0"
@@ -118,11 +118,7 @@ def compute_cost_summary(sessions: list[dict]) -> dict:
     n = len(sorted_costs)
 
     total_billable_input = total_input + total_cache_read + total_cache_write
-    cache_efficiency = (
-        round(total_cache_read / total_billable_input, 4)
-        if total_billable_input > 0
-        else 0.0
-    )
+    cache_efficiency = round(total_cache_read / total_billable_input, 4) if total_billable_input > 0 else 0.0
 
     p50 = sorted_costs[n // 2] if n > 0 else 0.0
     p90 = sorted_costs[int(n * 0.9)] if n > 1 else sorted_costs[-1] if n else 0.0
@@ -131,8 +127,7 @@ def compute_cost_summary(sessions: list[dict]) -> dict:
     most_expensive_model = max(model_costs, key=model_costs.get) if model_costs else "unknown"
 
     cost_by_model = [
-        {"model": m, "total_cost_usd": round(c, 4)}
-        for m, c in sorted(model_costs.items(), key=lambda x: -x[1])
+        {"model": m, "total_cost_usd": round(c, 4)} for m, c in sorted(model_costs.items(), key=lambda x: -x[1])
     ]
 
     return {

--- a/ee/observal_insights/pricing.py
+++ b/ee/observal_insights/pricing.py
@@ -1,0 +1,147 @@
+"""Model pricing lookup and cost computation for Agent Insights."""
+
+from __future__ import annotations
+
+# Pricing per 1M tokens (USD)
+# Keys: input, output, cache_read, cache_write
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    # Claude 4.6 family
+    "claude-opus-4-6-20250514": {"input": 15.00, "output": 75.00, "cache_read": 1.50, "cache_write": 18.75},
+    "claude-sonnet-4-6-20250514": {"input": 3.00, "output": 15.00, "cache_read": 0.30, "cache_write": 3.75},
+    # Claude 4.5 family
+    "claude-sonnet-4-5-20250514": {"input": 3.00, "output": 15.00, "cache_read": 0.30, "cache_write": 3.75},
+    "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00, "cache_read": 0.08, "cache_write": 1.00},
+    # Claude 3.5 family (legacy)
+    "claude-3-5-sonnet-20241022": {"input": 3.00, "output": 15.00, "cache_read": 0.30, "cache_write": 3.75},
+    "claude-3-5-haiku-20241022": {"input": 0.80, "output": 4.00, "cache_read": 0.08, "cache_write": 1.00},
+    # GPT-4o family
+    "gpt-4o": {"input": 2.50, "output": 10.00, "cache_read": 1.25, "cache_write": 2.50},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60, "cache_read": 0.075, "cache_write": 0.15},
+    # Gemini
+    "gemini-2.5-pro": {"input": 1.25, "output": 10.00, "cache_read": 0.315, "cache_write": 1.25},
+    "gemini-2.5-flash": {"input": 0.15, "output": 0.60, "cache_read": 0.0375, "cache_write": 0.15},
+    # Fallback (Sonnet pricing)
+    "_default": {"input": 3.00, "output": 15.00, "cache_read": 0.30, "cache_write": 3.75},
+}
+
+
+def get_pricing(model_name: str) -> dict[str, float]:
+    """Look up pricing for a model, with fuzzy matching."""
+    if not model_name:
+        return MODEL_PRICING["_default"]
+
+    if model_name in MODEL_PRICING:
+        return MODEL_PRICING[model_name]
+
+    # Strip common cloud prefixes/suffixes
+    normalized = model_name
+    for prefix in ("us.", "eu.", "ap.", "us.anthropic.", "eu.anthropic.", "anthropic."):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix):]
+            break
+
+    # Strip Bedrock version suffixes like ":0", "-v1:0"
+    if ":" in normalized:
+        normalized = normalized.split(":")[0]
+    if normalized.endswith("-v1"):
+        normalized = normalized[:-3]
+
+    if normalized in MODEL_PRICING:
+        return MODEL_PRICING[normalized]
+
+    # Substring match
+    for key in MODEL_PRICING:
+        if key == "_default":
+            continue
+        if key in normalized or normalized in key:
+            return MODEL_PRICING[key]
+
+    return MODEL_PRICING["_default"]
+
+
+def compute_session_cost(
+    input_tokens: int,
+    output_tokens: int,
+    cache_read: int,
+    cache_write: int,
+    model: str,
+) -> float:
+    """Compute cost in USD for a single session's token usage."""
+    pricing = get_pricing(model)
+    cost = (
+        (input_tokens / 1_000_000) * pricing["input"]
+        + (output_tokens / 1_000_000) * pricing["output"]
+        + (cache_read / 1_000_000) * pricing["cache_read"]
+        + (cache_write / 1_000_000) * pricing["cache_write"]
+    )
+    return round(cost, 6)
+
+
+def compute_cost_summary(sessions: list[dict]) -> dict:
+    """Compute aggregate cost metrics from per-session token data."""
+    if not sessions:
+        return {
+            "total_cost_usd": 0.0,
+            "avg_cost_per_session": 0.0,
+            "p50_session_cost": 0.0,
+            "p90_session_cost": 0.0,
+            "p99_session_cost": 0.0,
+            "cache_efficiency_ratio": 0.0,
+            "cost_by_model": [],
+        }
+
+    session_costs: list[float] = []
+    model_costs: dict[str, float] = {}
+    total_input = 0
+    total_cache_read = 0
+    total_cache_write = 0
+
+    for s in sessions:
+        inp = int(s.get("input_tokens") or 0)
+        out = int(s.get("output_tokens") or 0)
+        cr = int(s.get("cache_read") or 0)
+        cw = int(s.get("cache_write") or 0)
+        model = s.get("model") or ""
+
+        cost = compute_session_cost(inp, out, cr, cw, model)
+        session_costs.append(cost)
+
+        model_key = model or "unknown"
+        model_costs[model_key] = model_costs.get(model_key, 0.0) + cost
+
+        total_input += inp
+        total_cache_read += cr
+        total_cache_write += cw
+
+    total_cost = sum(session_costs)
+    sorted_costs = sorted(session_costs)
+    n = len(sorted_costs)
+
+    total_billable_input = total_input + total_cache_read + total_cache_write
+    cache_efficiency = (
+        round(total_cache_read / total_billable_input, 4)
+        if total_billable_input > 0
+        else 0.0
+    )
+
+    p50 = sorted_costs[n // 2] if n > 0 else 0.0
+    p90 = sorted_costs[int(n * 0.9)] if n > 1 else sorted_costs[-1] if n else 0.0
+    p99 = sorted_costs[int(n * 0.99)] if n > 1 else sorted_costs[-1] if n else 0.0
+
+    most_expensive_model = max(model_costs, key=model_costs.get) if model_costs else "unknown"
+
+    cost_by_model = [
+        {"model": m, "total_cost_usd": round(c, 4)}
+        for m, c in sorted(model_costs.items(), key=lambda x: -x[1])
+    ]
+
+    return {
+        "total_cost_usd": round(total_cost, 4),
+        "avg_cost_per_session": round(total_cost / n, 4) if n else 0.0,
+        "p50_session_cost": round(p50, 4),
+        "p90_session_cost": round(p90, 4),
+        "p99_session_cost": round(p99, 4),
+        "cache_efficiency_ratio": cache_efficiency,
+        "most_expensive_model": most_expensive_model,
+        "cost_by_model": cost_by_model,
+    }

--- a/ee/observal_insights/reconcile.py
+++ b/ee/observal_insights/reconcile.py
@@ -101,9 +101,7 @@ def parse_claude_code_jsonl(lines: list[str], session_id: str) -> SessionEnrichm
                 models_seen.add(turn.model)
 
             if turn.stop_reason:
-                enrichment.stop_reasons[turn.stop_reason] = (
-                    enrichment.stop_reasons.get(turn.stop_reason, 0) + 1
-                )
+                enrichment.stop_reasons[turn.stop_reason] = enrichment.stop_reasons.get(turn.stop_reason, 0) + 1
 
             if turn.has_thinking:
                 enrichment.thinking_turns += 1

--- a/ee/observal_insights/reconcile.py
+++ b/ee/observal_insights/reconcile.py
@@ -1,0 +1,214 @@
+"""Session file reconciliation — parse Claude Code JSONL session files
+and enrich ClickHouse telemetry with per-turn token counts, model info,
+stop reasons, and conversation structure.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+import structlog
+
+from .pricing import compute_session_cost
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class TurnMetrics:
+    """Per-turn metrics extracted from a session JSONL."""
+
+    turn_index: int
+    role: str  # "assistant" or "user"
+    model: str | None = None
+    stop_reason: str | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    service_tier: str | None = None
+    has_thinking: bool = False
+    thinking_token_estimate: int = 0
+    tool_uses: list[str] = field(default_factory=list)
+    tool_results: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SessionEnrichment:
+    """Full enrichment data for a session, ready to merge into ClickHouse."""
+
+    session_id: str
+    turns: list[TurnMetrics] = field(default_factory=list)
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    total_cache_creation_tokens: int = 0
+    models_used: list[str] = field(default_factory=list)
+    primary_model: str | None = None
+    total_cost_usd: float = 0.0
+    service_tier: str | None = None
+    conversation_turns: int = 0
+    tool_use_count: int = 0
+    thinking_turns: int = 0
+    stop_reasons: dict[str, int] = field(default_factory=dict)
+    completeness_score: float = 1.0
+    # Subagent attribution
+    is_subagent: bool = False
+    parent_session_id: str | None = None
+    subagent_id: str | None = None
+    agent_type: str | None = None
+    agent_description: str | None = None
+
+
+def parse_claude_code_jsonl(lines: list[str], session_id: str) -> SessionEnrichment:
+    """Parse Claude Code session JSONL lines into enrichment data.
+
+    Claude Code JSONL format:
+    - Each line is a JSON object with a "type" field
+    - Types: "assistant", "user", "system", "attachment", "last-prompt"
+    - Assistant records have: message.content[], usage{}, model, stop_reason
+    - User records have: message.content[] (tool_result blocks)
+    """
+    enrichment = SessionEnrichment(session_id=session_id)
+    models_seen: set[str] = set()
+    turn_index = 0
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        record_type = record.get("type")
+
+        if record_type == "assistant":
+            turn_index += 1
+            turn = _parse_assistant_record(record, turn_index)
+            enrichment.turns.append(turn)
+
+            # Accumulate totals
+            enrichment.total_input_tokens += turn.input_tokens
+            enrichment.total_output_tokens += turn.output_tokens
+            enrichment.total_cache_read_tokens += turn.cache_read_tokens
+            enrichment.total_cache_creation_tokens += turn.cache_creation_tokens
+
+            if turn.model:
+                models_seen.add(turn.model)
+
+            if turn.stop_reason:
+                enrichment.stop_reasons[turn.stop_reason] = (
+                    enrichment.stop_reasons.get(turn.stop_reason, 0) + 1
+                )
+
+            if turn.has_thinking:
+                enrichment.thinking_turns += 1
+
+            enrichment.tool_use_count += len(turn.tool_uses)
+
+        elif record_type == "user":
+            # Count tool results in user messages
+            content = record.get("message", {}).get("content", [])
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        pass  # Already tracked via assistant tool_use
+
+    enrichment.conversation_turns = turn_index
+    enrichment.models_used = sorted(models_seen)
+    enrichment.primary_model = enrichment.models_used[0] if enrichment.models_used else None
+    enrichment.service_tier = enrichment.turns[-1].service_tier if enrichment.turns else None
+
+    # Compute cost
+    enrichment.total_cost_usd = compute_session_cost(
+        input_tokens=enrichment.total_input_tokens,
+        output_tokens=enrichment.total_output_tokens,
+        cache_read=enrichment.total_cache_read_tokens,
+        cache_write=enrichment.total_cache_creation_tokens,
+        model=enrichment.primary_model or "claude-sonnet-4-6-20250514",
+    )
+
+    return enrichment
+
+
+def _parse_assistant_record(record: dict, turn_index: int) -> TurnMetrics:
+    """Extract metrics from a single assistant JSONL record."""
+    usage = record.get("usage", {})
+    message = record.get("message", {})
+    content = message.get("content", [])
+
+    # Extract tool uses and thinking blocks
+    tool_uses: list[str] = []
+    has_thinking = False
+    thinking_estimate = 0
+
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_use":
+                tool_uses.append(block.get("name", "unknown"))
+            elif block.get("type") == "thinking":
+                has_thinking = True
+                thinking_text = block.get("thinking", "")
+                # Rough token estimate: 4 chars per token
+                thinking_estimate += len(thinking_text) // 4
+
+    return TurnMetrics(
+        turn_index=turn_index,
+        role="assistant",
+        model=record.get("model") or message.get("model"),
+        stop_reason=record.get("stop_reason") or message.get("stop_reason"),
+        input_tokens=usage.get("input_tokens", 0),
+        output_tokens=usage.get("output_tokens", 0),
+        cache_read_tokens=usage.get("cache_read_input_tokens", 0),
+        cache_creation_tokens=usage.get("cache_creation_input_tokens", 0),
+        service_tier=usage.get("service_tier"),
+        has_thinking=has_thinking,
+        thinking_token_estimate=thinking_estimate,
+        tool_uses=tool_uses,
+        tool_results=[],
+    )
+
+
+def enrichment_to_dict(enrichment: SessionEnrichment) -> dict:
+    """Convert enrichment to JSON-serializable dict for API transport."""
+    return {
+        "session_id": enrichment.session_id,
+        "total_input_tokens": enrichment.total_input_tokens,
+        "total_output_tokens": enrichment.total_output_tokens,
+        "total_cache_read_tokens": enrichment.total_cache_read_tokens,
+        "total_cache_creation_tokens": enrichment.total_cache_creation_tokens,
+        "models_used": enrichment.models_used,
+        "primary_model": enrichment.primary_model,
+        "total_cost_usd": enrichment.total_cost_usd,
+        "service_tier": enrichment.service_tier,
+        "conversation_turns": enrichment.conversation_turns,
+        "tool_use_count": enrichment.tool_use_count,
+        "thinking_turns": enrichment.thinking_turns,
+        "stop_reasons": enrichment.stop_reasons,
+        "completeness_score": enrichment.completeness_score,
+        "is_subagent": enrichment.is_subagent,
+        "parent_session_id": enrichment.parent_session_id,
+        "subagent_id": enrichment.subagent_id,
+        "agent_type": enrichment.agent_type,
+        "agent_description": enrichment.agent_description,
+        "per_turn": [
+            {
+                "turn_index": t.turn_index,
+                "model": t.model,
+                "stop_reason": t.stop_reason,
+                "input_tokens": t.input_tokens,
+                "output_tokens": t.output_tokens,
+                "cache_read_tokens": t.cache_read_tokens,
+                "cache_creation_tokens": t.cache_creation_tokens,
+                "has_thinking": t.has_thinking,
+                "tool_uses": t.tool_uses,
+            }
+            for t in enrichment.turns
+        ],
+    }

--- a/ee/observal_insights/regression.py
+++ b/ee/observal_insights/regression.py
@@ -36,14 +36,16 @@ def detect_regressions(current: dict, previous: dict) -> list[dict]:
     if prev_error_rate > 0:
         error_change = curr_error_rate - prev_error_rate
         if abs(error_change) > THRESHOLDS["error_rate_increase"]:
-            regressions.append({
-                "metric": "error_rate",
-                "direction": "degraded" if error_change > 0 else "improved",
-                "magnitude": round(error_change * 100, 1),
-                "current_value": round(curr_error_rate * 100, 1),
-                "previous_value": round(prev_error_rate * 100, 1),
-                "severity": "high" if abs(error_change) > 0.2 else "medium",
-            })
+            regressions.append(
+                {
+                    "metric": "error_rate",
+                    "direction": "degraded" if error_change > 0 else "improved",
+                    "magnitude": round(error_change * 100, 1),
+                    "current_value": round(curr_error_rate * 100, 1),
+                    "previous_value": round(prev_error_rate * 100, 1),
+                    "severity": "high" if abs(error_change) > 0.2 else "medium",
+                }
+            )
 
     # Cost comparison
     current_cost = current.get("cost", {})
@@ -54,14 +56,16 @@ def detect_regressions(current: dict, previous: dict) -> list[dict]:
     if prev_total_cost > 0:
         cost_change_pct = (curr_total_cost - prev_total_cost) / prev_total_cost
         if abs(cost_change_pct) > THRESHOLDS["cost_increase"]:
-            regressions.append({
-                "metric": "total_cost",
-                "direction": "degraded" if cost_change_pct > 0 else "improved",
-                "magnitude": round(cost_change_pct * 100, 1),
-                "current_value": round(curr_total_cost, 4),
-                "previous_value": round(prev_total_cost, 4),
-                "severity": "medium" if abs(cost_change_pct) < 0.5 else "high",
-            })
+            regressions.append(
+                {
+                    "metric": "total_cost",
+                    "direction": "degraded" if cost_change_pct > 0 else "improved",
+                    "magnitude": round(cost_change_pct * 100, 1),
+                    "current_value": round(curr_total_cost, 4),
+                    "previous_value": round(prev_total_cost, 4),
+                    "severity": "medium" if abs(cost_change_pct) < 0.5 else "high",
+                }
+            )
 
     # Cost per session comparison
     curr_avg_cost = float(current_cost.get("avg_cost_per_session", 0))
@@ -70,14 +74,16 @@ def detect_regressions(current: dict, previous: dict) -> list[dict]:
     if prev_avg_cost > 0:
         avg_cost_change = (curr_avg_cost - prev_avg_cost) / prev_avg_cost
         if abs(avg_cost_change) > THRESHOLDS["cost_increase"]:
-            regressions.append({
-                "metric": "avg_cost_per_session",
-                "direction": "degraded" if avg_cost_change > 0 else "improved",
-                "magnitude": round(avg_cost_change * 100, 1),
-                "current_value": round(curr_avg_cost, 4),
-                "previous_value": round(prev_avg_cost, 4),
-                "severity": "low",
-            })
+            regressions.append(
+                {
+                    "metric": "avg_cost_per_session",
+                    "direction": "degraded" if avg_cost_change > 0 else "improved",
+                    "magnitude": round(avg_cost_change * 100, 1),
+                    "current_value": round(curr_avg_cost, 4),
+                    "previous_value": round(prev_avg_cost, 4),
+                    "severity": "low",
+                }
+            )
 
     # Cache efficiency comparison
     curr_cache = float(current_cost.get("cache_efficiency_ratio", 0))
@@ -86,14 +92,16 @@ def detect_regressions(current: dict, previous: dict) -> list[dict]:
     if prev_cache > 0:
         cache_change = curr_cache - prev_cache
         if abs(cache_change) > 0.10:  # >10% absolute change in cache efficiency
-            regressions.append({
-                "metric": "cache_efficiency",
-                "direction": "improved" if cache_change > 0 else "degraded",
-                "magnitude": round(cache_change * 100, 1),
-                "current_value": round(curr_cache * 100, 1),
-                "previous_value": round(prev_cache * 100, 1),
-                "severity": "low",
-            })
+            regressions.append(
+                {
+                    "metric": "cache_efficiency",
+                    "direction": "improved" if cache_change > 0 else "degraded",
+                    "magnitude": round(cache_change * 100, 1),
+                    "current_value": round(curr_cache * 100, 1),
+                    "previous_value": round(prev_cache * 100, 1),
+                    "severity": "low",
+                }
+            )
 
     # Interruption rate comparison
     current_interruptions = current.get("interruptions", {})
@@ -108,14 +116,16 @@ def detect_regressions(current: dict, previous: dict) -> list[dict]:
         prev_interrupt_rate = prev_interrupts / prev_total_stops
         interrupt_change = curr_interrupt_rate - prev_interrupt_rate
         if abs(interrupt_change) > THRESHOLDS["interruption_increase"]:
-            regressions.append({
-                "metric": "user_interruption_rate",
-                "direction": "degraded" if interrupt_change > 0 else "improved",
-                "magnitude": round(interrupt_change * 100, 1),
-                "current_value": round(curr_interrupt_rate * 100, 1),
-                "previous_value": round(prev_interrupt_rate * 100, 1),
-                "severity": "medium",
-            })
+            regressions.append(
+                {
+                    "metric": "user_interruption_rate",
+                    "direction": "degraded" if interrupt_change > 0 else "improved",
+                    "magnitude": round(interrupt_change * 100, 1),
+                    "current_value": round(curr_interrupt_rate * 100, 1),
+                    "previous_value": round(prev_interrupt_rate * 100, 1),
+                    "severity": "medium",
+                }
+            )
 
     # Session count change (informational, not a regression)
     curr_sessions = int(current.get("overview", {}).get("total_sessions", 0))
@@ -123,13 +133,15 @@ def detect_regressions(current: dict, previous: dict) -> list[dict]:
     if prev_sessions > 0:
         session_change = (curr_sessions - prev_sessions) / prev_sessions
         if abs(session_change) > 0.3:  # >30% change in usage
-            regressions.append({
-                "metric": "session_count",
-                "direction": "improved" if session_change > 0 else "degraded",
-                "magnitude": round(session_change * 100, 1),
-                "current_value": curr_sessions,
-                "previous_value": prev_sessions,
-                "severity": "low",
-            })
+            regressions.append(
+                {
+                    "metric": "session_count",
+                    "direction": "improved" if session_change > 0 else "degraded",
+                    "magnitude": round(session_change * 100, 1),
+                    "current_value": curr_sessions,
+                    "previous_value": prev_sessions,
+                    "severity": "low",
+                }
+            )
 
     return regressions

--- a/ee/observal_insights/regression.py
+++ b/ee/observal_insights/regression.py
@@ -1,0 +1,135 @@
+"""Regression detection between insight report periods."""
+
+from __future__ import annotations
+
+THRESHOLDS = {
+    "error_rate_increase": 0.10,  # >10% absolute increase
+    "cost_increase": 0.20,  # >20% relative increase
+    "satisfaction_drop": 0.15,  # >15% drop in positive satisfaction
+    "friction_spike": 0.25,  # >25% increase in any friction category
+    "interruption_increase": 0.15,  # >15% increase in user interruptions
+}
+
+
+def detect_regressions(current: dict, previous: dict) -> list[dict]:
+    """Compare metrics between current and previous periods.
+
+    Returns a list of regression/improvement flags, each with:
+    - metric: what changed
+    - direction: "improved" or "degraded"
+    - magnitude: percentage change
+    - current_value: current period value
+    - previous_value: previous period value
+    - severity: "low", "medium", "high"
+    """
+    if not current or not previous:
+        return []
+
+    regressions: list[dict] = []
+
+    # Error rate comparison
+    current_errors = current.get("errors", {})
+    previous_errors = previous.get("errors", {})
+    curr_error_rate = float(current_errors.get("error_rate", 0))
+    prev_error_rate = float(previous_errors.get("error_rate", 0))
+
+    if prev_error_rate > 0:
+        error_change = curr_error_rate - prev_error_rate
+        if abs(error_change) > THRESHOLDS["error_rate_increase"]:
+            regressions.append({
+                "metric": "error_rate",
+                "direction": "degraded" if error_change > 0 else "improved",
+                "magnitude": round(error_change * 100, 1),
+                "current_value": round(curr_error_rate * 100, 1),
+                "previous_value": round(prev_error_rate * 100, 1),
+                "severity": "high" if abs(error_change) > 0.2 else "medium",
+            })
+
+    # Cost comparison
+    current_cost = current.get("cost", {})
+    previous_cost = previous.get("cost", {})
+    curr_total_cost = float(current_cost.get("total_cost_usd", 0))
+    prev_total_cost = float(previous_cost.get("total_cost_usd", 0))
+
+    if prev_total_cost > 0:
+        cost_change_pct = (curr_total_cost - prev_total_cost) / prev_total_cost
+        if abs(cost_change_pct) > THRESHOLDS["cost_increase"]:
+            regressions.append({
+                "metric": "total_cost",
+                "direction": "degraded" if cost_change_pct > 0 else "improved",
+                "magnitude": round(cost_change_pct * 100, 1),
+                "current_value": round(curr_total_cost, 4),
+                "previous_value": round(prev_total_cost, 4),
+                "severity": "medium" if abs(cost_change_pct) < 0.5 else "high",
+            })
+
+    # Cost per session comparison
+    curr_avg_cost = float(current_cost.get("avg_cost_per_session", 0))
+    prev_avg_cost = float(previous_cost.get("avg_cost_per_session", 0))
+
+    if prev_avg_cost > 0:
+        avg_cost_change = (curr_avg_cost - prev_avg_cost) / prev_avg_cost
+        if abs(avg_cost_change) > THRESHOLDS["cost_increase"]:
+            regressions.append({
+                "metric": "avg_cost_per_session",
+                "direction": "degraded" if avg_cost_change > 0 else "improved",
+                "magnitude": round(avg_cost_change * 100, 1),
+                "current_value": round(curr_avg_cost, 4),
+                "previous_value": round(prev_avg_cost, 4),
+                "severity": "low",
+            })
+
+    # Cache efficiency comparison
+    curr_cache = float(current_cost.get("cache_efficiency_ratio", 0))
+    prev_cache = float(previous_cost.get("cache_efficiency_ratio", 0))
+
+    if prev_cache > 0:
+        cache_change = curr_cache - prev_cache
+        if abs(cache_change) > 0.10:  # >10% absolute change in cache efficiency
+            regressions.append({
+                "metric": "cache_efficiency",
+                "direction": "improved" if cache_change > 0 else "degraded",
+                "magnitude": round(cache_change * 100, 1),
+                "current_value": round(curr_cache * 100, 1),
+                "previous_value": round(prev_cache * 100, 1),
+                "severity": "low",
+            })
+
+    # Interruption rate comparison
+    current_interruptions = current.get("interruptions", {})
+    previous_interruptions = previous.get("interruptions", {})
+    curr_interrupts = int(current_interruptions.get("user_interruptions", 0))
+    prev_interrupts = int(previous_interruptions.get("user_interruptions", 0))
+    curr_total_stops = int(current_interruptions.get("total_stops", 0))
+    prev_total_stops = int(previous_interruptions.get("total_stops", 0))
+
+    if prev_total_stops > 0 and curr_total_stops > 0:
+        curr_interrupt_rate = curr_interrupts / curr_total_stops
+        prev_interrupt_rate = prev_interrupts / prev_total_stops
+        interrupt_change = curr_interrupt_rate - prev_interrupt_rate
+        if abs(interrupt_change) > THRESHOLDS["interruption_increase"]:
+            regressions.append({
+                "metric": "user_interruption_rate",
+                "direction": "degraded" if interrupt_change > 0 else "improved",
+                "magnitude": round(interrupt_change * 100, 1),
+                "current_value": round(curr_interrupt_rate * 100, 1),
+                "previous_value": round(prev_interrupt_rate * 100, 1),
+                "severity": "medium",
+            })
+
+    # Session count change (informational, not a regression)
+    curr_sessions = int(current.get("overview", {}).get("total_sessions", 0))
+    prev_sessions = int(previous.get("overview", {}).get("total_sessions", 0))
+    if prev_sessions > 0:
+        session_change = (curr_sessions - prev_sessions) / prev_sessions
+        if abs(session_change) > 0.3:  # >30% change in usage
+            regressions.append({
+                "metric": "session_count",
+                "direction": "improved" if session_change > 0 else "degraded",
+                "magnitude": round(session_change * 100, 1),
+                "current_value": curr_sessions,
+                "previous_value": prev_sessions,
+                "severity": "low",
+            })
+
+    return regressions

--- a/ee/observal_insights/sections.py
+++ b/ee/observal_insights/sections.py
@@ -27,6 +27,7 @@ def _get_synthesis_model() -> str | None:
     settings = get_settings()
     return getattr(settings, "INSIGHT_MODEL_SYNTHESIS", "") or None
 
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Section prompt templates — designed to produce structured JSON output
 # ──────────────────────────────────────────────────────────────────────────────
@@ -56,7 +57,6 @@ Produce a JSON object with this EXACT structure:
 }}
 
 Base everything on the actual data. Do not invent numbers. If data is limited, say so in the narrative.""",
-
     "what_works": """You are producing ONE section of a developer-facing insight report for an AI coding agent. This section highlights genuine strengths.
 
 {data_block}
@@ -79,7 +79,6 @@ Rules:
 - Each must be backed by a specific metric (name the number)
 - Don't stretch thin data — if you only have 1 session, you can only have 1-2 strengths
 - Focus on what would matter to the agent owner (reliability, cost efficiency, user satisfaction)""",
-
     "friction_analysis": """You are producing ONE section of a developer-facing insight report for an AI coding agent. This section identifies WHERE things go wrong.
 
 {data_block}
@@ -106,7 +105,6 @@ Rules:
 - Each MUST include a specific metric as evidence
 - Focus on patterns that actually hurt users, not one-off errors in tiny samples
 - If error counts are very low (1-2 total), note that statistical confidence is low""",
-
     "suggestions": """You are producing ONE section of a developer-facing insight report for an AI coding agent. This section provides SPECIFIC, IMPLEMENTABLE suggestions.
 
 {data_block}
@@ -135,7 +133,6 @@ Rules:
 - LOW priority: optimization opportunity
 - NEVER suggest "improve reliability" — say EXACTLY what to change
 - Suggestions should be things the agent OWNER can do (system prompt changes, tool config, workflow adjustments)""",
-
     "token_optimization": """You are producing ONE section of a developer-facing insight report for an AI coding agent. Focus on cost and token efficiency.
 
 {data_block}
@@ -165,7 +162,6 @@ Rules:
 - If cache efficiency is >70%, acknowledge it's good
 - Only suggest model downgrades if there's clear evidence simpler tasks don't need the expensive model
 - Maximum 3 opportunities""",
-
     "user_experience": """You are producing ONE section of a developer-facing insight report for an AI coding agent. Focus on the end-user experience.
 
 {data_block}
@@ -192,7 +188,6 @@ Rules:
 - Maximum 4 signals
 - Base satisfaction assessment on actual data (stop reasons, error rates, session completion)
 - Don't assume user satisfaction from limited data — say confidence is low if sample is small""",
-
     "regression_detection": """You are comparing current and previous period metrics for an AI coding agent.
 
 {data_block}
@@ -219,7 +214,6 @@ Produce a JSON object with this EXACT structure:
 
 If no previous period data is available, return:
 {{"regression_detection": {{"has_previous_data": false, "summary": "No previous period data available for comparison.", "changes": []}}}}""",
-
     "fun_ending": """You are producing the final section of a developer-facing insight report for an AI coding agent. Find ONE genuinely interesting or memorable observation from the data.
 
 {data_block}
@@ -341,13 +335,9 @@ async def generate_sections(
             narrative[name] = {} if name != "fun_ending" else {"headline": "", "detail": ""}
 
     # Run synthesis with all section outputs using synthesis model (Sonnet)
-    synthesis_prompt = SYNTHESIS_PROMPT.format(
-        sections_json=json.dumps(narrative, indent=2, default=str)
-    )
+    synthesis_prompt = SYNTHESIS_PROMPT.format(sections_json=json.dumps(narrative, indent=2, default=str))
     try:
-        synthesis_result = await call_model(
-            synthesis_prompt, model_override=synthesis_model, max_tokens=4096
-        )
+        synthesis_result = await call_model(synthesis_prompt, model_override=synthesis_model, max_tokens=4096)
         if synthesis_result and "at_a_glance" in synthesis_result:
             narrative["at_a_glance"] = synthesis_result["at_a_glance"]
         elif synthesis_result:

--- a/ee/observal_insights/sections.py
+++ b/ee/observal_insights/sections.py
@@ -1,0 +1,361 @@
+"""8+1 parallel section prompts for Agent Insights V2 narrative generation.
+
+Produces structured, actionable report sections modeled after professional
+developer experience reports — clear narratives with evidence, not bullet slop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import structlog
+
+from ._deps import get_call_model, get_settings
+
+logger = structlog.get_logger(__name__)
+
+
+def _get_section_model() -> str | None:
+    """Get the model for detailed section prompts (Opus by default)."""
+    settings = get_settings()
+    return getattr(settings, "INSIGHT_MODEL_SECTIONS", "") or None
+
+
+def _get_synthesis_model() -> str | None:
+    """Get the model for synthesis/aggregation (Sonnet by default)."""
+    settings = get_settings()
+    return getattr(settings, "INSIGHT_MODEL_SYNTHESIS", "") or None
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Section prompt templates — designed to produce structured JSON output
+# ──────────────────────────────────────────────────────────────────────────────
+
+SECTION_PROMPTS: dict[str, str] = {
+    "usage_patterns": """You are producing ONE section of a developer-facing insight report for an AI coding agent. Write for the agent's admin/owner — someone who wants to understand how their team uses this agent.
+
+{data_block}
+
+Produce a JSON object with this EXACT structure:
+{{
+  "usage_patterns": {{
+    "narrative": "<2-3 paragraph narrative describing HOW the agent is used. Write in 2nd person ('your agent', 'your users'). Be specific: name numbers, tools, and patterns. Don't be generic. Reference the actual metrics. Example: 'Your agent handled 42 sessions over 14 days, averaging 6 minutes per session. Bash dominates tool usage at 64% of all calls, suggesting users primarily delegate command execution rather than file editing.'",
+    "top_tasks": [
+      {{"name": "<task type>", "count": <number>, "description": "<one sentence>"}}
+    ],
+    "tool_distribution": [
+      {{"tool": "<name>", "calls": <number>, "error_rate": <percent as float>}}
+    ],
+    "session_profile": {{
+      "avg_duration_minutes": <number>,
+      "avg_tool_calls": <number>,
+      "avg_prompts": <number>,
+      "session_type": "<most common: single_task | multi_task | iterative_refinement | exploration>"
+    }}
+  }}
+}}
+
+Base everything on the actual data. Do not invent numbers. If data is limited, say so in the narrative.""",
+
+    "what_works": """You are producing ONE section of a developer-facing insight report for an AI coding agent. This section highlights genuine strengths.
+
+{data_block}
+
+Produce a JSON object with this EXACT structure:
+{{
+  "what_works": {{
+    "intro": "<1 sentence summarizing overall agent effectiveness>",
+    "strengths": [
+      {{
+        "title": "<short title, 3-5 words>",
+        "description": "<2-3 sentences explaining WHY this is a strength, with specific evidence from the metrics. Example: 'Agent and Write tools have 0% error rate across 4 invocations, providing reliable file operations without retry loops.'>"
+      }}
+    ]
+  }}
+}}
+
+Rules:
+- Maximum 4 strengths
+- Each must be backed by a specific metric (name the number)
+- Don't stretch thin data — if you only have 1 session, you can only have 1-2 strengths
+- Focus on what would matter to the agent owner (reliability, cost efficiency, user satisfaction)""",
+
+    "friction_analysis": """You are producing ONE section of a developer-facing insight report for an AI coding agent. This section identifies WHERE things go wrong.
+
+{data_block}
+
+Produce a JSON object with this EXACT structure:
+{{
+  "friction_analysis": {{
+    "intro": "<1 sentence summarizing the primary friction pattern>",
+    "categories": [
+      {{
+        "title": "<friction category name>",
+        "severity": "<high | medium | low>",
+        "description": "<1-2 sentences explaining the problem>",
+        "evidence": "<specific metrics: e.g. 'Bash tool: 1 command_failed error in 7 invocations (14% error rate)'>",
+        "impact": "<what this costs users: time, retries, abandoned sessions>"
+      }}
+    ]
+  }}
+}}
+
+Rules:
+- Rank by severity (high first)
+- Maximum 4 categories
+- Each MUST include a specific metric as evidence
+- Focus on patterns that actually hurt users, not one-off errors in tiny samples
+- If error counts are very low (1-2 total), note that statistical confidence is low""",
+
+    "suggestions": """You are producing ONE section of a developer-facing insight report for an AI coding agent. This section provides SPECIFIC, IMPLEMENTABLE suggestions.
+
+{data_block}
+
+Produce a JSON object with this EXACT structure:
+{{
+  "suggestions": {{
+    "intro": "<1 sentence framing these as next steps>",
+    "items": [
+      {{
+        "title": "<short action title>",
+        "action": "<Exactly what to do — specific enough that someone could implement it right now. Not vague. Example: 'Add to your agent system prompt: Before running any Bash command, verify the target file exists with a Read call first.'>",
+        "why": "<1 sentence explaining which metric this addresses and expected impact>",
+        "priority": "<high | medium | low>"
+      }}
+    ]
+  }}
+}}
+
+Rules:
+- Maximum 5 suggestions, minimum 2
+- Each must address a SPECIFIC metric or pattern from the data
+- Prioritize by expected impact
+- HIGH priority: addresses >10% error rate or >20% cost waste
+- MEDIUM priority: addresses known friction pattern
+- LOW priority: optimization opportunity
+- NEVER suggest "improve reliability" — say EXACTLY what to change
+- Suggestions should be things the agent OWNER can do (system prompt changes, tool config, workflow adjustments)""",
+
+    "token_optimization": """You are producing ONE section of a developer-facing insight report for an AI coding agent. Focus on cost and token efficiency.
+
+{data_block}
+
+Produce a JSON object with this EXACT structure:
+{{
+  "token_optimization": {{
+    "summary": "<1-2 sentences: overall cost assessment — is this agent expensive, cheap, efficient?>",
+    "metrics": {{
+      "total_cost_usd": <number>,
+      "cost_per_session": <number>,
+      "cache_efficiency_pct": <number 0-100>,
+      "most_expensive_model": "<model name or null>"
+    }},
+    "opportunities": [
+      {{
+        "title": "<opportunity name>",
+        "description": "<what to change>",
+        "estimated_savings": "<e.g. '~30% reduction in per-session cost'>"
+      }}
+    ]
+  }}
+}}
+
+Rules:
+- Be honest: if costs are already low, say so
+- If cache efficiency is >70%, acknowledge it's good
+- Only suggest model downgrades if there's clear evidence simpler tasks don't need the expensive model
+- Maximum 3 opportunities""",
+
+    "user_experience": """You are producing ONE section of a developer-facing insight report for an AI coding agent. Focus on the end-user experience.
+
+{data_block}
+
+Produce a JSON object with this EXACT structure:
+{{
+  "user_experience": {{
+    "narrative": "<2-3 sentences describing the overall user experience. Are users satisfied? Do they interrupt frequently? Do sessions complete successfully? Reference specific metrics.>",
+    "signals": [
+      {{
+        "signal": "<what was observed>",
+        "interpretation": "<what it means for user satisfaction>"
+      }}
+    ],
+    "satisfaction_indicators": {{
+      "completion_rate": "<percentage or 'N/A'>",
+      "interruption_rate": "<percentage or 'N/A'>",
+      "retry_patterns": "<description or 'none observed'>"
+    }}
+  }}
+}}
+
+Rules:
+- Maximum 4 signals
+- Base satisfaction assessment on actual data (stop reasons, error rates, session completion)
+- Don't assume user satisfaction from limited data — say confidence is low if sample is small""",
+
+    "regression_detection": """You are comparing current and previous period metrics for an AI coding agent.
+
+{data_block}
+
+{previous_data_block}
+
+Produce a JSON object with this EXACT structure:
+{{
+  "regression_detection": {{
+    "has_previous_data": <true|false>,
+    "summary": "<1-2 sentences: what changed between periods>",
+    "changes": [
+      {{
+        "metric": "<metric name>",
+        "direction": "<improved | degraded | stable>",
+        "previous_value": "<formatted value>",
+        "current_value": "<formatted value>",
+        "magnitude_pct": <number>,
+        "significance": "<meaningful | minor | noise>"
+      }}
+    ]
+  }}
+}}
+
+If no previous period data is available, return:
+{{"regression_detection": {{"has_previous_data": false, "summary": "No previous period data available for comparison.", "changes": []}}}}""",
+
+    "fun_ending": """You are producing the final section of a developer-facing insight report for an AI coding agent. Find ONE genuinely interesting or memorable observation from the data.
+
+{data_block}
+
+Produce a JSON object with this EXACT structure:
+{{
+  "fun_ending": {{
+    "headline": "<punchy 5-10 word headline>",
+    "detail": "<2-3 sentence observation that's genuinely interesting, not forced. Could be: an unusual stat, a contrast, a notable achievement, or something that characterizes this agent's personality. Keep it light.>"
+  }}
+}}
+
+Rules:
+- Don't force humor if there's nothing funny
+- Focus on what's genuinely notable or surprising in the data
+- Keep it SHORT (under 50 words for the detail)""",
+}
+
+SYNTHESIS_PROMPT = """You have analysis sections about an AI coding agent's recent performance. Write a concise executive summary.
+
+## Section Outputs
+{sections_json}
+
+Write a JSON response with this EXACT structure:
+{{
+  "at_a_glance": {{
+    "whats_working": "<1 sentence: the primary strength or positive pattern>",
+    "whats_hindering": "<1 sentence: the primary friction or concern>",
+    "quick_win": "<1 sentence: the single most impactful quick improvement>",
+    "health": "<healthy | mixed | concerning>"
+  }}
+}}
+
+Rules:
+- Each field must be ONE sentence, under 30 words
+- Be specific — name tools, error rates, or patterns by name
+- "healthy" = error rates low, costs reasonable, users satisfied
+- "mixed" = some friction but generally functional
+- "concerning" = high error rates, cost issues, or user dissatisfaction"""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Execution
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def _call_section(section_name: str, prompt: str, model: str | None = None) -> tuple[str, dict]:
+    """Call the eval model for a single section, return (name, result)."""
+    call_model = get_call_model()
+    try:
+        result = await call_model(prompt, model_override=model, max_tokens=8192)
+        if result and isinstance(result, dict):
+            return section_name, result
+        logger.warning("section_empty_response", section=section_name)
+        return section_name, {}
+    except Exception as e:
+        logger.error("section_call_failed", section=section_name, error=str(e))
+        return section_name, {}
+
+
+async def generate_sections(
+    data_block: str,
+    previous_report: dict | None = None,
+) -> dict:
+    """Run 8 parallel section prompts + 1 synthesis, return combined narrative.
+
+    Args:
+        data_block: Formatted string with all metrics, facets, and session data.
+        previous_report: Previous report's aggregated_data for regression comparison.
+
+    Returns:
+        Dict with structured section outputs for each narrative section.
+    """
+    call_model = get_call_model()
+
+    # Build previous data block for regression section
+    previous_data_block = ""
+    if previous_report:
+        previous_data_block = f"## Previous Period Metrics\n{json.dumps(previous_report, indent=2, default=str)}"
+    else:
+        previous_data_block = "## Previous Period Metrics\nNo previous period data available."
+
+    # Resolve models for this pipeline
+    section_model = _get_section_model()
+    synthesis_model = _get_synthesis_model()
+
+    logger.info(
+        "insight_sections_starting",
+        section_model=section_model or "default",
+        synthesis_model=synthesis_model or "default",
+    )
+
+    # Build prompts for all 8 sections
+    section_prompts: dict[str, str] = {}
+    for name, template in SECTION_PROMPTS.items():
+        if name == "regression_detection":
+            section_prompts[name] = template.format(
+                data_block=data_block,
+                previous_data_block=previous_data_block,
+            )
+        else:
+            section_prompts[name] = template.format(data_block=data_block)
+
+    # Run all 8 in parallel using the section model (Opus)
+    tasks = [_call_section(name, prompt, model=section_model) for name, prompt in section_prompts.items()]
+    results = await asyncio.gather(*tasks)
+
+    # Collect results
+    narrative: dict = {}
+    for name, result in results:
+        # Extract the section content from the JSON response
+        if name in result:
+            narrative[name] = result[name]
+        elif result:
+            # Model may have returned with a different key structure
+            first_value = next(iter(result.values()), None)
+            narrative[name] = first_value
+        else:
+            narrative[name] = {} if name != "fun_ending" else {"headline": "", "detail": ""}
+
+    # Run synthesis with all section outputs using synthesis model (Sonnet)
+    synthesis_prompt = SYNTHESIS_PROMPT.format(
+        sections_json=json.dumps(narrative, indent=2, default=str)
+    )
+    try:
+        synthesis_result = await call_model(
+            synthesis_prompt, model_override=synthesis_model, max_tokens=4096
+        )
+        if synthesis_result and "at_a_glance" in synthesis_result:
+            narrative["at_a_glance"] = synthesis_result["at_a_glance"]
+        elif synthesis_result:
+            narrative["at_a_glance"] = next(iter(synthesis_result.values()), {})
+        else:
+            narrative["at_a_glance"] = {}
+    except Exception as e:
+        logger.error("synthesis_failed", error=str(e))
+        narrative["at_a_glance"] = {}
+
+    return narrative

--- a/ee/observal_insights/session_cache.py
+++ b/ee/observal_insights/session_cache.py
@@ -103,6 +103,10 @@ async def load_cached_metas(
 ) -> dict[str, dict] | None:
     """Load cached session metadata from PostgreSQL.
 
+    The InsightSessionMeta model stores one row per session. We load all
+    cached sessions for the agent and return those whose start_time falls
+    within the requested period.
+
     Args:
         agent_id: The agent UUID (as string).
         period_start: ISO timestamp for period start.
@@ -116,19 +120,21 @@ async def load_cached_metas(
 
     from sqlalchemy import select
 
-    stmt = (
-        select(MetaModel)
-        .where(MetaModel.agent_id == agent_id)
-        .where(MetaModel.period_start == period_start)
-        .where(MetaModel.period_end == period_end)
-    )
+    stmt = select(MetaModel).where(MetaModel.agent_id == agent_id)
     result = await db.execute(stmt)
-    row = result.scalar_one_or_none()
+    rows = result.scalars().all()
 
-    if row is None:
+    if not rows:
         return None
 
-    return row.session_metas if hasattr(row, "session_metas") else None
+    metas: dict[str, dict] = {}
+    for row in rows:
+        meta = row.meta if hasattr(row, "meta") else None
+        if not meta:
+            continue
+        metas[row.session_id] = meta
+
+    return metas if metas else None
 
 
 async def store_cached_metas(
@@ -139,6 +145,9 @@ async def store_cached_metas(
     db,
 ) -> None:
     """Persist session metadata cache to PostgreSQL.
+
+    Stores one row per session in InsightSessionMeta. Upserts by
+    (agent_id, session_id) unique constraint.
 
     Args:
         agent_id: The agent UUID (as string).
@@ -151,28 +160,26 @@ async def store_cached_metas(
 
     from sqlalchemy import select
 
-    stmt = (
-        select(MetaModel)
-        .where(MetaModel.agent_id == agent_id)
-        .where(MetaModel.period_start == period_start)
-        .where(MetaModel.period_end == period_end)
-    )
-    result = await db.execute(stmt)
-    existing = result.scalar_one_or_none()
-
-    if existing:
-        existing.session_metas = session_metas
-        existing.updated_at = datetime.now(UTC)
-    else:
-        record = MetaModel(
-            agent_id=agent_id,
-            period_start=period_start,
-            period_end=period_end,
-            session_metas=session_metas,
-            created_at=datetime.now(UTC),
-            updated_at=datetime.now(UTC),
+    for session_id, meta in session_metas.items():
+        stmt = (
+            select(MetaModel)
+            .where(MetaModel.agent_id == agent_id)
+            .where(MetaModel.session_id == session_id)
         )
-        db.add(record)
+        result = await db.execute(stmt)
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.meta = meta
+            existing.computed_at = datetime.now(UTC)
+        else:
+            record = MetaModel(
+                agent_id=agent_id,
+                session_id=session_id,
+                computed_at=datetime.now(UTC),
+                meta=meta,
+            )
+            db.add(record)
 
     await db.flush()
 

--- a/ee/observal_insights/session_cache.py
+++ b/ee/observal_insights/session_cache.py
@@ -161,11 +161,7 @@ async def store_cached_metas(
     from sqlalchemy import select
 
     for session_id, meta in session_metas.items():
-        stmt = (
-            select(MetaModel)
-            .where(MetaModel.agent_id == agent_id)
-            .where(MetaModel.session_id == session_id)
-        )
+        stmt = select(MetaModel).where(MetaModel.agent_id == agent_id).where(MetaModel.session_id == session_id)
         result = await db.execute(stmt)
         existing = result.scalar_one_or_none()
 

--- a/ee/observal_insights/session_cache.py
+++ b/ee/observal_insights/session_cache.py
@@ -1,0 +1,243 @@
+"""Session metadata caching layer for Agent Insights.
+
+Loads session metadata from ClickHouse and caches processed results in
+PostgreSQL via the InsightSessionMeta model. This avoids re-querying
+ClickHouse for the same session data across report regenerations.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+
+from ._deps import get_meta_model, get_query
+
+logger = structlog.get_logger(__name__)
+
+
+async def fetch_session_metas(
+    agent_name: str,
+    period_start: str,
+    period_end: str,
+) -> list[dict]:
+    """Fetch session metadata from ClickHouse for a given agent and time range.
+
+    Args:
+        agent_name: The agent registry name (matches agent_type or agent_name in otel_logs).
+        period_start: ISO timestamp for period start.
+        period_end: ISO timestamp for period end.
+
+    Returns:
+        List of session metadata dicts from ClickHouse.
+    """
+    query = get_query()
+
+    sql = """
+        SELECT
+            LogAttributes['session.id'] AS session_id,
+            min(Timestamp) AS start_time,
+            max(Timestamp) AS end_time,
+            dateDiff('second', min(Timestamp), max(Timestamp)) AS duration_seconds,
+            count() AS event_count,
+            countIf(LogAttributes['event.name'] IN ('tool_result', 'hook_posttooluse')) AS tool_call_count,
+            countIf(LogAttributes['error'] != '') AS error_count,
+            any(LogAttributes['model']) AS model,
+            any(LogAttributes['platform']) AS platform,
+            any(LogAttributes['user_id']) AS user_id,
+            any(LogAttributes['user_name']) AS user_name,
+            any(LogAttributes['cwd']) AS cwd,
+            any(LogAttributes['stop_reason']) AS stop_reason,
+            sumIf(
+                toUInt64OrZero(LogAttributes['input_tokens']),
+                LogAttributes['event.name'] = 'api_request'
+            ) AS input_tokens,
+            sumIf(
+                toUInt64OrZero(LogAttributes['output_tokens']),
+                LogAttributes['event.name'] = 'api_request'
+            ) AS output_tokens,
+            sumIf(
+                toUInt64OrZero(LogAttributes['cache_read_tokens']),
+                LogAttributes['event.name'] = 'api_request'
+            ) AS cache_read_tokens,
+            sumIf(
+                toUInt64OrZero(LogAttributes['cache_write_tokens']),
+                LogAttributes['event.name'] = 'api_request'
+            ) AS cache_write_tokens
+        FROM otel_logs
+        WHERE (LogAttributes['agent_type'] = {aname:String}
+               OR LogAttributes['agent_name'] = {aname:String})
+          AND Timestamp >= {t_start:String}
+          AND Timestamp <= {t_end:String}
+          AND LogAttributes['session.id'] != ''
+        GROUP BY session_id
+        HAVING event_count >= 2
+        ORDER BY start_time
+        FORMAT JSON
+    """
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": period_start,
+        "param_t_end": period_end,
+    }
+
+    try:
+        r = await query(sql, params)
+        r.raise_for_status()
+        data = r.json().get("data", [])
+        return data
+    except Exception as e:
+        logger.error(
+            "session_meta_fetch_failed",
+            agent_name=agent_name,
+            error=str(e),
+        )
+        return []
+
+
+async def load_cached_metas(
+    agent_id: str,
+    period_start: str,
+    period_end: str,
+    db,
+) -> dict[str, dict] | None:
+    """Load cached session metadata from PostgreSQL.
+
+    Args:
+        agent_id: The agent UUID (as string).
+        period_start: ISO timestamp for period start.
+        period_end: ISO timestamp for period end.
+        db: An AsyncSession instance.
+
+    Returns:
+        Dict mapping session_id -> metadata, or None if no cache exists.
+    """
+    MetaModel = get_meta_model()
+
+    from sqlalchemy import select
+
+    stmt = (
+        select(MetaModel)
+        .where(MetaModel.agent_id == agent_id)
+        .where(MetaModel.period_start == period_start)
+        .where(MetaModel.period_end == period_end)
+    )
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+
+    if row is None:
+        return None
+
+    return row.session_metas if hasattr(row, "session_metas") else None
+
+
+async def store_cached_metas(
+    agent_id: str,
+    period_start: str,
+    period_end: str,
+    session_metas: dict[str, dict],
+    db,
+) -> None:
+    """Persist session metadata cache to PostgreSQL.
+
+    Args:
+        agent_id: The agent UUID (as string).
+        period_start: ISO timestamp for period start.
+        period_end: ISO timestamp for period end.
+        session_metas: Dict mapping session_id -> metadata.
+        db: An AsyncSession instance.
+    """
+    MetaModel = get_meta_model()
+
+    from sqlalchemy import select
+
+    stmt = (
+        select(MetaModel)
+        .where(MetaModel.agent_id == agent_id)
+        .where(MetaModel.period_start == period_start)
+        .where(MetaModel.period_end == period_end)
+    )
+    result = await db.execute(stmt)
+    existing = result.scalar_one_or_none()
+
+    if existing:
+        existing.session_metas = session_metas
+        existing.updated_at = datetime.now(UTC)
+    else:
+        record = MetaModel(
+            agent_id=agent_id,
+            period_start=period_start,
+            period_end=period_end,
+            session_metas=session_metas,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        db.add(record)
+
+    await db.flush()
+
+
+async def get_session_metas(
+    agent_id: str,
+    agent_name: str = "",
+    period_start: str = "",
+    period_end: str = "",
+    db=None,
+    use_cache: bool = True,
+) -> dict[str, dict]:
+    """Get session metadata, using cache when available.
+
+    Fetches from ClickHouse and optionally caches in PostgreSQL for
+    subsequent report regenerations.
+
+    Args:
+        agent_id: The agent UUID (used for cache key).
+        agent_name: The agent registry name (used for ClickHouse query).
+        period_start: ISO timestamp for period start.
+        period_end: ISO timestamp for period end.
+        db: Optional AsyncSession for caching. If None, caching is skipped.
+        use_cache: Whether to check/store cache.
+
+    Returns:
+        Dict mapping session_id -> metadata dict.
+    """
+    # Try cache first
+    if use_cache and db is not None:
+        try:
+            cached = await load_cached_metas(agent_id, period_start, period_end, db)
+            if cached:
+                logger.debug(
+                    "session_metas_cache_hit",
+                    agent_id=agent_id,
+                    count=len(cached),
+                )
+                return cached
+        except Exception as e:
+            logger.warning("session_metas_cache_load_failed", error=str(e))
+
+    # Fetch from ClickHouse using agent_name for the query
+    rows = await fetch_session_metas(agent_name or agent_id, period_start, period_end)
+    if not rows:
+        return {}
+
+    # Index by session_id
+    metas: dict[str, dict] = {}
+    for row in rows:
+        sid = row.get("session_id", "")
+        if sid:
+            metas[sid] = row
+
+    logger.info(
+        "session_metas_fetched",
+        agent_id=agent_id,
+        count=len(metas),
+    )
+
+    # Store in cache
+    if use_cache and db is not None and metas:
+        try:
+            await store_cached_metas(agent_id, period_start, period_end, metas, db)
+        except Exception as e:
+            logger.warning("session_metas_cache_store_failed", error=str(e))
+
+    return metas

--- a/ee/observal_insights/shim_enrichment.py
+++ b/ee/observal_insights/shim_enrichment.py
@@ -108,9 +108,7 @@ def _parse_ts_ms(ts: str) -> float | None:
     return None
 
 
-async def enrich_session_with_shim(
-    session_id: str, hook_events: list[dict], shim_spans: list[dict]
-) -> list[dict]:
+async def enrich_session_with_shim(session_id: str, hook_events: list[dict], shim_spans: list[dict]) -> list[dict]:
     """Join shim spans with hook events for a single session.
 
     Match by: tool_name + timestamp proximity (within 2 seconds).

--- a/ee/observal_insights/shim_enrichment.py
+++ b/ee/observal_insights/shim_enrichment.py
@@ -1,0 +1,343 @@
+"""MCP shim data enrichment — join spans table with hook events for richer insights.
+
+The shim provides data hooks cannot:
+- Precise latency (monotonic clock, not wall clock)
+- Schema compliance (hallucinated tool detection)
+- Full input/output (no 64KB truncation)
+- tools_available count (how many tools were exposed)
+
+Only Claude Code + the Observal shim produce this data.
+Other IDEs will have no spans, and all functions handle that gracefully.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+
+import structlog
+
+from ._deps import get_query
+
+logger = structlog.get_logger(__name__)
+
+# Subquery to find sessions belonging to an agent (same pattern as metrics.py).
+_SESSIONS_SUBQUERY = """
+    SELECT DISTINCT LogAttributes['session.id']
+    FROM otel_logs
+    WHERE (LogAttributes['agent_type'] = {aname:String}
+           OR LogAttributes['agent_name'] = {aname:String})
+      AND Timestamp >= {t_start:String}
+      AND Timestamp <= {t_end:String}
+      AND LogAttributes['session.id'] != ''
+"""
+
+
+async def get_shim_spans_for_sessions(
+    agent_name: str, session_ids: list[str], start: str, end: str
+) -> dict[str, list[dict]]:
+    """Query spans table for MCP tool calls matching the given sessions.
+
+    Returns a dict of session_id -> list of span dicts.
+    Each span has: tool_name, input, output, latency_ms, tool_schema_valid,
+    start_time, mcp_id, session_id.
+    """
+    if not session_ids:
+        return {}
+
+    _query = get_query()
+    ids_str = ", ".join(f"'{sid}'" for sid in session_ids)
+    sql = (
+        "SELECT "
+        "name AS tool_name, "
+        "input, "
+        "output, "
+        "latency_ms, "
+        "tool_schema_valid, "
+        "toString(start_time) AS start_time, "
+        "mcp_id, "
+        "metadata['session.id'] AS session_id "
+        "FROM spans FINAL "
+        f"WHERE metadata['session.id'] IN ({ids_str}) "
+        "AND type = 'tool_call' "
+        "AND is_deleted = 0 "
+        "AND start_time >= parseDateTimeBestEffort({t_start:String}) "
+        "AND start_time <= parseDateTimeBestEffort({t_end:String}) "
+        "ORDER BY start_time ASC "
+        "LIMIT 5000 "
+        "FORMAT JSON"
+    )
+    params = {"param_t_start": start, "param_t_end": end}
+
+    try:
+        r = await _query(sql, params)
+        r.raise_for_status()
+        rows = r.json().get("data", [])
+    except Exception as e:
+        logger.error("shim_spans_for_sessions_failed", error=str(e))
+        return {}
+
+    result: dict[str, list[dict]] = {}
+    for row in rows:
+        sid = row.get("session_id", "")
+        if not sid:
+            continue
+        result.setdefault(sid, []).append(row)
+    return result
+
+
+def _parse_ts_ms(ts: str) -> float | None:
+    """Parse an ISO-ish timestamp to milliseconds since epoch. Returns None on failure."""
+    if not ts:
+        return None
+    from datetime import datetime
+
+    fmts = [
+        "%Y-%m-%d %H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%SZ",
+    ]
+    ts_trimmed = ts[:26]
+    for fmt in fmts:
+        try:
+            dt = datetime.strptime(ts_trimmed, fmt).replace(tzinfo=UTC)
+            return dt.timestamp() * 1000
+        except ValueError:
+            continue
+    return None
+
+
+async def enrich_session_with_shim(
+    session_id: str, hook_events: list[dict], shim_spans: list[dict]
+) -> list[dict]:
+    """Join shim spans with hook events for a single session.
+
+    Match by: tool_name + timestamp proximity (within 2 seconds).
+
+    Enrichment adds to hook events:
+    - mcp_latency_ms: precise latency from shim
+    - tool_schema_valid: 0/1 whether tool call matched schema
+    - full_tool_input: complete input (no 64KB truncation)
+    - full_tool_response: complete output (no truncation)
+
+    Returns the enriched event list (events are modified in-place copies).
+    """
+    if not shim_spans:
+        return hook_events
+
+    used_span_indices: set[int] = set()
+    result: list[dict] = []
+
+    for event in hook_events:
+        event = dict(event)  # shallow copy to avoid mutating input
+        tool_name = event.get("tool_name", "")
+        event_ts_ms = _parse_ts_ms(event.get("timestamp", ""))
+
+        if tool_name and event_ts_ms is not None:
+            best_idx: int | None = None
+            best_diff = float("inf")
+
+            for idx, span in enumerate(shim_spans):
+                if idx in used_span_indices:
+                    continue
+                if span.get("tool_name", "") != tool_name:
+                    continue
+                span_ts_ms = _parse_ts_ms(span.get("start_time", ""))
+                if span_ts_ms is None:
+                    continue
+                diff = abs(event_ts_ms - span_ts_ms)
+                if diff <= 2000 and diff < best_diff:
+                    best_diff = diff
+                    best_idx = idx
+
+            if best_idx is not None:
+                span = shim_spans[best_idx]
+                used_span_indices.add(best_idx)
+                if span.get("latency_ms") is not None:
+                    event["mcp_latency_ms"] = int(span["latency_ms"])
+                if span.get("tool_schema_valid") is not None:
+                    event["tool_schema_valid"] = int(span["tool_schema_valid"])
+                if span.get("input"):
+                    event["full_tool_input"] = span["input"]
+                if span.get("output"):
+                    event["full_tool_response"] = span["output"]
+
+        result.append(event)
+
+    return result
+
+
+async def compute_mcp_metrics(agent_name: str, start: str, end: str) -> dict:
+    """Compute MCP-specific metrics from the spans table.
+
+    Returns:
+        total_mcp_calls: int
+        latency_p50_ms: int
+        latency_p95_ms: int
+        latency_p99_ms: int
+        schema_violations: int (calls where tool_schema_valid = 0)
+        schema_violation_rate: float
+        tools_available_count: int (avg tools exposed per call)
+        slowest_tools: list[dict] (top 5 by p95 latency)
+        error_tools: list[dict] (tools with highest failure rate)
+    """
+    _query = get_query()
+    _default = {
+        "total_mcp_calls": 0,
+        "latency_p50_ms": 0,
+        "latency_p95_ms": 0,
+        "latency_p99_ms": 0,
+        "schema_violations": 0,
+        "schema_violation_rate": 0.0,
+        "tools_available_count": 0,
+        "slowest_tools": [],
+        "error_tools": [],
+    }
+
+    # Aggregate query
+    agg_sql = """
+        SELECT
+            count() AS total_mcp_calls,
+            quantile(0.5)(latency_ms) AS latency_p50_ms,
+            quantile(0.95)(latency_ms) AS latency_p95_ms,
+            quantile(0.99)(latency_ms) AS latency_p99_ms,
+            countIf(tool_schema_valid = 0) AS schema_violations,
+            avg(tools_available) AS tools_available_count
+        FROM spans FINAL
+        WHERE is_deleted = 0
+          AND type = 'tool_call'
+          AND latency_ms IS NOT NULL
+          AND metadata['agent_name'] IN (
+              SELECT DISTINCT LogAttributes['agent_name']
+              FROM otel_logs
+              WHERE (LogAttributes['agent_type'] = {aname:String}
+                     OR LogAttributes['agent_name'] = {aname:String})
+                AND Timestamp >= {t_start:String}
+                AND Timestamp <= {t_end:String}
+          )
+          AND start_time >= parseDateTimeBestEffort({t_start:String})
+          AND start_time <= parseDateTimeBestEffort({t_end:String})
+        FORMAT JSON
+    """
+
+    # Slowest tools by p95 latency
+    slowest_sql = """
+        SELECT
+            name AS tool_name,
+            count() AS call_count,
+            quantile(0.95)(latency_ms) AS p95_latency_ms
+        FROM spans FINAL
+        WHERE is_deleted = 0
+          AND type = 'tool_call'
+          AND latency_ms IS NOT NULL
+          AND metadata['agent_name'] IN (
+              SELECT DISTINCT LogAttributes['agent_name']
+              FROM otel_logs
+              WHERE (LogAttributes['agent_type'] = {aname:String}
+                     OR LogAttributes['agent_name'] = {aname:String})
+                AND Timestamp >= {t_start:String}
+                AND Timestamp <= {t_end:String}
+          )
+          AND start_time >= parseDateTimeBestEffort({t_start:String})
+          AND start_time <= parseDateTimeBestEffort({t_end:String})
+        GROUP BY name
+        ORDER BY p95_latency_ms DESC
+        LIMIT 5
+        FORMAT JSON
+    """
+
+    # Tools with highest error rates
+    error_tools_sql = """
+        SELECT
+            name AS tool_name,
+            count() AS call_count,
+            countIf(status = 'error') AS error_count,
+            round(countIf(status = 'error') / count(), 4) AS error_rate
+        FROM spans FINAL
+        WHERE is_deleted = 0
+          AND type = 'tool_call'
+          AND metadata['agent_name'] IN (
+              SELECT DISTINCT LogAttributes['agent_name']
+              FROM otel_logs
+              WHERE (LogAttributes['agent_type'] = {aname:String}
+                     OR LogAttributes['agent_name'] = {aname:String})
+                AND Timestamp >= {t_start:String}
+                AND Timestamp <= {t_end:String}
+          )
+          AND start_time >= parseDateTimeBestEffort({t_start:String})
+          AND start_time <= parseDateTimeBestEffort({t_end:String})
+        GROUP BY name
+        HAVING error_count > 0
+        ORDER BY error_rate DESC
+        LIMIT 10
+        FORMAT JSON
+    """
+
+    params = {
+        "param_aname": agent_name,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+
+    try:
+        agg_resp = await _query(agg_sql, params)
+        agg_resp.raise_for_status()
+        agg_rows = agg_resp.json().get("data", [])
+    except Exception as e:
+        logger.error("mcp_metrics_agg_failed", error=str(e))
+        return _default
+
+    if not agg_rows:
+        return _default
+
+    row = agg_rows[0]
+    total = int(row.get("total_mcp_calls", 0) or 0)
+    violations = int(row.get("schema_violations", 0) or 0)
+    violation_rate = round(violations / total, 4) if total > 0 else 0.0
+
+    try:
+        slowest_resp = await _query(slowest_sql, params)
+        slowest_resp.raise_for_status()
+        slowest_tools = [
+            {
+                "tool_name": r["tool_name"],
+                "call_count": int(r["call_count"]),
+                "p95_latency_ms": int(r["p95_latency_ms"] or 0),
+            }
+            for r in slowest_resp.json().get("data", [])
+        ]
+    except Exception as e:
+        logger.warning("mcp_slowest_tools_failed", error=str(e))
+        slowest_tools = []
+
+    try:
+        error_resp = await _query(error_tools_sql, params)
+        error_resp.raise_for_status()
+        error_tools = [
+            {
+                "tool_name": r["tool_name"],
+                "call_count": int(r["call_count"]),
+                "error_count": int(r["error_count"]),
+                "error_rate": float(r["error_rate"]),
+            }
+            for r in error_resp.json().get("data", [])
+        ]
+    except Exception as e:
+        logger.warning("mcp_error_tools_failed", error=str(e))
+        error_tools = []
+
+    tools_available_raw = row.get("tools_available_count")
+    tools_available_count = int(float(tools_available_raw)) if tools_available_raw else 0
+
+    return {
+        "total_mcp_calls": total,
+        "latency_p50_ms": int(row.get("latency_p50_ms") or 0),
+        "latency_p95_ms": int(row.get("latency_p95_ms") or 0),
+        "latency_p99_ms": int(row.get("latency_p99_ms") or 0),
+        "schema_violations": violations,
+        "schema_violation_rate": violation_rate,
+        "tools_available_count": tools_available_count,
+        "slowest_tools": slowest_tools,
+        "error_tools": error_tools,
+    }

--- a/ee/observal_insights/transcript.py
+++ b/ee/observal_insights/transcript.py
@@ -1,0 +1,95 @@
+"""Build readable session transcripts from ClickHouse otel_logs for facet extraction."""
+
+from __future__ import annotations
+
+import structlog
+
+from ._deps import get_query
+
+logger = structlog.get_logger(__name__)
+
+MAX_TRANSCRIPT_CHARS = 4000
+MAX_TOOL_INPUT_CHARS = 200
+MAX_PROMPT_CHARS = 500
+
+
+async def build_session_transcript(session_id: str, start: str, end: str) -> str:
+    """Query otel_logs for a session and build a readable transcript.
+
+    Includes: user prompts (truncated), tool calls (name + outcome),
+    errors with context, stop event. Truncated to MAX_TRANSCRIPT_CHARS total.
+    """
+    query = get_query()
+
+    sql = """
+        SELECT
+            LogAttributes['event.name'] AS event_name,
+            LogAttributes['tool_name'] AS tool_name,
+            LogAttributes['tool_input'] AS tool_input,
+            LogAttributes['tool_response'] AS tool_response,
+            LogAttributes['error'] AS error,
+            LogAttributes['stop_reason'] AS stop_reason,
+            LogAttributes['body'] AS body,
+            Timestamp
+        FROM otel_logs
+        WHERE LogAttributes['session.id'] = {sid:String}
+          AND Timestamp >= {t_start:String}
+          AND Timestamp <= {t_end:String}
+        ORDER BY Timestamp
+        LIMIT 200
+        FORMAT JSON
+    """
+    params = {
+        "param_sid": session_id,
+        "param_t_start": start,
+        "param_t_end": end,
+    }
+
+    try:
+        r = await query(sql, params)
+        r.raise_for_status()
+        rows = r.json().get("data", [])
+    except Exception as e:
+        logger.warning("transcript_query_failed", session_id=session_id, error=str(e))
+        return ""
+
+    if not rows:
+        return ""
+
+    lines: list[str] = []
+    total_chars = 0
+
+    for row in rows:
+        ev = row.get("event_name", "")
+        line = ""
+
+        if ev in ("user_prompt", "hook_userpromptsubmit"):
+            body = (row.get("body") or "")[:MAX_PROMPT_CHARS]
+            if body:
+                line = f"[USER] {body}"
+
+        elif ev in ("tool_result", "hook_posttooluse"):
+            tool = row.get("tool_name", "unknown")
+            error = row.get("error", "")
+            if error:
+                line = f"[TOOL:{tool}] ERROR: {error[:200]}"
+            else:
+                response = (row.get("tool_response") or "")[:100]
+                line = f"[TOOL:{tool}] OK{' — ' + response if response else ''}"
+
+        elif ev in ("hook_stopfailure", "hook_stopsuccess"):
+            reason = row.get("stop_reason", "")
+            line = f"[STOP:{reason}]"
+
+        elif ev == "api_request":
+            # Skip API requests — too noisy
+            continue
+
+        if line:
+            if total_chars + len(line) > MAX_TRANSCRIPT_CHARS:
+                lines.append("[...truncated...]")
+                break
+            lines.append(line)
+            total_chars += len(line) + 1
+
+    return "\n".join(lines)

--- a/observal-server/services/insights/__init__.py
+++ b/observal-server/services/insights/__init__.py
@@ -26,10 +26,7 @@ else:
 
 
 def _not_available():
-    raise RuntimeError(
-        "Insights is an enterprise feature. "
-        "Set DEPLOYMENT_MODE=enterprise to enable."
-    )
+    raise RuntimeError("Insights is an enterprise feature. Set DEPLOYMENT_MODE=enterprise to enable.")
 
 
 async def generate_report_content(*args, **kwargs):

--- a/observal-server/services/insights/__init__.py
+++ b/observal-server/services/insights/__init__.py
@@ -1,51 +1,65 @@
 """Insights plugin loader.
 
-If the observal-insights private package is installed, this module re-exports
-its public API. Otherwise, all functions raise HTTP 402 and INSIGHTS_AVAILABLE
-is False — the frontend hides the feature entirely.
+The insights engine lives under ee/observal_insights/ and is only available
+when DEPLOYMENT_MODE=enterprise. If not in enterprise mode, all functions
+raise RuntimeError and INSIGHTS_AVAILABLE is False — the frontend hides the
+feature entirely.
 """
 
-try:
-    import observal_insights
+from config import settings
 
-    INSIGHTS_AVAILABLE = True
-except ImportError:
-    observal_insights = None  # type: ignore[assignment]
+# Insights is only available in enterprise mode
+if settings.DEPLOYMENT_MODE == "enterprise":
+    try:
+        from ee.observal_insights import (
+            generate_report_content as _generate,
+        )
+        from ee.observal_insights import (
+            render_report_html as _render,
+        )
+
+        INSIGHTS_AVAILABLE = True
+    except ImportError:
+        INSIGHTS_AVAILABLE = False
+else:
     INSIGHTS_AVAILABLE = False
 
 
 def _not_available():
-    raise RuntimeError("Insights package is not installed. Install observal-insights to enable this feature.")
+    raise RuntimeError(
+        "Insights is an enterprise feature. "
+        "Set DEPLOYMENT_MODE=enterprise to enable."
+    )
 
 
 async def generate_report_content(*args, **kwargs):
     if not INSIGHTS_AVAILABLE:
         _not_available()
-    return await observal_insights.generate_report_content(*args, **kwargs)
+    return await _generate(*args, **kwargs)
 
 
 def render_report_html(*args, **kwargs):
     if not INSIGHTS_AVAILABLE:
         _not_available()
-    return observal_insights.render_report_html(*args, **kwargs)
+    return _render(*args, **kwargs)
 
 
 def configure_insights():
     """Wire up dependencies from the host app into the insights package.
 
-    Called once at server startup. No-op if the package isn't installed.
+    Called once at server startup. No-op if not in enterprise mode.
     """
     if not INSIGHTS_AVAILABLE:
         return
 
-    from config import settings
     from database import async_session
+    from ee.observal_insights import configure
     from models.insight_session_facets import InsightSessionFacets
     from models.insight_session_meta import InsightSessionMeta
     from services.clickhouse import _query
     from services.eval.eval_service import call_eval_model
 
-    observal_insights.configure(
+    configure(
         settings=settings,
         query_fn=_query,
         call_model_fn=call_eval_model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,11 @@ known-first-party = ["observal_cli", "models", "schemas", "services", "api", "ee
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["F841", "RUF059", "B007", "TID251"]  # unused vars, allow ee imports in tests
-"ee/*" = ["TID251"]                     # ee/ may import from itself
+"ee/*" = ["TID251"]                                     # ee/ may import from itself
+"ee/observal_insights/*" = ["TID251", "N806", "SIM108", "B905", "F841", "TCH003"]  # ported code, preserve original style
 "observal_cli/main.py" = ["E402"]       # imports after app = typer.Typer()
 "observal-server/main.py" = ["TID251"]  # main.py is the single allowed ee/ crossing point
+"observal-server/services/insights/__init__.py" = ["TID251"]  # insights loader imports from ee/
 "demo/*" = ["E402"]
 
 [tool.ruff.format]

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -59,9 +60,6 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
     "zod": "^4.3.6"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": []
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -60,6 +60,9 @@
     "vaul": "^1.1.2",
     "zod": "^4.3.6"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": []
+  },
   "devDependencies": {
     "@eslint/compat": "^2.0.5",
     "@playwright/test": "^1.59.1",


### PR DESCRIPTION
## Purpose / Description

Merges the standalone `observal-insights` package (from `BlazeUp-AI/observal-insights`) into the main Observal repo under `ee/observal_insights/`. This makes the Agent Insights engine part of the enterprise edition, covered under the EE license, and removes the need for a separate package install.

Enterprise gating is now based on `DEPLOYMENT_MODE=enterprise` environment variable rather than package availability, returning HTTP 402 for non-enterprise users.

## Fixes
* Consolidates the insights engine into the monorepo for simpler distribution and licensing

## Approach

1. **Ported all 18 modules** from `observal-insights/src/observal_insights/` into `ee/observal_insights/`
2. **Converted imports** from absolute (`from observal_insights.X`) to relative (`from .X`)
3. **Updated enterprise gating** in `observal-server/services/insights/__init__.py` to check `DEPLOYMENT_MODE == "enterprise"` instead of checking for pip package availability
4. **Simplified Docker setup** — removed the optional pip install block from `Dockerfile.api` since code is now bundled
5. **Updated `docker-compose.enterprise.yml`** — just sets the env var, no separate image needed
6. **Updated Makefile** enterprise detection to check for `ee/observal_insights/__init__.py`
7. **Added ruff per-file-ignores** for the ported code to preserve original style

The dependency injection pattern (`_deps.py` / `configure()`) is preserved — the insights package never imports from the server directly.

## How Has This Been Tested?

- Full test suite passes (2005 tests collected, all pass)
- `ruff check` passes clean on entire repo
- Import boundary enforcement verified (core cannot import from `ee/`)

## Learning (optional, can help others)

- Using ruff's `TID251` (flake8-tidy-imports banned-api) rule to enforce the ee/ import boundary at lint time
- Dependency injection via a `configure()` + module-level container avoids circular imports between ee/ and server code

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)