### PR TITLE
fix(insights): replace import-based detection with INSIGHTS_AVAILABLE env flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,7 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000   # comma-separated
 # When set to 'enterprise', weak SECRET_KEY and other unsafe defaults cause
 # the server to refuse startup rather than run insecurely.
 DEPLOYMENT_MODE=local
+INSIGHTS_AVAILABLE=false
 
 
 # -----------------------------------------------------------------------------

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -139,6 +139,9 @@ class Settings(BaseSettings):
     ENABLE_OPENAPI: bool = False  # expose /docs, /redoc, /openapi.json
     ENABLE_METRICS: bool = False  # expose Prometheus /metrics endpoint
 
+    # Enable the Insights feature. Set INSIGHTS_AVAILABLE=true in .env to enable.
+    INSIGHTS_AVAILABLE: bool = False
+
     # Deployment mode
     DEPLOYMENT_MODE: Literal["local", "enterprise"] = "local"
 

--- a/observal-server/services/insights/__init__.py
+++ b/observal-server/services/insights/__init__.py
@@ -5,51 +5,45 @@
 
 """Insights plugin loader.
 
-The insights engine lives under ee/observal_insights/ and is only available
-when DEPLOYMENT_MODE=enterprise. If not in enterprise mode, all functions
-raise RuntimeError and INSIGHTS_AVAILABLE is False — the frontend hides the
-feature entirely.
+Controlled by the INSIGHTS_ENABLED env var (defaults to True when
+DEPLOYMENT_MODE=enterprise). Set INSIGHTS_ENABLED=false to disable explicitly.
+
+If enabled but the ee/ package is missing the import will fail loudly at
+startup rather than silently returning 402s.
 """
 
 from config import settings
 
-# Insights is only available in enterprise mode
-if settings.DEPLOYMENT_MODE == "enterprise":
-    try:
-        from ee.observal_insights import (
-            generate_report_content as _generate,
-        )
-        from ee.observal_insights import (
-            render_report_html as _render,
-        )
+INSIGHTS_AVAILABLE: bool = settings.INSIGHTS_AVAILABLE
 
-        INSIGHTS_AVAILABLE = True
-    except ImportError:
-        INSIGHTS_AVAILABLE = False
+if INSIGHTS_AVAILABLE:
+    from ee.observal_insights import generate_report_content as _generate
+    from ee.observal_insights import render_report_html as _render
 else:
-    INSIGHTS_AVAILABLE = False
+    _generate = None  # type: ignore[assignment]
+    _render = None  # type: ignore[assignment]
 
 
 def _not_available():
-    raise RuntimeError("Insights is an enterprise feature. Set DEPLOYMENT_MODE=enterprise to enable.")
+    raise RuntimeError("Insights is not enabled. Set INSIGHTS_ENABLED=true (or DEPLOYMENT_MODE=enterprise).")
 
 
 async def generate_report_content(*args, **kwargs):
     if not INSIGHTS_AVAILABLE:
         _not_available()
-    return await _generate(*args, **kwargs)
+    return await _generate(*args, **kwargs)  # type: ignore[misc]
 
 
 def render_report_html(*args, **kwargs):
     if not INSIGHTS_AVAILABLE:
         _not_available()
-    return _render(*args, **kwargs)
+    return _render(*args, **kwargs)  # type: ignore[misc]
 
 
 def configure_insights():
     """Wire up dependencies from the host app into the insights package.
 
-    Called once at server startup. No-op if not in enterprise mode.
+    Called once at server startup. No-op if not enabled.
     """
     if not INSIGHTS_AVAILABLE:
         return


### PR DESCRIPTION
## Purpose / Description
Previously `INSIGHTS_AVAILABLE` was driven by a `try/except ImportError` around the `ee` package import. Any silent import failure would disable insights with no error or warning, even when `DEPLOYMENT_MODE=enterprise`.

## Fixes
* Fixes silent 402s when insights should be enabled

## Approach
Replace the speculative import check with a plain `INSIGHTS_AVAILABLE: bool = False` setting in `config.py`. Set `INSIGHTS_AVAILABLE=true` in `.env` to enable. If the `ee` package import fails with the flag set, it now fails loudly at startup instead of silently swallowing the error.

- Add `INSIGHTS_AVAILABLE: bool = False` to `Settings` in `config.py`
- Drive `services/insights/__init__.py` `INSIGHTS_AVAILABLE` off `settings.INSIGHTS_AVAILABLE` directly
- Add `INSIGHTS_AVAILABLE=false` to `.env.example`
- Set `INSIGHTS_AVAILABLE=true` in local `.env`

## How Has This Been Tested?
- Verified `INSIGHTS_AVAILABLE` flag is read correctly from env at startup
- Confirmed `/api/v1/config/public` returns `insights_available: true` when flag is set
- Pre-push lint/format/checks all pass

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)