### PR TITLE
fix(mcp): return 409 instead of 500 on duplicate name in /submit

### DIFF
--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
@@ -141,35 +142,47 @@ async def submit_mcp(
         owner_org_id=current_user.org_id,
     )
     db.add(listing)
-    await db.flush()
 
-    version = McpVersion(
-        listing_id=listing.id,
-        version=req.version,
-        description=req.description,
-        transport=req.transport or ("sse" if req.url and not req.command else "stdio" if req.command else None),
-        framework=req.framework,
-        docker_image=req.docker_image,
-        command=req.command,
-        args=req.args,
-        url=req.url,
-        headers=[h.model_dump() for h in req.headers] if req.headers else None,
-        auto_approve=req.auto_approve,
-        environment_variables=[ev.model_dump() for ev in req.environment_variables],
-        supported_ides=req.supported_ides,
-        setup_instructions=req.setup_instructions,
-        changelog=req.changelog,
-        source_url=req.git_url,
-        status=ListingStatus.pending,
-        released_by=current_user.id,
-        released_at=datetime.now(UTC),
-    )
-    db.add(version)
-    await db.flush()
+    try:
+        await db.flush()
 
-    listing.latest_version_id = version.id
-    await db.commit()
-    await db.refresh(listing)
+        version = McpVersion(
+            listing_id=listing.id,
+            version=req.version,
+            description=req.description,
+            transport=req.transport or ("sse" if req.url and not req.command else "stdio" if req.command else None),
+            framework=req.framework,
+            docker_image=req.docker_image,
+            command=req.command,
+            args=req.args,
+            url=req.url,
+            headers=[h.model_dump() for h in req.headers] if req.headers else None,
+            auto_approve=req.auto_approve,
+            environment_variables=[ev.model_dump() for ev in req.environment_variables],
+            supported_ides=req.supported_ides,
+            setup_instructions=req.setup_instructions,
+            changelog=req.changelog,
+            source_url=req.git_url,
+            status=ListingStatus.pending,
+            released_by=current_user.id,
+            released_at=datetime.now(UTC),
+        )
+        db.add(version)
+        await db.flush()
+
+        listing.latest_version_id = version.id
+        await db.commit()
+        await db.refresh(listing)
+    except IntegrityError:
+        # Catch DB-level uniqueness conflicts (e.g. a listing with this name
+        # already exists for another user, or a (listing_id, version) pair
+        # collides) so callers see a 409 instead of the bare 500 the
+        # unhandled error would otherwise surface (issue #900).
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=f"A listing with this name already exists: '{req.name}'",
+        ) from None
 
     if req.client_analysis:
         # CLI already cloned and analyzed locally — store results directly


### PR DESCRIPTION
The `/api/v1/mcps/submit` endpoint returned a bare HTTP 500 when a unique-constraint violation surfaced on the DB flush/commit path (e.g. a duplicate listing name across users, or a `(listing_id, version)` collision at the `mcp_versions` level). The reporter in #900 hit this with two successive curl calls using `"name":"duplicate-test"` and expected a 409 with an actionable message.

## Change

In `observal-server/api/routes/mcp.py`, wrap the flush + commit sequence inside `submit_mcp()` with `try/except IntegrityError`, mirroring the pattern already used in `observal-server/api/routes/component_source.py:add_source`:

- The existing per-user "replace pending/rejected listing" path is untouched - that still runs before the constraint-sensitive block.
- The new `except IntegrityError` rolls back the session and raises `HTTPException(409)` with the listing name in the detail, so client integrations can surface the conflict cleanly instead of seeing a 500.
- Added `from sqlalchemy.exc import IntegrityError` (same import already pulled in by `component_source.py`).

## Verification

- `uv run --with ruff==0.15.10 ruff check observal-server/api/routes/mcp.py`: All checks passed.
- `uv run --with ruff==0.15.10 ruff format --check observal-server/api/routes/mcp.py`: already formatted.
- Python syntax (ast.parse): valid.

I'm happy to sign the CLA so this can merge.

Closes #900
