### PR TITLE
fix(security): restrict support diagnostics to admin role (OBSV-SEC-008)

### DIFF
--- a/observal-server/api/routes/support.py
+++ b/observal-server/api/routes/support.py
@@ -25,9 +25,10 @@ from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from sqlalchemy import text
 
-from api.deps import get_current_user, get_db
+from api.deps import get_db, require_role
 from api.ratelimit import limiter
 from config import Settings, settings
+from models.user import UserRole
 from services.clickhouse import CLICKHOUSE_DB, _query
 from services.redis import get_redis
 
@@ -461,7 +462,7 @@ COLLECTORS: dict[str, Any] = {
 async def collect_diagnostics(
     request: Request,
     body: CollectRequest,
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_role(UserRole.admin)),
     db: AsyncSession = Depends(get_db),
 ) -> CollectResponse:
     """Run server-side diagnostic collectors and return results.


### PR DESCRIPTION
## Purpose / Description

`POST /api/v1/support/collect` was accessible to any authenticated user. The endpoint runs collectors that return Alembic revision, ClickHouse table list, row counts across every Postgres and ClickHouse table, error fingerprints, and the in-memory log buffer — operational data that should only be visible to admins/operators.

## Fixes

* Fixes OBSV-SEC-008 — support diagnostics available to any authenticated user

## Approach

One-line change: swap `get_current_user` for `require_role(UserRole.admin)` on the `collect_diagnostics` endpoint.

```python
# Before
user: User = Depends(get_current_user)

# After
user: User = Depends(require_role(UserRole.admin))
```

Non-admin callers receive HTTP 403. Admin and super-admin roles are unaffected.

## How Has This Been Tested?

Existing support test suite — 128 tests pass.

```
128 passed in 1.96s
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A — backend only)