### PR TITLE
docs: add Contributor License Agreement and update CONTRIBUTING.md

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,83 @@
+# Observal Individual Contributor License Agreement
+
+**Version 1.0**
+
+Thank you for your interest in contributing to Observal, a project maintained by BlazeUp AI LLP ("BlazeUp AI", "we", or "us").
+
+To clarify the intellectual property license granted with contributions from any person or entity, BlazeUp AI must have a signed Contributor License Agreement ("CLA") on file from each contributor. This agreement is for your protection as a contributor as well as the protection of BlazeUp AI and its users. It does not change your rights to use your own contributions for any other purpose.
+
+By signing this agreement, you accept and agree to the following terms and conditions for your present and future contributions submitted to BlazeUp AI. Except for the licenses granted herein, you reserve all right, title, and interest in and to your contributions.
+
+---
+
+## 1. Definitions
+
+**"You"** (or "Your") means the copyright owner or legal entity authorized by the copyright owner that is entering into this Agreement with BlazeUp AI. For legal entities, the entity making a contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+**"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to BlazeUp AI for inclusion in, or documentation of, any of the products owned or managed by BlazeUp AI (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to BlazeUp AI or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, BlazeUp AI for the purpose of discussing and improving the Work — but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+---
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to BlazeUp AI and to recipients of software distributed by BlazeUp AI a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+This license grant includes the right for BlazeUp AI to sublicense Your Contributions under any license, including proprietary or commercial licenses, consistent with BlazeUp AI's dual-license structure (AGPL-3.0 for the open-source core and the Observal Enterprise License for the `ee/` directory). You acknowledge and agree that BlazeUp AI may offer Your Contributions as part of a commercial product or service.
+
+---
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to BlazeUp AI and to recipients of software distributed by BlazeUp AI a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+---
+
+## 4. You Represent That You Are Entitled to Grant This License
+
+You represent that you are legally entitled to grant the above licenses. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to BlazeUp AI, or that your employer has executed a separate Corporate CLA with BlazeUp AI.
+
+---
+
+## 5. Your Contributions Are Your Original Creation
+
+You represent that each of Your Contributions is Your original creation (see Section 7 for submissions on behalf of others). You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are associated with any part of Your Contributions.
+
+---
+
+## 6. No Obligation to Provide Support
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+---
+
+## 7. Third-Party Work
+
+Should You wish to submit work that is not Your original creation, You may submit it to BlazeUp AI separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+
+---
+
+## 8. Duty to Notify
+
+You agree to notify BlazeUp AI of any facts or circumstances of which you become aware that would make any of the representations in this Agreement inaccurate in any respect.
+
+---
+
+## 9. Governing Law
+
+This Agreement shall be governed by and construed in accordance with the laws of India. Any disputes arising under this Agreement shall be resolved by arbitration in Chennai, Tamil Nadu, India, under the Arbitration and Conciliation Act, 1996, before a sole mutually agreed arbitrator.
+
+---
+
+## How to Sign
+
+This CLA is managed via [CLA-assistant.io](https://cla-assistant.io). When you open a pull request against this repository for the first time, the CLA-assistant bot will prompt you to sign this agreement electronically. You do not need to sign anything manually.
+
+If you are contributing on behalf of a company or organization, please contact us at contact@observal.io to arrange a Corporate CLA.
+
+---
+
+*BlazeUp AI LLP*
+*Registered Office: Chennai, Tamil Nadu, India*
+*Contact: contact@observal.io*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ If you have questions about contributing or want to discuss your ideas before op
 - [Reporting Issues](#reporting-issues)
 - [Codebase Context](#codebase-context)
 - [License](#license)
+- [Contributor License Agreement (CLA)](#contributor-license-agreement-cla)
 
 ## Getting Started
 
@@ -165,7 +166,7 @@ Keep the subject line under 72 characters, use the imperative mood ("add", not "
 
 ### DCO Sign-off
 
-All commits must include a `Signed-off-by` line to certify the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). The DCO is a lightweight agreement that confirms you wrote (or have the right to submit) your contribution and that it is licensed under the project's open-source Apache 2.0 license (for all code outside `ee/`).
+All commits must include a `Signed-off-by` line to certify the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). The DCO is a lightweight agreement that confirms you wrote (or have the right to submit) your contribution and that it is licensed under the project's open-source license (AGPL-3.0 for all code outside `ee/`).
 
 You can add the sign-off manually to your commit message:
 
@@ -248,6 +249,12 @@ See [AGENTS.md](AGENTS.md) for internal architecture notes, file layout, and con
 
 ## License
 
-This repository uses a dual-license structure. By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE), which covers all code outside the `ee/` directory. The `ee/` directory is licensed separately under the [Observal Enterprise License](ee/LICENSE) and does not accept community contributions.
+This repository uses a dual-license structure. All code outside the `ee/` directory is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE). The `ee/` directory is licensed separately under the [Observal Enterprise License](ee/LICENSE) and does not accept community contributions.
 
-The DCO sign-off on each commit is your explicit acknowledgement of this.
+## Contributor License Agreement (CLA)
+
+Before your first pull request can be merged, you must sign the [Observal CLA](CLA.md). This is handled automatically — when you open a PR, the [CLA-assistant](https://cla-assistant.io) bot will comment with a link to sign electronically. You only need to sign once.
+
+The CLA and the DCO work together. The DCO (signed on every commit) certifies that you wrote the code and have the right to submit it. The CLA grants BlazeUp AI the rights needed to distribute your contribution under both the open-source and commercial licenses.
+
+If you are contributing on behalf of a company, contact contact@observal.io to arrange a Corporate CLA.


### PR DESCRIPTION
## Purpose / Description
Add the Observal Individual Contributor License Agreement (CLA.md) and update CONTRIBUTING.md to reference it. Without a CLA, contributors implicitly license under AGPL-3.0 only, which blocks BlazeUp AI from sublicensing contributions commercially under the dual-license model.

## Fixes
* Fixes #803

## Approach
CLA.md is modelled on Apache ICLA v2.2 and HashiCorp CLA, both lawyer-vetted. It grants BlazeUp AI a broad sublicensing right covering both the AGPL-3.0 open-source and commercial enterprise licenses, while contributors retain copyright. Patent grant and termination clauses are taken verbatim from Apache/HashiCorp.

CONTRIBUTING.md fixes incorrect Apache 2.0 license references (project is AGPL-3.0), adds a CLA section explaining CLA-assistant.io and how CLA + DCO work together, and updates the table of contents.

## How Has This Been Tested?
Docs-only change. Both files reviewed manually for correctness and consistency with the existing LICENSE and ee/LICENSE.

## Learning (optional, can help others)
- Apache ICLA v2.2: https://www.apache.org/licenses/icla.pdf
- HashiCorp CLA: https://www.hashicorp.com/cla
- CLA-assistant.io: https://cla-assistant.io

## Checklist
- [x] All commits are signed off (git commit -s) per the DCO
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A - docs only)