### PR TITLE
feat(admin): add "Create Another" button to Add User dialog

### DIFF
--- a/web/src/app/(admin)/users/page.tsx
+++ b/web/src/app/(admin)/users/page.tsx
@@ -248,7 +248,8 @@ export default function UsersPage() {
                 </div>
               </div>
               <DialogFooter>
-                <Button size="sm" onClick={closeDialog}>Done</Button>
+                <Button variant="ghost" size="sm" onClick={closeDialog}>Done</Button>
+                <Button size="sm" onClick={() => setCreatedPassword(null)}>Create Another</Button>
               </DialogFooter>
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- Add a "Create Another" button on the user creation success screen
- Allows admins to immediately create the next user without closing and reopening the dialog

## Test plan
- [x] Create a user → password screen shows "Done" and "Create Another"
- [x] Click "Create Another" → form resets, ready for next user
- [x] Click "Done" → dialog closes normally
- [x] ESLint and TypeScript pass clean