### PR TITLE
fix: replace all Apache 2.0 references with AGPL-3.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,5 +31,5 @@ _For each new external resource, add a row to the table below:_
 
 | Library | Description | License |
 | --- | --- | --- |
-| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |
+| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
 --->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
 **Note on contributions:** Community contributions are welcome across the
-open-source core (Apache 2.0). The `ee/` directory contains proprietary
+open-source core (AGPL-3.0). The `ee/` directory contains proprietary
 enterprise code and does not accept community contributions. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for details on the dual-license structure.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 **Discover, share, and monitor AI coding agents with full observability built in.**
 
 <p>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python">
   <img src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" alt="Status">
   <a href="https://github.com/BlazeUp-AI/Observal/stargazers"><img src="https://img.shields.io/github/stars/BlazeUp-AI/Observal?style=flat-square" alt="Stars"></a>
@@ -191,7 +191,7 @@ To report a vulnerability, please use [GitHub Private Vulnerability Reporting](h
 
 ## License
 
-Apache License 2.0. See [LICENSE](LICENSE).
+GNU Affero General Public License v3.0 (AGPL-3.0). See [LICENSE](LICENSE).
 
 ## Star history
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ The full matrix lives in [Integrations](integrations/README.md).
 
 ## Is Observal free?
 
-Yes. Observal is open source under the Apache 2.0 license. Self-host the whole thing for free. There is an enterprise edition with SSO, SCIM, and audit logging, but everything covered in these docs works without it.
+Yes. Observal is open source under the AGPL-3.0 license. Self-host the whole thing for free. There is an enterprise edition with SSO, SCIM, and audit logging, but everything covered in these docs works without it.
 
 ## Next
 

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -3,7 +3,7 @@ name = "observal-server"
 version = "0.4.0"
 description = "Observal API server"
 requires-python = ">=3.11"
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 dependencies = [
     "fastapi",
     "uvicorn[standard]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 
 dependencies = [
     "typer>=0.12.0",
@@ -24,7 +24,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Purpose / Description

The project license is AGPL-3.0 but Apache 2.0 was still referenced in several places across the repo.

## Fixes

* Closes #808 (partial, SPDX headers still to come)

## Approach

Grep sweep across all non-generated files. Six files updated:

| File | Change |
|---|---|
| `pyproject.toml` | `license` field + OSI classifier |
| `observal-server/pyproject.toml` | `license` field |
| `README.md` | License badge + footer line |
| `CODE_OF_CONDUCT.md` | Open-source core license mention |
| `docs/README.md` | FAQ license answer |
| `.github/pull_request_template.md` | Example row in the Licenses table |

Two intentionally untouched: the `structural_scorer.py` `"apache"` string (a license keyword list used in scoring, not a project license claim) and the CHANGELOG historical entry.

## How Has This Been Tested?

`grep -rn "Apache" --include="*.py,*.ts,*.tsx,*.md,*.toml,*.yml,*.sh"` returns zero hits outside CHANGELOG and structural scorer.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code