### PR TITLE
fix(security): apply execution time floor to every ClickHouse query (OBSV-SEC-026)

### DIFF
--- a/observal-server/services/clickhouse.py
+++ b/observal-server/services/clickhouse.py
@@ -78,7 +78,8 @@ async def _query(sql: str, params: dict | None = None, *, data: str | None = Non
         "user": CLICKHOUSE_USER,
         "password": CLICKHOUSE_PASSWORD,
     }
-    # Inject admin-configured resource overrides (e.g. max_memory_usage)
+    # Safety floors first, then admin overrides (which can raise but not remove limits)
+    query_params.update(DEFAULT_QUERY_SETTINGS)
     if _resource_overrides:
         query_params.update(_resource_overrides)
     if params:
@@ -488,6 +489,18 @@ RESOURCE_SETTINGS_MAP: dict[str, tuple[str, type]] = {
     "resource.group_by_spill_mb": ("max_bytes_before_external_group_by", int),
     "resource.sort_spill_mb": ("max_bytes_before_external_sort", int),
     "resource.join_memory_mb": ("max_bytes_in_join", int),
+}
+
+# Safety floor applied to every ClickHouse query (SEC-026).
+# Row-read and result-row caps are intentionally omitted from the universal default
+# because the insights pipeline, worker batch jobs, and session exports legitimately
+# read and return millions of rows.  Those limits belong at individual call-sites
+# or in admin-configured _resource_overrides, not here.
+#
+# max_execution_time IS applied universally: even background jobs should not run
+# forever.  The 5-minute ceiling is high enough for any legitimate batch query.
+DEFAULT_QUERY_SETTINGS: dict[str, str] = {
+    "max_execution_time": "300",  # 5 min ceiling — applies to background workers too
 }
 
 # Per-query overrides injected into every HTTP request.

--- a/tests/test_clickhouse_resource_tuning.py
+++ b/tests/test_clickhouse_resource_tuning.py
@@ -225,8 +225,12 @@ class TestQueryInjection:
         params = kwargs.get("params", {})
         assert params["max_memory_usage"] == "300000000"
 
-    async def test_no_overrides_no_extra_params(self):
-        """When no overrides are set, only standard params are sent."""
+    async def test_no_overrides_default_execution_timeout_present(self):
+        """Every query carries a max_execution_time floor even with no admin overrides.
+
+        Row-read/result caps are intentionally NOT in the universal default because
+        insights and batch worker queries legitimately read millions of rows.
+        """
         import services.clickhouse as ch
 
         ch._resource_overrides = {}
@@ -239,7 +243,10 @@ class TestQueryInjection:
 
         _, kwargs = mock_client.post.call_args
         params = kwargs.get("params", {})
-        assert "max_memory_usage" not in params
+        assert params["max_execution_time"] == "300"
+        # Row caps must NOT be forced on every query (would break insights/batch jobs)
+        assert "max_rows_to_read" not in params
+        assert "max_result_rows" not in params
 
     async def test_query_params_override_resource_params(self):
         """Explicit query params (e.g. param_x) take precedence over overrides."""


### PR DESCRIPTION
## Purpose / Description

Without an explicit timeout, any ClickHouse query can run indefinitely. A runaway dashboard request, misconfigured filter, or pathological query plan can pin the ClickHouse node and degrade the entire platform.

## Fixes

* Fixes OBSV-SEC-026 — ClickHouse queries have no default resource controls

## Approach

Add `DEFAULT_QUERY_SETTINGS` applied to every `_query()` call:

```python
DEFAULT_QUERY_SETTINGS: dict[str, str] = {
    "max_execution_time": "300",  # 5-minute ceiling per query
}
```

**Why only `max_execution_time` and not row caps?**

`_query()` is shared by user-facing API routes *and* the insights batch pipeline. The insights pipeline fires up to 50 concurrent `asyncio.gather` transcript queries (`session_events FINAL WHERE session_id = ? LIMIT 500`) plus a dozen `compute_all_metrics` range scans — each is a fast scoped query, but hard row caps on the shared function would break them.

Row limits belong at individual call-sites or in admin `_resource_overrides`, not here.

**Why is 300s safe for insights?** `max_execution_time` is per *ClickHouse query*, not per pipeline run. Each individual query in the insights pipeline completes in seconds. The pipeline might take several minutes total (50+ queries + LLM calls), but no single ClickHouse query should ever legitimately run for 5 minutes.

Priority order: `DEFAULT_QUERY_SETTINGS` → `_resource_overrides` → per-call `params`. Admin overrides can raise the timeout but cannot remove it.

## How Has This Been Tested?

`tests/test_clickhouse_resource_tuning.py` — 24 tests pass.

Key assertions:
- `max_execution_time: "300"` present in HTTP params on every `_query()` call
- `max_rows_to_read` and `max_result_rows` explicitly **not** in the universal default (regression guard)
- Admin `_resource_overrides` still apply on top of defaults

```
24 passed in 95s
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A — backend only)