### PR TITLE
fix(cli): handle invalid JSON in `hook submit` handler config prompt

### DIFF
--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -15,6 +15,22 @@ from observal_cli.ide_specs.claude_code_hooks_spec import get_desired_env, get_d
 from observal_cli.prompts import select_one
 from observal_cli.render import console, kv_panel, output_json, relative_time, spinner, status_badge
 
+
+def _prompt_json(label: str) -> dict:
+    """Prompt for JSON input, re-asking on invalid input instead of crashing."""
+    while True:
+        raw = typer.prompt(label)
+        try:
+            parsed = _json.loads(raw)
+            if not isinstance(parsed, dict):
+                rprint("[red]Expected a JSON object (e.g. {\"command\": \"...\"}), got a different type.[/red]")
+                continue
+            return parsed
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid JSON:[/red] {e}")
+            rprint('[dim]  Enter a valid JSON object, e.g. {"command": "echo hello"}[/dim]')
+
+
 hook_app = typer.Typer(help="Hook registry commands")
 
 
@@ -63,7 +79,7 @@ def hook_submit(
             "owner": typer.prompt("Owner"),
             "event": select_one("Event", VALID_HOOK_EVENTS),
             "handler_type": select_one("Handler type", VALID_HOOK_HANDLER_TYPES),
-            "handler_config": _json.loads(typer.prompt("Handler config (JSON)")),
+            "handler_config": _prompt_json("Handler config (JSON)"),
         }
 
     if draft:

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -23,7 +23,7 @@ def _prompt_json(label: str) -> dict:
         try:
             parsed = _json.loads(raw)
             if not isinstance(parsed, dict):
-                rprint("[red]Expected a JSON object (e.g. {\"command\": \"...\"}), got a different type.[/red]")
+                rprint('[red]Expected a JSON object (e.g. {"command": "..."}), got a different type.[/red]')
                 continue
             return parsed
         except _json.JSONDecodeError as e:


### PR DESCRIPTION

## Purpose / Description
`observal hook submit` crashes with a raw `JSONDecodeError` traceback when the user enters invalid JSON for the "Handler config" prompt. It should re-prompt instead of exiting.

## Approach
Added a `_prompt_json()` helper that wraps the JSON input in a retry loop. On invalid input it prints an error message with an example and re-prompts. Also validates the parsed value is a JSON object (dict), not an array or scalar.

## How Has This Been Tested?

1. Ran `observal hook submit`, entered garbage text at "Handler config (JSON)" -- shows error and re-prompts
2. Entered a JSON array (`[1,2]`) -- rejects with "Expected a JSON object" and re-prompts
3. Entered a valid JSON object (`{"command": "echo hi"}`) -- proceeds normally
4. Ran `ruff check observal_cli/cmd_hook.py` -- passes clean

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

BEFORE:

<img width="1332" height="766" alt="Before" src="https://github.com/user-attachments/assets/59f34502-e768-4ab9-b755-667680b682d7" />



AFTER:

<img width="800" height="298" alt="After" src="https://github.com/user-attachments/assets/4796be4b-7c4c-4fa5-830b-a1283b51dfbf" />


