### PR TITLE
fix(security): block operational paths at ALB by default (OBSV-SEC-018)

### DIFF
--- a/infra/terraform/aws/alb.tf
+++ b/infra/terraform/aws/alb.tf
@@ -130,8 +130,31 @@ resource "aws_lb_listener_rule" "http_api" {
   }
 }
 
+# Operational metadata paths (/docs, /redoc, /openapi.json).
+# Blocked by default (SEC-018); set enable_public_ops_paths=true to expose them.
+resource "aws_lb_listener_rule" "http_ops_block" {
+  count        = (local.enable_tls ? 0 : 1) * (var.enable_public_ops_paths ? 0 : 1)
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 90
+
+  action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Not found"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/openapi.json", "/docs", "/docs/*", "/redoc"]
+    }
+  }
+}
+
 resource "aws_lb_listener_rule" "http_api_docs" {
-  count        = local.enable_tls ? 0 : 1
+  count        = (local.enable_tls ? 0 : 1) * (var.enable_public_ops_paths ? 1 : 0)
   listener_arn = aws_lb_listener.http.arn
   priority     = 110
 
@@ -232,8 +255,29 @@ resource "aws_lb_listener_rule" "https_api" {
   }
 }
 
+resource "aws_lb_listener_rule" "https_ops_block" {
+  count        = (local.enable_tls ? 1 : 0) * (var.enable_public_ops_paths ? 0 : 1)
+  listener_arn = aws_lb_listener.https[0].arn
+  priority     = 90
+
+  action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Not found"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/openapi.json", "/docs", "/docs/*", "/redoc"]
+    }
+  }
+}
+
 resource "aws_lb_listener_rule" "https_api_docs" {
-  count        = local.enable_tls ? 1 : 0
+  count        = (local.enable_tls ? 1 : 0) * (var.enable_public_ops_paths ? 1 : 0)
   listener_arn = aws_lb_listener.https[0].arn
   priority     = 110
 

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -314,3 +314,9 @@ variable "backup_lifecycle_expire_days" {
   type        = number
   default     = 365
 }
+
+variable "enable_public_ops_paths" {
+  description = "Expose /docs, /redoc, /openapi.json publicly via the ALB. Set true only for internal or dev deployments. Default false blocks these paths with a 403."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Purpose / Description

`/docs`, `/redoc`, and `/openapi.json` were forwarded to the API unconditionally by ALB listener rules, exposing API metadata to anyone who can reach the load balancer on AWS deployments.

## Fixes

* Fixes OBSV-SEC-018, AWS ALB defaults expose sensitive operational paths

## Approach

Add a new variable `enable_public_ops_paths` (default `false`) to `variables.tf`. When false, a fixed-response 403 listener rule at priority 90 matches the operational paths before the existing forward rule at priority 110. When true, the forward rule is created instead and the block rule is not, restoring the previous behaviour for internal or dev deployments.

Applied to both the HTTP and HTTPS listeners.

```hcl
variable "enable_public_ops_paths" {
  type    = bool
  default = false
}
```

## How Has This Been Tested?

Manual Terraform config review. `terraform validate` passes.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A, infrastructure only)