### PR TITLE
feat(deploy): slim curl-install to use pre-built GHCR images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,28 +267,22 @@ jobs:
         run: |
           VERSION="${{ needs.preflight.outputs.version }}"
           STAGING="observal-server-v${VERSION}"
-          mkdir -p "$STAGING/docker/server-package"
-          mkdir -p "$STAGING/docker/clickhouse"
+          mkdir -p "$STAGING/clickhouse"
           mkdir -p "$STAGING/grafana"
 
-          # Docker Compose and configs
-          cp docker/docker-compose.yml "$STAGING/docker/"
-          cp docker/Dockerfile.api "$STAGING/docker/"
-          cp docker/Dockerfile.web "$STAGING/docker/"
-          cp docker/entrypoint.sh "$STAGING/docker/"
-          cp docker/nginx.conf "$STAGING/docker/"
-          cp -r docker/clickhouse/ "$STAGING/docker/clickhouse/"
-          cp -r docker/server-package/ "$STAGING/docker/server-package/"
-
-          # Application source
-          cp -r observal-server/ "$STAGING/observal-server/"
-          cp -r ee/ "$STAGING/ee/"
-          cp -r web/ "$STAGING/web/"
-          cp -r grafana/ "$STAGING/grafana/"
-          cp pyproject.toml "$STAGING/"
-          cp otel-collector-config.yaml "$STAGING/"
+          # Standalone compose (pre-built images, no source needed)
+          cp docker/server-package/docker-compose.yml "$STAGING/"
+          cp docker/server-package/setup.sh "$STAGING/"
+          cp docker/server-package/env.template "$STAGING/"
+          cp docker/nginx.conf "$STAGING/nginx.conf"
           cp prometheus.yml "$STAGING/"
           cp .env.example "$STAGING/"
+
+          # Supporting configs
+          cp -r docker/clickhouse/config.d "$STAGING/clickhouse/config.d"
+          cp -r docker/clickhouse/users.d "$STAGING/clickhouse/users.d"
+          cp -r grafana/provisioning "$STAGING/grafana/provisioning"
+          cp -r grafana/dashboards "$STAGING/grafana/dashboards"
 
           tar -czf "observal-server-v${VERSION}.tar.gz" "$STAGING"
 

