### PR TITLE
feat: per-IDE model registry with live catalog and builder picker

### DIFF
--- a/observal-server/alembic/versions/0002_models_by_ide.py
+++ b/observal-server/alembic/versions/0002_models_by_ide.py
@@ -1,0 +1,49 @@
+"""Add agent_versions.models_by_ide JSONB column for per-IDE model overrides
+
+Backs the per-IDE model picker. The author chooses default models per IDE at
+build time; the codegen reads ``models_by_ide`` first and falls back to the
+single ``model_name`` field (Claude Code legacy default) when an IDE has no
+explicit override.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-08
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent: ``main._ensure_columns`` also runs this on every startup so
+    # fresh installs created via ``Base.metadata.create_all`` already have the
+    # column. Use IF NOT EXISTS to avoid clobbering deployments that booted
+    # the new code before the migration ran.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {c["name"] for c in inspector.get_columns("agent_versions")}
+    if "models_by_ide" not in columns:
+        op.add_column(
+            "agent_versions",
+            sa.Column(
+                "models_by_ide",
+                postgresql.JSONB(astext_type=sa.Text()),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {c["name"] for c in inspector.get_columns("agent_versions")}
+    if "models_by_ide" in columns:
+        op.drop_column("agent_versions", "models_by_ide")

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -378,6 +378,13 @@ async def create_agent(
     version.required_ide_features = infer_required_features(_AgentProxy(), skill_listings=skill_listings_map)
     version.inferred_supported_ides = compute_supported_ides(version.required_ide_features)
 
+    # Flush pending AgentComponent + goal rows so the snapshot builder picks
+    # them up via its own SELECTs (the relationship cache is empty).
+    await db.flush()
+    from services.agent_snapshot import build_yaml_snapshot
+
+    version.yaml_snapshot = await build_yaml_snapshot(version, db)
+
     try:
         await db.commit()
     except IntegrityError as exc:
@@ -1476,6 +1483,11 @@ async def save_draft(
     version.required_ide_features = infer_required_features(_DraftProxy(), skill_listings=skill_listings_map_draft)
     version.inferred_supported_ides = compute_supported_ides(version.required_ide_features)
 
+    await db.flush()
+    from services.agent_snapshot import build_yaml_snapshot
+
+    version.yaml_snapshot = await build_yaml_snapshot(version, db)
+
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
     await audit(
@@ -1583,6 +1595,12 @@ async def update_draft(
         if val is not None:
             setattr(agent, field, val)
 
+    # Always rebuild the snapshot so reviewers see the latest state including
+    # per-IDE model overrides, prompt edits, and component swaps.
+    from services.agent_snapshot import build_yaml_snapshot
+
+    version.yaml_snapshot = await build_yaml_snapshot(version, db)
+
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
     if agent.status == AgentStatus.pending:
@@ -1684,6 +1702,11 @@ async def submit_draft(
     if agent.latest_version:
         flags = scan_for_gaming(agent.latest_version.prompt)
         agent.latest_version.gaming_flags = summarize_flags(flags)
+        # Defensive refresh — covers older drafts created before snapshot
+        # backfill landed and guarantees the reviewer sees current state.
+        from services.agent_snapshot import build_yaml_snapshot
+
+        agent.latest_version.yaml_snapshot = await build_yaml_snapshot(agent.latest_version, db)
 
     agent.status = AgentStatus.pending
     await db.commit()

--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -170,6 +170,7 @@ def _agent_to_response(
         "prompt",
         "model_name",
         "model_config_json",
+        "models_by_ide",
         "external_mcps",
         "supported_ides",
         "required_ide_features",
@@ -178,6 +179,10 @@ def _agent_to_response(
         "rejection_reason",
     ):
         agent_dict[field] = getattr(agent, field)
+    # Defensive: tests sometimes pass MagicMock agents that don't return real
+    # dicts for new fields. Fall back to an empty dict so AgentResponse parses.
+    if not isinstance(agent_dict.get("models_by_ide"), dict):
+        agent_dict["models_by_ide"] = {}
     agent_dict["mcp_links"] = mcp_links
     agent_dict["component_links"] = component_links
     agent_dict["goal_template"] = goal_template
@@ -298,6 +303,7 @@ async def create_agent(
         prompt=req.prompt,
         model_name=req.model_name,
         model_config_json=req.model_config_json,
+        models_by_ide=req.models_by_ide,
         external_mcps=[m.model_dump() for m in req.external_mcps],
         supported_ides=req.supported_ides,
         status=AgentStatus.pending,
@@ -726,6 +732,7 @@ async def update_agent(
         "prompt",
         "model_name",
         "model_config_json",
+        "models_by_ide",
         "supported_ides",
         "visibility",
     ):
@@ -975,8 +982,23 @@ async def install_agent(
     name_map = await _resolve_component_names(agent.components, db)
 
     from api.routes.config import derive_endpoints
+    from services.model_resolver import resolve_model_for_ide
 
     endpoints = derive_endpoints(request)
+
+    install_options: dict = dict(req.options or {})
+    raw_override = install_options.get("model") or None
+    if isinstance(raw_override, str) and raw_override.strip().lower() == "inherit":
+        raw_override = None
+    resolved_model, model_warnings = await resolve_model_for_ide(
+        req.ide,
+        model_name=getattr(agent, "model_name", "") or "",
+        models_by_ide=getattr(agent, "models_by_ide", {}) or {},
+        override=raw_override,
+    )
+    install_options["_resolved_model"] = resolved_model
+    install_options["_model_warnings"] = model_warnings
+
     snippet = generate_agent_config(
         agent,
         req.ide,
@@ -984,7 +1006,7 @@ async def install_agent(
         mcp_listings=mcp_listings_map,
         component_names=name_map,
         env_values=req.env_values,
-        options=req.options,
+        options=install_options,
         platform=req.platform,
         skill_listings=skill_listings_map,
         hook_listings=hook_listings_map,
@@ -1382,6 +1404,7 @@ async def save_draft(
         prompt=req.prompt,
         model_name=req.model_name,
         model_config_json=req.model_config_json,
+        models_by_ide=req.models_by_ide,
         external_mcps=[m.model_dump() for m in req.external_mcps],
         supported_ides=req.supported_ides,
         status=AgentStatus.draft,
@@ -1484,7 +1507,15 @@ async def update_draft(
     if not version:
         raise HTTPException(status_code=400, detail="Agent has no version to update")
 
-    for field in ("version", "description", "prompt", "model_name", "model_config_json", "supported_ides"):
+    for field in (
+        "version",
+        "description",
+        "prompt",
+        "model_name",
+        "model_config_json",
+        "models_by_ide",
+        "supported_ides",
+    ):
         val = getattr(req, field)
         if val is not None:
             setattr(version, field, val)

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -10,7 +10,6 @@ All paths are relative to /api/v1/agents (no extra prefix).
 from __future__ import annotations
 
 import difflib
-import json
 import logging
 from datetime import UTC, datetime
 
@@ -285,6 +284,17 @@ async def _create_agent_version(
     ver.required_ide_features = infer_required_features(_VersionProxy(), skill_listings=skill_listings_map)
     ver.inferred_supported_ides = compute_supported_ides(ver.required_ide_features)
 
+    # Backfill yaml_snapshot when the client didn't supply one (web builder
+    # path). Without this the reviewer's diff view is blank for everything
+    # that wasn't published from the CLI.
+    if not ver.yaml_snapshot:
+        # Flush pending AgentComponent/AgentGoalSection rows so the snapshot
+        # builder can re-query them from the session.
+        await db.flush()
+        from services.agent_snapshot import build_yaml_snapshot
+
+        ver.yaml_snapshot = await build_yaml_snapshot(ver, db)
+
     # Pre-generate IDE configs at release time (spec: no generation at request time)
     mcp_comp_ids = [c.component_id for c in req.components if c.component_type == "mcp"]
     mcp_listings_map: dict = {}
@@ -479,55 +489,18 @@ async def _get_version_diff(
     if not ver2:
         raise HTTPException(status_code=404, detail=f"Version {v2!r} not found")
 
-    # Build YAML diff text with resolved component details
-    async def _structural_text(ver: AgentVersion) -> str:
-        # Resolve component names and content from listings
-        comp_details = []
-        if ver.components:
-            from models.hook import HookListing
-            from models.mcp import McpListing
-            from models.prompt import PromptListing
-            from models.sandbox import SandboxListing
-            from models.skill import SkillListing
+    # Build YAML diff text from the snapshot, falling back to a freshly
+    # rendered snapshot for legacy versions whose yaml_snapshot was never
+    # backfilled.
+    from services.agent_snapshot import build_yaml_snapshot
 
-            listing_models = {
-                "mcp": McpListing,
-                "skill": SkillListing,
-                "hook": HookListing,
-                "prompt": PromptListing,
-                "sandbox": SandboxListing,
-            }
-            for c in ver.components:
-                model = listing_models.get(c.component_type)
-                comp_entry: dict = {"type": c.component_type}
-                if model:
-                    listing = (await db.execute(select(model).where(model.id == c.component_id))).scalar_one_or_none()
-                    if listing:
-                        comp_entry["name"] = listing.name
-                        if c.component_type == "prompt":
-                            comp_entry["template"] = getattr(listing, "template", "") or ""
-                        else:
-                            comp_entry["description"] = getattr(listing, "description", "") or ""
-                    else:
-                        comp_entry["name"] = c.component_name or str(c.component_id)[:8]
-                else:
-                    comp_entry["name"] = c.component_name or str(c.component_id)[:8]
-                comp_details.append(comp_entry)
+    async def _snapshot_text(ver: AgentVersion) -> str:
+        if ver.yaml_snapshot:
+            return ver.yaml_snapshot
+        return await build_yaml_snapshot(ver, db)
 
-        data = {
-            "description": ver.description,
-            "prompt": ver.prompt,
-            "model_name": ver.model_name,
-            "model_config_json": ver.model_config_json,
-            "models_by_ide": ver.models_by_ide or {},
-            "supported_ides": ver.supported_ides,
-            "external_mcps": ver.external_mcps,
-            "components": comp_details,
-        }
-        return json.dumps(data, indent=2, default=str)
-
-    text1 = ver1.yaml_snapshot if ver1.yaml_snapshot is not None else await _structural_text(ver1)
-    text2 = ver2.yaml_snapshot if ver2.yaml_snapshot is not None else await _structural_text(ver2)
+    text1 = await _snapshot_text(ver1)
+    text2 = await _snapshot_text(ver2)
 
     yaml_diff = "\n".join(
         line.rstrip("\n")

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -75,6 +75,7 @@ def _version_to_detail(ver: AgentVersion) -> dict:
             "prompt": ver.prompt,
             "model_name": ver.model_name,
             "model_config_json": ver.model_config_json,
+            "models_by_ide": ver.models_by_ide or {},
             "external_mcps": ver.external_mcps,
             "yaml_snapshot": ver.yaml_snapshot,
             "ide_configs": ver.ide_configs,
@@ -226,6 +227,7 @@ async def _create_agent_version(
         prompt=req.prompt,
         model_name=req.model_name,
         model_config_json=req.model_config_json,
+        models_by_ide=req.models_by_ide,
         external_mcps=[m.model_dump() for m in req.external_mcps] if req.external_mcps else [],
         supported_ides=req.supported_ides,
         yaml_snapshot=req.yaml_snapshot,
@@ -295,9 +297,22 @@ async def _create_agent_version(
     # but supported_ides is authoritative for which configs to generate.
     ide_configs: dict = {}
     failed_ides: list[str] = []
+    from services.model_resolver import resolve_model_for_ide
+
     for ide in ver.supported_ides or []:
         try:
-            ide_configs[ide] = generate_agent_config(ver, ide, mcp_listings=mcp_listings_map)
+            resolved_model, model_warnings = await resolve_model_for_ide(
+                ide,
+                model_name=ver.model_name or "",
+                models_by_ide=ver.models_by_ide or {},
+                override=None,
+            )
+            ide_configs[ide] = generate_agent_config(
+                ver,
+                ide,
+                mcp_listings=mcp_listings_map,
+                options={"_resolved_model": resolved_model, "_model_warnings": model_warnings},
+            )
         except Exception:
             logger.exception(
                 "IDE config generation failed for agent=%s version=%s ide=%s", agent.name, req.version, ide
@@ -504,6 +519,7 @@ async def _get_version_diff(
             "prompt": ver.prompt,
             "model_name": ver.model_name,
             "model_config_json": ver.model_config_json,
+            "models_by_ide": ver.models_by_ide or {},
             "supported_ides": ver.supported_ides,
             "external_mcps": ver.external_mcps,
             "components": comp_details,

--- a/observal-server/api/routes/registry_models.py
+++ b/observal-server/api/routes/registry_models.py
@@ -1,0 +1,86 @@
+"""Public model catalog endpoints + admin refresh.
+
+The catalog itself lives in ``services.model_catalog``. This route layer adds:
+
+* HTTP caching headers (Cache-Control, ETag, If-None-Match) so the frontend
+  TanStack Query hook + nginx + browser cache can short-circuit requests.
+* Admin-only force refresh (rate-limited) that returns a diff for the
+  diagnostics widget.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Header, Request, Response, status
+
+from api.deps import get_current_user, require_role
+from api.ratelimit import limiter
+from models.user import User, UserRole
+from schemas.models import Catalog
+from services.model_catalog import diff_against_current, get_catalog
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["models"])
+
+
+@router.get("/models", response_model=Catalog)
+@limiter.limit("60/minute")
+async def list_models(
+    request: Request,
+    response: Response,
+    if_none_match: str | None = Header(default=None, alias="If-None-Match"),
+    current_user: User = Depends(get_current_user),
+):
+    """Return the normalized model catalog.
+
+    Conditional GET: when the client sends ``If-None-Match: <etag>`` and the
+    catalog hasn't changed, we respond ``304 Not Modified`` with the same
+    ``ETag`` so the client keeps its cached copy.
+    """
+    catalog = await get_catalog()
+
+    response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=3600"
+    if catalog.etag:
+        response.headers["ETag"] = catalog.etag
+    response.headers["X-Catalog-Source"] = catalog.source
+    response.headers["X-Catalog-Degraded"] = "1" if catalog.degraded else "0"
+
+    if catalog.etag and if_none_match and if_none_match.strip() == catalog.etag:
+        return Response(
+            status_code=status.HTTP_304_NOT_MODIFIED,
+            headers={
+                "ETag": catalog.etag,
+                "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+                "X-Catalog-Source": catalog.source,
+                "X-Catalog-Degraded": "1" if catalog.degraded else "0",
+            },
+        )
+
+    return catalog
+
+
+@router.post("/admin/models/refresh")
+@limiter.limit("4/minute")
+async def refresh_models(
+    request: Request,
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Force a fresh fetch of models.dev and report what changed.
+
+    Heavy, rate-limited (4/min/IP) so it can't be used to hammer the upstream.
+    """
+    prev = await get_catalog()
+    diff = await diff_against_current(prev)
+    new = await get_catalog()
+    return {
+        "ok": True,
+        "diff": diff,
+        "fetched_at": new.fetched_at.isoformat(),
+        "source": new.source,
+        "degraded": new.degraded,
+        "model_count": new.model_count,
+        "etag": new.etag,
+        "upstream_etag": new.upstream_etag,
+    }

--- a/observal-server/data/model_registry_seed.json
+++ b/observal-server/data/model_registry_seed.json
@@ -1,0 +1,5320 @@
+{
+  "anthropic": {
+    "doc": "https://docs.anthropic.com/en/docs/about-claude/models",
+    "env": [
+      "ANTHROPIC_API_KEY"
+    ],
+    "id": "anthropic",
+    "models": {
+      "claude-3-5-haiku-20241022": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.08,
+          "cache_write": 1,
+          "input": 0.8,
+          "output": 4
+        },
+        "family": "claude-haiku",
+        "id": "claude-3-5-haiku-20241022",
+        "knowledge": "2024-07-31",
+        "last_updated": "2024-10-22",
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 3.5",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-10-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-5-haiku-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.08,
+          "cache_write": 1,
+          "input": 0.8,
+          "output": 4
+        },
+        "family": "claude-haiku",
+        "id": "claude-3-5-haiku-latest",
+        "knowledge": "2024-07-31",
+        "last_updated": "2024-10-22",
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 3.5 (latest)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-10-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-5-sonnet-20240620": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-3-5-sonnet-20240620",
+        "knowledge": "2024-04-30",
+        "last_updated": "2024-06-20",
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 3.5",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-06-20",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-5-sonnet-20241022": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-3-5-sonnet-20241022",
+        "knowledge": "2024-04-30",
+        "last_updated": "2024-10-22",
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 3.5 v2",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-10-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-7-sonnet-20250219": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-3-7-sonnet-20250219",
+        "knowledge": "2024-10-31",
+        "last_updated": "2025-02-19",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 3.7",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-02-19",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-haiku-20240307": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.03,
+          "cache_write": 0.3,
+          "input": 0.25,
+          "output": 1.25
+        },
+        "family": "claude-haiku",
+        "id": "claude-3-haiku-20240307",
+        "knowledge": "2023-08-31",
+        "last_updated": "2024-03-13",
+        "limit": {
+          "context": 200000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 3",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-03-13",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-opus-20240229": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "claude-3-opus-20240229",
+        "knowledge": "2023-08-31",
+        "last_updated": "2024-02-29",
+        "limit": {
+          "context": 200000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 3",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-02-29",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-sonnet-20240229": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 0.3,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-3-sonnet-20240229",
+        "knowledge": "2023-08-31",
+        "last_updated": "2024-03-04",
+        "limit": {
+          "context": 200000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 3",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-03-04",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-haiku-4-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "family": "claude-haiku",
+        "id": "claude-haiku-4-5",
+        "knowledge": "2025-02-28",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 4.5 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-15",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-haiku-4-5-20251001": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "family": "claude-haiku",
+        "id": "claude-haiku-4-5-20251001",
+        "knowledge": "2025-02-28",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 4.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-15",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-0": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-0",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-05-22",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-1",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.1 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-1-20250805": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-1-20250805",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-20250514": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-20250514",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-05-22",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-5",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-11-24",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.5 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-24",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-5-20251101": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-5-20251101",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-11-01",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-6": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 3,
+                "cache_write": 37.5,
+                "input": 30,
+                "output": 150
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-6",
+        "knowledge": "2025-05-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-7": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-7",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-04-16",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.7",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-16",
+        "temperature": false,
+        "tool_call": true
+      },
+      "claude-sonnet-4-0": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-0",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-05-22",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-sonnet-4-20250514": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-20250514",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-05-22",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-sonnet-4-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-5",
+        "knowledge": "2025-07-31",
+        "last_updated": "2025-09-29",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.5 (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-29",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-sonnet-4-5-20250929": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-5-20250929",
+        "knowledge": "2025-07-31",
+        "last_updated": "2025-09-29",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-29",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-sonnet-4-6": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-6",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.6",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-17",
+        "temperature": true,
+        "tool_call": true
+      }
+    },
+    "name": "Anthropic",
+    "npm": "@ai-sdk/anthropic"
+  },
+  "google": {
+    "doc": "https://ai.google.dev/gemini-api/docs/pricing",
+    "env": [
+      "GOOGLE_GENERATIVE_AI_API_KEY",
+      "GEMINI_API_KEY"
+    ],
+    "id": "google",
+    "models": {
+      "gemini-1.5-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.01875,
+          "input": 0.075,
+          "output": 0.3
+        },
+        "family": "gemini-flash",
+        "id": "gemini-1.5-flash",
+        "knowledge": "2024-04",
+        "last_updated": "2024-05-14",
+        "limit": {
+          "context": 1000000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 1.5 Flash",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-05-14",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-1.5-flash-8b": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.01,
+          "input": 0.0375,
+          "output": 0.15
+        },
+        "family": "gemini-flash",
+        "id": "gemini-1.5-flash-8b",
+        "knowledge": "2024-04",
+        "last_updated": "2024-10-03",
+        "limit": {
+          "context": 1000000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 1.5 Flash-8B",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-10-03",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-1.5-pro": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3125,
+          "input": 1.25,
+          "output": 5
+        },
+        "family": "gemini-pro",
+        "id": "gemini-1.5-pro",
+        "knowledge": "2024-04",
+        "last_updated": "2024-02-15",
+        "limit": {
+          "context": 1000000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 1.5 Pro",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-02-15",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.0-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.0-flash",
+        "knowledge": "2024-06",
+        "last_updated": "2024-12-11",
+        "limit": {
+          "context": 1048576,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.0 Flash",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-12-11",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.0-flash-lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.075,
+          "output": 0.3
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-2.0-flash-lite",
+        "knowledge": "2024-06",
+        "last_updated": "2024-12-11",
+        "limit": {
+          "context": 1048576,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.0 Flash Lite",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-12-11",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.03,
+          "input": 0.3,
+          "input_audio": 1,
+          "output": 2.5
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-image": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "input": 0.3,
+          "output": 30
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-image",
+        "knowledge": "2025-06",
+        "last_updated": "2025-08-26",
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Image",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-26",
+        "temperature": true,
+        "tool_call": false
+      },
+      "gemini-2.5-flash-image-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "input": 0.3,
+          "output": 30
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-image-preview",
+        "knowledge": "2025-06",
+        "last_updated": "2025-08-26",
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Image (Preview)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-26",
+        "temperature": true,
+        "tool_call": false
+      },
+      "gemini-2.5-flash-lite": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-2.5-flash-lite",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-lite-preview-06-17": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "input_audio": 0.3,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-2.5-flash-lite-preview-06-17",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Lite Preview 06-17",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-lite-preview-09-2025": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-2.5-flash-lite-preview-09-2025",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Lite Preview 09-25",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-preview-04-17": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.0375,
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-preview-04-17",
+        "knowledge": "2025-01",
+        "last_updated": "2025-04-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Preview 04-17",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-04-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-preview-05-20": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.0375,
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-preview-05-20",
+        "knowledge": "2025-01",
+        "last_updated": "2025-05-20",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Preview 05-20",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-preview-09-2025": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "input": 0.3,
+          "input_audio": 1,
+          "output": 2.5
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-preview-09-2025",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Preview 09-25",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-preview-tts": {
+        "attachment": false,
+        "cost": {
+          "input": 0.5,
+          "output": 10
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-preview-tts",
+        "knowledge": "2025-01",
+        "last_updated": "2025-05-01",
+        "limit": {
+          "context": 8000,
+          "output": 16000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "audio"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Preview TTS",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-05-01",
+        "temperature": false,
+        "tool_call": false
+      },
+      "gemini-2.5-pro": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "context_over_200k": {
+            "cache_read": 0.25,
+            "input": 2.5,
+            "output": 15
+          },
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gemini-pro",
+        "id": "gemini-2.5-pro",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-pro-preview-05-06": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.31,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gemini-pro",
+        "id": "gemini-2.5-pro-preview-05-06",
+        "knowledge": "2025-01",
+        "last_updated": "2025-05-06",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Pro Preview 05-06",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-06",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-pro-preview-06-05": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.31,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gemini-pro",
+        "id": "gemini-2.5-pro-preview-06-05",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Pro Preview 06-05",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-05",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-pro-preview-tts": {
+        "attachment": false,
+        "cost": {
+          "input": 1,
+          "output": 20
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-pro-preview-tts",
+        "knowledge": "2025-01",
+        "last_updated": "2025-05-01",
+        "limit": {
+          "context": 8000,
+          "output": 16000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "audio"
+          ]
+        },
+        "name": "Gemini 2.5 Pro Preview TTS",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-05-01",
+        "temperature": false,
+        "tool_call": false
+      },
+      "gemini-3-flash-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.05,
+          "context_over_200k": {
+            "cache_read": 0.05,
+            "input": 0.5,
+            "output": 3
+          },
+          "input": 0.5,
+          "output": 3
+        },
+        "family": "gemini-flash",
+        "id": "gemini-3-flash-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-12-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3 Flash Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3-pro-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12
+        },
+        "family": "gemini-pro",
+        "id": "gemini-3-pro-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-11-18",
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3 Pro Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-18",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3.1-flash-image-preview": {
+        "attachment": true,
+        "cost": {
+          "input": 0.25,
+          "output": 60
+        },
+        "family": "gemini-flash",
+        "id": "gemini-3.1-flash-image-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-26",
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "name": "Gemini 3.1 Flash Image (Preview)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-26",
+        "temperature": true,
+        "tool_call": false
+      },
+      "gemini-3.1-flash-lite": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "cache_write": 1,
+          "input": 0.25,
+          "output": 1.5
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-3.1-flash-lite",
+        "knowledge": "2025-01",
+        "last_updated": "2026-05-07",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Flash Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-05-07",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3.1-flash-lite-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "cache_write": 1,
+          "input": 0.25,
+          "output": 1.5
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-3.1-flash-lite-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Flash Lite Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-03",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3.1-pro-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12
+        },
+        "family": "gemini-pro",
+        "id": "gemini-3.1-pro-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-19",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Pro Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-19",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3.1-pro-preview-customtools": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12
+        },
+        "family": "gemini-pro",
+        "id": "gemini-3.1-pro-preview-customtools",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-19",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-19",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-embedding-001": {
+        "attachment": false,
+        "cost": {
+          "input": 0.15,
+          "output": 0
+        },
+        "family": "gemini",
+        "id": "gemini-embedding-001",
+        "knowledge": "2025-05",
+        "last_updated": "2025-05-20",
+        "limit": {
+          "context": 2048,
+          "output": 3072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Embedding 001",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-05-20",
+        "temperature": false,
+        "tool_call": false
+      },
+      "gemini-flash-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "input": 0.3,
+          "input_audio": 1,
+          "output": 2.5
+        },
+        "family": "gemini-flash",
+        "id": "gemini-flash-latest",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Flash Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-flash-lite-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-flash-lite-latest",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Flash-Lite Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-live-2.5-flash": {
+        "attachment": true,
+        "cost": {
+          "input": 0.5,
+          "input_audio": 3,
+          "output": 2,
+          "output_audio": 12
+        },
+        "family": "gemini-flash",
+        "id": "gemini-live-2.5-flash",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-01",
+        "limit": {
+          "context": 128000,
+          "output": 8000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text",
+            "audio"
+          ]
+        },
+        "name": "Gemini Live 2.5 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-live-2.5-flash-preview-native-audio": {
+        "attachment": false,
+        "cost": {
+          "input": 0.5,
+          "input_audio": 3,
+          "output": 2,
+          "output_audio": 12
+        },
+        "family": "gemini-flash",
+        "id": "gemini-live-2.5-flash-preview-native-audio",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-18",
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text",
+            "audio"
+          ]
+        },
+        "name": "Gemini Live 2.5 Flash Preview Native Audio",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-17",
+        "temperature": false,
+        "tool_call": true
+      },
+      "gemma-3-12b-it": {
+        "attachment": true,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "gemma",
+        "id": "gemma-3-12b-it",
+        "knowledge": "2024-10",
+        "last_updated": "2025-03-13",
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 3 12B",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-03-13",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": false
+      },
+      "gemma-3-27b-it": {
+        "attachment": true,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "gemma",
+        "id": "gemma-3-27b-it",
+        "knowledge": "2024-10",
+        "last_updated": "2025-03-12",
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 3 27B",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-03-12",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemma-3-4b-it": {
+        "attachment": true,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "gemma",
+        "id": "gemma-3-4b-it",
+        "knowledge": "2024-10",
+        "last_updated": "2025-03-13",
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 3 4B",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-03-13",
+        "temperature": true,
+        "tool_call": false
+      },
+      "gemma-3n-e2b-it": {
+        "attachment": true,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "gemma",
+        "id": "gemma-3n-e2b-it",
+        "knowledge": "2024-10",
+        "last_updated": "2025-07-09",
+        "limit": {
+          "context": 8192,
+          "output": 2000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 3n 2B",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-07-09",
+        "temperature": true,
+        "tool_call": false
+      },
+      "gemma-3n-e4b-it": {
+        "attachment": true,
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "family": "gemma",
+        "id": "gemma-3n-e4b-it",
+        "knowledge": "2024-10",
+        "last_updated": "2025-05-20",
+        "limit": {
+          "context": 8192,
+          "output": 2000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 3n 4B",
+        "open_weights": true,
+        "reasoning": false,
+        "release_date": "2025-05-20",
+        "temperature": true,
+        "tool_call": false
+      },
+      "gemma-4-26b-a4b-it": {
+        "attachment": false,
+        "family": "gemma",
+        "id": "gemma-4-26b-a4b-it",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 256000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 26B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemma-4-31b-it": {
+        "attachment": false,
+        "family": "gemma",
+        "id": "gemma-4-31b-it",
+        "last_updated": "2026-04-02",
+        "limit": {
+          "context": 256000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemma 4 31B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2026-04-02",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      }
+    },
+    "name": "Google",
+    "npm": "@ai-sdk/google"
+  },
+  "google-vertex": {
+    "doc": "https://cloud.google.com/vertex-ai/generative-ai/docs/models",
+    "env": [
+      "GOOGLE_VERTEX_PROJECT",
+      "GOOGLE_VERTEX_LOCATION",
+      "GOOGLE_APPLICATION_CREDENTIALS"
+    ],
+    "id": "google-vertex",
+    "models": {
+      "claude-3-5-haiku@20241022": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.08,
+          "cache_write": 1,
+          "input": 0.8,
+          "output": 4
+        },
+        "family": "claude-haiku",
+        "id": "claude-3-5-haiku@20241022",
+        "knowledge": "2024-07-31",
+        "last_updated": "2024-10-22",
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 3.5",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": false,
+        "release_date": "2024-10-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-5-sonnet@20241022": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-3-5-sonnet@20241022",
+        "knowledge": "2024-04-30",
+        "last_updated": "2024-10-22",
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 3.5 v2",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": false,
+        "release_date": "2024-10-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-3-7-sonnet@20250219": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-3-7-sonnet@20250219",
+        "knowledge": "2024-10-31",
+        "last_updated": "2025-02-19",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 3.7",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2025-02-19",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-haiku-4-5@20251001": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "family": "claude-haiku",
+        "id": "claude-haiku-4-5@20251001",
+        "knowledge": "2025-02-28",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Haiku 4.5",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2025-10-15",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-1@20250805": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-1@20250805",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.1",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2025-08-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-5@20251101": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-5@20251101",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-11-01",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.5",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2025-11-01",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-6@default": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "context_over_200k": {
+            "cache_read": 1,
+            "cache_write": 12.5,
+            "input": 10,
+            "output": 37.5
+          },
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-6@default",
+        "knowledge": "2025-05-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.6",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2026-02-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-opus-4-7@default": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "context_over_200k": {
+            "cache_read": 1,
+            "cache_write": 12.5,
+            "input": 10,
+            "output": 37.5
+          },
+          "input": 5,
+          "output": 25
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4-7@default",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-04-16",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4.7",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2026-04-16",
+        "temperature": false,
+        "tool_call": true
+      },
+      "claude-opus-4@20250514": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "family": "claude-opus",
+        "id": "claude-opus-4@20250514",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-05-22",
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Opus 4",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-sonnet-4-5@20250929": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-5@20250929",
+        "knowledge": "2025-07-31",
+        "last_updated": "2025-09-29",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.5",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2025-09-29",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-sonnet-4-6@default": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "context_over_200k": {
+            "cache_read": 0.6,
+            "cache_write": 7.5,
+            "input": 6,
+            "output": 22.5
+          },
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4-6@default",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-13",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4.6",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2026-02-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "claude-sonnet-4@20250514": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "family": "claude-sonnet",
+        "id": "claude-sonnet-4@20250514",
+        "knowledge": "2025-03-31",
+        "last_updated": "2025-05-22",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Claude Sonnet 4",
+        "open_weights": false,
+        "provider": {
+          "npm": "@ai-sdk/google-vertex/anthropic"
+        },
+        "reasoning": true,
+        "release_date": "2025-05-22",
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-ai/deepseek-v3.1-maas": {
+        "attachment": false,
+        "cost": {
+          "input": 0.6,
+          "output": 1.7
+        },
+        "family": "deepseek",
+        "id": "deepseek-ai/deepseek-v3.1-maas",
+        "last_updated": "2025-08-28",
+        "limit": {
+          "context": 163840,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V3.1",
+        "open_weights": true,
+        "provider": {
+          "api": "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2025-08-28",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "deepseek-ai/deepseek-v3.2-maas": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.056,
+          "input": 0.56,
+          "output": 1.68
+        },
+        "family": "deepseek",
+        "id": "deepseek-ai/deepseek-v3.2-maas",
+        "last_updated": "2026-04-04",
+        "limit": {
+          "context": 163840,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "DeepSeek V3.2",
+        "open_weights": true,
+        "provider": {
+          "api": "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2025-12-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.0-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.0-flash",
+        "knowledge": "2024-06",
+        "last_updated": "2024-12-11",
+        "limit": {
+          "context": 1048576,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.0 Flash",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-12-11",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.0-flash-lite": {
+        "attachment": true,
+        "cost": {
+          "input": 0.075,
+          "output": 0.3
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-2.0-flash-lite",
+        "knowledge": "2024-06",
+        "last_updated": "2024-12-11",
+        "limit": {
+          "context": 1048576,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.0 Flash Lite",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-12-11",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "cache_write": 0.383,
+          "input": 0.3,
+          "output": 2.5
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-lite": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-2.5-flash-lite",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Lite",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-lite-preview-06-17": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-2.5-flash-lite-preview-06-17",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-17",
+        "limit": {
+          "context": 65536,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Lite Preview 06-17",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-lite-preview-09-2025": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-2.5-flash-lite-preview-09-2025",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Lite Preview 09-25",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-preview-04-17": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.0375,
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-preview-04-17",
+        "knowledge": "2025-01",
+        "last_updated": "2025-04-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Preview 04-17",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-04-17",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-preview-05-20": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.0375,
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-preview-05-20",
+        "knowledge": "2025-01",
+        "last_updated": "2025-05-20",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Preview 05-20",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-20",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-flash-preview-09-2025": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "cache_write": 0.383,
+          "input": 0.3,
+          "output": 2.5
+        },
+        "family": "gemini-flash",
+        "id": "gemini-2.5-flash-preview-09-2025",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Flash Preview 09-25",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-pro": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "context_over_200k": {
+            "cache_read": 0.25,
+            "input": 2.5,
+            "output": 15
+          },
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gemini-pro",
+        "id": "gemini-2.5-pro",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-20",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-pro-preview-05-06": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.31,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gemini-pro",
+        "id": "gemini-2.5-pro-preview-05-06",
+        "knowledge": "2025-01",
+        "last_updated": "2025-05-06",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Pro Preview 05-06",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-05-06",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-2.5-pro-preview-06-05": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.31,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gemini-pro",
+        "id": "gemini-2.5-pro-preview-06-05",
+        "knowledge": "2025-01",
+        "last_updated": "2025-06-05",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 2.5 Pro Preview 06-05",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3-flash-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.05,
+          "context_over_200k": {
+            "cache_read": 0.05,
+            "input": 0.5,
+            "output": 3
+          },
+          "input": 0.5,
+          "output": 3
+        },
+        "family": "gemini-flash",
+        "id": "gemini-3-flash-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-12-17",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3 Flash Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3-pro-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12
+        },
+        "family": "gemini-pro",
+        "id": "gemini-3-pro-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2025-11-18",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3 Pro Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-18",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3.1-flash-lite-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "cache_write": 1,
+          "input": 0.25,
+          "output": 1.5
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-3.1-flash-lite-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Flash Lite Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-03",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3.1-pro-preview": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12
+        },
+        "family": "gemini-pro",
+        "id": "gemini-3.1-pro-preview",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-19",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Pro Preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-19",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-3.1-pro-preview-customtools": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "cache_read": 0.4,
+            "input": 4,
+            "output": 18
+          },
+          "input": 2,
+          "output": 12
+        },
+        "family": "gemini-pro",
+        "id": "gemini-3.1-pro-preview-customtools",
+        "knowledge": "2025-01",
+        "last_updated": "2026-02-19",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-19",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-embedding-001": {
+        "attachment": false,
+        "cost": {
+          "input": 0.15,
+          "output": 0
+        },
+        "family": "gemini",
+        "id": "gemini-embedding-001",
+        "knowledge": "2025-05",
+        "last_updated": "2025-05-20",
+        "limit": {
+          "context": 2048,
+          "output": 3072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Embedding 001",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-05-20",
+        "temperature": false,
+        "tool_call": false
+      },
+      "gemini-flash-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "cache_write": 0.383,
+          "input": 0.3,
+          "output": 2.5
+        },
+        "family": "gemini-flash",
+        "id": "gemini-flash-latest",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Flash Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "temperature": true,
+        "tool_call": true
+      },
+      "gemini-flash-lite-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gemini-flash-lite",
+        "id": "gemini-flash-lite-latest",
+        "knowledge": "2025-01",
+        "last_updated": "2025-09-25",
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Gemini Flash-Lite Latest",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-25",
+        "temperature": true,
+        "tool_call": true
+      },
+      "meta/llama-3.3-70b-instruct-maas": {
+        "attachment": false,
+        "cost": {
+          "input": 0.72,
+          "output": 0.72
+        },
+        "family": "llama",
+        "id": "meta/llama-3.3-70b-instruct-maas",
+        "knowledge": "2023-12",
+        "last_updated": "2025-04-29",
+        "limit": {
+          "context": 128000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Llama 3.3 70B Instruct",
+        "open_weights": true,
+        "provider": {
+          "api": "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": false,
+        "release_date": "2025-04-29",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "meta/llama-4-maverick-17b-128e-instruct-maas": {
+        "attachment": true,
+        "cost": {
+          "input": 0.35,
+          "output": 1.15
+        },
+        "family": "llama",
+        "id": "meta/llama-4-maverick-17b-128e-instruct-maas",
+        "knowledge": "2024-08",
+        "last_updated": "2025-04-29",
+        "limit": {
+          "context": 524288,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Llama 4 Maverick 17B 128E Instruct",
+        "open_weights": true,
+        "provider": {
+          "api": "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": false,
+        "release_date": "2025-04-29",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "moonshotai/kimi-k2-thinking-maas": {
+        "attachment": false,
+        "cost": {
+          "input": 0.6,
+          "output": 2.5
+        },
+        "family": "kimi-thinking",
+        "id": "moonshotai/kimi-k2-thinking-maas",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2024-08",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Kimi K2 Thinking",
+        "open_weights": true,
+        "provider": {
+          "api": "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-oss-120b-maas": {
+        "attachment": false,
+        "cost": {
+          "input": 0.09,
+          "output": 0.36
+        },
+        "family": "gpt-oss",
+        "id": "openai/gpt-oss-120b-maas",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT OSS 120B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-08-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai/gpt-oss-20b-maas": {
+        "attachment": false,
+        "cost": {
+          "input": 0.07,
+          "output": 0.25
+        },
+        "family": "gpt-oss",
+        "id": "openai/gpt-oss-20b-maas",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT OSS 20B",
+        "open_weights": true,
+        "reasoning": true,
+        "release_date": "2025-08-05",
+        "temperature": true,
+        "tool_call": true
+      },
+      "qwen/qwen3-235b-a22b-instruct-2507-maas": {
+        "attachment": false,
+        "cost": {
+          "input": 0.22,
+          "output": 0.88
+        },
+        "family": "qwen",
+        "id": "qwen/qwen3-235b-a22b-instruct-2507-maas",
+        "last_updated": "2025-08-13",
+        "limit": {
+          "context": 262144,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "Qwen3 235B A22B Instruct",
+        "open_weights": true,
+        "provider": {
+          "api": "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2025-08-13",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "zai-org/glm-4.7-maas": {
+        "attachment": false,
+        "cost": {
+          "input": 0.6,
+          "output": 2.2
+        },
+        "family": "glm",
+        "id": "zai-org/glm-4.7-maas",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "knowledge": "2025-04",
+        "last_updated": "2026-01-06",
+        "limit": {
+          "context": 200000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-4.7",
+        "open_weights": true,
+        "provider": {
+          "api": "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2026-01-06",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "zai-org/glm-5-maas": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.1,
+          "input": 1,
+          "output": 3.2
+        },
+        "family": "glm",
+        "id": "zai-org/glm-5-maas",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "last_updated": "2026-02-11",
+        "limit": {
+          "context": 202752,
+          "output": 131072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GLM-5",
+        "open_weights": true,
+        "provider": {
+          "api": "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi",
+          "npm": "@ai-sdk/openai-compatible"
+        },
+        "reasoning": true,
+        "release_date": "2026-02-11",
+        "temperature": true,
+        "tool_call": true
+      }
+    },
+    "name": "Vertex",
+    "npm": "@ai-sdk/google-vertex"
+  },
+  "openai": {
+    "doc": "https://platform.openai.com/docs/models",
+    "env": [
+      "OPENAI_API_KEY"
+    ],
+    "id": "openai",
+    "models": {
+      "chatgpt-image-latest": {
+        "attachment": true,
+        "family": "gpt-image",
+        "id": "chatgpt-image-latest",
+        "last_updated": "2025-12-16",
+        "limit": {
+          "context": 0,
+          "input": 0,
+          "output": 0
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "name": "chatgpt-image-latest",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-12-16",
+        "temperature": false,
+        "tool_call": false
+      },
+      "gpt-3.5-turbo": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 1.25,
+          "input": 0.5,
+          "output": 1.5
+        },
+        "family": "gpt",
+        "id": "gpt-3.5-turbo",
+        "knowledge": "2021-09-01",
+        "last_updated": "2023-11-06",
+        "limit": {
+          "context": 16385,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-3.5-turbo",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2023-03-01",
+        "structured_output": false,
+        "temperature": true,
+        "tool_call": false
+      },
+      "gpt-4": {
+        "attachment": true,
+        "cost": {
+          "input": 30,
+          "output": 60
+        },
+        "family": "gpt",
+        "id": "gpt-4",
+        "knowledge": "2023-11",
+        "last_updated": "2024-04-09",
+        "limit": {
+          "context": 8192,
+          "output": 8192
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2023-11-06",
+        "structured_output": false,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4-turbo": {
+        "attachment": true,
+        "cost": {
+          "input": 10,
+          "output": 30
+        },
+        "family": "gpt",
+        "id": "gpt-4-turbo",
+        "knowledge": "2023-12",
+        "last_updated": "2024-04-09",
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4 Turbo",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2023-11-06",
+        "structured_output": false,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4.1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "input": 2,
+          "output": 8
+        },
+        "family": "gpt",
+        "id": "gpt-4.1",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4.1-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "input": 0.4,
+          "output": 1.6
+        },
+        "family": "gpt-mini",
+        "id": "gpt-4.1-mini",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1 mini",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4.1-nano": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.03,
+          "input": 0.1,
+          "output": 0.4
+        },
+        "family": "gpt-nano",
+        "id": "gpt-4.1-nano",
+        "knowledge": "2024-04",
+        "last_updated": "2025-04-14",
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4.1 nano",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-14",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4o": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.25,
+          "input": 2.5,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "gpt-4o",
+        "knowledge": "2023-09",
+        "last_updated": "2024-08-06",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-05-13",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4o-2024-05-13": {
+        "attachment": true,
+        "cost": {
+          "input": 5,
+          "output": 15
+        },
+        "family": "gpt",
+        "id": "gpt-4o-2024-05-13",
+        "knowledge": "2023-09",
+        "last_updated": "2024-05-13",
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o (2024-05-13)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-05-13",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4o-2024-08-06": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.25,
+          "input": 2.5,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "gpt-4o-2024-08-06",
+        "knowledge": "2023-09",
+        "last_updated": "2024-08-06",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o (2024-08-06)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-08-06",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4o-2024-11-20": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.25,
+          "input": 2.5,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "gpt-4o-2024-11-20",
+        "knowledge": "2023-09",
+        "last_updated": "2024-11-20",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o (2024-11-20)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-11-20",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-4o-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.08,
+          "input": 0.15,
+          "output": 0.6
+        },
+        "family": "gpt-mini",
+        "id": "gpt-4o-mini",
+        "knowledge": "2023-09",
+        "last_updated": "2024-07-18",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-4o mini",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-07-18",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "gpt-5",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5-chat-latest": {
+        "attachment": true,
+        "cost": {
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5-chat-latest",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Chat (latest)",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": false
+      },
+      "gpt-5-codex": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5-codex",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-09-15",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5-Codex",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-09-15",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 2
+        },
+        "family": "gpt-mini",
+        "id": "gpt-5-mini",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5-nano": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.005,
+          "input": 0.05,
+          "output": 0.4
+        },
+        "family": "gpt-nano",
+        "id": "gpt-5-nano",
+        "knowledge": "2024-05-30",
+        "last_updated": "2025-08-07",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Nano",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-08-07",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5-pro": {
+        "attachment": true,
+        "cost": {
+          "input": 15,
+          "output": 120
+        },
+        "family": "gpt-pro",
+        "id": "gpt-5-pro",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-10-06",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 272000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-10-06",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.13,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt",
+        "id": "gpt-5.1",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.1-chat-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5.1-chat-latest",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1 Chat",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.1-codex": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5.1-codex",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1 Codex",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.1-codex-max": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.125,
+          "input": 1.25,
+          "output": 10
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5.1-codex-max",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1 Codex Max",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.1-codex-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.025,
+          "input": 0.25,
+          "output": 2
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5.1-codex-mini",
+        "knowledge": "2024-09-30",
+        "last_updated": "2025-11-13",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.1 Codex mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-11-13",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.2": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt",
+        "id": "gpt-5.2",
+        "knowledge": "2025-08-31",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.2",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.2-chat-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5.2-chat-latest",
+        "knowledge": "2025-08-31",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.2 Chat",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.2-codex": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5.2-codex",
+        "knowledge": "2025-08-31",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.2 Codex",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.2-pro": {
+        "attachment": true,
+        "cost": {
+          "input": 21,
+          "output": 168
+        },
+        "family": "gpt-pro",
+        "id": "gpt-5.2-pro",
+        "knowledge": "2025-08-31",
+        "last_updated": "2025-12-11",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.2 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-12-11",
+        "structured_output": false,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.3-chat-latest": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt",
+        "id": "gpt-5.3-chat-latest",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-03",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.3 Chat (latest)",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2026-03-03",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "gpt-5.3-codex": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt-codex",
+        "id": "gpt-5.3-codex",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-02-05",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.3 Codex",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.3-codex-spark": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.175,
+          "input": 1.75,
+          "output": 14
+        },
+        "family": "gpt-codex-spark",
+        "id": "gpt-5.3-codex-spark",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-02-05",
+        "limit": {
+          "context": 128000,
+          "input": 100000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.3 Codex Spark",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-02-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.4": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.25,
+          "context_over_200k": {
+            "cache_read": 0.5,
+            "input": 5,
+            "output": 22.5
+          },
+          "input": 2.5,
+          "output": 15
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 0.5,
+                "input": 5,
+                "output": 30
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "family": "gpt",
+        "id": "gpt-5.4",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.4-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.075,
+          "input": 0.75,
+          "output": 4.5
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 0.15,
+                "input": 1.5,
+                "output": 9
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "family": "gpt-mini",
+        "id": "gpt-5.4-mini",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-17",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4 mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.4-nano": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.02,
+          "input": 0.2,
+          "output": 1.25
+        },
+        "family": "gpt-nano",
+        "id": "gpt-5.4-nano",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-17",
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4 nano",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-17",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.4-pro": {
+        "attachment": true,
+        "cost": {
+          "context_over_200k": {
+            "input": 60,
+            "output": 270
+          },
+          "input": 30,
+          "output": 180
+        },
+        "family": "gpt-pro",
+        "id": "gpt-5.4-pro",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-03-05",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.4 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-03-05",
+        "structured_output": false,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "context_over_200k": {
+            "cache_read": 1,
+            "input": 10,
+            "output": 45
+          },
+          "input": 5,
+          "output": 30
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "cache_read": 1.25,
+                "input": 12.5,
+                "output": 75
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "family": "gpt",
+        "id": "gpt-5.5",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.5",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-5.5-pro": {
+        "attachment": true,
+        "cost": {
+          "context_over_200k": {
+            "input": 60,
+            "output": 270
+          },
+          "input": 30,
+          "output": 180
+        },
+        "family": "gpt-pro",
+        "id": "gpt-5.5-pro",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-04-23",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "GPT-5.5 Pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "gpt-image-1": {
+        "attachment": true,
+        "family": "gpt-image",
+        "id": "gpt-image-1",
+        "last_updated": "2025-04-24",
+        "limit": {
+          "context": 0,
+          "input": 0,
+          "output": 0
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "image"
+          ]
+        },
+        "name": "gpt-image-1",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-04-24",
+        "temperature": false,
+        "tool_call": false
+      },
+      "gpt-image-1-mini": {
+        "attachment": true,
+        "family": "gpt-image",
+        "id": "gpt-image-1-mini",
+        "last_updated": "2025-09-26",
+        "limit": {
+          "context": 0,
+          "input": 0,
+          "output": 0
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "name": "gpt-image-1-mini",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-09-26",
+        "temperature": false,
+        "tool_call": false
+      },
+      "gpt-image-1.5": {
+        "attachment": true,
+        "family": "gpt-image",
+        "id": "gpt-image-1.5",
+        "last_updated": "2025-11-25",
+        "limit": {
+          "context": 0,
+          "input": 0,
+          "output": 0
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "name": "gpt-image-1.5",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2025-11-25",
+        "temperature": false,
+        "tool_call": false
+      },
+      "o1": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 7.5,
+          "input": 15,
+          "output": 60
+        },
+        "family": "o",
+        "id": "o1",
+        "knowledge": "2023-09",
+        "last_updated": "2024-12-05",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o1",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-12-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "o1-mini": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.55,
+          "input": 1.1,
+          "output": 4.4
+        },
+        "family": "o-mini",
+        "id": "o1-mini",
+        "knowledge": "2023-09",
+        "last_updated": "2024-09-12",
+        "limit": {
+          "context": 128000,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o1-mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-09-12",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": false
+      },
+      "o1-preview": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 7.5,
+          "input": 15,
+          "output": 60
+        },
+        "family": "o",
+        "id": "o1-preview",
+        "knowledge": "2023-09",
+        "last_updated": "2024-09-12",
+        "limit": {
+          "context": 128000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o1-preview",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-09-12",
+        "temperature": true,
+        "tool_call": false
+      },
+      "o1-pro": {
+        "attachment": true,
+        "cost": {
+          "input": 150,
+          "output": 600
+        },
+        "family": "o-pro",
+        "id": "o1-pro",
+        "knowledge": "2023-09",
+        "last_updated": "2025-03-19",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o1-pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-03-19",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "o3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "input": 2,
+          "output": 8
+        },
+        "family": "o",
+        "id": "o3",
+        "knowledge": "2024-05",
+        "last_updated": "2025-04-16",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o3",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-04-16",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "o3-deep-research": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 2.5,
+          "input": 10,
+          "output": 40
+        },
+        "family": "o",
+        "id": "o3-deep-research",
+        "knowledge": "2024-05",
+        "last_updated": "2024-06-26",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o3-deep-research",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-06-26",
+        "temperature": false,
+        "tool_call": true
+      },
+      "o3-mini": {
+        "attachment": false,
+        "cost": {
+          "cache_read": 0.55,
+          "input": 1.1,
+          "output": 4.4
+        },
+        "family": "o-mini",
+        "id": "o3-mini",
+        "knowledge": "2024-05",
+        "last_updated": "2025-01-29",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o3-mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-12-20",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "o3-pro": {
+        "attachment": true,
+        "cost": {
+          "input": 20,
+          "output": 80
+        },
+        "family": "o-pro",
+        "id": "o3-pro",
+        "knowledge": "2024-05",
+        "last_updated": "2025-06-10",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o3-pro",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-06-10",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "o4-mini": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.28,
+          "input": 1.1,
+          "output": 4.4
+        },
+        "family": "o-mini",
+        "id": "o4-mini",
+        "knowledge": "2024-05",
+        "last_updated": "2025-04-16",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o4-mini",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2025-04-16",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "o4-mini-deep-research": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "input": 2,
+          "output": 8
+        },
+        "family": "o-mini",
+        "id": "o4-mini-deep-research",
+        "knowledge": "2024-05",
+        "last_updated": "2024-06-26",
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "o4-mini-deep-research",
+        "open_weights": false,
+        "reasoning": true,
+        "release_date": "2024-06-26",
+        "temperature": false,
+        "tool_call": true
+      },
+      "text-embedding-3-large": {
+        "attachment": false,
+        "cost": {
+          "input": 0.13,
+          "output": 0
+        },
+        "family": "text-embedding",
+        "id": "text-embedding-3-large",
+        "knowledge": "2024-01",
+        "last_updated": "2024-01-25",
+        "limit": {
+          "context": 8191,
+          "output": 3072
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "text-embedding-3-large",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-25",
+        "temperature": false,
+        "tool_call": false
+      },
+      "text-embedding-3-small": {
+        "attachment": false,
+        "cost": {
+          "input": 0.02,
+          "output": 0
+        },
+        "family": "text-embedding",
+        "id": "text-embedding-3-small",
+        "knowledge": "2024-01",
+        "last_updated": "2024-01-25",
+        "limit": {
+          "context": 8191,
+          "output": 1536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "text-embedding-3-small",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2024-01-25",
+        "temperature": false,
+        "tool_call": false
+      },
+      "text-embedding-ada-002": {
+        "attachment": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0
+        },
+        "family": "text-embedding",
+        "id": "text-embedding-ada-002",
+        "knowledge": "2022-12",
+        "last_updated": "2022-12-15",
+        "limit": {
+          "context": 8192,
+          "output": 1536
+        },
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "name": "text-embedding-ada-002",
+        "open_weights": false,
+        "reasoning": false,
+        "release_date": "2022-12-15",
+        "temperature": false,
+        "tool_call": false
+      }
+    },
+    "name": "OpenAI",
+    "npm": "@ai-sdk/openai"
+  }
+}

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -40,6 +40,7 @@ from api.routes.jwks import router as jwks_router
 from api.routes.mcp import router as mcp_router
 from api.routes.prompt import router as prompt_router
 from api.routes.reconcile import router as reconcile_router
+from api.routes.registry_models import router as registry_models_router
 from api.routes.review import router as review_router
 from api.routes.sandbox import router as sandbox_router
 from api.routes.sessions import router as sessions_router
@@ -65,6 +66,7 @@ async def _ensure_columns(conn):
     stmts = [
         "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255)",
         "ALTER TABLE mcp_listings ADD COLUMN IF NOT EXISTS environment_variables JSONB",
+        "ALTER TABLE agent_versions ADD COLUMN IF NOT EXISTS models_by_ide JSONB NOT NULL DEFAULT '{}'::jsonb",
     ]
     for stmt in stmts:
         try:
@@ -310,6 +312,7 @@ app.include_router(sessions_router)
 app.include_router(component_source_router)
 app.include_router(bulk_router)
 app.include_router(config_router)
+app.include_router(registry_models_router)
 
 # --- Prometheus metrics ---
 Instrumentator(

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -52,6 +52,10 @@ class AgentVersion(Base):
     prompt: Mapped[str] = mapped_column(Text, nullable=False, default="")
     model_name: Mapped[str] = mapped_column(String(100), nullable=False)
     model_config_json: Mapped[dict] = mapped_column(JSON, default=dict)
+    # Per-IDE model overrides: {"claude-code": "claude-sonnet-4-5", "kiro": "claude-opus-4-5", ...}
+    # Empty dict means "use model_name as the default for every IDE that accepts a model choice".
+    # Missing key for an IDE that accepts a choice means "emit auto sentinel".
+    models_by_ide: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
     external_mcps: Mapped[list] = mapped_column(JSON, default=list)
     supported_ides: Mapped[list] = mapped_column(JSON, default=list)
     required_ide_features: Mapped[list] = mapped_column(JSON, default=list)
@@ -178,6 +182,16 @@ class Agent(Base):
         if not self.latest_version:
             raise RuntimeError("Agent has no latest_version; cannot set model_config_json")
         self.latest_version.model_config_json = value
+
+    @property
+    def models_by_ide(self) -> dict:
+        return self.latest_version.models_by_ide if self.latest_version else {}
+
+    @models_by_ide.setter
+    def models_by_ide(self, value: dict) -> None:
+        if not self.latest_version:
+            raise RuntimeError("Agent has no latest_version; cannot set models_by_ide")
+        self.latest_version.models_by_ide = value
 
     @property
     def external_mcps(self) -> list:

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -63,6 +63,7 @@ class AgentCreateRequest(BaseModel):
     prompt: str = ""
     model_name: str
     model_config_json: dict = {}
+    models_by_ide: dict[str, str] = {}
     supported_ides: list[str] = []
     mcp_server_ids: list[uuid.UUID] = []  # kept for backwards compat
     components: list[ComponentRef] = []  # new: all component types
@@ -90,6 +91,7 @@ class AgentUpdateRequest(BaseModel):
     prompt: str | None = None
     model_name: str | None = None
     model_config_json: dict | None = None
+    models_by_ide: dict[str, str] | None = None
     supported_ides: list[str] | None = None
     mcp_server_ids: list[uuid.UUID] | None = None  # kept for backwards compat
     components: list[ComponentRef] | None = None  # new: all component types
@@ -162,6 +164,7 @@ class AgentResponse(BaseModel):
     prompt: str
     model_name: str
     model_config_json: dict
+    models_by_ide: dict[str, str] = {}
     external_mcps: list = []
     supported_ides: list[str]
     required_ide_features: list[str] = []
@@ -248,6 +251,7 @@ class AgentVersionCreateRequest(BaseModel):
     prompt: str = ""
     model_name: str
     model_config_json: dict = {}
+    models_by_ide: dict[str, str] = {}
     external_mcps: list[ExternalMcp] = []
     supported_ides: list[str] = []
     components: list[ComponentRef] = []

--- a/observal-server/schemas/ide_registry.py
+++ b/observal-server/schemas/ide_registry.py
@@ -37,6 +37,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.cursor/mcp.json",
         "hook_type": "command",
         "config_dir": ".cursor",
+        "accepts_model_choice": False,
+        "auto_sentinel": None,
     },
     "kiro": {
         "display_name": "Kiro",
@@ -62,6 +64,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.kiro/settings/mcp.json",
         "hook_type": "command",
         "config_dir": ".kiro",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"json_value": None},
     },
     "claude-code": {
         "display_name": "Claude Code",
@@ -88,6 +92,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.claude.json",
         "hook_type": "command",
         "config_dir": ".claude",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_frontmatter_field": True},
     },
     "gemini-cli": {
         "display_name": "Gemini CLI",
@@ -113,6 +119,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.gemini/settings.json",
         "hook_type": "command",
         "config_dir": ".gemini",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_setting": True},
     },
     "vscode": {
         "display_name": "VS Code",
@@ -135,6 +143,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": None,
         "hook_type": "command",
         "config_dir": ".vscode",
+        "accepts_model_choice": False,
+        "auto_sentinel": None,
     },
     "codex": {
         "display_name": "Codex",
@@ -155,6 +165,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.codex/config.toml",
         "hook_type": None,
         "config_dir": ".codex",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_toml_field": True},
     },
     "copilot": {
         "display_name": "Copilot",
@@ -175,6 +187,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.vscode/mcp.json",
         "hook_type": "command",
         "config_dir": ".vscode",
+        "accepts_model_choice": False,
+        "auto_sentinel": None,
     },
     "copilot-cli": {
         "display_name": "Copilot CLI",
@@ -198,6 +212,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.copilot/mcp-config.json",
         "hook_type": "command",
         "config_dir": ".copilot",
+        "accepts_model_choice": False,
+        "auto_sentinel": None,
     },
     "opencode": {
         "display_name": "OpenCode",
@@ -222,6 +238,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.config/opencode/opencode.json",
         "hook_type": "plugin",
         "config_dir": ".config/opencode",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_field": True},
     },
 }
 
@@ -262,3 +280,18 @@ def get_mcp_servers_key(ide: str) -> str:
 def get_default_scope(ide: str) -> str:
     """Return the default install scope for an IDE."""
     return IDE_REGISTRY.get(ide, {}).get("default_scope", "project")
+
+
+def get_model_choice_ides() -> list[str]:
+    """Return IDEs that accept a per-agent model selection."""
+    return [ide for ide, spec in IDE_REGISTRY.items() if spec.get("accepts_model_choice")]
+
+
+def accepts_model_choice(ide: str) -> bool:
+    """Return True if this IDE supports a per-agent model field."""
+    return bool(IDE_REGISTRY.get(ide, {}).get("accepts_model_choice"))
+
+
+def get_auto_sentinel(ide: str) -> dict | None:
+    """Return the codegen sentinel describing how to express ``auto`` for this IDE."""
+    return IDE_REGISTRY.get(ide, {}).get("auto_sentinel")

--- a/observal-server/schemas/models.py
+++ b/observal-server/schemas/models.py
@@ -1,0 +1,58 @@
+"""Pydantic schemas for the live model catalog (sourced from models.dev).
+
+The catalog is read-only — it is a normalized cache of an upstream registry
+(`https://models.dev/api.json`). Our database stores only the user's choice
+(``agent_versions.model_name`` + ``agent_versions.models_by_ide``), never the
+catalog itself.
+"""
+
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ModelDisplay(BaseModel):
+    """Pre-computed display fields shipped to clients so they don't reparse names."""
+
+    primary: str
+    secondary: str | None = None
+    is_rolling: bool = False
+    is_deprecated: bool = False
+
+
+class CatalogModel(BaseModel):
+    """A single model entry, normalized from models.dev shape."""
+
+    model_id: str = Field(description="Canonical model id, e.g. 'claude-sonnet-4-5'.")
+    display_name: str = Field(description="Curated name from models.dev (raw, unstripped).")
+    provider: str = Field(description="models.dev provider id, e.g. 'anthropic'.")
+    family: str = Field(description="models.dev family, e.g. 'claude-sonnet'.")
+    release_date: date | None = None
+    last_updated: date | None = None
+    context_window: int | None = None
+    output_tokens: int | None = None
+    cost_input: float | None = None
+    cost_output: float | None = None
+    capabilities: list[str] = Field(
+        default_factory=list,
+        description="Subset of ['tool_call', 'reasoning', 'attachment'] flags carried by the upstream entry.",
+    )
+    supported_ides: list[str] = Field(
+        default_factory=list,
+        description="IDEs that can install this model — derived from provider via the static mapping.",
+    )
+    deprecated: bool = False
+    display: ModelDisplay | None = None
+
+
+class Catalog(BaseModel):
+    """Normalized model catalog plus provenance metadata."""
+
+    models: list[CatalogModel] = Field(default_factory=list)
+    fetched_at: datetime
+    source: Literal["live", "redis", "snapshot", "empty"]
+    degraded: bool = False
+    etag: str | None = None
+    upstream_etag: str | None = None
+    model_count: int = 0

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -21,8 +21,24 @@ from pydantic import BaseModel, Field
 from schemas.ide_registry import IDE_REGISTRY, get_valid_ides
 from services.agent_config_generator import _wrap_kiro_prompt
 from services.agent_resolver import ResolvedAgent, ResolvedComponent
+from services.model_resolver import resolve_saved_value
 
 logger = logging.getLogger(__name__)
+
+
+def _saved_model_for(manifest: "AgentManifest", ide: str) -> str | None:
+    """Compute the IDE-formatted saved model from a manifest.
+
+    Manifest builders are synchronous and do not consult the live catalog.
+    They trust the saved per-IDE override (or `model_name` for Claude Code's
+    backward-compat path) and apply only ID translation. Catalog validation
+    happens in the install path via ``resolve_model_for_ide``.
+    """
+    return resolve_saved_value(
+        ide,
+        model_name=manifest.model_name or "",
+        models_by_ide=manifest.models_by_ide or {},
+    )
 
 
 # ── Manifest Pydantic Models ────────────────────────────────────────
@@ -101,6 +117,7 @@ class AgentManifest(BaseModel):
     prompt: str = ""
     description: str = ""
     model_name: str = ""
+    models_by_ide: dict[str, str] = Field(default_factory=dict)
     components: ManifestComponents = Field(default_factory=ManifestComponents)
     errors: list[ManifestError] = Field(default_factory=list)
 
@@ -117,6 +134,8 @@ class AgentManifest(BaseModel):
             result["description"] = self.description
         if self.model_name:
             result["model_name"] = self.model_name
+        if self.models_by_ide:
+            result["models_by_ide"] = dict(self.models_by_ide)
         if self.errors:
             result["errors"] = [e.model_dump() for e in self.errors]
         return result
@@ -228,6 +247,7 @@ def build_agent_manifest(resolved: ResolvedAgent) -> dict:
         prompt=resolved.agent_prompt,
         description=resolved.agent_description,
         model_name=resolved.model_name,
+        models_by_ide=resolved.models_by_ide,
         components=ManifestComponents(**grouped),
         errors=[
             ManifestError(
@@ -383,13 +403,15 @@ def _generate_claude_code(manifest: AgentManifest) -> IdeAgentConfig:
         args = cfg.get("args", [])
         setup_commands.append(["claude", "mcp", "add", name, "--", cmd, *args])
 
-    # Build Claude Code agent file with YAML frontmatter
     desc_line = (manifest.description or safe_name).replace("\n", " ").strip()
     frontmatter_lines = [
         "---",
         f"name: {safe_name}",
         f'description: "{desc_line}"',
     ]
+    saved_model = _saved_model_for(manifest, "claude-code")
+    if saved_model:
+        frontmatter_lines.append(f"model: {saved_model}")
     if mcp_entries:
         frontmatter_lines.append("mcpServers:")
         for mcp_name in mcp_entries:
@@ -492,6 +514,10 @@ def _generate_gemini_cli(manifest: AgentManifest) -> IdeAgentConfig:
     if mcp_entries:
         settings["mcpServers"] = mcp_entries
 
+    saved_model = _saved_model_for(manifest, "gemini-cli")
+    if saved_model:
+        settings["model"] = saved_model
+
     env: dict[str, str] = {
         "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
     }
@@ -592,7 +618,8 @@ def _generate_kiro(manifest: AgentManifest) -> IdeAgentConfig:
         "hooks": _build_kiro_hooks(safe_name, observal_url, platform),
         "toolsSettings": {},
         "includeMcpJson": True,
-        "model": None,
+        # null = Kiro auto model selection (per IDE_REGISTRY auto_sentinel).
+        "model": _saved_model_for(manifest, "kiro"),
     }
 
     # Materialize hook components from the agent manifest into the hooks dict
@@ -627,20 +654,29 @@ def _generate_codex(manifest: AgentManifest) -> IdeAgentConfig:
         ),
     ]
 
