### PR TITLE
fix(security): scope private registry listings to owner org

### DIFF
--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -360,3 +360,57 @@ async def resolve_prefix_id(
     if len(records) > MAX_AMBIGUOUS_MATCHES_SHOWN:
         detail += " and more..."
     raise HTTPException(status_code=400, detail=detail)
+
+
+def apply_visibility_filter(stmt, model, current_user):
+    """Exclude private listings from orgs other than the requesting user's.
+
+    Rules:
+    - Public items (is_private=False) are always visible.
+    - Private items are only visible to users in the same org, or to the
+      submitter directly, or to admins/reviewers.
+    """
+    from sqlalchemy import or_
+
+    from models.user import UserRole
+
+    if not hasattr(model, "is_private"):
+        return stmt
+
+    is_admin = (
+        current_user is not None and ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
+    )
+    if is_admin:
+        return stmt  # admins see everything
+
+    public = model.is_private == False  # noqa: E712
+    if current_user is None:
+        return stmt.where(public)
+
+    # Guard: only match same-org if user actually has an org (not NULL)
+    if current_user.org_id is not None:
+        same_org = (model.is_private == True) & (model.owner_org_id == current_user.org_id)  # noqa: E712
+        own = (model.is_private == True) & (model.submitted_by == current_user.id)  # noqa: E712
+        return stmt.where(or_(public, same_org, own))
+    # User has no org — can only see their own private items
+    own = (model.is_private == True) & (model.submitted_by == current_user.id)  # noqa: E712
+    return stmt.where(or_(public, own))
+
+
+def check_listing_visibility(listing, current_user) -> bool:
+    """Return True if current_user may see this listing.
+
+    Used on detail routes to gate access to private items.
+    """
+    from models.user import UserRole
+
+    if not getattr(listing, "is_private", False):
+        return True
+    if current_user is None:
+        return False
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
+    if is_admin:
+        return True
+    if listing.submitted_by == current_user.id:
+        return True
+    return current_user.org_id is not None and listing.owner_org_id == current_user.org_id

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -11,7 +11,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.deps import (
+    ROLE_HIERARCHY,
+    apply_visibility_filter,
+    check_listing_visibility,
+    get_db,
+    optional_current_user,
+    require_role,
+    resolve_listing,
+)
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.hook import HookDownload, HookListing, HookVersion
@@ -90,6 +98,7 @@ async def list_hooks(
     scope: str | None = Query(None),
     search: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
     stmt = (
         select(HookListing)
@@ -103,6 +112,7 @@ async def list_hooks(
     if search:
         safe = escape_like(search)
         stmt = stmt.where(HookListing.name.ilike(f"%{safe}%") | HookVersion.description.ilike(f"%{safe}%"))
+    stmt = apply_visibility_filter(stmt, HookListing, current_user)
     result = await db.execute(stmt.order_by(HookListing.created_at.desc()))
     listings = [HookListingSummary.model_validate(r) for r in result.scalars().all()]
     await audit(None, "hook.list", resource_type="hook")
@@ -140,10 +150,7 @@ async def get_hook(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
-    if current_user and (
-        listing.submitted_by == current_user.id
-        or ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
-    ):
+    if check_listing_visibility(listing, current_user):
         await audit(
             current_user, "hook.view", resource_type="hook", resource_id=str(listing.id), resource_name=listing.name
         )

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -12,7 +12,15 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, R
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.deps import (
+    ROLE_HIERARCHY,
+    apply_visibility_filter,
+    check_listing_visibility,
+    get_db,
+    optional_current_user,
+    require_role,
+    resolve_listing,
+)
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from database import async_session
@@ -190,6 +198,7 @@ async def list_mcps(
     category: str | None = Query(None),
     search: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
     stmt = (
         select(McpListing)
@@ -201,6 +210,7 @@ async def list_mcps(
     if search:
         safe = escape_like(search)
         stmt = stmt.where(McpListing.name.ilike(f"%{safe}%") | McpVersion.description.ilike(f"%{safe}%"))
+    stmt = apply_visibility_filter(stmt, McpListing, current_user)
     result = await db.execute(stmt.order_by(McpListing.created_at.desc()))
     listings = [McpListingSummary.model_validate(r) for r in result.scalars().all()]
     await audit(None, "mcp.list", resource_type="mcp")
@@ -236,10 +246,7 @@ async def get_mcp(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
-    if current_user and (
-        listing.submitted_by == current_user.id
-        or ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
-    ):
+    if check_listing_visibility(listing, current_user):
         await audit(
             current_user, "mcp.view", resource_type="mcp", resource_id=str(listing.id), resource_name=listing.name
         )

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -12,7 +12,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.deps import (
+    ROLE_HIERARCHY,
+    apply_visibility_filter,
+    check_listing_visibility,
+    get_db,
+    optional_current_user,
+    require_role,
+    resolve_listing,
+)
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
@@ -85,6 +93,7 @@ async def list_prompts(
     category: str | None = Query(None),
     search: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
     stmt = (
         select(PromptListing)
@@ -96,6 +105,7 @@ async def list_prompts(
     if search:
         safe = escape_like(search)
         stmt = stmt.where(PromptListing.name.ilike(f"%{safe}%") | PromptVersion.description.ilike(f"%{safe}%"))
+    stmt = apply_visibility_filter(stmt, PromptListing, current_user)
     result = await db.execute(stmt.order_by(PromptListing.created_at.desc()))
     listings = [PromptListingSummary.model_validate(r) for r in result.scalars().all()]
     await audit(None, "prompt.list", resource_type="prompt")
@@ -135,10 +145,7 @@ async def get_prompt(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
-    if current_user and (
-        listing.submitted_by == current_user.id
-        or ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
-    ):
+    if check_listing_visibility(listing, current_user):
         await audit(
             current_user, "prompt.view", resource_type="prompt", resource_id=str(listing.id), resource_name=listing.name
         )

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -10,7 +10,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.deps import (
+    ROLE_HIERARCHY,
+    apply_visibility_filter,
+    check_listing_visibility,
+    get_db,
+    optional_current_user,
+    require_role,
+    resolve_listing,
+)
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
@@ -86,6 +94,7 @@ async def list_sandboxes(
     runtime_type: str | None = Query(None),
     search: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
     stmt = (
         select(SandboxListing)
@@ -97,6 +106,7 @@ async def list_sandboxes(
     if search:
         safe = escape_like(search)
         stmt = stmt.where(SandboxListing.name.ilike(f"%{safe}%") | SandboxVersion.description.ilike(f"%{safe}%"))
+    stmt = apply_visibility_filter(stmt, SandboxListing, current_user)
     result = await db.execute(stmt.order_by(SandboxListing.created_at.desc()))
     listings = [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
     await audit(None, "sandbox.list", resource_type="sandbox")
@@ -140,10 +150,7 @@ async def get_sandbox(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
-    if current_user and (
-        listing.submitted_by == current_user.id
-        or ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
-    ):
+    if check_listing_visibility(listing, current_user):
         await audit(
             current_user,
             "sandbox.view",

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -11,7 +11,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import ROLE_HIERARCHY, get_db, optional_current_user, require_role, resolve_listing
+from api.deps import (
+    ROLE_HIERARCHY,
+    apply_visibility_filter,
+    check_listing_visibility,
+    get_db,
+    optional_current_user,
+    require_role,
+    resolve_listing,
+)
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
@@ -91,6 +99,7 @@ async def list_skills(
     target_agent: str | None = Query(None),
     search: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
     stmt = (
         select(SkillListing)
@@ -104,6 +113,7 @@ async def list_skills(
     if search:
         safe = escape_like(search)
         stmt = stmt.where(SkillListing.name.ilike(f"%{safe}%") | SkillVersion.description.ilike(f"%{safe}%"))
+    stmt = apply_visibility_filter(stmt, SkillListing, current_user)
     result = await db.execute(stmt.order_by(SkillListing.created_at.desc()))
     listings = [SkillListingSummary.model_validate(r) for r in result.scalars().all()]
     await audit(None, "skill.list", resource_type="skill")
@@ -143,10 +153,7 @@ async def get_skill(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
-    if current_user and (
-        listing.submitted_by == current_user.id
-        or ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
-    ):
+    if check_listing_visibility(listing, current_user):
         await audit(
             current_user, "skill.view", resource_type="skill", resource_id=str(listing.id), resource_name=listing.name
         )

--- a/tests/test_sec009_org_scoping.py
+++ b/tests/test_sec009_org_scoping.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tests for org-scoped visibility on registry list and detail endpoints.
+
+Verifies that private listings are hidden from users in other organisations,
+visible to users in the same organisation, and always visible to admins.
+The same rules apply to MCP, skill, hook, prompt, and sandbox routes.
+"""
+
+import uuid
+from unittest.mock import MagicMock
+
+from api.deps import apply_visibility_filter, check_listing_visibility
+
+# ── Unit tests for the shared helpers ─────────────────────────────────────────
+
+
+def _user(role="user", org_id=None):
+    from models.user import User, UserRole
+
+    u = MagicMock(spec=User)
+    u.id = uuid.uuid4()
+    u.role = getattr(UserRole, role)
+    u.org_id = org_id or uuid.uuid4()
+    return u
+
+
+def _listing(is_private=False, owner_org_id=None, submitted_by=None):
+    m = MagicMock()
+    m.is_private = is_private
+    m.owner_org_id = owner_org_id or uuid.uuid4()
+    m.submitted_by = submitted_by or uuid.uuid4()
+    return m
+
+
+class TestCheckListingVisibility:
+    def test_public_listing_always_visible(self):
+        assert check_listing_visibility(_listing(is_private=False), None) is True
+        assert check_listing_visibility(_listing(is_private=False), _user()) is True
+
+    def test_private_hidden_from_anonymous(self):
+        assert check_listing_visibility(_listing(is_private=True), None) is False
+
+    def test_private_hidden_from_other_org(self):
+        org_a = uuid.uuid4()
+        org_b = uuid.uuid4()
+        listing = _listing(is_private=True, owner_org_id=org_a)
+        user = _user(org_id=org_b)
+        assert check_listing_visibility(listing, user) is False
+
+    def test_private_visible_to_same_org(self):
+        org = uuid.uuid4()
+        listing = _listing(is_private=True, owner_org_id=org)
+        user = _user(org_id=org)
+        assert check_listing_visibility(listing, user) is True
+
+    def test_private_visible_to_submitter(self):
+        user = _user()
+        listing = _listing(is_private=True, submitted_by=user.id)
+        assert check_listing_visibility(listing, user) is True
+
+    def test_private_visible_to_admin(self):
+        listing = _listing(is_private=True)
+        assert check_listing_visibility(listing, _user(role="admin")) is True
+        assert check_listing_visibility(listing, _user(role="reviewer")) is True
+
+    def test_no_is_private_attr_is_visible(self):
+        m = MagicMock(spec=[])  # no is_private attribute
+        assert check_listing_visibility(m, None) is True
+
+
+class TestApplyVisibilityFilter:
+    def _stmt(self):
+        s = MagicMock()
+        s.where = MagicMock(return_value=s)
+        return s
+
+    def _model(self):
+        from models.mcp import McpListing
+
+        return McpListing
+
+    def test_no_is_private_attr_passes_through(self):
+        model = MagicMock(spec=[])
+        stmt = self._stmt()
+        result = apply_visibility_filter(stmt, model, None)
+        stmt.where.assert_not_called()
+        assert result is stmt
+
+    def test_anonymous_sees_only_public(self):
+        from models.mcp import McpListing
+
+        stmt = self._stmt()
+        apply_visibility_filter(stmt, McpListing, None)
+        stmt.where.assert_called_once()
+
+    def test_admin_sees_all(self):
+        from models.mcp import McpListing
+
+        stmt = self._stmt()
+        result = apply_visibility_filter(stmt, McpListing, _user(role="admin"))
+        stmt.where.assert_not_called()
+        assert result is stmt
+
+    def test_regular_user_filter_applied(self):
+        from models.mcp import McpListing
+
+        stmt = self._stmt()
+        apply_visibility_filter(stmt, McpListing, _user(role="user"))
+        stmt.where.assert_called_once()


### PR DESCRIPTION
## Purpose

Private listings (`is_private=True`) were accessible to any authenticated user who knew the UUID, regardless of which organisation they belonged to. A user in org A could read private listings owned by org B.

## Description

The detail endpoints checked `submitted_by == current_user.id` or admin role, but never checked `owner_org_id`. The list endpoints had no privacy filter at all, so private items from all orgs appeared in public listing responses.

## Approach

Two shared helpers added to `api/deps.py`:

- `apply_visibility_filter(stmt, model, current_user)`: appends a WHERE clause to list queries. Public items are always included. Private items are included only if the user is in the same org, is the submitter, or has admin/reviewer role. Anonymous callers see only public items.
- `check_listing_visibility(listing, current_user)`: boolean gate for detail routes. Returns False for private listings from other orgs, causing a 404 response.

Both helpers are applied across all five component routes: MCP, skill, hook, prompt, and sandbox. List endpoints now accept `optional_current_user` and pass it through the filter. Detail endpoints replace the old `submitted_by`-only check with `check_listing_visibility`.

## How Has This Been Tested

11 unit tests in `tests/test_sec009_org_scoping.py` covering all visibility rules. All 55 existing registry type tests continue to pass.

## Checklist

- [x] Self-review done
- [x] Tests added and passing
- [x] No new dependencies
- [x] No migration needed (no schema changes)