### PR TITLE
feat: make JSON paste the default MCP submission method + fix blank error on startup failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml -
 - `telemetry_buffer.py` : SQLite buffer (`~/.observal/telemetry_buffer.db`) for offline telemetry; stores events when server is unreachable and flushes on reconnect
 - `settings_reconciler.py` : Non-destructive reconciler for Claude Code `settings.json`; Terraform-style declarative reconciliation — reads current state, diffs against desired, applies only deltas
 - `cmd_auth.py` : `auth_app` subgroup: login (smart — auto-bootstrap on fresh server, supports --key for API keys, email+password), register, reset-password, logout, whoami, status. Also `config_app` subgroup: show, set, path, alias, aliases
-- `cmd_mcp.py` : `mcp_app` subgroup: submit (with --yes for non-interactive, client-side repo analysis via `analyzer.py`), list (--sort, --limit, --output), show, install (--raw), delete
+- `cmd_mcp.py` : `mcp_app` subgroup: submit (JSON paste default, --git for repo analysis, --draft, --yes for non-interactive), list (--sort, --limit, --output), show, install (--raw), delete
 - `cmd_agent.py` : `agent_app` subgroup: create (--from-file), list, show, install, delete; authoring: init, add, build, publish
 - `cmd_skill.py` : `skill_app` subgroup: submit, list, show, install, delete
 - `cmd_hook.py` : `hook_app` subgroup: submit, list, show, install, delete

