### PR TITLE
feat(UI): user profile picture is configurable

### DIFF
--- a/observal-server/alembic/versions/0004_add_avatar_url.py
+++ b/observal-server/alembic/versions/0004_add_avatar_url.py
@@ -1,0 +1,42 @@
+"""Add users.avatar_url TEXT column for user profile pictures
+
+Supports base64 data URLs for user-uploaded profile pictures. Nullable to
+allow users without avatars (shows initials instead).
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-05-10
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent: check if column exists before adding
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {c["name"] for c in inspector.get_columns("users")}
+    if "avatar_url" not in columns:
+        op.add_column(
+            "users",
+            sa.Column(
+                "avatar_url",
+                sa.Text(),
+                nullable=True,
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {c["name"] for c in inspector.get_columns("users")}
+    if "avatar_url" in columns:
+        op.drop_column("users", "avatar_url")

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -1,5 +1,7 @@
+import base64
 import json
 import logging
+import re
 import secrets
 from datetime import UTC, datetime
 
@@ -682,3 +684,91 @@ async def create_hooks_token(current_user: User = Depends(get_current_user)):
         detail="Hooks token created (30-day)",
     )
     return {"access_token": token, "expires_in": expires_in}
+
+
+# ── Avatar Upload ─────────────────────────────────────────────────
+
+_MAX_AVATAR_BYTES = 2 * 1024 * 1024
+# Data URL encoding adds ~33% overhead; 2MB binary → ~2.7MB encoded.
+# Frontend also caps at 2MB before upload so these stay in sync.
+_MAX_AVATAR_DATA_URL_LEN = int(2 * 1024 * 1024 * 1.4)
+_AVATAR_ALLOWED_MIMES = {"image/png", "image/jpeg", "image/webp"}
+_AVATAR_MAGIC_BYTES: dict[str, list[bytes]] = {
+    "image/png": [b"\x89PNG\r\n\x1a\n"],
+    "image/jpeg": [b"\xff\xd8\xff"],
+    "image/webp": [b"RIFF"],
+}
+
+
+def _validate_avatar_data_url(value: str) -> None:
+    if len(value) > _MAX_AVATAR_DATA_URL_LEN:
+        raise HTTPException(status_code=422, detail="Image data too large")
+
+    match = re.match(r"^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", value, re.DOTALL)
+    if not match:
+        raise HTTPException(status_code=422, detail="Avatar must be a base64 data URL")
+
+    mime_type = match.group(1)
+    b64_data = match.group(2)
+
+    if mime_type not in _AVATAR_ALLOWED_MIMES:
+        raise HTTPException(status_code=422, detail="Only PNG, JPEG, and WebP images are allowed")
+
+    try:
+        raw = base64.b64decode(b64_data)
+    except Exception:
+        raise HTTPException(status_code=422, detail="Invalid base64 data")
+
+    if len(raw) > _MAX_AVATAR_BYTES:
+        raise HTTPException(status_code=422, detail="Image too large (max 2MB)")
+
+    signatures = _AVATAR_MAGIC_BYTES.get(mime_type, [])
+    if not any(raw.startswith(sig) for sig in signatures):
+        raise HTTPException(status_code=422, detail="File content does not match declared type")
+    if mime_type == "image/webp" and raw[8:12] != b"WEBP":
+        raise HTTPException(status_code=422, detail="File content does not match declared type")
+
+
+@router.put("/profile/avatar", response_model=UserResponse)
+@limiter.limit("1/minute")
+async def upload_avatar(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    body = await request.json()
+    avatar_url = body.get("avatar_url")
+    if not avatar_url or not isinstance(avatar_url, str):
+        raise HTTPException(status_code=422, detail="avatar_url is required")
+
+    _validate_avatar_data_url(avatar_url)
+
+    current_user.avatar_url = avatar_url
+    await db.commit()
+    await db.refresh(current_user)
+    await audit(
+        current_user,
+        "auth.set_avatar",
+        resource_type="user",
+        resource_id=str(current_user.id),
+        detail="Avatar uploaded",
+    )
+    return UserResponse.model_validate(current_user)
+
+
+@router.delete("/profile/avatar", response_model=UserResponse)
+async def delete_avatar(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    current_user.avatar_url = None
+    await db.commit()
+    await db.refresh(current_user)
+    await audit(
+        current_user,
+        "auth.delete_avatar",
+        resource_type="user",
+        resource_id=str(current_user.id),
+        detail="Avatar removed",
+    )
+    return UserResponse.model_validate(current_user)

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -68,6 +68,7 @@ async def _ensure_columns(conn):
         "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255)",
         "ALTER TABLE mcp_listings ADD COLUMN IF NOT EXISTS environment_variables JSONB",
         "ALTER TABLE agent_versions ADD COLUMN IF NOT EXISTS models_by_ide JSONB NOT NULL DEFAULT '{}'::jsonb",
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_url TEXT",
     ]
     for stmt in stmts:
         try:

--- a/observal-server/models/user.py
+++ b/observal-server/models/user.py
@@ -4,7 +4,7 @@ import os
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -31,6 +31,7 @@ class User(Base):
     is_demo: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     auth_provider: Mapped[str] = mapped_column(String(50), default="local", server_default="local")
     sso_subject_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
     def __init__(self, **kwargs: object) -> None:

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -56,6 +56,7 @@ class UserResponse(BaseModel):
     username: str | None = None
     name: str
     role: UserRole
+    avatar_url: str | None = None
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/tests/test_auth2_security.py
+++ b/tests/test_auth2_security.py
@@ -32,6 +32,7 @@ def _make_mock_user(**overrides):
     user.auth_provider = overrides.get("auth_provider", "local")
     user.created_at = overrides.get("created_at", datetime.now(UTC))
     user.org_id = overrides.get("org_id", uuid.uuid4())
+    user.avatar_url = overrides.get("avatar_url")
     user._trace_privacy = False
     return user
 

--- a/tests/test_auth_redis_down.py
+++ b/tests/test_auth_redis_down.py
@@ -23,6 +23,7 @@ def _make_mock_user():
     user.username = "testuser"
     user.name = "Test User"
     user.role = UserRole.user
+    user.avatar_url = None
     user.verify_password = MagicMock(return_value=True)
     return user
 

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Eye, EyeOff, ArrowRight, Loader2, AlertCircle, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
-import { auth, setTokens, setUserRole, getUserRole, setUserName, setUserEmail, setUserUsername } from "@/lib/api";
+import { auth, setTokens, setUserRole, getUserRole, setUserName, setUserEmail, setUserUsername, setUserAvatar } from "@/lib/api";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -52,12 +52,13 @@ function LoginContent() {
           }
           return res.json();
         })
-        .then((data: { access_token: string; refresh_token: string; user: { role: string; name: string; email: string; username?: string } }) => {
+        .then((data: { access_token: string; refresh_token: string; user: { role: string; name: string; email: string; username?: string; avatar_url?: string | null } }) => {
           setTokens(data.access_token, data.refresh_token);
           setUserRole(data.user.role);
           setUserName(data.user.name);
           setUserEmail(data.user.email);
           if (data.user.username) setUserUsername(data.user.username);
+          if (data.user.avatar_url) setUserAvatar(data.user.avatar_url);
           toast.success("Signed in successfully via SSO");
           const nextPath = searchParams.get("next");
           const redirectTo = nextPath && nextPath.startsWith("/") ? nextPath : "/";
@@ -100,6 +101,7 @@ function LoginContent() {
       setUserName(res.user.name);
       setUserEmail(res.user.email);
       if (res.user.username) setUserUsername(res.user.username);
+      if (res.user.avatar_url) setUserAvatar(res.user.avatar_url);
       toast.success("Signed in successfully");
       router.push("/");
     } catch (e) {
@@ -135,6 +137,7 @@ function LoginContent() {
       setUserName(res.name);
       setUserEmail(res.email);
       if (res.username) setUserUsername(res.username);
+      if (res.avatar_url) setUserAvatar(res.avatar_url);
       router.push("/");
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Failed to change password";

--- a/web/src/app/(user)/account/page.tsx
+++ b/web/src/app/(user)/account/page.tsx
@@ -4,14 +4,15 @@ import { useState, useCallback, useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
 import { Check, Loader2 } from "lucide-react";
 import { toast } from "sonner";
-import { getUserName, getUserEmail, getUserRole, getUserUsername, setUserUsername, auth } from "@/lib/api";
+import { getUserName, getUserEmail, getUserRole, getUserUsername, getUserAvatar, setUserUsername, auth } from "@/lib/api";
 import { ROLE_LABELS, type Role } from "@/hooks/use-role-guard";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layouts/page-header";
+import { AvatarEditable } from "@/components/account/avatar-upload";
 
 // ── Theme definitions ──────────────────────────────────────────────────────
 // Swatches: [bg, accent, fg] in oklch — derived from globals.css
@@ -255,11 +256,17 @@ function getUsernameSnapshot() {
 }
 
 // ── Page ───────────────────────────────────────────────────────────────────
+function getAvatarSnapshot() {
+  if (typeof window === "undefined") return null;
+  return getUserAvatar();
+}
+
 export default function AccountPage() {
   const name = useSyncExternalStore(subscribe, getNameSnapshot, getServerSnapshot);
   const email = useSyncExternalStore(subscribe, getEmailSnapshot, getServerSnapshot);
   const role = useSyncExternalStore(subscribe, getRoleSnapshot, getServerSnapshot);
   const username = useSyncExternalStore(subscribe, getUsernameSnapshot, getServerSnapshot);
+  const avatar = useSyncExternalStore(subscribe, getAvatarSnapshot, () => null as string | null);
 
   const { theme, setTheme } = useTheme();
 
@@ -280,11 +287,7 @@ export default function AccountPage() {
           <Card>
             <CardContent className="p-4 space-y-3">
               <div className="flex items-center gap-4">
-                <Avatar className="h-12 w-12 shrink-0">
-                  <AvatarFallback className="text-sm font-semibold">
-                    {initials(displayName)}
-                  </AvatarFallback>
-                </Avatar>
+                <AvatarEditable name={displayName} avatarUrl={avatar} />
                 <div className="min-w-0 flex-1">
                   <p className="text-sm font-semibold truncate">{displayName}</p>
                   <p className="text-xs text-muted-foreground truncate mt-0.5">{displayEmail}</p>

--- a/web/src/components/account/avatar-upload.tsx
+++ b/web/src/components/account/avatar-upload.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { Camera, Loader2, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { auth, setUserAvatar } from "@/lib/api";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp"];
+// Match server-side _MAX_AVATAR_BYTES (2MB). Canvas always crops to 256x256 PNG
+// so the upload payload will be well under this, but guard the raw file too.
+const MAX_FILE_SIZE = 2 * 1024 * 1024;
+const MIN_OVERLAY = 80;
+
+interface Overlay {
+	x: number;
+	y: number;
+	size: number;
+}
+
+interface AvatarEditableProps {
+	name: string;
+	avatarUrl: string | null;
+}
+
+function initials(name: string) {
+	return name
+		.split(" ")
+		.map((w) => w[0])
+		.join("")
+		.toUpperCase()
+		.slice(0, 2);
+}
+
+export function AvatarEditable({ name, avatarUrl }: AvatarEditableProps) {
+	const [open, setOpen] = useState(false);
+	const [imageUrl, setImageUrl] = useState<string | null>(null);
+	const [overlay, setOverlay] = useState<Overlay>({ x: 0, y: 0, size: 200 });
+	const [uploading, setUploading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [imgDimensions, setImgDimensions] = useState({ w: 0, h: 0 });
+
+	const imgRef = useRef<HTMLImageElement>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const dragRef = useRef<{
+		type: "move" | "resize";
+		startX: number;
+		startY: number;
+		startOverlay: Overlay;
+	} | null>(null);
+
+	const reset = () => {
+		setImageUrl(null);
+		setOverlay({ x: 0, y: 0, size: 200 });
+		setImgDimensions({ w: 0, h: 0 });
+		setError(null);
+		if (fileInputRef.current) fileInputRef.current.value = "";
+	};
+
+	const handleOpenChange = (value: boolean) => {
+		if (!value) reset();
+		setOpen(value);
+	};
+
+	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+
+		if (!ALLOWED_TYPES.includes(file.type)) {
+			setError("Please upload a PNG, JPEG, or WebP image");
+			return;
+		}
+		if (file.size > MAX_FILE_SIZE) {
+			setError("Image must be under 2MB");
+			return;
+		}
+
+		// Use FileReader instead of URL.createObjectURL so the preview src is
+		// a browser-produced data: URL — not a user-controlled blob: URL.
+		const reader = new FileReader();
+		reader.onload = (ev) => {
+			const result = ev.target?.result;
+			if (typeof result === "string") {
+				setImageUrl(result);
+				setError(null);
+			}
+		};
+		reader.readAsDataURL(file);
+	};
+
+	const handleImageLoad = () => {
+		const img = imgRef.current;
+		if (!img) return;
+
+		const w = img.clientWidth;
+		const h = img.clientHeight;
+		setImgDimensions({ w, h });
+
+		const size = Math.min(Math.floor(Math.min(w, h) * 0.6), 300);
+		setOverlay({
+			x: Math.floor((w - size) / 2),
+			y: Math.floor((h - size) / 2),
+			size,
+		});
+	};
+
+	const handleMouseDown = useCallback(
+		(e: React.MouseEvent, type: "move" | "resize") => {
+			e.preventDefault();
+			e.stopPropagation();
+			dragRef.current = {
+				type,
+				startX: e.clientX,
+				startY: e.clientY,
+				startOverlay: { ...overlay },
+			};
+
+			const handleMouseMove = (me: MouseEvent) => {
+				if (!dragRef.current) return;
+				const dx = me.clientX - dragRef.current.startX;
+				const dy = me.clientY - dragRef.current.startY;
+				const start = dragRef.current.startOverlay;
+
+				if (dragRef.current.type === "move") {
+					let newX = start.x + dx;
+					let newY = start.y + dy;
+					newX = Math.max(0, Math.min(newX, imgDimensions.w - start.size));
+					newY = Math.max(0, Math.min(newY, imgDimensions.h - start.size));
+					setOverlay({ x: newX, y: newY, size: start.size });
+				} else {
+					const delta = Math.max(dx, dy);
+					let newSize = start.size + delta;
+					newSize = Math.max(MIN_OVERLAY, newSize);
+					newSize = Math.min(
+						newSize,
+						imgDimensions.w - start.x,
+						imgDimensions.h - start.y,
+					);
+					setOverlay({ x: start.x, y: start.y, size: newSize });
+				}
+			};
+
+			const handleMouseUp = () => {
+				dragRef.current = null;
+				document.removeEventListener("mousemove", handleMouseMove);
+				document.removeEventListener("mouseup", handleMouseUp);
+			};
+
+			document.addEventListener("mousemove", handleMouseMove);
+			document.addEventListener("mouseup", handleMouseUp);
+		},
+		[overlay, imgDimensions],
+	);
+
+	const handleCropAndSave = async () => {
+		const img = imgRef.current;
+		if (!img || !imageUrl) return;
+
+		setUploading(true);
+		try {
+			const scaleX = img.naturalWidth / img.clientWidth;
+			const scaleY = img.naturalHeight / img.clientHeight;
+
+			const sx = overlay.x * scaleX;
+			const sy = overlay.y * scaleY;
+			const sSize = overlay.size * Math.min(scaleX, scaleY);
+
+			const canvas = document.createElement("canvas");
+			canvas.width = 256;
+			canvas.height = 256;
+			const ctx = canvas.getContext("2d");
+			if (!ctx) throw new Error("Canvas not supported");
+
+			ctx.drawImage(img, sx, sy, sSize, sSize, 0, 0, 256, 256);
+			const dataUrl = canvas.toDataURL("image/png");
+
+			await auth.uploadAvatar({ avatar_url: dataUrl });
+			setUserAvatar(dataUrl);
+
+			reset();
+			setOpen(false);
+			toast.success("Profile picture updated");
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Upload failed");
+		} finally {
+			setUploading(false);
+		}
+	};
+
+	const handleRemoveAvatar = async () => {
+		setUploading(true);
+		try {
+			await auth.deleteAvatar();
+			setUserAvatar(null);
+			toast.success("Profile picture removed");
+			setOpen(false);
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Failed to remove avatar",
+			);
+		} finally {
+			setUploading(false);
+		}
+	};
+
+	return (
+		<>
+			{/* Clickable avatar */}
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				className="relative group shrink-0 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			>
+				<Avatar className="h-12 w-12" key={avatarUrl || "no-avatar"}>
+					{avatarUrl && <AvatarImage src={avatarUrl} alt={name} />}
+					<AvatarFallback className="text-sm font-semibold">
+						{initials(name || "U")}
+					</AvatarFallback>
+				</Avatar>
+				<div className="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+					<Camera className="h-4 w-4 text-white" />
+				</div>
+			</button>
+
+			{/* Edit dialog */}
+			<Dialog open={open} onOpenChange={handleOpenChange}>
+				<DialogContent className="sm:max-w-lg">
+					<DialogHeader>
+						<DialogTitle>Edit Profile Picture</DialogTitle>
+					</DialogHeader>
+
+					<div className="space-y-4">
+						{!imageUrl ? (
+							<>
+								<div
+									className="border-2 border-dashed border-border rounded-lg p-8 text-center hover:bg-accent/5 transition-colors cursor-pointer"
+									onClick={() => fileInputRef.current?.click()}
+									onDragOver={(e) => e.preventDefault()}
+									onDrop={(e) => {
+										e.preventDefault();
+										const file = e.dataTransfer.files?.[0];
+										if (file) {
+											const syntheticEvent = {
+												target: { files: e.dataTransfer.files },
+											} as unknown as React.ChangeEvent<HTMLInputElement>;
+											handleFileChange(syntheticEvent);
+										}
+									}}
+								>
+									<Camera className="mx-auto h-6 w-6 text-muted-foreground mb-2" />
+									<p className="text-sm font-medium">
+										Click to choose or drop an image
+									</p>
+									<p className="text-xs text-muted-foreground mt-1">
+										PNG, JPEG, or WebP (max 5MB)
+									</p>
+								</div>
+
+								<input
+									ref={fileInputRef}
+									type="file"
+									accept="image/png,image/jpeg,image/webp"
+									onChange={handleFileChange}
+									className="hidden"
+								/>
+
+								{error && <p className="text-sm text-destructive">{error}</p>}
+
+								{avatarUrl && (
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={handleRemoveAvatar}
+										disabled={uploading}
+										className="w-full"
+									>
+										{uploading ? (
+											<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+										) : (
+											<Trash2 className="mr-2 h-4 w-4" />
+										)}
+										Remove Picture
+									</Button>
+								)}
+							</>
+						) : (
+							<div className="space-y-3">
+								<p className="text-xs text-muted-foreground">
+									Drag the box to position. Drag the corner to resize.
+								</p>
+
+								<div
+									className="relative inline-block select-none overflow-hidden rounded-lg border border-border"
+									style={{ maxWidth: "100%" }}
+								>
+									{/* eslint-disable-next-line @next/next/no-img-element */}
+									<img
+										ref={imgRef}
+										src={imageUrl ?? undefined}
+										alt="Upload preview"
+										onLoad={handleImageLoad}
+										className="block max-w-full max-h-[350px] w-auto h-auto"
+										draggable={false}
+									/>
+
+									{imgDimensions.w > 0 && (
+										<>
+											<div className="absolute inset-0 pointer-events-none">
+												<div
+													style={{
+														position: "absolute",
+														top: overlay.y,
+														left: overlay.x,
+														width: overlay.size,
+														height: overlay.size,
+														boxShadow: "0 0 0 9999px rgba(0,0,0,0.5)",
+													}}
+												/>
+											</div>
+
+											<div
+												className="absolute border-2 border-white/90 rounded-sm cursor-move"
+												style={{
+													top: overlay.y,
+													left: overlay.x,
+													width: overlay.size,
+													height: overlay.size,
+												}}
+												onMouseDown={(e) => handleMouseDown(e, "move")}
+											>
+												<div
+													className="absolute bottom-0 right-0 w-4 h-4 bg-white border border-gray-400 rounded-sm cursor-nwse-resize translate-x-1/2 translate-y-1/2"
+													onMouseDown={(e) => handleMouseDown(e, "resize")}
+												/>
+											</div>
+										</>
+									)}
+								</div>
+
+								<div className="flex gap-2">
+									<Button
+										onClick={handleCropAndSave}
+										disabled={uploading || imgDimensions.w === 0}
+										className="flex-1"
+									>
+										{uploading ? (
+											<>
+												<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+												Saving...
+											</>
+										) : (
+											"Crop & Save"
+										)}
+									</Button>
+									<Button
+										variant="outline"
+										onClick={() => {
+											reset();
+										}}
+										disabled={uploading}
+									>
+										Cancel
+									</Button>
+								</div>
+							</div>
+						)}
+					</div>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/web/src/components/nav/nav-user.tsx
+++ b/web/src/components/nav/nav-user.tsx
@@ -2,7 +2,7 @@
 
 import { LogOut, Settings } from "lucide-react";
 import { ChevronsUpDown } from "lucide-react";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,8 +13,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SidebarMenuButton } from "@/components/ui/sidebar";
 import Link from "next/link";
-import { clearSession } from "@/lib/api";
+import { clearSession, getUserAvatar } from "@/lib/api";
 import { useRouter } from "next/navigation";
+import { useSyncExternalStore } from "react";
 
 function initials(name: string) {
   return name
@@ -31,6 +32,11 @@ interface NavUserProps {
 
 export function NavUser({ user }: NavUserProps) {
   const router = useRouter();
+  const avatarUrl = useSyncExternalStore(
+    (cb) => { window.addEventListener("storage", cb); return () => window.removeEventListener("storage", cb); },
+    () => getUserAvatar(),
+    () => null,
+  );
 
   return (
     <DropdownMenu>
@@ -39,7 +45,8 @@ export function NavUser({ user }: NavUserProps) {
           size="lg"
           className="data-[state=open]:bg-sidebar-accent"
         >
-          <Avatar className="h-8 w-8">
+          <Avatar className="h-8 w-8" key={avatarUrl || "no-avatar"}>
+            {avatarUrl && <AvatarImage src={avatarUrl} alt={user.name} />}
             <AvatarFallback className="text-xs">
               {initials(user.name || "U")}
             </AvatarFallback>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -46,6 +46,7 @@ const STORAGE_KEY_USER_ROLE = "observal_user_role";
 const STORAGE_KEY_USER_NAME = "observal_user_name";
 const STORAGE_KEY_USER_EMAIL = "observal_user_email";
 const STORAGE_KEY_USER_USERNAME = "observal_user_username";
+const STORAGE_KEY_USER_AVATAR = "observal_user_avatar";
 
 function getAccessToken(): string | null {
   if (typeof window === "undefined") return null;
@@ -70,6 +71,7 @@ export function clearSession() {
   localStorage.removeItem(STORAGE_KEY_USER_NAME);
   localStorage.removeItem(STORAGE_KEY_USER_EMAIL);
   localStorage.removeItem(STORAGE_KEY_USER_USERNAME);
+  localStorage.removeItem(STORAGE_KEY_USER_AVATAR);
 }
 
 export function setUserRole(role: string) {
@@ -106,6 +108,20 @@ export function setUserUsername(username: string) {
 export function getUserUsername(): string | null {
   if (typeof window === "undefined") return null;
   return localStorage.getItem(STORAGE_KEY_USER_USERNAME);
+}
+
+export function setUserAvatar(avatar: string | null) {
+  if (avatar) {
+    localStorage.setItem(STORAGE_KEY_USER_AVATAR, avatar);
+  } else {
+    localStorage.removeItem(STORAGE_KEY_USER_AVATAR);
+  }
+  window.dispatchEvent(new Event("storage"));
+}
+
+export function getUserAvatar(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(STORAGE_KEY_USER_AVATAR);
 }
 
 let _refreshPromise: Promise<boolean> | null = null;
@@ -237,7 +253,7 @@ export async function graphql<T = unknown>(
 
 // ── Auth ────────────────────────────────────────────────────────────
 type AuthResponse = {
-  user: { id: string; email: string; username?: string | null; name: string; role: string; created_at: string };
+  user: { id: string; email: string; username?: string | null; name: string; role: string; avatar_url?: string | null; created_at: string };
   access_token: string;
   refresh_token: string;
   expires_in: number;
@@ -248,13 +264,17 @@ export const auth = {
     post<AuthResponse>("/auth/init", body),
   login: (body: { email: string; password: string }) =>
     post<AuthResponse & { must_change_password?: boolean }>("/auth/login", body),
-  whoami: () => get<{ id: string; email: string; username?: string | null; name: string; role: string }>("/auth/whoami"),
+  whoami: () => get<{ id: string; email: string; username?: string | null; name: string; role: string; avatar_url?: string | null }>("/auth/whoami"),
   exchangeCode: (body: { code: string }) =>
     post<AuthResponse>("/auth/exchange", body),
   deviceConfirm: (userCode: string) =>
     post<{ message: string }>("/auth/device/confirm", { user_code: userCode }),
   changePassword: (body: { current_password: string; new_password: string }) =>
     put<{ message: string }>("/auth/profile/password", body),
+  uploadAvatar: (body: { avatar_url: string }) =>
+    put<{ avatar_url: string | null }>("/auth/profile/avatar", body),
+  deleteAvatar: () =>
+    del<{ avatar_url: null }>("/auth/profile/avatar"),
 };
 
 // ── Registry (all 8 types) ─────────────────────────────────────────


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Made the user profile picture changeable

## Fixes
* Fixes #774

## Approach
Added avatar_url column to the users table, two new auth endpoints 
-(PUT/DELETE) with base64 validation and magic byte checks to validate if it's an image
-crop dialog using CSS overlays with Canvas only at save time

## How Has This Been Tested?
tested by changing in frontend and editing multiple times

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<img width="1005" height="542" alt="image" src="https://github.com/user-attachments/assets/265b998d-3fc2-4241-948d-9627ff6c5ddb" />


<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
--->