### PR TITLE
fix: wire token counts and correct duration in session list

### DIFF
--- a/observal-server/services/session_ingest.py
+++ b/observal-server/services/session_ingest.py
@@ -22,6 +22,22 @@ from services.clickhouse import insert_session_events, query_existing_for_dedup,
 from services.secrets_redactor import redact_secrets
 from services.session_parsers.ingest_classify import extract_timestamp, get_classifier, get_extra_rows
 
+
+def _extract_usage_tokens(parsed: dict) -> dict:
+    """Extract input/output/cache token counts from a parsed JSONL line.
+
+    Claude Code embeds per-turn token counts in ``message.usage``.
+    All other IDEs (Kiro, etc.) have no per-line token data and default to 0.
+    """
+    usage = parsed.get("message", {}).get("usage") or {}
+    return {
+        "input_tokens": int(usage.get("input_tokens") or 0),
+        "output_tokens": int(usage.get("output_tokens") or 0),
+        "cache_read_tokens": int(usage.get("cache_read_input_tokens") or 0),
+        "cache_write_tokens": int(usage.get("cache_creation_input_tokens") or 0),
+    }
+
+
 logger = structlog.get_logger(__name__)
 
 
@@ -152,6 +168,8 @@ async def ingest_session_lines(
                 "raw_line": redacted_line,
                 "credits": 0.0,
                 "parent_session_id": parent_session_id,
+                # Token counts from the JSONL line (Claude Code: message.usage).
+                **_extract_usage_tokens(parsed),
             }
         )
         ingested += 1

--- a/web/src/app/(user)/traces/page.tsx
+++ b/web/src/app/(user)/traces/page.tsx
@@ -100,7 +100,9 @@ function fmtDuration(first?: string, last?: string): string {
 
 function toDate(ts: string): Date {
 	if (ts.endsWith("Z") || /[+-]\d{2}:\d{2}$/.test(ts)) return new Date(ts);
-	return new Date(ts + "Z");
+	// ClickHouse returns DateTime64 as "YYYY-MM-DD HH:MM:SS.mmm" (space, no Z).
+	// Replace the space with T and append Z for valid ISO 8601 UTC parsing.
+	return new Date(ts.replace(" ", "T") + "Z");
 }
 
 function relTime(ts?: string): string {
@@ -205,6 +207,9 @@ const columns: ColumnDef<Session>[] = [
 						{count} prompt{count !== 1 ? "s" : ""}
 					</span>
 				);
+			}
+			if (!r.total_input_tokens && !r.total_output_tokens) {
+				return <span className="text-[13px] text-muted-foreground">{"\u2014"}</span>;
 			}
 			const inp = fmtTokens(r.total_input_tokens);
 			const out = fmtTokens(r.total_output_tokens);


### PR DESCRIPTION
## Purpose / Description

Two display bugs in the traces/session list:

1. **Tokens column always showed 0** — The session list reads `input_tokens`/`output_tokens` from `session_stats_agg`, which is an `AggregatingMergeTree` fed by the `session_stats_mv` materialized view on `session_events`. The MV pipeline was correct, but `session_ingest.py` never wrote token values into the row dict on insert, so the MV had nothing to sum. Tokens were only visible inside a session detail because that path re-parses raw JSONL via `parse_raw_events`.

2. **Duration always showed `< 1m`, relative times showed `just now`** — ClickHouse returns `DateTime64` as `"YYYY-MM-DD HH:MM:SS.mmm"` (space separator, no timezone). `toDate()` was appending `Z` directly, producing `"2026-05-14 10:30:00.000Z"` which is not valid ISO 8601. All engines return `Invalid Date`, making `NaN - NaN = NaN` for every duration and relative time calculation.

## Fixes
* No issue number

## Approach

**`session_ingest.py`** — Added `_extract_usage_tokens(parsed)` which reads `message.usage` from a parsed JSONL line (Claude Code format) and returns `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`. Spread into the row dict on every insert, feeding the existing `session_stats_mv` → `session_stats_agg` pipeline. Kiro and other IDEs with no per-line token data default to 0.

**`traces/page.tsx`** — Fixed `toDate()` to replace the space separator with `T` before appending `Z`, producing valid ISO 8601 UTC strings (`"2026-05-14T10:30:00.000Z"`). Duration, relative timestamps, and sorting are all now correct.

No new queries, no schema changes — the optimised `session_stats_agg` read path was already in place and is used as-is.

## How Has This Been Tested?

- Verified `_extract_usage_tokens` returns correct values for Claude Code JSONL with `message.usage` present and zero-fills when absent
- Verified `toDate("2026-05-14 10:30:00.000")` now returns a valid UTC Date
- `make lint` and `make format` pass clean

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens