### PR TITLE
fix(registry): auto-populate Owner field in all submit forms

### DIFF
--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -60,7 +60,7 @@ def hook_submit(
             "name": typer.prompt("Hook name"),
             "version": typer.prompt("Version", default="1.0.0"),
             "description": typer.prompt("Description"),
-            "owner": typer.prompt("Owner"),
+            "owner": typer.prompt("Owner", default=config.load().get("user_name", "")),
             "event": select_one("Event", VALID_HOOK_EVENTS),
             "handler_type": select_one("Handler type", VALID_HOOK_HANDLER_TYPES),
             "handler_config": _json.loads(typer.prompt("Handler config (JSON)")),

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -440,13 +440,15 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
 
             _name = name or typer.prompt("Server name", default=_name)
             _desc = typer.prompt("Description (what does this server do?)", default="")
-            _owner = typer.prompt("Owner / Team (e.g. your GitHub username)", default="default")
+            _owner = typer.prompt(
+                "Owner / Team (e.g. your GitHub username)", default=config.load().get("user_name", "default")
+            )
             _category = category or select_one("Category", VALID_MCP_CATEGORIES, default="general")
         else:
             if dollar_vars:
                 rprint(f"\n[dim]Auto-detected {len(dollar_vars)} input variable(s) from $VAR patterns.[/dim]")
             _desc = ""
-            _owner = "default"
+            _owner = config.load().get("user_name", "") or "default"
             _category = category or "general"
 
         supported_ides = list(VALID_IDES)
@@ -616,7 +618,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         _name = name or detected_name
         _version = detected_ver
         _desc = detected_desc
-        _owner = "default"
+        _owner = config.load().get("user_name", "") or "default"
         _category = category or "general"
         if not _framework:
             _framework = "python"
@@ -712,7 +714,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         else:
             _desc = typer.prompt("Description (what does this server do?)")
 
-        _owner = typer.prompt("\nOwner / Team (e.g. your GitHub username)")
+        _owner = typer.prompt("\nOwner / Team (e.g. your GitHub username)", default=config.load().get("user_name", ""))
         rprint()
 
         _category = category or select_one("Category", VALID_MCP_CATEGORIES, default="general")

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -55,7 +55,7 @@ def prompt_submit(
                 "name": typer.prompt("Prompt name"),
                 "version": typer.prompt("Version", default="1.0.0"),
                 "description": typer.prompt("Description"),
-                "owner": typer.prompt("Owner"),
+                "owner": typer.prompt("Owner", default=config.load().get("user_name", "")),
                 "category": select_one("Category", VALID_PROMPT_CATEGORIES),
                 "template": content,
             }
@@ -64,7 +64,7 @@ def prompt_submit(
             "name": typer.prompt("Prompt name"),
             "version": typer.prompt("Version", default="1.0.0"),
             "description": typer.prompt("Description"),
-            "owner": typer.prompt("Owner"),
+            "owner": typer.prompt("Owner", default=config.load().get("user_name", "")),
             "category": select_one("Category", VALID_PROMPT_CATEGORIES),
             "template": typer.prompt("Template"),
         }

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -58,7 +58,7 @@ def sandbox_submit(
             "name": typer.prompt("Sandbox name"),
             "version": typer.prompt("Version", default="1.0.0"),
             "description": typer.prompt("Description"),
-            "owner": typer.prompt("Owner"),
+            "owner": typer.prompt("Owner", default=config.load().get("user_name", "")),
             "runtime_type": select_one("Runtime type", VALID_SANDBOX_RUNTIME_TYPES),
             "image": typer.prompt("Image"),
             "resource_limits": _json.loads(typer.prompt("Resource limits (JSON)")),

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -59,7 +59,7 @@ def skill_submit(
             "name": typer.prompt("Skill name"),
             "version": typer.prompt("Version", default="1.0.0"),
             "description": typer.prompt("Description"),
-            "owner": typer.prompt("Owner"),
+            "owner": typer.prompt("Owner", default=config.load().get("user_name", "")),
             "git_url": typer.prompt("Git URL"),
             "task_type": select_one("Task type", VALID_SKILL_TASK_TYPES),
             "target_agents": [a.strip() for a in agents_input.split(",") if a.strip()],

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -21,7 +21,7 @@ import {
 import { Info, Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
 import type { RegistryType } from "@/lib/api";
-import { useRegistryList, useMyComponents } from "@/hooks/use-api";
+import { useRegistryList, useMyComponents, useWhoami } from "@/hooks/use-api";
 
 const MCP_CATEGORIES = [
   "browser-automation", "cloud-platforms", "code-execution", "communication",
@@ -91,12 +91,15 @@ export function SubmitComponentDialog({
   editItem,
 }: SubmitComponentDialogProps) {
   const d = editItem as Record<string, unknown> | null;
+  const { data: whoami } = useWhoami();
+  const defaultOwner = (d?.owner as string) || whoami?.name || whoami?.username || whoami?.email || "";
 
   // ── Common ──────────────────────────────────────────────
   const [name, setName] = useState((d?.name as string) ?? "");
   const [version, setVersion] = useState((d?.version as string) ?? "0.1.0");
   const [description, setDescription] = useState((d?.description as string) ?? "");
-  const [owner, setOwner] = useState((d?.owner as string) ?? "");
+  const [ownerInput, setOwnerInput] = useState((d?.owner as string) ?? "");
+  const owner = ownerInput || defaultOwner;
   const [supportedIdes, setSupportedIdes] = useState<string[]>(Array.isArray(d?.supported_ides) ? d.supported_ides as string[] : []);
 
   // ── MCP ─────────────────────────────────────────────────
@@ -155,7 +158,7 @@ export function SubmitComponentDialog({
     setName("");
     setVersion("0.1.0");
     setDescription("");
-    setOwner("");
+    setOwnerInput("");
     setSupportedIdes([]);
     setCategory("general");
     setGitUrl("");
@@ -364,7 +367,7 @@ export function SubmitComponentDialog({
             <Input
               id="comp-owner"
               value={owner}
-              onChange={(e) => setOwner(e.target.value)}
+              onChange={(e) => setOwnerInput(e.target.value)}
               placeholder="your-username"
             />
           </div>


### PR DESCRIPTION
## Summary
- Auto-populate the Owner field with the logged-in user's name in the web submit dialog (MCPs, Skills, Hooks, Prompts, Sandboxes)
- Auto-populate the Owner field as the default in all CLI submit commands
- User can still override the value manually

## Test plan
- [x] Web: Open any submit dialog → Owner shows logged-in user's name
- [x] CLI: Run `observal registry sandbox submit --draft` → Owner prompt shows name in brackets, Enter accepts it
- [x] ESLint, TypeScript, and ruff checks pass clean