### PR TITLE
docs: add Component CLI reference

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@
 * [observal scan](cli/scan.md)
 * [observal pull](cli/pull.md)
 * [observal registry](cli/registry.md)
+* [observal component](cli/component.md)
 * [observal agent](cli/agent.md)
 * [observal ops](cli/ops.md)
 * [observal admin](cli/admin.md)

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -18,6 +18,7 @@ Complete reference for the `observal` CLI. Every subcommand has its own page —
 | [`observal scan`](scan.md) | Discover what's installed across your IDEs (read-only) |
 | [`observal pull`](pull.md) | Install a published agent into an IDE |
 | [`observal registry`](registry.md) | Publish and manage components (MCP / skill / hook / prompt / sandbox) |
+| [`observal component`](component.md) | Publish and list versions for registry components |
 | [`observal agent`](agent.md) | Author and publish agents |
 | [`observal ops`](ops.md) | Observability and operations (traces, spans, metrics, feedback) |
 | [`observal admin`](admin.md) | Admin operations (settings, users, review, eval, canaries) |

--- a/docs/cli/component.md
+++ b/docs/cli/component.md
@@ -1,0 +1,112 @@
+<!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# observal component
+
+Manage versions for registry components. Components include hooks, skills, prompts, MCP servers, and sandboxes.
+
+## Synopsis
+
+```bash
+observal component <command> [args] [options]
+```
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `version` | Manage component versions |
+
+## `observal component version`
+
+Manage version history for registry components.
+
+### Synopsis
+
+```bash
+observal component version <command> [args] [options]
+```
+
+### Commands
+
+| Command | What it does |
+| --- | --- |
+| `publish` | Publish a new version for a registry component |
+| `list` | List version history for a registry component |
+
+## `observal component version publish`
+
+Publish a new version for a registry component.
+
+### Synopsis
+
+```bash
+observal component version publish <component-type> <listing> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description |
+| --- | --- |
+| `<component-type>` | Component type: `hook`, `skill`, `prompt`, `mcp`, or `sandbox` |
+| `<listing>` | Listing name or ID |
+
+### Options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--version <text>` | `-v` | Version to publish, for example `1.2.0` |
+| `--description <text>` | `-d` | Short description of this version; required |
+| `--changelog <text>` | | Changelog notes |
+| `--ide <text>` | | Supported IDE; repeat for multiple IDEs |
+| `--extra <text>` | | Extra JSON for type-specific fields |
+
+### Example
+
+```bash
+observal component version publish skill code-reviewer \
+  --version 1.2.0 \
+  --description "Improve review checklist coverage" \
+  --changelog "Adds security and testing prompts" \
+  --ide claude-code \
+  --ide cursor
+```
+
+## `observal component version list`
+
+List version history for a registry component.
+
+### Synopsis
+
+```bash
+observal component version list <component-type> <listing> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description |
+| --- | --- |
+| `<component-type>` | Component type: `hook`, `skill`, `prompt`, `mcp`, or `sandbox` |
+| `<listing>` | Listing name or ID |
+
+### Options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--output <text>` | `-o` | Output format: `table` or `json`; default `table` |
+
+### Example
+
+```bash
+observal component version list skill code-reviewer --output json
+```
+
+## Related
+
+* [`observal registry`](registry.md)
+* [`observal skill`](skill.md)
+* [`observal prompt`](prompt.md)
+* [`observal mcp`](mcp.md)
+* [`observal sandbox`](sandbox.md)


### PR DESCRIPTION
﻿## Summary
- add a dedicated `observal component` CLI reference page
- document `component version publish` and `component version list` with current flags
- link the new page from docs/SUMMARY.md and docs/cli/README.md

## Testing
- uv run --frozen --python 3.11 python -m observal_cli.main component --help
- uv run --frozen --python 3.11 python -m observal_cli.main component version --help
- uv run --frozen --python 3.11 python -m observal_cli.main component version publish --help
- uv run --frozen --python 3.11 python -m observal_cli.main component version list --help
- git diff --check

Fixes #856
