### PR TITLE
feat: insights migration

### DIFF
--- a/observal-server/alembic/versions/0004_add_insight_tables.py
+++ b/observal-server/alembic/versions/0004_add_insight_tables.py
@@ -1,0 +1,140 @@
+"""Add insight_reports, insight_session_facets, insight_session_meta tables.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-05-10
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+# Enum type name — managed explicitly to ensure clean downgrade
+_STATUS_ENUM_NAME = "insight_report_status"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # --- Fix insight_meta_cache FK (0003 omitted ondelete CASCADE) ---
+    if inspector.has_table("insight_meta_cache"):
+        # Drop and recreate the FK constraint with CASCADE
+        fks = inspector.get_foreign_keys("insight_meta_cache")
+        for fk in fks:
+            if fk.get("referred_table") == "agents" and "agent_id" in fk.get("constrained_columns", []):
+                op.drop_constraint(fk["name"], "insight_meta_cache", type_="foreignkey")
+                op.create_foreign_key(
+                    fk["name"],
+                    "insight_meta_cache",
+                    "agents",
+                    ["agent_id"],
+                    ["id"],
+                    ondelete="CASCADE",
+                )
+                break
+
+    # --- insight_reports ---
+    if not inspector.has_table("insight_reports"):
+        # Create enum type explicitly (checkfirst handles re-runs)
+        status_enum = sa.Enum("pending", "running", "completed", "failed", name=_STATUS_ENUM_NAME)
+        status_enum.create(bind, checkfirst=True)
+
+        op.create_table(
+            "insight_reports",
+            sa.Column(
+                "id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")
+            ),
+            sa.Column(
+                "agent_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("agents.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "triggered_by",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "status",
+                sa.Enum("pending", "running", "completed", "failed", name=_STATUS_ENUM_NAME, create_type=False),
+                nullable=False,
+                server_default="pending",
+            ),
+            sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("metrics", postgresql.JSON(), nullable=True),
+            sa.Column("narrative", postgresql.JSON(), nullable=True),
+            sa.Column("sessions_analyzed", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("llm_model_used", sa.String(255), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column(
+                "previous_report_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("insight_reports.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("aggregated_data", postgresql.JSON(), nullable=True),
+            sa.Column("report_version", sa.Integer(), nullable=False, server_default="1"),
+        )
+        op.create_index("ix_insight_reports_agent_id", "insight_reports", ["agent_id"])
+        op.create_index("ix_insight_reports_triggered_by", "insight_reports", ["triggered_by"])
+
+    # --- insight_session_facets ---
+    if not inspector.has_table("insight_session_facets"):
+        op.create_table(
+            "insight_session_facets",
+            sa.Column(
+                "id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")
+            ),
+            sa.Column(
+                "agent_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("agents.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("session_id", sa.Text(), nullable=False),
+            sa.Column("extracted_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("model_used", sa.String(255), nullable=True),
+            sa.Column("facets", postgresql.JSON(), nullable=False),
+            sa.UniqueConstraint("agent_id", "session_id", name="uq_session_facets_agent_session"),
+        )
+
+    # --- insight_session_meta ---
+    if not inspector.has_table("insight_session_meta"):
+        op.create_table(
+            "insight_session_meta",
+            sa.Column(
+                "id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")
+            ),
+            sa.Column(
+                "agent_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("agents.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("session_id", sa.Text(), nullable=False),
+            sa.Column("computed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("meta", postgresql.JSON(), nullable=False),
+            sa.UniqueConstraint("agent_id", "session_id", name="uq_session_meta_agent_session"),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("insight_session_meta")
+    op.drop_table("insight_session_facets")
+    op.drop_table("insight_reports")
+
+    # Drop the enum type created by upgrade
+    sa.Enum(name=_STATUS_ENUM_NAME).drop(op.get_bind(), checkfirst=True)

--- a/observal-server/alembic/versions/0005_add_insight_tables.py
+++ b/observal-server/alembic/versions/0005_add_insight_tables.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026-present Observal (BlazeUp AI LLP)
+# SPDX-License-Identifier: AGPL-3.0-only
+
 """Add insight_reports, insight_session_facets, insight_session_meta tables.
 
 Revision ID: 0005

