### PR TITLE
fix(compliance): preserve SPDX headers in generated changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -2,7 +2,15 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 [changelog]
-header = """# Changelog
+header = """<!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Naraen Rammoorthi <naraen13@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 SrihariLegend <sriharilegend23@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 DoomsCoder <vedantkakade05@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Changelog
 
 All notable changes to this project will be documented in this file.\n
 """


### PR DESCRIPTION
## Purpose / Description

`git-cliff` regenerates `CHANGELOG.md` from scratch using the `header` template in `cliff.toml`. The template was missing the SPDX copyright block, so every release cut strips the headers.

## Approach

Added the SPDX comment block to the `header` field in `cliff.toml` so it's included every time the changelog is regenerated.

## How Has This Been Tested?

- Verified template output matches expected CHANGELOG.md header format

## Note

The release PR (#919) was generated before this fix, so its CHANGELOG.md is missing the headers. Merge this first, then regenerate the release PR (or rebase it).

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)