### PR TITLE
docs: update docs link, CLI examples, and fix self-hosting diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Admin approve/reject workflow for submissions
 
 ## Documentation
 
-**Full docs live at [observal.gitbook.io](https://observal.gitbook.io/observal)** (sourced from [`/docs`](docs/) in this repo).
+**Full docs live at [docs.observal.io](https://docs.observal.io/)**
 
 | Start here                           | Go to                                                        |
 | ------------------------------------ | ------------------------------------------------------------ |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -163,13 +163,13 @@ Browse what the community has published:
 
 ```bash
 observal agent list
-observal agent show <agent-id>
+observal agent show <agent-name>
 ```
 
 Install one into your IDE:
 
 ```bash
-observal pull <agent-id> --ide claude-code
+observal pull agent <agent-name> --ide <ide-name>
 ```
 
 This drops agent files, skills, hooks, and MCP configs into the right places for your IDE and wires up telemetry automatically.

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -5,21 +5,21 @@ Run Observal entirely on your own infrastructure. No SaaS, no egress, every byte
 ## Architecture at a glance
 
 ```
-                  ┌─────────────────────────────────────────┐
-                  │           observal-net (bridge)         │
-                  │                                         │
-  [Engineers] ──► │  observal-web  ◄──►  observal-api       │
-   (port 3000)    │      │                    │             │
-                  │      ▼                    ▼             │
-                  │  (static)        observal-worker        │
-                  │                     │  │  │             │
-                  │          ┌──────────┘  │  └──────────┐  │
-                  │          ▼             ▼             ▼  │
-                  │   observal-db   observal-redis  observal-clickhouse
-                  │   (Postgres)    (jobs, pubsub)   (telemetry)   │
-                  │                                               │
-                  │   observal-grafana  ──►  clickhouse (optional)│
-                  └───────────────────────────────────────────────┘
+                  ┌────────────────────────────────────────────────────┐
+                  │              observal-net (bridge)                 │
+                  │                                                    │
+  [Engineers] ──► │  observal-web  ◄──►  observal-api                  │
+   (port 3000)    │      │                    │                        │
+                  │      ▼                    ▼                        │
+                  │  (static)        observal-worker                   │
+                  │                     │  │  │                        │
+                  │          ┌──────────┘  │  └──────────┐             │
+                  │          ▼             ▼             ▼             │
+                  │   observal-db   observal-redis  observal-clickhouse│
+                  │   (Postgres)    (jobs, pubsub)   (telemetry)       │
+                  │                                                    │
+                  │   observal-grafana  ──►  clickhouse (optional)     │
+                  └────────────────────────────────────────────────────┘
 ```
 
 **Seven services:**


### PR DESCRIPTION
## Purpose / Description
Update documentation links, CLI command examples, and fix a broken ASCII diagram in self-hosting docs.

## Fixes
* N/A (docs cleanup)

## Approach
- Changed the docs link from observal.gitbook.io to docs.observal.io
- Updated quickstart CLI examples to use agent-name instead of agent-id and generic ide-name instead of hardcoded claude-code
- Widened the ASCII architecture box in self-hosting README so the right border aligns properly

## How Has This Been Tested?
Verified the markdown renders correctly locally. Confirmed the link resolves.

## Learning (optional, can help others)
N/A

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
