### PR TITLE
fix(security): centralise SSRF guard for webhooks, git clone, MCP analysis (OBSV-SEC-012/013/014)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,56 +7,172 @@
 # SPDX-FileCopyrightText: 2026 Swathi Saravanan <ss4522@cornell.edu>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Core settings (have sensible defaults, override for production)
+# =============================================================================
+# Observal — Environment Configuration
+#
+# Copy this file to .env and fill in values for your deployment.
+# SECURITY: never commit your real .env to version control.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Core — required for every deployment
+# -----------------------------------------------------------------------------
+
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@observal-db:5432/observal
-# Recommended: generate a unique key for production
-# python3 -c "import secrets; print(secrets.token_urlsafe(32))"
-SECRET_KEY=change-me-to-a-random-string
 CLICKHOUSE_URL=clickhouse://default:clickhouse@observal-clickhouse:8123/observal
 REDIS_URL=redis://observal-redis:6379
 
-# Postgres container credentials
+# Generate a unique secret:  python3 -c "import secrets; print(secrets.token_hex(32))"
+# SECURITY: change this before exposing to any non-local environment.
+SECRET_KEY=change-me-to-a-random-string
+
+
+# -----------------------------------------------------------------------------
+# Container credentials
+# (must match DATABASE_URL / CLICKHOUSE_URL above)
+# -----------------------------------------------------------------------------
+
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 
-# Optional: ClickHouse credentials
 CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=clickhouse
 
-# Optional: Eval engine (LLM-as-judge)
+
+# -----------------------------------------------------------------------------
+# Logging
+# -----------------------------------------------------------------------------
+
+LOG_LEVEL=INFO       # DEBUG | INFO | WARNING | ERROR
+LOG_FORMAT=json      # json | console (use console for local dev)
+
+
+# -----------------------------------------------------------------------------
+# Frontend / public URLs
+# -----------------------------------------------------------------------------
+
+FRONTEND_URL=http://localhost:3000
+# PUBLIC_URL=                  # base API URL clients use; derived from request if empty
+# OTLP_HTTP_URL=               # OTLP collector override; defaults to PUBLIC_URL
+CORS_ALLOWED_ORIGINS=http://localhost:3000   # comma-separated
+
+
+# -----------------------------------------------------------------------------
+# Deployment mode
+# -----------------------------------------------------------------------------
+
+# local      — self-registration, bootstrap endpoint, built-in account creation
+# enterprise — SSO-only login, SCIM provisioning, no self-registration
+DEPLOYMENT_MODE=local
+
+
+# -----------------------------------------------------------------------------
+# Authentication / JWT
+# -----------------------------------------------------------------------------
+
+JWT_KEY_DIR=~/.observal/keys   # EC signing key pair; generated automatically on first start
+# JWT_KEY_PASSWORD=            # optional password to encrypt the private key at rest
+# JWT_ACCESS_TOKEN_EXPIRE_MINUTES=60
+# JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+# JWT_HOOKS_TOKEN_EXPIRE_MINUTES=43200   # 30 days; used for long-lived OTEL hook tokens
+
+
+# -----------------------------------------------------------------------------
+# SSO
+# -----------------------------------------------------------------------------
+
+SSO_ONLY=false   # set true to disable all password-based auth (enterprise)
+
+# OAuth / OIDC (browser SSO login)
+OAUTH_CLIENT_ID=
+OAUTH_CLIENT_SECRET=
+OAUTH_SERVER_METADATA_URL=
+
+# SAML 2.0 (enterprise mode only — leave blank to disable)
+# SAML_IDP_ENTITY_ID=
+# SAML_IDP_SSO_URL=
+# SAML_IDP_SLO_URL=
+# SAML_IDP_X509_CERT=
+# SAML_IDP_METADATA_URL=
+# SAML_SP_ENTITY_ID=
+# SAML_SP_ACS_URL=
+# SAML_JIT_PROVISIONING=true
+# SAML_DEFAULT_ROLE=user
+# SAML_SP_KEY_ENCRYPTION_PASSWORD=
+
+
+# -----------------------------------------------------------------------------
+# Eval engine — LLM-as-judge for agent scoring
+# (leave blank to use the deterministic fallback scorer)
+# -----------------------------------------------------------------------------
+
 EVAL_MODEL_URL=
 EVAL_MODEL_API_KEY=
 EVAL_MODEL_NAME=
