### PR TITLE
ci: add GitHub Action to label first-time contributor PRs

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 0xSHSH <156781261+0xSHSH@users.noreply.github.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+name: Label First-Time Contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Label first-time contributor
+        uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: |
+            👋 Thanks for opening your first PR in Observal!
+            A maintainer will review it shortly.
+          pr-label: "first-time-contributor"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 0xSHSH <156781261+0xSHSH@users.noreply.github.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
There is currently no automated way to identify and welcome first-time contributors when they open a PR. This makes onboarding less friendly and harder to track for maintainers.

## Fixes
* Fixes #1009

## Approach
Added `.github/workflows/first-time-contributor.yml` using the official `actions/first-interaction@v1` GitHub Action. When a first-time contributor opens a PR, it automatically adds a `first-time-contributor` label and posts a welcome message.

## How Has This Been Tested?
- Verified workflow syntax with GitHub Actions YAML schema
- `actions/first-interaction@v1` is an official GitHub Action widely used in open source

## Learning (optional)
- `actions/first-interaction` docs: https://github.com/actions/first-interaction
- Uses `pull_request_target` for security with fork PRs

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: N/A - CI workflow only