--- a/docker/server-package/docker-compose.yml
+++ b/docker/server-package/docker-compose.yml
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Standalone Observal deployment — uses pre-built images from GHCR.
+# Generated for curl-install: no source code or build context required.
+
+services:
+  observal-init:
+    image: ghcr.io/blazeup-ai/observal-api:${OBSERVAL_VERSION:-latest}
+    command: ["/app/entrypoint.sh"]
+    env_file:
+      - ./.env
+    environment:
+      - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-local}
+      - DATA_RETENTION_DAYS=${DATA_RETENTION_DAYS:-90}
+    depends_on:
+      observal-db:
+        condition: service_healthy
+      observal-clickhouse:
+        condition: service_healthy
+      observal-redis:
+        condition: service_healthy
+    restart: "no"
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - observal-net
+
+  observal-api:
+    image: ghcr.io/blazeup-ai/observal-api:${OBSERVAL_VERSION:-latest}
+    command: ["/app/.venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]
+    env_file:
+      - ./.env
+    environment:
+      - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-local}
+      - DATA_RETENTION_DAYS=${DATA_RETENTION_DAYS:-90}
+      - JWT_KEY_DIR=/data/keys
+      - SKIP_DDL_ON_STARTUP=true
+      - DEMO_SUPER_ADMIN_EMAIL=${DEMO_SUPER_ADMIN_EMAIL:-super@demo.example}
+      - DEMO_SUPER_ADMIN_PASSWORD=${DEMO_SUPER_ADMIN_PASSWORD:-super-changeme}
+      - DEMO_ADMIN_EMAIL=${DEMO_ADMIN_EMAIL:-admin@demo.example}
+      - DEMO_ADMIN_PASSWORD=${DEMO_ADMIN_PASSWORD:-admin-changeme}
+      - DEMO_REVIEWER_EMAIL=${DEMO_REVIEWER_EMAIL:-reviewer@demo.example}
+      - DEMO_REVIEWER_PASSWORD=${DEMO_REVIEWER_PASSWORD:-reviewer-changeme}
+      - DEMO_USER_EMAIL=${DEMO_USER_EMAIL:-user@demo.example}
+      - DEMO_USER_PASSWORD=${DEMO_USER_PASSWORD:-user-changeme}
+    volumes:
+      - apidata:/data
+    depends_on:
+      observal-init:
+        condition: service_completed_successfully
+      observal-redis:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/readyz')\""]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      replicas: ${API_REPLICAS:-1}
+      resources:
+        limits:
+          memory: 512M
+    networks:
+      - observal-net
+
+  observal-db:
+    image: postgres:18
+    ports:
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
+    env_file:
+      - ./.env
+    environment:
+      POSTGRES_DB: observal
+    volumes:
+      - pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    networks:
+      - observal-net
+
+  observal-clickhouse:
+    image: clickhouse/clickhouse-server:26.4
+    ports:
+      - "${CLICKHOUSE_HOST_PORT:-8123}:8123"
+    env_file:
+      - ./.env
+    environment:
+      CLICKHOUSE_DB: observal
+      MAX_SERVER_MEMORY_USAGE_RATIO: "0.8"
+    volumes:
+      - chdata:/var/lib/clickhouse
+      - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
+      - ./clickhouse/users.d:/etc/clickhouse-server/users.d
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --password ${CLICKHOUSE_PASSWORD:-clickhouse} --query 'SELECT 1'"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    deploy:
+      resources:
+        limits:
+          memory: ${CLICKHOUSE_MEMORY_LIMIT:-2G}
+    networks:
+      - observal-net
+
+  observal-redis:
+    image: redis:8-alpine
+    ports:
+      - "${REDIS_HOST_PORT:-6379}:6379"
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - observal-net
+
+  observal-worker:
+    image: ghcr.io/blazeup-ai/observal-api:${OBSERVAL_VERSION:-latest}
+    command: ["/app/.venv/bin/python", "-c", "import asyncio; asyncio.set_event_loop(asyncio.new_event_loop()); from arq import run_worker; from worker import WorkerSettings; run_worker(WorkerSettings)"]
+    env_file:
+      - ./.env
+    environment:
+      - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-local}
+    depends_on:
+      observal-init:
+        condition: service_completed_successfully
+      observal-redis:
+        condition: service_healthy
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      replicas: ${WORKER_REPLICAS:-1}
+      resources:
+        limits:
+          memory: 512M
+    networks:
+      - observal-net
+
+  observal-web:
+    image: ghcr.io/blazeup-ai/observal-web:${OBSERVAL_VERSION:-latest}
+    ports:
+      - "${WEB_HOST_PORT:-3000}:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://observal-lb:80}
+    depends_on:
+      observal-lb:
+        condition: service_started
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - observal-net
+
+  observal-lb:
+    image: nginx:alpine
+    ports:
+      - "${API_HOST_PORT:-8000}:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      observal-api:
+        condition: service_healthy
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+    networks:
+      - observal-net
+
+  observal-prometheus:
+    image: prom/prometheus:v3.11.3
+    ports:
+      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      observal-api:
+        condition: service_healthy
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - observal-net
+
+  observal-grafana:
+    image: grafana/grafana-oss:11.6.5
+    ports:
+      - "${GRAFANA_HOST_PORT:-3001}:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-clickhouse}
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    depends_on:
+      observal-clickhouse:
+        condition: service_healthy
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    networks:
+      - observal-net
+
+volumes:
+  pgdata:
+  chdata:
+  redisdata:
+  grafanadata:
+  apidata:
+
+networks:
+  observal-net:
+    driver: bridge

--- a/docker/server-package/setup.sh
+++ b/docker/server-package/setup.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 INSTALL_DIR="${OBSERVAL_INSTALL_DIR:-/opt/observal}"
 ENV_FILE="$INSTALL_DIR/.env"
-COMPOSE_FILE="$INSTALL_DIR/docker/docker-compose.yml"
+COMPOSE_FILE="$INSTALL_DIR/docker-compose.yml"
 
 # ── Helpers ──────────────────────────────────────────────────
 
@@ -80,7 +80,7 @@ echo ""
 
 info "Writing configuration to $ENV_FILE"
 
-cp "$INSTALL_DIR/docker/server-package/env.template" "$ENV_FILE"
+cp "$INSTALL_DIR/env.template" "$ENV_FILE"
 
 sed -i.bak \
   -e "s|__SECRET_KEY__|$SECRET_KEY|g" \