-EVAL_MODEL_PROVIDER=
+EVAL_MODEL_PROVIDER=   # bedrock | openai | moonshot | (empty = auto-detect)
 
-# Moonshot / Kimi example (OpenAI-compatible). URL and Thinking-Mode toggle
-# are handled automatically when PROVIDER=moonshot.
+# Moonshot / Kimi example (OpenAI-compatible):
 # EVAL_MODEL_PROVIDER=moonshot
 # EVAL_MODEL_API_KEY=sk-...
 # EVAL_MODEL_NAME=kimi-k2.5-preview
 
-# Optional: AWS credentials for Bedrock eval engine
+# AWS credentials for Bedrock
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_SESSION_TOKEN=
 AWS_REGION=us-east-1
 
-# Optional: OAuth / SSO (disabled when unset)
-OAUTH_CLIENT_ID=
-OAUTH_CLIENT_SECRET=
-OAUTH_SERVER_METADATA_URL=
 
-# Deployment mode: "local" (default) or "enterprise"
-# Local mode: self-registration, bootstrap endpoint, built-in account creation
-# Enterprise mode: SSO-only login, SCIM provisioning, no self-registration
-DEPLOYMENT_MODE=local
+# -----------------------------------------------------------------------------
+# Agent Insights — per-model overrides
+# (all default to EVAL_MODEL_NAME when left blank)
+# -----------------------------------------------------------------------------
 
-# ClickHouse data retention (days). Set to 0 to disable TTL.
-DATA_RETENTION_DAYS=90
+# INSIGHT_MODEL_SECTIONS=    # e.g. us.anthropic.claude-opus-4-6-20250514-v1:0
+# INSIGHT_MODEL_SYNTHESIS=   # e.g. us.anthropic.claude-sonnet-4-6-20250514-v1:0
+# INSIGHT_MODEL_FACETS=      # e.g. us.anthropic.claude-haiku-4-5-20251001-v1:0
 
-# Demo accounts — seeded on first startup when no real users exist.
-# Automatically cleaned up when a real super_admin is created.
-# Set all 8 vars to enable, or leave unset to skip demo seeding.
+# Batch tuning (advanced)
+# INSIGHT_BATCH_ENABLED=true
+# INSIGHT_BATCH_PERIOD_DAYS=14
+# INSIGHT_MIN_SESSIONS=5
+# INSIGHT_FACET_MAX_CALLS=100
+# INSIGHT_FACET_CONCURRENCY=25
+
+
+# -----------------------------------------------------------------------------
+# Security
+# -----------------------------------------------------------------------------
+
+# Set to true if you run a private GitLab, GitHub Enterprise, or Gitea on an
+# internal network. Without this, git clone and MCP analysis reject URLs
+# that resolve to private/internal IP addresses (SSRF protection).
+ALLOW_INTERNAL_GIT_URLS=false
+
+# Private git repo authentication — injected into clone URLs at runtime.
+# GIT_CLONE_TOKEN=                     # personal access token or OAuth token
+# GIT_CLONE_TOKEN_USER=x-access-token  # x-access-token (GitHub), oauth2 (GitLab)
+# GIT_CLONE_TIMEOUT=120                # seconds before a clone is aborted
+
+# Maximum inbound request body size.
+# MAX_REQUEST_SIZE_MB=10
+
+
+# -----------------------------------------------------------------------------
+# Data retention
+# -----------------------------------------------------------------------------
+
+DATA_RETENTION_DAYS=90   # ClickHouse telemetry TTL in days. 0 = disable TTL.
+
+
+# -----------------------------------------------------------------------------
+# Demo accounts
+# Seeded on first startup when no real users exist.
+# SECURITY: change all passwords before exposing to any non-local environment.
+# -----------------------------------------------------------------------------
+
+SEED_DEMO_ACCOUNTS=true
 DEMO_SUPER_ADMIN_EMAIL=super@demo.example
 DEMO_SUPER_ADMIN_PASSWORD=super-changeme
 DEMO_ADMIN_EMAIL=admin@demo.example
