### PR TITLE
test: assert real behaviour in graphql, worker, and listing detail tests

### DIFF
--- a/tests/test_graphql_phase6.py
+++ b/tests/test_graphql_phase6.py
@@ -164,14 +164,47 @@ class TestDataLoaders:
 
 
 class TestSchema:
-    def test_schema_exists(self):
-        assert schema is not None
+    def test_schema_exposes_required_query_fields(self):
+        # Renames or removals of these resolvers would break the dashboard,
+        # so the schema must keep advertising them.
+        query_type = schema._schema.query_type
+        assert query_type is not None
+        field_names = set(query_type.fields.keys())
+        for required in ("traces", "trace", "span", "mcpMetrics", "overview", "trends"):
+            assert required in field_names, f"Query.{required} missing from schema; got {sorted(field_names)}"
 
-    def test_has_query_type(self):
-        assert schema._schema.query_type is not None
+    def test_query_trace_returns_trace_type(self):
+        # Guards against the resolver being retyped (e.g. to a connection or scalar).
+        query_type = schema._schema.query_type
+        trace_field = query_type.fields["trace"]
+        # GraphQL nullable Trace serialises as type name "Trace"
+        assert "Trace" in str(trace_field.type)
 
-    def test_has_subscription_type(self):
-        assert schema._schema.subscription_type is not None
+    def test_schema_exposes_required_subscription_fields(self):
+        sub_type = schema._schema.subscription_type
+        assert sub_type is not None
+        field_names = set(sub_type.fields.keys())
+        for required in ("traceCreated", "spanCreated", "sessionUpdated"):
+            assert required in field_names, f"Subscription.{required} missing from schema; got {sorted(field_names)}"
+
+    @pytest.mark.asyncio
+    async def test_schema_executes_traces_query(self):
+        # End-to-end: parse + execute a real GraphQL document so a broken
+        # resolver wiring (mis-named field, wrong return type) actually fails.
+        mock_rows = [{"trace_id": "t1", "user_id": "u1", "start_time": "2026-01-01"}]
+        with patch("api.graphql.query_traces", new_callable=AsyncMock, return_value=mock_rows):
+            result = await schema.execute(
+                "{ traces(limit: 10) { items { traceId userId } hasMore totalCount } }",
+                context_value=get_context(),
+            )
+        assert result.errors is None, result.errors
+        assert result.data == {
+            "traces": {
+                "items": [{"traceId": "t1", "userId": "u1"}],
+                "hasMore": False,
+                "totalCount": 1,
+            }
+        }
 
     def test_context_has_loaders(self):
         ctx = get_context()

--- a/tests/test_listing_detail_access.py
+++ b/tests/test_listing_detail_access.py
@@ -168,7 +168,15 @@ class TestUnauthenticatedAccess:
             mock_resolve.return_value = listing
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
-            assert r.status_code == 200
+            assert r.status_code == 200, r.text
+            body = r.json()
+            # The response must actually carry the listing's payload; otherwise
+            # a regression that returns an empty/wrong body would still pass a
+            # bare status-code check.
+            assert body["id"] == str(listing.id)
+            assert body["name"] == listing.name
+            assert body["version"] == listing.version
+            assert body["status"] == ListingStatus.approved.value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -252,7 +260,14 @@ class TestNonOwnerRegularUser:
             mock_resolve.return_value = listing
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
-            assert r.status_code == 200
+            assert r.status_code == 200, r.text
+            body = r.json()
+            # Non-owner regular user must see the same approved listing payload
+            # an anonymous user would — not just a 200 with a stripped body.
+            assert body["id"] == str(listing.id)
+            assert body["name"] == listing.name
+            assert body["version"] == listing.version
+            assert body["status"] == ListingStatus.approved.value
 
 
 @pytest.mark.parametrize("route_type,base_path,module_path", ENDPOINTS)

--- a/tests/test_worker_phase5.py
+++ b/tests/test_worker_phase5.py
@@ -82,10 +82,14 @@ class TestClose:
 
 
 class TestWorkerSettings:
