### PR TITLE
fix(security): CSP middleware and access token in sessionStorage (OBSV-SEC-025)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -60,9 +60,14 @@ const STORAGE_KEY_USER_EMAIL = "observal_user_email";
 const STORAGE_KEY_USER_USERNAME = "observal_user_username";
 const STORAGE_KEY_USER_AVATAR = "observal_user_avatar";
 
+// Access token is stored in sessionStorage (clears on tab close) to reduce
+// the XSS exposure window. Refresh token stays in localStorage so silent
+// refresh survives page reloads across tabs.
+// TODO(SEC-025): migrate to HttpOnly cookies via a Next.js API route for
+// full XSS protection.
 function getAccessToken(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem(STORAGE_KEY_ACCESS_TOKEN);
+  return sessionStorage.getItem(STORAGE_KEY_ACCESS_TOKEN);
 }
 
 function getRefreshToken(): string | null {
@@ -71,12 +76,12 @@ function getRefreshToken(): string | null {
 }
 
 export function setTokens(accessToken: string, refreshToken: string) {
-  localStorage.setItem(STORAGE_KEY_ACCESS_TOKEN, accessToken);
+  sessionStorage.setItem(STORAGE_KEY_ACCESS_TOKEN, accessToken);
   localStorage.setItem(STORAGE_KEY_REFRESH_TOKEN, refreshToken);
 }
 
 export function clearSession() {
-  localStorage.removeItem(STORAGE_KEY_ACCESS_TOKEN);
+  sessionStorage.removeItem(STORAGE_KEY_ACCESS_TOKEN);
   localStorage.removeItem(STORAGE_KEY_REFRESH_TOKEN);
   localStorage.removeItem("observal_api_key"); // clean up legacy
   localStorage.removeItem(STORAGE_KEY_USER_ROLE);

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Next.js edge middleware — injects security headers on every response.
+ *
+ * Content-Security-Policy prevents XSS by restricting where scripts,
+ * styles, and other resources can be loaded from.
+ *
+ * X-Frame-Options and frame-ancestors together prevent clickjacking.
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'", // unsafe-inline needed for Tailwind/shadcn
+  "img-src 'self' data: https:",
+  "font-src 'self'",
+  "connect-src 'self' https:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join("; ");
+
+export function middleware(_request: NextRequest) {
+  const response = NextResponse.next();
+  response.headers.set("Content-Security-Policy", CSP);
+  response.headers.set("X-Frame-Options", "DENY");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  return response;
+}
+
+export const config = {
+  // Apply to all routes except Next.js internals and static assets
+  matcher: "/((?!_next/static|_next/image|favicon.ico).*)",
+};


### PR DESCRIPTION
## Purpose / Description

Two XSS mitigations for the Next.js frontend. Any XSS in the web app could read `localStorage` and exfiltrate the access token. There was also no Content-Security-Policy restricting where scripts and resources can be loaded from.

## Fixes

* Fixes OBSV-SEC-025, browser-accessible token storage and missing Next.js CSP

## Approach

**1. `web/src/middleware.ts` (new file)**

Next.js edge middleware that injects security headers on every response:

- `Content-Security-Policy` restricts scripts, styles, images, and connections to `self` plus `https:`. Blocks inline scripts and framing.
- `X-Frame-Options: DENY` clickjacking protection (complements `frame-ancestors none` in CSP).
- `X-Content-Type-Options: nosniff`.

**2. `web/src/lib/api.ts`**

Access token moved from `localStorage` to `sessionStorage`. The token is cleared automatically when the tab closes, reducing the window during which a stored credential could be exfiltrated by an XSS payload. The refresh token stays in `localStorage` so silent refresh survives page reloads across tabs.

A TODO comment marks the path to a full HttpOnly cookie migration.

## How Has This Been Tested?

`pnpm run lint` passes (0 errors).

## Learning

`sessionStorage` is per-tab and cleared on tab close. `localStorage` persists across tabs and browser restarts. For the access token, sessionStorage is the right tradeoff: short-lived tokens do not need to persist, while the refresh token does.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (frontend-only, no visible UI change)