@@ -66,26 +182,69 @@ DEMO_REVIEWER_PASSWORD=reviewer-changeme
 DEMO_USER_EMAIL=user@demo.example
 DEMO_USER_PASSWORD=user-changeme
 
-# Resource limits (adjust based on your server's available RAM)
-# CLICKHOUSE_MEMORY_LIMIT=2G
-# OTEL_MEMORY_LIMIT=512M
 
-# Host port mappings (change these if defaults conflict with other services)
+# -----------------------------------------------------------------------------
+# Resource limits — adjust based on available RAM
+# -----------------------------------------------------------------------------
+
+# CLICKHOUSE_MEMORY_LIMIT=2G
+# CLICKHOUSE_TIMEOUT=10.0
+# REDIS_SOCKET_TIMEOUT=2.0
+
+
+# -----------------------------------------------------------------------------
+# Host port mappings
+# (change if these conflict with other services on the host)
+# -----------------------------------------------------------------------------
+
 # API_HOST_PORT=8000
+# WEB_HOST_PORT=3000
 # POSTGRES_HOST_PORT=5432
 # CLICKHOUSE_HOST_PORT=8123
 # REDIS_HOST_PORT=6379
-# WEB_HOST_PORT=3000
-# OTEL_GRPC_HOST_PORT=4317
-# OTEL_HTTP_HOST_PORT=4318
 # GRAFANA_HOST_PORT=3001
+# PROMETHEUS_HOST_PORT=9090
 
-# Horizontal scaling (multi-instance deployments)
+
+# -----------------------------------------------------------------------------
+# Horizontal scaling / connection pools
+# (advanced — only needed for multi-instance deployments)
+# -----------------------------------------------------------------------------
+
 # API_REPLICAS=1
 # WORKER_REPLICAS=1
-# CLICKHOUSE_MEMORY_LIMIT=2G
 # DB_POOL_SIZE=10
 # DB_MAX_OVERFLOW=20
 # REDIS_MAX_CONNECTIONS=50
 # CLICKHOUSE_MAX_CONNECTIONS=20
+# CLICKHOUSE_MAX_KEEPALIVE=10
 # GIT_MIRROR_BASE_PATH=
+# SKIP_DDL_ON_STARTUP=false
+
+
+# -----------------------------------------------------------------------------
+# Rate limiting (advanced)
+# -----------------------------------------------------------------------------
+
+# RATE_LIMIT_AUTH=10/minute
+# RATE_LIMIT_AUTH_STRICT=5/minute
+
+
+# -----------------------------------------------------------------------------
+# Cache TTL in seconds (advanced)
+# -----------------------------------------------------------------------------
+
+# CACHE_TTL_DEFAULT=30
+# CACHE_TTL_DASHBOARD=60
+# CACHE_TTL_OTEL=15
+
+
+# -----------------------------------------------------------------------------
+# Miscellaneous
+# -----------------------------------------------------------------------------
+
+# MIN_CLI_VERSION=0.4.0   # CLI warns users to upgrade if their version is older
+
+# Grafana admin credentials (Grafana container only)
+# GRAFANA_ADMIN_USER=admin
+# GRAFANA_ADMIN_PASSWORD=admin

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -74,6 +74,9 @@ class Settings(BaseSettings):
 
     # Git mirror storage (empty = system tempdir; set to shared path for multi-instance)
     GIT_MIRROR_BASE_PATH: str = ""