@@ -95,7 +95,7 @@ chmod 600 "$ENV_FILE"
 
 # ── Enterprise: authenticate to private registry ────────────
 
-COMPOSE_FILES="-f docker/docker-compose.yml"
+COMPOSE_FILES="-f docker-compose.yml"
 
 if [ "$DEPLOYMENT_MODE" = "enterprise" ]; then
   echo ""
@@ -103,7 +103,7 @@ if [ "$DEPLOYMENT_MODE" = "enterprise" ]; then
   if [ -n "$ENTERPRISE_TOKEN" ]; then
     info "Authenticating with enterprise registry..."
     echo "$ENTERPRISE_TOKEN" | docker login ghcr.io -u observal-customer --password-stdin
-    COMPOSE_FILES="-f docker/docker-compose.yml -f docker/docker-compose.enterprise.yml"
+    COMPOSE_FILES="-f docker-compose.yml -f docker-compose.enterprise.yml"
     info "Enterprise images will be used."
   fi
 fi
@@ -139,7 +139,7 @@ info "  API:        ${FRONTEND_URL%:*}:8000"
 info "  Grafana:    ${FRONTEND_URL%:*}:3001 (admin/admin)"
 info ""
 info "  Config:     $ENV_FILE"
-info "  Logs:       cd $INSTALL_DIR && docker compose -f docker/docker-compose.yml logs -f"
-info "  Stop:       cd $INSTALL_DIR && docker compose -f docker/docker-compose.yml down"
+info "  Logs:       cd $INSTALL_DIR && docker compose -f docker-compose.yml logs -f"
+info "  Stop:       cd $INSTALL_DIR && docker compose -f docker-compose.yml down"
 info ""
 info "Next: create your first admin account at $FRONTEND_URL"

--- a/install-server.sh
+++ b/install-server.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 GITHUB_REPO="BlazeUp-AI/Observal"
 VERSION="${OBSERVAL_VERSION:-latest}"
 INSTALL_DIR="${OBSERVAL_INSTALL_DIR:-/opt/observal}"
+BASE_URL="${OBSERVAL_BASE_URL:-}"  # Override for testing (e.g. http://localhost:9999)
 
 # ── Helpers ──────────────────────────────────────────────────
 
@@ -41,7 +42,11 @@ info "Installing Observal Server $VERSION"
 # ── Download ─────────────────────────────────────────────────
 
 ARTIFACT="observal-server-${VERSION}.tar.gz"
-URL="https://github.com/$GITHUB_REPO/releases/download/$VERSION/$ARTIFACT"
+if [ -n "$BASE_URL" ]; then
+  URL="${BASE_URL}/${ARTIFACT}"
+else
+  URL="https://github.com/$GITHUB_REPO/releases/download/$VERSION/$ARTIFACT"
+fi
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -71,4 +76,4 @@ fi
 # ── Run setup ────────────────────────────────────────────────
 
 info "Running guided setup..."
-OBSERVAL_INSTALL_DIR="$INSTALL_DIR" bash "$INSTALL_DIR/docker/server-package/setup.sh"
+OBSERVAL_INSTALL_DIR="$INSTALL_DIR" bash "$INSTALL_DIR/setup.sh"


### PR DESCRIPTION
## Purpose / Description

The curl-install flow (`curl ... | bash`) currently downloads a ~50MB tarball containing the full source code, even though Docker images are pre-built on GHCR. This PR slims the server package to only include configs (~50KB) and creates a standalone `docker-compose.yml` that uses pre-built images directly.

## Fixes
* Improves #<!-- curl-install experience — no issue yet -->

## Approach

1. **New `docker/server-package/docker-compose.yml`** — standalone compose file that only references GHCR images (no `build:` directives). All volume mount paths are relative to a flat install directory.
2. **Slimmed release tarball** — only ships: compose file, setup.sh, env.template, nginx.conf, prometheus.yml, and clickhouse/grafana configs.
3. **Path adjustments** in `setup.sh` and `install-server.sh` to match the new flat layout.
4. **Added `OBSERVAL_BASE_URL` env var** to `install-server.sh` for testing against local/custom servers.

## How Has This Been Tested?

- Verified tarball layout matches all compose volume mount paths
- Existing releases (`v0.3.4`) confirm the curl-install plumbing works; this PR changes the tarball contents and path layout which will take effect on next release cut

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)