-    def test_has_functions(self):
-        from worker import WorkerSettings
+    def test_registers_run_eval_function(self):
+        # arq dispatches by function __name__, so removing/renaming run_eval
+        # silently breaks every queued eval job. The registration must stay.
+        from worker import WorkerSettings, run_eval
 
-        assert len(WorkerSettings.functions) > 0
+        assert run_eval in WorkerSettings.functions
+        names = {f.__name__ for f in WorkerSettings.functions}
+        assert "run_eval" in names
 
     def test_has_redis_settings(self):
         from worker import WorkerSettings
@@ -108,25 +112,71 @@ class TestRunEval:
     async def test_calls_eval_and_publishes(self):
         from worker import run_eval
 
-        mock_traces = [{"trace_id": "t1", "spans": []}]
-        mock_result = {"score": 0.9}
+        # Two scores written → published payload should report scores_written=2
+        # so subscribers can show the eval result count, not just "something happened".
+        scores = [{"score_id": "sc1", "value": 0.9}, {"score_id": "sc2", "value": 0.8}]
 
         with (
-            patch("services.eval.eval_service.fetch_traces", new_callable=AsyncMock, return_value=mock_traces),
-            patch("services.eval.eval_service.evaluate_trace", new_callable=AsyncMock, return_value=mock_result),
+            patch(
+                "services.eval.eval_engine.run_eval_on_trace",
+                new_callable=AsyncMock,
+                return_value=scores,
+            ) as mock_run,
             patch("worker.publish", new_callable=AsyncMock) as mock_pub,
         ):
             await run_eval({}, "agent-1", "t1")
-            mock_pub.assert_called_once()
-            channel = mock_pub.call_args[0][0]
-            assert channel == "eval:agent-1"
+
+        mock_run.assert_awaited_once_with("agent-1", "t1", project_id="default")
+        mock_pub.assert_awaited_once()
+        channel, payload = mock_pub.call_args[0]
+        assert channel == "eval:agent-1"
+        assert payload == {
+            "agent_id": "agent-1",
+            "trace_id": "t1",
+            "scores_written": 2,
+        }
+
+    @pytest.mark.asyncio
+    async def test_iterates_traces_when_no_trace_id(self):
+        # Without trace_id, run_eval should fan out: query traces for the agent
+        # and publish one event per trace it scores.
+        from worker import run_eval
+
+        traces = [{"trace_id": "t1"}, {"trace_id": "t2"}]
+        score_calls = {"t1": [{"score_id": "sc1"}], "t2": []}
+
+        async def _fake_eval(agent_id, trace_id, project_id="default"):
+            return score_calls[trace_id]
+
+        with (
+            patch("services.clickhouse.query_traces", new_callable=AsyncMock, return_value=traces),
+            patch("services.eval.eval_engine.run_eval_on_trace", side_effect=_fake_eval),
+            patch("worker.publish", new_callable=AsyncMock) as mock_pub,
+        ):
+            await run_eval({}, "agent-1")
+
+        assert mock_pub.await_count == 2
+        published = [call.args for call in mock_pub.call_args_list]
+        assert published[0] == ("eval:agent-1", {"agent_id": "agent-1", "trace_id": "t1", "scores_written": 1})
+        assert published[1] == ("eval:agent-1", {"agent_id": "agent-1", "trace_id": "t2", "scores_written": 0})
 
     @pytest.mark.asyncio
     async def test_handles_eval_error(self):
         from worker import run_eval
 
-        with patch("services.eval.eval_service.fetch_traces", new_callable=AsyncMock, side_effect=Exception("db down")):
-            await run_eval({}, "agent-1")  # should not raise
+        # An eval crash should be swallowed (logged) and must not publish anything,
+        # so subscribers don't see a partial/false-success event.
+        with (
+            patch(
+                "services.eval.eval_engine.run_eval_on_trace",
+                new_callable=AsyncMock,
+                side_effect=Exception("boom"),
+            ),
+            patch("worker.publish", new_callable=AsyncMock) as mock_pub,
+        ):
+            await run_eval({}, "agent-1", "t1")  # should not raise
+
+        mock_pub.assert_not_awaited()
 
 
 # --- Docker compose ---
