### PR TITLE
docs: add reconcile CLI helper guide

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,6 +32,7 @@
 * [observal ops](cli/ops.md)
 * [observal admin](cli/admin.md)
 * [observal doctor](cli/doctor.md)
+* [reconcile recovery helper](cli/reconcile.md)
 * [observal profile](cli/profile.md)
 * [observal self](cli/self.md)
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -22,6 +22,7 @@ Complete reference for the `observal` CLI. Every subcommand has its own page —
 | [`observal ops`](ops.md) | Observability and operations (traces, spans, metrics, feedback) |
 | [`observal admin`](admin.md) | Admin operations (settings, users, review, eval, canaries) |
 | [`observal doctor`](doctor.md) | Diagnose IDE compatibility; `doctor patch` applies instrumentation |
+| [`python -m observal_cli.cmd_reconcile`](reconcile.md) | Recover stale session JSONL tails after a missed Stop hook |
 | [`observal migrate`](migrate.md) | Export/import PostgreSQL registry (shallow copy) and ClickHouse telemetry (deep copy) |
 | [`observal profile`](profile.md) | Switch IDE configs to a git-hosted profile |
 | [`observal self`](self.md) | Upgrade or downgrade the CLI |

--- a/docs/cli/reconcile.md
+++ b/docs/cli/reconcile.md
@@ -1,0 +1,89 @@
+<!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# reconcile recovery helper
+
+`observal_cli.cmd_reconcile` is the crash-recovery scanner for session JSONL ingestion. It is not a public `observal` subcommand; it runs as a small Python module so hooks can launch it in the background without blocking your IDE.
+
+## What it does
+
+When an IDE exits cleanly, the Stop hook pushes the final tail of the session JSONL file and marks the cursor as finalized. If the IDE is killed, crashes, or exits before Stop fires, the local cursor can have unsynced bytes.
+
+The reconcile helper:
+
+1. Reads `~/.observal/sync_state.json`.
+2. Finds sessions that are not finalized.
+3. Looks up the matching JSONL file under Claude Code or Kiro session directories.
+4. Skips sessions that are still active, too old, or have no new bytes.
+5. Pushes the remaining JSONL tail as a synthetic Stop event.
+6. Marks the cursor finalized after a successful push.
+
+This prevents lost final turns after a hard kill or missed Stop hook.
+
+## When it runs automatically
+
+Claude Code and Kiro hooks spawn the reconciler after non-Stop events:
+
+```bash
+python -m observal_cli.cmd_reconcile
+```
+
+The spawn is best-effort and detached. Hook execution continues even if the background process cannot start.
+
+The helper only recovers sessions whose JSONL file is idle for at least two minutes and no older than seven days. That delay avoids pushing the tail of a session that is still being written.
+
+## Run it manually
+
+Use manual invocation when a session is missing final turns in Observal after an IDE crash:
+
+```bash
+python -m observal_cli.cmd_reconcile
+```
+
+It uses the same local auth/config file as hooks:
+
+```text
+~/.observal/config.json
+```
+
+If the config file is missing, the server URL is missing, or no access token/API key is available, the helper exits without changing anything.
+
+## Output and logs
+
+The reconciler is quiet by design. A successful run normally prints nothing.
+
+Useful files:
+
+| Path | Purpose |
+| --- | --- |
+| `~/.observal/sync_state.json` | Per-session cursor offsets, line counts, and `finalized` status |
+| `~/.observal/sync.log` | Hook ingestion errors written by the session push pipeline |
+
+If a recovered tail still does not appear in Observal, check:
+
+```bash
+cat ~/.observal/sync.log
+cat ~/.observal/sync_state.json
+```
+
+Common causes are an expired token, an unreachable Observal server, or a session file that is still newer than the two-minute stale threshold.
+
+## Session files scanned
+
+The helper searches recent session files in:
+
+| IDE | Path |
+| --- | --- |
+| Claude Code | `~/.claude/projects/<project>/<session_id>.jsonl` |
+| Claude Code subagents | `~/.claude/projects/<project>/<session_id>/subagents/<agent_id>.jsonl` |
+| Kiro | `~/.kiro/sessions/cli/<session_id>.jsonl` |
+
+Only sessions modified within the last seven days are considered.
+
+## Related
+
+* [`observal doctor`](doctor.md)
+* [`observal scan`](scan.md)
+* [Telemetry pipeline](../self-hosting/telemetry-pipeline.md)


### PR DESCRIPTION
﻿## Summary
- add a CLI reference page for the reconcile recovery helper
- document automatic background invocation and manual module invocation
- link sync state and sync log paths for troubleshooting
- link the page from docs/SUMMARY.md and docs/cli/README.md

## Testing
- rg -n "cmd_reconcile|reconcile|sync\.log|sync_state|manual|automatic|python -m observal_cli.cmd_reconcile" docs/cli/reconcile.md docs/cli/README.md docs/SUMMARY.md
- git diff --check

Fixes #863
