### PR TITLE
fix: add hook_bridge to Cursor IDE capabilities list

### DIFF
--- a/web/src/lib/ide-features.ts
+++ b/web/src/lib/ide-features.ts
@@ -41,7 +41,7 @@ export type IdeFeature = (typeof IDE_FEATURES)[number];
 export const IDE_FEATURE_MATRIX: Record<IdeName, ReadonlySet<IdeFeature>> = {
   "claude-code": new Set(["skills", "hook_bridge", "mcp_servers", "rules", "otlp_telemetry"]),
   kiro: new Set(["superpowers", "hook_bridge", "mcp_servers", "rules", "steering_files", "otlp_telemetry"]),
-  cursor: new Set(["mcp_servers", "rules"]),
+  cursor: new Set(["mcp_servers", "rules", "hook_bridge"]),
   "gemini-cli": new Set(["hook_bridge", "mcp_servers", "rules", "otlp_telemetry"]),
   codex: new Set(["rules"]),
   copilot: new Set(["mcp_servers", "rules"]),


### PR DESCRIPTION
## Summary
Adds `hook_bridge` to the Cursor IDE capabilities set in `web/src/lib/ide-features.ts`.
Fixes #834

## Root Cause
The frontend's `IDE_CAPABILITIES` object listed Cursor as having only `mcp_servers` and `rules`, but the backend's `IDE_REGISTRY` (in both `observal_cli/ide_registry.py` and `observal-server/schemas/ide_registry.py`) also includes `hook_bridge` for Cursor. This mismatch caused the UI feature matrix to show incorrect capabilities.

## Fix
Added `"hook_bridge"` to `cursor: new Set([...])` at line 44 of `web/src/lib/ide-features.ts`.

## Changes
- `web/src/lib/ide-features.ts` (+1 -1): Added `"hook_bridge"` to Cursor capabilities Set

## Testing
- ✅ Verified the change matches the backend's Cursor capabilities in `IDE_REGISTRY`
- ✅ No other cursors/features sets affected
- ✅ The change is additive only (no breaking behavior)