### PR TITLE
fix(cli): allow fallback to name check for fewer than 4 chars 

### DIFF
--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -48,7 +48,7 @@ async def _find_listing(listing_id: str, db: AsyncSession):
             listing = await resolve_prefix_id(model, listing_id, db)
             hits.append((listing_type, listing))
         except HTTPException as e:
-            if e.status_code == 400:
+            if e.status_code == 400 and "too short" not in str(e.detail):
                 raise e
             continue
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
observal admin review approve throws a 400 error for component names shorter than 4 characters because _find_listing re-raises the "prefix too short" error instead of falling through to name-based lookup.

## Fixes
* Fixes #761 

## Approach
In _find_listing, skip re-raising 400 errors that contain "too short" so the name-based fallback query is used instead.

## How Has This Been Tested?
created and submitted component with a name of 2 chars, successfully approved

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)


<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->