### PR TITLE
docs: add Sandbox CLI reference

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -29,6 +29,7 @@
 * [observal pull](cli/pull.md)
 * [observal registry](cli/registry.md)
 * [observal agent](cli/agent.md)
+* [observal sandbox](cli/sandbox.md)
 * [observal ops](cli/ops.md)
 * [observal admin](cli/admin.md)
 * [observal doctor](cli/doctor.md)

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -19,6 +19,7 @@ Complete reference for the `observal` CLI. Every subcommand has its own page —
 | [`observal pull`](pull.md) | Install a published agent into an IDE |
 | [`observal registry`](registry.md) | Publish and manage components (MCP / skill / hook / prompt / sandbox) |
 | [`observal agent`](agent.md) | Author and publish agents |
+| [`observal sandbox`](sandbox.md) | Submit, list, install, edit, and delete sandbox runtime listings |
 | [`observal ops`](ops.md) | Observability and operations (traces, spans, metrics, feedback) |
 | [`observal admin`](admin.md) | Admin operations (settings, users, review, eval, canaries) |
 | [`observal doctor`](doctor.md) | Diagnose IDE compatibility; `doctor patch` applies instrumentation |

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -1,0 +1,179 @@
+<!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# observal sandbox
+
+Manage sandbox listings from the CLI. Sandboxes describe isolated runtimes that agents can use for safer code execution, testing, and tool workflows.
+
+## Synopsis
+
+```bash
+observal sandbox <command> [args] [options]
+```
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `submit` | Submit a new sandbox for review |
+| `list` | List approved sandboxes |
+| `show` | Show sandbox details |
+| `install` | Generate install config for a sandbox |
+| `edit` | Edit a draft, rejected, or pending sandbox submission |
+| `delete` | Delete a sandbox |
+
+IDs can be UUIDs, names, row numbers from the last list output, or aliases created with [`observal config alias`](config.md).
+
+## `observal sandbox submit`
+
+Submit a new sandbox for review. Only submit sandboxes you created or are the point of contact for.
+
+### Synopsis
+
+```bash
+observal sandbox submit [OPTIONS]
+```
+
+### Options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--from-file <text>` | `-f` | Create from a JSON file |
+| `--draft` | | Save as draft instead of submitting for review |
+| `--submit <sandbox-id>` | | Submit an existing draft for review |
+
+### Examples
+
+```bash
+observal sandbox submit
+observal sandbox submit --from-file sandbox.json --draft
+observal sandbox submit --submit 498c17ac-1234-4567-89ab-cdef01234567
+```
+
+## `observal sandbox list`
+
+List approved sandboxes.
+
+### Synopsis
+
+```bash
+observal sandbox list [OPTIONS]
+```
+
+### Options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--runtime <text>` | `-r` | Filter by runtime |
+| `--search <text>` | `-s` | Search sandboxes |
+| `--output <text>` | `-o` | Output format: `table`, `json`, or `plain`; default `table` |
+
+### Examples
+
+```bash
+observal sandbox list
+observal sandbox list --runtime docker
+observal sandbox list --search python --output json
+```
+
+## `observal sandbox show`
+
+Show details for one sandbox.
+
+### Synopsis
+
+```bash
+observal sandbox show <sandbox-id> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description |
+| --- | --- |
+| `<sandbox-id>` | ID, name, row number, or `@alias` |
+
+### Options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--output <text>` | `-o` | Output format; default `table` |
+
+## `observal sandbox install`
+
+Generate install config for one sandbox.
+
+### Synopsis
+
+```bash
+observal sandbox install <sandbox-id> --ide <ide> [--raw]
+```
+
+### Arguments
+
+| Argument | Description |
+| --- | --- |
+| `<sandbox-id>` | Sandbox ID, name, row number, or `@alias` |
+
+### Options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--ide <text>` | `-i` | Target IDE; required |
+| `--raw` | | Output raw JSON only |
+
+## `observal sandbox edit`
+
+Edit a draft, rejected, or pending sandbox submission.
+
+### Synopsis
+
+```bash
+observal sandbox edit <sandbox-id> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description |
+| --- | --- |
+| `<sandbox-id>` | ID, name, row number, or `@alias` |
+
+### Options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--from-file <text>` | `-f` | Load updates from a JSON file |
+| `--name <text>` | `-n` | New listing name |
+| `--description <text>` | `-d` | New description |
+| `--version <text>` | `-v` | New version string |
+| `--runtime-type <text>` | `-r` | New runtime type |
+| `--image <text>` | `-i` | New container image |
+
+## `observal sandbox delete`
+
+Delete a sandbox.
+
+### Synopsis
+
+```bash
+observal sandbox delete <sandbox-id> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description |
+| --- | --- |
+| `<sandbox-id>` | ID, name, row number, or `@alias` |
+
+### Options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--yes` | `-y` | Skip confirmation |
+
+## Related
+
+* [`observal agent`](agent.md)
+* [`observal registry`](registry.md)
+* [`observal config`](config.md)


### PR DESCRIPTION
﻿## Summary
- add a dedicated `observal sandbox` CLI reference page
- document submit, list, show, install, edit, and delete with current flags
- link the new page from docs/SUMMARY.md and docs/cli/README.md

## Testing
- uv run --frozen --python 3.11 python -m observal_cli.main sandbox --help
- uv run --frozen --python 3.11 python -m observal_cli.main sandbox submit --help
- uv run --frozen --python 3.11 python -m observal_cli.main sandbox list --help
- uv run --frozen --python 3.11 python -m observal_cli.main sandbox show --help
- uv run --frozen --python 3.11 python -m observal_cli.main sandbox install --help
- uv run --frozen --python 3.11 python -m observal_cli.main sandbox edit --help
- uv run --frozen --python 3.11 python -m observal_cli.main sandbox delete --help
- git diff --check

Fixes #859
