### PR TITLE
fix: update remaining localStorage reads to sessionStorage for access token

### DIFF
--- a/web/src/app/(auth)/device/page.tsx
+++ b/web/src/app/(auth)/device/page.tsx
@@ -32,7 +32,7 @@ function DeviceContent() {
   // Redirect to login if not authenticated
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const hasToken = !!localStorage.getItem("observal_access_token");
+    const hasToken = !!sessionStorage.getItem("observal_access_token");
     if (!hasToken) {
       const code = searchParams.get("code");
       const returnPath = code ? `/device?code=${encodeURIComponent(code)}` : "/device";
@@ -76,7 +76,7 @@ function DeviceContent() {
   }
 
   // Don't render form until we know user is authenticated
-  if (typeof window !== "undefined" && !localStorage.getItem("observal_access_token")) {
+  if (typeof window !== "undefined" && !sessionStorage.getItem("observal_access_token")) {
     return null;
   }
 

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -34,7 +34,7 @@ function LoginContent() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const hasToken = !!localStorage.getItem("observal_access_token");
+    const hasToken = !!sessionStorage.getItem("observal_access_token");
     if (hasToken && getUserRole()) {
       router.replace("/");
     }

--- a/web/src/app/(registry)/agents/[id]/page.tsx
+++ b/web/src/app/(registry)/agents/[id]/page.tsx
@@ -493,7 +493,7 @@ export default function AgentDetailPage({
   }, []);
   const isAuthenticated = useSyncExternalStore(
     storeSub,
-    () => !!localStorage.getItem("observal_access_token"),
+    () => !!sessionStorage.getItem("observal_access_token"),
     () => false,
   );
   const isAdmin = useSyncExternalStore(

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -476,7 +476,7 @@ function AgentBuilderInner() {
     });
 
     const releaseLock = () => {
-      const token = localStorage.getItem("observal_access_token");
+      const token = sessionStorage.getItem("observal_access_token");
       fetch(`/api/v1/agents/${agentIdParam}/cancel-edit`, {
         method: "POST",
         headers: {

--- a/web/src/app/(registry)/components/[id]/page.tsx
+++ b/web/src/app/(registry)/components/[id]/page.tsx
@@ -61,7 +61,7 @@ export default function ComponentDetailPage({ params }: { params: Promise<{ id: 
   }, []);
   const isAuthenticated = useSyncExternalStore(
     storeSub,
-    () => !!localStorage.getItem("observal_access_token"),
+    () => !!sessionStorage.getItem("observal_access_token"),
     () => false,
   );
 

--- a/web/src/app/(registry)/components/page.tsx
+++ b/web/src/app/(registry)/components/page.tsx
@@ -207,7 +207,7 @@ export default function ComponentsPage() {
       const item = editItemRef.current;
       if (item?.status === "pending") {
         const type = activeTypeRef.current;
-        const token = localStorage.getItem("observal_access_token");
+        const token = sessionStorage.getItem("observal_access_token");
         fetch(`/api/v1/${type}/${item.id}/cancel-edit`, {
           method: "POST",
           headers: {

--- a/web/src/app/(user)/account/page.tsx
+++ b/web/src/app/(user)/account/page.tsx
@@ -245,7 +245,7 @@ function ChangeUsernameSection() {
 				method: "PUT",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: `Bearer ${localStorage.getItem("observal_access_token")}`,
+					Authorization: `Bearer ${sessionStorage.getItem("observal_access_token")}`,
 				},
 				body: JSON.stringify({ username: newUsername }),
 			});

--- a/web/src/components/nav/nav-user.tsx
+++ b/web/src/components/nav/nav-user.tsx
@@ -95,7 +95,7 @@ export function NavUser({ user }: NavUserProps) {
         <DropdownMenuItem
           onClick={async () => {
             try {
-              const token = localStorage.getItem("observal_access_token");
+              const token = sessionStorage.getItem("observal_access_token");
               const refreshToken = localStorage.getItem("observal_refresh_token");
               if (token) {
                 await fetch("/api/v1/auth/logout", {

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -93,7 +93,7 @@ const storeSub = (cb: () => void) => {
   return () => window.removeEventListener("storage", cb);
 };
 const getAuthSnap = () =>
-  `${localStorage.getItem("observal_access_token") ?? ""}|${getUserRole() ?? ""}|${getUserName() ?? ""}|${getUserEmail() ?? ""}|${getUserUsername() ?? ""}`;
+  `${sessionStorage.getItem("observal_access_token") ?? ""}|${getUserRole() ?? ""}|${getUserName() ?? ""}|${getUserEmail() ?? ""}|${getUserUsername() ?? ""}`;
 const getServerSnap = () => "||||";
 
 export function RegistrySidebar() {

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -17,7 +17,7 @@ function subscribe(cb: () => void) {
 
 function getAuthSnapshot() {
   if (typeof window === "undefined") return "";
-  const key = localStorage.getItem("observal_access_token");
+  const key = sessionStorage.getItem("observal_access_token");
   const role = getUserRole();
   return key ? (role || "pending") : "";
 }

--- a/web/src/lib/graphql-ws.ts
+++ b/web/src/lib/graphql-ws.ts
@@ -15,7 +15,7 @@ function getWsUrl(): string {
 
 function getToken(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem("observal_access_token");
+  return sessionStorage.getItem("observal_access_token");
 }
 
 let client: Client | null = null;


### PR DESCRIPTION
## Purpose

Device authorization via browser was broken with a 'Missing credentials' error after SEC-025 moved the access token to sessionStorage.

## Description

SEC-025 updated api.ts to read/write the access token from sessionStorage, but 11 other files across the frontend still called localStorage.getItem('observal_access_token') directly. The device auth page checked localStorage for the token, found nothing, and sent requests to /confirm without an Authorization header.

## Approach

Replace all remaining localStorage.getItem('observal_access_token') calls with sessionStorage across 11 files. Refresh token references remain in localStorage by design.

## Checklist

- [x] Self-review done
- [x] No new dependencies
- [x] Fixes device auth regression from SEC-025