### PR TITLE
fix(security): redact secrets before sending content to LLM providers (OBSV-SEC-021)

### DIFF
--- a/observal-server/services/eval/eval_engine.py
+++ b/observal-server/services/eval/eval_engine.py
@@ -92,9 +92,11 @@ class LLMJudgeBackend(EvalBackend):
     """LLM-as-judge backend using OpenAI-compatible or Bedrock APIs."""
 
     async def score(self, template: dict, trace: dict, span: dict) -> dict:
+        from services.secrets_redactor import redact_secrets
+
         prompt = template["prompt"].format(
-            trace=json.dumps(trace, default=str)[:2000],
-            span=json.dumps(span, default=str)[:2000],
+            trace=redact_secrets(json.dumps(trace, default=str)[:2000]),
+            span=redact_secrets(json.dumps(span, default=str)[:2000]),
         )
         result = await _call_model(prompt)
         if isinstance(result, dict) and "score" in result:

--- a/observal-server/services/eval/ragas_eval.py
+++ b/observal-server/services/eval/ragas_eval.py
@@ -29,6 +29,7 @@ import structlog
 
 from services.clickhouse import insert_scores
 from services.eval.eval_engine import _call_model
+from services.secrets_redactor import redact_secrets
 
 logger = structlog.get_logger(__name__)
 
@@ -108,7 +109,7 @@ def _safe_score(result: dict) -> float:
 
 
 async def _eval_faithfulness(answer: str, context: str) -> dict:
-    prompt = FAITHFULNESS_PROMPT.format(context=context[:4000], answer=answer[:2000])
+    prompt = FAITHFULNESS_PROMPT.format(context=redact_secrets(context[:4000]), answer=redact_secrets(answer[:2000]))
     result = await _call_model(prompt)
     if not result or "score" not in result:
         return {"score": 0.0, "reason": "Model returned invalid response"}
@@ -116,7 +117,9 @@ async def _eval_faithfulness(answer: str, context: str) -> dict:
 
 
 async def _eval_answer_relevancy(question: str, answer: str) -> dict:
-    prompt = ANSWER_RELEVANCY_PROMPT.format(question=question[:2000], answer=answer[:2000])
+    prompt = ANSWER_RELEVANCY_PROMPT.format(
+        question=redact_secrets(question[:2000]), answer=redact_secrets(answer[:2000])
+    )
     result = await _call_model(prompt)
     if not result or "score" not in result:
         return {"score": 0.0, "reason": "Model returned invalid response"}
@@ -124,7 +127,9 @@ async def _eval_answer_relevancy(question: str, answer: str) -> dict:
 
 
 async def _eval_context_precision(question: str, chunks: str) -> dict:
-    prompt = CONTEXT_PRECISION_PROMPT.format(question=question[:2000], chunks=chunks[:4000])
+    prompt = CONTEXT_PRECISION_PROMPT.format(
+        question=redact_secrets(question[:2000]), chunks=redact_secrets(chunks[:4000])
+    )
     result = await _call_model(prompt)
     if not result or "score" not in result:
         return {"score": 0.0, "reason": "Model returned invalid response"}
@@ -132,7 +137,9 @@ async def _eval_context_precision(question: str, chunks: str) -> dict:
 
 
 async def _eval_context_recall(ground_truth: str, context: str) -> dict:
-    prompt = CONTEXT_RECALL_PROMPT.format(ground_truth=ground_truth[:2000], context=context[:4000])
+    prompt = CONTEXT_RECALL_PROMPT.format(
+        ground_truth=redact_secrets(ground_truth[:2000]), context=redact_secrets(context[:4000])
+    )
     result = await _call_model(prompt)
     if not result or "score" not in result:
         return {"score": 0.0, "reason": "Model returned invalid response"}

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -21,6 +21,7 @@ from models.agent import Agent, AgentStatus, AgentVersion
 from models.insight_report import InsightReport, InsightReportStatus
 from services.clickhouse import _query
 from services.redis import _get_arq_pool
+from services.secrets_redactor import redact_secrets
 
 logger = structlog.get_logger(__name__)
 
@@ -68,7 +69,7 @@ async def _load_agent_config(db, agent_id) -> dict | None:
 
     if version.prompt:
         # Include a truncated system prompt (first 2000 chars) for context
-        config["system_prompt_excerpt"] = version.prompt[:2000]
+        config["system_prompt_excerpt"] = redact_secrets(version.prompt[:2000])
         config["system_prompt_length"] = len(version.prompt)
 
     if mcp_names:

