### PR TITLE
fix(security): bind stateful services to loopback in Docker Compose (OBSV-SEC-016)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -88,7 +88,7 @@ services:
   observal-db:
     image: postgres:18
     ports:
-      - "${POSTGRES_HOST_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
     env_file:
       - ../.env
     environment:
@@ -110,7 +110,7 @@ services:
   observal-clickhouse:
     image: clickhouse/clickhouse-server:26.4
     ports:
-      - "${CLICKHOUSE_HOST_PORT:-8123}:8123"
+      - "127.0.0.1:${CLICKHOUSE_HOST_PORT:-8123}:8123"
     env_file:
       - ../.env
     environment:
@@ -135,7 +135,7 @@ services:
   observal-redis:
     image: redis:8-alpine
     ports:
-      - "${REDIS_HOST_PORT:-6379}:6379"
+      - "127.0.0.1:${REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - redisdata:/data
     healthcheck:
@@ -224,7 +224,7 @@ services:
   observal-prometheus:
     image: prom/prometheus:v3.11.3
     ports:
-      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
+      - "127.0.0.1:${PROMETHEUS_HOST_PORT:-9090}:9090"
     volumes:
       - ../prometheus.yml:/etc/prometheus/prometheus.yml:ro
     depends_on:
@@ -243,7 +243,7 @@ services:
   observal-grafana:
     image: grafana/grafana-oss:11.6.5
     ports:
-      - "${GRAFANA_HOST_PORT:-3001}:3000"
+      - "127.0.0.1:${GRAFANA_HOST_PORT:-3001}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}


### PR DESCRIPTION
## Purpose / Description

Postgres, ClickHouse, Redis, Prometheus, and Grafana were published on all host interfaces (`0.0.0.0`). On a self-hosted machine without a strict firewall these services are reachable from any network the host is attached to, exposing unauthenticated data store ports directly.

**Scope:** this change only affects the `docker/docker-compose.yml` self-hosted path (`make up`, `curl | bash` install). The AWS deployment uses a separate architecture: the API, worker, and web containers run on ECS Fargate (which has no host port bindings), and the data tier (ClickHouse, Grafana, Prometheus) runs on EC2 via an inline `docker-compose.data.yml` written by `user-data.sh.tftpl`, not this file. The EC2 data host sits in a private subnet with security groups as the actual network boundary.

## Fixes

* Fixes OBSV-SEC-016, Docker Compose publishes stateful services on all host interfaces

## Approach

Prefix each stateful service port binding with `127.0.0.1:` so Docker only binds to the loopback interface:

```yaml
# Before
- "${POSTGRES_HOST_PORT:-5432}:5432"

# After
- "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
```

Services changed: `observal-db`, `observal-clickhouse`, `observal-redis`, `observal-prometheus`, `observal-grafana`.

`observal-lb` (port 8000) and `observal-web` (port 3000) are intentionally left unchanged as they are the public entry points.

The `*_HOST_PORT` env vars still work for port remapping on localhost. They just no longer expose the ports externally.

**Note for operators** who connect to these services from a separate machine (e.g. a BI tool, a read replica, or a dev machine accessing staging): change the binding back to `0.0.0.0` or a specific LAN IP for the relevant service in a local override file.

## How Has This Been Tested?

Manual diff review. Docker Compose validates the YAML on `docker compose config`.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A, config only)