+    # Set to true to allow git clone and MCP analysis against internal/private hosts.
+    # For self-hosted GitLab, GitHub Enterprise, or Gitea on a private network.
+    ALLOW_INTERNAL_GIT_URLS: bool = False
 
     # Multi-instance startup: skip DDL when using a dedicated init container
     SKIP_DDL_ON_STARTUP: bool = False

--- a/observal-server/services/alert_evaluator.py
+++ b/observal-server/services/alert_evaluator.py
@@ -4,12 +4,9 @@
 
 """Alert evaluation engine: periodic metric checks and webhook delivery."""
 
-import ipaddress
 import logging
-import socket
 import uuid
 from datetime import UTC, datetime
-from urllib.parse import urlparse
 
 from sqlalchemy import select
 
@@ -17,39 +14,12 @@ from database import async_session
 from models.alert import AlertRule
 from models.alert_history import AlertHistory
 from services.clickhouse import _query
+from services.ssrf_guard import is_private_url  # noqa: F401 -- re-exported for callers
 
 logger = logging.getLogger(__name__)
 
-_PRIVATE_CIDRS = [
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("::1/128"),
-]
-
 LOOKBACK_MINUTES = 5
 WEBHOOK_TIMEOUT = 5
-
-
-def is_private_url(url: str) -> bool:
-    """Check if a URL resolves to a private/internal IP address (SSRF protection)."""
-    parsed = urlparse(url)
-    hostname = parsed.hostname
-    if not hostname:
-        return True
-    try:
-        addr = ipaddress.ip_address(hostname)
-    except ValueError:
-        try:
-            resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
-            if not resolved:
-                return True
-            addr = ipaddress.ip_address(resolved[0][4][0])
-        except (socket.gaierror, OSError):
-            return True
-    return any(addr in cidr for cidr in _PRIVATE_CIDRS)
 
 
 async def _query_error_rate(target_type: str, target_id: str, lookback_minutes: int) -> float | None:

--- a/observal-server/services/git_mirror_service.py
+++ b/observal-server/services/git_mirror_service.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from config import settings
+from services.ssrf_guard import is_private_url as _ssrf_is_private
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,14 @@ def _run_git(args: list[str], cwd: str | None = None, timeout: int = 120) -> sub
 
 def clone_or_update(git_url: str, branch: str = "main", base: Path = DEFAULT_MIRROR_BASE) -> Path:
     """Shallow clone or update a repo mirror. Returns the mirror directory path."""
+    # Block SSRF via git clone (SEC-013).
+    # Set ALLOW_INTERNAL_GIT_URLS=true for self-hosted GitLab / GitHub Enterprise.
+    if (
+        git_url.startswith(("http://", "https://"))
+        and not settings.ALLOW_INTERNAL_GIT_URLS
+        and _ssrf_is_private(git_url)
+    ):
+        raise ValueError(f"Repository URL resolves to a private/internal address: {git_url}")
     base.mkdir(parents=True, exist_ok=True)
     mirror_dir = _mirror_path(git_url, base)
 

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -19,12 +19,14 @@ from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.mcp import McpListing, McpValidationResult
+from services.ssrf_guard import is_private_url as _ssrf_is_private
 
 ALLOWED_SCHEMES = {"https", "http"}
 BLOCKED_SCHEMES = {"file", "ftp", "ssh", "git"}
 
-# Self-hosted deployments set this to allow corporate GitLab/GitHub Enterprise URLs
-ALLOW_INTERNAL_URLS = os.environ.get("ALLOW_INTERNAL_URLS", "").lower() in ("1", "true", "yes")
+# Self-hosted deployments set ALLOW_INTERNAL_GIT_URLS=true to allow corporate
+# GitLab / GitHub Enterprise / Gitea on a private network.
+ALLOW_INTERNAL_URLS = os.environ.get("ALLOW_INTERNAL_GIT_URLS", "").lower() in ("1", "true", "yes")
 
 # Clone timeout in seconds (default 120s; internal GitLab may need more)
 CLONE_TIMEOUT = int(os.environ.get("GIT_CLONE_TIMEOUT", "120"))
