### PR TITLE
fix(hooks): replace nonexistent observal-hook.sh with session_push.py

### DIFF
--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -39,32 +39,16 @@ _KIRO_EVENT_MAP = {
     "Stop": "stop",
 }
 
-# Hook events that send to the generic observal-hook.sh handler.
-_GENERIC_HOOK_EVENTS = [
-    "SessionStart",
-    "UserPromptSubmit",
-    "PreToolUse",
-    "PostToolUse",
-    "PostToolUseFailure",
-    "SubagentStart",
-    "SubagentStop",
-    "StopFailure",
-    "Notification",
-    "TaskCreated",
-    "TaskCompleted",
-    "PreCompact",
-    "PostCompact",
-    "WorktreeCreate",
-    "WorktreeRemove",
-    "Elicitation",
-    "ElicitationResult",
-]
+# Session push hook command — reads JSONL incrementally, only needs 2 events.
+_SESSION_PUSH_CMD = "python3 -m observal_cli.hooks.session_push"
+
+# The two events that drive JSONL-based telemetry collection.
+# UserPromptSubmit: push new lines accumulated since last push.
+# Stop: push final lines and mark session complete.
+_SESSION_PUSH_EVENTS = ("UserPromptSubmit", "Stop")
 
 
 def _claude_code_hooks_frontmatter_lines(
-    hook_script: str,
-    stop_script: str,
-    agent_name: str = "",
     custom_hooks: list[dict] | None = None,
 ) -> list[str]:
     """Build the YAML lines for a hooks: section in Claude Code frontmatter.
@@ -72,14 +56,12 @@ def _claude_code_hooks_frontmatter_lines(
     Returns a list of indented strings (no trailing newlines) ready to be
     appended to the frontmatter_lines list before the closing '---'.
 
-    agent_name: baked into hook commands so each agent's telemetry carries
-    its identity (mirrors Kiro's --agent-name pattern).
+    Only two events are needed (UserPromptSubmit + Stop) because the hook
+    reads the session JSONL file incrementally — no per-event shell scripts.
 
     custom_hooks: list of dicts with event, handler_type, handler_config
     from hook components attached to the agent.
     """
-    import re
-
     custom_hooks = custom_hooks or []
     custom_by_event: dict[str, list[dict]] = {}
     for h in custom_hooks:
