### PR TITLE
fix: return conflict for duplicate component submissions

### DIFF
--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -9,10 +9,12 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
 from api.routes.component_versions import create_version_router
+from api.routes.submission_conflicts import raise_listing_integrity_error
 from api.sanitize import escape_like
 from models.hook import HookDownload, HookListing, HookVersion
 from models.mcp import ListingStatus
@@ -50,33 +52,35 @@ async def submit_hook(
         submitted_by=current_user.id,
         owner_org_id=current_user.org_id,
     )
-    db.add(listing)
-    await db.flush()
+    try:
+        db.add(listing)
+        await db.flush()
 
-    version = HookVersion(
-        listing_id=listing.id,
-        version=req.version,
-        description=req.description,
-        event=req.event,
-        execution_mode=req.execution_mode,
-        priority=req.priority,
-        handler_type=req.handler_type,
-        handler_config=req.handler_config,
-        input_schema=req.input_schema,
-        output_schema=req.output_schema,
-        scope=req.scope,
-        tool_filter=req.tool_filter,
-        file_pattern=req.file_pattern,
-        supported_ides=req.supported_ides,
-        status=ListingStatus.pending,
-        released_by=current_user.id,
-        released_at=datetime.now(UTC),
-    )
-    db.add(version)
-    await db.flush()
-
-    listing.latest_version_id = version.id
-    await db.commit()
+        version = HookVersion(
+            listing_id=listing.id,
+            version=req.version,
+            description=req.description,
+            event=req.event,
+            execution_mode=req.execution_mode,
+            priority=req.priority,
+            handler_type=req.handler_type,
+            handler_config=req.handler_config,
+            input_schema=req.input_schema,
+            output_schema=req.output_schema,
+            scope=req.scope,
+            tool_filter=req.tool_filter,
+            file_pattern=req.file_pattern,
+            supported_ides=req.supported_ides,
+            status=ListingStatus.pending,
+            released_by=current_user.id,
+            released_at=datetime.now(UTC),
+        )
+        db.add(version)
+        await db.flush()
+        listing.latest_version_id = version.id
+        await db.commit()
+    except IntegrityError as exc:
+        await raise_listing_integrity_error(db, "hook", req.name, exc)
     await db.refresh(listing)
     await audit(
         current_user, "hook.submit", resource_type="hook", resource_id=str(listing.id), resource_name=listing.name

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -10,10 +10,12 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
 from api.routes.component_versions import create_version_router
+from api.routes.submission_conflicts import raise_listing_integrity_error
 from api.sanitize import escape_like
 from database import async_session
 from models.mcp import ListingStatus, McpDownload, McpListing, McpValidationResult, McpVersion
@@ -140,35 +142,37 @@ async def submit_mcp(
         submitted_by=current_user.id,
         owner_org_id=current_user.org_id,
     )
-    db.add(listing)
-    await db.flush()
+    try:
+        db.add(listing)
+        await db.flush()
 
-    version = McpVersion(
-        listing_id=listing.id,
-        version=req.version,
-        description=req.description,
-        transport=req.transport or ("sse" if req.url and not req.command else "stdio" if req.command else None),
-        framework=req.framework,
-        docker_image=req.docker_image,
-        command=req.command,
-        args=req.args,
-        url=req.url,
-        headers=[h.model_dump() for h in req.headers] if req.headers else None,
-        auto_approve=req.auto_approve,
-        environment_variables=[ev.model_dump() for ev in req.environment_variables],
-        supported_ides=req.supported_ides,
-        setup_instructions=req.setup_instructions,
-        changelog=req.changelog,
-        source_url=req.git_url,
-        status=ListingStatus.pending,
-        released_by=current_user.id,
-        released_at=datetime.now(UTC),
-    )
-    db.add(version)
-    await db.flush()
-
-    listing.latest_version_id = version.id
-    await db.commit()
+        version = McpVersion(
+            listing_id=listing.id,
+            version=req.version,
+            description=req.description,
+            transport=req.transport or ("sse" if req.url and not req.command else "stdio" if req.command else None),
+            framework=req.framework,
+            docker_image=req.docker_image,
+            command=req.command,
+            args=req.args,
+            url=req.url,
+            headers=[h.model_dump() for h in req.headers] if req.headers else None,
+            auto_approve=req.auto_approve,
+            environment_variables=[ev.model_dump() for ev in req.environment_variables],
+            supported_ides=req.supported_ides,
+            setup_instructions=req.setup_instructions,
+            changelog=req.changelog,
+            source_url=req.git_url,
+            status=ListingStatus.pending,
+            released_by=current_user.id,
+            released_at=datetime.now(UTC),
+        )
+        db.add(version)
+        await db.flush()
+        listing.latest_version_id = version.id
+        await db.commit()
+    except IntegrityError as exc:
+        await raise_listing_integrity_error(db, "MCP", req.name, exc)
     await db.refresh(listing)
 
     if req.client_analysis:

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -10,10 +10,12 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
 from api.routes.component_versions import create_version_router
+from api.routes.submission_conflicts import raise_listing_integrity_error
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.prompt import PromptDownload, PromptListing, PromptVersion
@@ -51,28 +53,30 @@ async def submit_prompt(
         submitted_by=current_user.id,
         owner_org_id=current_user.org_id,
     )
-    db.add(listing)
-    await db.flush()
+    try:
+        db.add(listing)
+        await db.flush()
 
-    version = PromptVersion(
-        listing_id=listing.id,
-        version=req.version,
-        description=req.description,
-        category=req.category,
-        template=req.template,
-        variables=req.variables,
-        model_hints=req.model_hints,
-        tags=req.tags,
-        supported_ides=req.supported_ides,
-        status=ListingStatus.pending,
-        released_by=current_user.id,
-        released_at=datetime.now(UTC),
-    )
-    db.add(version)
-    await db.flush()
-
-    listing.latest_version_id = version.id
-    await db.commit()
+        version = PromptVersion(
+            listing_id=listing.id,
+            version=req.version,
+            description=req.description,
+            category=req.category,
+            template=req.template,
+            variables=req.variables,
+            model_hints=req.model_hints,
+            tags=req.tags,
+            supported_ides=req.supported_ides,
+            status=ListingStatus.pending,
+            released_by=current_user.id,
+            released_at=datetime.now(UTC),
+        )
+        db.add(version)
+        await db.flush()
+        listing.latest_version_id = version.id
+        await db.commit()
+    except IntegrityError as exc:
+        await raise_listing_integrity_error(db, "prompt", req.name, exc)
     await db.refresh(listing)
     await audit(
         current_user, "prompt.submit", resource_type="prompt", resource_id=str(listing.id), resource_name=listing.name

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -8,10 +8,12 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
 from api.routes.component_versions import create_version_router
+from api.routes.submission_conflicts import raise_listing_integrity_error
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.sandbox import SandboxDownload, SandboxListing, SandboxVersion
@@ -49,31 +51,33 @@ async def submit_sandbox(
         submitted_by=current_user.id,
         owner_org_id=current_user.org_id,
     )
-    db.add(listing)
-    await db.flush()
+    try:
+        db.add(listing)
+        await db.flush()
 
-    version = SandboxVersion(
-        listing_id=listing.id,
-        version=req.version,
-        description=req.description,
-        runtime_type=req.runtime_type,
-        image=req.image,
-        dockerfile_url=req.dockerfile_url,
-        resource_limits=req.resource_limits,
-        network_policy=req.network_policy,
-        allowed_mounts=req.allowed_mounts,
-        env_vars=req.env_vars,
-        entrypoint=req.entrypoint,
-        supported_ides=req.supported_ides,
-        status=ListingStatus.pending,
-        released_by=current_user.id,
-        released_at=datetime.now(UTC),
-    )
-    db.add(version)
-    await db.flush()
-
-    listing.latest_version_id = version.id
-    await db.commit()
+        version = SandboxVersion(
+            listing_id=listing.id,
+            version=req.version,
+            description=req.description,
+            runtime_type=req.runtime_type,
+            image=req.image,
+            dockerfile_url=req.dockerfile_url,
+            resource_limits=req.resource_limits,
+            network_policy=req.network_policy,
+            allowed_mounts=req.allowed_mounts,
+            env_vars=req.env_vars,
+            entrypoint=req.entrypoint,
+            supported_ides=req.supported_ides,
+            status=ListingStatus.pending,
+            released_by=current_user.id,
+            released_at=datetime.now(UTC),
+        )
+        db.add(version)
+        await db.flush()
+        listing.latest_version_id = version.id
+        await db.commit()
+    except IntegrityError as exc:
+        await raise_listing_integrity_error(db, "sandbox", req.name, exc)
     await db.refresh(listing)
     await audit(
         current_user, "sandbox.submit", resource_type="sandbox", resource_id=str(listing.id), resource_name=listing.name

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -9,10 +9,12 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
 from api.routes.component_versions import create_version_router
+from api.routes.submission_conflicts import raise_listing_integrity_error
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
 from models.skill import SkillDownload, SkillListing, SkillVersion
@@ -50,34 +52,36 @@ async def submit_skill(
         submitted_by=current_user.id,
         owner_org_id=current_user.org_id,
     )
-    db.add(listing)
-    await db.flush()
+    try:
+        db.add(listing)
+        await db.flush()
 
-    version = SkillVersion(
-        listing_id=listing.id,
-        version=req.version,
-        description=req.description,
-        skill_path=req.skill_path,
-        target_agents=req.target_agents,
-        task_type=req.task_type,
-        triggers=req.triggers,
-        slash_command=req.slash_command,
-        has_scripts=req.has_scripts,
-        has_templates=req.has_templates,
-        supported_ides=req.supported_ides,
-        is_power=req.is_power,
-        power_md=req.power_md,
-        mcp_server_config=req.mcp_server_config,
-        activation_keywords=req.activation_keywords,
-        status=ListingStatus.pending,
-        released_by=current_user.id,
-        released_at=datetime.now(UTC),
-    )
-    db.add(version)
-    await db.flush()
-
-    listing.latest_version_id = version.id
-    await db.commit()
+        version = SkillVersion(
+            listing_id=listing.id,
+            version=req.version,
+            description=req.description,
+            skill_path=req.skill_path,
+            target_agents=req.target_agents,
+            task_type=req.task_type,
+            triggers=req.triggers,
+            slash_command=req.slash_command,
+            has_scripts=req.has_scripts,
+            has_templates=req.has_templates,
+            supported_ides=req.supported_ides,
+            is_power=req.is_power,
+            power_md=req.power_md,
+            mcp_server_config=req.mcp_server_config,
+            activation_keywords=req.activation_keywords,
+            status=ListingStatus.pending,
+            released_by=current_user.id,
+            released_at=datetime.now(UTC),
+        )
+        db.add(version)
+        await db.flush()
+        listing.latest_version_id = version.id
+        await db.commit()
+    except IntegrityError as exc:
+        await raise_listing_integrity_error(db, "skill", req.name, exc)
     await db.refresh(listing)
     await audit(
         current_user, "skill.submit", resource_type="skill", resource_id=str(listing.id), resource_name=listing.name

--- a/observal-server/api/routes/submission_conflicts.py
+++ b/observal-server/api/routes/submission_conflicts.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _looks_like_unique_violation(exc: IntegrityError) -> bool:
+    text = f"{exc} {getattr(exc, 'orig', '')}".lower()
+    return any(token in text for token in ("duplicate key", "unique constraint", "unique violation"))
+
+
+async def raise_listing_integrity_error(
+    db: AsyncSession,
+    listing_type: str,
+    listing_name: str,
+    exc: IntegrityError,
+) -> None:
+    await db.rollback()
+    if _looks_like_unique_violation(exc):
+        raise HTTPException(
+            status_code=409,
+            detail=f"A {listing_type} listing named '{listing_name}' already exists",
+        ) from exc
+    raise exc

--- a/observal-server/tests/test_submission_conflicts.py
+++ b/observal-server/tests/test_submission_conflicts.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+
+def _duplicate_name_error() -> IntegrityError:
+    return IntegrityError(
+        "INSERT",
+        {},
+        Exception('duplicate key value violates unique constraint "mcp_listings_name_key"'),
+    )
+
+
+@pytest.mark.asyncio
+async def test_listing_integrity_error_returns_conflict_for_unique_violation():
+    from api.routes.submission_conflicts import raise_listing_integrity_error
+
+    db = MagicMock()
+    db.rollback = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await raise_listing_integrity_error(db, "MCP", "duplicate-test", _duplicate_name_error())
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "A MCP listing named 'duplicate-test' already exists"
+    db.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_mcp_returns_conflict_when_duplicate_name_hits_flush():
+    from api.routes.mcp import submit_mcp
+    from schemas.mcp import McpSubmitRequest
+
+    no_existing = MagicMock()
+    no_existing.scalars.return_value.first.return_value = None
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=no_existing)
+    db.flush = AsyncMock(side_effect=_duplicate_name_error())
+    db.rollback = AsyncMock()
+
+    current_user = MagicMock()
+    current_user.id = uuid.uuid4()
+    current_user.org_id = None
+
+    req = McpSubmitRequest(
+        name="duplicate-test",
+        version="1.0.0",
+        description="Test duplicate handling",
+        category="developer-tools",
+        owner="admin",
+        command="node",
+        args=["index.js"],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await submit_mcp(req, MagicMock(), db, current_user)
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "A MCP listing named 'duplicate-test' already exists"
+    db.rollback.assert_awaited_once()


### PR DESCRIPTION
﻿## Summary
- catch duplicate-name IntegrityError during MCP/component submit flush or commit paths
- return 409 Conflict with a clear duplicate listing message instead of surfacing a 500
- cover the shared conflict helper and MCP submit flush failure path with tests

## Testing
- uv run pytest tests/test_submission_conflicts.py -q
- uv run python -m py_compile api/routes/submission_conflicts.py api/routes/mcp.py api/routes/skill.py api/routes/hook.py api/routes/prompt.py api/routes/sandbox.py tests/test_submission_conflicts.py
- git diff --check

Fixes #900
