### PR TITLE
fix: stop enterprise compose file from overriding DEPLOYMENT_MODE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,12 @@ hooks:  ## Install pre-commit hooks
 
 # ── Docker ───────────────────────────────────────────────
 
-# Auto-detect enterprise mode: if ee/observal_insights/ exists, use enterprise override
+# Auto-detect enterprise edition: if ee/observal_insights/ exists, include enterprise compose file.
+# NOTE: DEPLOYMENT_MODE is always sourced from .env — the enterprise file does NOT override it.
 COMPOSE_FILES := -f docker-compose.yml
 ifneq (,$(wildcard ee/observal_insights/__init__.py))
   COMPOSE_FILES += -f docker-compose.enterprise.yml
-  $(info [enterprise mode] ee/observal_insights/ detected)
+  $(info [enterprise mode] ee/observal_insights/ detected — DEPLOYMENT_MODE from .env)
 endif
 
 up:  ## Start Docker stack

--- a/docker/docker-compose.enterprise.yml
+++ b/docker/docker-compose.enterprise.yml
@@ -3,13 +3,10 @@
 
 # Enterprise override — enables enterprise features including insights.
 # The insights engine is bundled in ee/observal_insights/ and activated
-# when DEPLOYMENT_MODE=enterprise.
+# when DEPLOYMENT_MODE=enterprise (set via .env, NOT hardcoded here).
 #
 # Usage: docker compose -f docker-compose.yml -f docker-compose.enterprise.yml up -d
-services:
-  observal-api:
-    environment:
-      - DEPLOYMENT_MODE=enterprise
-  observal-worker:
-    environment:
-      - DEPLOYMENT_MODE=enterprise
+#
+# NOTE: DEPLOYMENT_MODE is controlled by .env (source of truth).
+# This file must NOT override environment variables from .env.
+services: {}


### PR DESCRIPTION
## Purpose / Description

The `docker-compose.enterprise.yml` was hardcoding `DEPLOYMENT_MODE=enterprise`, silently overriding `.env`. This broke local dev for anyone with `ee/` present and a default `SECRET_KEY` (< 32 chars), because the startup guard rejects weak secrets in non-local mode.

## Fixes

* Fixes startup crash when `ee/` directory exists and `SECRET_KEY` is the default dev value

## Approach

`.env` is the source of truth for environment variables. Compose override files add services/volumes — they do not override env vars that developers control.

Removed the `DEPLOYMENT_MODE=enterprise` hardcoding from `docker-compose.enterprise.yml`. The Makefile still auto-detects `ee/` to include the file, but it no longer changes behavior behind the developer's back.

## How Has This Been Tested?

- Verified `DEPLOYMENT_MODE=local` in `.env` is respected even with enterprise compose file loaded
- `make rebuild` succeeds with default `SECRET_KEY`

## Checklist

- [x] Descriptive commit message with a short title
- [x] Self-review performed
- [x] No UI changes