### PR TITLE
fix(security): block operational metadata paths in nginx (OBSV-SEC-017)

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -21,6 +21,14 @@ server {
     # Reconcile endpoint receives full session JSONL — allow up to 10MB
     client_max_body_size 10m;
 
+    # Block operational metadata paths at the proxy layer (SEC-017).
+    # Requests matching this rule never reach the API — nginx returns 404
+    # directly. To re-expose these paths (e.g. for local development),
+    # remove or comment out this block.
+    location ~* ^/(docs|redoc|openapi\.json|metrics) {
+        return 404;
+    }
+
     location / {
         proxy_pass http://observal_api;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
## Purpose / Description

`/docs`, `/redoc`, `/openapi.json`, and `/metrics` were proxied to the API unconditionally, exposing route structure, API metadata, and Prometheus metrics to anyone who can reach the load balancer.

## Fixes

* Fixes OBSV-SEC-017, public API discovery reachable through multiple front doors

## Approach

Add a `location` block in `docker/nginx.conf` that returns 404 for all four paths before the catch-all proxy rule:

```nginx
location ~* ^/(docs|redoc|openapi\.json|metrics) {
    return 404;
}
```

The API-side `ENABLE_OPENAPI=true` flag can re-enable the docs endpoints upstream; this nginx rule ensures they are never exposed through the reverse proxy regardless of API configuration.

## How Has This Been Tested?

Manual config review. Nginx validates syntax on `nginx -t`.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A, config only)