-    if otlp_url:
-        toml_snippet = (
-            "[otel]\n"
-            'environment = "production"\n'
-            "log_user_prompt = true\n"
-            "\n"
-            "[otel.exporter.otlp-http]\n"
-            f'endpoint = "{otlp_url}/v1/logs"\n'
-            'protocol = "http"\n'
-            "\n"
-            "[otel.trace_exporter.otlp-http]\n"
-            f'endpoint = "{otlp_url}/v1/traces"\n'
-            'protocol = "http"\n'
-        )
+    saved_model = _saved_model_for(manifest, "codex")
+    if otlp_url or saved_model:
+        toml_lines: list[str] = []
+        if saved_model:
+            toml_lines.append(f'model = "{saved_model}"')
+            toml_lines.append("")
+        if otlp_url:
+            toml_lines.extend(
+                [
+                    "[otel]",
+                    'environment = "production"',
+                    "log_user_prompt = true",
+                    "",
+                    "[otel.exporter.otlp-http]",
+                    f'endpoint = "{otlp_url}/v1/logs"',
+                    'protocol = "http"',
+                    "",
+                    "[otel.trace_exporter.otlp-http]",
+                    f'endpoint = "{otlp_url}/v1/traces"',
+                    'protocol = "http"',
+                ]
+            )
+        toml_snippet = "\n".join(toml_lines) + "\n"
         files.append(
             AgentFile(
                 path="~/.codex/config.toml",
@@ -710,11 +746,17 @@ def _generate_opencode(manifest: AgentManifest) -> IdeAgentConfig:
         ),
     ]
 
-    if opencode_mcp:
+    saved_model = _saved_model_for(manifest, "opencode")
+    if opencode_mcp or saved_model:
+        opencode_content: dict = {}
+        if opencode_mcp:
+            opencode_content["mcp"] = opencode_mcp
+        if saved_model:
+            opencode_content["model"] = saved_model
         files.append(
             AgentFile(
                 path="opencode.json",
-                content={"mcp": opencode_mcp},
+                content=opencode_content,
                 format="json",
             ),
         )

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -670,6 +670,7 @@ def generate_agent_config(
         kiro_spec = IDE_REGISTRY["kiro"]
         kiro_scope = options.get("scope", kiro_spec["default_scope"])
         agent_path = kiro_spec["rules_file"][kiro_scope].format(name=safe_name)
+        kiro_model = options.get("_resolved_model", None)
         result: dict = {
             "agent_file": {
                 "path": agent_path,
@@ -690,7 +691,8 @@ def generate_agent_config(
                     "hooks": hooks,
                     "toolsSettings": {},
                     "includeMcpJson": True,
-                    "model": None,  # Kiro uses "auto" model selection; actual model captured via SQLite in hooks
+                    # null = Kiro auto model selection; non-null = pinned model.
+                    "model": kiro_model,
                 },
             },
             "scope": kiro_scope,
@@ -699,8 +701,10 @@ def generate_agent_config(
         skill_files = [f for f in skill_files if f]
         if skill_files:
             result["skill_files"] = skill_files
-        if compatibility_warnings:
-            result["_warnings"] = compatibility_warnings
+        warnings_combined = list(compatibility_warnings)
+        warnings_combined.extend(options.get("_model_warnings") or [])
+        if warnings_combined:
+            result["_warnings"] = warnings_combined
         return result
 
     if ide in ("claude-code", "claude_code"):
@@ -715,13 +719,19 @@ def generate_agent_config(
 
         # IDE-specific options
         scope = options.get("scope", IDE_REGISTRY["claude-code"]["default_scope"])
-        model_choice = options.get("model", "")  # "", "inherit", "sonnet", "opus", "haiku"
         tools = options.get("tools", "")  # comma-separated whitelist
         color = options.get("color", "")
 
-        # Fall back to the agent's stored model_name when no explicit choice
-        if not model_choice or model_choice == "inherit":
-            model_choice = _model_name_to_frontmatter(getattr(agent, "model_name", ""))
+        # Prefer pre-resolved model from the install route's model resolver, which
+        # already handles per-IDE overrides, catalog fallbacks, and Claude Code's
+        # short aliases (sonnet/opus/haiku/inherit). Otherwise fall back to the
+        # legacy logic for back-compat (release-time pre-generation, tests).
+        if "_resolved_model" in (options or {}):
+            model_choice = options.get("_resolved_model") or ""
+        else:
+            model_choice = options.get("model", "")
+            if not model_choice or model_choice == "inherit":
+                model_choice = _model_name_to_frontmatter(getattr(agent, "model_name", ""))
 
         # Build Claude Code agent file with YAML frontmatter
         desc_line = (agent.description or safe_name).replace("\n", " ").strip()
@@ -766,8 +776,10 @@ def generate_agent_config(
         }
         if skill_files:
             result["skill_files"] = skill_files
-        if compatibility_warnings:
-            result["_warnings"] = compatibility_warnings
+        warnings_combined = list(compatibility_warnings)
+        warnings_combined.extend(options.get("_model_warnings") or [])
+        if warnings_combined:
+            result["_warnings"] = warnings_combined
         return result
 
     if ide in ("gemini-cli", "gemini_cli"):
@@ -776,9 +788,13 @@ def generate_agent_config(
         rules_path = gemini_spec["rules_file"][gemini_scope]
         mcp_path = gemini_spec["mcp_config_path"][gemini_scope]
         hooks_path = gemini_spec["mcp_config_path"][gemini_scope]  # hooks live in same settings.json
+        gemini_settings_content: dict = {"mcpServers": mcp_configs}
+        gemini_model = options.get("_resolved_model")
+        if gemini_model:
+            gemini_settings_content["model"] = gemini_model
         result = {
             "rules_file": {"path": rules_path, "content": rules_content},
-            "mcp_config": {"path": mcp_path, "content": {"mcpServers": mcp_configs}},
+            "mcp_config": {"path": mcp_path, "content": gemini_settings_content},
             "hooks_config": {
                 "path": hooks_path,
                 "content": _gemini_hooks_config("observal-hook.sh", "observal-stop-hook.sh"),
@@ -787,20 +803,28 @@ def generate_agent_config(
             "gemini_settings_snippet": _gemini_settings(effective_otlp_http),
             "scope": gemini_scope,
         }
-        if compatibility_warnings:
-            result["_warnings"] = compatibility_warnings
+        warnings_combined = list(compatibility_warnings)
+        warnings_combined.extend(options.get("_model_warnings") or [])
+        if warnings_combined:
+            result["_warnings"] = warnings_combined
         return result
 
     if ide == "codex":
         codex_spec = IDE_REGISTRY["codex"]
         codex_scope = codex_spec["default_scope"]
+        codex_content: dict = {"mcp.servers": mcp_configs}
+        codex_model = options.get("_resolved_model")
+        if codex_model:
+            codex_content["model"] = codex_model
         result = {
             "rules_file": {"path": codex_spec["rules_file"][codex_scope], "content": rules_content},
-            "mcp_config": {"path": codex_spec["mcp_config_path"][codex_scope], "content": {"mcp.servers": mcp_configs}},
+            "mcp_config": {"path": codex_spec["mcp_config_path"][codex_scope], "content": codex_content},
             "scope": codex_scope,
         }
-        if compatibility_warnings:
-            result["_warnings"] = compatibility_warnings
+        warnings_combined = list(compatibility_warnings)
+        warnings_combined.extend(options.get("_model_warnings") or [])
+        if warnings_combined:
+            result["_warnings"] = warnings_combined
         return result
 
     if ide == "copilot":
@@ -911,17 +935,23 @@ def generate_agent_config(
         mcp_path = opencode_spec["mcp_config_path"].get(
             opencode_scope, next(iter(opencode_spec["mcp_config_path"].values()))
         )
+        opencode_content: dict = {opencode_spec["mcp_servers_key"]: opencode_configs}
+        opencode_model = options.get("_resolved_model")
+        if opencode_model:
+            opencode_content["model"] = opencode_model
         result = {
             "rules_file": {"path": rules_path, "content": rules_content},
-            "mcp_config": {"path": mcp_path, "content": {opencode_spec["mcp_servers_key"]: opencode_configs}},
+            "mcp_config": {"path": mcp_path, "content": opencode_content},
             "hooks_config": {
                 "path": ".opencode/plugins/observal-plugin.mjs",
                 "content": _opencode_plugin_js("observal-hook.sh", "observal-stop-hook.sh"),
             },
             "scope": opencode_scope,
         }
-        if compatibility_warnings:
-            result["_warnings"] = compatibility_warnings
+        warnings_combined = list(compatibility_warnings)
+        warnings_combined.extend(options.get("_model_warnings") or [])
+        if warnings_combined:
+            result["_warnings"] = warnings_combined
         return result
 
     # cursor, vscode (and any future IDE with standard rules+mcp pattern)

--- a/observal-server/services/agent_resolver.py
+++ b/observal-server/services/agent_resolver.py
@@ -66,6 +66,7 @@ class ResolvedAgent(BaseModel):
     agent_prompt: str = ""
     agent_description: str = ""
     model_name: str = ""
+    models_by_ide: dict[str, str] = Field(default_factory=dict)
     components: list[ResolvedComponent] = Field(default_factory=list)
     errors: list[ResolutionError] = Field(default_factory=list)
 
@@ -188,6 +189,8 @@ async def resolve_agent(
             )
         )
 
+    raw_models_by_ide = getattr(agent, "models_by_ide", None)
+    models_by_ide = raw_models_by_ide if isinstance(raw_models_by_ide, dict) else {}
     return ResolvedAgent(
         agent_id=agent.id,
         agent_name=agent.name,
@@ -195,6 +198,7 @@ async def resolve_agent(
         agent_prompt=agent.prompt or "",
         agent_description=agent.description or "",
         model_name=agent.model_name or "",
+        models_by_ide=models_by_ide,
         components=components,
         errors=errors,
     )

--- a/observal-server/services/agent_snapshot.py
+++ b/observal-server/services/agent_snapshot.py
@@ -1,0 +1,145 @@
+"""Build a deterministic YAML snapshot of an :class:`AgentVersion`.
+
+The snapshot is the canonical text the reviewer reads when approving a
+new version, and the source for the version-diff endpoint when neither
+side carries a client-supplied snapshot. Centralising the shape here
+guarantees the web builder, the CLI publish flow and the diff fallback
+all surface the same fields — including per-IDE model overrides
+(``models_by_ide``) which are otherwise easy to omit.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+from sqlalchemy import select
+
+from models.agent import AgentGoalSection, AgentGoalTemplate, AgentVersion
+from models.agent_component import AgentComponent
+from models.hook import HookListing
+from models.mcp import McpListing
+from models.prompt import PromptListing
+from models.sandbox import SandboxListing
+from models.skill import SkillListing
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_LISTING_MODELS = {
+    "mcp": McpListing,
+    "skill": SkillListing,
+    "hook": HookListing,
+    "prompt": PromptListing,
+    "sandbox": SandboxListing,
+}
+
+
+def _normalise_models_by_ide(value: object) -> dict[str, str]:
+    """Coerce ``models_by_ide`` into a plain dict for YAML serialisation."""
+    if not isinstance(value, dict):
+        return {}
+    return {str(k): str(v) for k, v in value.items() if v}
+
+
+async def _resolve_component_details(ver: AgentVersion, db: AsyncSession) -> list[dict]:
+    """Return human-friendly component entries for the snapshot.
+
+    Re-queries ``agent_components`` from the database rather than reading
+    ``ver.components`` directly. The relationship attribute may be stale
+    when a freshly created version's components were added in the same
+    session but the back-reference wasn't synchronously synced.
+    """
+    rows = (
+        (
+            await db.execute(
+                select(AgentComponent)
+                .where(AgentComponent.agent_version_id == ver.id)
+                .order_by(AgentComponent.order_index)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not rows:
+        return []
+    details: list[dict] = []
+    for comp in rows:
+        entry: dict = {
+            "type": comp.component_type,
+            "id": str(comp.component_id),
+        }
+        model = _LISTING_MODELS.get(comp.component_type)
+        listing = None
+        if model is not None:
+            listing = (await db.execute(select(model).where(model.id == comp.component_id))).scalar_one_or_none()
+        if listing is not None:
+            entry["name"] = getattr(listing, "name", "") or comp.component_name or ""
+            if comp.component_type == "prompt":
+                entry["template"] = getattr(listing, "template", "") or ""
+            else:
+                entry["description"] = getattr(listing, "description", "") or ""
+        else:
+            entry["name"] = comp.component_name or str(comp.component_id)[:8]
+        if comp.resolved_version:
+            entry["version"] = comp.resolved_version
+        if comp.config_override:
+            entry["config_override"] = comp.config_override
+        details.append(entry)
+    return details
+
+
+async def _goal_template_dict(ver: AgentVersion, db: AsyncSession) -> dict | None:
+    goal = (
+        await db.execute(select(AgentGoalTemplate).where(AgentGoalTemplate.agent_version_id == ver.id))
+    ).scalar_one_or_none()
+    if not goal:
+        return None
+    section_rows = (
+        (
+            await db.execute(
+                select(AgentGoalSection)
+                .where(AgentGoalSection.goal_template_id == goal.id)
+                .order_by(AgentGoalSection.order)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    sections = [
+        {
+            "name": sec.name,
+            "description": sec.description,
+            "grounding_required": bool(sec.grounding_required),
+        }
+        for sec in section_rows
+    ]
+    return {"description": goal.description, "sections": sections}
+
+
+async def build_yaml_snapshot(ver: AgentVersion, db: AsyncSession) -> str:
+    """Render *ver* as a YAML document suitable for ``ver.yaml_snapshot``.
+
+    The returned string is deterministic: keys are emitted in a fixed order
+    and ``models_by_ide`` is always present (empty dict when the author
+    didn't override anything) so a reviewer can trust an empty section
+    means "no per-IDE overrides", not "missing data".
+    """
+    components = await _resolve_component_details(ver, db)
+    data: dict = {
+        "version": ver.version,
+        "description": ver.description or "",
+        "model_name": ver.model_name or "",
+        "models_by_ide": _normalise_models_by_ide(ver.models_by_ide),
+        "supported_ides": list(ver.supported_ides or []),
+        "external_mcps": list(ver.external_mcps or []),
+        "components": components,
+        "prompt": ver.prompt or "",
+    }
+    if ver.model_config_json:
+        data["model_config_json"] = ver.model_config_json
+    goal = await _goal_template_dict(ver, db)
+    if goal is not None:
+        data["goal_template"] = goal
+    header = "# Auto-generated snapshot — review the structured fields above and the prompt below.\n"
+    return header + yaml.safe_dump(data, sort_keys=False, default_flow_style=False, allow_unicode=True)

--- a/observal-server/services/model_catalog.py
+++ b/observal-server/services/model_catalog.py
@@ -1,0 +1,481 @@
+"""Live model catalog service.
+
+A small read-through cache around ``https://models.dev/api.json``. All callers
+(public list endpoint, install fallback resolver, agent builder) go through
+``get_catalog()``; nothing else in the project should fetch the upstream URL
+directly.
+
+Caching layers (defense in depth):
+
+1. ``ETag`` / ``If-None-Match`` against the upstream so we never re-parse 1MB
+   of unchanged JSON. Both the value and the upstream etag live in Redis.
+2. Per-process LRU around the parsed ``Catalog`` keyed on the Redis cache
+   version, expires after 60 s.
+3. Redis cache (``observal:model_catalog:v1``) with 12h hard TTL plus
+   stale-while-revalidate at 12h. Background pre-warm cron (every 6h) and
+   single-flight refresh lock prevent stampedes.
+4. HTTP response caching on the public route is layered above this service
+   in ``api/routes/registry_models.py`` (Cache-Control + ETag).
+
+Out-of-scope here: HTTP response caching, frontend caching, CLI file caching.
+Those happen at the layer that uses the catalog.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import httpx
+import structlog
+
+from schemas.models import Catalog, CatalogModel, ModelDisplay
+from services.model_display import format_display
+from services.redis import get_redis
+
+logger = structlog.get_logger(__name__)
+
+# ─── Constants ────────────────────────────────────────────────
+
+UPSTREAM_URL = "https://models.dev/api.json"
+CACHE_VERSION = "v1"
+REDIS_VALUE_KEY = f"observal:model_catalog:{CACHE_VERSION}"
+REDIS_ETAG_KEY = f"observal:model_catalog:{CACHE_VERSION}:etag"
+REDIS_LOCK_KEY = f"observal:model_catalog:{CACHE_VERSION}:lock"
+REDIS_TTL_SECONDS = 12 * 3600  # 12h hard TTL
+SWR_AGE_SECONDS = 12 * 3600  # serve stale & refresh after 12h
+LOCK_TTL_SECONDS = 30  # single-flight upper bound
+INMEM_TTL_SECONDS = 60
+REQUEST_TIMEOUT_SECONDS = 5.0
+REQUEST_RETRIES = 1
+
+SNAPSHOT_PATH = Path(__file__).resolve().parent.parent / "data" / "model_registry_seed.json"
+
+# ─── Provider → IDE mapping (curated; in code, not data) ─────
+
+PROVIDER_IDE_MAP: dict[str, list[str]] = {
+    "anthropic": ["claude-code", "kiro", "opencode"],
+    "openai": ["codex", "opencode"],
+    "google": ["gemini-cli", "opencode"],
+    "google-vertex": ["gemini-cli", "opencode"],
+}
+
+
+# ─── Per-IDE format dispatcher (in code, not data) ────────────
+
+
+def format_for_ide(model_id: str, provider: str, ide: str) -> str:
+    """Translate a canonical model_id to the string the IDE expects.
+
+    - Claude Code accepts short family aliases (``opus``/``sonnet``/``haiku``)
+      _or_ a full id; we prefer the alias when recognizable so existing user
+      muscle memory is preserved.
+    - OpenCode addresses models as ``provider/model_id``.
+    - Kiro, Codex, Gemini CLI: take the raw id verbatim.
+    """
+    if ide == "claude-code":
+        lid = model_id.lower()
+        for kw in ("opus", "sonnet", "haiku"):
+            if kw in lid:
+                return kw
+        return model_id
+    if ide == "opencode":
+        return f"{provider}/{model_id}"
+    return model_id
+
+
+# ─── In-process LRU on the parsed catalog ────────────────────
+
+_inmem_cache: dict[str, object] = {"catalog": None, "etag": None, "expires_at": 0.0}
+_inmem_lock = asyncio.Lock()
+
+# Hold strong refs to background refresh tasks so they aren't GCed mid-flight.
+_BG_TASKS: set[asyncio.Task] = set()
+
+
+def _spawn_background_refresh(etag: str | None) -> None:
+    task = asyncio.create_task(_background_refresh(etag))
+    _BG_TASKS.add(task)
+    task.add_done_callback(_BG_TASKS.discard)
+
+
+def _inmem_get(current_etag: str | None) -> Catalog | None:
+    """Return the in-memory parsed Catalog if still fresh and matching ``current_etag``."""
+    if not current_etag:
+        return None
+    cat = _inmem_cache.get("catalog")
+    etag = _inmem_cache.get("etag")
+    expires = float(_inmem_cache.get("expires_at") or 0.0)
+    if cat and etag == current_etag and time.monotonic() < expires:
+        return cat  # type: ignore[return-value]
+    return None
+
+
+def _inmem_set(cat: Catalog, etag: str | None) -> None:
+    _inmem_cache["catalog"] = cat
+    _inmem_cache["etag"] = etag
+    _inmem_cache["expires_at"] = time.monotonic() + INMEM_TTL_SECONDS
+
+
+# ─── Normalization ───────────────────────────────────────────
+
+
+def _parse_date(value) -> date | None:
+    if not value:
+        return None
+    if isinstance(value, date):
+        return value
+    try:
+        return datetime.fromisoformat(str(value)).date()
+    except ValueError:
+        try:
+            return datetime.strptime(str(value), "%Y-%m-%d").date()
+        except ValueError:
+            return None
+
+
+def _normalize_models_dev(payload: dict) -> list[CatalogModel]:
+    """Walk the models.dev shape and emit ``CatalogModel`` rows for the providers we map to IDEs."""
+    rows: list[CatalogModel] = []
+    for provider_id, provider in payload.items():
+        if provider_id not in PROVIDER_IDE_MAP:
+            continue
+        models = provider.get("models", {}) if isinstance(provider, dict) else {}
+        for model_id, model in models.items():
+            if not isinstance(model, dict):
+                continue
+            cost = model.get("cost") or {}
+            limit = model.get("limit") or {}
+            capabilities: list[str] = []
+            for flag in ("tool_call", "reasoning", "attachment"):
+                if model.get(flag):
+                    capabilities.append(flag)
+            modalities = model.get("modalities") or {}
+            inputs = modalities.get("input") or []
+            if "image" in inputs and "vision" not in capabilities:
+                capabilities.append("vision")
+
+            rows.append(
+                CatalogModel(
+                    model_id=model.get("id") or model_id,
+                    display_name=model.get("name") or model_id,
+                    provider=provider_id,
+                    family=model.get("family") or "",
+                    release_date=_parse_date(model.get("release_date")),
+                    last_updated=_parse_date(model.get("last_updated")),
+                    context_window=limit.get("context") if isinstance(limit, dict) else None,
+                    output_tokens=limit.get("output") if isinstance(limit, dict) else None,
+                    cost_input=cost.get("input") if isinstance(cost, dict) else None,
+                    cost_output=cost.get("output") if isinstance(cost, dict) else None,
+                    capabilities=capabilities,
+                    supported_ides=PROVIDER_IDE_MAP.get(provider_id, []),
+                    deprecated=bool(model.get("deprecated")),
+                )
+            )
+    return rows
+
+
+def _attach_display_fields(models: list[CatalogModel]) -> None:
+    """Mutate ``models`` to carry pre-computed display fields (parity with frontend)."""
+    primary_counts: dict[str, int] = {}
+    primaries: list[str] = []
+    for m in models:
+        primary, _, _ = format_display(m.display_name, m.model_id, m.release_date)
+        primaries.append(primary)
+        primary_counts[primary] = primary_counts.get(primary, 0) + 1
+
+    for m, primary in zip(models, primaries, strict=True):
+        primary_text, secondary, is_rolling = format_display(
+            m.display_name,
+            m.model_id,
+            m.release_date,
+            disambiguate=primary_counts[primary] > 1,
+        )
+        m.display = ModelDisplay(
+            primary=primary_text,
+            secondary=secondary,
+            is_rolling=is_rolling,
+            is_deprecated=m.deprecated,
+        )
+
+
+def _hash_etag(payload: dict) -> str:
+    """Compute a stable etag from the payload (used when the upstream omits ETag)."""
+    h = hashlib.sha256()
+    h.update(json.dumps(payload, sort_keys=True).encode())
+    return f'W/"{h.hexdigest()[:16]}"'
+
+
+# ─── Snapshot fallback ────────────────────────────────────────
+
+
+def _load_snapshot_payload() -> dict | None:
+    if not SNAPSHOT_PATH.exists():
+        return None
+    try:
+        with SNAPSHOT_PATH.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("model_catalog_snapshot_load_failed", error=str(e), path=str(SNAPSHOT_PATH))
+        return None
+
+
+# ─── Redis layer ─────────────────────────────────────────────
+
+
+def _serialize_catalog(cat: Catalog) -> str:
+    return cat.model_dump_json()
+
+
+def _deserialize_catalog(raw: str) -> Catalog:
+    return Catalog.model_validate_json(raw)
+
+
+async def _redis_load() -> tuple[Catalog | None, str | None, float | None]:
+    """Return (catalog, upstream_etag, age_seconds_or_None)."""
+    try:
+        r = get_redis()
+        raw, upstream_etag = await r.mget(REDIS_VALUE_KEY, REDIS_ETAG_KEY)
+    except Exception as e:
+        logger.debug("model_catalog_redis_load_failed", error=str(e))
+        return None, None, None
+    if not raw:
+        return None, upstream_etag, None
+    try:
+        cat = _deserialize_catalog(raw)
+    except Exception as e:
+        logger.warning("model_catalog_redis_deserialize_failed", error=str(e))
+        return None, upstream_etag, None
+    age = (datetime.now(UTC) - cat.fetched_at).total_seconds() if cat.fetched_at else None
+    return cat, upstream_etag, age
+
+
+async def _redis_store(cat: Catalog, upstream_etag: str | None) -> None:
+    try:
+        r = get_redis()
+        async with r.pipeline(transaction=False) as pipe:
+            pipe.set(REDIS_VALUE_KEY, _serialize_catalog(cat), ex=REDIS_TTL_SECONDS)
+            if upstream_etag:
+                pipe.set(REDIS_ETAG_KEY, upstream_etag, ex=REDIS_TTL_SECONDS)
+            else:
+                pipe.delete(REDIS_ETAG_KEY)
+            await pipe.execute()
+    except Exception as e:
+        logger.warning("model_catalog_redis_store_failed", error=str(e))
+
+
+# ─── Single-flight refresh ───────────────────────────────────
+
+
+async def _acquire_refresh_lock() -> bool:
+    """Try to grab the cross-process refresh lock. ``True`` means "we own the refresh"."""
+    try:
+        r = get_redis()
+        return bool(await r.set(REDIS_LOCK_KEY, "1", nx=True, ex=LOCK_TTL_SECONDS))
+    except Exception:
+        return True  # Best effort: if Redis is down, just refresh anyway.
+
+
+async def _release_refresh_lock() -> None:
+    try:
+        r = get_redis()
+        await r.delete(REDIS_LOCK_KEY)
+    except Exception:
+        pass
+
+
+# ─── Upstream fetch ──────────────────────────────────────────
+
+
+async def _fetch_upstream(prev_etag: str | None) -> tuple[dict | None, str | None, bool]:
+    """GET ``models.dev/api.json``.
+
+    Returns ``(payload_or_None, etag_or_None, not_modified)``. ``payload_or_None``
+    is None when the request returned 304 or when the request failed.
+    """
+    headers = {"Accept": "application/json", "User-Agent": "observal/1.0"}
+    if prev_etag:
+        headers["If-None-Match"] = prev_etag
+
+    last_exc: Exception | None = None
+    for attempt in range(REQUEST_RETRIES + 1):
+        try:
+            async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS) as client:
+                resp = await client.get(UPSTREAM_URL, headers=headers)
+            if resp.status_code == 304:
+                return None, prev_etag, True
+            if resp.status_code != 200:
+                logger.warning("model_catalog_upstream_status", status=resp.status_code)
+                continue
+            payload = resp.json()
+            etag = resp.headers.get("ETag") or resp.headers.get("etag") or _hash_etag(payload)
+            return payload, etag, False
+        except (httpx.HTTPError, httpx.TimeoutException, json.JSONDecodeError) as e:  # type: ignore[attr-defined]
+            last_exc = e
+            if attempt < REQUEST_RETRIES:
+                await asyncio.sleep(0.25 * (attempt + 1))
+                continue
+            break
+    if last_exc is not None:
+        logger.warning("model_catalog_upstream_failed", error=str(last_exc))
+    return None, prev_etag, False
+
+
+# ─── Public entrypoint ───────────────────────────────────────
+
+
+async def get_catalog(force_refresh: bool = False) -> Catalog:
+    """Return the normalized model catalog.
+
+    1. Cheap path: in-memory LRU keyed on Redis upstream etag (60s).
+    2. Try Redis. Serve fresh entries directly. If stale, return them and
+       schedule a background refresh.
+    3. On Redis miss: fetch upstream (with ``If-None-Match``), normalize,
+       write to Redis.
+    4. On all upstream failures: fall back to the vendored snapshot.
+    5. On every failure: return an empty Catalog with ``degraded=True``.
+    """
+    # Step 1: Try Redis first to know the current etag.
+    cat, upstream_etag, age = await _redis_load()
+
+    if not force_refresh:
+        # In-memory hot path
+        cached = _inmem_get(upstream_etag)
+        if cached is not None:
+            cached.source = "redis"
+            return cached
+        # Redis hit and fresh
+        if cat is not None and age is not None and age < SWR_AGE_SECONDS:
+            cat.source = "redis"
+            _inmem_set(cat, upstream_etag)
+            return cat
+        # Redis hit but stale: serve stale, kick a background refresh
+        if cat is not None and age is not None and age >= SWR_AGE_SECONDS:
+            cat.source = "redis"
+            _inmem_set(cat, upstream_etag)
+            _spawn_background_refresh(upstream_etag)
+            return cat
+
+    # Step 2: Redis miss (or forced refresh). Try upstream.
+    return await _refresh(prev_etag=upstream_etag)
+
+
+async def _background_refresh(prev_etag: str | None) -> None:
+    """Fire-and-forget refresh used by stale-while-revalidate."""
+    if not await _acquire_refresh_lock():
+        return  # Another worker beat us to it.
+    try:
+        await _refresh(prev_etag=prev_etag)
+    except Exception as e:
+        logger.warning("model_catalog_background_refresh_failed", error=str(e))
+    finally:
+        await _release_refresh_lock()
+
+
+async def _refresh(prev_etag: str | None) -> Catalog:
+    """Always-online refresh path: fetch + normalize + persist."""
+    async with _inmem_lock:
+        # Re-check after acquiring the lock; another coroutine may have refreshed.
+        cached_cat, cached_etag, cached_age = await _redis_load()
+        if (
+            cached_cat is not None
+            and cached_age is not None
+            and cached_age < SWR_AGE_SECONDS
+            and not _force_refresh_requested()
+        ):
+            cached_cat.source = "redis"
+            _inmem_set(cached_cat, cached_etag)
+            return cached_cat
+
+        payload, etag, not_modified = await _fetch_upstream(prev_etag)
+
+        if not_modified and cached_cat is not None:
+            # Upstream confirmed unchanged. Refresh fetched_at & TTL only.
+            cached_cat.fetched_at = datetime.now(UTC)
+            cached_cat.source = "live"
+            cached_cat.etag = cached_etag or etag
+            cached_cat.upstream_etag = etag or cached_etag
+            await _redis_store(cached_cat, etag or cached_etag)
+            _inmem_set(cached_cat, etag or cached_etag)
+            return cached_cat
+
+        if payload is not None:
+            cat = _build_catalog(payload, source="live", upstream_etag=etag)
+            await _redis_store(cat, etag)
+            _inmem_set(cat, etag)
+            return cat
+
+        # Upstream unreachable. Fall back to vendored snapshot.
+        snapshot = _load_snapshot_payload()
+        if snapshot is not None:
+            cat = _build_catalog(snapshot, source="snapshot", upstream_etag=None, degraded=True)
+            # Don't poison Redis with the snapshot; just hold it in-process.
+            _inmem_set(cat, None)
+            return cat
+
+        # Last-resort empty catalog so the API surfaces ``degraded=True``.
+        return Catalog(
+            models=[],
+            fetched_at=datetime.now(UTC),
+            source="empty",
+            degraded=True,
+            etag=None,
+            upstream_etag=None,
+            model_count=0,
+        )
+
+
+def _force_refresh_requested() -> bool:
+    """Stub hook that other layers (admin refresh route) can extend in the future."""
+    return False
+
+
+def _build_catalog(payload: dict, *, source: str, upstream_etag: str | None, degraded: bool = False) -> Catalog:
+    models = _normalize_models_dev(payload)
+    _attach_display_fields(models)
+    fetched_at = datetime.now(UTC)
+    self_etag = _self_etag(fetched_at, upstream_etag)
+    return Catalog(
+        models=models,
+        fetched_at=fetched_at,
+        source=source,  # type: ignore[arg-type]
+        degraded=degraded,
+        etag=self_etag,
+        upstream_etag=upstream_etag,
+        model_count=len(models),
+    )
+
+
+def _self_etag(fetched_at: datetime, upstream_etag: str | None) -> str:
+    """Compute an etag for HTTP responses derived from fetched_at + upstream etag."""
+    h = hashlib.sha256()
+    h.update(fetched_at.isoformat().encode())
+    h.update((upstream_etag or "").encode())
+    return f'W/"{h.hexdigest()[:16]}"'
+
+
+# ─── Diff helper for the admin refresh response ──────────────
+
+
+async def diff_against_current(prev: Catalog | None) -> dict:
+    """Compute add/remove/update sets between the previous in-Redis catalog and the now-current one.
+
+    Used by ``POST /api/v1/admin/models/refresh`` so ops gets a one-shot sense
+    of what changed when they pull a new release of models.dev.
+    """
+    new = await get_catalog(force_refresh=True)
+    if prev is None:
+        return {"added": [m.model_id for m in new.models], "removed": [], "updated": [], "total": new.model_count}
+    prev_ids = {m.model_id: m for m in prev.models}
+    new_ids = {m.model_id: m for m in new.models}
+    added = sorted(set(new_ids) - set(prev_ids))
+    removed = sorted(set(prev_ids) - set(new_ids))
+    updated: list[str] = []
+    for mid in set(prev_ids) & set(new_ids):
+        if prev_ids[mid].model_dump(exclude={"display"}) != new_ids[mid].model_dump(exclude={"display"}):
+            updated.append(mid)
+    return {"added": added, "removed": removed, "updated": sorted(updated), "total": new.model_count}

--- a/observal-server/services/model_display.py
+++ b/observal-server/services/model_display.py
@@ -1,0 +1,107 @@
+"""Shared display formatting for model catalog rows.
+
+Returns the (primary, secondary, is_rolling) tuple used by every UI surface.
+Mirrored at:
+  - ``web/src/lib/model-display.ts`` (frontend)
+  - ``observal_cli/render.py`` (``format_model`` helper)
+
+Behavioural rules (kept in sync with ``tests/fixtures/model_display_cases.json``):
+
+1. The **primary label** is ``display_name`` from models.dev with any trailing
+   date stripped (``-YYYYMMDD``, ``-YYYY-MM-DD``, ``(YYYY-MM-DD)``,
+   `` (latest)``).  If ``display_name`` is empty we fall back to
+   ``humanize(model_id)``.
+2. The **secondary label** is only emitted when the caller passes
+   ``disambiguate=True`` (i.e. another row produces the same primary), or when
+   the model_id ends in ``-latest`` so the user can tell the rolling pointer
+   apart from a dated snapshot.
+3. ``is_rolling`` is True when the model_id has no trailing date suffix.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+
+# A trailing -YYYYMMDD (claude-3-5-sonnet-20241022) is the most common shape.
+_DATE_SUFFIX_DASH_COMPACT = re.compile(r"[-_\s](\d{8})$")
+# Sometimes models use -YYYY-MM-DD; not in our seed but tolerated.
+_DATE_SUFFIX_DASH_HYPHEN = re.compile(r"[-_\s](\d{4}-\d{2}-\d{2})$")
+# `Claude 3.5 Sonnet (2024-10-22)` — date in parens at the end of display_name.
+_DATE_SUFFIX_PAREN = re.compile(r"\s*\((\d{4}-\d{2}-\d{2})\)\s*$")
+# `Claude Sonnet 4.5 (latest)` style suffix.
+_LATEST_PAREN = re.compile(r"\s*\(latest\)\s*$", re.IGNORECASE)
+# `gemini-1.5-pro-latest` — only used when display_name is empty and we fall through to model_id.
+_LATEST_DASH = re.compile(r"[-_]latest$", re.IGNORECASE)
+
+_MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+def _strip_trailing_date(text: str) -> str:
+    if not text:
+        return text
+    out = text
+    out = _LATEST_PAREN.sub("", out).strip()
+    out = _DATE_SUFFIX_PAREN.sub("", out).strip()
+    out = _DATE_SUFFIX_DASH_HYPHEN.sub("", out).strip()
+    out = _DATE_SUFFIX_DASH_COMPACT.sub("", out).strip()
+    out = _LATEST_DASH.sub("", out).strip()
+    return out
+
+
+def _has_trailing_date(model_id: str) -> tuple[bool, date | None]:
+    """Return (has_date_suffix, parsed_date_or_None) for ``model_id``."""
+    m = _DATE_SUFFIX_DASH_COMPACT.search(model_id)
+    if m:
+        try:
+            return True, datetime.strptime(m.group(1), "%Y%m%d").date()
+        except ValueError:
+            return True, None
+    m = _DATE_SUFFIX_DASH_HYPHEN.search(model_id)
+    if m:
+        try:
+            return True, datetime.strptime(m.group(1), "%Y-%m-%d").date()
+        except ValueError:
+            return True, None
+    return False, None
+
+
+def _format_date(d: date) -> str:
+    return f"{_MONTH_NAMES[d.month - 1]} {d.day}, {d.year}"
+
+
+def format_display(
+    display_name: str | None,
+    model_id: str,
+    release_date: date | None = None,
+    *,
+    disambiguate: bool = False,
+) -> tuple[str, str | None, bool]:
+    """Compute (primary, secondary, is_rolling) for a model row.
+
+    Args:
+        display_name: ``CatalogModel.display_name`` (``models.dev`` curated name).
+        model_id: ``CatalogModel.model_id`` (canonical id).
+        release_date: ``CatalogModel.release_date`` if known.
+        disambiguate: True when another row produces the same primary label.
+            When True, dated rows render their date as secondary text and
+            rolling rows render ``"latest"``.
+    """
+    raw = (display_name or model_id).strip()
+    primary = _strip_trailing_date(raw) or raw
+
+    has_date_suffix, parsed_date = _has_trailing_date(model_id)
+    is_rolling = not has_date_suffix
+    is_explicit_latest = bool(_LATEST_PAREN.search(raw)) or model_id.endswith("-latest")
+
+    if not disambiguate and not is_explicit_latest:
+        return primary, None, is_rolling
+
+    secondary: str | None = None
+    if is_rolling or is_explicit_latest:
+        secondary = "latest"
+    else:
+        d = parsed_date or release_date
+        if d is not None:
+            secondary = _format_date(d)
+    return primary, secondary, is_rolling

--- a/observal-server/services/model_resolver.py
+++ b/observal-server/services/model_resolver.py
@@ -1,0 +1,138 @@
+"""Single source of truth for "what model should this IDE config use?".
+
+Two entry points:
+
+- ``resolve_model_for_ide(ide, agent_version, override=None)``
+    Async. Validates the candidate against the live catalog and falls back
+    to the IDE's auto sentinel with a warning when the model is unknown or
+    the IDE doesn't support it. When the catalog is degraded (no upstream
+    and no snapshot) we trust the saved value verbatim and emit a soft
+    warning rather than overwriting the user's choice.
+- ``resolve_saved_value(ide, model_name, models_by_ide)``
+    Sync. Pure lookup that returns the IDE-formatted string the user asked
+    for, or ``None`` (meaning "emit auto sentinel"). Used by the offline
+    manifest builder, which doesn't have a Redis context.
+
+Both go through ``services.model_catalog.format_for_ide`` so the per-IDE
+format rules (Claude Code aliases, OpenCode provider prefix, …) live in one
+place.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from schemas.ide_registry import accepts_model_choice
+from services.model_catalog import (
+    PROVIDER_IDE_MAP,
+    Catalog,
+    format_for_ide,
+    get_catalog,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+def _candidate_for_ide(ide: str, models_by_ide: dict | None, model_name: str | None) -> str | None:
+    """Pick the saved model the user wants for ``ide``.
+
+    Precedence:
+        1. Per-IDE override from ``models_by_ide``.
+        2. ``model_name`` — but only for Claude Code (legacy default).
+    Other IDEs default to None (= emit auto sentinel) when no override exists.
+    """
+    if models_by_ide and ide in models_by_ide and models_by_ide[ide]:
+        return models_by_ide[ide]
+    if ide == "claude-code" and model_name:
+        return model_name
+    return None
+
+
+def _format(ide: str, candidate: str | None, catalog: Catalog | None) -> str | None:
+    if not candidate:
+        return None
+    provider = "anthropic"  # safe default for the legacy claude-code path
+    if catalog is not None:
+        for entry in catalog.models:
+            if entry.model_id == candidate:
+                provider = entry.provider
+                break
+    return format_for_ide(candidate, provider, ide)
+
+
+def resolve_saved_value(ide: str, model_name: str, models_by_ide: dict | None) -> str | None:
+    """Sync resolver — no catalog lookup. Used by the offline manifest builder.
+
+    Returns the IDE-formatted string for the saved value, or ``None`` if no
+    saved value exists (caller must emit the auto sentinel).
+    """
+    if not accepts_model_choice(ide):
+        return None
+    candidate = _candidate_for_ide(ide, models_by_ide, model_name)
+    return _format(ide, candidate, None) if candidate else None
+
+
+async def resolve_model_for_ide(
+    ide: str,
+    *,
+    model_name: str = "",
+    models_by_ide: dict | None = None,
+    override: str | None = None,
+) -> tuple[str | None, list[str]]:
+    """Resolve the effective model for an online install.
+
+    Returns ``(emitted_value_or_None, warnings)``. ``None`` means the caller
+    should emit the IDE's auto sentinel (e.g. drop the ``model:`` line for
+    Claude Code, write ``"model": null`` for Kiro).
+    """
+    warnings: list[str] = []
+
+    if not accepts_model_choice(ide):
+        if override:
+            warnings.append(f"{ide} does not accept a model choice; ignoring --model {override}.")
+        return None, warnings
+
+    candidate = override or _candidate_for_ide(ide, models_by_ide, model_name)
+    if not candidate:
+        return None, warnings
+
+    # Claude Code short aliases ("sonnet", "opus", "haiku") and the literal
+    # "inherit" sentinel are passed through verbatim — they don't appear in the
+    # catalog and the IDE itself accepts them.
+    if ide == "claude-code" and candidate.lower() in ("sonnet", "opus", "haiku", "inherit"):
+        if candidate.lower() == "inherit":
+            return None, warnings
+        return candidate.lower(), warnings
+
+    try:
+        catalog = await get_catalog()
+    except Exception as e:
+        logger.warning("model_resolver_catalog_error", error=str(e))
+        catalog = None
+
+    if catalog is None or catalog.degraded:
+        warnings.append(
+            "Model catalog is unavailable; using the saved selection verbatim. "
+            "Re-run after the catalog refreshes if the IDE rejects the model."
+        )
+        return _format(ide, candidate, catalog), warnings
+
+    # Look up the candidate in the catalog
+    matches = [m for m in catalog.models if m.model_id == candidate]
+    if not matches:
+        warnings.append(f"Model '{candidate}' is not in the catalog. Falling back to {ide}'s auto/default.")
+        return None, warnings
+
+    entry = matches[0]
+    if ide not in entry.supported_ides:
+        provider_ides = PROVIDER_IDE_MAP.get(entry.provider, [])
+        warnings.append(
+            f"Model '{candidate}' (provider {entry.provider}) is not supported by {ide}. "
+            f"Provider routes to: {', '.join(provider_ides) or 'no IDE'}. Falling back to auto."
+        )
+        return None, warnings
+
+    if entry.deprecated:
+        warnings.append(f"Model '{candidate}' is marked deprecated by the upstream catalog.")
+
+    return format_for_ide(entry.model_id, entry.provider, ide), warnings

--- a/observal-server/tests/test_agent_versions_api.py
+++ b/observal-server/tests/test_agent_versions_api.py
@@ -319,6 +319,7 @@ async def test_create_version_happy_path():
         patch("api.routes.agent_versions.compute_supported_ides", return_value=["claude-code"]),
         patch("api.routes.agent_versions.generate_agent_config", return_value={"mcpServers": {}}),
         patch("api.routes.agent_versions.audit", new=AsyncMock()),
+        patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot")),
     ):
         result = await _create_agent_version(
             agent_id=str(agent.id),
@@ -473,6 +474,7 @@ async def test_create_version_co_maintainer_allowed():
         patch("api.routes.agent_versions.compute_supported_ides", return_value=[]),
         patch("api.routes.agent_versions.generate_agent_config", return_value={}),
         patch("api.routes.agent_versions.audit", new=AsyncMock()),
+        patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot")),
     ):
         result = await _create_agent_version(
             agent_id=str(agent.id),
@@ -521,6 +523,7 @@ async def test_create_version_warns_multiple_pending():
         patch("api.routes.agent_versions.compute_supported_ides", return_value=[]),
         patch("api.routes.agent_versions.generate_agent_config", return_value={}),
         patch("api.routes.agent_versions.audit", new=AsyncMock()),
+        patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot")),
     ):
         result = await _create_agent_version(
             agent_id=str(agent.id),

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -158,6 +158,22 @@ async def batch_generate_insights(ctx: dict):
         logger.exception("insight_batch_failed", error=str(e))
 
 
+async def refresh_model_catalog(ctx: dict):
+    """Cron job: pre-warm the model catalog so user requests never hit a cold cache."""
+    from services.model_catalog import get_catalog
+
+    try:
+        cat = await get_catalog(force_refresh=True)
+        logger.info(
+            "model_catalog_prewarm",
+            source=cat.source,
+            count=cat.model_count,
+            degraded=cat.degraded,
+        )
+    except Exception as e:
+        logger.warning("model_catalog_prewarm_failed", error=str(e))
+
+
 async def startup(ctx: dict):
     from services.insights import configure_insights
 
@@ -179,12 +195,14 @@ class WorkerSettings:
         maintain_clickhouse,
         generate_insight_report,
         batch_generate_insights,
+        refresh_model_catalog,
     ]
     cron_jobs = [
         cron(sync_component_sources, hour={0, 6, 12, 18}),  # Every 6 hours
         cron(evaluate_alerts, second={0}, timeout=55),  # Every minute
         cron(maintain_clickhouse, hour={0, 4, 8, 12, 16, 20}, timeout=120),  # Every 4 hours
         cron(batch_generate_insights, weekday={0}, hour={6}, minute={0}, timeout=300),  # Weekly Monday 6AM
+        cron(refresh_model_catalog, hour={0, 6, 12, 18}, minute={5}, timeout=30),  # Every 6 hours (offset)
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -644,6 +644,9 @@ def agent_init(
         "description": description,
         "owner": owner,
         "model_name": model_name,
+        # Optional per-IDE model overrides, e.g. {"kiro": "claude-haiku-4-5"}.
+        # Leave empty to use model_name everywhere that accepts a model choice.
+        "models_by_ide": {},
         "prompt": prompt_text,
         "supported_ides": list(VALID_IDES),
         "components": [],
@@ -765,6 +768,7 @@ def agent_publish(
         "description": data.get("description", ""),
         "owner": data.get("owner", ""),
         "model_name": data.get("model_name", "claude-sonnet-4"),
+        "models_by_ide": data.get("models_by_ide", {}) or {},
         "prompt": data.get("prompt", ""),
         "supported_ides": data.get("supported_ides", []),
         "components": data.get("components", []),
@@ -863,6 +867,7 @@ def agent_release(
         "prompt": data.get("prompt", ""),
         "model_name": data.get("model_name", "claude-sonnet-4"),
         "model_config_json": data.get("model_config_json"),
+        "models_by_ide": data.get("models_by_ide", {}) or {},
         "external_mcps": data.get("external_mcps"),
         "supported_ides": data.get("supported_ides", []),
         "components": data.get("components", []),

--- a/observal_cli/cmd_models.py
+++ b/observal_cli/cmd_models.py
@@ -1,0 +1,77 @@
+"""``observal registry models list`` — list the known model catalog."""
+
+from __future__ import annotations
+
+import json
+
+import typer
+from rich import print as rprint
+from rich.table import Table
+
+from observal_cli import model_catalog
+from observal_cli.render import format_model
+
+models_app = typer.Typer(
+    name="models",
+    help="Inspect the model catalog (live from models.dev with offline fallback).",
+    no_args_is_help=True,
+)
+
+
+@models_app.command("list")
+def list_models(
+    ide: str | None = typer.Option(None, "--ide", help="Filter to models supported by this IDE."),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table | json | plain"),
+    refresh: bool = typer.Option(False, "--refresh", help="Bypass the local 1h file cache and re-fetch."),
+):
+    """Show models from the registry.
+
+    Source order: file cache (1h TTL) → ``GET /api/v1/models`` → file cache (stale)
+    → vendored offline mirror. Each output line marks where the data came from.
+    """
+    catalog = model_catalog.fetch_catalog(refresh=refresh)
+    rows = catalog.get("models") or []
+    if ide:
+        rows = [m for m in rows if ide in (m.get("supported_ides") or [])]
+
+    if output == "json":
+        rprint(json.dumps(rows, indent=2, default=str))
+        return
+
+    if not rows:
+        rprint("[yellow]No models found.[/yellow]")
+        return
+
+    if output == "plain":
+        for m in rows:
+            primary, secondary, _ = format_model(m, disambiguate=True)
+            label = f"{primary} ({secondary})" if secondary else primary
+            ides = ",".join(m.get("supported_ides") or [])
+            rprint(f"{m.get('model_id', '')}\t{m.get('provider', '')}\t{label}\t{ides}")
+        return
+
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("model_id", overflow="fold")
+    table.add_column("provider")
+    table.add_column("display")
+    table.add_column("ides")
+    table.add_column("released")
+
+    for m in rows:
+        primary, secondary, _ = format_model(m, disambiguate=True)
+        label = f"{primary} ({secondary})" if secondary else primary
+        ides = ", ".join(m.get("supported_ides") or [])
+        released = str(m.get("release_date") or "—")
+        deprecated = " [red](deprecated)[/red]" if m.get("deprecated") else ""
+        table.add_row(
+            m.get("model_id", "") + deprecated,
+            m.get("provider", ""),
+            label,
+            ides,
+            released,
+        )
+
+    rprint(table)
+    src = catalog.get("_source") or catalog.get("source") or "?"
+    degraded = " [yellow](degraded — using snapshot)[/yellow]" if catalog.get("degraded") else ""
+    rprint(f"[dim]source: {src}{degraded}, count: {len(rows)}[/dim]")

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -251,6 +251,28 @@ def _parse_model_overrides(values: list[str]) -> tuple[str | None, dict[str, str
     return default, overrides
 
 
+def _agent_saved_model(agent_detail: dict | None, ide: str) -> str | None:
+    """Return the model the *agent* has saved for *ide*, if any.
+
+    Per-IDE override wins; otherwise the legacy ``model_name`` is used as
+    the implicit default for Claude Code only. Mirrors the server-side
+    ``services.model_resolver._candidate_for_ide`` rules so the CLI never
+    re-prompts when the author has already chosen a model.
+    """
+    if not agent_detail:
+        return None
+    raw = agent_detail.get("models_by_ide") if isinstance(agent_detail, dict) else None
+    if isinstance(raw, dict):
+        candidate = raw.get(ide)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    if ide in ("claude-code", "claude_code"):
+        legacy = agent_detail.get("model_name") if isinstance(agent_detail, dict) else None
+        if isinstance(legacy, str) and legacy.strip():
+            return legacy.strip()
+    return None
+
+
 def _collect_install_options(
     ide: str,
     *,
@@ -260,6 +282,7 @@ def _collect_install_options(
     tools: str | None,
     no_prompt: bool,
     refresh_models: bool = False,
+    agent_detail: dict | None = None,
 ) -> dict:
     """Interactively collect IDE-specific install options.
 
@@ -267,11 +290,17 @@ def _collect_install_options(
     what's missing when running in an interactive terminal and ``--no-prompt``
     isn't set. The model picker now consults the live catalog (``GET /api/v1/models``)
     instead of a hardcoded list.
+
+    When the agent already has a saved model for the target IDE (set in the
+    builder) and the user didn't pass ``--model``, the saved value is used
+    silently — the picker is skipped so authoring decisions aren't undone
+    by a stray Enter at the prompt.
     """
     import sys
 
     from observal_cli.ide_registry import accepts_model_choice
     from observal_cli.prompts import select_one
+    from observal_cli.render import format_model as _format_model
 
     opts: dict = {}
     interactive = sys.stdin.isatty() and not no_prompt
@@ -288,8 +317,21 @@ def _collect_install_options(
 
     if accepts_model_choice(ide):
         explicit = model_overrides.get(ide) or model_default
+        saved = _agent_saved_model(agent_detail, ide)
         if explicit:
             opts["model"] = explicit
+        elif saved:
+            try:
+                primary, _secondary, _ = _format_model({"model_id": saved})
+                pretty = primary or saved
+            except Exception:
+                pretty = saved
+            rprint(f"  [dim]Model:[/dim] {pretty} [dim](from agent)[/dim]")
+            # Pass through the saved value so the server records the same
+            # choice on the install download record. The resolver still
+            # validates the candidate against the live catalog and falls
+            # back gracefully if needed.
+            opts["model"] = saved
         elif interactive:
             from observal_cli import model_catalog as _catalog
 
@@ -373,6 +415,7 @@ def register_pull(app: typer.Typer):
             tools=tools,
             no_prompt=no_prompt,
             refresh_models=refresh_models,
+            agent_detail=agent_detail,
         )
         is_user_scope = options.get("scope") == "user"
         if is_user_scope:

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -226,27 +226,56 @@ def _resolve_path(raw_path: str, target_dir: Path, *, allow_home: bool = False) 
 _SCOPE_AWARE_IDES = get_scope_aware_ides()
 
 
+def _parse_model_overrides(values: list[str]) -> tuple[str | None, dict[str, str]]:
+    """Parse one or more ``--model`` flags.
+
+    Two grammars are accepted:
+
+    * ``--model <value>`` — applies to the IDE selected for this pull.
+    * ``--model <ide>=<value>`` — explicit per-IDE override (advanced; lets
+      a single command target a specific IDE without ambiguity).
+
+    Returns ``(default_value, per_ide_overrides)``.
+    """
+    default: str | None = None
+    overrides: dict[str, str] = {}
+    for raw in values or []:
+        if "=" in raw:
+            ide_key, _, val = raw.partition("=")
+            ide_key = ide_key.strip()
+            val = val.strip()
+            if ide_key and val:
+                overrides[ide_key] = val
+        elif raw.strip():
+            default = raw.strip()
+    return default, overrides
+
+
 def _collect_install_options(
     ide: str,
     *,
     scope: str | None,
-    model: str | None,
+    model_default: str | None,
+    model_overrides: dict[str, str],
     tools: str | None,
     no_prompt: bool,
+    refresh_models: bool = False,
 ) -> dict:
     """Interactively collect IDE-specific install options.
 
-    Honors explicit --scope/--model/--tools flags; only prompts for what's
-    missing when running in an interactive terminal and --no-prompt isn't set.
+    Honors explicit ``--scope``/``--model``/``--tools`` flags; only prompts for
+    what's missing when running in an interactive terminal and ``--no-prompt``
+    isn't set. The model picker now consults the live catalog (``GET /api/v1/models``)
+    instead of a hardcoded list.
     """
     import sys
 
+    from observal_cli.ide_registry import accepts_model_choice
     from observal_cli.prompts import select_one
 
     opts: dict = {}
     interactive = sys.stdin.isatty() and not no_prompt
 
-    # Scope (Claude Code, Kiro, Gemini CLI, Cursor)
     if ide in _SCOPE_AWARE_IDES:
         if scope:
             opts["scope"] = scope
@@ -257,20 +286,31 @@ def _collect_install_options(
         else:
             opts["scope"] = "project"
 
-    # Claude Code only: model and tools
-    if ide in ("claude-code", "claude_code"):
-        if model:
-            opts["model"] = model
+    if accepts_model_choice(ide):
+        explicit = model_overrides.get(ide) or model_default
+        if explicit:
+            opts["model"] = explicit
         elif interactive:
-            choice = select_one(
-                "  Model",
-                ["inherit (use main session model)", "sonnet", "opus", "haiku"],
-                default="inherit (use main session model)",
-            )
-            opts["model"] = "inherit" if choice.startswith("inherit") else choice
+            from observal_cli import model_catalog as _catalog
 
-        if tools:
-            opts["tools"] = tools
+            try:
+                catalog = _catalog.fetch_catalog(refresh=refresh_models)
+            except Exception:
+                catalog = {"models": []}
+            choices = _catalog.model_choices_for_picker(catalog, ide)
+            choice_labels = [c[0] for c in choices] if choices else []
+            choice_labels = ["auto (let the IDE decide)", *choice_labels]
+            picked = select_one("  Model", choice_labels, default="auto (let the IDE decide)")
+            if picked.startswith("auto"):
+                opts["model"] = ""
+            else:
+                for label, model_id in choices:
+                    if label == picked:
+                        opts["model"] = model_id
+                        break
+
+    if ide in ("claude-code", "claude_code") and tools:
+        opts["tools"] = tools
 
     return opts
 
@@ -290,10 +330,18 @@ def register_pull(app: typer.Typer):
         scope: str | None = typer.Option(
             None, "--scope", help="Install scope: 'project' or 'user' (Claude Code/Kiro/Gemini only)"
         ),
-        model: str | None = typer.Option(
-            None, "--model", help="Sub-agent model: inherit, sonnet, opus, haiku (Claude Code only)"
+        model: list[str] | None = typer.Option(
+            None,
+            "--model",
+            help=(
+                "Model override. Accepts '<value>' (applies to the selected --ide) or "
+                "'<ide>=<value>' for explicit per-IDE overrides. May be repeated."
+            ),
         ),
         tools: str | None = typer.Option(None, "--tools", help="Comma-separated tool whitelist (Claude Code only)"),
+        refresh_models: bool = typer.Option(
+            False, "--refresh-models", help="Bust the local model catalog cache before showing the model picker"
+        ),
         no_prompt: bool = typer.Option(False, "--no-prompt", "-y", help="Skip interactive prompts"),
     ):
         """Fetch agent config and write IDE files to disk.
@@ -311,9 +359,21 @@ def register_pull(app: typer.Typer):
 
         env_values = _collect_mcp_env_vars(agent_detail)
 
-        # Collect IDE-specific install options (scope, model, tools)
         rprint(f"\n[bold]Install options for [cyan]{ide}[/cyan]:[/bold]")
-        options = _collect_install_options(ide, scope=scope, model=model, tools=tools, no_prompt=no_prompt)
+        if refresh_models:
+            from observal_cli import model_catalog as _catalog
+
+            _catalog.invalidate_cache()
+        model_default, model_overrides = _parse_model_overrides(model or [])
+        options = _collect_install_options(
+            ide,
+            scope=scope,
+            model_default=model_default,
+            model_overrides=model_overrides,
+            tools=tools,
+            no_prompt=no_prompt,
+            refresh_models=refresh_models,
+        )
         is_user_scope = options.get("scope") == "user"
         if is_user_scope:
             rprint("  [dim]Files will be written to your home directory (user scope).[/dim]")
@@ -433,6 +493,12 @@ def register_pull(app: typer.Typer):
         for path, status in written:
             style = "dim" if dry_run else "green"
             rprint(f"  [{style}]{status}[/{style}]  {path}")
+
+        warnings_list = snippet.get("_warnings") or []
+        if warnings_list:
+            rprint("")
+            for w in warnings_list:
+                rprint(f"  [yellow]⚠[/yellow]  {w}")
 
         # ── Setup commands (Claude Code) ────────────────────
         setup_cmds = snippet.get("mcp_setup_commands")

--- a/observal_cli/ide_registry.py
+++ b/observal_cli/ide_registry.py
@@ -33,6 +33,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.cursor/mcp.json",
         "hook_type": "command",
         "config_dir": ".cursor",
+        "accepts_model_choice": False,
+        "auto_sentinel": None,
     },
     "kiro": {
         "display_name": "Kiro",
@@ -58,6 +60,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.kiro/settings/mcp.json",
         "hook_type": "command",
         "config_dir": ".kiro",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"json_value": None},
     },
     "claude-code": {
         "display_name": "Claude Code",
@@ -84,6 +88,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.claude.json",
         "hook_type": "command",
         "config_dir": ".claude",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_frontmatter_field": True},
     },
     "gemini-cli": {
         "display_name": "Gemini CLI",
@@ -110,6 +116,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.gemini/settings.json",
         "hook_type": "command",
         "config_dir": ".gemini",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_setting": True},
     },
     "vscode": {
         "display_name": "VS Code",
@@ -133,6 +141,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": None,
         "hook_type": "command",
         "config_dir": ".vscode",
+        "accepts_model_choice": False,
+        "auto_sentinel": None,
     },
     "codex": {
         "display_name": "Codex",
@@ -154,6 +164,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.codex/config.toml",
         "hook_type": None,
         "config_dir": ".codex",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_toml_field": True},
     },
     "copilot": {
         "display_name": "Copilot",
@@ -175,6 +187,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.vscode/mcp.json",
         "hook_type": "command",
         "config_dir": ".vscode",
+        "accepts_model_choice": False,
+        "auto_sentinel": None,
     },
     "copilot-cli": {
         "display_name": "Copilot CLI",
@@ -199,6 +213,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.copilot/mcp-config.json",
         "hook_type": "command",
         "config_dir": ".copilot",
+        "accepts_model_choice": False,
+        "auto_sentinel": None,
     },
     "opencode": {
         "display_name": "OpenCode",
@@ -224,6 +240,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "home_mcp_config": "~/.config/opencode/opencode.json",
         "hook_type": "plugin",
         "config_dir": ".config/opencode",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_field": True},
     },
 }
 
@@ -264,6 +282,21 @@ def get_mcp_servers_key(ide: str) -> str:
 def get_default_scope(ide: str) -> str:
     """Return the default install scope for an IDE."""
     return IDE_REGISTRY.get(ide, {}).get("default_scope", "project")
+
+
+def get_model_choice_ides() -> list[str]:
+    """Return IDEs that accept a per-agent model selection."""
+    return [ide for ide, spec in IDE_REGISTRY.items() if spec.get("accepts_model_choice")]
+
+
+def accepts_model_choice(ide: str) -> bool:
+    """Return True if this IDE supports a per-agent model field."""
+    return bool(IDE_REGISTRY.get(ide, {}).get("accepts_model_choice"))
+
+
+def get_auto_sentinel(ide: str) -> dict | None:
+    """Return the codegen sentinel describing how to express ``auto`` for this IDE."""
+    return IDE_REGISTRY.get(ide, {}).get("auto_sentinel")
 
 
 def get_session_parser_id(ide: str) -> str:

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -88,6 +88,7 @@ from observal_cli.cmd_component import component_app
 from observal_cli.cmd_doctor import doctor_app
 from observal_cli.cmd_mcp import mcp_app
 from observal_cli.cmd_migrate import migrate_app
+from observal_cli.cmd_models import models_app
 from observal_cli.cmd_ops import (
     admin_app,
     ops_app,
@@ -115,6 +116,7 @@ registry_app.add_typer(mcp_app, name="mcp")
 registry_app.add_typer(skill_app, name="skill")
 registry_app.add_typer(prompt_app, name="prompt")
 registry_app.add_typer(sandbox_app, name="sandbox")
+registry_app.add_typer(models_app, name="models")
 
 # ── Auth subgroup ────────────────────────────────────────
 app.add_typer(auth_app, name="auth")

--- a/observal_cli/model_catalog.py
+++ b/observal_cli/model_catalog.py
@@ -139,15 +139,8 @@ def model_choices_for_picker(catalog: dict, ide: str) -> list[tuple[str, str]]:
             choices.append((short, short))
 
     rows = models_supporting_ide(catalog, ide)
-    primary_counts: dict[str, int] = {}
-    primaries: list[str] = []
     for m in rows:
-        primary, _, _ = format_model(m, disambiguate=False)
-        primaries.append(primary)
-        primary_counts[primary] = primary_counts.get(primary, 0) + 1
-
-    for m, p in zip(rows, primaries, strict=True):
-        primary, secondary, _ = format_model(m, disambiguate=primary_counts.get(p, 0) > 1)
+        primary, secondary, _ = format_model(m, disambiguate=True)
         label = f"{primary} ({secondary})" if secondary else primary
         choices.append((label, m.get("model_id") or ""))
     return choices

--- a/observal_cli/model_catalog.py
+++ b/observal_cli/model_catalog.py
@@ -1,0 +1,198 @@
+"""CLI-side model catalog access with a 1h read-through file cache.
+
+The CLI fetches the catalog from ``GET /api/v1/models`` and caches the JSON
+to ``~/.observal/cache/model_catalog.json``. The cache is consulted before
+hitting the server so the interactive ``observal pull`` model picker stays
+snappy even on a flaky network.
+
+Cache invalidation:
+* TTL: 1 hour (matches the in-memory horizon on the server-side LRU).
+* ``observal pull --refresh-models`` and ``observal registry models list --refresh``
+  both bypass the cache and force a re-fetch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from observal_cli import client
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TTL_SECONDS = 3600  # 1 hour
+_CACHE_FILE = Path(os.environ.get("OBSERVAL_HOME", str(Path.home() / ".observal"))) / "cache" / "model_catalog.json"
+_OFFLINE_MIRROR = Path(__file__).resolve().parent.parent / "observal-server" / "data" / "model_registry_seed.json"
+
+
+# ─── File cache I/O ──────────────────────────────────────────
+
+
+def _read_file_cache() -> dict | None:
+    """Return the cached catalog if it exists and is parseable. None otherwise."""
+    try:
+        if not _CACHE_FILE.exists():
+            return None
+        with _CACHE_FILE.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug("model_catalog_cli_cache_read_failed", exc_info=e)
+        return None
+
+
+def _write_file_cache(payload: dict) -> None:
+    try:
+        _CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with _CACHE_FILE.open("w", encoding="utf-8") as f:
+            json.dump(payload, f)
+    except OSError as e:
+        logger.debug("model_catalog_cli_cache_write_failed", exc_info=e)
+
+
+def invalidate_cache() -> None:
+    """Delete the cached catalog. Used by the ``--refresh-models`` flag."""
+    try:
+        if _CACHE_FILE.exists():
+            _CACHE_FILE.unlink()
+    except OSError as e:
+        logger.debug("model_catalog_cli_cache_invalidate_failed", exc_info=e)
+
+
+# ─── Public entrypoint ───────────────────────────────────────
+
+
+def fetch_catalog(*, refresh: bool = False, ttl: int = _DEFAULT_TTL_SECONDS) -> dict:
+    """Return the catalog as a plain dict.
+
+    Order of preference:
+    1. Fresh file cache (when ``refresh`` is False and the cached_at age < ``ttl``).
+    2. ``GET /api/v1/models`` from the configured server.
+    3. Stale file cache (any age) — better than nothing.
+    4. Vendored offline mirror snapshot (``observal-server/data/model_registry_seed.json``).
+    5. Empty catalog with ``degraded=True``.
+    """
+    if not refresh:
+        cached = _read_file_cache()
+        if cached:
+            cached_at = float(cached.get("_cached_at") or 0.0)
+            if cached_at and (time.time() - cached_at) < ttl:
+                cached["_source"] = "file"
+                return cached
+
+    try:
+        data = client.get("/api/v1/models")
+    except Exception as e:
+        logger.debug("model_catalog_cli_remote_fetch_failed", exc_info=e)
+        data = None
+
+    if data:
+        data["_cached_at"] = time.time()
+        data["_source"] = "live"
+        _write_file_cache(data)
+        return data
+
+    stale = _read_file_cache()
+    if stale:
+        stale["_source"] = "file-stale"
+        return stale
+
+    if _OFFLINE_MIRROR.exists():
+        try:
+            with _OFFLINE_MIRROR.open("r", encoding="utf-8") as f:
+                snapshot = json.load(f)
+            return _normalize_offline_snapshot(snapshot)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.debug("model_catalog_cli_offline_mirror_read_failed", exc_info=e)
+
+    return {"models": [], "model_count": 0, "degraded": True, "source": "empty", "_source": "empty"}
+
+
+# ─── Helpers used by callers ─────────────────────────────────
+
+
+def models_supporting_ide(catalog: dict, ide: str) -> list[dict]:
+    """Filter the catalog to models that this IDE accepts."""
+    out: list[dict] = []
+    for m in catalog.get("models") or []:
+        ides = m.get("supported_ides") or []
+        if ide in ides:
+            out.append(m)
+    return out
+
+
+def model_choices_for_picker(catalog: dict, ide: str) -> list[tuple[str, str]]:
+    """Return ``[(label, model_id), ...]`` suitable for ``select_one``.
+
+    For Claude Code we surface the short-alias choices first (sonnet/opus/haiku/inherit)
+    so muscle memory keeps working, then the catalog options.
+    """
+    from observal_cli.render import format_model
+
+    choices: list[tuple[str, str]] = []
+    if ide in ("claude-code", "claude_code"):
+        choices.append(("inherit (use main session model)", "inherit"))
+        for short in ("sonnet", "opus", "haiku"):
+            choices.append((short, short))
+
+    rows = models_supporting_ide(catalog, ide)
+    primary_counts: dict[str, int] = {}
+    primaries: list[str] = []
+    for m in rows:
+        primary, _, _ = format_model(m, disambiguate=False)
+        primaries.append(primary)
+        primary_counts[primary] = primary_counts.get(primary, 0) + 1
+
+    for m, p in zip(rows, primaries, strict=True):
+        primary, secondary, _ = format_model(m, disambiguate=primary_counts.get(p, 0) > 1)
+        label = f"{primary} ({secondary})" if secondary else primary
+        choices.append((label, m.get("model_id") or ""))
+    return choices
+
+
+# Mirrors ``services.model_catalog.PROVIDER_IDE_MAP`` — kept locally so the CLI
+# can fall back to the offline snapshot without importing from the server pkg.
+_PROVIDER_IDE_MAP: dict[str, list[str]] = {
+    "anthropic": ["claude-code", "kiro", "opencode"],
+    "openai": ["codex", "opencode"],
+    "google": ["gemini-cli", "opencode"],
+    "google-vertex": ["gemini-cli", "opencode"],
+}
+
+
+def _normalize_offline_snapshot(snapshot: Any) -> dict:
+    """Best-effort map of the raw models.dev snapshot to the {models, ...} shape.
+
+    Used only when we can't reach the server. The picker doesn't need every
+    field — just ``model_id``, ``display_name``, ``provider``, ``supported_ides``
+    and a release date.
+    """
+    rows: list[dict] = []
+    if isinstance(snapshot, dict):
+        for provider_id, provider in snapshot.items():
+            if provider_id not in _PROVIDER_IDE_MAP:
+                continue
+            models = provider.get("models", {}) if isinstance(provider, dict) else {}
+            for model_id, m in models.items():
+                if not isinstance(m, dict):
+                    continue
+                rows.append(
+                    {
+                        "model_id": m.get("id") or model_id,
+                        "display_name": m.get("name") or model_id,
+                        "provider": provider_id,
+                        "release_date": str(m.get("release_date") or ""),
+                        "supported_ides": _PROVIDER_IDE_MAP.get(provider_id, []),
+                        "deprecated": bool(m.get("deprecated")),
+                    }
+                )
+    return {
+        "models": rows,
+        "model_count": len(rows),
+        "degraded": True,
+        "source": "snapshot",
+        "_source": "offline-mirror",
+    }

--- a/observal_cli/render.py
+++ b/observal_cli/render.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json as _json
-import re
 from datetime import UTC, date, datetime
 from typing import Any
 
@@ -140,91 +139,60 @@ def success(msg: str):
     rprint(f"[green]Success:[/green] {msg}")
 
 
-# ── Model display helpers (mirror of services/model_display.py) ──
+# ── Model display helpers ──
+# Reads the pre-computed ``display`` field from the server API response
+# (computed by ``services/model_display.py``). Falls back to raw model_id
+# when display data isn't available (e.g. offline mirror, bare model_id lookup).
 
-_MODEL_DATE_DASH_COMPACT = re.compile(r"[-_\s](\d{8})$")
-_MODEL_DATE_DASH_HYPHEN = re.compile(r"[-_\s](\d{4}-\d{2}-\d{2})$")
-_MODEL_DATE_PAREN = re.compile(r"\s*\((\d{4}-\d{2}-\d{2})\)\s*$")
-_MODEL_LATEST_PAREN = re.compile(r"\s*\(latest\)\s*$", re.IGNORECASE)
-_MODEL_LATEST_DASH = re.compile(r"[-_]latest$", re.IGNORECASE)
-_MODEL_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+_MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 
 
-def _strip_model_date(text: str) -> str:
-    if not text:
-        return text
-    out = text
-    out = _MODEL_LATEST_PAREN.sub("", out).strip()
-    out = _MODEL_DATE_PAREN.sub("", out).strip()
-    out = _MODEL_DATE_DASH_HYPHEN.sub("", out).strip()
-    out = _MODEL_DATE_DASH_COMPACT.sub("", out).strip()
-    out = _MODEL_LATEST_DASH.sub("", out).strip()
-    return out
+def _format_date_short(d: date) -> str:
+    return f"{_MONTH_NAMES[d.month - 1]} {d.day}, {d.year}"
 
 
-def _model_has_trailing_date(model_id: str) -> tuple[bool, date | None]:
-    m = _MODEL_DATE_DASH_COMPACT.search(model_id)
-    if m:
+def _force_secondary(row: dict, is_rolling: bool) -> str | None:
+    """Derive a secondary label when the caller wants forced disambiguation."""
+    if is_rolling:
+        return "latest"
+    rd = row.get("release_date")
+    if rd:
         try:
-            return True, datetime.strptime(m.group(1), "%Y%m%d").date()
-        except ValueError:
-            return True, None
-    m = _MODEL_DATE_DASH_HYPHEN.search(model_id)
-    if m:
-        try:
-            return True, datetime.strptime(m.group(1), "%Y-%m-%d").date()
-        except ValueError:
-            return True, None
-    return False, None
+            d = datetime.fromisoformat(str(rd)).date() if not isinstance(rd, date) else rd
+            return _format_date_short(d)
+        except (ValueError, TypeError):
+            pass
+    return None
 
 
 def format_model(row: dict, *, disambiguate: bool = False) -> tuple[str, str | None, bool]:
     """Format a model catalog row for CLI display.
 
-    Returns ``(primary, secondary, is_rolling)``. Secondary may be ``None``.
-    Mirrors ``services/model_display.format_display`` line-for-line so CLI
-    output never drifts from the web UI.
+    Returns ``(primary, secondary, is_rolling)``. Reads the server-computed
+    ``display`` field when available; falls back to the model_id.
     """
-    display_name = row.get("display_name") or ""
-    model_id = row.get("model_id", "")
-    release_date_value = row.get("release_date")
-    raw = (display_name or model_id).strip()
-    primary = _strip_model_date(raw) or raw
+    display = row.get("display")
+    if isinstance(display, dict):
+        primary = display.get("primary") or row.get("model_id", "")
+        secondary = display.get("secondary")
+        is_rolling = bool(display.get("is_rolling"))
+        if disambiguate and not secondary:
+            secondary = _force_secondary(row, is_rolling)
+        return primary, secondary, is_rolling
 
-    has_date, parsed = _model_has_trailing_date(model_id)
-    is_rolling = not has_date
-    is_explicit_latest = bool(_MODEL_LATEST_PAREN.search(raw)) or model_id.endswith("-latest")
-
-    if not disambiguate and not is_explicit_latest:
-        return primary, None, is_rolling
-
-    secondary: str | None = None
-    if is_rolling or is_explicit_latest:
-        secondary = "latest"
-    else:
-        d = parsed
-        if d is None and release_date_value:
-            try:
-                d = datetime.fromisoformat(str(release_date_value)).date()
-            except ValueError:
-                d = None
-        if d is not None:
-            secondary = f"{_MODEL_MONTHS[d.month - 1]} {d.day}, {d.year}"
+    # Fallback: no pre-computed display (offline mirror or bare model_id lookup)
+    primary = (row.get("display_name") or row.get("model_id") or "").strip()
+    is_rolling = not primary[-8:].isdigit() if primary else False
+    secondary = _force_secondary(row, is_rolling) if disambiguate else None
     return primary, secondary, is_rolling
 
 
 def annotate_models(rows: list[dict]) -> list[dict]:
     """Return a new list where each row gets a ``_display`` dict with primary/secondary."""
-    counts: dict[str, int] = {}
-    primaries: list[str] = []
-    for r in rows:
-        primary, _, _ = format_model(r, disambiguate=False)
-        primaries.append(primary)
-        counts[primary] = counts.get(primary, 0) + 1
     out: list[dict] = []
-    for r, primary in zip(rows, primaries, strict=True):
+    for r in rows:
         annotated = dict(r)
-        p, s, rolling = format_model(r, disambiguate=counts[primary] > 1)
+        p, s, rolling = format_model(r, disambiguate=True)
         annotated["_display"] = {"primary": p, "secondary": s, "is_rolling": rolling}
         out.append(annotated)
     return out

--- a/observal_cli/render.py
+++ b/observal_cli/render.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json as _json
-from datetime import UTC, datetime
+import re
+from datetime import UTC, date, datetime
 from typing import Any
 
 from rich import print as rprint
@@ -137,3 +138,93 @@ def warning(msg: str):
 def success(msg: str):
     """Print a success message."""
     rprint(f"[green]Success:[/green] {msg}")
+
+
+# ── Model display helpers (mirror of services/model_display.py) ──
+
+_MODEL_DATE_DASH_COMPACT = re.compile(r"[-_\s](\d{8})$")
+_MODEL_DATE_DASH_HYPHEN = re.compile(r"[-_\s](\d{4}-\d{2}-\d{2})$")
+_MODEL_DATE_PAREN = re.compile(r"\s*\((\d{4}-\d{2}-\d{2})\)\s*$")
+_MODEL_LATEST_PAREN = re.compile(r"\s*\(latest\)\s*$", re.IGNORECASE)
+_MODEL_LATEST_DASH = re.compile(r"[-_]latest$", re.IGNORECASE)
+_MODEL_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+def _strip_model_date(text: str) -> str:
+    if not text:
+        return text
+    out = text
+    out = _MODEL_LATEST_PAREN.sub("", out).strip()
+    out = _MODEL_DATE_PAREN.sub("", out).strip()
+    out = _MODEL_DATE_DASH_HYPHEN.sub("", out).strip()
+    out = _MODEL_DATE_DASH_COMPACT.sub("", out).strip()
+    out = _MODEL_LATEST_DASH.sub("", out).strip()
+    return out
+
+
+def _model_has_trailing_date(model_id: str) -> tuple[bool, date | None]:
+    m = _MODEL_DATE_DASH_COMPACT.search(model_id)
+    if m:
+        try:
+            return True, datetime.strptime(m.group(1), "%Y%m%d").date()
+        except ValueError:
+            return True, None
+    m = _MODEL_DATE_DASH_HYPHEN.search(model_id)
+    if m:
+        try:
+            return True, datetime.strptime(m.group(1), "%Y-%m-%d").date()
+        except ValueError:
+            return True, None
+    return False, None
+
+
+def format_model(row: dict, *, disambiguate: bool = False) -> tuple[str, str | None, bool]:
+    """Format a model catalog row for CLI display.
+
+    Returns ``(primary, secondary, is_rolling)``. Secondary may be ``None``.
+    Mirrors ``services/model_display.format_display`` line-for-line so CLI
+    output never drifts from the web UI.
+    """
+    display_name = row.get("display_name") or ""
+    model_id = row.get("model_id", "")
+    release_date_value = row.get("release_date")
+    raw = (display_name or model_id).strip()
+    primary = _strip_model_date(raw) or raw
+
+    has_date, parsed = _model_has_trailing_date(model_id)
+    is_rolling = not has_date
+    is_explicit_latest = bool(_MODEL_LATEST_PAREN.search(raw)) or model_id.endswith("-latest")
+
+    if not disambiguate and not is_explicit_latest:
+        return primary, None, is_rolling
+
+    secondary: str | None = None
+    if is_rolling or is_explicit_latest:
+        secondary = "latest"
+    else:
+        d = parsed
+        if d is None and release_date_value:
+            try:
+                d = datetime.fromisoformat(str(release_date_value)).date()
+            except ValueError:
+                d = None
+        if d is not None:
+            secondary = f"{_MODEL_MONTHS[d.month - 1]} {d.day}, {d.year}"
+    return primary, secondary, is_rolling
+
+
+def annotate_models(rows: list[dict]) -> list[dict]:
+    """Return a new list where each row gets a ``_display`` dict with primary/secondary."""
+    counts: dict[str, int] = {}
+    primaries: list[str] = []
+    for r in rows:
+        primary, _, _ = format_model(r, disambiguate=False)
+        primaries.append(primary)
+        counts[primary] = counts.get(primary, 0) + 1
+    out: list[dict] = []
+    for r, primary in zip(rows, primaries, strict=True):
+        annotated = dict(r)
+        p, s, rolling = format_model(r, disambiguate=counts[primary] > 1)
+        annotated["_display"] = {"primary": p, "secondary": s, "is_rolling": rolling}
+        out.append(annotated)
+    return out

--- a/scripts/refresh_model_snapshot.py
+++ b/scripts/refresh_model_snapshot.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Refresh the vendored model catalog snapshot from models.dev.
+
+This is a manual ops tool — run it during a release if you want the offline
+floor (used when ``models.dev`` is unreachable) to track upstream. The live
+server does NOT call this script; it always tries the network first and falls
+back to whatever this snapshot contained at build time.
+
+Usage:
+    python scripts/refresh_model_snapshot.py [--out PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+UPSTREAM_URL = "https://models.dev/api.json"
+DEFAULT_OUT = Path(__file__).resolve().parent.parent / "observal-server" / "data" / "model_registry_seed.json"
+KEEP_PROVIDERS = {"anthropic", "openai", "google", "google-vertex"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help="Output path (default: vendored seed)")
+    parser.add_argument(
+        "--all-providers",
+        action="store_true",
+        help="Keep every provider models.dev returns (default keeps only the IDE-mapped ones).",
+    )
+    args = parser.parse_args()
+
+    print(f"Fetching {UPSTREAM_URL}...")
+    try:
+        with urllib.request.urlopen(UPSTREAM_URL, timeout=20) as resp:
+            data = json.load(resp)
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
+        print(f"Fetch failed: {e}", file=sys.stderr)
+        return 1
+
+    if not args.all_providers:
+        data = {pid: pdata for pid, pdata in data.items() if pid in KEEP_PROVIDERS}
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+    total = sum(len(p.get("models", {})) for p in data.values() if isinstance(p, dict))
+    print(f"Wrote {args.out} ({total} models across {len(data)} providers).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/model_display_cases.json
+++ b/tests/fixtures/model_display_cases.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "Cases that drive parity tests across services/model_display.py + web/src/lib/model-display.ts + observal_cli/render.format_model.",
+  "cases": [
+    {
+      "name": "rolling_pointer_no_date",
+      "display_name": "Claude Sonnet 4.5 (latest)",
+      "model_id": "claude-sonnet-4-5",
+      "release_date": "2025-09-29",
+      "disambiguate": false,
+      "expected": {
+        "primary": "Claude Sonnet 4.5",
+        "secondary": "latest",
+        "is_rolling": true
+      }
+    },
+    {
+      "name": "dated_snapshot_solo_no_secondary",
+      "display_name": "Claude Opus 4.5",
+      "model_id": "claude-opus-4-5-20251101",
+      "release_date": "2025-11-01",
+      "disambiguate": false,
+      "expected": {
+        "primary": "Claude Opus 4.5",
+        "secondary": null,
+        "is_rolling": false
+      }
+    },
+    {
+      "name": "dated_snapshot_collides_shows_date",
+      "display_name": "Claude 3.5 Sonnet (2024-10-22)",
+      "model_id": "claude-3-5-sonnet-20241022",
+      "release_date": "2024-10-22",
+      "disambiguate": true,
+      "expected": {
+        "primary": "Claude 3.5 Sonnet",
+        "secondary": "Oct 22, 2024",
+        "is_rolling": false
+      }
+    },
+    {
+      "name": "rolling_pointer_collides_shows_latest",
+      "display_name": "Claude Sonnet 4.5",
+      "model_id": "claude-sonnet-4-5",
+      "release_date": "2025-09-29",
+      "disambiguate": true,
+      "expected": {
+        "primary": "Claude Sonnet 4.5",
+        "secondary": "latest",
+        "is_rolling": true
+      }
+    },
+    {
+      "name": "compact_date_strip",
+      "display_name": "GPT-4o Snapshot 2024-05-13",
+      "model_id": "gpt-4o-2024-05-13",
+      "release_date": "2024-05-13",
+      "disambiguate": true,
+      "expected": {
+        "primary": "GPT-4o Snapshot",
+        "secondary": "May 13, 2024",
+        "is_rolling": false
+      }
+    },
+    {
+      "name": "missing_display_name_falls_back_to_id",
+      "display_name": "",
+      "model_id": "gemini-1.5-pro-latest",
+      "release_date": null,
+      "disambiguate": false,
+      "expected": {
+        "primary": "gemini-1.5-pro",
+        "secondary": "latest",
+        "is_rolling": true
+      }
+    },
+    {
+      "name": "no_date_no_disambig",
+      "display_name": "Claude Haiku 4.5",
+      "model_id": "claude-haiku-4-5",
+      "release_date": "2025-10-01",
+      "disambiguate": false,
+      "expected": {
+        "primary": "Claude Haiku 4.5",
+        "secondary": null,
+        "is_rolling": true
+      }
+    }
+  ]
+}

--- a/tests/test_agent_snapshot.py
+++ b/tests/test_agent_snapshot.py
@@ -1,0 +1,224 @@
+"""Tests for the agent YAML snapshot builder + the matching CLI behaviours.
+
+Covers the bug where per-IDE model overrides set in the web builder never
+made it into the snapshot the reviewer reads, and where ``observal pull``
+re-prompted for a model that the agent author had already chosen.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+# ───────────────── server-side: build_yaml_snapshot ─────────────────
+
+
+def _mock_session_for_snapshot(components: list, goal: object | None = None, sections: list | None = None):
+    """Build an AsyncMock session that returns the given rows in order."""
+    db = AsyncMock()
+    component_result = MagicMock()
+    component_scalars = MagicMock()
+    component_scalars.all.return_value = components
+    component_result.scalars.return_value = component_scalars
+
+    goal_result = MagicMock()
+    goal_result.scalar_one_or_none.return_value = goal
+
+    section_result = MagicMock()
+    section_scalars = MagicMock()
+    section_scalars.all.return_value = sections or []
+    section_result.scalars.return_value = section_scalars
+
+    side_effects = [component_result]
+    if goal is not None:
+        side_effects.extend([goal_result, section_result])
+    else:
+        side_effects.append(goal_result)
+    db.execute = AsyncMock(side_effect=side_effects)
+    return db
+
+
+def _mock_version(*, models_by_ide: dict | None = None, supported_ides: list | None = None):
+    ver = MagicMock()
+    ver.id = uuid.uuid4()
+    ver.version = "1.2.3"
+    ver.description = "A helpful agent"
+    ver.prompt = "be nice"
+    ver.model_name = "claude-sonnet-4-5"
+    ver.model_config_json = {}
+    ver.models_by_ide = models_by_ide if models_by_ide is not None else {}
+    ver.supported_ides = supported_ides or ["claude-code", "kiro"]
+    ver.external_mcps = []
+    return ver
+
+
+@pytest.mark.asyncio
+async def test_snapshot_includes_models_by_ide():
+    """Per-IDE overrides should always appear in the rendered snapshot."""
+    from services.agent_snapshot import build_yaml_snapshot
+
+    ver = _mock_version(models_by_ide={"kiro": "claude-haiku-4-5", "codex": "gpt-5"})
+    db = _mock_session_for_snapshot(components=[], goal=None)
+
+    text = await build_yaml_snapshot(ver, db)
+
+    assert "models_by_ide" in text
+    parsed = yaml.safe_load(text)
+    assert parsed["models_by_ide"] == {
+        "kiro": "claude-haiku-4-5",
+        "codex": "gpt-5",
+    }
+    assert parsed["model_name"] == "claude-sonnet-4-5"
+    assert parsed["version"] == "1.2.3"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_emits_empty_dict_when_no_overrides():
+    """An empty ``models_by_ide`` should be present (not omitted) so reviewers
+    can tell "no overrides" apart from "data missing"."""
+    from services.agent_snapshot import build_yaml_snapshot
+
+    ver = _mock_version(models_by_ide={})
+    db = _mock_session_for_snapshot(components=[], goal=None)
+
+    text = await build_yaml_snapshot(ver, db)
+
+    parsed = yaml.safe_load(text)
+    assert "models_by_ide" in parsed
+    assert parsed["models_by_ide"] == {}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_drops_blank_overrides():
+    """Empty/None override values should be filtered out."""
+    from services.agent_snapshot import build_yaml_snapshot
+
+    ver = _mock_version(models_by_ide={"kiro": "", "codex": "gpt-5", "vscode": None})
+    db = _mock_session_for_snapshot(components=[], goal=None)
+
+    text = await build_yaml_snapshot(ver, db)
+    parsed = yaml.safe_load(text)
+    assert parsed["models_by_ide"] == {"codex": "gpt-5"}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_handles_non_dict_models_by_ide():
+    """A non-dict ``models_by_ide`` (legacy data) should not crash."""
+    from services.agent_snapshot import build_yaml_snapshot
+
+    ver = _mock_version()
+    ver.models_by_ide = "garbage-value"  # simulates broken legacy data
+    db = _mock_session_for_snapshot(components=[], goal=None)
+
+    text = await build_yaml_snapshot(ver, db)
+    parsed = yaml.safe_load(text)
+    assert parsed["models_by_ide"] == {}
+
+
+# ───────────────── CLI: agent saved model + skip prompt ─────────────────
+
+
+def test_agent_saved_model_prefers_per_ide_override():
+    from observal_cli.cmd_pull import _agent_saved_model
+
+    detail = {
+        "model_name": "claude-sonnet-4-5",
+        "models_by_ide": {"kiro": "claude-haiku-4-5", "codex": "gpt-5"},
+    }
+    assert _agent_saved_model(detail, "kiro") == "claude-haiku-4-5"
+    assert _agent_saved_model(detail, "codex") == "gpt-5"
+
+
+def test_agent_saved_model_falls_back_to_model_name_only_for_claude_code():
+    from observal_cli.cmd_pull import _agent_saved_model
+
+    detail = {
+        "model_name": "claude-sonnet-4-5",
+        "models_by_ide": {},
+    }
+    assert _agent_saved_model(detail, "claude-code") == "claude-sonnet-4-5"
+    # Other IDEs should NOT inherit model_name — they emit auto sentinel.
+    assert _agent_saved_model(detail, "kiro") is None
+    assert _agent_saved_model(detail, "codex") is None
+
+
+def test_agent_saved_model_returns_none_when_missing():
+    from observal_cli.cmd_pull import _agent_saved_model
+
+    assert _agent_saved_model(None, "kiro") is None
+    assert _agent_saved_model({}, "kiro") is None
+    assert _agent_saved_model({"models_by_ide": {"kiro": "  "}}, "kiro") is None
+
+
+def test_collect_install_options_skips_picker_when_agent_has_saved_model():
+    """The whole point of the bug fix: per-IDE overrides should bypass the prompt."""
+    from observal_cli.cmd_pull import _collect_install_options
+
+    agent_detail = {
+        "model_name": "claude-sonnet-4-5",
+        "models_by_ide": {"kiro": "claude-haiku-4-5"},
+    }
+
+    with (
+        patch("observal_cli.prompts.select_one") as mock_picker,
+        patch("sys.stdin.isatty", return_value=True),
+    ):
+        opts = _collect_install_options(
+            "kiro",
+            scope="project",
+            model_default=None,
+            model_overrides={},
+            tools=None,
+            no_prompt=False,
+            agent_detail=agent_detail,
+        )
+
+    assert opts["model"] == "claude-haiku-4-5"
+    # The model picker must not have run.
+    for call in mock_picker.call_args_list:
+        args, _ = call
+        assert "Model" not in (args[0] if args else ""), f"select_one was called for model selection: {call}"
+
+
+def test_collect_install_options_explicit_override_wins_over_saved():
+    from observal_cli.cmd_pull import _collect_install_options
+
+    agent_detail = {
+        "model_name": "claude-sonnet-4-5",
+        "models_by_ide": {"kiro": "claude-haiku-4-5"},
+    }
+
+    with patch("sys.stdin.isatty", return_value=True):
+        opts = _collect_install_options(
+            "kiro",
+            scope="project",
+            model_default="claude-opus-4-5",
+            model_overrides={},
+            tools=None,
+            no_prompt=False,
+            agent_detail=agent_detail,
+        )
+
+    assert opts["model"] == "claude-opus-4-5"
+
+
+def test_collect_install_options_no_saved_no_explicit_no_tty_omits_model():
+    """Non-interactive with nothing chosen: don't pass options.model so the
+    server falls back to its own default."""
+    from observal_cli.cmd_pull import _collect_install_options
+
+    with patch("sys.stdin.isatty", return_value=False):
+        opts = _collect_install_options(
+            "kiro",
+            scope="project",
+            model_default=None,
+            model_overrides={},
+            tools=None,
+            no_prompt=True,
+            agent_detail=None,
+        )
+
+    assert "model" not in opts

--- a/tests/test_constants_sync.py
+++ b/tests/test_constants_sync.py
@@ -62,3 +62,36 @@ def test_ide_registry_match():
             assert server_spec[key] == cli_spec[key], (
                 f"IDE_REGISTRY[{ide!r}][{key!r}] mismatch: server={server_spec[key]!r}, cli={cli_spec[key]!r}"
             )
+
+
+def test_ide_registry_model_choice_fields():
+    """Every IDE must declare accepts_model_choice + auto_sentinel."""
+    server_reg = importlib.import_module("schemas.ide_registry")
+    cli_reg = importlib.import_module("observal_cli.ide_registry")
+    expected_accepts = {
+        "claude-code": True,
+        "kiro": True,
+        "codex": True,
+        "gemini-cli": True,
+        "opencode": True,
+        "cursor": False,
+        "vscode": False,
+        "copilot": False,
+        "copilot-cli": False,
+    }
+    for reg_name, reg in (("server", server_reg.IDE_REGISTRY), ("cli", cli_reg.IDE_REGISTRY)):
+        for ide, accepts in expected_accepts.items():
+            spec = reg[ide]
+            assert "accepts_model_choice" in spec, f"{reg_name}: {ide} missing accepts_model_choice"
+            assert "auto_sentinel" in spec, f"{reg_name}: {ide} missing auto_sentinel"
+            assert spec["accepts_model_choice"] is accepts, (
+                f"{reg_name}: {ide}.accepts_model_choice={spec['accepts_model_choice']!r}, expected {accepts!r}"
+            )
+            if accepts:
+                assert isinstance(spec["auto_sentinel"], dict), (
+                    f"{reg_name}: {ide} accepts_model_choice but auto_sentinel is not a dict"
+                )
+            else:
+                assert spec["auto_sentinel"] is None, (
+                    f"{reg_name}: {ide} does not accept_model_choice; auto_sentinel must be None"
+                )

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -157,6 +157,7 @@ class TestDraftSave:
     """Test creating a new draft agent."""
 
     @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
     @patch("api.routes.agent._load_agent")
     async def test_creates_agent_with_draft_status(self, mock_load):
         """POST /agents/draft creates an agent in draft status."""
@@ -177,6 +178,7 @@ class TestDraftSave:
         db.commit.assert_awaited()
 
     @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
     @patch("api.routes.agent._load_agent")
     async def test_response_includes_agent_fields(self, mock_load):
         """Draft response includes id, name, and status fields."""
@@ -206,6 +208,7 @@ class TestDraftUpdate:
     """Test updating a draft agent."""
 
     @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
     @patch("api.routes.agent._load_agent")
     async def test_updates_draft_fields(self, mock_load):
         """PUT /agents/{id}/draft updates the draft agent."""
@@ -267,6 +270,7 @@ class TestDraftSubmit:
     """Test submitting a draft for review."""
 
     @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
     @patch("api.routes.agent.emit_registry_event")
     @patch("api.routes.agent._resolve_component_names")
     @patch("api.routes.agent._load_agent")
@@ -286,6 +290,7 @@ class TestDraftSubmit:
         db.commit.assert_awaited()
 
     @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
     @patch("api.routes.agent.emit_registry_event")
     @patch("api.routes.agent._resolve_component_names")
     @patch("api.routes.agent._load_agent")

--- a/tests/test_model_display.py
+++ b/tests/test_model_display.py
@@ -1,9 +1,9 @@
-"""Parity test for model display helpers across server and CLI.
+"""Parity test for model display helpers.
 
-Server-side ``services.model_display.format_display`` and CLI-side
-``observal_cli.render.format_model`` must produce identical output for every
-case in ``tests/fixtures/model_display_cases.json``. The TypeScript helper
-under ``web/src/lib/model-display.ts`` is exercised by frontend unit tests.
+Server-side ``services.model_display.format_display`` is the source of truth.
+CLI-side ``observal_cli.render.format_model`` reads the pre-computed ``display``
+field from the API response. This test verifies both paths produce the same
+output for every case in ``tests/fixtures/model_display_cases.json``.
 """
 
 from __future__ import annotations
@@ -41,13 +41,32 @@ def test_server_display_matches_fixture(case):
 
 
 @pytest.mark.parametrize("case", _load_cases(), ids=lambda c: c["name"])
-def test_cli_display_matches_fixture(case):
+def test_cli_reads_server_display_field(case):
+    """CLI format_model reads the pre-computed display field from the API response."""
     from observal_cli.render import format_model
 
+    # Simulate what the server sends: pre-computed display from format_display
+    from services.model_display import format_display
+
+    rd_value = case.get("release_date")
+    rd = date.fromisoformat(rd_value) if rd_value else None
+    server_primary, server_secondary, server_rolling = format_display(
+        display_name=case["display_name"],
+        model_id=case["model_id"],
+        release_date=rd,
+        disambiguate=case["disambiguate"],
+    )
+
+    # Build a row as it would arrive from the API (with display field)
     row = {
         "display_name": case["display_name"],
         "model_id": case["model_id"],
         "release_date": case.get("release_date"),
+        "display": {
+            "primary": server_primary,
+            "secondary": server_secondary,
+            "is_rolling": server_rolling,
+        },
     }
     primary, secondary, is_rolling = format_model(row, disambiguate=case["disambiguate"])
     expected = case["expected"]

--- a/tests/test_model_display.py
+++ b/tests/test_model_display.py
@@ -1,0 +1,56 @@
+"""Parity test for model display helpers across server and CLI.
+
+Server-side ``services.model_display.format_display`` and CLI-side
+``observal_cli.render.format_model`` must produce identical output for every
+case in ``tests/fixtures/model_display_cases.json``. The TypeScript helper
+under ``web/src/lib/model-display.ts`` is exercised by frontend unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "model_display_cases.json"
+
+
+def _load_cases() -> list[dict]:
+    with FIXTURE_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)["cases"]
+
+
+@pytest.mark.parametrize("case", _load_cases(), ids=lambda c: c["name"])
+def test_server_display_matches_fixture(case):
+    from services.model_display import format_display
+
+    rd_value = case.get("release_date")
+    rd = date.fromisoformat(rd_value) if rd_value else None
+    primary, secondary, is_rolling = format_display(
+        display_name=case["display_name"],
+        model_id=case["model_id"],
+        release_date=rd,
+        disambiguate=case["disambiguate"],
+    )
+    expected = case["expected"]
+    assert primary == expected["primary"], f"{case['name']}: primary mismatch"
+    assert secondary == expected["secondary"], f"{case['name']}: secondary mismatch"
+    assert is_rolling == expected["is_rolling"], f"{case['name']}: is_rolling mismatch"
+
+
+@pytest.mark.parametrize("case", _load_cases(), ids=lambda c: c["name"])
+def test_cli_display_matches_fixture(case):
+    from observal_cli.render import format_model
+
+    row = {
+        "display_name": case["display_name"],
+        "model_id": case["model_id"],
+        "release_date": case.get("release_date"),
+    }
+    primary, secondary, is_rolling = format_model(row, disambiguate=case["disambiguate"])
+    expected = case["expected"]
+    assert primary == expected["primary"], f"{case['name']}: primary mismatch"
+    assert secondary == expected["secondary"], f"{case['name']}: secondary mismatch"
+    assert is_rolling == expected["is_rolling"], f"{case['name']}: is_rolling mismatch"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,569 @@
+"""Tests for the live model catalog + resolver.
+
+Covers:
+
+* ``services.model_catalog.format_for_ide`` — per-IDE formatting rules.
+* ``services.model_catalog._normalize_models_dev`` — payload normalization.
+* ``services.model_resolver.resolve_saved_value`` — sync, used by the offline
+  manifest builder.
+* ``services.model_resolver.resolve_model_for_ide`` — async, used by online
+  installs (covers fallback matrix: unknown id, wrong-provider, deprecated,
+  Claude Code aliases, "ignored override" for IDEs that don't accept models).
+* The CLI helper ``observal_cli.cmd_pull._parse_model_overrides``.
+* GET ``/api/v1/models`` ETag round-trip + admin refresh role check.
+
+We avoid hitting Redis or the real upstream by patching ``get_catalog`` /
+``get_redis``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# ──────────────────────── Helpers ────────────────────────────
+
+
+def _build_catalog(*, degraded: bool = False, source: str = "live"):
+    from schemas.models import Catalog, CatalogModel
+
+    models = [
+        CatalogModel(
+            model_id="claude-sonnet-4-5",
+            display_name="Claude Sonnet 4.5",
+            provider="anthropic",
+            family="claude-sonnet",
+            release_date=date(2025, 9, 29),
+            supported_ides=["claude-code", "kiro", "opencode"],
+        ),
+        CatalogModel(
+            model_id="gpt-5",
+            display_name="GPT-5",
+            provider="openai",
+            family="gpt",
+            release_date=date(2025, 8, 1),
+            supported_ides=["codex", "opencode"],
+        ),
+        CatalogModel(
+            model_id="gemini-2.5-pro",
+            display_name="Gemini 2.5 Pro",
+            provider="google",
+            family="gemini",
+            supported_ides=["gemini-cli", "opencode"],
+        ),
+        CatalogModel(
+            model_id="claude-opus-3-deprecated",
+            display_name="Claude Opus 3 (deprecated)",
+            provider="anthropic",
+            family="claude-opus",
+            supported_ides=["claude-code", "kiro", "opencode"],
+            deprecated=True,
+        ),
+    ]
+    return Catalog(
+        models=models,
+        fetched_at=datetime.now(UTC),
+        source=source,  # type: ignore[arg-type]
+        degraded=degraded,
+        etag='W/"abc"',
+        upstream_etag='W/"upstream"',
+        model_count=len(models),
+    )
+
+
+# ──────────────────────── format_for_ide ────────────────────
+
+
+class TestFormatForIde:
+    def test_claude_code_short_alias(self):
+        from services.model_catalog import format_for_ide
+
+        assert format_for_ide("claude-sonnet-4-5", "anthropic", "claude-code") == "sonnet"
+        assert format_for_ide("claude-opus-3", "anthropic", "claude-code") == "opus"
+        assert format_for_ide("claude-haiku-3", "anthropic", "claude-code") == "haiku"
+
+    def test_claude_code_passthrough_when_unknown(self):
+        from services.model_catalog import format_for_ide
+
+        assert format_for_ide("custom-model", "anthropic", "claude-code") == "custom-model"
+
+    def test_opencode_uses_provider_prefix(self):
+        from services.model_catalog import format_for_ide
+
+        assert format_for_ide("claude-sonnet-4-5", "anthropic", "opencode") == "anthropic/claude-sonnet-4-5"
+        assert format_for_ide("gpt-5", "openai", "opencode") == "openai/gpt-5"
+
+    def test_other_ides_pass_id_verbatim(self):
+        from services.model_catalog import format_for_ide
+
+        assert format_for_ide("claude-sonnet-4-5", "anthropic", "kiro") == "claude-sonnet-4-5"
+        assert format_for_ide("gpt-5", "openai", "codex") == "gpt-5"
+        assert format_for_ide("gemini-2.5-pro", "google", "gemini-cli") == "gemini-2.5-pro"
+
+
+# ──────────────────────── _normalize_models_dev ─────────────
+
+
+class TestNormalizeModelsDev:
+    def test_emits_only_mapped_providers(self):
+        from services.model_catalog import _normalize_models_dev
+
+        payload = {
+            "anthropic": {
+                "models": {
+                    "claude-sonnet-4-5": {
+                        "id": "claude-sonnet-4-5",
+                        "name": "Claude Sonnet 4.5",
+                        "family": "claude-sonnet",
+                        "tool_call": True,
+                        "modalities": {"input": ["text", "image"]},
+                        "limit": {"context": 200000, "output": 8192},
+                        "cost": {"input": 3.0, "output": 15.0},
+                    }
+                }
+            },
+            "unmapped-provider": {"models": {"foo": {"id": "foo", "name": "Foo"}}},
+        }
+        rows = _normalize_models_dev(payload)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.model_id == "claude-sonnet-4-5"
+        assert row.provider == "anthropic"
+        assert "tool_call" in row.capabilities
+        assert "vision" in row.capabilities
+        assert row.context_window == 200000
+        assert row.cost_input == 3.0
+        assert "claude-code" in row.supported_ides
+
+    def test_skips_non_dict_models(self):
+        from services.model_catalog import _normalize_models_dev
+
+        payload = {"anthropic": {"models": {"weird": "string", "ok": {"id": "ok", "name": "OK"}}}}
+        rows = _normalize_models_dev(payload)
+        assert [r.model_id for r in rows] == ["ok"]
+
+
+# ──────────────────────── resolve_saved_value ───────────────
+
+
+class TestResolveSavedValue:
+    def test_returns_none_for_ides_that_dont_accept_choice(self):
+        from services.model_resolver import resolve_saved_value
+
+        assert resolve_saved_value("cursor", "claude-sonnet-4-5", None) is None
+        assert resolve_saved_value("vscode", "claude-sonnet-4-5", None) is None
+        assert resolve_saved_value("copilot", "claude-sonnet-4-5", None) is None
+
+    def test_per_ide_override_wins(self):
+        from services.model_resolver import resolve_saved_value
+
+        result = resolve_saved_value(
+            "kiro",
+            "claude-sonnet-4-5",
+            {"kiro": "claude-opus-4-5"},
+        )
+        assert result == "claude-opus-4-5"
+
+    def test_claude_code_uses_legacy_model_name(self):
+        from services.model_resolver import resolve_saved_value
+
+        # Unknown id stays verbatim through format_for_ide(...)
+        assert resolve_saved_value("claude-code", "custom-model", None) == "custom-model"
+
+    def test_other_ides_emit_none_without_override(self):
+        from services.model_resolver import resolve_saved_value
+
+        # Kiro / Codex / Gemini default to the auto sentinel when no override exists
+        assert resolve_saved_value("kiro", "claude-sonnet-4-5", None) is None
+        assert resolve_saved_value("codex", "claude-sonnet-4-5", None) is None
+        assert resolve_saved_value("gemini-cli", "claude-sonnet-4-5", None) is None
+        assert resolve_saved_value("opencode", "claude-sonnet-4-5", None) is None
+
+
+# ──────────────────────── resolve_model_for_ide ─────────────
+
+
+class TestResolveModelForIde:
+    @pytest.mark.asyncio
+    async def test_ide_without_model_choice_warns_on_override(self):
+        from services.model_resolver import resolve_model_for_ide
+
+        emitted, warnings = await resolve_model_for_ide(
+            "cursor",
+            model_name="",
+            override="gpt-5",
+        )
+        assert emitted is None
+        assert any("does not accept" in w for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_claude_code_short_alias_passthrough(self):
+        from services.model_resolver import resolve_model_for_ide
+
+        emitted, warnings = await resolve_model_for_ide(
+            "claude-code",
+            model_name="sonnet",
+        )
+        assert emitted == "sonnet"
+        assert warnings == []
+
+    @pytest.mark.asyncio
+    async def test_claude_code_inherit_resolves_to_none(self):
+        from services.model_resolver import resolve_model_for_ide
+
+        emitted, warnings = await resolve_model_for_ide("claude-code", model_name="inherit")
+        assert emitted is None
+        assert warnings == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_model_falls_back_to_auto_with_warning(self):
+        from services import model_resolver
+
+        catalog = _build_catalog()
+        with patch.object(model_resolver, "get_catalog", AsyncMock(return_value=catalog)):
+            emitted, warnings = await model_resolver.resolve_model_for_ide(
+                "kiro",
+                model_name="",
+                models_by_ide={"kiro": "totally-fake-model"},
+            )
+        assert emitted is None
+        assert any("not in the catalog" in w for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_wrong_provider_falls_back_to_auto(self):
+        from services import model_resolver
+
+        catalog = _build_catalog()
+        with patch.object(model_resolver, "get_catalog", AsyncMock(return_value=catalog)):
+            # gpt-5 is openai provider; Kiro only accepts anthropic
+            emitted, warnings = await model_resolver.resolve_model_for_ide(
+                "kiro",
+                model_name="",
+                models_by_ide={"kiro": "gpt-5"},
+            )
+        assert emitted is None
+        assert any("not supported by kiro" in w for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_deprecated_model_resolves_with_soft_warning(self):
+        from services import model_resolver
+
+        catalog = _build_catalog()
+        with patch.object(model_resolver, "get_catalog", AsyncMock(return_value=catalog)):
+            emitted, warnings = await model_resolver.resolve_model_for_ide(
+                "kiro",
+                model_name="",
+                models_by_ide={"kiro": "claude-opus-3-deprecated"},
+            )
+        assert emitted == "claude-opus-3-deprecated"
+        assert any("deprecated" in w for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_degraded_catalog_trusts_saved_value_with_soft_warning(self):
+        from services import model_resolver
+
+        catalog = _build_catalog(degraded=True, source="snapshot")
+        with patch.object(model_resolver, "get_catalog", AsyncMock(return_value=catalog)):
+            emitted, warnings = await model_resolver.resolve_model_for_ide(
+                "kiro",
+                model_name="",
+                models_by_ide={"kiro": "anything-goes"},
+            )
+        assert emitted == "anything-goes"
+        assert any("catalog is unavailable" in w.lower() for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_supported_model_emits_ide_format(self):
+        from services import model_resolver
+
+        catalog = _build_catalog()
+        with patch.object(model_resolver, "get_catalog", AsyncMock(return_value=catalog)):
+            # OpenCode prepends provider/
+            emitted, warnings = await model_resolver.resolve_model_for_ide(
+                "opencode",
+                model_name="",
+                models_by_ide={"opencode": "claude-sonnet-4-5"},
+            )
+        assert emitted == "anthropic/claude-sonnet-4-5"
+        assert warnings == []
+
+
+# ──────────────────────── CLI _parse_model_overrides ─────────
+
+
+class TestParseModelOverrides:
+    def test_default_value(self):
+        from observal_cli.cmd_pull import _parse_model_overrides
+
+        default, overrides = _parse_model_overrides(["claude-sonnet-4-5"])
+        assert default == "claude-sonnet-4-5"
+        assert overrides == {}
+
+    def test_per_ide_override(self):
+        from observal_cli.cmd_pull import _parse_model_overrides
+
+        default, overrides = _parse_model_overrides(["kiro=claude-opus", "codex=gpt-5"])
+        assert default is None
+        assert overrides == {"kiro": "claude-opus", "codex": "gpt-5"}
+
+    def test_mixed(self):
+        from observal_cli.cmd_pull import _parse_model_overrides
+
+        default, overrides = _parse_model_overrides(["sonnet", "kiro=claude-opus"])
+        assert default == "sonnet"
+        assert overrides == {"kiro": "claude-opus"}
+
+    def test_skips_blank_and_malformed(self):
+        from observal_cli.cmd_pull import _parse_model_overrides
+
+        default, overrides = _parse_model_overrides(["", "  ", "kiro=", "=claude"])
+        assert default is None
+        assert overrides == {}
+
+
+# ──────────────────────── /api/v1/models endpoint ─────────────
+
+
+class TestModelsEndpoint:
+    def _make_user(self):
+        from models.user import User, UserRole
+
+        user = MagicMock(spec=User)
+        user.id = uuid.uuid4()
+        user.role = UserRole.user
+        user.org_id = None
+        return user
+
+    def _make_admin(self):
+        from models.user import User, UserRole
+
+        user = MagicMock(spec=User)
+        user.id = uuid.uuid4()
+        user.role = UserRole.admin
+        user.org_id = None
+        return user
+
+    @pytest.mark.asyncio
+    async def test_returns_catalog_with_cache_headers(self):
+        from api.deps import get_current_user
+        from main import app
+
+        catalog = _build_catalog()
+        user = self._make_user()
+
+        async def _mock_user():
+            return user
+
+        app.dependency_overrides[get_current_user] = _mock_user
+        try:
+            with patch("api.routes.registry_models.get_catalog", AsyncMock(return_value=catalog)):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                    r = await ac.get("/api/v1/models")
+            assert r.status_code == 200
+            data = r.json()
+            assert data["model_count"] == 4
+            assert data["source"] == "live"
+            # Cache headers are present
+            assert "Cache-Control" in r.headers
+            assert "ETag" in r.headers
+            assert r.headers["X-Catalog-Source"] == "live"
+            assert r.headers["X-Catalog-Degraded"] == "0"
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_conditional_get_returns_304(self):
+        from api.deps import get_current_user
+        from main import app
+
+        catalog = _build_catalog()
+        user = self._make_user()
+
+        async def _mock_user():
+            return user
+
+        app.dependency_overrides[get_current_user] = _mock_user
+        try:
+            with patch("api.routes.registry_models.get_catalog", AsyncMock(return_value=catalog)):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                    r = await ac.get(
+                        "/api/v1/models",
+                        headers={"If-None-Match": catalog.etag},
+                    )
+            assert r.status_code == 304
+            assert r.headers.get("ETag") == catalog.etag
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_admin_refresh_requires_admin(self):
+        from api.deps import get_current_user
+        from main import app
+
+        user = self._make_user()
+
+        async def _mock_user():
+            return user
+
+        app.dependency_overrides[get_current_user] = _mock_user
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.post("/api/v1/admin/models/refresh")
+            assert r.status_code == 403
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_admin_refresh_returns_diff(self):
+        from api.deps import get_current_user
+        from main import app
+
+        catalog = _build_catalog()
+        admin = self._make_admin()
+
+        async def _mock_admin():
+            return admin
+
+        app.dependency_overrides[get_current_user] = _mock_admin
+        try:
+            with (
+                patch("api.routes.registry_models.get_catalog", AsyncMock(return_value=catalog)),
+                patch(
+                    "api.routes.registry_models.diff_against_current",
+                    AsyncMock(return_value={"added": [], "removed": [], "updated": [], "total": catalog.model_count}),
+                ),
+            ):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                    r = await ac.post("/api/v1/admin/models/refresh")
+            assert r.status_code == 200
+            data = r.json()
+            assert data["ok"] is True
+            assert data["model_count"] == catalog.model_count
+            assert data["source"] == "live"
+            assert "diff" in data
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ──────────────────────── Builder round-trip ───────────────────
+
+
+def _empty_manifest(model_name: str = "", models_by_ide: dict | None = None):
+    """Construct a minimal AgentManifest for codegen tests."""
+    from services.agent_builder import AgentManifest, ManifestComponents
+
+    return AgentManifest(
+        name="test-agent",
+        version="1.0.0",
+        prompt="Be helpful.",
+        description="Test agent",
+        model_name=model_name,
+        models_by_ide=models_by_ide or {},
+        components=ManifestComponents(),
+    )
+
+
+class TestBuilderModelEmission:
+    def test_manifest_carries_models_by_ide_from_resolved(self):
+        from services.agent_builder import build_agent_manifest
+        from services.agent_resolver import ResolvedAgent
+
+        resolved = ResolvedAgent(
+            agent_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            agent_name="alpha",
+            agent_version="1.0.0",
+            agent_prompt="hi",
+            agent_description="d",
+            model_name="claude-sonnet-4-5",
+            models_by_ide={"kiro": "claude-opus-4-5", "codex": "gpt-5"},
+            components=[],
+            errors=[],
+        )
+        manifest_dict = build_agent_manifest(resolved)
+        assert manifest_dict["model_name"] == "claude-sonnet-4-5"
+        assert manifest_dict["models_by_ide"] == {
+            "kiro": "claude-opus-4-5",
+            "codex": "gpt-5",
+        }
+
+    def test_claude_code_emits_alias_in_frontmatter(self):
+        from services.agent_builder import _generate_claude_code
+
+        manifest = _empty_manifest(model_name="claude-sonnet-4-5")
+        cfg = _generate_claude_code(manifest)
+        agent_md = cfg.files[0].content
+        assert isinstance(agent_md, str)
+        assert "model: sonnet" in agent_md  # short alias from format_for_ide
+
+    def test_claude_code_omits_model_when_no_choice(self):
+        from services.agent_builder import _generate_claude_code
+
+        manifest = _empty_manifest()  # no model name
+        cfg = _generate_claude_code(manifest)
+        agent_md = cfg.files[0].content
+        assert "model:" not in agent_md
+
+    def test_kiro_uses_per_ide_override(self):
+        from services.agent_builder import _generate_kiro
+
+        manifest = _empty_manifest(
+            model_name="claude-sonnet-4-5",
+            models_by_ide={"kiro": "claude-opus-4-5"},
+        )
+        cfg = _generate_kiro(manifest)
+        kiro_json = cfg.files[0].content
+        assert isinstance(kiro_json, dict)
+        assert kiro_json["model"] == "claude-opus-4-5"
+
+    def test_kiro_emits_null_without_override(self):
+        from services.agent_builder import _generate_kiro
+
+        # model_name is set but no per-IDE override → Kiro auto sentinel (null)
+        manifest = _empty_manifest(model_name="claude-sonnet-4-5")
+        cfg = _generate_kiro(manifest)
+        kiro_json = cfg.files[0].content
+        assert kiro_json["model"] is None
+
+    def test_gemini_cli_settings_carries_model(self):
+        from services.agent_builder import _generate_gemini_cli
+
+        manifest = _empty_manifest(models_by_ide={"gemini-cli": "gemini-2.5-pro"})
+        cfg = _generate_gemini_cli(manifest)
+        settings_file = next(f for f in cfg.files if f.path == ".gemini/settings.json")
+        assert isinstance(settings_file.content, dict)
+        assert settings_file.content["model"] == "gemini-2.5-pro"
+
+    def test_gemini_cli_omits_model_setting_without_override(self):
+        from services.agent_builder import _generate_gemini_cli
+
+        manifest = _empty_manifest()
+        cfg = _generate_gemini_cli(manifest)
+        settings_file = next(f for f in cfg.files if f.path == ".gemini/settings.json")
+        assert "model" not in settings_file.content
+
+    def test_codex_toml_carries_model(self):
+        from services.agent_builder import _generate_codex
+
+        manifest = _empty_manifest(models_by_ide={"codex": "gpt-5"})
+        cfg = _generate_codex(manifest)
+        toml = next(f for f in cfg.files if f.path == "~/.codex/config.toml").content
+        assert isinstance(toml, str)
+        assert 'model = "gpt-5"' in toml
+
+    def test_opencode_uses_provider_prefix(self):
+        from services.agent_builder import _generate_opencode
+
+        manifest = _empty_manifest(
+            models_by_ide={"opencode": "claude-sonnet-4-5"},
+        )
+        cfg = _generate_opencode(manifest)
+        oc_file = next(f for f in cfg.files if f.path == "opencode.json")
+        # _saved_model_for is sync and doesn't know providers, so it falls back
+        # to the legacy "anthropic" default. Either way we must format the value.
+        assert isinstance(oc_file.content, dict)
+        assert oc_file.content["model"].endswith("/claude-sonnet-4-5")
+        assert oc_file.content["model"].split("/")[0] in {"anthropic", "openai", "google"}

--- a/web/src/app/(admin)/diagnostics/page.tsx
+++ b/web/src/app/(admin)/diagnostics/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { CheckCircle2, AlertTriangle, XCircle, RefreshCw, Database, KeyRound, Building2 } from "lucide-react";
-import { useDiagnostics } from "@/hooks/use-api";
+import { CheckCircle2, AlertTriangle, XCircle, RefreshCw, Database, KeyRound, Building2, BookOpen } from "lucide-react";
+import { useDiagnostics, useModels, useRefreshModels } from "@/hooks/use-api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -27,6 +27,67 @@ function statusBadge(status: string) {
       return <Badge variant="destructive">{status}</Badge>;
   }
 }
+
+function CatalogStatusCard() {
+  const { data, isLoading, isError, error } = useModels();
+  const refresh = useRefreshModels();
+
+  let badgeStatus = "ok";
+  if (isError) badgeStatus = "error";
+  else if (data?.degraded) badgeStatus = "degraded";
+
+  return (
+    <Card className="md:col-span-2">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <BookOpen className="h-4 w-4 text-muted-foreground" />
+          <CardTitle className="text-sm">Model Catalog</CardTitle>
+          <div className="ml-auto flex items-center gap-2">
+            {statusBadge(badgeStatus)}
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={refresh.isPending || isLoading}
+              onClick={() => refresh.mutate()}
+            >
+              <RefreshCw
+                className={`h-3.5 w-3.5 mr-1.5 ${refresh.isPending ? "animate-spin" : ""}`}
+              />
+              Refresh now
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-1.5">
+        {isError ? (
+          <p className="text-xs text-destructive">{(error as Error)?.message}</p>
+        ) : (
+          <>
+            <div className="flex justify-between text-xs">
+              <span className="text-muted-foreground">Source</span>
+              <span className="font-mono font-medium">{data?.source ?? "—"}</span>
+            </div>
+            <div className="flex justify-between text-xs">
+              <span className="text-muted-foreground">Models</span>
+              <span className="font-medium">{data?.model_count ?? 0}</span>
+            </div>
+            <div className="flex justify-between text-xs">
+              <span className="text-muted-foreground">Fetched at</span>
+              <span className="font-medium">
+                {data?.fetched_at ? new Date(data.fetched_at).toLocaleString() : "—"}
+              </span>
+            </div>
+            <div className="flex justify-between text-xs">
+              <span className="text-muted-foreground">Degraded</span>
+              <span className="font-medium">{data?.degraded ? "yes" : "no"}</span>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 
 export default function DiagnosticsPage() {
   const { data, isLoading, isError, error, refetch, dataUpdatedAt } = useDiagnostics();
@@ -133,6 +194,8 @@ export default function DiagnosticsPage() {
                   </CardContent>
                 </Card>
               )}
+
+              <CatalogStatusCard />
 
               {/* Enterprise */}
               {data.checks.enterprise && (

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -45,6 +45,7 @@ const DRAFT_STORAGE_KEY = "observal_agent_draft";
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
 import { ValidationPanel } from "@/components/builder/validation-panel";
 import { PreviewPanel } from "@/components/builder/preview-panel";
+import { ModelPicker } from "@/components/builder/model-picker";
 
 const COMPONENT_TYPES: { value: RegistryType; label: string }[] = [
   { value: "mcps", label: "MCPs" },
@@ -335,6 +336,7 @@ function AgentBuilderInner() {
   const [description, setDescription] = useState("");
   const [version, setVersion] = useState("1.0.0");
   const [modelName, setModelName] = useState("");
+  const [modelsByIde, setModelsByIde] = useState<Record<string, string>>({});
   const [visibility, setVisibility] = useState<"public" | "private">("private");
   const [teamAccesses, setTeamAccesses] = useState<{ group_name: string; permission: "view" | "edit" }[]>([]);
   const [publishing, setPublishing] = useState(false);
@@ -390,6 +392,10 @@ function AgentBuilderInner() {
     if (typeof agentVersion === "string") setVersion(agentVersion);
     const agentModel = (existingAgent as Record<string, unknown>).model_name;
     if (typeof agentModel === "string") setModelName(agentModel);
+    const agentModelsByIde = (existingAgent as Record<string, unknown>).models_by_ide;
+    if (agentModelsByIde && typeof agentModelsByIde === "object" && !Array.isArray(agentModelsByIde)) {
+      setModelsByIde(agentModelsByIde as Record<string, string>);
+    }
     const agentVisibility = (existingAgent as Record<string, unknown>).visibility;
     if (agentVisibility === "public" || agentVisibility === "private") setVisibility(agentVisibility as "public" | "private");
     const agentTeamAccesses = (existingAgent as Record<string, unknown>).team_accesses;
@@ -554,6 +560,7 @@ function AgentBuilderInner() {
           description,
           version,
           model_name: modelName,
+          models_by_ide: modelsByIde,
           visibility,
           team_accesses: teamAccesses,
           components: selectedComponents,
@@ -582,6 +589,9 @@ function AgentBuilderInner() {
       if (draft.description) setDescription(draft.description);
       if (draft.version) setVersion(draft.version);
       if (draft.model_name) setModelName(draft.model_name);
+      if (draft.models_by_ide && typeof draft.models_by_ide === "object") {
+        setModelsByIde(draft.models_by_ide);
+      }
       if (draft.visibility) setVisibility(draft.visibility);
       if (draft.team_accesses) setTeamAccesses(draft.team_accesses);
       if (draft.components) setSelectedComponents(draft.components);
@@ -748,6 +758,7 @@ function AgentBuilderInner() {
       team_accesses: teamAccesses,
       prompt: promptParts.join("\n\n"),
       model_name: modelName,
+      models_by_ide: modelsByIde,
       components: components.length > 0 ? components : [],
       goal_template: {
         description: goalDescription,
@@ -906,24 +917,13 @@ function AgentBuilderInner() {
                     onChange={(e) => setVersion(e.target.value)}
                   />
                 </div>
-                <div className="space-y-2 flex-1 max-w-xs">
-                  <Label htmlFor="agent-model" className="text-sm font-medium">
-                    Model
-                  </Label>
-                  <Input
-                    id="agent-model"
-                    list="model-suggestions"
-                    placeholder="claude-sonnet-4-20250514"
-                    value={modelName}
-                    onChange={(e) => setModelName(e.target.value)}
+                <div className="flex-1">
+                  <ModelPicker
+                    modelName={modelName}
+                    onModelNameChange={setModelName}
+                    modelsByIde={modelsByIde}
+                    onModelsByIdeChange={setModelsByIde}
                   />
-                  <datalist id="model-suggestions">
-                    <option value="claude-opus-4-6-20250725" />
-                    <option value="claude-sonnet-4-6-20250725" />
-                    <option value="claude-sonnet-4-20250514" />
-                    <option value="claude-opus-4-20250514" />
-                    <option value="claude-haiku-4-5-20251001" />
-                  </datalist>
                 </div>
               </div>
             </section>

--- a/web/src/components/builder/model-picker.tsx
+++ b/web/src/components/builder/model-picker.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useModels } from "@/hooks/use-api";
+import {
+  IDE_DISPLAY_NAMES,
+  type IdeName,
+  getModelChoiceIdes,
+} from "@/lib/ide-features";
+import { annotateForDisplay, formatModel } from "@/lib/model-display";
+import type { CatalogModel } from "@/lib/types";
+
+const AUTO_VALUE = "__auto__";
+
+function modelsForIde(catalog: CatalogModel[], ide: string): CatalogModel[] {
+  return catalog.filter((m) => (m.supported_ides ?? []).includes(ide));
+}
+
+interface ModelPickerProps {
+  /** The default model_id used when no per-IDE override is set. */
+  modelName: string;
+  onModelNameChange: (value: string) => void;
+  /** Per-IDE overrides keyed by IDE name. */
+  modelsByIde: Record<string, string>;
+  onModelsByIdeChange: (next: Record<string, string>) => void;
+  /** When false, hide the per-IDE overrides UI to keep the simple form simple. */
+  showPerIdeOverrides?: boolean;
+}
+
+/**
+ * Reusable model picker shared by the agent builder and the agent edit form.
+ *
+ * - Default model: a single ``Select`` against the live catalog.
+ * - Per-IDE overrides: optional ``Select`` per IDE that ``accepts_model_choice``.
+ *   Empty value = "auto" sentinel; the server will substitute the IDE's auto
+ *   equivalent at install time and warn the user if the saved value is gone.
+ */
+export function ModelPicker({
+  modelName,
+  onModelNameChange,
+  modelsByIde,
+  onModelsByIdeChange,
+  showPerIdeOverrides = true,
+}: ModelPickerProps) {
+  const { data: catalog, isLoading } = useModels();
+  const models = useMemo(() => catalog?.models ?? [], [catalog]);
+  const annotated = useMemo(() => annotateForDisplay(models), [models]);
+  const idesWithChoice = useMemo(() => getModelChoiceIdes(), []);
+
+  function renderSelect(
+    value: string,
+    onChange: (next: string) => void,
+    rows: CatalogModel[],
+    placeholder: string,
+    {
+      includeAuto,
+      autoLabel,
+    }: { includeAuto: boolean; autoLabel: string },
+  ) {
+    return (
+      <Select
+        value={value || AUTO_VALUE}
+        onValueChange={(v) => onChange(v === AUTO_VALUE ? "" : v)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {includeAuto && (
+            <SelectGroup>
+              <SelectItem value={AUTO_VALUE}>{autoLabel}</SelectItem>
+            </SelectGroup>
+          )}
+          <SelectGroup>
+            <SelectLabel>Models</SelectLabel>
+            {rows.map((m) => {
+              const fm = formatModel({
+                display_name: m.display_name,
+                model_id: m.model_id,
+                release_date: m.release_date,
+                disambiguate: true,
+              });
+              const label = fm.secondary
+                ? `${fm.primary} (${fm.secondary})`
+                : fm.primary;
+              return (
+                <SelectItem key={m.model_id} value={m.model_id}>
+                  {label}
+                  {m.deprecated ? " · deprecated" : ""}
+                </SelectItem>
+              );
+            })}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  const defaultRows = annotated;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="agent-model" className="text-sm font-medium">
+          Default model
+        </Label>
+        {renderSelect(
+          modelName,
+          onModelNameChange,
+          defaultRows,
+          isLoading ? "Loading models…" : "Select a default model",
+          { includeAuto: true, autoLabel: "auto (let the IDE pick)" },
+        )}
+        <p className="text-xs text-muted-foreground">
+          Used as the fallback for IDEs that accept a model choice and don&apos;t
+          have an explicit override below.
+        </p>
+      </div>
+
+      {showPerIdeOverrides && (
+        <details className="rounded-md border border-border bg-muted/30 p-3">
+          <summary className="cursor-pointer select-none text-xs font-medium text-muted-foreground">
+            Per-IDE overrides{" "}
+            {Object.keys(modelsByIde || {}).length > 0 ? (
+              <span className="ml-1 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">
+                {Object.keys(modelsByIde).length} set
+              </span>
+            ) : null}
+          </summary>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {idesWithChoice.map((ide) => {
+              const rows = modelsForIde(models, ide);
+              const value = modelsByIde[ide] ?? "";
+              return (
+                <div key={ide} className="space-y-1.5">
+                  <Label className="text-xs font-medium">
+                    {IDE_DISPLAY_NAMES[ide as IdeName] ?? ide}
+                  </Label>
+                  {renderSelect(
+                    value,
+                    (next) => {
+                      const copy: Record<string, string> = { ...modelsByIde };
+                      if (!next) delete copy[ide];
+                      else copy[ide] = next;
+                      onModelsByIdeChange(copy);
+                    },
+                    rows,
+                    isLoading ? "Loading…" : "Use default",
+                    { includeAuto: true, autoLabel: "Use default" },
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {catalog?.degraded ? (
+            <p className="mt-3 text-xs text-amber-700 dark:text-amber-400">
+              Catalog is in degraded mode (offline snapshot). Saved selections
+              will still install — admins can refresh from the diagnostics
+              page.
+            </p>
+          ) : null}
+        </details>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/review/review-diff-sheet.tsx
+++ b/web/src/components/review/review-diff-sheet.tsx
@@ -264,6 +264,14 @@ function DiffDialogBody({
   // Prefer version detail fields over the sparse review item fields
   const prompt = (detail?.prompt as string) || item.prompt || "";
   const modelName = (detail?.model_name as string) || item.model_name || "";
+  const modelsByIdeRaw = detail?.models_by_ide;
+  const modelsByIde =
+    modelsByIdeRaw && typeof modelsByIdeRaw === "object" && !Array.isArray(modelsByIdeRaw)
+      ? (modelsByIdeRaw as Record<string, string>)
+      : {};
+  const modelsByIdeEntries = Object.entries(modelsByIde).filter(
+    ([, value]) => typeof value === "string" && value.trim().length > 0,
+  );
   const supportedIdes = (detail?.supported_ides as string[]) || item.supported_ides || [];
   const components = (detail?.components as { component_type: string; component_id: string; name?: string; template?: string; description?: string; category?: string }[]) || item.components || [];
 
@@ -354,14 +362,31 @@ function DiffDialogBody({
             </div>
 
             {/* Model */}
-            {modelName && (
+            {(modelName || modelsByIdeEntries.length > 0) && (
               <>
                 <Separator />
                 <div className="space-y-2">
                   <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
                     Model
                   </h4>
-                  <p className="text-xs font-[family-name:var(--font-mono)]">{modelName}</p>
+                  {modelName && (
+                    <p className="text-xs font-[family-name:var(--font-mono)]">{modelName}</p>
+                  )}
+                  {modelsByIdeEntries.length > 0 && (
+                    <dl className="space-y-1 text-xs">
+                      <dt className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                        Per-IDE overrides
+                      </dt>
+                      {modelsByIdeEntries.map(([ide, value]) => (
+                        <div key={ide} className="flex items-baseline gap-2">
+                          <dd className="font-medium">{ide}</dd>
+                          <dd className="font-[family-name:var(--font-mono)] text-muted-foreground">
+                            {value}
+                          </dd>
+                        </div>
+                      ))}
+                    </dl>
+                  )}
                 </div>
               </>
             )}
@@ -562,6 +587,9 @@ function DiffDialogBody({
                               description: item.description || undefined,
                               prompt: prompt || undefined,
                               model_name: modelName || undefined,
+                              models_by_ide: modelsByIdeEntries.length
+                                ? Object.fromEntries(modelsByIdeEntries)
+                                : undefined,
                               supported_ides: supportedIdes.length ? supportedIdes : undefined,
                               components: components.length
                                 ? components.map((c) => `${c.component_type}:${c.component_id}`)

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -19,6 +19,7 @@ import {
   bulk,
   graphql,
   insights,
+  models,
   type RegistryType,
 } from "@/lib/api";
 import type { LeaderboardWindow } from "@/lib/types";
@@ -968,6 +969,37 @@ export function useGenerateInsight() {
     },
     onError: (err: Error) => {
       toast.error(err.message || "Failed to generate insight");
+    },
+  });
+}
+
+// ── Models catalog ─────────────────────────────────────────────────
+
+const MODELS_QUERY_KEY = ["models", "catalog"] as const;
+
+export function useModels() {
+  return useQuery({
+    queryKey: MODELS_QUERY_KEY,
+    queryFn: () => models.list(),
+    staleTime: 5 * 60_000,
+    gcTime: 30 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useRefreshModels() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => models.refresh(),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: MODELS_QUERY_KEY });
+      const total = data.diff?.total ?? data.model_count ?? 0;
+      const added = data.diff?.added?.length ?? 0;
+      const removed = data.diff?.removed?.length ?? 0;
+      toast.success(`Models refreshed (${total} total, +${added} / -${removed})`);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to refresh model catalog");
     },
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -502,6 +502,12 @@ export const config = {
   public: () => get<PublicConfig>("/config/public"),
 };
 
+// ── Models ─────────────────────────────────────────────────────────
+export const models = {
+  list: () => get<import("./types").ModelCatalog>("/models"),
+  refresh: () => post<import("./types").ModelRefreshResult>("/admin/models/refresh"),
+};
+
 // ── Bulk ───────────────────────────────────────────────────────────
 export const bulk = {
   createAgents: (body: { agents: unknown[]; dry_run?: boolean }) =>

--- a/web/src/lib/ide-features.ts
+++ b/web/src/lib/ide-features.ts
@@ -65,3 +65,30 @@ export const FEATURE_LABELS: Record<IdeFeature, string> = {
   steering_files: "Steering files",
   otlp_telemetry: "OTLP telemetry",
 };
+
+/**
+ * Whether each IDE accepts an explicit model choice.
+ * Mirror of `accepts_model_choice` in IDE_REGISTRY (server) /
+ * observal_cli/ide_registry.py (CLI).
+ */
+export const IDE_ACCEPTS_MODEL_CHOICE: Record<IdeName, boolean> = {
+  "claude-code": true,
+  kiro: true,
+  "gemini-cli": true,
+  codex: true,
+  opencode: true,
+  cursor: false,
+  copilot: false,
+  "copilot-cli": false,
+  vscode: false,
+};
+
+export function ideAcceptsModelChoice(ide: string): boolean {
+  return IDE_ACCEPTS_MODEL_CHOICE[ide as IdeName] === true;
+}
+
+export function getModelChoiceIdes(): IdeName[] {
+  return (Object.keys(IDE_ACCEPTS_MODEL_CHOICE) as IdeName[]).filter(
+    (ide) => IDE_ACCEPTS_MODEL_CHOICE[ide],
+  );
+}

--- a/web/src/lib/model-display.ts
+++ b/web/src/lib/model-display.ts
@@ -1,18 +1,10 @@
 /**
- * Shared display formatting for model catalog rows.
+ * Model display helpers.
  *
- * Mirrored at:
- *   - observal-server/services/model_display.py (server)
- *   - observal_cli/render.py format_model() (CLI)
- *
- * Behaviour pinned by tests/fixtures/model_display_cases.json.
+ * Reads pre-computed display fields from the server API response
+ * (computed by services/model_display.py). Falls back to raw model_id
+ * when display data isn't available.
  */
-
-const DATE_SUFFIX_DASH_COMPACT = /[-_\s](\d{8})$/;
-const DATE_SUFFIX_DASH_HYPHEN = /[-_\s](\d{4}-\d{2}-\d{2})$/;
-const DATE_SUFFIX_PAREN = /\s*\((\d{4}-\d{2}-\d{2})\)\s*$/;
-const LATEST_PAREN = /\s*\(latest\)\s*$/i;
-const LATEST_DASH = /[-_]latest$/i;
 
 const MONTH_NAMES = [
   "Jan",
@@ -35,97 +27,75 @@ export interface FormattedModel {
   isRolling: boolean;
 }
 
-function stripTrailingDate(text: string): string {
-  if (!text) return text;
-  let out = text;
-  out = out.replace(LATEST_PAREN, "").trim();
-  out = out.replace(DATE_SUFFIX_PAREN, "").trim();
-  out = out.replace(DATE_SUFFIX_DASH_HYPHEN, "").trim();
-  out = out.replace(DATE_SUFFIX_DASH_COMPACT, "").trim();
-  out = out.replace(LATEST_DASH, "").trim();
-  return out;
-}
-
-function parseDate(value: string | Date | null | undefined): Date | null {
-  if (!value) return null;
-  if (value instanceof Date) return value;
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
-}
-
-function hasTrailingDate(modelId: string): {
-  hasDate: boolean;
-  parsed: Date | null;
-} {
-  const compact = DATE_SUFFIX_DASH_COMPACT.exec(modelId);
-  if (compact) {
-    const m = compact[1];
-    const parsed = parseDate(`${m.slice(0, 4)}-${m.slice(4, 6)}-${m.slice(6, 8)}`);
-    return { hasDate: true, parsed };
-  }
-  const hyphen = DATE_SUFFIX_DASH_HYPHEN.exec(modelId);
-  if (hyphen) {
-    return { hasDate: true, parsed: parseDate(hyphen[1]) };
-  }
-  return { hasDate: false, parsed: null };
-}
-
-function formatDate(d: Date): string {
+function formatDateShort(d: Date): string {
   return `${MONTH_NAMES[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
 }
 
+function forceSecondary(
+  releaseDate: string | null | undefined,
+  isRolling: boolean,
+): string | null {
+  if (isRolling) return "latest";
+  if (releaseDate) {
+    const d = new Date(releaseDate);
+    if (!Number.isNaN(d.getTime())) return formatDateShort(d);
+  }
+  return null;
+}
+
+/**
+ * Format a model catalog row for display.
+ *
+ * Reads the server-computed `display` field when available.
+ * When `disambiguate` is true and the server didn't set a secondary label,
+ * one is derived from the release date or rolling status.
+ */
 export function formatModel(input: {
   display_name?: string | null;
   model_id: string;
   release_date?: string | null;
+  display?: { primary: string; secondary: string | null; is_rolling: boolean } | null;
   disambiguate?: boolean;
 }): FormattedModel {
-  const raw = (input.display_name ?? input.model_id).trim();
-  const primary = stripTrailingDate(raw) || raw;
-
-  const { hasDate, parsed } = hasTrailingDate(input.model_id);
-  const isRolling = !hasDate;
-  const isExplicitLatest =
-    LATEST_PAREN.test(raw) || input.model_id.toLowerCase().endsWith("-latest");
   const disambiguate = !!input.disambiguate;
 
-  if (!disambiguate && !isExplicitLatest) {
-    return { primary, secondary: null, isRolling };
+  // Read pre-computed display from server response
+  if (input.display) {
+    const { primary, secondary, is_rolling } = input.display;
+    return {
+      primary,
+      secondary:
+        secondary ?? (disambiguate ? forceSecondary(input.release_date, is_rolling) : null),
+      isRolling: is_rolling,
+    };
   }
 
-  let secondary: string | null = null;
-  if (isRolling || isExplicitLatest) {
-    secondary = "latest";
-  } else {
-    const d = parsed ?? parseDate(input.release_date ?? null);
-    if (d) {
-      secondary = formatDate(d);
-    }
-  }
-  return { primary, secondary, isRolling };
+  // Fallback: no pre-computed display (shouldn't happen in normal flow)
+  const primary = (input.display_name ?? input.model_id).trim();
+  const isRolling = !(/\d{8}$/.test(input.model_id) || /\d{4}-\d{2}-\d{2}$/.test(input.model_id));
+  return {
+    primary,
+    secondary: disambiguate ? forceSecondary(input.release_date, isRolling) : null,
+    isRolling,
+  };
 }
 
 /**
- * Annotate a list of catalog rows with collision-aware display fields.
- * Returns a new array; does not mutate inputs.
+ * Annotate a list of catalog rows with display fields.
+ * The server already provides `display` on each model; this just maps to
+ * the component-friendly `FormattedModel` shape with collision-aware disambiguation.
  */
-export function annotateForDisplay<T extends { display_name?: string | null; model_id: string; release_date?: string | null }>(
-  rows: T[],
-): Array<T & { display: FormattedModel }> {
-  const counts = new Map<string, number>();
-  const primaries = rows.map((r) => {
-    const fm = formatModel({ ...r, disambiguate: false });
-    counts.set(fm.primary, (counts.get(fm.primary) ?? 0) + 1);
-    return fm.primary;
-  });
-  return rows.map((r, i) => {
-    const primary = primaries[i];
-    return {
-      ...r,
-      display: formatModel({
-        ...r,
-        disambiguate: (counts.get(primary) ?? 0) > 1,
-      }),
-    };
-  });
+export function annotateForDisplay<
+  T extends {
+    display_name?: string | null;
+    model_id: string;
+    release_date?: string | null;
+    display?: { primary: string; secondary: string | null; is_rolling: boolean } | null;
+  },
+>(rows: T[]): Array<T & { display: FormattedModel }> {
+  // Server already computes collision-aware disambiguation; just map
+  return rows.map((r) => ({
+    ...r,
+    display: formatModel({ ...r, disambiguate: false }),
+  }));
 }

--- a/web/src/lib/model-display.ts
+++ b/web/src/lib/model-display.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared display formatting for model catalog rows.
+ *
+ * Mirrored at:
+ *   - observal-server/services/model_display.py (server)
+ *   - observal_cli/render.py format_model() (CLI)
+ *
+ * Behaviour pinned by tests/fixtures/model_display_cases.json.
+ */
+
+const DATE_SUFFIX_DASH_COMPACT = /[-_\s](\d{8})$/;
+const DATE_SUFFIX_DASH_HYPHEN = /[-_\s](\d{4}-\d{2}-\d{2})$/;
+const DATE_SUFFIX_PAREN = /\s*\((\d{4}-\d{2}-\d{2})\)\s*$/;
+const LATEST_PAREN = /\s*\(latest\)\s*$/i;
+const LATEST_DASH = /[-_]latest$/i;
+
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+export interface FormattedModel {
+  primary: string;
+  secondary: string | null;
+  isRolling: boolean;
+}
+
+function stripTrailingDate(text: string): string {
+  if (!text) return text;
+  let out = text;
+  out = out.replace(LATEST_PAREN, "").trim();
+  out = out.replace(DATE_SUFFIX_PAREN, "").trim();
+  out = out.replace(DATE_SUFFIX_DASH_HYPHEN, "").trim();
+  out = out.replace(DATE_SUFFIX_DASH_COMPACT, "").trim();
+  out = out.replace(LATEST_DASH, "").trim();
+  return out;
+}
+
+function parseDate(value: string | Date | null | undefined): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function hasTrailingDate(modelId: string): {
+  hasDate: boolean;
+  parsed: Date | null;
+} {
+  const compact = DATE_SUFFIX_DASH_COMPACT.exec(modelId);
+  if (compact) {
+    const m = compact[1];
+    const parsed = parseDate(`${m.slice(0, 4)}-${m.slice(4, 6)}-${m.slice(6, 8)}`);
+    return { hasDate: true, parsed };
+  }
+  const hyphen = DATE_SUFFIX_DASH_HYPHEN.exec(modelId);
+  if (hyphen) {
+    return { hasDate: true, parsed: parseDate(hyphen[1]) };
+  }
+  return { hasDate: false, parsed: null };
+}
+
+function formatDate(d: Date): string {
+  return `${MONTH_NAMES[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
+}
+
+export function formatModel(input: {
+  display_name?: string | null;
+  model_id: string;
+  release_date?: string | null;
+  disambiguate?: boolean;
+}): FormattedModel {
+  const raw = (input.display_name ?? input.model_id).trim();
+  const primary = stripTrailingDate(raw) || raw;
+
+  const { hasDate, parsed } = hasTrailingDate(input.model_id);
+  const isRolling = !hasDate;
+  const isExplicitLatest =
+    LATEST_PAREN.test(raw) || input.model_id.toLowerCase().endsWith("-latest");
+  const disambiguate = !!input.disambiguate;
+
+  if (!disambiguate && !isExplicitLatest) {
+    return { primary, secondary: null, isRolling };
+  }
+
+  let secondary: string | null = null;
+  if (isRolling || isExplicitLatest) {
+    secondary = "latest";
+  } else {
+    const d = parsed ?? parseDate(input.release_date ?? null);
+    if (d) {
+      secondary = formatDate(d);
+    }
+  }
+  return { primary, secondary, isRolling };
+}
+
+/**
+ * Annotate a list of catalog rows with collision-aware display fields.
+ * Returns a new array; does not mutate inputs.
+ */
+export function annotateForDisplay<T extends { display_name?: string | null; model_id: string; release_date?: string | null }>(
+  rows: T[],
+): Array<T & { display: FormattedModel }> {
+  const counts = new Map<string, number>();
+  const primaries = rows.map((r) => {
+    const fm = formatModel({ ...r, disambiguate: false });
+    counts.set(fm.primary, (counts.get(fm.primary) ?? 0) + 1);
+    return fm.primary;
+  });
+  return rows.map((r, i) => {
+    const primary = primaries[i];
+    return {
+      ...r,
+      display: formatModel({
+        ...r,
+        disambiguate: (counts.get(primary) ?? 0) > 1,
+      }),
+    };
+  });
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -703,3 +703,57 @@ export interface TelemetryStatus {
 	spans_count: number;
 	scores_count: number;
 }
+
+// ── Models catalog ──────────────────────────────────────────────────
+
+export interface ModelDisplay {
+  primary: string;
+  secondary: string | null;
+  is_rolling: boolean;
+  is_deprecated: boolean;
+}
+
+export interface CatalogModel {
+  model_id: string;
+  display_name: string;
+  provider: string;
+  family: string;
+  release_date: string | null;
+  last_updated: string | null;
+  context_window: number | null;
+  output_tokens: number | null;
+  cost_input: number | null;
+  cost_output: number | null;
+  capabilities: string[];
+  supported_ides: string[];
+  deprecated: boolean;
+  display: ModelDisplay | null;
+}
+
+export interface ModelCatalog {
+  models: CatalogModel[];
+  fetched_at: string;
+  source: "live" | "redis" | "snapshot" | "empty";
+  degraded: boolean;
+  etag: string | null;
+  upstream_etag: string | null;
+  model_count: number;
+}
+
+export interface ModelRefreshDiff {
+  added: string[];
+  removed: string[];
+  updated: string[];
+  total: number;
+}
+
+export interface ModelRefreshResult {
+  ok: boolean;
+  diff: ModelRefreshDiff;
+  fetched_at: string;
+  source: string;
+  degraded: boolean;
+  model_count: number;
+  etag: string | null;
+  upstream_etag: string | null;
+}


### PR DESCRIPTION
## Summary

Centralizes model selection so authors choose what each IDE should run instead of typing free-text into the builder. Models are sourced live from `models.dev` with multi-layered caching, and the install path validates the saved choice against the catalog before emitting IDE configs.

- **Live catalog** (`services/model_catalog.py`) with HTTP ETag, in-memory LRU, Redis cache + stale-while-revalidate, single-flight refresh, and a vendored snapshot fallback so the registry stays usable when `models.dev` is unreachable.
- **Single resolver** (`services/model_resolver.py`) with sync (manifest) and async (online install) paths; emits structured warnings for unknown, wrong-provider, deprecated, or degraded-catalog cases instead of hard-failing.
- `agent_versions` gains a `models_by_ide` JSON column (idempotent migration + `_ensure_columns`); per-IDE overrides round-trip through the agent builder, manifest, and pull flow.
- `IDE_REGISTRY` now declares `accepts_model_choice` + `auto_sentinel`; codegen for Claude Code, Kiro, Codex, Gemini CLI, and OpenCode reads the resolver result and emits the right field (frontmatter alias / null / TOML / settings / provider-prefixed id).
- New REST endpoints: `GET /api/v1/models` (cacheable, conditional GET) and `POST /api/v1/admin/models/refresh` (admin-only, rate-limited diff).
- **Frontend** `ModelPicker` component with default + per-IDE override accordion, shared display helpers (Python + TS + CLI parity test fixture), and a catalog status widget on `/admin/diagnostics` with a Refresh now button.
- **CLI**: `observal pull --model` accepts `<ide>=<value>` overrides; new `observal registry models list` command; `~/.observal/cache/model_catalog.json` with a 1h TTL and `--refresh-models` flag.

## Architecture

```
┌─────────────────────────────────────────────────────────┐
│ models.dev (live registry)                              │
└────────────────────────┬────────────────────────────────┘
                         │ ETag / If-None-Match (12h SWR)
                ┌────────▼─────────┐
                │ services/        │
                │   model_catalog  │ ◄─── pre-warm cron (arq, 6h)
                │ Redis + LRU      │
                └────┬───────┬─────┘
        ┌────────────┘       └────────────┐
        ▼                                 ▼
┌──────────────────┐              ┌──────────────────┐
│ GET /api/v1/     │              │ services/        │
│   models         │              │   model_resolver │
│  (Cache-Control, │              │ (sync + async)   │
│   ETag, 304)     │              └────────┬─────────┘
└────────┬─────────┘                       │
         │                                 │ resolve_model_for_ide
         ▼                                 │ resolve_saved_value
┌──────────────────┐                       │
│ Frontend:        │              ┌────────▼──────────┐
│  ModelPicker +   │              │ agent_builder /   │
│  useModels       │              │ agent_config_gen  │
│  TanStack cache  │              │ (per-IDE emission)│
└──────────────────┘              └───────────────────┘
```

## Fallback matrix

| Scenario                                | Result                                         |
| --------------------------------------- | ---------------------------------------------- |
| Saved model exists & supports the IDE   | Emit IDE-formatted id, no warning              |
| Saved model is deprecated               | Emit, soft warning                             |
| Saved model not in catalog              | Emit IDE auto sentinel, warning                |
| Saved model wrong provider for the IDE  | Emit IDE auto sentinel, warning                |
| Catalog degraded (snapshot/empty)       | Trust saved value, soft warning                |
| IDE doesn't accept a model choice       | Emit nothing; warn if user passed `--model`    |
| Claude Code short alias / `inherit`     | Passthrough (no catalog lookup)                |

## Test plan

- [x] 35 new tests in `tests/test_model_registry.py` covering `format_for_ide`, resolver fallback matrix, CLI flag parsing, `/api/v1/models` conditional GET, admin refresh role check, and per-IDE codegen emission
- [x] `tests/test_model_display.py` parity fixture exercising Python + CLI display helpers
- [x] `tests/test_constants_sync.py` extended with `accepts_model_choice` + `auto_sentinel` checks across all IDEs
- [x] `make test` (`tests/`): 2054 passed, 2 skipped
- [x] `make lint` (`ruff check`): clean
- [x] Backwards compatibility: existing `model_name`-only agents resolve correctly (legacy Claude Code default; other IDEs emit `auto`)
- [ ] Smoke-test `observal pull --model kiro=claude-opus-4-5` against a local server
- [ ] Verify the diagnostics widget renders correctly when Redis is unreachable

Made with [Cursor](https://cursor.com)