### PR TITLE
fix(security): require authentication on GraphQL telemetry endpoint

### DIFF
--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -632,8 +632,16 @@ def _is_admin(ctx: dict) -> bool:
 
 
 async def get_context_dep(request: Request = None) -> dict:
-    """Strawberry FastAPI context getter — receives the incoming ``Request``."""
+    """Strawberry FastAPI context getter — receives the incoming ``Request``.
+
+    Rejects unauthenticated requests with HTTP 401 so that telemetry data
+    (traces, spans, metrics) is never exposed to anonymous callers.
+    """
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
     uctx = await _resolve_user_context_from_request(request)
+    if uctx["user_id"] is None:
+        raise StarletteHTTPException(status_code=401, detail="Authentication required")
     return get_context(uctx["project_id"], uctx["user_id"], uctx["user_role"], uctx.get("trace_privacy", False))
 
 

--- a/tests/test_sec007_graphql_auth.py
+++ b/tests/test_sec007_graphql_auth.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tests for the GraphQL endpoint authentication requirement.
+
+Verifies that the /api/v1/graphql endpoint rejects unauthenticated requests
+and that authenticated requests are allowed through to the resolvers.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_client():
+    from httpx import ASGITransport, AsyncClient
+
+    from api.ratelimit import limiter
+    from main import app
+
+    limiter.enabled = False
+    return AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    )
+
+
+GQL_TRACES = '{ "query": "{ traces { edges { node { trace_id } } } }" }'
+GQL_SPAN = '{ "query": "{ span(spanId: \\"abc\\") { span_id } }" }'
+
+
+@pytest.mark.asyncio
+async def test_graphql_rejects_unauthenticated():
+    """Anonymous POST to /api/v1/graphql must return 401."""
+    from main import app
+
+    app.dependency_overrides.clear()
+    async with _make_client() as client:
+        r = await client.post(
+            "/api/v1/graphql",
+            content=GQL_TRACES,
+            headers={"Content-Type": "application/json"},
+        )
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_graphql_rejects_invalid_token():
+    """A request with a malformed Bearer token must return 401."""
+    from main import app
+
+    app.dependency_overrides.clear()
+    async with _make_client() as client:
+        r = await client.post(
+            "/api/v1/graphql",
+            content=GQL_TRACES,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer not-a-real-token",
+            },
+        )
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_graphql_allows_authenticated_user():
+    """A valid authenticated context reaches the resolver (no 401/403)."""
+    from api.graphql import get_context_dep
+    from main import app
+
+    async def _fake_ctx():
+        return {
+            "project_id": "default",
+            "user_id": str(uuid.uuid4()),
+            "user_role": "user",
+            "trace_privacy": False,
+            "span_loader": MagicMock(),
+            "score_by_trace_loader": MagicMock(),
+            "score_by_span_loader": MagicMock(),
+        }
+
+    app.dependency_overrides[get_context_dep] = _fake_ctx
+    try:
+        with patch("api.graphql.query_traces", new_callable=AsyncMock, return_value=[]):
+            async with _make_client() as client:
+                r = await client.post(
+                    "/api/v1/graphql",
+                    content=GQL_TRACES,
+                    headers={"Content-Type": "application/json"},
+                )
+        assert r.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_graphql_get_rejects_unauthenticated():
+    """GraphQL introspection via GET also requires auth."""
+    from main import app
+
+    app.dependency_overrides.clear()
+    async with _make_client() as client:
+        r = await client.get("/api/v1/graphql?query={__typename}")
+    assert r.status_code == 401


### PR DESCRIPTION
## Purpose

The `/api/v1/graphql` endpoint had no authentication gate. Any anonymous caller could query every trace, span, and metric across all users directly from ClickHouse.

## Description

The `get_context_dep` context getter already decoded the JWT and resolved the user, but it never rejected requests where no valid user was found. It silently returned `user_id=None`, which resolvers treated as an unauthenticated read with no scoping applied.

## Approach

One targeted change in `get_context_dep` (`api/graphql.py`): after calling `_resolve_user_context_from_request`, raise `HTTP 401` if `user_id` is still `None`. This is the earliest possible rejection point, before any resolver or DataLoader executes.

No schema changes, no new dependencies.

## How Has This Been Tested

4 tests in `tests/test_sec007_graphql_auth.py`:
- Anonymous POST returns 401
- Invalid Bearer token returns 401
- Valid authenticated context reaches resolver (200)
- Anonymous GET (introspection) returns 401

All 31 existing GraphQL tests continue to pass.

## Checklist

- [x] Self-review done
- [x] Tests added and passing
- [x] No new dependencies
- [x] No schema or API contract changes