### PR TITLE
fix: add unsafe-inline to CSP script-src for Next.js hydration

### DIFF
--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -15,7 +15,7 @@ import type { NextRequest } from "next/server";
 
 const CSP = [
   "default-src 'self'",
-  "script-src 'self'",
+  "script-src 'self' 'unsafe-inline'", // unsafe-inline required for Next.js hydration scripts
   "style-src 'self' 'unsafe-inline'", // unsafe-inline needed for Tailwind/shadcn
   "img-src 'self' data: https:",
   "font-src 'self'",


### PR DESCRIPTION
## Purpose

Hotfix for broken CSP introduced in #979 (SEC-025). `script-src 'self'` blocked Next.js inline hydration scripts, causing React to never mount, leaving the entire UI frozen and unresponsive.

## Fixes

Replaces `script-src 'self'` with `script-src 'self' 'unsafe-inline'`.

Next.js injects several inline `<script>` blocks for RSC payload hydration, theme detection, and font loading. These are same-origin scripts generated at render time, not injected by third parties. Blocking them breaks the app entirely.

## Approach

One-line change in `web/src/middleware.ts`. The CSP still provides meaningful protection: `default-src 'self'` blocks all external resource loading, `frame-ancestors 'none'` prevents clickjacking, `connect-src 'self' https:` restricts fetch targets.

## How Has This Been Tested

Verified locally: `localhost:3000` now loads and is fully interactive after rebuild.

## Checklist

- [x] Self-review done
- [x] No new dependencies
- [x] Hotfix only, no scope creep