### PR TITLE
fix(e2e): use sessionStorage for access token in loginToWebUI helper

### DIFF
--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -41,7 +41,7 @@ export async function loginToWebUI(page: Page) {
   const token = await getAccessToken();
   await page.goto("/");
   await page.evaluate((t) => {
-    localStorage.setItem("observal_access_token", t);
+    sessionStorage.setItem("observal_access_token", t);
     localStorage.setItem("observal_user_role", "admin");
   }, token);
   await page.reload();


### PR DESCRIPTION
## Purpose / Description
The `loginToWebUI` helper in `web/e2e/helpers.ts` stores the access token in `localStorage`, but the app (`api.ts`, `use-auth.ts`) reads it from `sessionStorage`. This mismatch causes the auth guard to not find the token and redirect to `/login`, making any e2e test that uses this helper fail to authenticate.

## Fixes
* Discovered while working on #962 (no dedicated issue)

## Approach
Changed `localStorage.setItem("observal_access_token", t)` to `sessionStorage.setItem("observal_access_token", t)` in the `loginToWebUI` function. The `observal_user_role` remains in `localStorage` since that's where `getUserRole()` reads it from.

## How Has This Been Tested?
(`leaderboard.spec.ts` is part of the PR in #962, yet to create the PR so it won't be visible in the codebase )
- Ran the leaderboard e2e tests (`web/e2e/leaderboard.spec.ts`) which depend on this auth flow
- Before fix: page redirected to `/login` after `loginToWebUI` — tests failed
- After fix: page renders authenticated content correctly — tests pass
- Ran 3x repeated (`--repeat-each=3`) to confirm stability

## Learning (optional, can help others)
The app migrated access token storage from `localStorage` to `sessionStorage` (for XSS exposure reduction — see comment in `api.ts`) but the e2e helper wasn't updated to match.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
