### PR TITLE
chore(ci): add Codecov for test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,17 @@ jobs:
             --with asyncpg \
             --with hypothesis \
             --with pyarrow \
-            pytest ../tests/ -q
+            --with pytest-cov \
+            pytest ../tests/ -q \
+              ${{ matrix.python-version == '3.13' && '--cov=../observal_cli --cov=. --cov-report=xml' || '' }}
+
+      - name: Upload coverage to Codecov
+        if: needs.changes.outputs.python == 'true' && matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v5
+        with:
+          files: observal-server/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
 # ── Job 4: Next.js lint + typecheck ───────────────────────────────────────────
   web-lint:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
   <img src="https://img.shields.io/badge/python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python">
   <img src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" alt="Status">
   <a href="https://github.com/BlazeUp-AI/Observal/stargazers"><img src="https://img.shields.io/github/stars/BlazeUp-AI/Observal?style=flat-square" alt="Stars"></a>
+  <a href="https://codecov.io/gh/BlazeUp-AI/Observal"><img src="https://img.shields.io/codecov/c/github/BlazeUp-AI/Observal?style=flat-square&logo=codecov" alt="Coverage"></a>
 </p>
 
 > If you find Observal useful, please consider giving it a star. It helps others discover the project and keeps development going.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - "tests/"
+  - "ee/"
+  - "web/"
+  - "demo/"
+  - "alembic/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
 coverage:
   status:
     project:

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -51,3 +51,11 @@ dev = [
     "typer",
     "rich",
 ]
+
+[tool.coverage.run]
+source = ["../observal_cli", "."]
+omit = ["tests/*", "**/tests/*", "../ee/*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,16 @@ indent-style = "space"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 
+# ── Coverage ────────────────────────────────────────────
+
+[tool.coverage.run]
+source = ["observal_cli", "observal-server"]
+omit = ["tests/*", "ee/*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+
 # ── Bandit ───────────────────────────────────────────────
 
 [tool.bandit]
@@ -139,4 +149,5 @@ dev = [
     "ruff==0.15.12",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
+    "pytest-cov>=6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,16 +119,6 @@ indent-style = "space"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 
-# ── Coverage ────────────────────────────────────────────
-
-[tool.coverage.run]
-source = ["observal_cli", "observal-server"]
-omit = ["tests/*", "ee/*"]
-
-[tool.coverage.report]
-show_missing = true
-skip_empty = true
-
 # ── Bandit ───────────────────────────────────────────────
 
 [tool.bandit]

--- a/scripts/update_spdx_copyright.py
+++ b/scripts/update_spdx_copyright.py
@@ -128,7 +128,9 @@ def add_fresh_header(path: Path, name: str, email: str, year: int):
 
     prefix, suffix = style
     copyright_line = f"{prefix}SPDX-FileCopyrightText: {year} {name} <{email}>{suffix}"
+    # REUSE-IgnoreStart
     license_line = f"{prefix}SPDX-License-Identifier: AGPL-3.0-only{suffix}"
+    # REUSE-IgnoreEnd
 
     raw = path.read_bytes()
     eol = b"\r\n" if b"\r\n" in raw[:1024] else b"\n"

--- a/scripts/update_spdx_copyright.py
+++ b/scripts/update_spdx_copyright.py
@@ -120,6 +120,34 @@ def inject_copyright(path: Path, name: str, email: str, year: int):
     path.write_bytes("".join(lines).encode("utf-8", errors="replace"))
 
 
+def add_fresh_header(path: Path, name: str, email: str, year: int):
+    """Add a complete SPDX header to a file that doesn't have one yet."""
+    style = comment_prefix(path)
+    if style is None:
+        return
+
+    prefix, suffix = style
+    copyright_line = f"{prefix}SPDX-FileCopyrightText: {year} {name} <{email}>{suffix}"
+    license_line = f"{prefix}SPDX-License-Identifier: AGPL-3.0-only{suffix}"
+
+    raw = path.read_bytes()
+    eol = b"\r\n" if b"\r\n" in raw[:1024] else b"\n"
+    nl = "\r\n" if eol == b"\r\n" else "\n"
+
+    text = raw.decode("utf-8", errors="replace")
+
+    header = copyright_line + nl + license_line + nl + nl
+
+    # Preserve shebang on first line
+    if text.startswith("#!"):
+        newline_pos = text.index("\n") + 1
+        new_content = text[:newline_pos] + header + text[newline_pos:]
+    else:
+        new_content = header + text
+
+    path.write_bytes(new_content.encode("utf-8", errors="replace"))
+
+
 def staged_files() -> list[Path]:
     result = subprocess.run(
         ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
@@ -143,6 +171,7 @@ def main():
     year = date.today().year
     files = staged_files()
     modified = []
+    created = []
 
     for path in files:
         try:
@@ -151,6 +180,10 @@ def main():
             continue
 
         if not has_spdx_header(raw):
+            # New file without header — add a fresh one
+            add_fresh_header(path, name, email, year)
+            subprocess.run(["git", "add", str(path)])
+            created.append(str(path))
             continue
         if already_has_email(raw, email):
             continue
@@ -160,6 +193,10 @@ def main():
         subprocess.run(["git", "add", str(path)])
         modified.append(str(path))
 
+    if created:
+        print(f"[spdx-update] Added SPDX header to {len(created)} new file(s):")
+        for f in created:
+            print(f"  {f}")
     if modified:
         print(f"[spdx-update] Added copyright line to {len(modified)} file(s):")
         for f in modified:


### PR DESCRIPTION
## Purpose / Description
Set up Codecov integration so we get coverage reports on every PR and can identify untested areas. Currently there is no coverage tracking in CI.

## Fixes
* Fixes #807

## Approach
- Add `pytest-cov` to dev dependencies
- Modify CI workflow to generate coverage XML on the Python 3.13 matrix run and upload via `codecov/codecov-action@v5`
- Add `codecov.yml` with project/patch coverage targets and ignore paths (tests, ee, web, demo, alembic)
- Add Codecov badge to README
- Place `[tool.coverage.*]` config in `observal-server/pyproject.toml` (where pytest actually runs from)

## How Has This Been Tested?

- Ran `pytest --cov` locally — 2380 tests pass, `coverage.xml` generated correctly
- Verified test files are excluded from the report (46% real coverage)
- CODECOV_TOKEN has been added as a repo secret

## Learning (optional, can help others)
- Coverage config must live in the `pyproject.toml` of the working directory where pytest runs, not the repo root
- `codecov/codecov-action@v5` requires a token even for public repos for reliable uploads
- https://docs.codecov.com/docs/quick-start
- https://github.com/codecov/codecov-action

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)