### PR TITLE
feat(ci): label PRs from first-time contributors

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+name: Auto-label PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels based on changed files
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const repo = context.repo;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              ...repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const paths = files.map((f) => f.filename);
+
+            const isTest = paths.some((p) =>
+              /^tests\//.test(p) ||
+              /\/tests\//.test(p) ||
+              /\/test_[^/]+$/.test(p) ||
+              /\/[^/]+_test\.[^/]+$/.test(p) ||
+              /\.spec\.[jt]sx?$/.test(p)
+            );
+
+            const isEnterprise = paths.some((p) => /^ee\//.test(p));
+
+            const labelsToApply = [
+              ...(isTest ? ['tests'] : []),
+              ...(isEnterprise ? ['enterprise'] : []),
+            ];
+
+            if (labelsToApply.length === 0) return;
+
+            const labelDefs = {
+              tests: { color: '0075ca', description: 'Pull request adds or modifies tests' },
+              enterprise: { color: 'e11d48', description: 'Pull request touches enterprise (ee/) code' },
+            };
+
+            for (const name of labelsToApply) {
+              try {
+                await github.rest.issues.getLabel({ ...repo, name });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                await github.rest.issues.createLabel({ ...repo, name, ...labelDefs[name] });
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              ...repo,
+              issue_number: pr.number,
+              labels: labelsToApply,
+            });
+
+            console.log(`Applied labels: ${labelsToApply.join(', ')}`);

--- a/.github/workflows/new-contributor.yml
+++ b/.github/workflows/new-contributor.yml
@@ -16,46 +16,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if author is a first-time contributor
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const author = context.payload.pull_request.user.login;
             const repo = context.repo;
 
-            // Search for previously merged PRs by this author
-            const { data: pulls } = await github.rest.pulls.list({
-              ...repo,
-              state: 'closed',
-              sort: 'created',
-              direction: 'desc',
-              per_page: 100,
+            const { data: results } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${repo.owner}/${repo.repo} is:pr is:merged author:${author}`,
+              per_page: 1,
             });
 
-            const hasMergedPR = pulls.some(
-              (pr) => pr.user.login === author && pr.merged_at !== null && pr.number !== context.payload.pull_request.number
-            );
+            const hasMergedPR = results.total_count > 0;
 
             if (hasMergedPR) {
-              console.log(`${author} has previous merged PRs — skipping label.`);
+              console.log(`${author} has previous merged PRs, skipping label.`);
               return;
             }
 
-            console.log(`${author} is a new contributor — adding label.`);
+            console.log(`${author} is a new contributor, adding label.`);
 
             // Ensure the label exists
             const labelName = 'new contributor';
             try {
               await github.rest.issues.getLabel({ ...repo, name: labelName });
             } catch (e) {
-              if (e.status === 404) {
-                await github.rest.issues.createLabel({
-                  ...repo,
-                  name: labelName,
-                  color: '7057ff',
-                  description: 'Pull request from a first-time contributor',
-                });
-              }
+              if (e.status !== 404) throw e;
+              await github.rest.issues.createLabel({
+                ...repo,
+                name: labelName,
+                color: '7057ff',
+                description: 'Pull request from a first-time contributor',
+              });
             }
 
             // Apply the label

--- a/.github/workflows/new-contributor.yml
+++ b/.github/workflows/new-contributor.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+name: Label New Contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label-new-contributor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if author is a first-time contributor
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const repo = context.repo;
+
+            // Search for previously merged PRs by this author
+            const { data: pulls } = await github.rest.pulls.list({
+              ...repo,
+              state: 'closed',
+              sort: 'created',
+              direction: 'desc',
+              per_page: 100,
+            });
+
+            const hasMergedPR = pulls.some(
+              (pr) => pr.user.login === author && pr.merged_at !== null && pr.number !== context.payload.pull_request.number
+            );
+
+            if (hasMergedPR) {
+              console.log(`${author} has previous merged PRs — skipping label.`);
+              return;
+            }
+
+            console.log(`${author} is a new contributor — adding label.`);
+
+            // Ensure the label exists
+            const labelName = 'new contributor';
+            try {
+              await github.rest.issues.getLabel({ ...repo, name: labelName });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  ...repo,
+                  name: labelName,
+                  color: '7057ff',
+                  description: 'Pull request from a first-time contributor',
+                });
+              }
+            }
+
+            // Apply the label
+            await github.rest.issues.addLabels({
+              ...repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [labelName],
+            });


### PR DESCRIPTION
## Purpose / Description

Adds two GitHub Actions workflows for automatic PR labeling:

1. **New contributor** — labels PRs from authors with no prior merged PRs with `new contributor`
2. **Auto-label** — labels PRs with `tests` or `enterprise` based on changed file paths

Closes #1009
Closes #1065

## Approach

**`.github/workflows/new-contributor.yml`**
- Triggers on `pull_request_target: [opened]`
- Uses the search API to check for prior merged PRs by the author (accurate at any repo size)
- Creates the `new contributor` label if it doesn't exist

**`.github/workflows/auto-label.yml`**
- Triggers on `pull_request_target: [opened, synchronize]`
- Inspects changed file paths via `pulls.listFiles`
- Applies `tests` for files matching `tests/**`, `*/tests/**`, `test_*`, or `*_test.*`
- Applies `enterprise` for anything under `ee/`
- Creates labels if missing, both labels can apply to the same PR

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code