--- a/docs/cli/registry.md
+++ b/docs/cli/registry.md
@@ -29,43 +29,64 @@ Prompts also support [`render`](#observal-registry-prompt-render).
 
 ## `observal registry mcp submit`
 
-Submit an MCP server for review. The CLI clones the repo locally (using your git credentials), analyzes it via AST parsing, then sends the analysis to the server.
+Submit an MCP server to the registry. By default, paste your server's JSON config (the same format you use in your IDE). Use `--git` to analyze a git repository instead.
 
 ### Synopsis
 
 ```bash
-observal registry mcp submit <git-url> [OPTIONS]
-observal registry mcp submit --from-file <path> [OPTIONS]
+observal registry mcp submit [OPTIONS]
+observal registry mcp submit --git <url> [OPTIONS]
 ```
 
 ### Options
 
 | Option | Short | Description |
 | --- | --- | --- |
+| `--git` | `-g` | Analyze a git repository instead of pasting config |
 | `--name` | `-n` | Pre-fill server name (skip prompt) |
 | `--category` | `-c` | Pre-fill category (skip prompt) |
-| `--yes` | `-y` | Accept all defaults from repo analysis |
+| `--yes` | `-y` | Accept all defaults |
+| `--draft` | | Save as draft instead of submitting for review |
+| `--submit` | | Submit an existing draft for review (MCP ID) |
 
-### What happens
+### Default flow (JSON paste)
+
+1. Prompts you to paste your MCP server JSON config.
+2. Accepts multiple formats:
+   - **IDE config** — `{"mcpServers": {"name": {"command": "...", "args": [...], "env": {...}}}}`
+   - **Bare config** — `{"command": "npx", "args": ["-y", "pkg"]}`
+   - **SSE/HTTP** — `{"url": "http://...", "type": "sse", "headers": {...}}`
+   - **server.json manifest** — `{"packages": [...], "remotes": [...]}`
+3. Auto-detects environment variables from `$VAR` patterns and `env` keys.
+4. Shows a config preview and prompts for metadata (name, description, category).
+5. Submits to registry for review.
+
+### Git analysis flow (`--git`)
 
 1. Shallow-clones the repo.
 2. Detects the MCP framework (FastMCP, MCP SDK, TypeScript SDK, Go SDK).
 3. Extracts server name, description, and exposed tools via AST.
-4. Scans for required env vars (`os.environ`, `os.getenv`, `.env.example`, Dockerfile `ENV`/`ARG`).
-5. Prompts for metadata (description, owner, category, supported IDEs, setup instructions).
-6. Shows detected env vars — confirm, reject, or add more.
-7. Submits to the server with `client_analysis` attached. The server stores the analysis directly without re-cloning.
-
-If local analysis fails (e.g., git not available), falls back to server-side analysis.
+4. Scans for required env vars (`os.environ`, `os.getenv`, `.env.example`, `server.json`).
+5. Prompts for metadata confirmation.
+6. Submits to registry for review.
 
 ### Examples
 
 ```bash
-# Interactive
-observal registry mcp submit https://github.com/MarkusPfundstein/mcp-obsidian
+# Paste config (default — recommended)
+observal registry mcp submit
 
-# Non-interactive, accept defaults
-observal registry mcp submit https://github.com/sooperset/mcp-atlassian -y
+# Non-interactive with piped JSON
+echo '{"command": "npx", "args": ["-y", "@example/mcp-server"]}' | observal registry mcp submit -y -n my-server -c developer-tools
+
+# Save as draft
+observal registry mcp submit --draft
+
+# Analyze a git repo
+observal registry mcp submit --git https://github.com/MarkusPfundstein/mcp-obsidian
+
+# Non-interactive git analysis
+observal registry mcp submit --git https://github.com/sooperset/mcp-atlassian -y
 ```
 
 ### Valid categories

--- a/observal-server/services/component_version_extras.py
+++ b/observal-server/services/component_version_extras.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Per-type field validation for component version publishing."""
@@ -47,6 +48,16 @@ MCP_FIELDS = {
     "source_url",
     "source_ref",
     "resolved_sha",
+    "transport",
+    "framework",
+    "docker_image",
+    "command",
+    "args",
+    "url",
+    "headers",
+    "auto_approve",
+    "environment_variables",
+    "setup_instructions",
 }
 
 SANDBOX_FIELDS = {
@@ -87,6 +98,12 @@ FIELD_TYPES: dict[str, type | tuple[type, ...]] = {
     "source_url": str,
     "source_ref": str,
     "resolved_sha": str,
+    "transport": str,
+    "framework": str,
+    "docker_image": str,
+    "command": str,
+    "url": str,
+    "setup_instructions": str,
     # int fields
     "priority": int,
     # bool fields — must come before int since bool is a subclass of int
@@ -107,6 +124,10 @@ FIELD_TYPES: dict[str, type | tuple[type, ...]] = {
     "activation_keywords": list,
     "tags": list,
     "variables": list,
+    "args": list,
+    "headers": list,
+    "auto_approve": list,
+    "environment_variables": list,
 }
 
 

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -574,6 +574,11 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         return
 
     # ── Path A: Git URL analysis ─────────────────────────────
+    rprint(
+        "\n[yellow]Note:[/yellow] Git analysis is best-effort and not a long-term supported feature."
+        "\n      Environment variable detection may not cover all cases — please review"
+        "\n      and add any missing variables manually.\n"
+    )
     analyzed_locally = False
     with spinner("Analyzing repository..."):
         try:

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -243,14 +243,87 @@ def _unwrap_mcp_config(cfg: dict) -> tuple[dict, str | None]:
     return cfg, None
 
 
-def _parse_direct_config(cfg: dict) -> dict:
-    """Normalize a JSON config dict (mcp.json style) into submit-ready fields.
+def _parse_server_json_manifest(cfg: dict) -> dict | None:
+    """Parse a server.json manifest format (packages[]/remotes[] arrays).
 
-    Accepts wrapped (mcpServers) or bare configs.
+    Also handles the MCP registry format where data is nested under a "server" key:
+      {"server": {"name": "...", "remotes": [...]}, "_meta": {...}}
+
+    Returns parsed dict if this looks like a server.json manifest, None otherwise.
+    """
+    # Handle registry format: unwrap "server" envelope
+    manifest = cfg
+    server_meta = cfg.get("server")
+    if isinstance(server_meta, dict) and ("remotes" in server_meta or "packages" in server_meta):
+        manifest = server_meta
+
+    if "packages" not in manifest and "remotes" not in manifest:
+        return None
+
+    parsed: dict = {}
+    env_vars: list[dict] = []
+
+    # Extract server name/description from registry metadata
+    if server_meta and isinstance(server_meta, dict):
+        reg_name = server_meta.get("title") or server_meta.get("name")
+        if reg_name:
+            parsed["_server_name"] = reg_name
+        reg_desc = server_meta.get("description")
+        if reg_desc:
+            parsed["_description"] = reg_desc
+
+    # packages[].runtimeArguments — Docker -e flags
+    for pkg in manifest.get("packages", []):
+        for arg in pkg.get("runtimeArguments", []):
+            value = arg.get("value", "")
+            # Pattern: "ENV_VAR={placeholder}" — extract the var name before '='
+            if "=" in value:
+                var_name = value.split("=", 1)[0]
+                if var_name and var_name == var_name.upper():
+                    desc = arg.get("description", "")
+                    env_vars.append({"name": var_name, "description": desc, "required": True})
+
+    # remotes[].variables — URL-interpolated secrets
+    for remote in manifest.get("remotes", []):
+        url = remote.get("url", "")
+        if url and not parsed.get("url"):
+            parsed["url"] = url
+            parsed["transport"] = remote.get("type", "sse")
+        for var_key, var_meta in (remote.get("variables") or {}).items():
+            desc = var_meta.get("description", "") if isinstance(var_meta, dict) else ""
+            env_vars.append({"name": var_key, "description": desc, "required": True})
+
+    if env_vars:
+        parsed["environment_variables"] = env_vars
+
+    # Determine transport: URL means SSE/HTTP, packages-only means stdio/docker
+    if not parsed.get("url"):
+        has_remotes = bool(manifest.get("remotes"))
+        if not has_remotes:
+            # Packages-only manifest implies stdio (Docker typically)
+            parsed["transport"] = "stdio"
+            parsed["framework"] = "docker"
+        # else: remotes without a URL — don't assume transport
+
+    return parsed
+
+
+def _parse_direct_config(cfg: dict) -> dict:
+    """Normalize a JSON config dict into submit-ready fields.
+
+    Accepts:
+    - IDE config: wrapped (mcpServers) or bare {command, args} / {url, type}
+    - server.json manifest: {packages: [...]} / {remotes: [...]}
+
     Handles two transport shapes:
     - stdio: {command, args, env}
     - SSE/HTTP: {url, type, headers, autoApprove}
     """
+    # Try server.json manifest format first
+    manifest_result = _parse_server_json_manifest(cfg)
+    if manifest_result is not None:
+        return manifest_result
+
     inner, server_name = _unwrap_mcp_config(cfg)
     parsed: dict = {}
     if server_name:
@@ -421,6 +494,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
 
         parsed = _parse_direct_config(cfg)
         _name = name or parsed.pop("_server_name", None) or "my-mcp-server"
+        _parsed_desc = parsed.pop("_description", None)
 
         # Extract dollar-sign input variables before preview
         dollar_vars = parsed.pop("_dollar_vars_detected", None)
@@ -446,7 +520,12 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
                 parsed["environment_variables"] = _review_env_vars(parsed.get("environment_variables", []))
 
             _name = name or typer.prompt("Server name", default=_name)
-            _desc = typer.prompt("Description (what does this server do?)", default="")
+            _desc_default = _parsed_desc or ""
+            _desc = typer.prompt("Description (what does this server do?)", default=_desc_default or None)
+            while not _desc.strip():
+                rprint("[yellow]Description is required.[/yellow]")
+                _desc = typer.prompt("Description (what does this server do?)")
+            _desc = _desc.strip()
             _owner = typer.prompt(
                 "Owner / Team (e.g. your GitHub username)", default=config.load().get("user_name", "default")
             )
@@ -454,7 +533,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         else:
             if dollar_vars:
                 rprint(f"\n[dim]Auto-detected {len(dollar_vars)} input variable(s) from $VAR patterns.[/dim]")
-            _desc = ""
+            _desc = _parsed_desc or _name
             _owner = config.load().get("user_name", "") or "default"
             _category = category or "general"
 
@@ -504,15 +583,16 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
                 rprint("[dim]Falling back to server-side analysis...[/dim]")
                 try:
                     prefill = client.post("/api/v1/mcps/analyze", {"git_url": git_url})
-                except (Exception, SystemExit):
+                except SystemExit:
                     rprint("[yellow]Server analysis also failed. Fill in details manually.[/yellow]")
                     prefill = {}
             else:
                 analyzed_locally = True
-        except Exception:
+        except (OSError, ValueError, RuntimeError):
+            # Local analysis can fail with filesystem/git/parsing errors
             try:
                 prefill = client.post("/api/v1/mcps/analyze", {"git_url": git_url})
-            except (Exception, SystemExit):
+            except SystemExit:
                 rprint("[yellow]Could not analyze repo. Fill in details manually.[/yellow]")
                 prefill = {}
 
@@ -1003,15 +1083,18 @@ def _delete_impl(mcp_id, yes):
 
 @mcp_app.command()
 def submit(
-    git_url: str = typer.Argument(None, help="Git repository URL (optional if --config used)"),
+    git_url: str = typer.Option(None, "--git", "-g", help="Analyze a git repository instead of pasting config"),
     name: str = typer.Option(None, "--name", "-n", help="Skip name prompt"),
     category: str = typer.Option(None, "--category", "-c", help="Skip category prompt"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Accept defaults from repo analysis"),
-    config: bool = typer.Option(False, "--config", help="Submit via direct JSON config (paste mode)"),
+    config: bool = typer.Option(False, "--config", hidden=True, help="(deprecated) JSON paste is now the default"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (MCP ID)"),
 ):
-    """Submit an MCP server for review.
+    """Submit an MCP server to the registry.
+
+    By default, paste your server's JSON config (the same format you use in
+    your IDE). Use --git to analyze a git repository instead.
 
     Only submit servers you created or are the point-of-contact for.
     """
@@ -1028,11 +1111,12 @@ def submit(
             result = client.post(f"/api/v1/mcps/{resolved}/submit")
         rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
         return
-    if not git_url and not config:
-        rprint("[red]Provide a git URL or use --config[/red]")
-        raise typer.Exit(1)
+    if config:
+        rprint("[dim]Note: --config is now the default. You can just run `observal mcp submit`.[/dim]")
     rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
-    _submit_impl(git_url, name, category, yes, config, draft=draft)
+    # Default is JSON paste (direct_config=True), unless --git is provided
+    direct_config = not git_url
+    _submit_impl(git_url, name, category, yes, direct_config, draft=draft)
 
 
 @mcp_app.command(name="list")
@@ -1146,26 +1230,137 @@ def edit_mcp(
             updates["url"] = url
 
     if not updates:
-        rprint("[yellow]No changes specified.[/yellow] Use --from-file or field options (--name, --description, etc.)")
+        # Interactive JSON paste mode (like submit)
+        rprint("[bold]Paste your updated MCP server JSON config below.[/bold]")
+        rprint("[dim]Press Enter on an empty line when done.[/dim]\n")
+        lines: list[str] = []
+        has_content = False
+        while True:
+            try:
+                line = input()
+            except EOFError:
+                break
+            if line.strip() == "":
+                if has_content:
+                    break
+            else:
+                has_content = True
+                lines.append(line)
+        raw_text = "\n".join(lines).strip()
+        if not raw_text:
+            rprint("[yellow]No input received.[/yellow]")
+            raise typer.Exit(code=1)
+        try:
+            cfg = json.loads(raw_text)
+        except json.JSONDecodeError:
+            try:
+                cfg = json.loads("".join(part.strip() for part in lines))
+            except json.JSONDecodeError as e:
+                rprint(f"[red]Invalid JSON:[/red] {e}")
+                raise typer.Exit(1)
+
+        parsed = _parse_direct_config(cfg)
+        _name = parsed.pop("_server_name", None)
+        _desc = parsed.pop("_description", None)
+        parsed.pop("_dollar_vars_detected", None)
+
+        # Build updates from parsed config
+        if _name:
+            updates["name"] = _name
+        if _desc:
+            updates["description"] = _desc
+        if parsed.get("command"):
+            updates["command"] = parsed["command"]
+        if parsed.get("args") is not None:
+            updates["args"] = parsed["args"]
+        if parsed.get("url"):
+            updates["url"] = parsed["url"]
+        if parsed.get("transport"):
+            updates["transport"] = parsed["transport"]
+        if parsed.get("framework"):
+            updates["framework"] = parsed["framework"]
+        if parsed.get("environment_variables"):
+            updates["environment_variables"] = parsed["environment_variables"]
+
+        rprint("\n[bold]Config preview:[/bold]")
+        preview_name = _name or mcp_id
+        console.print_json(json.dumps(_build_config_preview(preview_name, parsed), indent=2))
+
+        if not typer.confirm("\nApply these changes?", default=True):
+            raise typer.Abort()
+
+    if not updates:
+        rprint("[yellow]No changes could be parsed from input.[/yellow]")
         raise typer.Exit(code=1)
 
+    # Check listing status — approved listings need a new version, drafts can be edited directly
+    is_approved = False
+    listing = None
     try:
-        client.post(f"/api/v1/mcps/{resolved}/start-edit")
-    except Exception as exc:
-        if "409" in str(exc) or "currently being edited" in str(exc):
-            rprint(f"[red]✗ Cannot edit:[/red] {exc}")
-            raise typer.Exit(code=1)
-    try:
-        with spinner("Saving changes..."):
-            result = client.put(f"/api/v1/mcps/{resolved}/draft", updates)
-        rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
-    except Exception as exc:
+        with spinner("Checking listing status..."):
+            listing = client.get(f"/api/v1/mcps/{resolved}")
+        if listing.get("status") == "approved":
+            is_approved = True
+    except SystemExit:
+        # client raises typer.Exit on API failure — fall through to draft edit flow
+        pass
+
+    if is_approved:
+        # Approved listing → publish a new version with semver bump
+        current_ver = listing.get("version", "0.1.0") if listing else "0.1.0"
+        rprint(f"[dim]Current version: {current_ver}[/dim]")
+        bump_type = select_one("Version bump", ["patch", "minor", "major"], default="patch")
+
+        parts = current_ver.split(".")
+        if len(parts) == 3 and all(p.isdigit() for p in parts):
+            major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+            if bump_type == "major":
+                _new_version = f"{major + 1}.0.0"
+            elif bump_type == "minor":
+                _new_version = f"{major}.{minor + 1}.0"
+            else:
+                _new_version = f"{major}.{minor}.{patch + 1}"
+        else:
+            _new_version = "0.2.0"
+
+        rprint(f"[bold]New version:[/bold] {_new_version}")
+        _changelog = typer.prompt("Changelog (what changed?)", default="")
+
+        # Separate top-level fields from extra (version-specific) fields
+        version_description = updates.pop("description", None) or (listing.get("description", "") if listing else "")
+        updates.pop("name", None)  # name is a listing field, not a version field
+
+        version_body: dict = {
+            "version": _new_version.strip(),
+            "description": version_description,
+        }
+        if updates:
+            version_body["extra"] = updates
+        if _changelog.strip():
+            version_body["changelog"] = _changelog.strip()
+
+        # client.post prints its own error message and raises typer.Exit on failure — let it propagate
+        with spinner("Publishing new version..."):
+            result = client.post(f"/api/v1/mcps/{resolved}/versions", version_body)
+        rprint(f"[green]✓ Published v{_new_version.strip()}[/green] for [bold]{result.get('name', mcp_id)}[/bold]")
+    else:
+        # Draft/pending/rejected → edit in place
         try:
-            client.post(f"/api/v1/mcps/{resolved}/cancel-edit")
-        except Exception:
+            client.post(f"/api/v1/mcps/{resolved}/start-edit")
+        except SystemExit:
+            # start-edit may 409 if already locked — client prints the error, proceed anyway
             pass
-        rprint(f"[red]Failed to update:[/red] {exc}")
-        raise typer.Exit(code=1)
+        try:
+            with spinner("Saving changes..."):
+                result = client.put(f"/api/v1/mcps/{resolved}/draft", updates)
+            rprint(f"[green]✓ Updated {result['name']}[/green] (status: {result.get('status', 'unknown')})")
+        except SystemExit:
+            # Save failed — attempt to release the edit lock before exiting
+            try:
+                client.post(f"/api/v1/mcps/{resolved}/cancel-edit")
+            except SystemExit:
+                pass
+            raise typer.Exit(code=1)
 
 
 @mcp_app.command(name="delete")

--- a/observal_cli/shim.py
+++ b/observal_cli/shim.py
@@ -26,6 +26,10 @@ from observal_cli.config import load as load_config
 
 logger = logging.getLogger("observal-shim")
 
+# How long to wait after spawn before checking if the process crashed immediately.
+# Covers missing binaries and module import errors without flagging slow starts.
+_STARTUP_HEALTH_CHECK_SEC = float(os.environ.get("OBSERVAL_SHIM_STARTUP_TIMEOUT_SEC", "0.5"))
+
 # --- JSON-RPC span type mapping ---
 
 METHOD_TO_SPAN: dict[str, tuple[str, str | None]] = {
@@ -345,6 +349,52 @@ def _thread_read_stdin(loop: asyncio.AbstractEventLoop, reader: asyncio.StreamRe
         loop.call_soon_threadsafe(reader.feed_eof)
 
 
+def _emit_error_notification(message: str) -> None:
+    """Write a JSON-RPC error notification to stdout and a human-readable message to stderr."""
+    notification = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": {
+                    "level": "error",
+                    "logger": "observal-shim",
+                    "data": message,
+                },
+            }
+        )
+        + "\n"
+    )
+    sys.stdout.buffer.write(notification.encode())
+    sys.stdout.buffer.flush()
+    sys.stderr.write(f"[observal-shim] {message}\n")
+    sys.stderr.flush()
+
+
+async def _emit_error_notification_async(message: str, ide_stdout) -> None:
+    """Write a JSON-RPC error notification to the IDE stream (async version for post-relay errors)."""
+    notification = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": {
+                    "level": "error",
+                    "logger": "observal-shim",
+                    "data": message,
+                },
+            }
+        )
+        + "\n"
+    )
+    if ide_stdout is not None:
+        ide_stdout.write(notification.encode())
+        await ide_stdout.drain()
+    else:
+        sys.stdout.buffer.write(notification.encode())
+        sys.stdout.buffer.flush()
+
+
 async def run_shim(mcp_id: str, command: list[str]):
     """Main shim entry point: spawn MCP process and relay stdio."""
     # On Windows, asyncio.create_subprocess_exec cannot find .cmd/.bat
@@ -376,12 +426,28 @@ async def run_shim(mcp_id: str, command: list[str]):
     state = ShimState(mcp_id, server_url, access_token, agent_id)
 
     # Spawn the real MCP process
-    proc = await asyncio.create_subprocess_exec(
-        *command,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        error_msg = f"{type(exc).__name__}: {exc}"
+        _emit_error_notification(f"MCP server failed to start: {error_msg}")
+        return 1
+
+    # Startup health check: catch immediate crashes (missing module, bad
+    # command, permission denied) before setting up the relay.
+    await asyncio.sleep(_STARTUP_HEALTH_CHECK_SEC)
+    if proc.returncode is not None:
+        stderr_output = await proc.stderr.read()
+        error_msg = stderr_output.decode(errors="replace").strip()
+        if not error_msg:
+            error_msg = f"MCP process exited immediately with code {proc.returncode}"
+        _emit_error_notification(f"MCP server failed to start: {error_msg}")
+        return proc.returncode
 
     # Set up IDE stdin reader.
     # On Windows, connect_read_pipe / connect_write_pipe don't work with
@@ -409,12 +475,16 @@ async def run_shim(mcp_id: str, command: list[str]):
     ide_queue = await _read_messages(ide_reader)
     mcp_queue = await _read_messages(proc.stdout)
 
-    # Forward stderr
+    # Forward stderr (captured for error reporting on crash)
+    stderr_lines: list[str] = []
+
     async def _forward_stderr():
         while True:
             data = await proc.stderr.read(65536)
             if not data:
                 break
+            text = data.decode(errors="replace")
+            stderr_lines.append(text)
             sys.stderr.buffer.write(data)
             sys.stderr.buffer.flush()
 
@@ -431,7 +501,12 @@ async def run_shim(mcp_id: str, command: list[str]):
         stderr_task.cancel()
         await state.send_final()
 
-    return await proc.wait()
+    rc = proc.returncode if proc.returncode is not None else await proc.wait()
+    if rc != 0:
+        captured = "".join(stderr_lines).strip()
+        error_msg = captured[-500:] if captured else f"Process exited with code {rc}"
+        await _emit_error_notification_async(f"MCP server crashed: {error_msg}", ide_stdout)
+    return rc
 
 
 def main():

--- a/tests/test_component_version_extras.py
+++ b/tests/test_component_version_extras.py
@@ -97,3 +97,92 @@ class TestValidateAndExtract:
         with pytest.raises(HTTPException) as exc_info:
             validate_and_extract("hook", {})
         assert exc_info.value.status_code == 422
+
+    # ── MCP config fields (added for version publishing) ──
+
+    def test_mcp_transport_field(self):
+        """MCP transport field accepts strings."""
+        result = validate_and_extract("mcp", {"transport": "stdio"})
+        assert result == {"transport": "stdio"}
+
+    def test_mcp_framework_field(self):
+        """MCP framework field accepts strings."""
+        result = validate_and_extract("mcp", {"framework": "docker"})
+        assert result == {"framework": "docker"}
+
+    def test_mcp_docker_image_field(self):
+        """MCP docker_image field accepts strings."""
+        result = validate_and_extract("mcp", {"docker_image": "myimage:latest"})
+        assert result == {"docker_image": "myimage:latest"}
+
+    def test_mcp_command_field(self):
+        """MCP command field accepts strings."""
+        result = validate_and_extract("mcp", {"command": "npx"})
+        assert result == {"command": "npx"}
+
+    def test_mcp_args_field(self):
+        """MCP args field accepts lists."""
+        result = validate_and_extract("mcp", {"args": ["-y", "@example/server"]})
+        assert result == {"args": ["-y", "@example/server"]}
+
+    def test_mcp_url_field(self):
+        """MCP url field accepts strings."""
+        result = validate_and_extract("mcp", {"url": "https://api.example.com/mcp"})
+        assert result == {"url": "https://api.example.com/mcp"}
+
+    def test_mcp_headers_field(self):
+        """MCP headers field accepts lists."""
+        headers = [{"name": "Authorization", "value": "Bearer tok"}]
+        result = validate_and_extract("mcp", {"headers": headers})
+        assert result == {"headers": headers}
+
+    def test_mcp_auto_approve_field(self):
+        """MCP auto_approve field accepts lists."""
+        result = validate_and_extract("mcp", {"auto_approve": ["read_file"]})
+        assert result == {"auto_approve": ["read_file"]}
+
+    def test_mcp_environment_variables_field(self):
+        """MCP environment_variables field accepts lists."""
+        env_vars = [{"name": "API_KEY", "description": "Key", "required": True}]
+        result = validate_and_extract("mcp", {"environment_variables": env_vars})
+        assert result == {"environment_variables": env_vars}
+
+    def test_mcp_setup_instructions_field(self):
+        """MCP setup_instructions field accepts strings."""
+        result = validate_and_extract("mcp", {"setup_instructions": "Run npm install first"})
+        assert result == {"setup_instructions": "Run npm install first"}
+
+    def test_mcp_full_config(self):
+        """MCP with all config fields passes validation."""
+        extra = {
+            "transport": "stdio",
+            "framework": "typescript",
+            "command": "npx",
+            "args": ["-y", "@example/server"],
+            "environment_variables": [{"name": "KEY", "description": "", "required": True}],
+            "auto_approve": ["read_file"],
+            "setup_instructions": "Install Node.js first",
+        }
+        result = validate_and_extract("mcp", extra)
+        assert result == extra
+
+    def test_mcp_args_wrong_type_raises(self):
+        """MCP args field rejects non-list types."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_and_extract("mcp", {"args": "not-a-list"})
+        assert exc_info.value.status_code == 422
+        assert "list" in str(exc_info.value.detail)
+
+    def test_mcp_transport_wrong_type_raises(self):
+        """MCP transport field rejects non-string types."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_and_extract("mcp", {"transport": 123})
+        assert exc_info.value.status_code == 422
+        assert "str" in str(exc_info.value.detail)
+
+    def test_mcp_unknown_field_rejected(self):
+        """MCP rejects fields not in the allowlist."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_and_extract("mcp", {"transport": "stdio", "bogus_field": "x"})
+        assert exc_info.value.status_code == 422
+        assert "bogus_field" in str(exc_info.value.detail)

--- a/tests/test_mcp_config_parser.py
+++ b/tests/test_mcp_config_parser.py
@@ -1,0 +1,386 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for MCP config parsing functions in cmd_mcp.py.
+
+Covers _parse_server_json_manifest, _parse_direct_config, and _unwrap_mcp_config.
+"""
+
+from observal_cli.cmd_mcp import (
+    _parse_direct_config,
+    _parse_server_json_manifest,
+    _unwrap_mcp_config,
+)
+
+# --- _parse_server_json_manifest ---
+
+
+class TestParseServerJsonManifest:
+    """Tests for the server.json manifest parser."""
+
+    def test_returns_none_for_non_manifest(self):
+        """Non-manifest config returns None."""
+        assert _parse_server_json_manifest({"command": "npx", "args": []}) is None
+        assert _parse_server_json_manifest({"url": "http://x.com"}) is None
+        assert _parse_server_json_manifest({}) is None
+
+    def test_remotes_basic(self):
+        """Parses a remotes-only manifest with URL and variables."""
+        cfg = {
+            "remotes": [
+                {
+                    "type": "sse",
+                    "url": "https://api.example.com/mcp",
+                    "variables": {
+                        "API_KEY": {"description": "Your API key"},
+                        "ORG_ID": {"description": "Organization ID"},
+                    },
+                }
+            ]
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert result is not None
+        assert result["url"] == "https://api.example.com/mcp"
+        assert result["transport"] == "sse"
+        assert len(result["environment_variables"]) == 2
+        names = {ev["name"] for ev in result["environment_variables"]}
+        assert names == {"API_KEY", "ORG_ID"}
+
+    def test_remotes_streamable_http(self):
+        """Handles streamable-http type."""
+        cfg = {
+            "remotes": [
+                {
+                    "type": "streamable-http",
+                    "url": "https://api.example.com/v2/mcp",
+                }
+            ]
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert result["transport"] == "streamable-http"
+        assert result["url"] == "https://api.example.com/v2/mcp"
+
+    def test_packages_only_implies_docker(self):
+        """Packages-only manifest implies stdio/docker transport."""
+        cfg = {
+            "packages": [
+                {
+                    "runtimeArguments": [
+                        {"value": "API_KEY={key}", "description": "API key"},
+                        {"value": "SECRET={secret}", "description": "Secret"},
+                    ]
+                }
+            ]
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert result is not None
+        assert result["transport"] == "stdio"
+        assert result["framework"] == "docker"
+        assert len(result["environment_variables"]) == 2
+
+    def test_packages_ignores_lowercase_vars(self):
+        """Only UPPERCASE variable names from packages are extracted."""
+        cfg = {
+            "packages": [
+                {
+                    "runtimeArguments": [
+                        {"value": "API_KEY={key}", "description": "Key"},
+                        {"value": "not_a_var=something", "description": "Lower"},
+                    ]
+                }
+            ]
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert len(result["environment_variables"]) == 1
+        assert result["environment_variables"][0]["name"] == "API_KEY"
+
+    def test_packages_no_equals_sign_skipped(self):
+        """Runtime args without '=' are skipped."""
+        cfg = {
+            "packages": [
+                {
+                    "runtimeArguments": [
+                        {"value": "justaflag", "description": "No equals"},
+                    ]
+                }
+            ]
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert "environment_variables" not in result
+
+    def test_registry_format_unwraps_server_envelope(self):
+        """Registry format with server envelope is unwrapped."""
+        cfg = {
+            "server": {
+                "name": "inference-sh",
+                "title": "Inference.sh MCP",
+                "description": "Fast LLM inference",
+                "remotes": [
+                    {
+                        "type": "sse",
+                        "url": "https://inference.sh/mcp",
+                        "variables": {"TOKEN": {"description": "Auth token"}},
+                    }
+                ],
+            },
+            "_meta": {"version": "1.0"},
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert result is not None
+        assert result["_server_name"] == "Inference.sh MCP"
+        assert result["_description"] == "Fast LLM inference"
+        assert result["url"] == "https://inference.sh/mcp"
+        assert result["transport"] == "sse"
+        assert len(result["environment_variables"]) == 1
+
+    def test_registry_format_uses_name_if_no_title(self):
+        """Falls back to 'name' field if 'title' is absent."""
+        cfg = {
+            "server": {
+                "name": "my-server",
+                "remotes": [{"url": "http://x.com"}],
+            }
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert result["_server_name"] == "my-server"
+
+    def test_registry_format_packages_with_meta(self):
+        """Registry format with packages array nested under server."""
+        cfg = {
+            "server": {
+                "title": "Docker MCP",
+                "description": "Runs in Docker",
+                "packages": [
+                    {
+                        "runtimeArguments": [
+                            {"value": "DB_HOST={host}", "description": "Database host"},
+                        ]
+                    }
+                ],
+            }
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert result["_server_name"] == "Docker MCP"
+        assert result["_description"] == "Runs in Docker"
+        assert result["transport"] == "stdio"
+        assert result["framework"] == "docker"
+        assert result["environment_variables"][0]["name"] == "DB_HOST"
+
+    def test_multiple_remotes_uses_first_url(self):
+        """Only the first remote's URL is used."""
+        cfg = {
+            "remotes": [
+                {"url": "https://first.example.com", "type": "sse"},
+                {"url": "https://second.example.com", "type": "streamable-http"},
+            ]
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert result["url"] == "https://first.example.com"
+        assert result["transport"] == "sse"
+
+    def test_remotes_variable_meta_non_dict(self):
+        """Variable metadata that isn't a dict defaults to empty description."""
+        cfg = {
+            "remotes": [
+                {
+                    "url": "http://x.com",
+                    "variables": {"KEY": "just a string"},
+                }
+            ]
+        }
+        result = _parse_server_json_manifest(cfg)
+        assert result["environment_variables"][0]["name"] == "KEY"
+        assert result["environment_variables"][0]["description"] == ""
+
+
+# --- _unwrap_mcp_config ---
+
+
+class TestUnwrapMcpConfig:
+    """Tests for the IDE config unwrapper."""
+
+    def test_mcp_servers_wrapper(self):
+        """Unwraps {mcpServers: {name: config}} format."""
+        cfg = {"mcpServers": {"my-server": {"command": "npx", "args": ["-y", "server"]}}}
+        inner, name = _unwrap_mcp_config(cfg)
+        assert name == "my-server"
+        assert inner["command"] == "npx"
+
+    def test_mcp_servers_multiple_keys(self):
+        """Multiple keys in mcpServers returns the whole dict."""
+        cfg = {"mcpServers": {"a": {"command": "x"}, "b": {"command": "y"}}}
+        inner, name = _unwrap_mcp_config(cfg)
+        assert name is None
+
+    def test_bare_config_with_command(self):
+        """Bare config dict with command key."""
+        cfg = {"command": "python3", "args": ["-m", "myserver"]}
+        inner, name = _unwrap_mcp_config(cfg)
+        assert inner is cfg
+        assert name is None
+
+    def test_bare_config_with_url(self):
+        """Bare config dict with url key."""
+        cfg = {"url": "http://x.com/mcp", "type": "sse"}
+        inner, name = _unwrap_mcp_config(cfg)
+        assert inner is cfg
+        assert name is None
+
+    def test_single_named_key(self):
+        """Single named key wrapping a config dict."""
+        cfg = {"inference-sh": {"command": "docker", "args": ["run", "img"]}}
+        inner, name = _unwrap_mcp_config(cfg)
+        assert name == "inference-sh"
+        assert inner["command"] == "docker"
+
+    def test_single_named_key_no_config_keys(self):
+        """Single named key but inner dict lacks config keys — returns as-is."""
+        cfg = {"something": {"foo": "bar"}}
+        inner, name = _unwrap_mcp_config(cfg)
+        assert inner is cfg
+        assert name is None
+
+
+# --- _parse_direct_config ---
+
+
+class TestParseDirectConfig:
+    """Tests for the main config parser entry point."""
+
+    def test_stdio_bare_config(self):
+        """Bare stdio config is parsed correctly."""
+        cfg = {"command": "npx", "args": ["-y", "@example/mcp-server"], "env": {"API_KEY": "xxx"}}
+        result = _parse_direct_config(cfg)
+        assert result["transport"] == "stdio"
+        assert result["command"] == "npx"
+        assert result["args"] == ["-y", "@example/mcp-server"]
+        assert result["framework"] == "typescript"
+        assert any(ev["name"] == "API_KEY" for ev in result["environment_variables"])
+
+    def test_stdio_python_framework(self):
+        """Python command is detected."""
+        cfg = {"command": "python3", "args": ["-m", "myserver"]}
+        result = _parse_direct_config(cfg)
+        assert result["framework"] == "python"
+
+    def test_stdio_docker_framework(self):
+        """Docker command extracts docker_image."""
+        cfg = {"command": "docker", "args": ["run", "-i", "--rm", "myimage:latest"]}
+        result = _parse_direct_config(cfg)
+        assert result["framework"] == "docker"
+        assert result["docker_image"] == "myimage:latest"
+
+    def test_stdio_unknown_framework(self):
+        """Unknown command results in None framework."""
+        cfg = {"command": "mybin", "args": []}
+        result = _parse_direct_config(cfg)
+        assert result["framework"] is None
+
+    def test_sse_config(self):
+        """SSE config with URL is parsed."""
+        cfg = {"url": "https://api.example.com/mcp", "type": "sse"}
+        result = _parse_direct_config(cfg)
+        assert result["transport"] == "sse"
+        assert result["url"] == "https://api.example.com/mcp"
+
+    def test_sse_default_type(self):
+        """SSE config without explicit type defaults to 'sse'."""
+        cfg = {"url": "https://api.example.com/mcp"}
+        result = _parse_direct_config(cfg)
+        assert result["transport"] == "sse"
+
+    def test_sse_with_headers(self):
+        """SSE config with headers dict converts to list."""
+        cfg = {
+            "url": "http://x.com",
+            "type": "sse",
+            "headers": {"Authorization": "Bearer tok"},
+        }
+        result = _parse_direct_config(cfg)
+        assert len(result["headers"]) == 1
+        assert result["headers"][0]["name"] == "Authorization"
+        assert result["headers"][0]["value"] == "Bearer tok"
+
+    def test_sse_with_auto_approve(self):
+        """autoApprove is mapped to auto_approve."""
+        cfg = {"url": "http://x.com", "autoApprove": ["read_file", "list_dir"]}
+        result = _parse_direct_config(cfg)
+        assert result["auto_approve"] == ["read_file", "list_dir"]
+
+    def test_wrapped_mcp_servers_format(self):
+        """Handles mcpServers wrapper and extracts server name."""
+        cfg = {"mcpServers": {"my-mcp": {"command": "node", "args": ["server.js"], "env": {"PORT": "8080"}}}}
+        result = _parse_direct_config(cfg)
+        assert result["_server_name"] == "my-mcp"
+        assert result["command"] == "node"
+        assert result["framework"] == "typescript"
+
+    def test_server_json_manifest_delegated(self):
+        """server.json manifest is handled by _parse_server_json_manifest."""
+        cfg = {"remotes": [{"url": "https://api.example.com/mcp", "type": "sse", "variables": {"KEY": {}}}]}
+        result = _parse_direct_config(cfg)
+        assert result["url"] == "https://api.example.com/mcp"
+        assert result["transport"] == "sse"
+
+    def test_dollar_var_detection_in_args(self):
+        """$VAR references in args are detected."""
+        cfg = {"command": "npx", "args": ["-y", "server", "--token", "$MY_TOKEN"]}
+        result = _parse_direct_config(cfg)
+        assert "MY_TOKEN" in (result.get("_dollar_vars_detected") or [])
+        # Should also be in environment_variables
+        names = {ev["name"] for ev in result.get("environment_variables", [])}
+        assert "MY_TOKEN" in names
+
+    def test_dollar_var_detection_in_env_values(self):
+        """$VAR references in env values are detected."""
+        cfg = {"command": "npx", "args": [], "env": {"TOKEN": "$SECRET_TOKEN"}}
+        result = _parse_direct_config(cfg)
+        assert "SECRET_TOKEN" in (result.get("_dollar_vars_detected") or [])
+
+    def test_env_as_list_passthrough(self):
+        """Env dict keys become environment_variables list."""
+        cfg = {"command": "npx", "args": [], "env": {"A": "1", "B": "2"}}
+        result = _parse_direct_config(cfg)
+        names = {ev["name"] for ev in result["environment_variables"]}
+        assert names == {"A", "B"}
+
+    def test_registry_format_end_to_end(self):
+        """Full registry format through _parse_direct_config."""
+        cfg = {
+            "server": {
+                "title": "My MCP",
+                "description": "Does things",
+                "remotes": [
+                    {
+                        "type": "streamable-http",
+                        "url": "https://my.server/mcp",
+                        "variables": {"API_KEY": {"description": "Key"}},
+                    }
+                ],
+            },
+            "_meta": {"version": "1.0"},
+        }
+        result = _parse_direct_config(cfg)
+        assert result["_server_name"] == "My MCP"
+        assert result["_description"] == "Does things"
+        assert result["url"] == "https://my.server/mcp"
+        assert result["transport"] == "streamable-http"
+        assert result["environment_variables"][0]["name"] == "API_KEY"
+
+    def test_sse_dollar_var_in_header_values(self):
+        """$VAR in header values are detected and added to env vars."""
+        cfg = {
+            "url": "http://x.com",
+            "type": "sse",
+            "headers": {"Authorization": "Bearer $API_TOKEN"},
+        }
+        result = _parse_direct_config(cfg)
+        assert "API_TOKEN" in (result.get("_dollar_vars_detected") or [])
+        names = {ev["name"] for ev in result.get("environment_variables", [])}
+        assert "API_TOKEN" in names
+
+    def test_stdio_auto_approve(self):
+        """autoApprove on stdio config is mapped to auto_approve."""
+        cfg = {"command": "npx", "args": ["-y", "server"], "autoApprove": ["read", "write"]}
+        result = _parse_direct_config(cfg)
+        assert result["auto_approve"] == ["read", "write"]

--- a/tests/test_mcp_edit_submit.py
+++ b/tests/test_mcp_edit_submit.py
@@ -1,0 +1,506 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for MCP edit and submit CLI commands (interactive flows).
+
+Covers the interactive JSON paste mode in edit_mcp, the version publishing
+flow for approved listings, and the submit command changes.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from observal_cli.main import app as cli_app
+
+runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+_FAKE_CONFIG = {"server_url": "http://localhost:8000", "api_key": "test-key", "user_name": "testuser"}
+
+
+def _patch_config():
+    return patch("observal_cli.config.get_or_exit", return_value=_FAKE_CONFIG)
+
+
+def _patch_config_load():
+    return patch("observal_cli.config.load", return_value=_FAKE_CONFIG)
+
+
+def _patch_resolve_alias(resolved="abc-123"):
+    return patch("observal_cli.config.resolve_alias", return_value=resolved)
+
+
+# ── edit_mcp: interactive JSON paste mode ─────────────────────────
+
+
+class TestEditMcpInteractive:
+    """Tests for the interactive JSON paste mode in edit_mcp."""
+
+    def test_edit_interactive_json_paste_draft(self):
+        """Interactive paste mode parses config and edits a draft listing."""
+        config_json = json.dumps({"command": "npx", "args": ["-y", "@example/server"], "env": {"KEY": "val"}})
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "draft", "name": "test-mcp"}
+        mock_client.post.return_value = {}
+        mock_client.put.return_value = {"name": "test-mcp", "status": "draft"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp"], input=f"{config_json}\n\ny\n")
+
+        assert result.exit_code == 0, _plain(result.output)
+        assert "Updated" in _plain(result.output) or "updated" in _plain(result.output).lower()
+
+    def test_edit_interactive_empty_input_exits(self):
+        """Empty input in interactive mode exits with code 1."""
+        mock_client = MagicMock()
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp"], input="\n")
+
+        assert result.exit_code == 1
+        assert "No input" in _plain(result.output)
+
+    def test_edit_interactive_invalid_json_exits(self):
+        """Invalid JSON in interactive mode exits with error."""
+        mock_client = MagicMock()
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp"], input="not json at all{{\n\n")
+
+        assert result.exit_code == 1
+        assert "Invalid JSON" in _plain(result.output)
+
+    def test_edit_interactive_user_declines(self):
+        """User declining confirmation aborts."""
+        config_json = json.dumps({"command": "npx", "args": ["-y", "server"]})
+        mock_client = MagicMock()
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp"], input=f"{config_json}\n\nn\n")
+
+        # Aborted = non-zero exit
+        assert result.exit_code != 0
+
+    def test_edit_with_flags_skips_interactive(self):
+        """Providing --name flag skips interactive mode."""
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "draft", "name": "old-name"}
+        mock_client.post.return_value = {}
+        mock_client.put.return_value = {"name": "new-name", "status": "draft"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp", "--name", "new-name"])
+
+        assert result.exit_code == 0, _plain(result.output)
+        mock_client.put.assert_called_once()
+        call_args = mock_client.put.call_args[0]
+        assert "new-name" in str(call_args) or mock_client.put.call_args[1].get("name") == "new-name"
+
+    def test_edit_from_file(self):
+        """--from-file loads updates from a JSON file."""
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "draft", "name": "test-mcp"}
+        mock_client.post.return_value = {}
+        mock_client.put.return_value = {"name": "test-mcp", "status": "draft"}
+
+        file_content = json.dumps({"name": "updated-mcp", "description": "New desc"})
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+            patch("builtins.open", create=True) as mock_open,
+        ):
+            mock_open.return_value.__enter__ = lambda s: MagicMock(read=lambda: file_content)
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            # Patch json.load to use file_content
+            with patch("json.load", return_value={"name": "updated-mcp", "description": "New desc"}):
+                result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp", "--from-file", "updates.json"])
+
+        assert result.exit_code == 0, _plain(result.output)
+
+
+# ── edit_mcp: version publishing for approved listings ────────────
+
+
+class TestEditMcpVersionPublish:
+    """Tests for the version publishing flow when editing approved MCPs."""
+
+    def test_edit_approved_publishes_new_version_patch(self):
+        """Editing an approved listing with patch bump publishes a new version."""
+        config_json = json.dumps({"command": "npx", "args": ["-y", "@example/v2"]})
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "approved", "name": "my-mcp", "version": "1.2.3"}
+        mock_client.post.return_value = {"name": "my-mcp", "version": "1.2.4"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+            patch("observal_cli.cmd_mcp.select_one", return_value="patch"),
+        ):
+            # Input: config JSON, blank line, confirm, changelog
+            result = runner.invoke(cli_app, ["mcp", "edit", "my-mcp"], input=f"{config_json}\n\ny\nFixed bug\n")
+
+        assert result.exit_code == 0, _plain(result.output)
+        assert "1.2.4" in _plain(result.output)
+        # Verify the versions endpoint was called
+        post_calls = [c for c in mock_client.post.call_args_list if "/versions" in str(c)]
+        assert len(post_calls) == 1
+
+    def test_edit_approved_minor_bump(self):
+        """Minor bump increments correctly."""
+        config_json = json.dumps({"url": "https://new-url.com/mcp", "type": "sse"})
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "approved", "name": "my-mcp", "version": "1.2.3"}
+        mock_client.post.return_value = {"name": "my-mcp", "version": "1.3.0"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+            patch("observal_cli.cmd_mcp.select_one", return_value="minor"),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "my-mcp"], input=f"{config_json}\n\ny\nNew feature\n")
+
+        assert result.exit_code == 0, _plain(result.output)
+        assert "1.3.0" in _plain(result.output)
+
+    def test_edit_approved_major_bump(self):
+        """Major bump increments correctly."""
+        config_json = json.dumps({"command": "docker", "args": ["run", "new-image:2.0"]})
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "approved", "name": "my-mcp", "version": "1.2.3"}
+        mock_client.post.return_value = {"name": "my-mcp", "version": "2.0.0"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+            patch("observal_cli.cmd_mcp.select_one", return_value="major"),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "my-mcp"], input=f"{config_json}\n\ny\nBreaking change\n")
+
+        assert result.exit_code == 0, _plain(result.output)
+        assert "2.0.0" in _plain(result.output)
+
+    def test_edit_approved_publish_failure(self):
+        """Failure to publish a new version exits with error."""
+        config_json = json.dumps({"command": "npx", "args": ["-y", "server"]})
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "approved", "name": "my-mcp", "version": "0.1.0"}
+        # Client raises SystemExit (typer.Exit) on API failure
+        mock_client.post.side_effect = SystemExit(1)
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+            patch("observal_cli.cmd_mcp.select_one", return_value="patch"),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "my-mcp"], input=f"{config_json}\n\ny\n\n")
+
+        assert result.exit_code == 1
+
+
+# ── submit command changes ────────────────────────────────────────
+
+
+class TestSubmitCommand:
+    """Tests for submit command changes (default JSON paste, --git flag)."""
+
+    def test_submit_deprecated_config_flag_shows_note(self):
+        """--config flag shows deprecation note."""
+        config_json = json.dumps({"command": "npx", "args": ["-y", "server"]})
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"id": "new-123", "name": "my-mcp", "status": "pending"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+            patch("observal_cli.cmd_mcp.select_one", return_value="general"),
+        ):
+            result = runner.invoke(
+                cli_app,
+                ["mcp", "submit", "--config", "--yes", "--name", "my-mcp"],
+                input=f"{config_json}\n\n",
+            )
+
+        output = _plain(result.output)
+        assert "--config is now the default" in output
+
+    def test_submit_draft_and_submit_together_fails(self):
+        """Cannot use --draft and --submit together."""
+        with _patch_config(), _patch_config_load():
+            result = runner.invoke(cli_app, ["mcp", "submit", "--draft", "--submit", "abc-123"])
+
+        assert result.exit_code == 1
+        assert "Cannot use" in _plain(result.output)
+
+    def test_submit_draft_for_review(self):
+        """--submit flag submits an existing draft for review."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"id": "abc-123", "name": "my-mcp"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias("abc-123"),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "submit", "--submit", "abc-123"])
+
+        assert result.exit_code == 0, _plain(result.output)
+        assert "Draft submitted" in _plain(result.output) or "submitted" in _plain(result.output).lower()
+
+    def test_submit_yes_mode_uses_parsed_description(self):
+        """In --yes mode, parsed description from registry format is used."""
+        config_json = json.dumps(
+            {
+                "server": {
+                    "title": "My Server",
+                    "description": "A great server",
+                    "remotes": [{"url": "https://api.example.com", "type": "sse"}],
+                }
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"id": "new-123", "name": "My Server", "status": "pending"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+        ):
+            result = runner.invoke(
+                cli_app,
+                ["mcp", "submit", "--yes", "--name", "My Server"],
+                input=f"{config_json}\n\n",
+            )
+
+        # The submit should use the parsed description "A great server"
+        if result.exit_code == 0:
+            post_call = mock_client.post.call_args
+            if post_call and len(post_call[0]) > 1:
+                payload = post_call[0][1]
+                assert payload.get("description") == "A great server"
+
+    def test_submit_description_required_in_interactive_mode(self):
+        """Interactive mode requires non-empty description."""
+        config_json = json.dumps({"command": "npx", "args": ["-y", "server"]})
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"id": "new-123", "name": "my-mcp", "status": "pending"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+            patch("observal_cli.cmd_mcp.select_one", return_value="general"),
+        ):
+            # Input: config + blank line, confirm, name prompt accepts default,
+            # empty spaces for description (triggers required), then real description, owner
+            result = runner.invoke(
+                cli_app,
+                ["mcp", "submit", "--name", "my-mcp"],
+                input=f"{config_json}\n\ny\n   \nA real description\n\n",
+            )
+
+        output = _plain(result.output)
+        assert "Description is required" in output
+
+
+# ── edit_mcp: edge cases and error paths ──────────────────────────
+
+
+class TestEditMcpEdgeCases:
+    """Tests for edge cases in edit_mcp."""
+
+    def test_edit_from_file_not_found(self):
+        """--from-file with missing file exits with error."""
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp", "--from-file", "/nonexistent/file.json"])
+
+        assert result.exit_code == 1
+        assert "not found" in _plain(result.output).lower() or "File not found" in _plain(result.output)
+
+    def test_edit_from_file_invalid_json(self, tmp_path):
+        """--from-file with invalid JSON exits with error."""
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("not valid json {{{")
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp", "--from-file", str(bad_file)])
+
+        assert result.exit_code == 1
+        assert "Invalid JSON" in _plain(result.output)
+
+    def test_edit_draft_save_failure_cancels_edit(self):
+        """Draft save failure triggers cancel-edit and exits with error."""
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "draft", "name": "my-mcp"}
+        mock_client.post.return_value = {}  # start-edit succeeds
+        # Client raises SystemExit (typer.Exit) on API failure
+        mock_client.put.side_effect = SystemExit(1)
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp", "--name", "new-name"])
+
+        assert result.exit_code == 1
+        # Verify cancel-edit was attempted
+        cancel_calls = [c for c in mock_client.post.call_args_list if "cancel-edit" in str(c)]
+        assert len(cancel_calls) == 1
+
+    def test_edit_non_semver_version_fallback(self):
+        """Non-semver version string falls back to 0.2.0."""
+        config_json = json.dumps({"command": "npx", "args": ["-y", "server"]})
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = {
+            "id": "abc-123",
+            "status": "approved",
+            "name": "my-mcp",
+            "version": "not-semver",
+        }
+        mock_client.post.return_value = {"name": "my-mcp", "version": "0.2.0"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+            patch("observal_cli.cmd_mcp.select_one", return_value="patch"),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "my-mcp"], input=f"{config_json}\n\ny\nChangelog\n")
+
+        assert result.exit_code == 0, _plain(result.output)
+        assert "0.2.0" in _plain(result.output)
+
+    def test_edit_status_fetch_failure_falls_through(self):
+        """If status fetch fails, edit proceeds with draft flow."""
+        mock_client = MagicMock()
+        # Client raises SystemExit (typer.Exit) on connection/API failure
+        mock_client.get.side_effect = SystemExit(1)
+        mock_client.post.return_value = {}
+        mock_client.put.return_value = {"name": "test-mcp", "status": "draft"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "test-mcp", "--description", "New desc"])
+
+        assert result.exit_code == 0, _plain(result.output)
+        assert "Updated" in _plain(result.output) or "updated" in _plain(result.output).lower()
+
+    def test_edit_interactive_registry_format_extracts_name_and_desc(self):
+        """Registry format in interactive mode extracts name and description into updates."""
+        config_json = json.dumps(
+            {
+                "server": {
+                    "title": "New Name",
+                    "description": "Updated description",
+                    "remotes": [{"url": "https://api.new.com/mcp", "type": "sse"}],
+                }
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"id": "abc-123", "status": "draft", "name": "old-name"}
+        mock_client.post.return_value = {}
+        mock_client.put.return_value = {"name": "New Name", "status": "draft"}
+
+        with (
+            _patch_config(),
+            _patch_config_load(),
+            _patch_resolve_alias(),
+            patch("observal_cli.cmd_mcp.client", mock_client),
+            patch("observal_cli.cmd_mcp.spinner", MagicMock()),
+        ):
+            result = runner.invoke(cli_app, ["mcp", "edit", "old-name"], input=f"{config_json}\n\ny\n")
+
+        assert result.exit_code == 0, _plain(result.output)
+        # Verify the PUT was called with name and description
+        put_call = mock_client.put.call_args
+        updates_sent = put_call[0][1] if put_call else {}
+        assert updates_sent.get("name") == "New Name"
+        assert updates_sent.get("description") == "Updated description"

--- a/tests/test_shim_error_handling.py
+++ b/tests/test_shim_error_handling.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for shim error handling: startup failures and crash reporting."""
+
+import json
+from io import BytesIO, StringIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from observal_cli.shim import run_shim
+
+
+def _make_stdio_mocks():
+    """Create stdout (buffer=BytesIO) and stderr (StringIO) mocks."""
+    stdout_buf = BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = stdout_buf
+
+    stderr_io = StringIO()
+    mock_stderr = MagicMock()
+    mock_stderr.write = stderr_io.write
+    mock_stderr.flush = stderr_io.flush
+    mock_stderr.buffer = MagicMock()
+
+    return mock_stdout, stdout_buf, mock_stderr, stderr_io
+
+
+class TestRunShimStartupErrors:
+    """Tests for MCP process spawn failures in run_shim."""
+
+    @pytest.mark.asyncio
+    async def test_file_not_found_returns_1(self):
+        """FileNotFoundError when spawning MCP returns exit code 1."""
+        mock_stdout, stdout_buf, mock_stderr, stderr_io = _make_stdio_mocks()
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_KEY": "test", "OBSERVAL_SERVER": "http://localhost"}),
+            patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("No such file: nonexistent")),
+            patch("sys.stdout", mock_stdout),
+            patch("sys.stderr", mock_stderr),
+        ):
+            rc = await run_shim("test-mcp", ["nonexistent", "--stdio"])
+
+        assert rc == 1
+        output = stdout_buf.getvalue().decode()
+        assert "notifications/message" in output
+        assert "MCP server failed to start" in output
+        assert "FileNotFoundError" in output
+
+    @pytest.mark.asyncio
+    async def test_permission_error_returns_1(self):
+        """PermissionError when spawning MCP returns exit code 1."""
+        mock_stdout, stdout_buf, mock_stderr, stderr_io = _make_stdio_mocks()
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_KEY": "test", "OBSERVAL_SERVER": "http://localhost"}),
+            patch("asyncio.create_subprocess_exec", side_effect=PermissionError("Permission denied")),
+            patch("sys.stdout", mock_stdout),
+            patch("sys.stderr", mock_stderr),
+        ):
+            rc = await run_shim("test-mcp", ["./restricted-binary"])
+
+        assert rc == 1
+        output = stdout_buf.getvalue().decode()
+        assert "PermissionError" in output
+
+    @pytest.mark.asyncio
+    async def test_os_error_returns_1(self):
+        """OSError when spawning MCP returns exit code 1."""
+        mock_stdout, stdout_buf, mock_stderr, stderr_io = _make_stdio_mocks()
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_KEY": "test", "OBSERVAL_SERVER": "http://localhost"}),
+            patch("asyncio.create_subprocess_exec", side_effect=OSError("exec format error")),
+            patch("sys.stdout", mock_stdout),
+            patch("sys.stderr", mock_stderr),
+        ):
+            rc = await run_shim("test-mcp", ["bad-binary"])
+
+        assert rc == 1
+        output = stdout_buf.getvalue().decode()
+        assert "OSError" in output
+
+    @pytest.mark.asyncio
+    async def test_immediate_crash_detected(self):
+        """Process that exits immediately (returncode set after sleep) is caught."""
+        mock_stdout, stdout_buf, mock_stderr, stderr_io = _make_stdio_mocks()
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1  # Already exited
+        mock_proc.stderr = AsyncMock()
+        mock_proc.stderr.read = AsyncMock(return_value=b"ModuleNotFoundError: No module named 'foo'\n")
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_KEY": "test", "OBSERVAL_SERVER": "http://localhost"}),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),  # Skip the 0.3s wait
+            patch("sys.stdout", mock_stdout),
+            patch("sys.stderr", mock_stderr),
+        ):
+            rc = await run_shim("test-mcp", ["python3", "-m", "broken_server"])
+
+        assert rc == 1
+        output = stdout_buf.getvalue().decode()
+        assert "MCP server failed to start" in output
+        assert "ModuleNotFoundError" in output
+
+    @pytest.mark.asyncio
+    async def test_immediate_crash_empty_stderr(self):
+        """Process that exits immediately with no stderr gets a generic message."""
+        mock_stdout, stdout_buf, mock_stderr, stderr_io = _make_stdio_mocks()
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 127
+        mock_proc.stderr = AsyncMock()
+        mock_proc.stderr.read = AsyncMock(return_value=b"")
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_KEY": "test", "OBSERVAL_SERVER": "http://localhost"}),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch("sys.stdout", mock_stdout),
+            patch("sys.stderr", mock_stderr),
+        ):
+            rc = await run_shim("test-mcp", ["missing-cmd"])
+
+        assert rc == 127
+        output = stdout_buf.getvalue().decode()
+        assert "exited immediately with code 127" in output
+
+    @pytest.mark.asyncio
+    async def test_no_config_passthrough(self):
+        """Without OBSERVAL_KEY/SERVER and no config file, falls through to passthrough."""
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_KEY": "", "OBSERVAL_SERVER": ""}, clear=False),
+            patch("observal_cli.shim.load_config", return_value={}),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                await run_shim("test-mcp", ["echo", "hi"])
+            assert exc_info.value.code == 0
+
+    @pytest.mark.asyncio
+    async def test_error_notification_is_valid_jsonrpc(self):
+        """The error notification written to stdout is valid JSON-RPC."""
+        mock_stdout, stdout_buf, mock_stderr, stderr_io = _make_stdio_mocks()
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_KEY": "test", "OBSERVAL_SERVER": "http://localhost"}),
+            patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("not found")),
+            patch("sys.stdout", mock_stdout),
+            patch("sys.stderr", mock_stderr),
+        ):
+            await run_shim("test-mcp", ["nonexistent"])
+
+        output = stdout_buf.getvalue().decode().strip()
+        msg = json.loads(output)
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["method"] == "notifications/message"
+        assert msg["params"]["level"] == "error"
+        assert msg["params"]["logger"] == "observal-shim"
+
+    @pytest.mark.asyncio
+    async def test_stderr_message_on_spawn_failure(self):
+        """Stderr gets a human-readable error message on spawn failure."""
+        mock_stdout, stdout_buf, mock_stderr, stderr_io = _make_stdio_mocks()
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_KEY": "test", "OBSERVAL_SERVER": "http://localhost"}),
+            patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("/usr/bin/missing")),
+            patch("sys.stdout", mock_stdout),
+            patch("sys.stderr", mock_stderr),
+        ):
+            await run_shim("test-mcp", ["missing"])
+
+        stderr_output = stderr_io.getvalue()
+        assert "[observal-shim]" in stderr_output
+        assert "MCP server failed to start" in stderr_output