@@ -55,15 +57,8 @@ def _validate_git_url(url: str) -> str | None:
     if not parsed.hostname:
         return "URL has no hostname"
     # Block internal/private IPs unless self-hosted mode is enabled
-    if not ALLOW_INTERNAL_URLS:
-        hostname = parsed.hostname.lower()
-        if (
-            hostname in ("localhost", "127.0.0.1", "0.0.0.0", "::1")
-            or hostname.startswith("10.")
-            or hostname.startswith("192.168.")
-            or hostname.startswith("172.")
-        ):
-            return "Internal/private URLs not allowed (set ALLOW_INTERNAL_URLS=true for self-hosted deployments)"
+    if not ALLOW_INTERNAL_URLS and _ssrf_is_private(url):
+        return "Internal/private URLs not allowed (set ALLOW_INTERNAL_URLS=true for self-hosted deployments)"
     return None
 
 

--- a/observal-server/services/ssrf_guard.py
+++ b/observal-server/services/ssrf_guard.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Shared SSRF guard for all outbound HTTP and Git clone operations.
+
+Replaces the narrow string-match hostname blocklists that existed in
+alert_evaluator.py and mcp_validator.py with a single function that
+covers the full set of private, link-local, and cloud-metadata ranges
+for both IPv4 and IPv6.
+
+Usage
+-----
+from services.ssrf_guard import is_private_url
+
+if is_private_url(url):
+    raise ValueError("URL resolves to a private/internal address")
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# Hostnames that must always be blocked regardless of IP resolution.
+_BLOCKED_HOSTNAMES = frozenset(
+    {
+        "169.254.169.254",  # AWS / Azure / GCP instance metadata
+        "metadata.google.internal",
+        "fd00:ec2::254",  # AWS IMDSv2 IPv6
+    }
+)
+
+# All private, link-local, and reserved ranges for IPv4 and IPv6.
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),  # loopback
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local / APIPA
+    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT
+    ipaddress.ip_network("0.0.0.0/8"),  # unspecified
+    ipaddress.ip_network("240.0.0.0/4"),  # reserved
+    ipaddress.ip_network("224.0.0.0/4"),  # multicast
+    ipaddress.ip_network("::1/128"),  # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),  # IPv6 ULA
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
+    ipaddress.ip_network("ff00::/8"),  # IPv6 multicast
+    ipaddress.ip_network("::ffff:0:0/96"),  # IPv4-mapped IPv6
+]
+
+
+def _ip_is_private(addr_str: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(addr_str)
+    except ValueError:
+        return True  # unparseable, block it
+    # IPv4-mapped IPv6 (::ffff:a.b.c.d): extract and check the IPv4 part
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+        addr = addr.ipv4_mapped
+    return any(addr in net for net in _PRIVATE_NETWORKS)
+
+
+def is_private_url(url: str) -> bool:
+    """Return True if *url* resolves to a private or internal host.
+
+    Blocks:
+    - All RFC-1918 and loopback ranges
+    - CGNAT (100.64/10), link-local, multicast, reserved
+    - IPv6 ULA, link-local, loopback, multicast
+    - IPv4-mapped IPv6 addresses
+    - Cloud metadata endpoints (169.254.169.254 etc.)
+
+    DNS failures are treated as private (fail closed).
+    """
+    if not url:
+        return True
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return True
+    hostname = parsed.hostname
+    if not hostname:
+        return True
+
+    hostname_lower = hostname.lower().strip("[]")  # strip IPv6 brackets
+    if hostname_lower in _BLOCKED_HOSTNAMES:
+        return True
+
+    # Direct IP literal: check without DNS
+    try:
+        ipaddress.ip_address(hostname_lower)
+        return _ip_is_private(hostname_lower)
+    except ValueError:
+        pass  # not an IP literal, fall through to DNS
+
+    # Hostname: resolve and check every returned address
+    try:
+        results = socket.getaddrinfo(hostname_lower, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        if not results:
+            return True
+        return any(_ip_is_private(r[4][0]) for r in results)
+    except (socket.gaierror, OSError):
+        return True  # DNS failure, fail closed

--- a/tests/test_alert_evaluator.py
+++ b/tests/test_alert_evaluator.py
@@ -55,7 +55,7 @@ class TestIsPrivateUrl:
     def test_public_domain_is_not_private(self):
         from services.alert_evaluator import is_private_url
 
-        with patch("services.alert_evaluator.socket.getaddrinfo") as mock_gai:
+        with patch("services.ssrf_guard.socket.getaddrinfo") as mock_gai:
             mock_gai.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
             assert is_private_url("https://example.com/webhook") is False
 
@@ -68,7 +68,7 @@ class TestIsPrivateUrl:
         from services.alert_evaluator import is_private_url
 
         with patch(
-            "services.alert_evaluator.socket.getaddrinfo",
+            "services.ssrf_guard.socket.getaddrinfo",
             side_effect=OSError("DNS failed"),
         ):
             assert is_private_url("http://nonexistent.invalid/hook") is True

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tests for services.ssrf_guard (OBSV-SEC-012/013/014)."""
+
+import socket
+from unittest.mock import patch
+
+
+class TestIsPrivateUrl:
+    def test_private_rfc1918_10(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://10.0.0.1/") is True
+
+    def test_private_rfc1918_192_168(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://192.168.1.1/") is True
+
+    def test_private_rfc1918_172_16(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://172.16.0.1/") is True
+
+    def test_loopback(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://127.0.0.1/") is True
+
+    def test_ipv6_loopback(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://[::1]/") is True
+
+    def test_cgnat(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://100.64.0.1/") is True
+
+    def test_link_local_metadata(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://169.254.169.254/latest/meta-data/") is True
+
+    def test_ipv4_mapped_ipv6_loopback(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://[::ffff:127.0.0.1]/") is True
+
+    def test_ipv6_ula(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://[fc00::1]/") is True
+
+    def test_blocked_metadata_hostname(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://metadata.google.internal/") is True
+
+    def test_empty_url(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("") is True
+
+    def test_no_hostname(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("not-a-url") is True
+
+    def test_dns_failure_is_private(self):
+        from services.ssrf_guard import is_private_url
+
+        with patch("services.ssrf_guard.socket.getaddrinfo", side_effect=socket.gaierror("fail")):
+            assert is_private_url("http://nonexistent.invalid/") is True
+
+    def test_public_ip(self):
+        from services.ssrf_guard import is_private_url
+
+        assert is_private_url("http://8.8.8.8/") is False
+
+    def test_public_domain_via_dns(self):
+        from services.ssrf_guard import is_private_url
+
+        with patch(
+            "services.ssrf_guard.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            assert is_private_url("https://example.com/webhook") is False
+
+
+class TestMcpValidatorUsesGuard:
+    def test_private_ip_rejected(self):
+        from services.mcp_validator import _validate_git_url
+
+        err = _validate_git_url("https://10.0.0.1/evil/repo")
+        assert err is not None
+        assert "private" in err.lower() or "internal" in err.lower()
+
+    def test_ipv6_ula_rejected(self):
+        from services.mcp_validator import _validate_git_url
+
+        err = _validate_git_url("https://[fc00::1]/repo")
+        assert err is not None
+
+    def test_valid_github_url_accepted(self):
+        from services.mcp_validator import _validate_git_url
+
+        with patch(
+            "services.ssrf_guard.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("140.82.121.3", 0))],
+        ):
+            err = _validate_git_url("https://github.com/example/repo")
+            assert err is None
+
+
+class TestGitMirrorUsesGuard:
+    def test_private_url_raises(self):
+        from services.git_mirror_service import clone_or_update
+
+        try:
+            clone_or_update("https://192.168.1.1/repo.git")
+            raise AssertionError("Expected ValueError")
+        except ValueError as e:
+            assert "private" in str(e).lower() or "internal" in str(e).lower()
+
+    def test_allow_internal_git_urls_bypasses_check(self):
+        """ALLOW_INTERNAL_GIT_URLS=true lets self-hosted GitLab / GH Enterprise through."""
+        from unittest.mock import patch as _patch
+
+        from services.git_mirror_service import clone_or_update
+
+        with _patch("services.git_mirror_service.settings") as mock_settings:
+            mock_settings.ALLOW_INTERNAL_GIT_URLS = True
+            with _patch("services.git_mirror_service._run_git") as mock_git:
+                mock_git.return_value.returncode = 0
+                try:
+                    clone_or_update("https://192.168.1.50/internal/repo.git")
+                except ValueError:
+                    raise AssertionError("Should not raise with ALLOW_INTERNAL_GIT_URLS=True")
+                except Exception:
+                    pass  # filesystem errors fine
+
+    def test_non_http_url_not_checked(self):
+        """git:// and ssh:// URLs bypass the HTTP SSRF check (handled by scheme validation elsewhere)."""
+        from unittest.mock import patch as _patch
+
+        from services.git_mirror_service import clone_or_update
+
+        with _patch("services.git_mirror_service._run_git") as mock_git:
+            mock_git.return_value.returncode = 0
+            try:
+                clone_or_update("git@github.com:example/repo.git")
+            except Exception:
+                pass  # path/filesystem errors are fine, no ValueError expected


### PR DESCRIPTION
## Purpose / Description

Three places validated outbound URLs independently with different coverage gaps:

| Caller | Old approach | Gap |
|--------|-------------|-----|
| `alert_evaluator.py` | 6 hardcoded IPv4 CIDRs | Missed CGNAT, IPv6 ULA, IPv4-mapped IPv6, cloud metadata |
| `mcp_validator.py` | String prefix match on hostname | Missed all IPv6 variants and DNS-resolved IPs |
| `git_mirror_service.py` | No check | Any HTTP/HTTPS URL accepted before `git clone` |

## Fixes

* Fixes OBSV-SEC-012, webhook SSRF validation misses private-address variants
* Fixes OBSV-SEC-013, component source Git clone can reach private-address hosts
* Fixes OBSV-SEC-014, MCP repository analysis accepts insecure or private-address Git targets

## Self-hosted GitLab / GitHub Enterprise

If you run a private git host on an internal network, set:

```env
ALLOW_INTERNAL_GIT_URLS=true
```

This bypasses the SSRF check in both `git_mirror_service.py` and `mcp_validator.py`. The env var is also exposed as `ALLOW_INTERNAL_GIT_URLS` in `config.py`. Note: the old env var name was `ALLOW_INTERNAL_URLS`, this renames it for clarity.

## Approach

New `services/ssrf_guard.py` with a single `is_private_url()` covering:

- RFC-1918 (10/8, 172.16/12, 192.168/16)
- Loopback (127/8, ::1)
- Link-local / APIPA (169.254/16, fe80::/10)
- CGNAT (100.64/10)
- IPv4-mapped IPv6 (::ffff:0:0/96)
- IPv6 ULA (fc00::/7) and multicast (ff00::/8)
- Cloud metadata hostnames (169.254.169.254, metadata.google.internal)
- DNS failures treated as private (fail closed)

`alert_evaluator.py` re-exports `is_private_url` for backward compatibility with `api/routes/alert.py`.

## How Has This Been Tested?

`tests/test_ssrf_guard.py` (21 tests) + `tests/test_alert_evaluator.py` (36 tests) + `tests/test_git_mirror.py` (38 tests), 95 passed.

Includes: all private ranges, CGNAT, IPv4-mapped IPv6, IPv6 ULA, cloud metadata hostname, DNS failure, public IP/domain, MCP validator rejects private hosts, git mirror raises on private URL, and `ALLOW_INTERNAL_GIT_URLS=true` correctly bypasses the check for internal repos.

```
95 passed in 33s
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A, backend only)