### PR TITLE
fix(security): redact secrets from support log collector output (OBSV-SEC-022)

### DIFF
--- a/observal-server/api/routes/support.py
+++ b/observal-server/api/routes/support.py
@@ -31,6 +31,7 @@ from config import Settings, settings
 from models.user import UserRole
 from services.clickhouse import CLICKHOUSE_DB, _query
 from services.redis import get_redis
+from services.secrets_redactor import redact_dict
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -396,8 +397,9 @@ def _parse_duration(duration_str: str) -> timedelta:
 async def _collect_logs(logs_since: str = "1h") -> dict:
     """Collect structured log lines from the in-memory ring buffer.
 
-    Filters entries by the ``logs_since`` duration. The CLI is
-    responsible for redacting the returned lines before writing.
+    Filters entries by the ``logs_since`` duration. Secrets are redacted
+    server-side before returning; the CLI applies a second redaction pass
+    as defence-in-depth.
     Returns an empty list gracefully if the buffer is empty.
     """
     try:
@@ -427,7 +429,11 @@ async def _collect_logs(logs_since: str = "1h") -> dict:
                     clean[k] = str(v)
             sanitized.append(clean)
 
-        return {"lines": sanitized}
+        # Redact secrets server-side before returning (SEC-022).
+        # redact_dict scrubs all string values; redact_secrets handles
+        # individual strings that were coerced to str above.
+        redacted = [redact_dict(entry) for entry in sanitized]
+        return {"lines": redacted}
     except ImportError:
         return {
             "lines": [],

--- a/tests/test_support_endpoint.py
+++ b/tests/test_support_endpoint.py
@@ -1081,3 +1081,57 @@ class TestConfigAllowlistFiltering:
         assert "AWS_REGION" in filtered
         assert "SECRET_KEY" not in filtered
         assert "OAUTH_CLIENT_SECRET" not in filtered
+
+
+class TestCollectLogsRedaction:
+    """SEC-022: server-side redaction applied to log lines before return."""
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_redacted(self):
+        from datetime import UTC, datetime
+
+        from api.routes.support import _collect_logs
+
+        now = datetime.now(UTC)
+        entries = [
+            {
+                "timestamp": now.isoformat(),
+                "event": "request",
+                "auth": "Bearer ghp_abc123def456ghi789jkl0123456789012345",
+            }
+        ]
+        mock_buffer = MagicMock()
+        mock_buffer.get_since.return_value = entries
+
+        with patch("services.log_buffer.get_log_buffer", return_value=mock_buffer):
+            result = await _collect_logs("1h")
+
+        import json
+
+        raw = json.dumps(result["lines"])
+        assert "ghp_abc123def456ghi789jkl0123456789012345" not in raw
+
+    @pytest.mark.asyncio
+    async def test_db_url_password_redacted(self):
+        from datetime import UTC, datetime
+
+        from api.routes.support import _collect_logs
+
+        now = datetime.now(UTC)
+        entries = [
+            {"timestamp": now.isoformat(), "event": "connect", "url": "postgres://admin:s3cr3tPass@db.example.com/prod"}
+        ]
+        mock_buffer = MagicMock()
+        mock_buffer.get_since.return_value = entries
+
+        with patch("services.log_buffer.get_log_buffer", return_value=mock_buffer):
+            result = await _collect_logs("1h")
+
+        import json
+        from urllib.parse import urlparse
+
+        raw = json.dumps(result["lines"])
+        assert "s3cr3tPass" not in raw
+        # Parse the redacted URL from the result to confirm hostname is intact
+        url_field = result["lines"][0]["url"]
+        assert urlparse(url_field).hostname == "db.example.com"


### PR DESCRIPTION
## Purpose / Description

The log collector in `POST /api/v1/support/collect` returned raw in-memory ring buffer entries without any server-side secret scrubbing. Server logs can contain bearer tokens, database URLs with embedded passwords, API keys, and other credentials that passed through request handlers.

## Fixes

* Fixes OBSV-SEC-022 — support log collector returns unredacted log fields

## Approach

Apply `redact_dict()` from the existing `services/secrets_redactor.py` module to every log entry before returning. The function recursively scrubs all string values in the dict, covering the same patterns already used at telemetry ingestion time:

```python
# Before
return {"lines": sanitized}

# After
redacted = [redact_dict(entry) for entry in sanitized]
return {"lines": redacted}
```

The CLI's own redaction pass is kept as defence-in-depth but is no longer the only guard.

## How Has This Been Tested?

`tests/test_support_endpoint.py` — 66 tests pass.

Two new tests in `TestCollectLogsRedaction`:
- GitHub bearer token in a log entry is redacted before return
- DB URL password in a log entry is redacted; hostname is preserved

```
66 passed in 0.62s
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A — backend only)