--- a/observal-server/alembic/versions/0005_add_insight_tables.py
+++ b/observal-server/alembic/versions/0005_add_insight_tables.py
@@ -1,8 +1,8 @@
 """Add insight_reports, insight_session_facets, insight_session_meta tables.
 
-Revision ID: 0004
-Revises: 0003
-Create Date: 2026-05-10
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-05-12
 """
 
 import sqlalchemy as sa
@@ -10,8 +10,8 @@ from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
-revision = "0004"
-down_revision = "0003"
+revision = "0005"
+down_revision = "0004"
 branch_labels = None
 depends_on = None
 

--- a/observal-server/alembic/versions/0005_add_insight_tables.py
+++ b/observal-server/alembic/versions/0005_add_insight_tables.py
@@ -28,10 +28,12 @@ def upgrade() -> None:
 
     # --- Fix insight_meta_cache FK (0003 omitted ondelete CASCADE) ---
     if inspector.has_table("insight_meta_cache"):
-        # Drop and recreate the FK constraint with CASCADE
         fks = inspector.get_foreign_keys("insight_meta_cache")
         for fk in fks:
             if fk.get("referred_table") == "agents" and "agent_id" in fk.get("constrained_columns", []):
+                # Skip if already has CASCADE (e.g. table created via Base.metadata.create_all after model fix)
+                if fk.get("options", {}).get("ondelete", "").upper() == "CASCADE":
+                    break
                 op.drop_constraint(fk["name"], "insight_meta_cache", type_="foreignkey")
                 op.create_foreign_key(
                     fk["name"],
@@ -82,6 +84,8 @@ def upgrade() -> None:
             sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
             sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
             sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            # Self-referential FK: import ordering is handled by session_replication_role = 'replica'
+            # which disables FK enforcement, same pattern as listing/version circular FKs.
             sa.Column(
                 "previous_report_id",
                 postgresql.UUID(as_uuid=True),

--- a/observal-server/models/insight_meta_cache.py
+++ b/observal-server/models/insight_meta_cache.py
@@ -23,7 +23,9 @@ class InsightMetaCache(Base):
     __table_args__ = (UniqueConstraint("agent_id", "period_start", "period_end", name="uq_meta_cache_agent_period"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
+    )
     period_start: Mapped[str] = mapped_column(String(30), nullable=False)
     period_end: Mapped[str] = mapped_column(String(30), nullable=False)
     session_metas: Mapped[dict] = mapped_column(JSON, nullable=False)

--- a/observal-server/models/insight_report.py
+++ b/observal-server/models/insight_report.py
@@ -32,7 +32,9 @@ class InsightReport(Base):
     triggered_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
     )
-    status: Mapped[InsightReportStatus] = mapped_column(Enum(InsightReportStatus), default=InsightReportStatus.pending)
+    status: Mapped[InsightReportStatus] = mapped_column(
+        Enum(InsightReportStatus, name="insight_report_status"), default=InsightReportStatus.pending
+    )
     period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     period_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 

--- a/observal-server/models/insight_report.py
+++ b/observal-server/models/insight_report.py
@@ -26,8 +26,12 @@ class InsightReport(Base):
     __tablename__ = "insight_reports"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False)
-    triggered_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    triggered_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     status: Mapped[InsightReportStatus] = mapped_column(Enum(InsightReportStatus), default=InsightReportStatus.pending)
     period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     period_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/observal-server/models/insight_session_facets.py
+++ b/observal-server/models/insight_session_facets.py
@@ -19,7 +19,9 @@ class InsightSessionFacets(Base):
     __table_args__ = (UniqueConstraint("agent_id", "session_id", name="uq_session_facets_agent_session"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
+    )
     session_id: Mapped[str] = mapped_column(Text, nullable=False)
     extracted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     model_used: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/observal-server/models/insight_session_meta.py
+++ b/observal-server/models/insight_session_meta.py
@@ -19,7 +19,9 @@ class InsightSessionMeta(Base):
     __table_args__ = (UniqueConstraint("agent_id", "session_id", name="uq_session_meta_agent_session"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
+    )
     session_id: Mapped[str] = mapped_column(Text, nullable=False)
     computed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     meta: Mapped[dict] = mapped_column(JSON, nullable=False)

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -319,7 +319,7 @@ def _safe_tar_extract(tar: tarfile.TarFile, dest: Path) -> None:
             if member.issym() or member.islnk():
                 msg = f"Tar member {member.name!r} is a symlink (rejected for safety)"
                 raise ValueError(msg)
-        tar.extractall(dest)
+        tar.extractall(dest)  # nosec B202 — path traversal validated above
 
 
 def _parse_clickhouse_url(url: str) -> tuple[str, str, str, str]:

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -273,7 +273,9 @@ def _require_admin() -> None:
 def _build_select(table: str, columns: list[str]) -> str:
     """Build SELECT query, casting JSONB columns to ::text.
 
-    Table names are validated against INSERT_ORDER to prevent SQL injection.
+    Table names are validated against INSERT_ORDER as a defense-in-depth
+    assertion — callers always pass values from INSERT_ORDER, but this
+    guards against accidental misuse by future callers passing unknown tables.
     """
     if table not in INSERT_ORDER:
         msg = f"Unknown table: {table!r}"
@@ -311,9 +313,10 @@ def _safe_tar_extract(tar: tarfile.TarFile, dest: Path) -> None:
         tar.extractall(dest, filter="data")
     else:
         # Manual path traversal protection for Python < 3.12
+        dest_resolved = dest.resolve()
         for member in tar.getmembers():
             member_path = (dest / member.name).resolve()
-            if not str(member_path).startswith(str(dest.resolve())):
+            if not member_path.is_relative_to(dest_resolved):
                 msg = f"Tar member {member.name!r} would escape destination directory"
                 raise ValueError(msg)
             if member.issym() or member.islnk():
@@ -1004,11 +1007,11 @@ async def _import_archive(db_url: str, archive_path: Path, normalize_org_id: str
                 if "owner_org_id" not in tbl_cols:
                     continue
                 result = await conn.execute(
-                    f'UPDATE "{tbl}" SET "owner_org_id" = u."org_id" '
-                    f"FROM users u "
-                    f'WHERE "{tbl}"."{creator_col}" = u."id" '
+                    f'UPDATE "{tbl}" SET "owner_org_id" = "u"."org_id" '
+                    f'FROM "users" "u" '
+                    f'WHERE "{tbl}"."{creator_col}" = "u"."id" '
                     f'AND "{tbl}"."owner_org_id" IS NULL '
-                    f'AND u."org_id" IS NOT NULL'
+                    f'AND "u"."org_id" IS NOT NULL'
                 )
                 count = int(result.split()[-1])
                 if count > 0:

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -98,6 +98,11 @@ INSERT_ORDER: list[str] = [
     # Tier 11 — FK to scorecards + penalty_definitions
     "scorecard_dimensions",
     "trace_penalties",
+    # Tier 12 — FK to agents + users (insight tables)
+    "insight_meta_cache",
+    "insight_session_facets",
+    "insight_session_meta",
+    "insight_reports",
 ]
 
 JSONB_COLUMNS: dict[str, list[str]] = {
@@ -125,6 +130,10 @@ JSONB_COLUMNS: dict[str, list[str]] = {
     "scorecards": ["raw_output", "dimension_scores", "scoring_recommendations", "dimensions_skipped", "warnings"],
     "agent_components": ["config_override"],
     "exporter_configs": ["config"],
+    "insight_reports": ["metrics", "narrative", "aggregated_data"],
+    "insight_session_facets": ["facets"],
+    "insight_session_meta": ["meta"],
+    "insight_meta_cache": ["session_metas"],
 }
 
 # ── Phase 2: ClickHouse telemetry constants ──────────────
@@ -262,17 +271,23 @@ def _require_admin() -> None:
 
 
 def _build_select(table: str, columns: list[str]) -> str:
-    """Build SELECT query, casting JSONB columns to ::text."""
+    """Build SELECT query, casting JSONB columns to ::text.
+
+    Table names are validated against INSERT_ORDER to prevent SQL injection.
+    """
+    if table not in INSERT_ORDER:
+        msg = f"Unknown table: {table!r}"
+        raise ValueError(msg)
     jsonb_cols = JSONB_COLUMNS.get(table, [])
     if not jsonb_cols:
-        return f"SELECT * FROM {table}"
+        return f'SELECT * FROM "{table}"'
     parts = []
     for col in columns:
         if col in jsonb_cols:
-            parts.append(f"{col}::text AS {col}")
+            parts.append(f'"{col}"::text AS "{col}"')
         else:
-            parts.append(col)
-    return f"SELECT {', '.join(parts)} FROM {table}"
+            parts.append(f'"{col}"')
+    return f'SELECT {", ".join(parts)} FROM "{table}"'
 
 
 def _sha256_file(path: Path) -> str:
@@ -284,10 +299,34 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def _safe_tar_extract(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract tar archive safely, preventing path traversal on all Python versions.
+
+    On Python 3.12+ uses the built-in ``filter="data"`` parameter.
+    On older versions, manually validates each member path.
+    """
+    import sys
+
+    if sys.version_info >= (3, 12):
+        tar.extractall(dest, filter="data")
+    else:
+        # Manual path traversal protection for Python < 3.12
+        for member in tar.getmembers():
+            member_path = (dest / member.name).resolve()
+            if not str(member_path).startswith(str(dest.resolve())):
+                msg = f"Tar member {member.name!r} would escape destination directory"
+                raise ValueError(msg)
+            if member.issym() or member.islnk():
+                msg = f"Tar member {member.name!r} is a symlink (rejected for safety)"
+                raise ValueError(msg)
+        tar.extractall(dest)
+
+
 def _parse_clickhouse_url(url: str) -> tuple[str, str, str, str]:
     """Parse clickhouse://user:pass@host:port/db -> (http_url, db, user, password).
 
     Supports ``clickhouses://`` for TLS (maps to https, default port 8443).
+    Emits a warning when using unencrypted HTTP transport with credentials.
     """
     from urllib.parse import urlparse
 
@@ -306,6 +345,14 @@ def _parse_clickhouse_url(url: str) -> tuple[str, str, str, str]:
     db = (parsed.path or "/").strip("/") or "default"
     user = parsed.username or "default"
     password = parsed.password or ""
+
+    # Warn about cleartext credentials
+    if scheme == "http" and password:
+        rprint(
+            "[yellow]⚠  ClickHouse credentials will be sent over unencrypted HTTP.[/yellow]\n"
+            "[yellow]   Use clickhouses:// (TLS) for production environments.[/yellow]"
+        )
+
     return http_url, db, user, password
 
 
@@ -441,7 +488,7 @@ def _build_insert(table: str, columns: list[str], col_types: dict[str, str]) -> 
         else:
             parts.append(f"${i + 1}")
     placeholders = ", ".join(parts)
-    return f'INSERT INTO {table} ({cols_str}) VALUES ({placeholders}) ON CONFLICT ("id") DO NOTHING'
+    return f'INSERT INTO "{table}" ({cols_str}) VALUES ({placeholders}) ON CONFLICT ("id") DO NOTHING'
 
 
 async def _flush_batch(
@@ -802,7 +849,7 @@ async def _import_archive(db_url: str, archive_path: Path, normalize_org_id: str
     try:
         # Extract archive
         with tarfile.open(archive_path, "r:gz") as tar:
-            tar.extractall(staging_dir, filter="data")
+            _safe_tar_extract(tar, staging_dir)
 
         # Read manifest
         manifest_path = staging_dir / "manifest.json"
@@ -882,7 +929,7 @@ async def _import_archive(db_url: str, archive_path: Path, normalize_org_id: str
                     rprint(f"[dim]  Normalizing {len(org_rewrite_map)} source org(s) to: {normalize_org_id}[/dim]")
             elif source_org_ids:
                 # Check if any source orgs don't exist on the target
-                target_org_ids = {str(row["id"]) for row in await conn.fetch("SELECT id FROM organizations")}
+                target_org_ids = {str(row["id"]) for row in await conn.fetch('SELECT "id" FROM "organizations"')}
                 foreign_orgs = source_org_ids - target_org_ids
                 if foreign_orgs:
                     rprint(f"[yellow]⚠  Archive contains {len(foreign_orgs)} org(s) not present on target.[/yellow]")
@@ -942,7 +989,7 @@ async def _import_archive(db_url: str, archive_path: Path, normalize_org_id: str
                 await conn.execute("SET session_replication_role = 'origin'")
 
             # Post-import fixup: backfill NULL owner_org_id from creator's org
-            _org_backfill = [
+            _org_backfill: list[tuple[str, str]] = [
                 ("agents", "created_by"),
                 ("mcp_listings", "submitted_by"),
                 ("skill_listings", "submitted_by"),
@@ -957,11 +1004,11 @@ async def _import_archive(db_url: str, archive_path: Path, normalize_org_id: str
                 if "owner_org_id" not in tbl_cols:
                     continue
                 result = await conn.execute(
-                    f"UPDATE {tbl} SET owner_org_id = u.org_id "
+                    f'UPDATE "{tbl}" SET "owner_org_id" = u."org_id" '
                     f"FROM users u "
-                    f"WHERE {tbl}.{creator_col} = u.id "
-                    f"AND {tbl}.owner_org_id IS NULL "
-                    f"AND u.org_id IS NOT NULL"
+                    f'WHERE "{tbl}"."{creator_col}" = u."id" '
+                    f'AND "{tbl}"."owner_org_id" IS NULL '
+                    f'AND u."org_id" IS NOT NULL'
                 )
                 count = int(result.split()[-1])
                 if count > 0:
@@ -991,7 +1038,7 @@ async def _validate_archive(archive_path: Path, db_url: str | None) -> Validatio
     os.chmod(staging_dir, 0o700)
     try:
         with tarfile.open(archive_path, "r:gz") as tar:
-            tar.extractall(staging_dir, filter="data")
+            _safe_tar_extract(tar, staging_dir)
 
         manifest_path = staging_dir / "manifest.json"
         if not manifest_path.exists():
@@ -1033,7 +1080,7 @@ async def _validate_archive(archive_path: Path, db_url: str | None) -> Validatio
                     if table not in existing_tables:
                         cross_db_results[table] = (archive_count, -1)  # -1 signals table missing
                         continue
-                    db_count = await conn.fetchval(f"SELECT count(*) FROM {table}")
+                    db_count = await conn.fetchval(f'SELECT count(*) FROM "{table}"')
                     cross_db_results[table] = (archive_count, db_count)
             finally:
                 await conn.close()
@@ -1094,7 +1141,7 @@ async def _export_database(db_url: str, output_path: Path) -> ExportResult:
                         continue
 
                     # Discover columns via prepared statement
-                    stmt = await conn.prepare(f"SELECT * FROM {table} LIMIT 0")
+                    stmt = await conn.prepare(f'SELECT * FROM "{table}" LIMIT 0')
                     columns = [attr.name for attr in stmt.get_attributes()]
 
                     query = _build_select(table, columns)
@@ -1583,7 +1630,7 @@ async def _validate_fk_references(
             for i in range(0, len(id_list), 1000):
                 batch = id_list[i : i + 1000]
                 rows = await conn.fetch(
-                    f"SELECT id::text FROM {pg_table} WHERE id = ANY($1::uuid[])",
+                    f'SELECT id::text FROM "{pg_table}" WHERE id = ANY($1::uuid[])',
                     batch,
                 )
                 existing.update(row["id"] for row in rows)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -164,8 +164,8 @@ class TestPGEncoder:
 
 
 class TestConstants:
-    def test_insert_order_has_39_entries(self):
-        assert len(INSERT_ORDER) == 39
+    def test_insert_order_has_43_entries(self):
+        assert len(INSERT_ORDER) == 43
 
     def test_insert_order_no_duplicates(self):
         assert len(INSERT_ORDER) == len(set(INSERT_ORDER))
@@ -201,24 +201,23 @@ class TestBuildSelect:
     def test_table_with_jsonb_columns(self):
         columns = ["id", "name", "model_config_json", "external_mcps", "supported_ides", "created_at"]
         sql = _build_select("agents", columns)
-        assert "model_config_json::text AS model_config_json" in sql
-        assert "external_mcps::text AS external_mcps" in sql
-        assert "supported_ides::text AS supported_ides" in sql
+        assert '"model_config_json"::text AS "model_config_json"' in sql
+        assert '"external_mcps"::text AS "external_mcps"' in sql
+        assert '"supported_ides"::text AS "supported_ides"' in sql
         # Non-JSONB columns should not have ::text
         assert "id::text" not in sql
         assert "name::text" not in sql
 
     def test_table_without_jsonb_columns(self):
         sql = _build_select("organizations", ["id", "name", "slug"])
-        assert sql == "SELECT * FROM organizations"
+        assert sql == 'SELECT * FROM "organizations"'
 
     def test_agents_produces_correct_sql(self):
         columns = ["id", "name", "model_config_json"]
         sql = _build_select("agents", columns)
         assert sql.startswith("SELECT ")
-        assert "FROM agents" in sql
-        assert "model_config_json::text AS model_config_json" in sql
-        assert ", id," not in sql or "id" in sql  # id should be plain
+        assert 'FROM "agents"' in sql
+        assert '"model_config_json"::text AS "model_config_json"' in sql
 
     def test_all_jsonb_tables_produce_casts(self):
         for table, jsonb_cols in JSONB_COLUMNS.items():
@@ -226,7 +225,11 @@ class TestBuildSelect:
             columns = ["id", *jsonb_cols]
             sql = _build_select(table, columns)
             for col in jsonb_cols:
-                assert f"{col}::text AS {col}" in sql, f"Missing cast for {col} in {table}"
+                assert f'"{col}"::text AS "{col}"' in sql, f"Missing cast for {col} in {table}"
+
+    def test_unknown_table_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Unknown table"):
+            _build_select("nonexistent_table", ["id"])
 
 
 # ── 5. _require_admin Tests ─────────────────────────────
@@ -386,7 +389,7 @@ class TestBuildInsert:
         columns = ["id", "name", "email"]
         col_types = {"id": "uuid", "name": "text", "email": "text"}
         sql = _build_insert("users", columns, col_types)
-        assert 'INSERT INTO users ("id", "name", "email")' in sql
+        assert 'INSERT INTO "users" ("id", "name", "email")' in sql
 
     def test_multiple_jsonb_columns(self):
         columns = ["id", "tools_schema", "environment_variables", "supported_ides"]
@@ -533,13 +536,13 @@ class TestDataclasses:
     def test_import_result_fields(self):
         result = ImportResult(
             migration_id="abc-123",
-            tables_imported=39,
+            tables_imported=43,
             rows_inserted={"users": 10},
             rows_skipped={"users": 2},
             duration_seconds=2.0,
             warnings=[],
         )
-        assert result.tables_imported == 39
+        assert result.tables_imported == 43
         assert result.rows_inserted["users"] == 10
 
     def test_checksum_result_fields(self):
@@ -586,6 +589,12 @@ class TestInsertOrderDependencies:
         ("hook_downloads", "hook_listings"),
         ("prompt_downloads", "prompt_listings"),
         ("sandbox_downloads", "sandbox_listings"),
+        # Tier 12 — insight tables
+        ("insight_reports", "agents"),
+        ("insight_reports", "users"),
+        ("insight_session_facets", "agents"),
+        ("insight_session_meta", "agents"),
+        ("insight_meta_cache", "agents"),
     ]
 
     @pytest.mark.parametrize("child,parent", KNOWN_FK_PAIRS)
@@ -722,10 +731,10 @@ class TestJSONBCastProperty:
         sql = _build_select(table, columns)
 
         if not jsonb_cols:
-            assert sql == f"SELECT * FROM {table}"
+            assert sql == f'SELECT * FROM "{table}"'
         else:
             for col in jsonb_cols:
-                assert f"{col}::text AS {col}" in sql
+                assert f'"{col}"::text AS "{col}"' in sql
             # Non-JSONB columns should NOT have ::text
             assert "id::text" not in sql
 
@@ -927,6 +936,12 @@ class TestInsertOrderFKProperty:
         ("scorecard_dimensions", "scorecards"),
         ("trace_penalties", "scorecards"),
         ("trace_penalties", "penalty_definitions"),
+        # Tier 12 — insight tables
+        ("insight_reports", "agents"),
+        ("insight_reports", "users"),
+        ("insight_session_facets", "agents"),
+        ("insight_session_meta", "agents"),
+        ("insight_meta_cache", "agents"),
     ]
 
     @given(pair=st.sampled_from(ALL_FK_PAIRS))


### PR DESCRIPTION
## Purpose / Description

Add the four insight-related PostgreSQL tables (`insight_reports`, `insight_session_facets`, `insight_session_meta`, `insight_meta_cache`) to the Observal CLI migration system. This enables shallow-copy export/import of insight data alongside the existing tables, ensuring FK ordering is respected and JSONB columns are properly cast during export.

Previously, running `observal migrate export` and `import` would silently skip all insight data since the tables weren't in `INSERT_ORDER`. Operators migrating between environments would lose all generated insight reports.

## Approach

### 1. Constants Update (`observal_cli/cmd_migrate.py`)

**INSERT_ORDER** (39 → 43 entries):
- Added `insight_meta_cache`, `insight_session_facets`, `insight_session_meta`, `insight_reports` as Tier 12
- `insight_reports` is last among the four (most FK dependencies: agents, users, self-FK)
- Self-referential `previous_report_id` FK is handled by `session_replication_role = 'replica'` during import (same pattern as listing/version circular FKs)

**JSONB_COLUMNS** (4 new entries):
| Table | JSONB Columns |
|-------|--------------|
| `insight_reports` | `metrics`, `narrative`, `aggregated_data` |
| `insight_session_facets` | `facets` |
| `insight_session_meta` | `meta` |
| `insight_meta_cache` | `session_metas` |

### 2. Alembic Migration 0005 (`observal-server/alembic/versions/0005_add_insight_tables.py`)

- Creates `insight_reports`, `insight_session_facets`, `insight_session_meta` tables
- Idempotent: uses `has_table()` checks before each `create_table()` (handles race with `Base.metadata.create_all` on fresh installs)
- Creates indexes on `insight_reports.agent_id` and `insight_reports.triggered_by` (prevents full table scans on CASCADE deletes)
- Fixes `insight_meta_cache` FK to add missing `ondelete="CASCADE"`
- `downgrade()` drops tables in reverse creation order + cleans up enum type
- All timestamp columns use `server_default=sa.func.now()`

### 3. Model Fixes (`observal-server/models/`)

- Added `ondelete="CASCADE"` / `ondelete="SET NULL"` to insight model FKs (matching the Alembic DDL)
- Added `index=True` on `insight_reports.agent_id` and `triggered_by`

### 4. Test Updates (`tests/test_migrate.py`)

- Count assertion: 39 → 43
- Added 5 FK pairs to both `KNOWN_FK_PAIRS` and `ALL_FK_PAIRS`
- Existing Property 3 (JSONB cast) and Property 8 (FK ordering) automatically cover new tables

## How Has This Been Tested?

- Exported from dev.observal.io (43 tables, 665 rows including insight data)
- Imported into a fresh local instance with `--org-id` — 661 inserted, 4 skipped (expected demo conflicts)
- Verified insight data landed: 10 `insight_reports`, 6 `insight_session_facets`, 7 `insight_session_meta`
- Confirmed insight data is queryable via direct SQL after import
- Ruff check + format pass
- Note: Insights UI requires enterprise feature flag to display reports (data is present but API gates access)


## Execution Example

```
# Export from dev (includes insight tables)
observal migrate export --db-url <source-postgres-url> --output ./migration/dev-export.tar.gz

# Import into local with org remapping
observal migrate import --db-url <target-postgres-url> --archive ./migration/dev-export.tar.gz --org-id <target-org-id>
```

> [!NOTE]
> **Insights UI Visibility:** After import, the Insights page on localhost shows "No reports generated yet" despite the data being present in the database. This is because the `/api/v1/insights` endpoint is gated behind an enterprise feature flag — the API returns `"Insights is an enterprise feature"` when the flag is not enabled. The data is confirmed imported correctly via direct DB query:
>
> ```sql
> SELECT 'insight_reports' as tbl, count(*) FROM insight_reports
> UNION ALL SELECT 'insight_session_facets', count(*) FROM insight_session_facets
> UNION ALL SELECT 'insight_session_meta', count(*) FROM insight_session_meta;
> ```
>
> | tbl | count |
> |-----|-------|
> | insight_reports | 10 |
> | insight_session_facets | 6 |
> | insight_session_meta | 7 |
>
> This confirms the migration works correctly — the UI limitation is an access control gate, not a data issue.


## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A - backend only)
