### PR TITLE
fix(web): display rate limit error properly on login page

### DIFF
--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -103,7 +103,12 @@ function LoginContent() {
       toast.success("Signed in successfully");
       router.push("/");
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "Login failed";
+      const raw = e instanceof Error ? e.message : "Login failed";
+      const status = e instanceof Error ? (e as Error & { status?: number }).status : undefined;
+      let msg = raw;
+      if (status === 429 || raw.toLowerCase().includes("rate limit")) {
+        msg = "Too many login attempts. Please wait a minute before trying again.";
+      }
       setError(msg);
       toast.error(msg);
     } finally {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -194,6 +194,7 @@ async function request<T = unknown>(
     try {
       const parsed = JSON.parse(text);
       if (parsed.detail) detail = typeof parsed.detail === "string" ? parsed.detail : JSON.stringify(parsed.detail);
+      else if (parsed.error) detail = typeof parsed.error === "string" ? parsed.error : JSON.stringify(parsed.error);
     } catch {
       // not JSON — use raw text
     }


### PR DESCRIPTION
## Purpose / Description
The login page shows raw JSON `{"error":"Rate limit exceeded: 5 per 1 minute"}` when the user hits the rate limit. It should show a readable message telling the user what happened and what to do.

## Fixes
* Fixes #<!-- no linked issue -->

## Approach
1. `api.ts`: The shared `request()` function now extracts the `error` field from JSON responses (slowapi uses `{"error": "..."}` instead of FastAPI's `{"detail": "..."}`).
2. `login/page.tsx`: Catches 429 status or rate-limit messages and shows: "Too many login attempts. Please wait a minute before trying again."

## How Has This Been Tested?

1. Started the server with `make rebuild`
2. Entered credentials and clicked Sign in rapidly 6 times within a minute
3. Verified the 6th attempt shows the friendly message instead of raw JSON

## Learning (optional, can help others)
slowapi returns `{"error": "..."}` not `{"detail": "..."}` like standard FastAPI error responses. The frontend error parser only checked for `detail`, so the raw JSON string was passed through as the error message.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)


Before:

<img width="513" height="511" alt="Before2" src="https://github.com/user-attachments/assets/6204ac02-c3bb-477b-bfa3-c82de333ad0c" />


After :

<img width="902" height="964" alt="after2" src="https://github.com/user-attachments/assets/2f1fe0c5-2246-430c-bfb6-9895cb80d849" />
