### PR TITLE
test: add E2E tests for CLI doctor commands

### DIFF
--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -1,0 +1,952 @@
+# SPDX-FileCopyrightText: 2026 0xSHSH <156781261+0xSHSH@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral coverage for the doctor CLI commands and untested state branches."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import httpx
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import observal_cli.cmd_doctor as doctor_module
+from observal_cli.harness.protocol import NotSupportedError
+
+_ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_DIAGNOSTIC_CHECKS = (
+    "_check_observal_config",
+    "_check_claude_code",
+    "_check_kiro",
+    "_check_pi",
+    "_check_cursor",
+    "_check_codex",
+    "_check_copilot",
+    "_check_copilot_cli",
+    "_check_opencode",
+    "_check_antigravity",
+    "_check_goose",
+)
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def isolated_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Keep every doctor test away from the real home, network, and processes."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    for name in ("APPDATA", "APPDATA_WIN", "GOOSE_PATH_ROOT", "XDG_CONFIG_HOME", "XDG_DATA_HOME"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    network = MagicMock(side_effect=AssertionError("unexpected network request"))
+    process = MagicMock(side_effect=AssertionError("unexpected subprocess"))
+    prompt = MagicMock(side_effect=AssertionError("unexpected prompt"))
+    monkeypatch.setattr(httpx, "get", network)
+    monkeypatch.setattr(subprocess, "run", process)
+    monkeypatch.setattr(doctor_module.typer, "confirm", prompt)
+    return SimpleNamespace(network=network, process=process, prompt=prompt)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def quiet_diagnosis(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    from observal_cli import lockfile_reconcile
+
+    checks: dict[str, MagicMock] = {}
+    for name in _DIAGNOSTIC_CHECKS:
+        check = MagicMock(name=name)
+        monkeypatch.setattr(doctor_module, name, check)
+        checks[name] = check
+
+    skill_check = MagicMock(return_value=[])
+    monkeypatch.setattr(doctor_module, "_check_observal_skill_missing", skill_check)
+    plan = SimpleNamespace(changes=[], warnings=[], apply=MagicMock())
+    planner = MagicMock(return_value=plan)
+    monkeypatch.setattr(lockfile_reconcile, "plan_lockfile_reconciliation", planner)
+    return SimpleNamespace(checks=checks, skill_check=skill_check, plan=plan, planner=planner)
+
+
+class TestDoctorDiagnosis:
+    def test_all_clear_runs_every_check_and_reports_success(self, runner: CliRunner, quiet_diagnosis: SimpleNamespace):
+        result = runner.invoke(doctor_module.doctor_app, [])
+
+        assert result.exit_code == 0
+        assert "Observal Doctor" in _plain(result.output)
+        assert "Checking Goose" in _plain(result.output)
+        assert "All clear! No issues found." in _plain(result.output)
+        for check in quiet_diagnosis.checks.values():
+            check.assert_called_once()
+        quiet_diagnosis.skill_check.assert_called_once_with()
+
+    def test_issues_and_warnings_have_deterministic_counts_and_guidance(
+        self,
+        runner: CliRunner,
+        quiet_diagnosis: SimpleNamespace,
+        isolated_runtime: SimpleNamespace,
+    ):
+        def config_issue(issues: list[str], _warnings: list[str]) -> None:
+            issues.append("configuration is broken")
+
+        def cursor_warning(_issues: list[str], warnings: list[str]) -> None:
+            warnings.append("cursor hooks are stale")
+
+        quiet_diagnosis.checks["_check_observal_config"].side_effect = config_issue
+        quiet_diagnosis.checks["_check_cursor"].side_effect = cursor_warning
+        quiet_diagnosis.skill_check.return_value = ["Pi"]
+
+        result = runner.invoke(doctor_module.doctor_app, [])
+        output = _plain(result.output)
+
+        assert result.exit_code == 1
+        assert "1 issue(s):" in output
+        assert "configuration is broken" in output
+        assert "2 warning(s):" in output
+        assert "cursor hooks are stale" in output
+        assert "Observal AI skill not installed for: Pi" in output
+        assert "observal doctor patch --all-harnesses" in output
+        isolated_runtime.process.assert_not_called()
+        isolated_runtime.prompt.assert_not_called()
+
+    def test_interactive_decline_uses_prompt_and_does_not_patch(
+        self,
+        quiet_diagnosis: SimpleNamespace,
+        isolated_runtime: SimpleNamespace,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        def warning(_issues: list[str], warnings: list[str]) -> None:
+            warnings.append("hooks missing")
+
+        quiet_diagnosis.checks["_check_cursor"].side_effect = warning
+        confirm = MagicMock(return_value=False)
+        monkeypatch.setattr(doctor_module.typer, "confirm", confirm)
+        monkeypatch.setattr(doctor_module.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+
+        with pytest.raises(typer.Exit) as exc:
+            doctor_module.doctor(SimpleNamespace(invoked_subcommand=None), yes=False)
+
+        assert exc.value.exit_code == 0
+        confirm.assert_called_once_with(
+            "Fix all issues? (configures telemetry + installs AI skill for all detected harnesses)", default=True
+        )
+        isolated_runtime.process.assert_not_called()
+        assert "observal doctor patch --all-harnesses" in _plain(capsys.readouterr().out)
+
+    def test_yes_reconciles_lockfile_runs_patch_and_installs_skill(
+        self,
+        runner: CliRunner,
+        quiet_diagnosis: SimpleNamespace,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from observal_cli import skill_installer
+
+        changes = [
+            SimpleNamespace(label=f"component-{index}", field="version", old="1", new="2") for index in range(12)
+        ]
+        plan = SimpleNamespace(changes=changes, warnings=[], apply=MagicMock())
+        quiet_diagnosis.planner.return_value = plan
+        run = MagicMock(return_value=SimpleNamespace(returncode=0))
+        install_skill = MagicMock()
+        monkeypatch.setattr(subprocess, "run", run)
+        monkeypatch.setattr(skill_installer, "install_observal_skill", install_skill)
+
+        result = runner.invoke(doctor_module.doctor_app, ["--yes"])
+        output = _plain(result.output)
+
+        assert result.exit_code == 0
+        assert "Registry metadata drift found in 12 lockfile field(s)." in output
+        assert "component-0: version '1' → '2'" in output
+        assert "...and 2 more change(s)" in output
+        assert "Reconciled 12 lockfile field(s)" in output
+        plan.apply.assert_called_once_with()
+        run.assert_called_once()
+        assert run.call_args.args[0] == [
+            doctor_module.sys.executable,
+            "-m",
+            "observal_cli.main",
+            "doctor",
+            "patch",
+            "--all-harnesses",
+        ]
+        assert run.call_args.kwargs["timeout"] == 60
+        assert run.call_args.kwargs["env"]["PYTHONIOENCODING"] == "utf-8"
+        install_skill.assert_called_once_with()
+
+    def test_lockfile_planning_failure_is_reported_as_an_issue(
+        self, runner: CliRunner, quiet_diagnosis: SimpleNamespace
+    ):
+        quiet_diagnosis.planner.side_effect = RuntimeError("lock unavailable")
+
+        result = runner.invoke(doctor_module.doctor_app, [])
+
+        assert result.exit_code == 1
+        assert "Lockfile reconciliation failed: lock unavailable" in _plain(result.output)
+
+
+class TestConfigAndSkillDiagnosis:
+    def test_skill_check_returns_empty_when_bundled_source_is_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(doctor_module, "__file__", str(tmp_path / "pkg" / "cmd_doctor.py"))
+
+        assert doctor_module._check_observal_skill_missing() == []
+
+    def test_skill_check_uses_detected_harnesses_and_skips_unsupported_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import observal_shared.harness_registry as harness_registry
+
+        module_file = tmp_path / "pkg" / "cmd_doctor.py"
+        skill_source = module_file.parent / "skills" / "observal" / "SKILL.md"
+        skill_source.parent.mkdir(parents=True)
+        skill_source.write_text("skill", encoding="utf-8")
+        (tmp_path / ".kiro").mkdir()
+        registry = {
+            "unsupported": {"display_name": "Unsupported", "config_dir": ".unsupported", "skills": {}},
+            "kiro": {"display_name": "Kiro", "config_dir": ".kiro", "skills": {}},
+            "absent": {
+                "display_name": "Absent",
+                "config_dir": ".absent",
+                "skills": {"user": "~/.absent/skills/{name}/SKILL.md"},
+            },
+        }
+        monkeypatch.setattr(doctor_module, "__file__", str(module_file))
+        monkeypatch.setattr(harness_registry, "HARNESS_REGISTRY", registry)
+
+        assert doctor_module._check_observal_skill_missing() == ["Kiro"]
+
+    def test_invalid_config_is_reported_without_network(self, tmp_path: Path, isolated_runtime: SimpleNamespace):
+        config_path = tmp_path / ".observal" / "config.json"
+        config_path.parent.mkdir()
+        config_path.write_text("{bad json", encoding="utf-8")
+        issues: list[str] = []
+
+        doctor_module._check_observal_config(issues, [])
+
+        assert issues == ["~/.observal/config.json is not valid JSON."]
+        isolated_runtime.network.assert_not_called()
+
+    def test_missing_config_fields_are_both_reported(self, tmp_path: Path, isolated_runtime: SimpleNamespace):
+        _write_json(tmp_path / ".observal" / "config.json", {})
+        issues: list[str] = []
+
+        doctor_module._check_observal_config(issues, [])
+
+        assert issues == [
+            "No access token in ~/.observal/config.json. Run `observal auth login`.",
+            "No server_url in ~/.observal/config.json. Run `observal auth login`.",
+        ]
+        isolated_runtime.network.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (200, []),
+            (503, ["Observal server at https://server.test returned status 503."]),
+        ],
+    )
+    def test_server_health_status_controls_config_issue(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        status: int,
+        expected: list[str],
+    ):
+        _write_json(
+            tmp_path / ".observal" / "config.json",
+            {"access_token": "placeholder", "server_url": "https://server.test"},
+        )
+        get = MagicMock(return_value=SimpleNamespace(status_code=status))
+        monkeypatch.setattr(httpx, "get", get)
+        issues: list[str] = []
+
+        doctor_module._check_observal_config(issues, [])
+
+        assert issues == expected
+        get.assert_called_once_with("https://server.test/health", timeout=5)
+
+
+class TestHarnessDiagnosisState:
+    def test_claude_accepts_current_hooks_and_reports_only_legacy_hooks(self, tmp_path: Path):
+        _write_json(
+            tmp_path / ".claude" / "settings.json",
+            {
+                "hooks": {
+                    "UserPromptSubmit": [{"hooks": [{"command": "python -m observal_cli.hooks.session_push"}]}],
+                    "Legacy": [{"hooks": [{"command": "/tmp/observal-hook"}]}],
+                    "Ignored": "not-a-list",
+                }
+            },
+        )
+        issues: list[str] = []
+        warnings: list[str] = []
+
+        doctor_module._check_claude_code(issues, warnings)
+
+        assert issues == []
+        assert warnings == [
+            "Legacy Observal hooks detected (old hook scripts). "
+            "Run `observal doctor cleanup --harness claude-code` to remove them."
+        ]
+
+    def test_claude_invalid_settings_are_an_issue(self, tmp_path: Path):
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.parent.mkdir()
+        settings.write_text("invalid", encoding="utf-8")
+        issues: list[str] = []
+
+        doctor_module._check_claude_code(issues, [])
+
+        assert issues == [f"{settings}: not valid JSON."]
+
+    def test_kiro_empty_directory_and_current_profile_have_no_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        agents = tmp_path / ".kiro" / "agents"
+        agents.mkdir(parents=True)
+
+        doctor_module._check_kiro([], [])
+        assert "No Kiro agent configs found" in _plain(capsys.readouterr().out)
+
+        (agents / "broken.json").write_text("invalid", encoding="utf-8")
+        _write_json(
+            agents / "current.json",
+            {
+                "hooks": {
+                    "ignored": "not-a-list",
+                    "userPromptSubmit": [{"command": "python -m observal_cli.hooks.session_push --harness kiro"}],
+                }
+            },
+        )
+        warnings: list[str] = []
+
+        doctor_module._check_kiro([], warnings)
+
+        assert warnings == []
+
+    def test_pi_current_extension_reports_legacy_dict_registration(self, tmp_path: Path):
+        source = doctor_module._pi_extension_source()
+        extension = tmp_path / ".pi" / "agent" / "extensions" / "observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text(source, encoding="utf-8")
+        _write_json(
+            tmp_path / ".pi" / "agent" / "settings.json",
+            {"packages": [{"source": "npm:observal-pi@1.0.0"}, 7]},
+        )
+        issues: list[str] = []
+        warnings: list[str] = []
+
+        doctor_module._check_pi(issues, warnings)
+
+        assert issues == []
+        assert warnings == ["Legacy npm:observal-pi registration remains. Doctor can remove it."]
+        assert doctor_module._is_legacy_pi_package(7) is False
+
+    def test_pi_source_and_settings_failures_are_issues(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        (tmp_path / ".pi" / "agent").mkdir(parents=True)
+        monkeypatch.setattr(doctor_module, "_pi_extension_source", MagicMock(side_effect=OSError("source missing")))
+        issues: list[str] = []
+
+        doctor_module._check_pi(issues, [])
+
+        assert issues == ["source missing"]
+
+        monkeypatch.setattr(doctor_module, "_pi_extension_source", lambda: "source")
+        settings = tmp_path / ".pi" / "agent" / "settings.json"
+        settings.write_text("invalid", encoding="utf-8")
+        issues = []
+
+        doctor_module._check_pi(issues, [])
+
+        assert issues == [f"{settings}: not valid JSON."]
+
+    def test_pi_extension_source_fails_when_no_bundled_or_source_file_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(doctor_module, "__file__", str(tmp_path / "pkg" / "observal_cli" / "cmd_doctor.py"))
+
+        with pytest.raises(FileNotFoundError, match="Bundled Pi telemetry extension is missing"):
+            doctor_module._pi_extension_source()
+
+    @pytest.mark.parametrize(
+        ("harness", "relative_path", "checker", "expected"),
+        [
+            ("cursor", ".cursor/hooks.json", doctor_module._check_cursor, "not valid JSON"),
+            ("copilot-cli", ".copilot/hooks/observal.json", doctor_module._check_copilot_cli, "not valid JSON"),
+        ],
+    )
+    def test_invalid_hook_files_are_diagnosis_issues(
+        self,
+        tmp_path: Path,
+        harness: str,
+        relative_path: str,
+        checker,
+        expected: str,
+    ):
+        del harness
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True)
+        path.write_text("invalid", encoding="utf-8")
+        issues: list[str] = []
+
+        checker(issues, [])
+
+        assert issues == [f"{path}: {expected}."]
+
+    @pytest.mark.parametrize(
+        ("relative_path", "checker", "hooks"),
+        [
+            (
+                ".cursor/hooks.json",
+                doctor_module._check_cursor,
+                {"beforeSubmitPrompt": [{"command": "python -m hooks.session_push --harness cursor"}]},
+            ),
+            (
+                ".copilot/hooks/observal.json",
+                doctor_module._check_copilot_cli,
+                {"sessionStart": [{"bash": "python -m hooks.session_push --harness copilot-cli"}]},
+            ),
+        ],
+    )
+    def test_current_cursor_and_copilot_cli_hooks_have_no_findings(
+        self, tmp_path: Path, relative_path: str, checker, hooks: dict
+    ):
+        _write_json(tmp_path / relative_path, {"hooks": hooks})
+        issues: list[str] = []
+        warnings: list[str] = []
+
+        checker(issues, warnings)
+
+        assert issues == []
+        assert warnings == []
+
+    def test_current_codex_hooks_survive_unreadable_optional_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        hooks_path = tmp_path / ".codex" / "hooks.json"
+        config_path = tmp_path / ".codex" / "config.toml"
+        _write_json(
+            hooks_path,
+            {"hooks": {"UserPromptSubmit": [{"hooks": [{"command": "python -m hooks.session_push --harness codex"}]}]}},
+        )
+        config_path.write_text("codex_hooks = true\n", encoding="utf-8")
+        original_read_text = Path.read_text
+
+        def read_text(path: Path, *args, **kwargs) -> str:
+            if path == config_path:
+                raise OSError("denied")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", read_text)
+        issues: list[str] = []
+        warnings: list[str] = []
+
+        doctor_module._check_codex(issues, warnings)
+
+        assert issues == []
+        assert warnings == []
+
+    def test_copilot_detects_current_project_hook(self, tmp_path: Path):
+        (tmp_path / ".vscode").mkdir()
+        _write_json(
+            tmp_path / ".github" / "hooks" / "observal.json",
+            {"hooks": {"Stop": [{"command": "run_hook.ps1"}]}},
+        )
+        warnings: list[str] = []
+
+        doctor_module._check_copilot([], warnings)
+
+        assert warnings == []
+
+    def test_opencode_read_failure_is_an_issue(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        plugin = tmp_path / ".config" / "opencode" / "plugins" / "observal-plugin.ts"
+        plugin.parent.mkdir(parents=True)
+        plugin.write_text("plugin", encoding="utf-8")
+        original_read_text = Path.read_text
+
+        def read_text(path: Path, *args, **kwargs) -> str:
+            if path == plugin:
+                raise OSError("denied")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", read_text)
+        issues: list[str] = []
+
+        doctor_module._check_opencode(issues, [])
+
+        assert issues == [f"{plugin}: failed to read OpenCode plugin: denied"]
+
+    @pytest.mark.parametrize(
+        ("data", "issue", "warning"),
+        [
+            (None, "not valid JSON", None),
+            ({"observal-telemetry": []}, None, "not installed"),
+            ({"observal-telemetry": {"PreInvocation": "invalid"}}, None, "not installed"),
+            (
+                {"observal-telemetry": {"Stop": [{"command": "antigravity_session_push"}]}},
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_antigravity_hook_states(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        data: dict | None,
+        issue: str | None,
+        warning: str | None,
+    ):
+        from observal_cli.shared import utils
+
+        config_dir = tmp_path / ".gemini" / "config"
+        config_dir.mkdir(parents=True)
+        hooks_path = config_dir / "hooks.json"
+        if data is None:
+            hooks_path.write_text("invalid", encoding="utf-8")
+        else:
+            _write_json(hooks_path, data)
+        monkeypatch.setattr(utils, "resolve_antigravity_config_dir", lambda: config_dir)
+        issues: list[str] = []
+        warnings: list[str] = []
+
+        doctor_module._check_antigravity(issues, warnings)
+
+        assert (issue is None) == (issues == [])
+        assert (warning is None) == (warnings == [])
+        if issue:
+            assert issue in issues[0]
+        if warning:
+            assert warning in warnings[0]
+
+
+@pytest.fixture
+def patch_dispatch(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    import observal_cli.audit as audit_module
+
+    config_load = MagicMock(return_value={"server_url": "https://server.test"})
+    ensure_loaded = MagicMock()
+    get_adapter = MagicMock()
+    audit = MagicMock()
+    monkeypatch.setattr(doctor_module.config, "load", config_load)
+    monkeypatch.setattr(doctor_module, "ensure_loaded", ensure_loaded)
+    monkeypatch.setattr(doctor_module, "get_adapter", get_adapter)
+    monkeypatch.setattr(audit_module, "emit_cli_audit", audit)
+    monkeypatch.setattr(doctor_module, "_VALID_HARNESSES", ["claude-code", "pi"])
+    return SimpleNamespace(config_load=config_load, ensure_loaded=ensure_loaded, get_adapter=get_adapter, audit=audit)
+
+
+class TestDoctorPatchCommand:
+    def test_requires_a_target_before_loading_config(self, runner: CliRunner, patch_dispatch: SimpleNamespace):
+        result = runner.invoke(doctor_module.doctor_app, ["patch"])
+
+        assert result.exit_code == 1
+        assert "Specify --all-harnesses or --harness <name>" in _plain(result.output)
+        patch_dispatch.config_load.assert_not_called()
+        patch_dispatch.ensure_loaded.assert_not_called()
+
+    def test_requires_login_before_loading_adapters(self, runner: CliRunner, patch_dispatch: SimpleNamespace):
+        patch_dispatch.config_load.return_value = {}
+
+        result = runner.invoke(doctor_module.doctor_app, ["patch", "--harness", "pi"])
+
+        assert result.exit_code == 1
+        assert "Not configured. Run observal auth login first." in _plain(result.output)
+        patch_dispatch.ensure_loaded.assert_not_called()
+        patch_dispatch.get_adapter.assert_not_called()
+
+    def test_rejects_unknown_harness_with_valid_choices(self, runner: CliRunner, patch_dispatch: SimpleNamespace):
+        result = runner.invoke(doctor_module.doctor_app, ["patch", "--harness", "unknown"])
+
+        assert result.exit_code == 1
+        assert "Unknown harness: unknown. Valid: claude-code, pi" in _plain(result.output)
+        patch_dispatch.ensure_loaded.assert_not_called()
+
+    def test_selected_harnesses_dispatch_in_order_and_emit_audit(
+        self, runner: CliRunner, patch_dispatch: SimpleNamespace
+    ):
+        adapters = {name: MagicMock() for name in ("claude-code", "pi")}
+        adapters["claude-code"].patch_hooks.return_value = False
+        adapters["pi"].patch_hooks.return_value = True
+        patch_dispatch.get_adapter.side_effect = adapters.__getitem__
+
+        result = runner.invoke(
+            doctor_module.doctor_app,
+            ["patch", "--harness", "claude-code", "--harness", "pi"],
+        )
+
+        assert result.exit_code == 0
+        assert "Patch complete. Restart your harness sessions" in _plain(result.output)
+        patch_dispatch.ensure_loaded.assert_called_once_with()
+        assert patch_dispatch.get_adapter.call_args_list == [call("claude-code"), call("pi")]
+        adapters["claude-code"].patch_hooks.assert_called_once_with(False)
+        adapters["pi"].patch_hooks.assert_called_once_with(False)
+        patch_dispatch.audit.assert_called_once_with(
+            "doctor.patch",
+            resource_type="harness",
+            detail="harnesses=claude-code,pi, hooks=true",
+            sensitivity="high",
+        )
+
+    def test_all_harnesses_dry_run_dispatches_every_target_without_audit(
+        self, runner: CliRunner, patch_dispatch: SimpleNamespace
+    ):
+        adapters = {name: MagicMock() for name in ("claude-code", "pi")}
+        for adapter in adapters.values():
+            adapter.patch_hooks.return_value = True
+        patch_dispatch.get_adapter.side_effect = adapters.__getitem__
+
+        result = runner.invoke(doctor_module.doctor_app, ["patch", "--all-harnesses", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run - no changes made." in _plain(result.output)
+        assert patch_dispatch.get_adapter.call_args_list == [call("claude-code"), call("pi")]
+        for adapter in adapters.values():
+            adapter.patch_hooks.assert_called_once_with(True)
+        patch_dispatch.audit.assert_not_called()
+
+    def test_no_adapter_changes_reports_up_to_date_without_audit(
+        self, runner: CliRunner, patch_dispatch: SimpleNamespace
+    ):
+        adapter = MagicMock()
+        adapter.patch_hooks.return_value = False
+        patch_dispatch.get_adapter.return_value = adapter
+
+        result = runner.invoke(doctor_module.doctor_app, ["patch", "--harness", "pi"])
+
+        assert result.exit_code == 0
+        assert "Everything already up to date." in _plain(result.output)
+        patch_dispatch.audit.assert_not_called()
+
+    def test_unsupported_adapter_failure_is_not_hidden(self, runner: CliRunner, patch_dispatch: SimpleNamespace):
+        adapter = MagicMock()
+        adapter.patch_hooks.side_effect = NotSupportedError("pi", "patch_hooks")
+        patch_dispatch.get_adapter.return_value = adapter
+
+        result = runner.invoke(doctor_module.doctor_app, ["patch", "--harness", "pi"])
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, NotSupportedError)
+        assert str(result.exception) == "pi does not support patch_hooks"
+        assert "Patch complete" not in _plain(result.output)
+        patch_dispatch.audit.assert_not_called()
+
+
+@pytest.fixture
+def cleanup_dispatch(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    ensure_loaded = MagicMock()
+    get_adapter = MagicMock()
+    valid_harnesses = MagicMock(return_value=["claude-code", "pi"])
+    monkeypatch.setattr(doctor_module, "ensure_loaded", ensure_loaded)
+    monkeypatch.setattr(doctor_module, "get_adapter", get_adapter)
+    monkeypatch.setattr(doctor_module, "get_valid_harnesses", valid_harnesses)
+    return SimpleNamespace(ensure_loaded=ensure_loaded, get_adapter=get_adapter, valid_harnesses=valid_harnesses)
+
+
+class TestDoctorCleanupCommand:
+    def test_selected_harness_dispatches_and_reports_completion(
+        self, runner: CliRunner, cleanup_dispatch: SimpleNamespace
+    ):
+        adapter = MagicMock()
+        adapter.cleanup_hooks.return_value = True
+        cleanup_dispatch.get_adapter.return_value = adapter
+
+        result = runner.invoke(doctor_module.doctor_app, ["cleanup", "--harness", "claude-code"])
+
+        assert result.exit_code == 0
+        assert "Cleanup complete. Restart your harness sessions" in _plain(result.output)
+        cleanup_dispatch.valid_harnesses.assert_not_called()
+        cleanup_dispatch.ensure_loaded.assert_called_once_with()
+        cleanup_dispatch.get_adapter.assert_called_once_with("claude-code")
+        adapter.cleanup_hooks.assert_called_once_with(False)
+
+    def test_default_selection_honors_exclusions_and_dry_run(
+        self, runner: CliRunner, cleanup_dispatch: SimpleNamespace
+    ):
+        adapter = MagicMock()
+        adapter.cleanup_hooks.return_value = True
+        cleanup_dispatch.get_adapter.return_value = adapter
+
+        result = runner.invoke(
+            doctor_module.doctor_app,
+            ["cleanup", "--exclude", "pi", "--dry-run"],
+        )
+
+        assert result.exit_code == 0
+        cleanup_dispatch.valid_harnesses.assert_called_once_with()
+        cleanup_dispatch.get_adapter.assert_called_once_with("claude-code")
+        adapter.cleanup_hooks.assert_called_once_with(True)
+        output = _plain(result.output)
+        assert "Cleanup complete" not in output
+        assert "Nothing to clean up" not in output
+
+    def test_unknown_adapter_is_reported_and_cleanup_continues(
+        self, runner: CliRunner, cleanup_dispatch: SimpleNamespace
+    ):
+        cleanup_dispatch.get_adapter.side_effect = KeyError("missing")
+
+        result = runner.invoke(doctor_module.doctor_app, ["cleanup", "--harness", "unknown"])
+        output = _plain(result.output)
+
+        assert result.exit_code == 0
+        assert "Unknown harness: unknown" in output
+        assert "Nothing to clean up - no Observal artifacts found." in output
+
+    def test_no_changes_reports_nothing_to_clean(self, runner: CliRunner, cleanup_dispatch: SimpleNamespace):
+        adapter = MagicMock()
+        adapter.cleanup_hooks.return_value = False
+        cleanup_dispatch.get_adapter.return_value = adapter
+
+        result = runner.invoke(doctor_module.doctor_app, ["cleanup", "--harness", "pi"])
+
+        assert result.exit_code == 0
+        assert "Nothing to clean up - no Observal artifacts found." in _plain(result.output)
+
+    def test_unsupported_cleanup_failure_is_not_hidden(self, runner: CliRunner, cleanup_dispatch: SimpleNamespace):
+        adapter = MagicMock()
+        adapter.cleanup_hooks.side_effect = NotSupportedError("pi", "cleanup_hooks")
+        cleanup_dispatch.get_adapter.return_value = adapter
+
+        result = runner.invoke(doctor_module.doctor_app, ["cleanup", "--harness", "pi"])
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, NotSupportedError)
+        assert str(result.exception) == "pi does not support cleanup_hooks"
+        assert "Cleanup complete" not in _plain(result.output)
+
+
+class TestCleanupStateEdges:
+    def test_claude_dry_run_preserves_file_then_cleanup_removes_empty_sections(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        settings = tmp_path / ".claude" / "settings.json"
+        _write_json(
+            settings,
+            {
+                "env": {"OBSERVAL_HOOKS_URL": "https://server.test"},
+                "hooks": {
+                    "Stop": [
+                        {
+                            "_observal": {"version": "1"},
+                            "hooks": [{"command": "python -m observal_cli.hooks.session_push"}],
+                        }
+                    ]
+                },
+            },
+        )
+        original = settings.read_text(encoding="utf-8")
+
+        assert doctor_module._cleanup_claude_code(dry_run=True) is True
+        assert settings.read_text(encoding="utf-8") == original
+        assert "Would remove env vars" in _plain(capsys.readouterr().out)
+
+        assert doctor_module._cleanup_claude_code(dry_run=False) is True
+        assert json.loads(settings.read_text(encoding="utf-8")) == {}
+
+    @pytest.mark.parametrize(
+        ("relative_path", "cleanup", "message"),
+        [
+            (".claude/settings.json", doctor_module._cleanup_claude_code, "Failed to read settings"),
+            (".pi/agent/settings.json", doctor_module._cleanup_pi, "Cannot read"),
+            (".cursor/hooks.json", doctor_module._cleanup_cursor, "Failed to read hooks"),
+            (".codex/hooks.json", doctor_module._cleanup_codex, "Failed to read hooks"),
+        ],
+    )
+    def test_invalid_cleanup_files_fail_open_without_mutation(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        relative_path: str,
+        cleanup,
+        message: str,
+    ):
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True)
+        path.write_text("invalid", encoding="utf-8")
+
+        assert cleanup(dry_run=False) is False
+        assert path.read_text(encoding="utf-8") == "invalid"
+        assert message in _plain(capsys.readouterr().out)
+
+    @pytest.mark.parametrize(
+        "cleanup",
+        [
+            doctor_module._cleanup_kiro,
+            doctor_module._cleanup_cursor,
+            doctor_module._cleanup_codex,
+            doctor_module._cleanup_copilot,
+            doctor_module._cleanup_copilot_cli,
+            doctor_module._cleanup_opencode,
+        ],
+    )
+    def test_missing_cleanup_artifacts_report_no_change(self, cleanup):
+        assert cleanup(dry_run=False) is False
+
+
+class TestPatchStateEdges:
+    def test_kiro_skips_unusable_lock_entries_and_reports_profiles(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        from observal_cli import lockfile
+
+        invalid = tmp_path / ".kiro" / "agents" / "invalid.json"
+        invalid.parent.mkdir(parents=True)
+        invalid.write_text("invalid", encoding="utf-8")
+        current = invalid.parent / "current.json"
+        _write_json(current, {"hooks": {}})
+        registry = {
+            "harnesses": {
+                "kiro": {
+                    "agents": [
+                        {"id": "no-name", "scope": "user"},
+                        {"id": "no-directory", "local_name": "project", "scope": "project"},
+                        {
+                            "id": "missing-profile",
+                            "local_name": "missing",
+                            "scope": "project",
+                            "directory": str(tmp_path / "repo"),
+                        },
+                        {"id": "invalid-profile", "local_name": "invalid", "scope": "user"},
+                        {"id": "current-profile", "local_name": "current", "scope": "user"},
+                    ]
+                }
+            }
+        }
+        adapter = MagicMock()
+        adapter.rewrite_agent_profile.side_effect = lambda profile, *, agent_id: profile
+        monkeypatch.setattr(lockfile, "read_registry_lockfile", MagicMock(return_value=(None, registry)))
+        monkeypatch.setattr(doctor_module, "ensure_loaded", MagicMock())
+        monkeypatch.setattr(doctor_module, "get_adapter", MagicMock(return_value=adapter))
+
+        assert doctor_module._patch_kiro(dry_run=False) is False
+        output = _plain(capsys.readouterr().out)
+        assert "Missing locked profile" in output
+        assert "Cannot read" in output
+        assert "Already up to date" in output
+        adapter.rewrite_agent_profile.assert_called_once_with({"hooks": {}}, agent_id="current-profile")
+
+    def test_cursor_missing_directory_and_invalid_file_dry_run_do_not_write(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        assert doctor_module._patch_cursor(dry_run=False) is False
+        assert "skipping" in _plain(capsys.readouterr().out)
+
+        hooks = tmp_path / ".cursor" / "hooks.json"
+        hooks.parent.mkdir()
+        hooks.write_text("invalid", encoding="utf-8")
+
+        assert doctor_module._patch_cursor(dry_run=True) is True
+        assert hooks.read_text(encoding="utf-8") == "invalid"
+        assert "Would install hooks" in _plain(capsys.readouterr().out)
+
+    def test_antigravity_missing_detection_and_invalid_file_dry_run_do_not_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        from observal_cli.shared import utils
+
+        resolver = MagicMock(return_value=None)
+        monkeypatch.setattr(utils, "resolve_antigravity_config_dir", resolver)
+        assert doctor_module._patch_antigravity(dry_run=False) is False
+        assert "skipping" in _plain(capsys.readouterr().out)
+
+        config_dir = tmp_path / ".gemini" / "config"
+        config_dir.mkdir(parents=True)
+        hooks = config_dir / "hooks.json"
+        hooks.write_text("invalid", encoding="utf-8")
+        resolver.return_value = config_dir
+
+        assert doctor_module._patch_antigravity(dry_run=True) is True
+        assert hooks.read_text(encoding="utf-8") == "invalid"
+        assert "Would install hooks" in _plain(capsys.readouterr().out)
+
+    def test_pi_missing_detection_and_invalid_settings_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        assert doctor_module._patch_pi(dry_run=False) is False
+        assert "skipping" in _plain(capsys.readouterr().out)
+
+        pi_dir = tmp_path / ".pi" / "agent"
+        pi_dir.mkdir(parents=True)
+        settings = pi_dir / "settings.json"
+        settings.write_text("invalid", encoding="utf-8")
+        monkeypatch.setattr(doctor_module, "_pi_extension_source", lambda: "source")
+
+        with pytest.raises(RuntimeError, match=r"Cannot update .*settings.json"):
+            doctor_module._patch_pi(dry_run=False)
+        assert not (pi_dir / "extensions" / "observal.ts").exists()
+
+    def test_pi_dry_run_preserves_legacy_settings_and_extension_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        settings = tmp_path / ".pi" / "agent" / "settings.json"
+        _write_json(settings, {"packages": ["npm:observal-pi"]})
+        monkeypatch.setattr(doctor_module, "_pi_extension_source", lambda: "source")
+        before = settings.read_text(encoding="utf-8")
+
+        assert doctor_module._patch_pi(dry_run=True) is True
+        assert settings.read_text(encoding="utf-8") == before
+        assert not (tmp_path / ".pi" / "agent" / "extensions" / "observal.ts").exists()
+        output = _plain(capsys.readouterr().out)
+        assert "Would install" in output
+        assert "Would remove legacy npm:observal-pi" in output
+
+    def test_codex_dry_run_on_missing_state_does_not_create_directory(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        assert doctor_module._patch_codex(dry_run=True) is True
+        assert not (tmp_path / ".codex").exists()
+        output = _plain(capsys.readouterr().out)
+        assert "Would install hooks" in output
+        assert "Would enable codex_hooks flag" in output
+
+    @pytest.mark.parametrize(
+        ("patcher", "relative_path", "message"),
+        [
+            (
+                doctor_module._patch_copilot_cli,
+                ".copilot/hooks/observal.json",
+                "Would install hooks",
+            ),
+            (
+                doctor_module._patch_opencode,
+                ".config/opencode/plugins/observal-plugin.ts",
+                "Would update plugin",
+            ),
+        ],
+    )
+    def test_plugin_patch_dry_runs_leave_files_untouched(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        patcher,
+        relative_path: str,
+        message: str,
+    ):
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True)
+        path.write_text("stale", encoding="utf-8")
+
+        assert patcher(dry_run=True) is True
+        assert path.read_text(encoding="utf-8") == "stale"
+        assert message in _plain(capsys.readouterr().out)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 0xSHSH 
<156781261+0xSHSH@users.noreply.github.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
The CLI doctor commands had no dedicated E2E test coverage. This PR adds comprehensive tests for doctor diagnose, patch, and cleanup commands to improve reliability and catch regressions.

## Fixes
* Fixes #980

## Approach
Created `tests/test_cli_doctor_commands.py` with test classes:
- `TestDoctorDiagnose` — tests health check with missing/invalid/valid config
- `TestDoctorPatch` — tests hook patching, dry run, invalid IDE handling
- `TestDoctorCleanup` — tests artifact removal, dry run, env var cleanup

All file I/O and HTTP calls are mocked so tests run without a live server.

## How Has This Been Tested?
- Follows same patterns as `tests/test_auth2_security.py`
- Uses `typer.testing.CliRunner` for command invocation
- Run with: `pytest tests/test_cli_doctor_commands.py -v`

## Learning (optional)
- Doctor uses `typer.Context` callback pattern with `invoke_without_command=True`
- `typer.testing.CliRunner` is the correct way to test Typer apps

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: N/A - tests only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for doctor CLI diagnosis, configuration, skill detection, and adapter states.
  * Added tests for patching, cleanup, dry-run behavior, lockfile reconciliation, invalid files, audit events, and error handling.
  * Verified that dry runs preserve files and that external interactions are safely isolated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->