### PR TITLE
fixed preview accuracy and added a full config view

### DIFF
--- a/observal-server/api/routes/preview.py
+++ b/observal-server/api/routes/preview.py
@@ -1,0 +1,208 @@
+"""Preview endpoint — generates full IDE config without persisting an agent."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from api.deps import get_current_user, get_db
+from api.ratelimit import limiter
+from models.hook import HookListing
+from models.mcp import McpListing
+from models.prompt import PromptListing
+from models.skill import SkillListing
+from models.user import User
+from schemas.ide_registry import IDE_REGISTRY
+from services.agent_config_generator import generate_agent_config
+
+router = APIRouter(prefix="/api/v1/agents", tags=["agents"])
+
+_VALID_IDES = set(IDE_REGISTRY.keys())
+_MAX_COMPONENTS = 20
+_MAX_NAME_LEN = 100
+_MAX_PROMPT_LEN = 50_000
+
+
+# ── Request / response schemas ────────────────────────────────
+
+
+class PreviewComponentRef(BaseModel):
+    component_type: str = Field(pattern=r"^(mcp|skill|hook|prompt)$")
+    component_id: uuid.UUID
+
+
+class PreviewConfigRequest(BaseModel):
+    name: str = Field(max_length=_MAX_NAME_LEN, default="untitled")
+    description: str = Field(max_length=1000, default="")
+    prompt: str = Field(max_length=_MAX_PROMPT_LEN, default="")
+    model_name: str = Field(max_length=100, default="")
+    components: list[PreviewComponentRef] = Field(default_factory=list, max_length=_MAX_COMPONENTS)
+    target_ides: list[str] = Field(default_factory=list, max_length=9)
+
+
+class PreviewConfigResponse(BaseModel):
+    configs: dict[str, dict[str, str]]
+
+
+# ── Transient agent-like dataclass ────────────────────────────
+
+
+@dataclass
+class _TransientComponent:
+    component_type: str
+    component_id: uuid.UUID
+    order_index: int = 0
+    resolved_version: str = "latest"
+    config_override: dict | None = None
+
+
+@dataclass
+class _TransientAgent:
+    """Minimal object satisfying generate_agent_config's interface."""
+
+    id: uuid.UUID
+    name: str
+    description: str
+    prompt: str
+    model_name: str
+    components: list[_TransientComponent] = field(default_factory=list)
+    external_mcps: list[dict] = field(default_factory=list)
+    required_ide_features: list[str] = field(default_factory=list)
+
+
+# ── Endpoint ──────────────────────────────────────────────────
+
+
+@router.post("/preview-config", response_model=PreviewConfigResponse)
+@limiter.limit("10/minute")
+async def preview_config(
+    req: PreviewConfigRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    target_ides = [ide for ide in req.target_ides if ide in _VALID_IDES]
+    if not target_ides:
+        target_ides = [ide for ide in IDE_REGISTRY if ide != "copilot-cli"]
+
+    components = [
+        _TransientComponent(
+            component_type=c.component_type,
+            component_id=c.component_id,
+            order_index=i,
+        )
+        for i, c in enumerate(req.components)
+    ]
+
+    agent = _TransientAgent(
+        id=uuid.uuid4(),
+        name=req.name or "untitled",
+        description=req.description,
+        prompt=req.prompt,
+        model_name=req.model_name,
+        components=components,
+    )
+
+    # Resolve component listings by ID (same pattern as install endpoint —
+    # the builder UI already scoped what the user can select)
+    mcp_ids = [c.component_id for c in components if c.component_type == "mcp"]
+    skill_ids = [c.component_id for c in components if c.component_type == "skill"]
+    hook_ids = [c.component_id for c in components if c.component_type == "hook"]
+    prompt_ids = [c.component_id for c in components if c.component_type == "prompt"]
+
+    mcp_map: dict = {}
+    if mcp_ids:
+        rows = (await db.execute(select(McpListing).where(McpListing.id.in_(mcp_ids)))).scalars().all()
+        mcp_map = {row.id: row for row in rows}
+
+    skill_map: dict = {}
+    if skill_ids:
+        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_ids)))).scalars().all()
+        skill_map = {row.id: row for row in rows}
+
+    hook_map: dict = {}
+    if hook_ids:
+        rows = (
+            await db.execute(
+                select(HookListing)
+                .options(selectinload(HookListing.latest_version))
+                .where(HookListing.id.in_(hook_ids))
+            )
+        ).scalars().all()
+        hook_map = {row.id: row for row in rows}
+
+    prompt_map: dict = {}
+    if prompt_ids:
+        rows = (
+            await db.execute(
+                select(PromptListing)
+                .options(selectinload(PromptListing.latest_version))
+                .where(PromptListing.id.in_(prompt_ids))
+            )
+        ).scalars().all()
+        prompt_map = {row.id: row for row in rows}
+
+    # Build component name map
+    name_map: dict[str, str] = {}
+    for row in mcp_map.values():
+        name_map[str(row.id)] = row.name
+    for row in skill_map.values():
+        name_map[str(row.id)] = row.name
+    for row in hook_map.values():
+        name_map[str(row.id)] = row.name
+    for row in prompt_map.values():
+        name_map[str(row.id)] = row.name
+
+    # Generate configs for all target IDEs
+    import json as _json
+
+    configs: dict[str, dict[str, str]] = {}
+    placeholder_url = "https://observal.example"
+
+    for ide in target_ides:
+        try:
+            config = generate_agent_config(
+                agent=agent,
+                ide=ide,
+                observal_url=placeholder_url,
+                mcp_listings=mcp_map,
+                component_names=name_map,
+                skill_listings=skill_map,
+                hook_listings=hook_map,
+                prompt_listings=prompt_map,
+            )
+        except Exception:
+            continue
+
+        files: dict[str, str] = {}
+        if "rules_file" in config:
+            rf = config["rules_file"]
+            files[rf["path"]] = rf["content"]
+        if "agent_file" in config:
+            af = config["agent_file"]
+            content = af["content"]
+            files[af["path"]] = _json.dumps(content, indent=2) if isinstance(content, dict) else content
+        if "mcp_config" in config:
+            mc = config["mcp_config"]
+            if isinstance(mc, dict) and "path" in mc:
+                content = mc["content"]
+                files[mc["path"]] = _json.dumps(content, indent=2) if isinstance(content, dict) else content
+        if "hooks_config" in config:
+            hc = config["hooks_config"]
+            if isinstance(hc, dict) and "path" in hc:
+                content = hc["content"]
+                files[hc["path"]] = _json.dumps(content, indent=2) if isinstance(content, dict) else content
+        if "skill_files" in config:
+            for sf in config["skill_files"]:
+                files[sf["path"]] = sf["content"]
+
+        if files:
+            configs[ide] = files
+
+    return PreviewConfigResponse(configs=configs)

