### PR TITLE
fix(security): redact secrets before sending content to LLM providers (OBSV-SEC-021)

### DIFF
--- a/observal-server/services/eval/eval_engine.py
+++ b/observal-server/services/eval/eval_engine.py
@@ -92,9 +92,11 @@ class LLMJudgeBackend(EvalBackend):
     """LLM-as-judge backend using OpenAI-compatible or Bedrock APIs."""
 
     async def score(self, template: dict, trace: dict, span: dict) -> dict:
+        from services.secret_redactor import sanitize_for_provider
+
         prompt = template["prompt"].format(
-            trace=json.dumps(trace, default=str)[:2000],
-            span=json.dumps(span, default=str)[:2000],
+            trace=sanitize_for_provider(json.dumps(trace, default=str)[:2000]),
+            span=sanitize_for_provider(json.dumps(span, default=str)[:2000]),
         )
         result = await _call_model(prompt)
         if isinstance(result, dict) and "score" in result:

--- a/observal-server/services/eval/ragas_eval.py
+++ b/observal-server/services/eval/ragas_eval.py
@@ -29,6 +29,7 @@ import structlog
 
 from services.clickhouse import insert_scores
 from services.eval.eval_engine import _call_model
+from services.secret_redactor import sanitize_for_provider
 
 logger = structlog.get_logger(__name__)
 
@@ -108,7 +109,10 @@ def _safe_score(result: dict) -> float:
 
 
 async def _eval_faithfulness(answer: str, context: str) -> dict:
-    prompt = FAITHFULNESS_PROMPT.format(context=context[:4000], answer=answer[:2000])
+    prompt = FAITHFULNESS_PROMPT.format(
+        context=sanitize_for_provider(context[:4000]),
+        answer=sanitize_for_provider(answer[:2000]),
+    )
     result = await _call_model(prompt)
     if not result or "score" not in result:
         return {"score": 0.0, "reason": "Model returned invalid response"}
@@ -116,7 +120,10 @@ async def _eval_faithfulness(answer: str, context: str) -> dict:
 
 
 async def _eval_answer_relevancy(question: str, answer: str) -> dict:
-    prompt = ANSWER_RELEVANCY_PROMPT.format(question=question[:2000], answer=answer[:2000])
+    prompt = ANSWER_RELEVANCY_PROMPT.format(
+        question=sanitize_for_provider(question[:2000]),
+        answer=sanitize_for_provider(answer[:2000]),
+    )
     result = await _call_model(prompt)
     if not result or "score" not in result:
         return {"score": 0.0, "reason": "Model returned invalid response"}
@@ -124,7 +131,10 @@ async def _eval_answer_relevancy(question: str, answer: str) -> dict:
 
 
 async def _eval_context_precision(question: str, chunks: str) -> dict:
-    prompt = CONTEXT_PRECISION_PROMPT.format(question=question[:2000], chunks=chunks[:4000])
+    prompt = CONTEXT_PRECISION_PROMPT.format(
+        question=sanitize_for_provider(question[:2000]),
+        chunks=sanitize_for_provider(chunks[:4000]),
+    )
     result = await _call_model(prompt)
     if not result or "score" not in result:
         return {"score": 0.0, "reason": "Model returned invalid response"}
@@ -132,7 +142,10 @@ async def _eval_context_precision(question: str, chunks: str) -> dict:
 
 
 async def _eval_context_recall(ground_truth: str, context: str) -> dict:
-    prompt = CONTEXT_RECALL_PROMPT.format(ground_truth=ground_truth[:2000], context=context[:4000])
+    prompt = CONTEXT_RECALL_PROMPT.format(
+        ground_truth=sanitize_for_provider(ground_truth[:2000]),
+        context=sanitize_for_provider(context[:4000]),
+    )
     result = await _call_model(prompt)
     if not result or "score" not in result:
         return {"score": 0.0, "reason": "Model returned invalid response"}

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -21,6 +21,7 @@ from models.agent import Agent, AgentStatus, AgentVersion
 from models.insight_report import InsightReport, InsightReportStatus
 from services.clickhouse import _query
 from services.redis import _get_arq_pool
+from services.secret_redactor import sanitize_for_provider
 
 logger = structlog.get_logger(__name__)
 
@@ -68,7 +69,7 @@ async def _load_agent_config(db, agent_id) -> dict | None:
 
     if version.prompt:
         # Include a truncated system prompt (first 2000 chars) for context
