### PR TITLE
fix(docker): update postgres volume mount for v18 compatibility

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     environment:
       POSTGRES_DB: observal
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s


### PR DESCRIPTION
## Purpose / Description
Fix PostgreSQL 18 container failing to start after the automated version bump in 0905772b.

PostgreSQL 18+ changed the data directory layout — it expects the volume mount at `/var/lib/postgresql` (not `/var/lib/postgresql/data`). The renovate bot bumped `postgres:16` → `postgres:18` without updating the volume mount, breaking `docker compose up` for all users.

## Fixes
* Fixes the breakage introduced by 0905772b (`chore(deps): update postgres docker tag to v18`)

## Approach
Changed the volume mount from `pgdata:/var/lib/postgresql/data` to `pgdata:/var/lib/postgresql` in `docker/docker-compose.yml`. This matches the PostgreSQL 18+ requirement documented at https://github.com/docker-library/postgres/pull/1259.

## How Has This Been Tested?
- `docker compose down -v && docker compose up -d` — all 10 services start healthy
- PostgreSQL container passes healthcheck (`pg_isready`)
- Init container successfully runs migrations and seeds demo accounts
- API container starts and serves requests on port 8000

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A - docker config only)
