### PR TITLE
fix(traces): correct sentinel timestamp causing broken duration/started columns

### DIFF
--- a/observal-server/api/routes/sessions.py
+++ b/observal-server/api/routes/sessions.py
@@ -162,7 +162,7 @@ async def _list_sessions_query(
     return await _ch_json(
         "SELECT "
         "session_id, "
-        "if(first_event_time > '1970-01-02 00:00:00' AND first_event_time < '2099-01-01 00:00:00', "
+        "if(first_event_time > '2020-01-01 00:00:00' AND first_event_time < '2099-01-01 00:00:00', "
         "   first_event_time, last_event_time) AS first_event_time, "
         "last_event_time, "
         "(last_event_time > now() - INTERVAL 30 MINUTE) AS is_active, "

--- a/observal-server/services/session_ingest.py
+++ b/observal-server/services/session_ingest.py
@@ -144,7 +144,7 @@ async def ingest_session_lines(
         ts = extract_timestamp(ide, parsed)
         if ts is not None:
             last_real_ts = ts
-        timestamp = ts if ts is not None else (last_real_ts if last_real_ts is not None else "2000-01-01 00:00:00.000")
+        timestamp = ts if ts is not None else (last_real_ts if last_real_ts is not None else "1970-01-01 00:00:00.000")
 
         rows.append(
             {


### PR DESCRIPTION
## Purpose / Description
The traces list page displays absurd Duration ("231151h 36m") and Started ("9631d ago") values for sessions whose first JSONL line lacks a parseable timestamp.

The ingest fallback timestamp `"2000-01-01 00:00:00.000"` passed the SQL sentinel guard (`> 1970-01-02`) and was stored as `first_event_time` in `session_stats_agg`. The frontend then computed Duration = `last_event_time (2026)` − `first_event_time (2000)` = ~26 years.

## Fixes
* Fixes broken Duration and Started columns on the `/traces` page for sessions with missing initial timestamps

## Approach
Two-layer fix:

1. **Ingest sentinel** (`session_ingest.py`): Changed the fallback from `"2000-01-01"` to `"1970-01-01"` (epoch). The existing SQL guard already rejects timestamps ≤ 1970-01-02, so newly-ingested sessions will correctly fall through to `last_event_time`.

2. **SQL guard** (`sessions.py`): Tightened the lower bound from `'1970-01-02'` to `'2020-01-01'`. This catches the `2000-01-01` timestamps already stored in ClickHouse from previously-ingested sessions (the product didn't exist before 2024, so any date before 2020 is clearly invalid).

## How Has This Been Tested?

- Verified the logic: `2000-01-01 > '2020-01-01'` → false → falls through to `last_event_time` ✓
- Verified the logic: `1970-01-01 > '2020-01-01'` → false → falls through to `last_event_time` ✓
- Verified valid timestamps (e.g. `2026-05-15`) still pass both bounds ✓

## Learning (optional, can help others)
ClickHouse `SimpleAggregateFunction(min, DateTime64)` doesn't use a sentinel you can easily detect — it stores whatever minimum value it receives. When using fallback timestamps in ingest code, they need to be coordinated with any downstream validity guards in queries.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)