### PR TITLE
fix(security): block password lifecycle routes in SSO-only mode (OBSV-SEC-028)

### DIFF
--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -92,7 +92,7 @@ async def _issue_tokens(user: User, groups: list[str] | None = None) -> tuple[st
     return access_token, refresh_token, expires_in
 
 
-@router.post("/init", response_model=InitResponse)
+@router.post("/init", response_model=InitResponse, dependencies=[Depends(require_password_auth)])
 async def init_admin(req: InitRequest, db: AsyncSession = Depends(get_db)):
     count = await db.scalar(select(func.count()).select_from(User))
     if count and count > 0:
@@ -603,7 +603,7 @@ async def revoke_token(request: Request, req: RevokeRequest):
     return {"detail": "Token revoked"}
 
 
-@router.put("/profile/password")
+@router.put("/profile/password", dependencies=[Depends(require_password_auth)])
 @limiter.limit("5/minute")
 async def change_password(
     request: Request,

--- a/tests/test_sec028_sso_guards.py
+++ b/tests/test_sec028_sso_guards.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""SEC-028: Password lifecycle routes must be blocked when SSO_ONLY=True."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_async_client():
+    from httpx import ASGITransport, AsyncClient
+
+    from api.ratelimit import limiter
+    from main import app
+
+    limiter.enabled = False
+
+    return AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    )
+
+
+def _cleanup():
+    from main import app
+
+    app.dependency_overrides.clear()
+
+
+class TestSec028SsoGuards:
+    """POST /init and PUT /profile/password must return 403 when SSO_ONLY=True."""
+
+    @pytest.mark.asyncio
+    async def test_init_blocked_when_sso_only(self):
+        """POST /api/v1/auth/init returns 403 when SSO_ONLY=True."""
+        fake_settings = MagicMock()
+        fake_settings.SSO_ONLY = True
+
+        with patch("api.deps.settings", fake_settings):
+            async with _make_async_client() as client:
+                response = await client.post(
+                    "/api/v1/auth/init",
+                    json={
+                        "email": "admin@example.com",
+                        "password": "secret123",
+                        "name": "Admin",
+                    },
+                )
+
+        _cleanup()
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_change_password_blocked_when_sso_only(self):
+        """PUT /api/v1/auth/profile/password returns 403 when SSO_ONLY=True."""
+        fake_settings = MagicMock()
+        fake_settings.SSO_ONLY = True
+
+        with patch("api.deps.settings", fake_settings):
+            async with _make_async_client() as client:
+                response = await client.put(
+                    "/api/v1/auth/profile/password",
+                    json={
+                        "current_password": "old",
+                        "new_password": "new",
+                    },
+                    headers={"Authorization": "Bearer dummy"},
+                )
+
+        _cleanup()
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_init_not_blocked_when_sso_only_false(self):
+        """POST /api/v1/auth/init is not blocked when SSO_ONLY=False (returns 400 for already-initialized)."""
+        from api.deps import get_db
+        from main import app
+
+        # Fake DB: pretend system already has a user so init returns 400, not 500
+        mock_scalar = AsyncMock(return_value=1)
+        mock_db = AsyncMock()
+        mock_db.scalar = mock_scalar
+
+        async def _mock_get_db():
+            yield mock_db
+
+        fake_settings = MagicMock()
+        fake_settings.SSO_ONLY = False
+
+        app.dependency_overrides[get_db] = _mock_get_db
+
+        with patch("api.deps.settings", fake_settings):
+            async with _make_async_client() as client:
+                response = await client.post(
+                    "/api/v1/auth/init",
+                    json={
+                        "email": "admin@example.com",
+                        "password": "secret123",
+                        "name": "Admin",
+                    },
+                )
+
+        _cleanup()
+        # Must NOT be 403 — the route is reachable; it returns 400 because system
+        # is already initialized (our mock DB returns count=1).
+        assert response.status_code != 403
+        assert response.status_code == 400


### PR DESCRIPTION
## Purpose / Description

`/auth/init` and `/auth/profile/password` did not check `SSO_ONLY`. In an SSO-only deployment these endpoints allowed local password creation and changes that should be disabled, bypassing the SSO requirement.

## Fixes

* Fixes OBSV-SEC-028, SSO-only and SCIM deactivation controls are inconsistent

## Approach

`require_password_auth` is already defined in `api/deps.py` and used on `/login` and `/token`. It raises HTTP 403 when `settings.SSO_ONLY=True`. Apply the same dependency to:

- `POST /api/v1/auth/init` (initial admin creation)
- `PUT /api/v1/auth/profile/password` (password change)

One-line change per route, identical pattern to the existing `/login` guard.

## How Has This Been Tested?

`tests/test_sec028_sso_guards.py`, 3 tests. Full suite: ~1900 passed.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A, backend only)