### PR TITLE
fix(deploy): fix curl|bash interactive prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,32 @@ See [CHANGELOG.md](CHANGELOG.md) for recent updates.
 
 ## Quick start
 
-See [SETUP.md](SETUP.md) for the full setup guide.
+### One-line install (recommended)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install-server.sh | bash
+```
+
+Downloads a lightweight config package, runs a guided setup, pulls pre-built Docker images from GHCR, and starts the full stack. No repo clone required.
+
+### From source
 
 ```bash
 git clone https://github.com/BlazeUp-AI/Observal.git && cd Observal
 cp .env.example .env
 make up
-uv tool install --editable .
+```
+
+### Connect your IDE
+
+```bash
+uv tool install observal-cli
 observal auth login
 ```
+
+This installs hooks in your IDE (Claude Code, Kiro, etc.) to automatically capture traces.
+
+See [SETUP.md](SETUP.md) for the full setup guide.
 
 ## Supported IDEs
 
@@ -205,10 +222,6 @@ observal support inspect observal-support-*.tar.gz
 
 To report a vulnerability, please use [GitHub Private Vulnerability Reporting](https://github.com/BlazeUp-AI/Observal/security/advisories) or email contact@blazeup.app. **Do not open a public issue.** See [SECURITY.md](SECURITY.md).
 
-## License
-
-GNU Affero General Public License v3.0 (AGPL-3.0). See [LICENSE](LICENSE).
-
 ## Star history
 
 <a href="https://www.star-history.com/?repos=BlazeUp-AI%2FObserval&type=date&legend=top-left">
@@ -218,3 +231,7 @@ GNU Affero General Public License v3.0 (AGPL-3.0). See [LICENSE](LICENSE).
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=BlazeUp-AI/Observal&type=date&legend=top-left" />
  </picture>
 </a>
+
+## License
+
+GNU Affero General Public License v3.0 (AGPL-3.0). See [LICENSE](LICENSE).

--- a/install-server.sh
+++ b/install-server.sh
@@ -59,7 +59,7 @@ curl -fsSL -o "$TMPDIR/$ARTIFACT" "$URL" || die "Download failed. Check that $VE
 if [ -d "$INSTALL_DIR" ] && [ "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
   warn "Directory $INSTALL_DIR already exists and is not empty."
   printf 'Overwrite? [y/N]: '
-  read -r confirm
+  read -r confirm </dev/tty
   [ "$confirm" = "y" ] || [ "$confirm" = "Y" ] || die "Aborted."
 fi
 
@@ -76,4 +76,4 @@ fi
 # ── Run setup ────────────────────────────────────────────────
 
 info "Running guided setup..."
-OBSERVAL_INSTALL_DIR="$INSTALL_DIR" bash "$INSTALL_DIR/setup.sh"
+OBSERVAL_INSTALL_DIR="$INSTALL_DIR" bash "$INSTALL_DIR/setup.sh" </dev/tty

--- a/install-server.sh
+++ b/install-server.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Options (via env vars):
 #   OBSERVAL_VERSION=latest        Version to install (default: latest)
 #   OBSERVAL_INSTALL_DIR=/path     Install directory (default: /opt/observal)
+#   OBSERVAL_FORCE=1               Skip overwrite confirmation on re-install
 
 GITHUB_REPO="BlazeUp-AI/Observal"
 VERSION="${OBSERVAL_VERSION:-latest}"
@@ -57,10 +58,14 @@ curl -fsSL -o "$TMPDIR/$ARTIFACT" "$URL" || die "Download failed. Check that $VE
 # ── Unpack ───────────────────────────────────────────────────
 
 if [ -d "$INSTALL_DIR" ] && [ "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
-  warn "Directory $INSTALL_DIR already exists and is not empty."
-  printf 'Overwrite? [y/N]: '
-  read -r confirm </dev/tty
-  [ "$confirm" = "y" ] || [ "$confirm" = "Y" ] || die "Aborted."
+  if [ "${OBSERVAL_FORCE:-}" = "1" ]; then
+    info "Overwriting existing installation at $INSTALL_DIR"
+  else
+    warn "Directory $INSTALL_DIR already exists and is not empty."
+    printf 'Overwrite? [y/N]: '
+    read -r confirm </dev/tty
+    [ "$confirm" = "y" ] || [ "$confirm" = "Y" ] || die "Aborted."
+  fi
 fi
 
 info "Unpacking to $INSTALL_DIR..."

--- a/install-server.sh
+++ b/install-server.sh
@@ -9,13 +9,23 @@ set -euo pipefail
 #
 # Options (via env vars):
 #   OBSERVAL_VERSION=latest        Version to install (default: latest)
-#   OBSERVAL_INSTALL_DIR=/path     Install directory (default: /opt/observal)
+#   OBSERVAL_INSTALL_DIR=/path     Install directory (default: ~/.observal on macOS, /opt/observal on Linux)
 #   OBSERVAL_FORCE=1               Skip overwrite confirmation on re-install
 
 GITHUB_REPO="BlazeUp-AI/Observal"
 VERSION="${OBSERVAL_VERSION:-latest}"
-INSTALL_DIR="${OBSERVAL_INSTALL_DIR:-/opt/observal}"
 BASE_URL="${OBSERVAL_BASE_URL:-}"  # Override for testing (e.g. http://localhost:9999)
+
+# Default install directory: ~/.observal on macOS (Docker file sharing),
+# /opt/observal on Linux (standard system path).
+if [ -z "${OBSERVAL_INSTALL_DIR:-}" ]; then
+  case "$(uname -s)" in
+    Darwin) INSTALL_DIR="$HOME/.observal" ;;
+    *)      INSTALL_DIR="/opt/observal" ;;
+  esac
+else
+  INSTALL_DIR="$OBSERVAL_INSTALL_DIR"
+fi
 
 # ── Helpers ──────────────────────────────────────────────────
 

--- a/observal-server/api/routes/sessions.py
+++ b/observal-server/api/routes/sessions.py
@@ -139,58 +139,46 @@ async def _list_sessions_query(
     is_admin: bool,
     uid: str,
 ) -> list[dict]:
-    """Session list from session_stats_agg — no FINAL, no JSONExtract.
+    """Session list from session_stats_agg FINAL.
 
     session_stats_agg is an AggregatingMergeTree table fed by session_stats_mv.
-    Each row is a partial aggregate for (project_id, session_id); GROUP BY merges
-    parts at read time.  At ~1 tiny row per session this is orders of magnitude
-    cheaper than session_events FINAL (ClickHouse Bluesky benchmark: 44s → 6ms).
+    FINAL merges parts at read time; at ~1 row per session this is fast and
+    avoids illegal nested-aggregation errors with SimpleAggregateFunction columns.
     """
-    user_where = ""
+    where_parts = ["session_id != ''", "parent_session_id = ''"]
     params: dict[str, str] = {}
 
     if not is_admin:
-        user_where = "AND user_id = {uid:String} "
+        where_parts.append("user_id = {uid:String}")
         params["param_uid"] = uid
-
-    # HAVING filters operate on the merged aggregate result (correct for all
-    # SimpleAggregateFunction columns; cannot use WHERE for those columns).
-    having_parts = ["anyLast(parent_session_id) = ''"]
     if days is not None and days > 0:
-        having_parts.append(f"max(last_event_time) > now() - INTERVAL {int(days)} DAY")
+        where_parts.append(f"last_event_time > now() - INTERVAL {int(days)} DAY")
     if platform:
-        having_parts.append("anyLast(ide) = {platform:String}")
+        where_parts.append("ide = {platform:String}")
         params["param_platform"] = platform
-    having_clause = "HAVING " + " AND ".join(having_parts) + " "
+
+    where_clause = "WHERE " + " AND ".join(where_parts) + " "
 
     return await _ch_json(
         "SELECT "
         "session_id, "
-        "minIf(first_event_time, "
-        "  first_event_time > '1970-01-02 00:00:00' AND first_event_time < '2099-01-01 00:00:00'"
-        ") AS first_event_time, "
-        "maxIf(last_event_time, "
-        "  last_event_time > '1970-01-02 00:00:00' AND last_event_time < '2099-01-01 00:00:00'"
-        ") AS last_event_time, "
-        "(max(last_event_time) > now() - INTERVAL 30 MINUTE) AS is_active, "
-        "sum(prompt_count)       AS prompt_count, "
-        "0                       AS api_request_count, "
-        "sum(tool_result_count)  AS tool_result_count, "
-        "sum(input_tokens)       AS total_input_tokens, "
-        "sum(output_tokens)      AS total_output_tokens, "
-        "sum(cache_read_tokens)  AS total_cache_read_tokens, "
-        "sum(cache_write_tokens) AS total_cache_write_tokens, "
-        "sum(total_credits)      AS total_credits, "
-        "anyLastIf(model, model != '') AS model, "
-        "anyLast(ide)      AS ide, "
-        "anyLast(agent_id) AS agent_id, "
-        "anyLast(user_id)  AS user_id "
-        "FROM session_stats_agg "
-        "WHERE session_id != '' "
-        + user_where
-        + "GROUP BY session_id "
-        + having_clause
-        + "ORDER BY last_event_time DESC "
+        "if(first_event_time > '1970-01-02 00:00:00' AND first_event_time < '2099-01-01 00:00:00', "
+        "   first_event_time, last_event_time) AS first_event_time, "
+        "last_event_time, "
+        "(last_event_time > now() - INTERVAL 30 MINUTE) AS is_active, "
+        "prompt_count, "
+        "0                   AS api_request_count, "
+        "tool_result_count, "
+        "input_tokens        AS total_input_tokens, "
+        "output_tokens       AS total_output_tokens, "
+        "cache_read_tokens   AS total_cache_read_tokens, "
+        "cache_write_tokens  AS total_cache_write_tokens, "
+        "total_credits, "
+        "model, "
+        "ide, "
+        "agent_id, "
+        "user_id "
+        "FROM session_stats_agg FINAL " + where_clause + "ORDER BY last_event_time DESC "
         "LIMIT 100",
         params or None,
     )


### PR DESCRIPTION
## Purpose / Description

When running `curl -fsSL ... | bash`, stdin is the pipe from curl — so all `read` prompts in the install/setup scripts immediately get EOF and exit. This is why the installer aborts at the first prompt.

## Approach

Redirect interactive reads from `/dev/tty` so terminal input works regardless of how the script was invoked. This is the standard pattern used by Docker, rustup, nvm, etc.

## How Has This Been Tested?

- Reproduced the failure: `curl ... | bash` exits at first prompt
- After fix: `read </dev/tty` reads from the terminal correctly

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)