@@ -87,31 +69,26 @@ def _claude_code_hooks_frontmatter_lines(
         if ev:
             custom_by_event.setdefault(ev, []).append(h)
 
-    agent_name = re.sub(r"[^a-zA-Z0-9_\-.]", "", agent_name)
-    agent_flag = f" --agent-name {agent_name}" if agent_name else ""
+    cmd = _SESSION_PUSH_CMD
 
     lines = ["hooks:"]
-    for event in _GENERIC_HOOK_EVENTS:
+    for event in _SESSION_PUSH_EVENTS:
         lines += [
             f"  {event}:",
             "    - hooks:",
             "        - type: command",
-            f'          command: "{hook_script}{agent_flag}"',
+            f'          command: "{cmd}"',
         ]
         for ch in custom_by_event.get(event, []):
             lines += _custom_hook_matcher_lines(ch)
 
-    lines += [
-        "  Stop:",
-        "    - hooks:",
-        "        - type: command",
-        f'          command: "{hook_script}{agent_flag}"',
-        "    - hooks:",
-        "        - type: command",
-        f'          command: "{stop_script}{agent_flag}"',
-    ]
-    for ch in custom_by_event.get("Stop", []):
-        lines += _custom_hook_matcher_lines(ch)
+    # Append any custom hooks on events we don't natively use
+    for event, hooks in custom_by_event.items():
+        if event in _SESSION_PUSH_EVENTS:
+            continue
+        lines.append(f"  {event}:")
+        for ch in hooks:
+            lines += _custom_hook_matcher_lines(ch)
 
     return lines
 
@@ -136,117 +113,97 @@ def _custom_hook_matcher_lines(hook: dict) -> list[str]:
     return lines
 
 
-_CURSOR_HOOK_EVENTS = (
-    "sessionStart",
-    "preToolUse",
-    "postToolUse",
-    "postToolUseFailure",
-    "subagentStart",
-    "subagentStop",
-    "beforeShellExecution",
-    "afterShellExecution",
-    "afterFileEdit",
-    "preCompact",
-    "stop",
-)
+def _cursor_hooks_config() -> dict:
+    """Build .cursor/hooks.json content with Observal telemetry hooks.
 
-_VSCODE_HOOK_EVENTS = (
-    "SessionStart",
-    "UserPromptSubmit",
-    "PreToolUse",
-    "PostToolUse",
-    "PreCompact",
-    "SubagentStart",
-    "SubagentStop",
-    "Stop",
-)
+    Cursor uses camelCase event names.  Only userPromptSubmit + stop needed.
+
+    TODO: Cursor does not have a JSONL session push implementation yet
+    (no observal_cli/hooks/cursor_session_push.py).  The command below
+    invokes the Claude Code session_push script which expects Claude's
+    JSONL layout.  This is a stub — it will no-op gracefully until a
+    Cursor-specific pusher is written.
+    """
+    cmd = _SESSION_PUSH_CMD
+    return {
+        "version": 1,
+        "hooks": {
+            "userPromptSubmit": [{"command": cmd, "type": "command"}],
+            "stop": [{"command": cmd, "type": "command"}],
+        },
+    }
 
 
-def _cursor_hooks_config(hook_script: str, stop_script: str) -> dict:
-    """Build .cursor/hooks.json content with Observal telemetry hooks."""
-    hooks: dict[str, list] = {}
-    for event in _CURSOR_HOOK_EVENTS:
-        if event == "stop":
-            hooks[event] = [
-                {"command": hook_script, "type": "command"},
-                {"command": stop_script, "type": "command"},
-            ]
-        else:
-            hooks[event] = [{"command": hook_script, "type": "command"}]
-    return {"version": 1, "hooks": hooks}
+def _vscode_copilot_hooks_config() -> dict:
+    """Build .github/hooks/observal.json content for VS Code Copilot hooks.
+
+    TODO: No JSONL session push implementation for VS Code / Copilot yet.
+    Stub — session_push.py will no-op gracefully when it can't find a
+    matching session file.
+    """
+    cmd = _SESSION_PUSH_CMD
+    return {
+        "hooks": {
+            "UserPromptSubmit": [{"type": "command", "command": cmd}],
+            "Stop": [{"type": "command", "command": cmd}],
+        },
+    }
 
 
-def _vscode_copilot_hooks_config(hook_script: str, stop_script: str) -> dict:
-    """Build .github/hooks/observal.json content for VS Code Copilot hooks."""
-    hooks: dict[str, list] = {}
-    for event in _VSCODE_HOOK_EVENTS:
-        if event == "Stop":
-            hooks[event] = [
-                {"type": "command", "command": hook_script},
-                {"type": "command", "command": stop_script},
-            ]
-        else:
-            hooks[event] = [{"type": "command", "command": hook_script}]
-    return {"hooks": hooks}
+def _vscode_copilot_hooks_frontmatter_lines() -> list[str]:
+    """Build YAML lines for hooks in a VS Code Copilot .agent.md frontmatter.
+
+    TODO: No JSONL session push for Copilot yet — stub (no-ops gracefully).
+    """
+    cmd = _SESSION_PUSH_CMD
+    return [
+        "hooks:",
+        "  UserPromptSubmit:",
+        "    - type: command",
+        f'      command: "{cmd}"',
+        "  Stop:",
+        "    - type: command",
+        f'      command: "{cmd}"',
+    ]
 
 
-def _vscode_copilot_hooks_frontmatter_lines(hook_script: str, stop_script: str) -> list[str]:
-    """Build YAML lines for hooks in a VS Code Copilot .agent.md frontmatter."""
-    lines = ["hooks:"]
-    for event in _VSCODE_HOOK_EVENTS:
-        if event == "Stop":
-            lines += [
-                f"  {event}:",
-                "    - type: command",
-                f'      command: "{hook_script}"',
-                "    - type: command",
-                f'      command: "{stop_script}"',
-            ]
-        else:
-            lines += [
-                f"  {event}:",
-                "    - type: command",
-                f'      command: "{hook_script}"',
-            ]
-    return lines
+def _gemini_hooks_config() -> dict:
+    """Build the hooks block for Gemini CLI settings.json.
+
+    Gemini uses SessionStart/SessionEnd.  We hook SessionStart (first turn)
+    and SessionEnd (final flush) which maps to our UserPromptSubmit + Stop pattern.
+
+    TODO: No JSONL session push for Gemini CLI yet.  session_push.py will
+    no-op when it can't locate a matching session JSONL file.
+    """
+    cmd = _SESSION_PUSH_CMD
+    return {
+        "hooks": {
+            "SessionStart": [{"hooks": [{"type": "command", "command": cmd}]}],
+            "SessionEnd": [{"hooks": [{"type": "command", "command": cmd}]}],
+        },
+    }
 
 
-_GEMINI_HOOK_EVENTS = (
-    "SessionStart",
-    "BeforeAgent",
-    "AfterAgent",
-    "BeforeTool",
-    "AfterTool",
-    "SessionEnd",
-    "Notification",
-)
+def _opencode_plugin_js() -> str:
+    """Build JS plugin source for OpenCode telemetry.
 
+    Only fires on session.created (start) and session.idle (stop).
 
-def _gemini_hooks_config(hook_script: str, stop_script: str) -> dict:
-    """Build the hooks block for Gemini CLI settings.json."""
-    hooks: dict[str, list] = {}
-    for event in _GEMINI_HOOK_EVENTS:
-        if event in ("AfterAgent", "SessionEnd"):
-            hooks[event] = [{"hooks": [{"type": "command", "command": stop_script}]}]
-        else:
-            hooks[event] = [{"hooks": [{"type": "command", "command": hook_script}]}]
-    return {"hooks": hooks}
-
-
-def _opencode_plugin_js(hook_script: str, stop_script: str) -> str:
-    """Build JS plugin source for OpenCode telemetry."""
-    hs = hook_script.replace("\\", "\\\\").replace('"', '\\"')
-    ss = stop_script.replace("\\", "\\\\").replace('"', '\\"')
-    return f'''// Observal telemetry plugin for OpenCode
+    TODO: No JSONL session push for OpenCode yet.  The plugin invokes
+    session_push.py which will no-op gracefully until an OpenCode-specific
+    pusher is written.
+    """
+    cmd = _SESSION_PUSH_CMD.replace("\\", "\\\\").replace('"', '\\"')
+    return f"""// Observal telemetry plugin for OpenCode
 // Auto-generated by `observal pull`
 import {{ execSync }} from "child_process";
 
-const HOOK_SCRIPT = "{hs}";
-const STOP_SCRIPT = "{ss}";
+const SESSION_PUSH = "{cmd}";
 
-function fireHook(script, event, input) {{
+function fireHook(event, input) {{
   try {{
-    execSync(script, {{
+    execSync(SESSION_PUSH, {{
       input: JSON.stringify({{ hook_event_name: event, ...input }}),
       timeout: 10000,
       stdio: ["pipe", "pipe", "pipe"],
@@ -258,16 +215,11 @@ function fireHook(script, event, input) {{
 
 export const ObservalPlugin = async ({{ project, client }}) => {{
   return {{
-    "session.created": () => fireHook(HOOK_SCRIPT, "session.created", {{}}),
-    "session.idle": () => fireHook(STOP_SCRIPT, "session.idle", {{}}),
-    "session.error": (input) => fireHook(STOP_SCRIPT, "session.error", input),
-    "session.compacted": () => fireHook(HOOK_SCRIPT, "session.compacted", {{}}),
-    "tool.execute.before": (input) => fireHook(HOOK_SCRIPT, "tool.execute.before", input),
-    "tool.execute.after": (input, output) => fireHook(HOOK_SCRIPT, "tool.execute.after", {{ ...input, output }}),
-    "file.edited": (input) => fireHook(HOOK_SCRIPT, "file.edited", input),
+    "session.created": () => fireHook("session.created", {{}}),
+    "session.idle": () => fireHook("session.idle", {{}}),
   }};
 }};
-'''
+"""
 
 
 _MODEL_SHORT_NAMES: dict[str, str] = {
@@ -620,40 +572,14 @@ def generate_agent_config(
 
     if ide == "kiro":
         # Kiro agent JSON: drop into ~/.kiro/agents/<name>.json
-        # Telemetry collected via observal-shim + hook bridge
+        # Telemetry via JSONL session push — only 2 events needed.
         if platform == "win32":
-            # PowerShell-compatible: pipe stdin through the Python hook script.
-            # No cat/sed/curl/$PPID/$TERM/$SHELL — those don't exist in PowerShell.
-            hook_cmd = (
-                f"python -m observal_cli.hooks.kiro_hook "
-                f"--url {observal_url}/api/v1/telemetry/hooks "
-                f"--agent-name {safe_name}"
-            )
-            stop_cmd = (
-                f"python -m observal_cli.hooks.kiro_stop_hook "
-                f"--url {observal_url}/api/v1/telemetry/hooks "
-                f"--agent-name {safe_name}"
-            )
-            spawn_cmd = hook_cmd  # Windows: Python script handles session IDs
+            push_cmd = "python -m observal_cli.hooks.kiro_session_push"
         else:
-            # Unix: use the same Python hook scripts as Windows.
-            hook_cmd = (
-                f"python3 -m observal_cli.hooks.kiro_hook "
-                f"--url {observal_url}/api/v1/telemetry/hooks "
-                f"--agent-name {safe_name}"
-            )
-            stop_cmd = (
-                f"python3 -m observal_cli.hooks.kiro_stop_hook "
-                f"--url {observal_url}/api/v1/telemetry/hooks "
-                f"--agent-name {safe_name}"
-            )
-            spawn_cmd = hook_cmd  # Python script handles session IDs
+            push_cmd = "python3 -m observal_cli.hooks.kiro_session_push"
         hooks = {
-            "agentSpawn": [{"command": spawn_cmd}],
-            "userPromptSubmit": [{"command": hook_cmd}],
-            "preToolUse": [{"matcher": "*", "command": hook_cmd}],
-            "postToolUse": [{"matcher": "*", "command": hook_cmd}],
-            "stop": [{"command": stop_cmd}],
+            "userPromptSubmit": [{"command": push_cmd}],
+            "stop": [{"command": push_cmd}],
         }
         # Merge hook components (e.g. tester1) into the Kiro hooks dict
         for hc in hook_configs:
@@ -764,9 +690,6 @@ def generate_agent_config(
                 frontmatter_lines.append(f"  - {mcp_name}")
         frontmatter_lines.extend(
             _claude_code_hooks_frontmatter_lines(
-                "observal-hook.sh",
-                "observal-stop-hook.sh",
-                agent_name=safe_name,
                 custom_hooks=hook_configs,
             )
         )
@@ -809,7 +732,7 @@ def generate_agent_config(
             "mcp_config": {"path": mcp_path, "content": gemini_settings_content},
             "hooks_config": {
                 "path": hooks_path,
-                "content": _gemini_hooks_config("observal-hook.sh", "observal-stop-hook.sh"),
+                "content": _gemini_hooks_config(),
             },
             "otlp_env": _gemini_otlp_env(effective_otlp_http),
             "gemini_settings_snippet": _gemini_settings(effective_otlp_http),
@@ -861,7 +784,7 @@ def generate_agent_config(
             f'description: "{desc_line}"',
             "tools: ['*']",
         ]
-        frontmatter_lines.extend(_vscode_copilot_hooks_frontmatter_lines("observal-hook.sh", "observal-stop-hook.sh"))
+        frontmatter_lines.extend(_vscode_copilot_hooks_frontmatter_lines())
         frontmatter_lines.append("---")
         agent_content = "\n".join(frontmatter_lines) + "\n\n" + rules_content
 
@@ -876,7 +799,7 @@ def generate_agent_config(
             },
             "hooks_config": {
                 "path": ".github/hooks/observal.json",
-                "content": _vscode_copilot_hooks_config("observal-hook.sh", "observal-stop-hook.sh"),
+                "content": _vscode_copilot_hooks_config(),
             },
             "scope": copilot_spec["default_scope"],
         }
@@ -911,7 +834,7 @@ def generate_agent_config(
             f'description: "{desc_line}"',
             "tools: ['*']",
         ]
-        frontmatter_lines.extend(_vscode_copilot_hooks_frontmatter_lines("observal-hook.sh", "observal-stop-hook.sh"))
+        frontmatter_lines.extend(_vscode_copilot_hooks_frontmatter_lines())
         frontmatter_lines.append("---")
         agent_content = "\n".join(frontmatter_lines) + "\n\n" + rules_content
 
@@ -926,7 +849,7 @@ def generate_agent_config(
             },
             "hooks_config": {
                 "path": ".github/hooks/observal.json",
-                "content": _vscode_copilot_hooks_config("observal-hook.sh", "observal-stop-hook.sh"),
+                "content": _vscode_copilot_hooks_config(),
             },
             "scope": copilot_cli_spec["default_scope"],
         }
@@ -956,7 +879,7 @@ def generate_agent_config(
             "mcp_config": {"path": mcp_path, "content": opencode_content},
             "hooks_config": {
                 "path": ".opencode/plugins/observal-plugin.mjs",
-                "content": _opencode_plugin_js("observal-hook.sh", "observal-stop-hook.sh"),
+                "content": _opencode_plugin_js(),
             },
             "scope": opencode_scope,
         }
@@ -985,12 +908,12 @@ def generate_agent_config(
         hooks_path = ".cursor/hooks.json" if ide_scope == "project" else "~/.cursor/hooks.json"
         result["hooks_config"] = {
             "path": hooks_path,
-            "content": _cursor_hooks_config("observal-hook.sh", "observal-stop-hook.sh"),
+            "content": _cursor_hooks_config(),
         }
     elif ide == "vscode":
         result["hooks_config"] = {
             "path": ".github/hooks/observal.json",
-            "content": _vscode_copilot_hooks_config("observal-hook.sh", "observal-stop-hook.sh"),
+            "content": _vscode_copilot_hooks_config(),
         }
     if skill_files:
         result["skill_files"] = skill_files

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -381,8 +381,12 @@ class TestGenerateKiro:
         agent = _make_agent()
         cfg = generate_agent_config(agent, "kiro")
         hooks = cfg["agent_file"]["content"]["hooks"]
-        for event in ("agentSpawn", "userPromptSubmit", "preToolUse", "postToolUse", "stop"):
+        # Only 2 events needed — JSONL session push reads incrementally
+        for event in ("userPromptSubmit", "stop"):
             assert event in hooks
+        # Legacy bloat events should NOT be present
+        for event in ("agentSpawn", "preToolUse", "postToolUse"):
+            assert event not in hooks
 
     def test_no_steering_file_generated(self):
         """Prompt lives in agent JSON only — no redundant steering file."""
@@ -850,12 +854,12 @@ class TestGenerateKiroWin32:
             assert "python3" not in cmd
             assert "python " in cmd or "python -m" in cmd
 
-    def test_win32_hooks_include_agent_name(self):
+    def test_win32_hooks_use_session_push(self):
         agent = _make_agent(name="my-cool-agent")
         cfg = generate_agent_config(agent, "kiro", platform="win32")
         cmds = self._all_hook_commands(cfg)
         for cmd in cmds:
-            assert "--agent-name my-cool-agent" in cmd
+            assert "kiro_session_push" in cmd
 
     def test_hooks_omit_model_flag(self):
         """Model is detected from Kiro SQLite at runtime, not baked into hook commands."""
@@ -865,12 +869,14 @@ class TestGenerateKiroWin32:
         for cmd in cmds:
             assert "--model" not in cmd
 
-    def test_win32_still_has_all_hook_events(self):
+    def test_win32_has_session_push_events_only(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "kiro", platform="win32")
         hooks = cfg["agent_file"]["content"]["hooks"]
-        for event in ("agentSpawn", "userPromptSubmit", "preToolUse", "postToolUse", "stop"):
+        for event in ("userPromptSubmit", "stop"):
             assert event in hooks
+        for event in ("agentSpawn", "preToolUse", "postToolUse"):
+            assert event not in hooks
 
     def test_win32_agent_file_path_unchanged(self):
         agent = _make_agent()
@@ -899,15 +905,15 @@ class TestGenerateKiroPreservation:
         cfg_empty = generate_agent_config(agent, "kiro", platform="")
         assert cfg_default == cfg_empty
 
-    def test_unix_hooks_use_python_hook_scripts(self):
+    def test_unix_hooks_use_kiro_session_push(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "kiro", platform="linux")
         hooks = cfg["agent_file"]["content"]["hooks"]
-        spawn_cmd = hooks["agentSpawn"][0]["command"]
-        assert "python3 -m observal_cli.hooks.kiro_hook" in spawn_cmd
-        assert "cat |" not in spawn_cmd
-        assert "sed " not in spawn_cmd
-        assert "curl" not in spawn_cmd
+        cmd = hooks["userPromptSubmit"][0]["command"]
+        assert "python3 -m observal_cli.hooks.kiro_session_push" in cmd
+        assert "cat |" not in cmd
+        assert "sed " not in cmd
+        assert "curl" not in cmd
 
     def test_non_kiro_ides_unaffected_by_platform(self):
         agent = _make_agent()


### PR DESCRIPTION
## Purpose / Description

`agent_config_generator.py` emits hook configs into agent files for all IDEs. It was referencing `observal-hook.sh` and `observal-stop-hook.sh` — shell scripts that **do not exist** anywhere in the codebase. Every generated agent config was broken for telemetry collection.

The actual telemetry mechanism is JSONL session push (`python3 -m observal_cli.hooks.session_push` for Claude Code, `kiro_session_push` for Kiro), which only needs **2 events** (UserPromptSubmit + Stop) to incrementally read session files. This is already how `observal doctor patch` and the `ide_specs/` modules work — the agent config generator was just never updated to match.

## Fixes

* Fixes agent configs referencing nonexistent `observal-hook.sh` / `observal-stop-hook.sh`
* Fixes hook spam — was emitting hooks on 17+ events when only 2 are needed
* Fixes Kiro configs referencing nonexistent `kiro_hook` / `kiro_stop_hook` modules

## Approach

Aligned `agent_config_generator.py` with the pattern already established in `observal_cli/ide_specs/claude_code_hooks_spec.py` and `kiro_hooks_spec.py`:

- **Claude Code**: 2 events (`UserPromptSubmit` + `Stop`), command = `python3 -m observal_cli.hooks.session_push`
- **Kiro**: 2 events (`userPromptSubmit` + `stop`), command = `python3 -m observal_cli.hooks.kiro_session_push`
- **Cursor, Gemini CLI, VS Code/Copilot, OpenCode**: Emit correct 2-event structure with the session_push command. Added TODO comments noting these IDEs don't have JSONL session push implementations yet — `session_push.py` will no-op gracefully when it can't locate a matching session file.

Removed:
- `_GENERIC_HOOK_EVENTS` list (17 events)
- `hook_script` / `stop_script` / `agent_name` parameters from all helper functions
- All `"observal-hook.sh"` and `"observal-stop-hook.sh"` string literals

Added:
- `_SESSION_PUSH_CMD` constant
- `_SESSION_PUSH_EVENTS` tuple (2 events)
- TODO stubs documenting which IDEs still need their own JSONL pusher

## How Has This Been Tested?

```bash
cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml \
  --with typer --with rich --with docker pytest \
  ../tests/test_agent_config_generator.py ../tests/test_ide_config_e2e.py -q
# 265 passed

# Full suite (excluding unrelated collection errors for missing deps):
# 2409 passed, 2 skipped
```

- `ruff check` passes
- `ruff format --check` passes
- Verified no remaining references to `observal-hook.sh` or `observal-stop-hook.sh`

## Learning

- The `ide_specs/` modules (used by `doctor patch`) were already correct — they were written later and independently from `agent_config_generator.py`
- `session_push.py` is designed to no-op when it can't find a session file, making it safe to use as a stub command for IDEs without JSONL support

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: N/A (server-side only)