-        config["system_prompt_excerpt"] = version.prompt[:2000]
+        config["system_prompt_excerpt"] = sanitize_for_provider(version.prompt[:2000])
         config["system_prompt_length"] = len(version.prompt)
 
     if mcp_names:

--- a/observal-server/services/secret_redactor.py
+++ b/observal-server/services/secret_redactor.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Redact secrets from text before sending it to a third-party LLM provider.
+
+Keeps this module dependency-free so it can be imported anywhere early
+in startup without pulling in heavy optional packages.
+
+Usage
+-----
+from services.secret_redactor import sanitize_for_provider
+
+prompt = sanitize_for_provider(raw_text)
+
+What it redacts
+---------------
+- JWT tokens  (eyJ…)
+- Bearer / Authorization header values
+- Embedded URL credentials  (scheme://user:password@host)
+- key=value assignments for common secret field names
+- PEM private-key blocks
+- Long hex strings that look like tokens / hashes  (≥ 32 hex chars)
+
+What it does NOT do
+-------------------
+- It does not remove prompt-injection vectors — use TraceSanitizer for that.
+- It is not a complete DLP solution; it covers the most common patterns.
+"""
+
+import re
+
+# ── Patterns ─────────────────────────────────────────────────────────────────
+
+_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # JWT  (header.payload.signature, each part ≥ 4 chars of base64url)
+    (
+        re.compile(r"eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}"),
+        "[REDACTED_JWT]",
+    ),
+    # Authorization / Bearer header values
+    (
+        re.compile(r"((?:Bearer|Token|Authorization)\s+)[A-Za-z0-9_\-\.]{16,}", re.IGNORECASE),
+        r"\1[REDACTED]",
+    ),
+    # URL-embedded credentials  scheme://user:password@host
+    (
+        re.compile(r"([a-z][a-z0-9+\-.]*://[^:/\s@]{1,64}:)[^@\s]{1,256}(@)", re.IGNORECASE),
+        r"\1[REDACTED]\2",
+    ),
+    # key=value / key: value for common secret field names
+    (
+        re.compile(
+            r"(?P<key>(?:password|passwd|secret|api[_-]?key|access[_-]?token"
+            r"|auth[_-]?token|private[_-]?key|client[_-]?secret|x-api-key)"
+            r"\s*[=:]\s*)(?P<val>[^\s,\]{}\"\';\n]{6,})",
+            re.IGNORECASE,
+        ),
+        r"\g<key>[REDACTED]",
+    ),
+    # PEM private-key blocks
+    (
+        re.compile(r"-----BEGIN [A-Z ]*PRIVATE[A-Z ]*KEY-----[\s\S]{0,4096}?-----END [A-Z ]*PRIVATE[A-Z ]*KEY-----"),
+        "[REDACTED_PEM]",
+    ),
+    # Long hex strings (≥ 32 chars) — tokens, hashes, API keys
+    (
+        re.compile(r"\b[0-9a-fA-F]{32,}\b"),
+        "[REDACTED_HEX]",
+    ),
+]
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def sanitize_for_provider(text: str) -> str:
+    """Return *text* with secrets redacted.
+
+    Safe to call on non-string values — they are returned unchanged.
+    Compose with ``TraceSanitizer.sanitize_for_judge()`` for full protection:
+
+    - ``sanitize_for_judge``  strips prompt-injection vectors
+    - ``sanitize_for_provider``  strips credential leakage
+    """
+    if not isinstance(text, str):
+        return text  # type: ignore[return-value]
+    for pattern, replacement in _PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text

--- a/tests/eval/test_secret_redactor.py
+++ b/tests/eval/test_secret_redactor.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tests for services.secret_redactor (OBSV-SEC-021)."""
+
+from unittest.mock import patch
+
+
+class TestSanitizeForProvider:
+    def test_redacts_jwt(self):
+        from services.secret_redactor import sanitize_for_provider
+
+        token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.abc123def456ghi789jkl"
+        result = sanitize_for_provider(f"Authorization: Bearer {token}")
+        assert token not in result
+        assert "[REDACTED" in result
+
+    def test_redacts_db_url_password(self):
+        from services.secret_redactor import sanitize_for_provider
+
+        result = sanitize_for_provider("postgres://admin:s3cr3tPass@db.example.com/mydb")
+        assert "s3cr3tPass" not in result
+        assert "db.example.com" in result  # host preserved
+
+    def test_redacts_api_key_value(self):
+        from services.secret_redactor import sanitize_for_provider
+
+        result = sanitize_for_provider("api_key=sk-abc1234567890abcdef1234567890ab")
+        assert "sk-abc1234567890abcdef1234567890ab" not in result
+        assert "api_key=" in result  # key name preserved
+
+    def test_redacts_pem_block(self):
+        from services.secret_redactor import sanitize_for_provider
+
+        pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQ==\n-----END RSA PRIVATE KEY-----"
+        result = sanitize_for_provider(pem)
+        assert "MIIEpAIBAAKCAQ==" not in result
+        assert "[REDACTED_PEM]" in result
+
+    def test_non_string_passthrough(self):
+        from services.secret_redactor import sanitize_for_provider
+
+        assert sanitize_for_provider(None) is None
+        assert sanitize_for_provider(42) == 42
+
+    def test_clean_text_unchanged(self):
+        from services.secret_redactor import sanitize_for_provider
+
+        text = "The agent completed the task in 3 tool calls."
+        assert sanitize_for_provider(text) == text
+
+
+class TestLLMJudgeBackendRedaction:
+    async def test_secret_not_sent_to_llm(self):
+        """LLMJudgeBackend.score must redact secrets before building the prompt."""
+        from services.eval.eval_engine import LLMJudgeBackend
+
+        captured: dict = {}
+
+        async def _mock_call_model(prompt: str) -> dict:
+            captured["prompt"] = prompt
+            return {"score": 0.9, "reason": "ok"}
+
+        backend = LLMJudgeBackend()
+        template = {
+            "prompt": "Trace: {trace}\nSpan: {span}",
+            "id": "tpl-test",
+            "name": "Test",
+        }
+        trace = {"tool_response": "Authorization: Bearer eyJmYWtlLnRva2VuLmhlcmU.abc.def"}
+        span = {"error": "DATABASE_URL=postgres://user:s3cr3t@host/db"}
+
+        with patch("services.eval.eval_engine._call_model", side_effect=_mock_call_model):
+            await backend.score(template, trace, span)
+
+        assert "eyJmYWtlLnRva2VuLmhlcmU" not in captured["prompt"]
+        assert "s3cr3t" not in captured["prompt"]


### PR DESCRIPTION
## Purpose / Description

Traces, spans, tool outputs, and agent system prompts are forwarded to third-party LLM providers for eval scoring (OpenAI-compatible judge, RAGAS, insights generation). These payloads can contain credentials captured by the telemetry pipeline — bearer tokens in tool call responses, database URLs in error messages, API keys in environment variable dumps.

## Fixes

* Fixes OBSV-SEC-021 — eval and insight prompts can send unredacted secrets to third-party LLM providers

## Approach

### New module: `services/secret_redactor.py`

`sanitize_for_provider(text)` redacts:

| Pattern | Replacement |
|---------|-------------|
| JWT tokens (`eyJ…`) | `[REDACTED_JWT]` |
| Bearer / Authorization header values | `Bearer [REDACTED]` |
| URL-embedded passwords (`scheme://user:pass@host`) | password replaced |
| `key=value` for common secret field names | value replaced |
| PEM private-key blocks | `[REDACTED_PEM]` |
| Long hex strings ≥ 32 chars | `[REDACTED_HEX]` |

Intentionally dependency-free — safe to import anywhere in startup.

### Three egress paths wired:

- **`eval_engine.py`** — `LLMJudgeBackend.score`: trace and span serialised via `json.dumps` before being substituted into the judge prompt template
- **`ragas_eval.py`** — all four metric helpers: `answer`, `context`, `question`, `chunks`, `ground_truth`
- **`insights/batch.py`** — `system_prompt_excerpt` included in the insights generation context

### Relationship to `TraceSanitizer`

`TraceSanitizer.sanitize_for_judge()` (existing) strips prompt-injection vectors. `sanitize_for_provider()` (this PR) strips credential leakage. They are complementary — apply both for full protection.

## How Has This Been Tested?

`tests/eval/test_secret_redactor.py` — 7 tests, full eval suite 280 passed.

Key assertions:
- JWT, DB URL password, API key value, PEM block are each redacted
- Non-string values pass through unchanged
- Clean text is returned unchanged (no false positives)
- `LLMJudgeBackend.score` with a secret in the trace does not include the secret in the captured prompt

```
280 passed in 0.55s
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A — backend only)