### PR TITLE
fix(tests): update redis image assertion to 8-alpine

### DIFF
--- a/tests/test_worker_phase5.py
+++ b/tests/test_worker_phase5.py
@@ -141,7 +141,7 @@ class TestDockerCompose:
         with open(COMPOSE_PATH) as f:
             compose = yaml.safe_load(f)
         assert "observal-redis" in compose["services"]
-        assert compose["services"]["observal-redis"]["image"] == "redis:7-alpine"
+        assert compose["services"]["observal-redis"]["image"] == "redis:8-alpine"
 
     def test_worker_service_exists(self):
         import yaml


### PR DESCRIPTION
## Purpose / Description

`test_redis_service_exists` was hardcoded to assert `redis:7-alpine` but the compose file was already bumped to `redis:8-alpine`, causing the test to fail in CI.

## Fixes

* Unblocks CI (1 failing test)

## Approach

Update the hardcoded version string in the assertion to match the current image in `docker/docker-compose.yml`.

## How Has This Been Tested?

Assertion now matches the actual value in the compose file.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code