### PR TITLE
fix(deploy): trigger EC2 deploy on push to main instead of tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    tags: ['v*']
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -23,8 +23,8 @@ jobs:
           script: |
             set -e
             cd ~/Observal
-            git fetch origin --tags
-            git checkout ${{ github.ref_name }}
+            git fetch origin main
+            git reset --hard origin/main
 
             cd docker
             docker compose -f docker-compose.yml -f docker-compose.production.yml up -d --build --remove-orphans


### PR DESCRIPTION
## Purpose / Description
Revive continuous deployment to EC2. The workflow was previously gated on release tags, meaning every push to main required a manual release to deploy. This changes it to deploy automatically on every push to main.

## Fixes
* Fixes the failing EC2 deploy CI check that was blocking Renovate auto-merges

## Approach
- Changed trigger from `push: tags: ['v*']` to `push: branches: [main]`
- Updated the deploy script to `git fetch origin main` + `git reset --hard origin/main` instead of checking out a tag
- Updated the `EC2_SSH_KEY` secret with a new key since the previous .pem was lost

## How Has This Been Tested?
- SSH connection to EC2 verified manually
- Instance switched from v0.4.0 tag to main branch and pulled successfully

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
