### PR TITLE
fix: login page respects ?next= param after authentication

### DIFF
--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -110,7 +110,8 @@ function LoginContent() {
       if (res.user.username) setUserUsername(res.user.username);
       if (res.user.avatar_url) setUserAvatar(res.user.avatar_url);
       toast.success("Signed in successfully");
-      router.push("/");
+      const nextPath = searchParams.get("next");
+      router.push(nextPath && nextPath.startsWith("/") ? nextPath : "/");
     } catch (e) {
       const raw = e instanceof Error ? e.message : "Login failed";
       const status = e instanceof Error ? (e as Error & { status?: number }).status : undefined;


### PR DESCRIPTION
## Purpose

Device auth flow was still broken after #1002. After logging in, users were redirected to / instead of back to /device?code=XXXX, leaving the CLI hanging with no confirmation.

## Description

handlePasswordLogin in login/page.tsx called router.push('/') unconditionally. The ?next= handling existed in the SSO useEffect callback (line 72) but was never applied to the password login path.

## Fix

One line: read searchParams.get('next') after successful login and redirect there if it starts with /.

## Checklist

- [x] Self-review done
- [x] No new dependencies