--- a/observal-server/api/routes/preview.py
+++ b/observal-server/api/routes/preview.py
@@ -133,23 +133,31 @@ async def preview_config(
     hook_map: dict = {}
     if hook_ids:
         rows = (
-            await db.execute(
-                select(HookListing)
-                .options(selectinload(HookListing.latest_version))
-                .where(HookListing.id.in_(hook_ids))
+            (
+                await db.execute(
+                    select(HookListing)
+                    .options(selectinload(HookListing.latest_version))
+                    .where(HookListing.id.in_(hook_ids))
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         hook_map = {row.id: row for row in rows}
 
     prompt_map: dict = {}
     if prompt_ids:
         rows = (
-            await db.execute(
-                select(PromptListing)
-                .options(selectinload(PromptListing.latest_version))
-                .where(PromptListing.id.in_(prompt_ids))
+            (
+                await db.execute(
+                    select(PromptListing)
+                    .options(selectinload(PromptListing.latest_version))
+                    .where(PromptListing.id.in_(prompt_ids))
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         prompt_map = {row.id: row for row in rows}
 
     # Build component name map

--- a/observal-server/api/routes/preview.py
+++ b/observal-server/api/routes/preview.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from api.deps import get_current_user, get_db
@@ -17,9 +17,13 @@ from models.hook import HookListing
 from models.mcp import McpListing
 from models.prompt import PromptListing
 from models.skill import SkillListing
-from models.user import User
 from schemas.ide_registry import IDE_REGISTRY
 from services.agent_config_generator import generate_agent_config
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from models.user import User
 
 router = APIRouter(prefix="/api/v1/agents", tags=["agents"])
 

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -37,6 +37,7 @@ from api.routes.hook import router as hook_router
 from api.routes.insights import router as insights_router
 from api.routes.jwks import router as jwks_router
 from api.routes.mcp import router as mcp_router
+from api.routes.preview import router as preview_router
 from api.routes.prompt import router as prompt_router
 from api.routes.reconcile import router as reconcile_router
 from api.routes.review import router as review_router
@@ -296,6 +297,7 @@ app.include_router(jwks_router)
 app.include_router(mcp_router)
 app.include_router(review_router)
 app.include_router(agent_router)
+app.include_router(preview_router)
 app.include_router(skill_router)
 app.include_router(hook_router)
 app.include_router(prompt_router)

--- a/tests/test_preview_config.py
+++ b/tests/test_preview_config.py
@@ -1,0 +1,232 @@
+"""Tests for the preview-config endpoint.
+
+Verifies that POST /api/v1/agents/preview-config returns IDE config files
+for all target IDEs without persisting anything to the database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import get_current_user, get_db
+from api.routes.preview import router
+from models.user import User, UserRole
+
+
+def _user(**kw):
+    u = MagicMock(spec=User)
+    u.id = kw.get("id", uuid.uuid4())
+    u.role = kw.get("role", UserRole.user)
+    u.email = kw.get("email", "test@example.com")
+    u.username = kw.get("username", "testuser")
+    u.org_id = kw.get("org_id")
+    return u
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.execute = AsyncMock()
+    return db
+
+
+def _app_with(user=None, db=None):
+    user = user or _user()
+    db = db or _mock_db()
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app, db, user
+
+
+@pytest.mark.asyncio
+class TestPreviewConfigNoComponents:
+    """Preview with no components should return configs for all IDEs."""
+
+    async def test_returns_configs_for_all_ides(self):
+        app, db, _user = _app_with()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={
+                    "name": "test-agent",
+                    "description": "A test agent",
+                    "prompt": "You are helpful.",
+                    "model_name": "claude-sonnet-4",
+                    "components": [],
+                },
+            )
+
+        assert res.status_code == 200
+        data = res.json()
+        configs = data["configs"]
+        assert "claude-code" in configs
+        assert "kiro" in configs
+        assert "cursor" in configs
+        assert "vscode" in configs
+        assert "gemini-cli" in configs
+        assert "codex" in configs
+        assert "copilot" in configs
+        assert "opencode" in configs
+        assert "copilot-cli" not in configs
+
+    async def test_claude_code_has_agent_file(self):
+        app, db, _user = _app_with()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={
+                    "name": "my-agent",
+                    "description": "desc",
+                    "prompt": "Be helpful",
+                    "model_name": "",
+                    "components": [],
+                },
+            )
+
+        assert res.status_code == 200
+        files = res.json()["configs"]["claude-code"]
+        assert ".claude/agents/my-agent.md" in files
+        content = files[".claude/agents/my-agent.md"]
+        assert "name: my-agent" in content
+
+    async def test_kiro_has_correct_structure(self):
+        app, db, _user = _app_with()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={
+                    "name": "kiro-test",
+                    "description": "test kiro",
+                    "prompt": "Do stuff",
+                    "model_name": "",
+                    "components": [],
+                },
+            )
+
+        assert res.status_code == 200
+        import json
+
+        files = res.json()["configs"]["kiro"]
+        kiro_path = "~/.kiro/agents/kiro-test.json"
+        assert kiro_path in files
+        agent_json = json.loads(files[kiro_path])
+        assert agent_json["tools"] == ["*"]
+        assert agent_json["model"] is None
+        assert "includeMcpJson" in agent_json
+        assert "Agent Specialization" in agent_json["prompt"]
+
+    async def test_vscode_uses_correct_paths(self):
+        app, db, _user = _app_with()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={
+                    "name": "vs-test",
+                    "description": "",
+                    "prompt": "",
+                    "model_name": "",
+                    "components": [],
+                },
+            )
+
+        assert res.status_code == 200
+        files = res.json()["configs"]["vscode"]
+        assert ".github/instructions/vs-test.instructions.md" in files
+
+    async def test_copilot_uses_agent_md_path(self):
+        app, db, _user = _app_with()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={
+                    "name": "cop-test",
+                    "description": "",
+                    "prompt": "",
+                    "model_name": "",
+                    "components": [],
+                },
+            )
+
+        assert res.status_code == 200
+        files = res.json()["configs"]["copilot"]
+        assert ".github/agents/cop-test.agent.md" in files
+
+    async def test_no_real_urls_in_output(self):
+        app, db, _user = _app_with()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={
+                    "name": "url-test",
+                    "description": "",
+                    "prompt": "",
+                    "model_name": "",
+                    "components": [],
+                },
+            )
+
+        assert res.status_code == 200
+        raw = res.text
+        assert "localhost" not in raw
+        assert "127.0.0.1" not in raw
+
+    async def test_validates_payload_limits(self):
+        app, db, _user = _app_with()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={
+                    "name": "x" * 200,
+                    "description": "",
+                    "prompt": "",
+                    "model_name": "",
+                    "components": [],
+                },
+            )
+
+        assert res.status_code == 422
+
+    async def test_rejects_unauthenticated(self):
+        app = FastAPI()
+        app.include_router(router)
+        # Don't override get_current_user — it will raise 401
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={"name": "test", "description": "", "prompt": "", "model_name": "", "components": []},
+            )
+
+        assert res.status_code == 401

--- a/tests/test_preview_config.py
+++ b/tests/test_preview_config.py
@@ -54,9 +54,7 @@ class TestPreviewConfigNoComponents:
     async def test_returns_configs_for_all_ides(self):
         app, db, _user = _app_with()
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             res = await client.post(
                 "/api/v1/agents/preview-config",
                 json={
@@ -84,9 +82,7 @@ class TestPreviewConfigNoComponents:
     async def test_claude_code_has_agent_file(self):
         app, db, _user = _app_with()
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             res = await client.post(
                 "/api/v1/agents/preview-config",
                 json={
@@ -107,9 +103,7 @@ class TestPreviewConfigNoComponents:
     async def test_kiro_has_correct_structure(self):
         app, db, _user = _app_with()
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             res = await client.post(
                 "/api/v1/agents/preview-config",
                 json={
@@ -136,9 +130,7 @@ class TestPreviewConfigNoComponents:
     async def test_vscode_uses_correct_paths(self):
         app, db, _user = _app_with()
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             res = await client.post(
                 "/api/v1/agents/preview-config",
                 json={
@@ -157,9 +149,7 @@ class TestPreviewConfigNoComponents:
     async def test_copilot_uses_agent_md_path(self):
         app, db, _user = _app_with()
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             res = await client.post(
                 "/api/v1/agents/preview-config",
                 json={
@@ -178,9 +168,7 @@ class TestPreviewConfigNoComponents:
     async def test_no_real_urls_in_output(self):
         app, db, _user = _app_with()
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             res = await client.post(
                 "/api/v1/agents/preview-config",
                 json={
@@ -200,9 +188,7 @@ class TestPreviewConfigNoComponents:
     async def test_validates_payload_limits(self):
         app, db, _user = _app_with()
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             res = await client.post(
                 "/api/v1/agents/preview-config",
                 json={
@@ -221,9 +207,7 @@ class TestPreviewConfigNoComponents:
         app.include_router(router)
         # Don't override get_current_user — it will raise 401
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             res = await client.post(
                 "/api/v1/agents/preview-config",
                 json={"name": "test", "description": "", "prompt": "", "model_name": "", "components": []},

--- a/tests/test_preview_config.py
+++ b/tests/test_preview_config.py
@@ -7,7 +7,7 @@ for all target IDEs without persisting anything to the database.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { useState } from "react";
-import { CheckCircle2, XCircle } from "lucide-react";
+import { useState, useCallback, useRef } from "react";
+import { CheckCircle2, XCircle, Loader2, Maximize2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { IDE_DISPLAY_NAMES, type IdeName } from "@/lib/ide-features";
+import { registry } from "@/lib/api";
 import type { ValidationResult } from "@/lib/types";
 
 // Curated display order for the builder preview (copilot-cli excluded)
@@ -87,6 +95,7 @@ function buildMarkdownBody(
 
 function buildMcpJson(
   mcps: { id: string; name: string }[],
+  key: string = "mcpServers",
 ): string {
   if (mcps.length === 0) return "";
   const servers: Record<string, object> = {};
@@ -96,15 +105,14 @@ function buildMcpJson(
       args: ["--mcp-id", mcp.id, "--", "python", "-m", mcp.name],
     };
   }
-  return JSON.stringify({ mcpServers: servers }, null, 2);
+  return JSON.stringify({ [key]: servers }, null, 2);
 }
 
-// ── Per-IDE preview generators ────────────────────────────────
+// ── Per-IDE preview generators (simplified mode) ─────────────
 
 interface PreviewFile {
   path: string;
   content: string;
-  language: "markdown" | "json";
 }
 
 function generateClaudeCode(
@@ -140,31 +148,47 @@ function generateClaudeCode(
     {
       path: `.claude/agents/${safeName}.md`,
       content: lines.join("\n"),
-      language: "markdown",
     },
   ];
 }
 
-function generateCursorOrVscode(
-  ide: "cursor" | "vscode",
+function generateCursor(
   name: string,
   mcps: { id: string; name: string }[],
   body: string,
 ): PreviewFile[] {
   const safeName = name || "(untitled)";
-  const dir = ide === "cursor" ? ".cursor" : ".vscode";
   const files: PreviewFile[] = [
     {
-      path: `${dir}/rules/${safeName}.md`,
+      path: `.cursor/rules/${safeName}.mdc`,
       content: body || `# ${safeName}`,
-      language: "markdown",
     },
   ];
   if (mcps.length > 0) {
     files.push({
-      path: `${dir}/mcp.json`,
-      content: buildMcpJson(mcps),
-      language: "json",
+      path: ".cursor/mcp.json",
+      content: buildMcpJson(mcps, "mcpServers"),
+    });
+  }
+  return files;
+}
+
+function generateVscode(
+  name: string,
+  mcps: { id: string; name: string }[],
+  body: string,
+): PreviewFile[] {
+  const safeName = name || "(untitled)";
+  const files: PreviewFile[] = [
+    {
+      path: `.github/instructions/${safeName}.instructions.md`,
+      content: body || `# ${safeName}`,
+    },
+  ];
+  if (mcps.length > 0) {
+    files.push({
+      path: ".vscode/mcp.json",
+      content: buildMcpJson(mcps, "servers"),
     });
   }
   return files;
@@ -173,7 +197,6 @@ function generateCursorOrVscode(
 function generateKiro(
   name: string,
   description: string,
-  modelName: string,
   mcps: { id: string; name: string }[],
   body: string,
 ): PreviewFile[] {
@@ -186,40 +209,42 @@ function generateKiro(
     };
   }
 
-  const agent = {
+  const wrappedPrompt = body
+    ? `# ${safeName} — Agent Specialization\n\nYou are a Kiro agent with the following specialization.\n\n## Instructions\n\n${body}`
+    : "";
+
+  const agent: Record<string, unknown> = {
     name: safeName,
     description: (description || "").slice(0, 200),
-    prompt: body,
+    prompt: wrappedPrompt,
     mcpServers: servers,
-    tools: [...mcps.map((m) => `@${m.name}`), "read", "write", "shell"],
-    model: modelName || "default",
+    tools: ["*"],
+    toolAliases: {},
+    allowedTools: [],
+    resources: [
+      "file://AGENTS.md",
+      "file://README.md",
+      "skill://.kiro/skills/*/SKILL.md",
+      "skill://~/.kiro/skills/*/SKILL.md",
+    ],
+    hooks: {
+      agentSpawn: [{ command: "..." }],
+      userPromptSubmit: [{ command: "..." }],
+      preToolUse: [{ matcher: "*", command: "..." }],
+      postToolUse: [{ matcher: "*", command: "..." }],
+      stop: [{ command: "..." }],
+    },
+    toolsSettings: {},
+    includeMcpJson: true,
+    model: null,
   };
 
   return [
     {
       path: `~/.kiro/agents/${safeName}.json`,
       content: JSON.stringify(agent, null, 2),
-      language: "json",
     },
   ];
-}
-
-function buildGeminiSettings(mcps: { id: string; name: string }[]): string {
-  const servers: Record<string, object> = {};
-  for (const mcp of mcps) {
-    servers[mcp.name] = {
-      command: "observal-shim",
-      args: ["--mcp-id", mcp.id, "--", "python", "-m", mcp.name],
-    };
-  }
-  const settings: Record<string, unknown> = {
-    telemetry: {
-      enabled: false,
-      logPrompts: true,
-    },
-    mcpServers: servers,
-  };
-  return JSON.stringify(settings, null, 2);
 }
 
 function generateGemini(
@@ -227,33 +252,66 @@ function generateGemini(
   body: string,
 ): PreviewFile[] {
   const files: PreviewFile[] = [
-    { path: "GEMINI.md", content: body || "", language: "markdown" },
+    { path: "GEMINI.md", content: body || "" },
   ];
-  files.push({
-    path: ".gemini/settings.json",
-    content: mcps.length > 0 ? buildGeminiSettings(mcps) : JSON.stringify({
-      telemetry: {
-        enabled: false,
-        logPrompts: true,
-      },
-    }, null, 2),
-    language: "json",
-  });
+  if (mcps.length > 0) {
+    const servers: Record<string, object> = {};
+    for (const mcp of mcps) {
+      servers[mcp.name] = {
+        command: "observal-shim",
+        args: ["--mcp-id", mcp.id, "--", "python", "-m", mcp.name],
+      };
+    }
+    files.push({
+      path: ".gemini/settings.json",
+      content: JSON.stringify({ mcpServers: servers }, null, 2),
+    });
+  }
   return files;
 }
 
-function generateCodex(body: string): PreviewFile[] {
-  return [{ path: "AGENTS.md", content: body || "", language: "markdown" }];
+function generateCodex(
+  mcps: { id: string; name: string }[],
+  body: string,
+): PreviewFile[] {
+  const files: PreviewFile[] = [
+    { path: "AGENTS.md", content: body || "" },
+  ];
+  if (mcps.length > 0) {
+    const tomlLines = ["[mcp.servers]"];
+    for (const mcp of mcps) {
+      tomlLines.push("");
+      tomlLines.push(`[mcp.servers.${mcp.name}]`);
+      tomlLines.push(`command = "observal-shim"`);
+      tomlLines.push(`args = ["--mcp-id", "${mcp.id}", "--", "python", "-m", "${mcp.name}"]`);
+    }
+    files.push({
+      path: "~/.codex/config.toml",
+      content: tomlLines.join("\n"),
+    });
+  }
+  return files;
 }
 
-function generateCopilot(body: string): PreviewFile[] {
-  return [
+function generateCopilot(
+  name: string,
+  mcps: { id: string; name: string }[],
+  body: string,
+): PreviewFile[] {
+  const safeName = name || "(untitled)";
+  const files: PreviewFile[] = [
     {
-      path: ".github/copilot-instructions.md",
+      path: `.github/agents/${safeName}.agent.md`,
       content: body || "",
-      language: "markdown",
     },
   ];
+  if (mcps.length > 0) {
+    files.push({
+      path: ".vscode/mcp.json",
+      content: buildMcpJson(mcps, "servers"),
+    });
+  }
+  return files;
 }
 
 function generateOpenCode(
@@ -261,7 +319,7 @@ function generateOpenCode(
   body: string,
 ): PreviewFile[] {
   const files: PreviewFile[] = [
-    { path: "AGENTS.md", content: body || "", language: "markdown" },
+    { path: "AGENTS.md", content: body || "" },
   ];
   if (mcps.length > 0) {
     const mcp: Record<string, object> = {};
@@ -272,9 +330,8 @@ function generateOpenCode(
       };
     }
     files.push({
-      path: "opencode.json",
+      path: "~/.config/opencode/opencode.json",
       content: JSON.stringify({ mcp }, null, 2),
-      language: "json",
     });
   }
   return files;
@@ -292,37 +349,85 @@ export function PreviewPanel({
   validationResult,
 }: PreviewPanelProps) {
   const [ide, setIde] = useState<Ide>("claude-code");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalIde, setModalIde] = useState<Ide>("claude-code");
+  const [fullConfigs, setFullConfigs] = useState<Record<string, Record<string, string>> | null>(null);
+  const [fullLoading, setFullLoading] = useState(false);
+  const [fullError, setFullError] = useState<string | null>(null);
+  const modalScrollRef = useRef<HTMLDivElement>(null);
 
   const mcps = selectedComponents.mcps ?? [];
   const body = buildMarkdownBody(description, selectedComponents, goalSections, customPrompts);
 
+  // Simplified mode: client-side generators
   let files: PreviewFile[];
   switch (ide) {
     case "claude-code":
       files = generateClaudeCode(name, description, modelName ?? "", mcps, body);
       break;
     case "cursor":
-      files = generateCursorOrVscode("cursor", name, mcps, body);
+      files = generateCursor(name, mcps, body);
       break;
     case "vscode":
-      files = generateCursorOrVscode("vscode", name, mcps, body);
+      files = generateVscode(name, mcps, body);
       break;
     case "kiro":
-      files = generateKiro(name, description, modelName ?? "", mcps, body);
+      files = generateKiro(name, description, mcps, body);
       break;
     case "gemini-cli":
       files = generateGemini(mcps, body);
       break;
     case "codex":
-      files = generateCodex(body);
+      files = generateCodex(mcps, body);
       break;
     case "copilot":
-      files = generateCopilot(body);
+      files = generateCopilot(name, mcps, body);
       break;
     case "opencode":
       files = generateOpenCode(mcps, body);
       break;
   }
+
+  const fetchFullConfig = useCallback(async () => {
+    const components: { component_type: string; component_id: string }[] = [];
+    for (const [type, items] of Object.entries(selectedComponents)) {
+      const componentType = type === "mcps" ? "mcp" : type === "skills" ? "skill" : type === "hooks" ? "hook" : type === "prompts" ? "prompt" : null;
+      if (!componentType) continue;
+      for (const item of items) {
+        components.push({ component_type: componentType, component_id: item.id });
+      }
+    }
+
+    setFullLoading(true);
+    setFullError(null);
+
+    try {
+      const res = await registry.previewConfig({
+        name: name || "untitled",
+        description,
+        prompt: body,
+        model_name: modelName ?? "",
+        components,
+      });
+      setFullConfigs(res.configs);
+    } catch (e) {
+      setFullError(e instanceof Error ? e.message : "Failed to generate config");
+    } finally {
+      setFullLoading(false);
+    }
+  }, [name, description, body, modelName, selectedComponents]);
+
+  const handleOpenFullPreview = useCallback(() => {
+    setModalIde(ide);
+    setModalOpen(true);
+    fetchFullConfig();
+  }, [ide, fetchFullConfig]);
+
+  // Files for the modal view
+  const modalFiles: PreviewFile[] =
+    fullConfigs && fullConfigs[modalIde]
+      ? Object.entries(fullConfigs[modalIde]).map(([path, content]) => ({ path, content }))
+      : [];
 
   const errorCount = validationResult
     ? validationResult.issues.filter((i) => i.severity === "error").length
@@ -334,25 +439,35 @@ export function PreviewPanel({
         <h3 className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
           Preview
         </h3>
-        {validationResult && (
-          <span className="inline-flex items-center gap-1 text-xs">
-            {validationResult.valid ? (
-              <>
-                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
-                <span className="text-emerald-600 dark:text-emerald-400">
-                  Valid
-                </span>
-              </>
-            ) : (
-              <>
-                <XCircle className="h-3.5 w-3.5 text-destructive" />
-                <span className="text-destructive">
-                  {errorCount} {errorCount === 1 ? "error" : "errors"}
-                </span>
-              </>
-            )}
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleOpenFullPreview}
+            className="inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-2.5 py-1 text-[11px] font-medium text-primary transition-colors hover:bg-primary/20"
+          >
+            <Maximize2 className="h-3 w-3" />
+            Full Config
+          </button>
+          {validationResult && (
+            <span className="inline-flex items-center gap-1 text-xs">
+              {validationResult.valid ? (
+                <>
+                  <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+                  <span className="text-emerald-600 dark:text-emerald-400">
+                    Valid
+                  </span>
+                </>
+              ) : (
+                <>
+                  <XCircle className="h-3.5 w-3.5 text-destructive" />
+                  <span className="text-destructive">
+                    {errorCount} {errorCount === 1 ? "error" : "errors"}
+                  </span>
+                </>
+              )}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* IDE selector */}
@@ -373,7 +488,7 @@ export function PreviewPanel({
         ))}
       </div>
 
-      {/* File previews */}
+      {/* Simplified file previews */}
       <Card>
         <CardContent className="p-0 divide-y">
           {files.map((file) => (
@@ -381,13 +496,101 @@ export function PreviewPanel({
               <div className="px-4 py-2 text-[11px] font-medium text-muted-foreground bg-muted/40 font-[family-name:var(--font-mono)]">
                 {file.path}
               </div>
-              <pre className="min-h-[100px] whitespace-pre-wrap p-4 text-sm leading-relaxed font-[family-name:var(--font-mono)] text-foreground/80">
+              <pre className="overflow-x-auto min-h-[100px] whitespace-pre p-4 text-sm leading-relaxed font-[family-name:var(--font-mono)] text-foreground/80">
                 {file.content}
               </pre>
             </div>
           ))}
         </CardContent>
       </Card>
+
+      <p className="text-[11px] text-muted-foreground">
+        Telemetry hooks and environment variables are configured during installation via <code className="font-[family-name:var(--font-mono)]">observal pull</code>.
+      </p>
+
+      {/* Full config modal */}
+      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+        <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col p-0">
+          <DialogHeader className="px-6 pt-6 pb-0">
+            <DialogTitle>Full Config Preview</DialogTitle>
+            <DialogDescription>
+              Exact files written by <code className="font-[family-name:var(--font-mono)]">observal pull</code>. Server URLs are placeholders.
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* IDE tabs inside modal */}
+          <div className="flex flex-wrap gap-1 px-6 pt-3">
+            {IDE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => {
+                  setModalIde(opt.value);
+                  modalScrollRef.current?.scrollTo({ top: 0 });
+                }}
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                  modalIde === opt.value
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted/50 text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          {/* File tabs — sticky below IDE tabs */}
+          {!fullLoading && !fullError && modalFiles.length > 1 && (
+            <div className="flex flex-wrap gap-1 px-6 pb-2 pt-1 border-b border-border">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground/60 self-center mr-1">Files</span>
+              {modalFiles.map((file, i) => (
+                <button
+                  key={file.path}
+                  type="button"
+                  onClick={() => {
+                    document.getElementById(`preview-file-${i}`)?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  }}
+                  className="rounded px-2 py-0.5 text-[11px] font-medium font-[family-name:var(--font-mono)] text-muted-foreground border border-border/50 bg-background hover:bg-muted hover:text-foreground transition-colors"
+                >
+                  {file.path.split("/").pop()}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Modal file content */}
+          <div ref={modalScrollRef} className="flex-1 overflow-y-auto px-6 pb-6 pt-3">
+            {fullLoading ? (
+              <div className="flex items-center justify-center py-16 text-muted-foreground">
+                <Loader2 className="h-5 w-5 animate-spin mr-2" />
+                <span className="text-sm">Generating configs...</span>
+              </div>
+            ) : fullError ? (
+              <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+                <XCircle className="h-5 w-5 mb-2 text-destructive" />
+                <span className="text-sm">{fullError}</span>
+              </div>
+            ) : modalFiles.length === 0 ? (
+              <div className="flex items-center justify-center py-16 text-muted-foreground">
+                <span className="text-sm">No config generated for this IDE.</span>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {modalFiles.map((file, i) => (
+                  <div key={file.path} id={`preview-file-${i}`} className="rounded-md border border-border overflow-hidden">
+                    <div className="px-4 py-2 text-[11px] font-medium text-muted-foreground bg-muted/40 font-[family-name:var(--font-mono)]">
+                      {file.path}
+                    </div>
+                    <pre className="overflow-x-auto whitespace-pre p-4 text-sm leading-relaxed font-[family-name:var(--font-mono)] text-foreground/80 bg-background">
+                      {file.content}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -284,6 +284,14 @@ export const registry = {
     get<{ total: number; unique_users: number; recent_7d: number }>(`/agents/${id}/downloads`),
   validate: (body: { components: { component_type: string; component_id: string }[] }) =>
     post<ValidationResult>("/agents/validate", body),
+  previewConfig: (body: {
+    name: string;
+    description: string;
+    prompt: string;
+    model_name: string;
+    components: { component_type: string; component_id: string }[];
+    target_ides?: string[];
+  }) => post<{ configs: Record<string, Record<string, string>> }>("/agents/preview-config", body),
   my: (type?: RegistryType) => get<RegistryItem[]>(`/${type ?? "agents"}/my`),
   archived: () => get<RegistryItem[]>("/agents/archived"),
   archive: (id: string) => patch(`/agents/${id}/archive`),


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Preview panel in the agent builder showed wrong file paths, JSON keys, and config structures for most IDEs. Also added a "Full Config" modal that shows the exact output from the backend's config generator.

## Fixes
* Fixes #771

## Approach
Fixed all simplified preview generators to match `ide_registry.py` (Cursor extension, VS Code paths/keys, Kiro JSON shape, Copilot file path, Codex TOML, OpenCode path, Gemini telemetry removal, parameterized MCP key).

Added `POST /api/v1/agents/preview-config` — calls the real `generate_agent_config()` with a transient agent object, no DB writes. Auth required, rate limited, placeholder URLs. Frontend opens it in a fullscreen modal with IDE tabs and file quick-jump anchors.

## How Has This Been Tested?
`test_preview_config.py`: new integration test for the endpoint
Each IDE tab manually verified against `ide_registry.py` and `agent_config_generator.py`
Tested full UI flow manually

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

Before:
<img width="1600" height="866" alt="image" src="https://github.com/user-attachments/assets/987f5d3c-e977-435f-9eda-a422a0cfd3fe" />

<img width="1006" height="1178" alt="image" src="https://github.com/user-attachments/assets/d61a46ee-b804-4608-9e48-db5148b13166" />

<img width="996" height="1324" alt="image" src="https://github.com/user-attachments/assets/89b49e33-be0b-403a-b8e7-157ade16e9c2" />


After:
<img width="1399" height="772" alt="image" src="https://github.com/user-attachments/assets/ff70d6ab-12f8-482f-97c7-d9e1e2c4c3fe" />

<img width="451" height="737" alt="image" src="https://github.com/user-attachments/assets/47481ee9-5f1b-49ca-8fa0-bb683081467a" />

<img width="1424" height="774" alt="image" src="https://github.com/user-attachments/assets/9946259c-ae1c-454b-a68b-adec977d9a0c" />



<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->