### PR TITLE
fix(security): include auth identity in cache key to prevent cross-user hits (OBSV-SEC-023)

### DIFF
--- a/observal-server/services/cache.py
+++ b/observal-server/services/cache.py
@@ -20,11 +20,27 @@ _redis: aioredis.Redis | None = None
 
 
 def _request_key_builder(func, namespace="", *, request: Request | None = None, **kwargs):
-    """Build cache key from path + query string only, ignoring Depends params."""
+    """Build cache key from auth identity + path + query string.
+
+    Including a per-user identity component prevents a shared cache from
+    serving one authenticated user's response to a different user whose
+    request happens to hit the same path and query string (SEC-023).
+
+    Anonymous requests use the literal identity ``anon`` so they can
+    still share a cache bucket with each other.
+    """
     prefix = f"{CACHE_PREFIX}:{namespace}" if namespace else CACHE_PREFIX
     url = request.url.path if request else func.__name__
     qs = str(request.query_params) if request and request.query_params else ""
-    raw = f"{url}?{qs}" if qs else url
+
+    identity = "anon"
+    if request:
+        auth = request.headers.get("authorization", "")
+        if auth.startswith("Bearer "):
+            # Hash the token so the raw credential never appears in a cache key.
+            identity = hashlib.sha256(auth.encode(), usedforsecurity=False).hexdigest()[:16]
+
+    raw = f"{identity}:{url}?{qs}" if qs else f"{identity}:{url}"
     return f"{prefix}:{hashlib.md5(raw.encode(), usedforsecurity=False).hexdigest()}"
 
 

--- a/tests/test_sec023_cache_isolation.py
+++ b/tests/test_sec023_cache_isolation.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tests for SEC-023: cache key isolation per authenticated user."""
+
+from unittest.mock import MagicMock
+
+
+def _make_request(auth: str | None = None, path: str = "/api/v1/sessions", qs: str = "") -> MagicMock:
+    req = MagicMock()
+    req.url.path = path
+    req.query_params = qs
+    req.headers = {"authorization": auth} if auth else {}
+    return req
+
+
+class TestCacheKeyIsolation:
+    def test_different_tokens_produce_different_keys(self):
+        """Two users hitting the same path must get different cache keys."""
+        from services.cache import _request_key_builder
+
+        key_alice = _request_key_builder(lambda: None, request=_make_request("Bearer token-alice"))
+        key_bob = _request_key_builder(lambda: None, request=_make_request("Bearer token-bob"))
+        assert key_alice != key_bob
+
+    def test_same_token_produces_same_key(self):
+        """The same token always maps to the same cache slot (deterministic)."""
+        from services.cache import _request_key_builder
+
+        k1 = _request_key_builder(lambda: None, request=_make_request("Bearer same-token"))
+        k2 = _request_key_builder(lambda: None, request=_make_request("Bearer same-token"))
+        assert k1 == k2
+
+    def test_anonymous_request_uses_anon_identity(self):
+        """Unauthenticated requests get a distinct key from authenticated ones."""
+        from services.cache import _request_key_builder
+
+        key_anon = _request_key_builder(lambda: None, request=_make_request(None))
+        key_authed = _request_key_builder(lambda: None, request=_make_request("Bearer some-token"))
+        assert key_anon != key_authed
+
+    def test_anonymous_requests_share_cache_bucket(self):
+        """Two anonymous requests for the same path share a cache entry."""
+        from services.cache import _request_key_builder
+
+        k1 = _request_key_builder(lambda: None, request=_make_request(None))
+        k2 = _request_key_builder(lambda: None, request=_make_request(None))
+        assert k1 == k2
+
+    def test_raw_token_not_in_key(self):
+        """The bearer token itself must not appear in the cache key."""
+        from services.cache import _request_key_builder
+
+        token = "super-secret-bearer-token-value"
+        key = _request_key_builder(lambda: None, request=_make_request(f"Bearer {token}"))
+        assert token not in key
+
+    def test_different_paths_different_keys(self):
+        """Path is still part of the key — different routes don't collide."""
+        from services.cache import _request_key_builder
+
+        k1 = _request_key_builder(lambda: None, request=_make_request("Bearer tok", path="/api/v1/sessions"))
+        k2 = _request_key_builder(lambda: None, request=_make_request("Bearer tok", path="/api/v1/dashboard"))
+        assert k1 != k2


### PR DESCRIPTION
## Purpose / Description

`_request_key_builder` keyed cache entries on path + query string only. Two authenticated users requesting the same endpoint could receive each other's cached response if their requests happened to share the same path and query string.

The dashboard endpoints (`token_stats`, `ide_usage`, `latency_heatmap`, etc.) are all decorated with `@cache` and return per-org telemetry. Without this fix, org-A's dashboard data could be served to org-B's admin if they requested the same time range.

## Fixes

* Fixes OBSV-SEC-023, authenticated cached responses are identity-blind

## Approach

Include a per-user identity component in every cache key, derived from a 16-char SHA-256 prefix of the `Authorization` header:

```python
# Before
raw = f"{url}?{qs}" if qs else url

# After
identity = "anon"
if request:
    auth = request.headers.get("authorization", "")
    if auth.startswith("Bearer "):
        identity = hashlib.sha256(auth.encode(), usedforsecurity=False).hexdigest()[:16]
raw = f"{identity}:{url}?{qs}" if qs else f"{identity}:{url}"
```

- Anonymous requests use `"anon"`, they can still share a cache bucket with each other
- The raw token never appears in the key, only a short hash prefix
- Public endpoints (health, public registry listings) carry no `Authorization` header so they are unaffected

## How Has This Been Tested?

`tests/test_sec023_cache_isolation.py`, 6 tests.

| Test | Asserts |
|------|---------|
| `test_different_tokens_produce_different_keys` | Alice and Bob get different keys for the same path |
| `test_same_token_produces_same_key` | Same token is deterministic |
| `test_anonymous_request_uses_anon_identity` | Anon key differs from authed key |
| `test_anonymous_requests_share_cache_bucket` | Two anon requests share the same key |
| `test_raw_token_not_in_key` | Raw bearer value is not present in the key string |
| `test_different_paths_different_keys` | Path is still part of the discriminator |

```
6 passed in 0.09s
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A, backend only)