@@ -143,13 +193,30 @@ class TestDockerCompose:
         assert "observal-redis" in compose["services"]
         assert compose["services"]["observal-redis"]["image"] == "redis:7-alpine"
 
-    def test_worker_service_exists(self):
+    def test_worker_service_runs_arq_with_worker_settings(self):
+        # The worker container must launch arq against worker.WorkerSettings,
+        # otherwise eval/cron jobs never run even though the container is "up".
         import yaml
 
         with open(COMPOSE_PATH) as f:
             compose = yaml.safe_load(f)
-        assert "observal-worker" in compose["services"]
-        assert "worker" in str(compose["services"]["observal-worker"]["command"])
+        worker_svc = compose["services"]["observal-worker"]
+        cmd = " ".join(worker_svc["command"]) if isinstance(worker_svc["command"], list) else worker_svc["command"]
+        assert "arq" in cmd
+        assert "WorkerSettings" in cmd
+        assert "from worker import" in cmd or "worker.WorkerSettings" in cmd
+
+    def test_worker_depends_on_redis_healthy(self):
+        # arq won't start without a reachable Redis. The compose file must wait
+        # for Redis to pass its healthcheck before booting the worker, otherwise
+        # the worker crash-loops on first boot.
+        import yaml
+
+        with open(COMPOSE_PATH) as f:
+            compose = yaml.safe_load(f)
+        deps = compose["services"]["observal-worker"]["depends_on"]
+        assert "observal-redis" in deps, deps
+        assert deps["observal-redis"]["condition"] == "service_healthy"
 
     def test_redis_volume_exists(self):
         import yaml


### PR DESCRIPTION
## Summary
Three tests named in #806 passed even when the underlying behaviour was broken: `test_schema_exists` only checked the schema object existed, `test_has_functions` only checked the list was non-empty, and the listing detail tests only asserted a 200. This PR rewrites them so they fail when resolvers, arq registrations, the worker compose command, or the listing response body actually regress. Scope is intentionally limited to the three files called out in the issue — the broader hollow-test sweep is ongoing.

## Changes
- `tests/test_graphql_phase6.py`: replace `test_schema_exists` / `test_has_query_type` / `test_has_subscription_type` with assertions on required `Query` field names (`traces`, `trace`, `span`, `mcpMetrics`, `overview`, `trends`), required `Subscription` fields (`traceCreated`, `spanCreated`, `sessionUpdated`), the return type of `Query.trace`, and an end-to-end `schema.execute` of a `traces` query that pins the response shape.
- `tests/test_worker_phase5.py`: replace `test_has_functions` with a check that `run_eval` is registered in `WorkerSettings.functions` by identity and by `__name__`. Tighten `test_calls_eval_and_publishes` to assert the published payload (`agent_id`, `trace_id`, `scores_written`) and the `run_eval_on_trace` call args. Add `test_iterates_traces_when_no_trace_id` for the fan-out path and harden `test_handles_eval_error` to assert nothing is published on failure.
- `tests/test_worker_phase5.py`: replace `test_worker_service_exists` with `test_worker_service_runs_arq_with_worker_settings` (asserts the compose command actually invokes `arq` against `WorkerSettings`) and add `test_worker_depends_on_redis_healthy` so a missing healthcheck dependency fails the suite.
- `tests/test_listing_detail_access.py`: in both `TestUnauthenticatedAccess.test_sees_approved` and `TestNonOwnerRegularUser.test_sees_approved`, validate the JSON body's `id` / `name` / `version` / `status` against the mocked listing instead of only checking `r.status_code == 200`.

## Testing
- `make test` — full suite passes locally with the rewritten assertions.

## Notes
- Other hollow tests across the suite are out of scope for this PR per the issue description ("ongoing"); this only covers the three files explicitly named.
- The new GraphQL execute test assumes the `traces` resolver delegates to `query_traces` in `api.graphql`; if that indirection changes, the patch target needs to move with it.

Closes #806