--- a/web/src/components/registry/component-edit-form.tsx
+++ b/web/src/components/registry/component-edit-form.tsx
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+// SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
 "use client";
 
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { ArrowRight, Loader2, RotateCcw, Construction } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import { parseMcpConfigJson, applyParsedConfig } from "@/lib/mcp-parser";
 import {
   Dialog,
   DialogContent,
@@ -87,18 +89,278 @@ interface PromptFieldState {
   tags: string;
 }
 
-// ── WIP Stub ───────────────────────────────────────────────────────
 
-function WipStub({ type }: { type: string }) {
+// ── MCP Edit Form ──────────────────────────────────────────────────
+
+function McpEditForm({
+  listingId,
+  type,
+  currentVersion,
+  item,
+  onSuccess,
+}: {
+  listingId: string;
+  type: RegistryType;
+  currentVersion: string;
+  item: RegistryItem;
+  onSuccess?: () => void;
+}) {
+  // Build current config as editable JSON for the textarea
+  const itemCommand = (item.command as string) ?? "";
+  const itemUrl = (item.url as string) ?? "";
+  const itemTransport = (item.transport as string) ?? "";
+  const itemName = (item.name as string) ?? "";
+  const itemArgs = Array.isArray(item.args) ? (item.args as string[]) : [];
+  const itemEnvVars = Array.isArray(item.environment_variables) ? (item.environment_variables as { name: string }[]) : [];
+
+  const currentConfigJson = useMemo(() => {
+    const cfg: Record<string, unknown> = {};
+    if (itemCommand) {
+      cfg.command = itemCommand;
+      if (itemArgs.length > 0) cfg.args = itemArgs;
+      if (itemEnvVars.length > 0) {
+        cfg.env = Object.fromEntries(itemEnvVars.map((ev) => [ev.name, `$${ev.name}`]));
+      }
+    } else if (itemUrl) {
+      cfg.url = itemUrl;
+      if (itemTransport) cfg.type = itemTransport;
+    }
+    if (Object.keys(cfg).length === 0) return "";
+    const wrapper = { mcpServers: { [itemName]: cfg } };
+    return JSON.stringify(wrapper, null, 2);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemCommand, itemUrl, itemTransport, itemName, JSON.stringify(itemArgs), JSON.stringify(itemEnvVars)]);
+
+  const [jsonInput, setJsonInput] = useState(currentConfigJson);
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [jsonParsed, setJsonParsed] = useState(false);
+  const [description, setDescription] = useState((item.description as string) ?? "");
+  const [command, setCommand] = useState((item.command as string) ?? "");
+  const [args, setArgs] = useState(Array.isArray(item.args) ? (item.args as string[]).join(" ") : "");
+  const [mcpUrl, setMcpUrl] = useState((item.url as string) ?? "");
+  const [transport, setTransport] = useState((item.transport as string) ?? "");
+  const [framework, setFramework] = useState((item.framework as string) ?? "");
+  const [dockerImage, setDockerImage] = useState((item.docker_image as string) ?? "");
+  const [envVars, setEnvVars] = useState<{ name: string; description: string; required: boolean }[]>(
+    Array.isArray(item.environment_variables) ? item.environment_variables as { name: string; description: string; required: boolean }[] : []
+  );
+  const [changelog, setChangelog] = useState("");
+  const [showVersionDialog, setShowVersionDialog] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+
+  const publishVersion = usePublishComponentVersion();
+  const { data: versionSuggestions } = useComponentVersionSuggestions(type, listingId);
+
+  const itemDescription = (item.description as string) ?? "";
+  const isDirty = useMemo(() => {
+    return (
+      jsonParsed ||
+      changelog.trim() !== "" ||
+      description !== itemDescription ||
+      jsonInput !== currentConfigJson
+    );
+  }, [jsonParsed, changelog, description, jsonInput, currentConfigJson, itemDescription]);
+
+  const jsonParseTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const handleJsonInput = useCallback((value: string) => {
+    setJsonInput(value);
+    setJsonError(null);
+    setJsonParsed(false);
+
+    clearTimeout(jsonParseTimerRef.current);
+    if (!value.trim()) return;
+
+    jsonParseTimerRef.current = setTimeout(() => {
+      const { parsed, error } = parseMcpConfigJson(value);
+      if (error) {
+        setJsonError(error);
+        return;
+      }
+      if (!parsed) return;
+
+      applyParsedConfig(parsed, {
+        setCommand, setArgs, setMcpUrl, setTransport,
+        setFramework, setDockerImage, setEnvVars,
+        setDescription,
+      }, "fill");
+      setJsonParsed(true);
+    }, 300);
+  }, []);
+
+  function buildBody(version: string): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      version,
+      description: description.trim() || undefined,
+      changelog: changelog.trim() || undefined,
+    };
+    const extra: Record<string, unknown> = {};
+    if (command) extra.command = command;
+    if (args.trim()) extra.args = args.split(/\s+/).filter(Boolean);
+    if (mcpUrl) extra.url = mcpUrl;
+    if (transport) extra.transport = transport;
+    if (framework) extra.framework = framework;
+    if (dockerImage) extra.docker_image = dockerImage;
+    if (envVars.length > 0) extra.environment_variables = envVars;
+    if (Object.keys(extra).length > 0) body.extra = extra;
+    return body;
+  }
+
+  async function handleRelease(selectedVersion: string) {
+    setPublishing(true);
+    try {
+      const body = buildBody(selectedVersion);
+      await publishVersion.mutateAsync({ type, listingId, body });
+      setShowVersionDialog(false);
+      setJsonInput("");
+      setJsonParsed(false);
+      setChangelog("");
+      onSuccess?.();
+    } catch {
+      // handled by mutation
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="mcp-name" className="text-sm font-medium">Name</Label>
+          <Input id="mcp-name" value={item.name} disabled className="max-w-md bg-muted/40 text-muted-foreground" />
+          <p className="text-xs text-muted-foreground">Component name cannot be changed after creation.</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="mcp-description" className="text-sm font-medium">Description</Label>
+          <Textarea
+            id="mcp-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="max-w-lg resize-y"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="mcp-changelog" className="text-sm font-medium">Changelog</Label>
+          <Textarea
+            id="mcp-changelog"
+            placeholder="What changed in this version?"
+            value={changelog}
+            onChange={(e) => setChangelog(e.target.value)}
+            rows={2}
+            className="max-w-lg resize-y"
+          />
+        </div>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-4">
+        <div>
+          <h3 className="text-sm font-medium font-[family-name:var(--font-display)]">Update Server Config</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Paste your updated server JSON config below. Accepts IDE config, bare config, SSE, or server.json formats.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Textarea
+            id="mcp-json"
+            value={jsonInput}
+            onChange={(e) => handleJsonInput(e.target.value)}
+            placeholder={`Paste your updated config, e.g.:\n{\n  "mcpServers": {\n    "${item.name}": {\n      "command": "npx",\n      "args": ["-y", "@example/server@latest"]\n    }\n  }\n}`}
+            rows={8}
+            className="resize-y font-[family-name:var(--font-mono)] text-xs"
+          />
+          {jsonError && <p className="text-xs text-destructive">{jsonError}</p>}
+          {jsonParsed && (
+            <p className="text-xs text-green-600 flex items-center gap-1.5">
+              <ArrowRight className="h-3 w-3" />
+              Config parsed: {command && `${command} `}{args && `${args} `}{mcpUrl && `${mcpUrl} `}
+              {envVars.length > 0 && `(${envVars.length} env var${envVars.length > 1 ? "s" : ""})`}
+            </p>
+          )}
+        </div>
+
+        {/* Current config summary */}
+        <div className="rounded-md border border-border/50 bg-muted/30 px-3 py-2 space-y-1">
+          <p className="text-xs font-medium text-muted-foreground">Current config:</p>
+          {command && <p className="text-xs font-mono">command: {command} {args}</p>}
+          {mcpUrl && <p className="text-xs font-mono">url: {mcpUrl}</p>}
+          {transport && <p className="text-xs font-mono">transport: {transport}</p>}
+          {framework && <p className="text-xs font-mono">framework: {framework}</p>}
+          {envVars.length > 0 && <p className="text-xs font-mono">env vars: {envVars.map(e => e.name).join(", ")}</p>}
+          {!command && !mcpUrl && <p className="text-xs text-muted-foreground italic">No config set</p>}
+        </div>
+      </section>
+
+      <Separator />
+
+      <div className="flex items-center gap-3">
+        <Button
+          onClick={() => setShowVersionDialog(true)}
+          disabled={publishing || !isDirty}
+          className="min-w-[160px]"
+        >
+          {publishing ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <ArrowRight className="mr-2 h-4 w-4" />
+          )}
+          Save &amp; Release
+        </Button>
+
+        <Button
+          variant="ghost"
+          onClick={() => {
+            setJsonInput(currentConfigJson);
+            setJsonError(null);
+            setJsonParsed(false);
+            setDescription((item.description as string) ?? "");
+            setChangelog("");
+            setCommand((item.command as string) ?? "");
+            setArgs(Array.isArray(item.args) ? (item.args as string[]).join(" ") : "");
+            setMcpUrl((item.url as string) ?? "");
+            setTransport((item.transport as string) ?? "");
+            setFramework((item.framework as string) ?? "");
+            setDockerImage((item.docker_image as string) ?? "");
+            setEnvVars(Array.isArray(item.environment_variables) ? item.environment_variables as { name: string; description: string; required: boolean }[] : []);
+          }}
+          disabled={!isDirty || publishing}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <RotateCcw className="mr-2 h-4 w-4" />
+          Discard
+        </Button>
+      </div>
+
+      <VersionBumpDialog
+        open={showVersionDialog}
+        onOpenChange={setShowVersionDialog}
+        currentVersion={currentVersion}
+        suggestions={versionSuggestions}
+        onConfirm={handleRelease}
+        publishing={publishing}
+      />
+    </div>
+  );
+}
+
+// ── WIP Stub (sandboxes only) ──────────────────────────────────────
+
+function WipStub() {
   return (
     <div className="rounded-md border border-dashed border-border p-8 text-center space-y-3">
       <Construction className="h-8 w-8 mx-auto text-muted-foreground" />
       <h3 className="text-sm font-semibold font-[family-name:var(--font-display)]">
-        {type === "mcp" ? "MCP" : "Sandbox"} Editing — Coming Soon
+        Sandbox Editing — Coming Soon
       </h3>
       <p className="text-xs text-muted-foreground max-w-md mx-auto">
-        Version editing for {type === "mcp" ? "MCP servers" : "sandboxes"} requires lock file
-        support and semver resolution, which is planned for Phase 2.
+        Version editing for sandboxes requires lock file support and semver resolution,
+        which is planned for Phase 2.
       </p>
       <Badge variant="secondary" className="text-[10px]">Phase 2</Badge>
     </div>
@@ -839,8 +1101,36 @@ export function ComponentEditForm({
 }: ComponentEditFormProps) {
   const singularType = type === "sandboxes" ? "sandbox" : type.replace(/s$/, "");
 
-  if (singularType === "mcp" || singularType === "sandbox") {
-    return <WipStub type={singularType} />;
+  if (item.status === "pending") {
+    return (
+      <div className="rounded-md border border-dashed border-border p-8 text-center space-y-3">
+        <Construction className="h-8 w-8 mx-auto text-muted-foreground" />
+        <h3 className="text-sm font-semibold font-[family-name:var(--font-display)]">
+          Pending Review
+        </h3>
+        <p className="text-xs text-muted-foreground max-w-md mx-auto">
+          This component is currently pending review and cannot be edited.
+          You can edit it once it has been approved or rejected.
+        </p>
+        <Badge variant="secondary" className="text-[10px]">Pending</Badge>
+      </div>
+    );
+  }
+
+  if (singularType === "mcp") {
+    return (
+      <McpEditForm
+        listingId={listingId}
+        type={type}
+        currentVersion={currentVersion}
+        item={item}
+        onSuccess={onSuccess}
+      />
+    );
+  }
+
+  if (singularType === "sandbox") {
+    return <WipStub />;
   }
 
   return (

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -5,7 +5,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useCallback } from "react";
 import {
   Dialog,
   DialogContent,
@@ -23,10 +23,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Info, Loader2, Plus, X } from "lucide-react";
+import { Check, Info, Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
 import type { RegistryType } from "@/lib/api";
 import { useRegistryList, useMyComponents, useWhoami } from "@/hooks/use-api";
+import { parseMcpConfigJson, applyParsedConfig } from "@/lib/mcp-parser";
+import type { EnvVar } from "@/lib/mcp-parser";
+
 
 const MCP_CATEGORIES = [
   "browser-automation", "cloud-platforms", "code-execution", "communication",
@@ -66,11 +69,6 @@ const PROMPT_CATEGORIES = [
 const SANDBOX_RUNTIME_TYPES = ["docker", "lxc", "firecracker", "wasm"];
 const SANDBOX_NETWORK_POLICIES = ["none", "host", "bridge", "restricted"];
 
-interface EnvVar {
-  name: string;
-  description: string;
-  required: boolean;
-}
 
 interface SubmitComponentDialogProps {
   open: boolean;
@@ -108,6 +106,10 @@ export function SubmitComponentDialog({
   const [supportedIdes, setSupportedIdes] = useState<string[]>(Array.isArray(d?.supported_ides) ? d.supported_ides as string[] : []);
 
   // ── MCP ─────────────────────────────────────────────────
+  const [mcpMode, setMcpMode] = useState<"json" | "manual">("json");
+  const [jsonInput, setJsonInput] = useState("");
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [jsonParsed, setJsonParsed] = useState(false);
   const [category, setCategory] = useState((d?.category as string) ?? "general");
   const [gitUrl, setGitUrl] = useState((d?.git_url as string) ?? "");
   const [command, setCommand] = useState((d?.command as string) ?? "");
@@ -159,12 +161,61 @@ export function SubmitComponentDialog({
     return merged;
   })();
 
+  function bumpPatchVersion(ver: string): string {
+    const parts = ver.split(".");
+    if (parts.length === 3) {
+      const patch = parseInt(parts[2], 10);
+      if (!isNaN(patch)) return `${parts[0]}.${parts[1]}.${patch + 1}`;
+    }
+    return ver;
+  }
+
+  const jsonParseTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const isEditing = !!editItem;
+
+  const handleJsonInput = useCallback((value: string) => {
+    setJsonInput(value);
+    setJsonError(null);
+    setJsonParsed(false);
+
+    clearTimeout(jsonParseTimerRef.current);
+    if (!value.trim()) return;
+
+    jsonParseTimerRef.current = setTimeout(() => {
+      const { parsed, error } = parseMcpConfigJson(value);
+      if (error) {
+        setJsonError(error);
+        return;
+      }
+      if (!parsed) return;
+
+      const setters = {
+        setCommand, setArgs, setMcpUrl, setTransport,
+        setFramework, setDockerImage, setEnvVars,
+        setName: isEditing ? setName : (!name ? setName : undefined),
+        setDescription: isEditing ? setDescription : (!description ? setDescription : undefined),
+      };
+
+      if (isEditing) {
+        applyParsedConfig(parsed, setters, "overwrite");
+        setVersion(bumpPatchVersion(version));
+      } else {
+        applyParsedConfig(parsed, setters, "fill");
+      }
+      setJsonParsed(true);
+    }, 300);
+  }, [isEditing, name, description, version]);
+
   function reset() {
     setName("");
     setVersion("0.1.0");
     setDescription("");
     setOwnerInput("");
     setSupportedIdes([]);
+    setMcpMode("json");
+    setJsonInput("");
+    setJsonError(null);
+    setJsonParsed(false);
     setCategory("general");
     setGitUrl("");
     setCommand("");
@@ -270,7 +321,19 @@ export function SubmitComponentDialog({
     if (!description) return "Description is required";
 
     if (type === "mcps" && !gitUrl && !command && !mcpUrl) {
-      return "At least one of Git URL, Command, or Server URL is required";
+      if (mcpMode === "json" && !jsonParsed && !isEditMode) {
+        return "Paste a valid server config JSON";
+      }
+      if (mcpMode === "json" && !jsonParsed && isEditMode) {
+        // Edit mode: existing fields from editItem are still valid
+        const d = editItem as Record<string, unknown> | null;
+        if (!d?.command && !d?.url && !d?.git_url) {
+          return "Paste a new server config JSON to update";
+        }
+      }
+      if (mcpMode === "manual") {
+        return "At least one of Git URL, Command, or Server URL is required";
+      }
     }
     if (type === "prompts" && !template) {
       return "Template is required";
@@ -391,149 +454,203 @@ export function SubmitComponentDialog({
           {/* ── MCP-specific ──────────────────────────────── */}
           {type === "mcps" && (
             <>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label>Category</Label>
-                  <Select value={category} onValueChange={setCategory}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      {MCP_CATEGORIES.map((c) => (
-                        <SelectItem key={c} value={c}>{c}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1.5">
-                  <Label>Transport</Label>
-                  <Select value={transport || "auto"} onValueChange={(v) => setTransport(v === "auto" ? "" : v)}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="auto">Auto-detect</SelectItem>
-                      {MCP_TRANSPORTS.map((t) => (
-                        <SelectItem key={t} value={t}>{t}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
               <div className="space-y-1.5">
-                <Label htmlFor="mcp-git-url">Git URL</Label>
-                <Input
-                  id="mcp-git-url"
-                  value={gitUrl}
-                  onChange={(e) => setGitUrl(e.target.value)}
-                  placeholder="https://github.com/user/mcp-server"
-                />
+                <Label>Category</Label>
+                <Select value={category} onValueChange={setCategory}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {MCP_CATEGORIES.map((c) => (
+                      <SelectItem key={c} value={c}>{c}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
 
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="mcp-command">Command</Label>
-                  <Input
-                    id="mcp-command"
-                    value={command}
-                    onChange={(e) => setCommand(e.target.value)}
-                    placeholder="npx, uvx, node..."
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="mcp-args">Args</Label>
-                  <Input
-                    id="mcp-args"
-                    value={args}
-                    onChange={(e) => setArgs(e.target.value)}
-                    placeholder="space-separated args"
-                  />
-                </div>
-              </div>
+              {/* ── JSON paste mode (default) ─────────────── */}
+              {mcpMode === "json" && (
+                <>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="mcp-json">
+                      {isEditMode ? "Paste Updated Config (JSON)" : "Server Config (JSON)"}
+                    </Label>
+                    <Textarea
+                      id="mcp-json"
+                      value={jsonInput}
+                      onChange={(e) => handleJsonInput(e.target.value)}
+                      placeholder={isEditMode
+                        ? `Paste the new server config to update this MCP:\n{\n  "mcpServers": {\n    "${name || "my-server"}": {\n      "command": "npx",\n      "args": ["-y", "@example/mcp-server@latest"],\n      "env": { "API_KEY": "$API_KEY" }\n    }\n  }\n}`
+                        : `Paste your MCP server config, e.g.:\n{\n  "mcpServers": {\n    "my-server": {\n      "command": "npx",\n      "args": ["-y", "@example/mcp-server"],\n      "env": { "API_KEY": "$API_KEY" }\n    }\n  }\n}`}
+                      rows={8}
+                      className="text-xs font-mono"
+                    />
+                    {jsonError && (
+                      <p className="text-xs text-destructive">{jsonError}</p>
+                    )}
+                    {jsonParsed && (
+                      <div className="flex items-center gap-1.5 text-xs text-green-600">
+                        <Check className="h-3 w-3" />
+                        <span>
+                          {isEditMode ? "Config updated" : "Config parsed"}: {command && `${command} `}{args && `${args} `}{mcpUrl && `${mcpUrl} `}
+                          {envVars.length > 0 && `(${envVars.length} env var${envVars.length > 1 ? "s" : ""})`}
+                          {isEditMode && ` — version bumped to ${version}`}
+                        </span>
+                      </div>
+                    )}
+                  </div>
 
-              <div className="space-y-1.5">
-                <Label htmlFor="mcp-url">Server URL (SSE/HTTP)</Label>
-                <Input
-                  id="mcp-url"
-                  value={mcpUrl}
-                  onChange={(e) => setMcpUrl(e.target.value)}
-                  placeholder="http://localhost:3000/sse"
-                />
-              </div>
-
-              {!gitUrl && !command && !mcpUrl && (
-                <p className="text-xs text-destructive">
-                  At least one of Git URL, Command, or Server URL is required for submission.
-                </p>
+                  <button
+                    type="button"
+                    onClick={() => setMcpMode("manual")}
+                    className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+                  >
+                    Switch to manual entry
+                  </button>
+                </>
               )}
 
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label>Framework</Label>
-                  <Select value={framework || "none"} onValueChange={(v) => setFramework(v === "none" ? "" : v)}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">None</SelectItem>
-                      {MCP_FRAMEWORKS.map((f) => (
-                        <SelectItem key={f} value={f}>{f}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="mcp-docker">Docker Image</Label>
-                  <Input
-                    id="mcp-docker"
-                    value={dockerImage}
-                    onChange={(e) => setDockerImage(e.target.value)}
-                    placeholder="user/image:tag"
-                  />
-                </div>
-              </div>
+              {/* ── Manual mode (field-by-field) ──────────── */}
+              {mcpMode === "manual" && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setMcpMode("json")}
+                    className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+                  >
+                    Switch to paste config
+                  </button>
 
-              {/* Environment Variables */}
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label>Environment Variables</Label>
-                  <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={addEnvVar}>
-                    <Plus className="h-3 w-3 mr-1" /> Add
-                  </Button>
-                </div>
-                {envVars.map((ev, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <Input
-                      value={ev.name}
-                      onChange={(e) => updateEnvVar(i, "name", e.target.value)}
-                      placeholder="ENV_NAME"
-                      className="flex-1 h-8 text-xs font-mono"
-                    />
-                    <Input
-                      value={ev.description}
-                      onChange={(e) => updateEnvVar(i, "description", e.target.value)}
-                      placeholder="Description"
-                      className="flex-1 h-8 text-xs"
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-7 w-7 p-0 shrink-0"
-                      onClick={() => removeEnvVar(i)}
-                    >
-                      <X className="h-3 w-3" />
-                    </Button>
+                  <div className="space-y-1.5">
+                    <Label>Transport</Label>
+                    <Select value={transport || "auto"} onValueChange={(v) => setTransport(v === "auto" ? "" : v)}>
+                      <SelectTrigger><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="auto">Auto-detect</SelectItem>
+                        {MCP_TRANSPORTS.map((t) => (
+                          <SelectItem key={t} value={t}>{t}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
-                ))}
-              </div>
 
-              <div className="space-y-1.5">
-                <Label htmlFor="mcp-setup">Setup Instructions</Label>
-                <Textarea
-                  id="mcp-setup"
-                  value={setupInstructions}
-                  onChange={(e) => setSetupInstructions(e.target.value)}
-                  placeholder="Steps to configure this MCP server..."
-                  rows={3}
-                  className="text-sm"
-                />
-              </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="mcp-git-url">Git URL</Label>
+                    <Input
+                      id="mcp-git-url"
+                      value={gitUrl}
+                      onChange={(e) => setGitUrl(e.target.value)}
+                      placeholder="https://github.com/user/mcp-server"
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="mcp-command">Command</Label>
+                      <Input
+                        id="mcp-command"
+                        value={command}
+                        onChange={(e) => setCommand(e.target.value)}
+                        placeholder="npx, uvx, node..."
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="mcp-args">Args</Label>
+                      <Input
+                        id="mcp-args"
+                        value={args}
+                        onChange={(e) => setArgs(e.target.value)}
+                        placeholder="space-separated args"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="mcp-url">Server URL (SSE/HTTP)</Label>
+                    <Input
+                      id="mcp-url"
+                      value={mcpUrl}
+                      onChange={(e) => setMcpUrl(e.target.value)}
+                      placeholder="http://localhost:3000/sse"
+                    />
+                  </div>
+
+                  {!gitUrl && !command && !mcpUrl && (
+                    <p className="text-xs text-destructive">
+                      At least one of Git URL, Command, or Server URL is required for submission.
+                    </p>
+                  )}
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label>Framework</Label>
+                      <Select value={framework || "none"} onValueChange={(v) => setFramework(v === "none" ? "" : v)}>
+                        <SelectTrigger><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">None</SelectItem>
+                          {MCP_FRAMEWORKS.map((f) => (
+                            <SelectItem key={f} value={f}>{f}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="mcp-docker">Docker Image</Label>
+                      <Input
+                        id="mcp-docker"
+                        value={dockerImage}
+                        onChange={(e) => setDockerImage(e.target.value)}
+                        placeholder="user/image:tag"
+                      />
+                    </div>
+                  </div>
+
+                  {/* Environment Variables */}
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <Label>Environment Variables</Label>
+                      <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={addEnvVar}>
+                        <Plus className="h-3 w-3 mr-1" /> Add
+                      </Button>
+                    </div>
+                    {envVars.map((ev, i) => (
+                      <div key={i} className="flex items-center gap-2">
+                        <Input
+                          value={ev.name}
+                          onChange={(e) => updateEnvVar(i, "name", e.target.value)}
+                          placeholder="ENV_NAME"
+                          className="flex-1 h-8 text-xs font-mono"
+                        />
+                        <Input
+                          value={ev.description}
+                          onChange={(e) => updateEnvVar(i, "description", e.target.value)}
+                          placeholder="Description"
+                          className="flex-1 h-8 text-xs"
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 w-7 p-0 shrink-0"
+                          onClick={() => removeEnvVar(i)}
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="mcp-setup">Setup Instructions</Label>
+                    <Textarea
+                      id="mcp-setup"
+                      value={setupInstructions}
+                      onChange={(e) => setSetupInstructions(e.target.value)}
+                      placeholder="Steps to configure this MCP server..."
+                      rows={3}
+                      className="text-sm"
+                    />
+                  </div>
+                </>
+              )}
             </>
           )}
 

--- a/web/src/lib/mcp-parser.ts
+++ b/web/src/lib/mcp-parser.ts
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * MCP config JSON parser — shared between submit dialog and edit form.
+ * Mirrors the CLI's _parse_direct_config logic.
+ */
+
+export interface ParsedMcpConfig {
+  serverName?: string;
+  description?: string;
+  command?: string;
+  args?: string[];
+  url?: string;
+  transport?: string;
+  framework?: string;
+  dockerImage?: string;
+  envVars: EnvVar[];
+  headers?: { name: string; value: string }[];
+  autoApprove?: string[];
+}
+
+export interface EnvVar {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+export function parseMcpConfigJson(raw: string): { parsed?: ParsedMcpConfig; error?: string } {
+  let cfg: Record<string, unknown>;
+  try {
+    cfg = JSON.parse(raw);
+  } catch {
+    return { error: "Invalid JSON" };
+  }
+
+  // Registry format: {server: {remotes: [...]}, _meta: {...}}
+  let manifest = cfg;
+  const serverMeta = cfg.server;
+  if (serverMeta && typeof serverMeta === "object" && !Array.isArray(serverMeta)) {
+    const sm = serverMeta as Record<string, unknown>;
+    if (sm.remotes || sm.packages) {
+      manifest = sm;
+    }
+  }
+
+  // server.json manifest format (packages[]/remotes[])
+  if (manifest.packages || manifest.remotes) {
+    const result = parseServerJsonManifest(manifest);
+    // Extract name/description from registry metadata
+    if (serverMeta && typeof serverMeta === "object") {
+      const sm = serverMeta as Record<string, string>;
+      const regName = sm.title || sm.name;
+      if (regName) result.serverName = regName;
+      const regDesc = sm.description;
+      if (regDesc) result.description = regDesc;
+    }
+    return { parsed: result };
+  }
+
+  // Unwrap IDE config formats
+  const { inner, serverName } = unwrapMcpConfig(cfg);
+  const result: ParsedMcpConfig = { envVars: [] };
+  if (serverName) result.serverName = serverName;
+
+  const i = inner as Record<string, unknown>;
+
+  if (i.url && !i.command) {
+    // SSE / streamable-http
+    result.transport = (i.type as string) || "sse";
+    result.url = i.url as string;
+    const rawEnv = (i.env || {}) as Record<string, string>;
+    result.envVars = Object.keys(rawEnv).map((k) => ({ name: k, description: "", required: true }));
+    // Detect $VAR patterns in env values and header values
+    const dollarVars = detectDollarVars([], rawEnv);
+    if (i.headers && typeof i.headers === "object") {
+      const headerEntries = Object.entries(i.headers as Record<string, string>);
+      result.headers = headerEntries.map(([k, v]) => ({ name: k, value: v }));
+      for (const [, v] of headerEntries) {
+        for (const m of v.matchAll(/\$([A-Z][A-Z0-9_]*)/g)) {
+          dollarVars.add(m[1]);
+        }
+      }
+    }
+    mergeDollarVarsIntoEnv(result, dollarVars);
+    if (Array.isArray(i.autoApprove)) result.autoApprove = i.autoApprove as string[];
+  } else if (i.command) {
+    // stdio
+    result.transport = "stdio";
+    result.command = i.command as string;
+    result.args = Array.isArray(i.args) ? (i.args as string[]) : [];
+    const rawEnv = (i.env || {}) as Record<string, string>;
+    result.envVars = Object.keys(rawEnv).map((k) => ({ name: k, description: "", required: true }));
+    // Detect $VAR patterns in args and env values
+    const dollarVars = detectDollarVars(result.args, rawEnv);
+    mergeDollarVarsIntoEnv(result, dollarVars);
+    // Derive framework
+    if (result.command === "docker") {
+      result.framework = "docker";
+      const lastNonFlag = [...result.args].reverse().find((a) => !a.startsWith("-"));
+      if (lastNonFlag) result.dockerImage = lastNonFlag;
+    } else if (result.command === "python" || result.command === "python3") {
+      result.framework = "python";
+    } else if (result.command === "npx" || result.command === "node") {
+      result.framework = "typescript";
+    }
+    if (Array.isArray(i.autoApprove)) result.autoApprove = i.autoApprove as string[];
+  } else {
+    return { error: "Could not detect command or url in config" };
+  }
+
+  return { parsed: result };
+}
+
+export function parseServerJsonManifest(cfg: Record<string, unknown>): ParsedMcpConfig {
+  const result: ParsedMcpConfig = { envVars: [] };
+  const packages = Array.isArray(cfg.packages) ? cfg.packages : [];
+  const remotes = Array.isArray(cfg.remotes) ? cfg.remotes : [];
+
+  for (const pkg of packages) {
+    for (const arg of ((pkg as Record<string, unknown[]>).runtimeArguments || [])) {
+      const value = (arg as Record<string, string>).value || "";
+      if (value.includes("=")) {
+        const varName = value.split("=", 1)[0];
+        if (varName && varName === varName.toUpperCase()) {
+          result.envVars.push({ name: varName, description: (arg as Record<string, string>).description || "", required: true });
+        }
+      }
+    }
+  }
+
+  for (const remote of remotes) {
+    const r = remote as Record<string, unknown>;
+    if (r.url && !result.url) {
+      result.url = r.url as string;
+      result.transport = (r.type as string) || "sse";
+    }
+    for (const [key, meta] of Object.entries((r.variables || {}) as Record<string, unknown>)) {
+      const desc = meta && typeof meta === "object" ? ((meta as Record<string, string>).description || "") : "";
+      result.envVars.push({ name: key, description: desc, required: true });
+    }
+  }
+
+  if (!result.url) {
+    const hasRemotes = Array.isArray(cfg.remotes) && cfg.remotes.length > 0;
+    if (!hasRemotes) {
+      // Packages-only manifest implies stdio (Docker typically)
+      result.transport = "stdio";
+      result.framework = "docker";
+    }
+    // else: remotes without a URL — don't assume transport
+  }
+
+  return result;
+}
+
+/** Detect $VAR patterns in args and env values, returning a set of variable names. */
+function detectDollarVars(args: string[], env: Record<string, string>): Set<string> {
+  const vars = new Set<string>();
+  for (const arg of args) {
+    for (const m of arg.matchAll(/\$([A-Z][A-Z0-9_]*)/g)) {
+      vars.add(m[1]);
+    }
+  }
+  for (const v of Object.values(env)) {
+    for (const m of v.matchAll(/\$([A-Z][A-Z0-9_]*)/g)) {
+      vars.add(m[1]);
+    }
+  }
+  return vars;
+}
+
+/** Merge detected $VAR names into envVars, skipping names already present from explicit env keys. */
+function mergeDollarVarsIntoEnv(result: ParsedMcpConfig, dollarVars: Set<string>): void {
+  const existing = new Set(result.envVars.map((ev) => ev.name));
+  for (const name of dollarVars) {
+    if (!existing.has(name)) {
+      result.envVars.push({ name, description: "", required: true });
+    }
+  }
+}
+
+export interface McpFieldSetters {
+  setCommand: (v: string) => void;
+  setArgs: (v: string) => void;
+  setMcpUrl: (v: string) => void;
+  setTransport: (v: string) => void;
+  setFramework: (v: string) => void;
+  setDockerImage: (v: string) => void;
+  setEnvVars: (v: EnvVar[]) => void;
+  setName?: (v: string) => void;
+  setDescription?: (v: string) => void;
+}
+
+/**
+ * Apply parsed MCP config fields to state setters.
+ * `mode` controls whether blank fields in parsed config overwrite existing state:
+ * - "overwrite": always set all fields (for edit mode)
+ * - "fill": only set fields that have values (for new submissions / edit form)
+ */
+export function applyParsedConfig(
+  parsed: ParsedMcpConfig,
+  setters: McpFieldSetters,
+  mode: "overwrite" | "fill" = "fill",
+): void {
+  if (mode === "overwrite") {
+    if (parsed.serverName && setters.setName) setters.setName(parsed.serverName);
+    if (parsed.description && setters.setDescription) setters.setDescription(parsed.description);
+    setters.setCommand(parsed.command || "");
+    setters.setArgs(parsed.args ? parsed.args.join(" ") : "");
+    setters.setMcpUrl(parsed.url || "");
+    setters.setTransport(parsed.transport || "");
+    setters.setFramework(parsed.framework || "");
+    setters.setDockerImage(parsed.dockerImage || "");
+    setters.setEnvVars(parsed.envVars.length > 0 ? parsed.envVars : []);
+  } else {
+    if (parsed.serverName && setters.setName) setters.setName(parsed.serverName);
+    if (parsed.description && setters.setDescription) setters.setDescription(parsed.description);
+    if (parsed.command) setters.setCommand(parsed.command);
+    if (parsed.args) setters.setArgs(parsed.args.join(" "));
+    if (parsed.url) setters.setMcpUrl(parsed.url);
+    if (parsed.transport) setters.setTransport(parsed.transport);
+    if (parsed.framework) setters.setFramework(parsed.framework);
+    if (parsed.dockerImage) setters.setDockerImage(parsed.dockerImage);
+    if (parsed.envVars.length > 0) setters.setEnvVars(parsed.envVars);
+  }
+}
+
+export function unwrapMcpConfig(cfg: Record<string, unknown>): { inner: Record<string, unknown>; serverName?: string } {
+  // Shape 1: {mcpServers: {name: config}}
+  if (cfg.mcpServers && typeof cfg.mcpServers === "object") {
+    const servers = cfg.mcpServers as Record<string, unknown>;
+    const keys = Object.keys(servers);
+    if (keys.length === 1 && typeof servers[keys[0]] === "object") {
+      return { inner: servers[keys[0]] as Record<string, unknown>, serverName: keys[0] };
+    }
+    return { inner: cfg };
+  }
+  // Shape 3: bare config
+  if (cfg.command || cfg.url || cfg.type) return { inner: cfg };
+  // Shape 2: single named key
+  const keys = Object.keys(cfg);
+  if (keys.length === 1 && typeof cfg[keys[0]] === "object") {
+    const inner = cfg[keys[0]] as Record<string, unknown>;
+    if (inner.command || inner.url || inner.type) return { inner, serverName: keys[0] };
+  }
+  return { inner: cfg };
+}


### PR DESCRIPTION
## Purpose / Description

Two changes bundled in this PR:

1. **MCP Submit UX overhaul** — The git URL + regex analysis path was the default but is unreliable (MCP servers have constantly changing structures). Since authors always have a working JSON config from their IDE, we invert the default: JSON paste is now the primary submission method.

2. **Shim blank error fix** — When an MCP server fails to start (missing binary, bad module, permission denied), the shim previously showed a blank "failed" status with no error message. Now it emits a JSON-RPC `notifications/message` with the actual error text.

## Approach

**CLI (`cmd_mcp.py`):**
- `observal mcp submit` defaults to JSON paste (no args needed)
- Git analysis moved behind `--git` / `-g` flag
- Added `server.json` manifest format support (`packages[]`/`remotes[]`)
- `--config` kept as hidden deprecated alias

**Frontend (`submit-component-dialog.tsx`):**
- Default MCP mode is a JSON textarea with auto-parsing
- Accepts IDE config, bare config, SSE, and server.json formats
- "Switch to manual entry" reveals the old field-by-field form
- Fields pre-populated from parsed JSON

**Shim (`shim.py`):**
- Catches `FileNotFoundError`/`PermissionError`/`OSError` at spawn time
- 0.3s startup health check catches immediate process crashes
- Captures stderr into buffer for late crash reporting
- Emits JSON-RPC error notification with actual error text

## How Has This Been Tested?

**CLI:**
- `observal mcp submit` → prompts for JSON paste (verified)
- Piped stdio config → parsed, preview shown, draft saved
- Piped SSE config with `$VAR` → detected as install-time variable
- Piped server.json manifest → `packages[].runtimeArguments` env vars extracted
- `--config` deprecated flag → shows notice, still works
- `--git` flag → uses old analysis flow

**Shim:**
- `observal-shim --mcp-id test -- nonexistent-binary` → JSON-RPC error with FileNotFoundError
- `observal-shim --mcp-id test -- python3 -c "import bad_module"` → JSON-RPC error with ModuleNotFoundError

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)