--- a/tests/eval/test_sec021_llm_redaction.py
+++ b/tests/eval/test_sec021_llm_redaction.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tests for SEC-021: secrets redacted before sending content to LLM providers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestLLMJudgeBackendRedaction:
+    async def test_secret_in_trace_not_sent_to_llm(self):
+        """LLMJudgeBackend.score must redact secrets via secrets_redactor before building the prompt."""
+        from services.eval.eval_engine import LLMJudgeBackend
+
+        captured: dict = {}
+
+        async def _mock_call_model(prompt: str) -> dict:
+            captured["prompt"] = prompt
+            return {"score": 0.9, "reason": "ok"}
+
+        template = {"prompt": "Trace: {trace}\nSpan: {span}", "id": "tpl-test", "name": "Test"}
+        trace = {"tool_response": "Authorization: Bearer ghp_abc123def456ghi789jkl0123456789"}
+        span = {"error": "DATABASE_URL=postgres://user:s3cr3t@db.example.com/prod"}
+
+        with patch("services.eval.eval_engine._call_model", side_effect=_mock_call_model):
+            await LLMJudgeBackend().score(template, trace, span)
+
+        assert "ghp_abc123def456ghi789jkl0123456789" not in captured["prompt"]
+        assert "s3cr3t" not in captured["prompt"]
+
+    async def test_clean_trace_passes_through(self):
+        """Content without secrets is passed through unchanged."""
+        from services.eval.eval_engine import LLMJudgeBackend
+
+        captured: dict = {}
+
+        async def _mock_call_model(prompt: str) -> dict:
+            captured["prompt"] = prompt
+            return {"score": 0.8, "reason": "ok"}
+
+        template = {"prompt": "Trace: {trace}\nSpan: {span}", "id": "tpl-test", "name": "Test"}
+        trace = {"tool_name": "read_file", "status": "success"}
+        span = {"latency_ms": 42}
+
+        with patch("services.eval.eval_engine._call_model", side_effect=_mock_call_model):
+            await LLMJudgeBackend().score(template, trace, span)
+
+        assert "read_file" in captured["prompt"]
+        assert "42" in captured["prompt"]
+
+
+class TestRagasRedaction:
+    """redact_secrets() is applied to all four RAGAS metric helpers."""
+
+    async def _call_with_secret(self, fn, **kwargs) -> str:
+        """Call a ragas helper with a mock model, return the captured prompt."""
+        captured: dict = {}
+
+        async def _mock(prompt: str) -> dict:
+            captured["prompt"] = prompt
+            return {"score": 0.5, "reason": "ok"}
+
+        with patch("services.eval.ragas_eval._call_model", side_effect=_mock):
+            await fn(**kwargs)
+
+        return captured.get("prompt", "")
+
+    async def test_faithfulness_redacts_secret(self):
+        from services.eval.ragas_eval import _eval_faithfulness
+
+        prompt = await self._call_with_secret(
+            _eval_faithfulness,
+            answer="The key is sk-ant-api03-abc123def456",
+            context="Some context",
+        )
+        assert "sk-ant-api03-abc123def456" not in prompt
+
+    async def test_answer_relevancy_redacts_secret(self):
+        from services.eval.ragas_eval import _eval_answer_relevancy
+
+        prompt = await self._call_with_secret(
+            _eval_answer_relevancy,
+            question="What is the API key?",
+            answer="api_key=AKIAIOSFODNN7EXAMPLE",
+        )
+        assert "AKIAIOSFODNN7EXAMPLE" not in prompt
+
+    async def test_context_precision_redacts_secret(self):
+        from services.eval.ragas_eval import _eval_context_precision
+
+        prompt = await self._call_with_secret(
+            _eval_context_precision,
+            question="How to connect?",
+            chunks="Use postgres://admin:hunter2@db.host/prod",
+        )
+        assert "hunter2" not in prompt
+
+    async def test_context_recall_redacts_secret(self):
+        from services.eval.ragas_eval import _eval_context_recall
+
+        prompt = await self._call_with_secret(
+            _eval_context_recall,
+            ground_truth="Use the secret token",
+            context="token=ghp_realtoken123456789012345678901234567890",
+        )
+        assert "ghp_realtoken123456789012345678901234567890" not in prompt
+
+
+class TestInsightsBatchRedaction:
+    """redact_secrets() is applied to system_prompt_excerpt in _load_agent_config."""
+
+    async def test_system_prompt_secret_redacted(self):
+        from services.insights.batch import _load_agent_config
+
+        mock_version = MagicMock()
+        mock_version.version = "1.0.0"
+        mock_version.model_name = "claude-3"
+        mock_version.supported_ides = []
+        mock_version.prompt = "System key: sk-proj-abc123def456ghi789jkl0123456789xyz"
+        mock_version.components = []
+        mock_version.external_mcps = []
+        mock_version.model_config_json = None
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_version)
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        config = await _load_agent_config(mock_db, "agent-id-123")
+
+        assert config is not None
+        assert "sk-proj-abc123def456ghi789jkl0123456789xyz" not in config["system_prompt_excerpt"]
+        assert "**REDACTED**" in config["system_prompt_excerpt"]


### PR DESCRIPTION
## Purpose / Description

Traces, spans, tool outputs, and agent system prompts forwarded to third-party LLM providers (eval judge, RAGAS, insights generation) can contain credentials captured by the telemetry pipeline — bearer tokens in tool call responses, database URLs in error messages, API keys in environment variable dumps.

## Fixes

* Fixes OBSV-SEC-021 — eval and insight prompts can send unredacted secrets to third-party LLM providers

## Approach

`services/secrets_redactor.py` already exists and is used at telemetry ingestion time to scrub ClickHouse storage. This PR wires the same `redact_secrets()` function into the three LLM **egress** paths that were missing it:

| File | Where applied |
|------|---------------|
| `eval_engine.py` | `LLMJudgeBackend.score` — trace and span before judge prompt |
| `ragas_eval.py` | All four metric helpers — answer, context, question, chunks, ground_truth |
| `insights/batch.py` | `system_prompt_excerpt` included in insights generation context |

`redact_secrets()` covers: known API key prefixes (OpenAI `sk-`, Anthropic `sk-ant-`, GitHub `ghp_`, AWS `AKIA…`), JWTs, PEM private-key blocks, URL-embedded passwords, Authorization headers, and `key=value` assignments for common secret field names.

No new module needed — reuses the existing production implementation.

## How Has This Been Tested?

`tests/eval/test_sec021_llm_redaction.py` — 2 tests, full eval suite 273 passed.

- GitHub token in trace not present in captured judge prompt
- DB URL password in span not present in captured judge prompt
- Clean content (tool name, latency) passes through unchanged

```
273 passed in 0.44s
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A — backend only)