### PR TITLE
test(e2e): add Playwright tests for auth login error and logout flow

### DIFF
--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Tanvi Reddy <tanvi.reddy330@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { test, expect } from "@playwright/test";
+
+const EMAIL = process.env.DEMO_ADMIN_EMAIL ?? "admin@demo.example";
+const PASSWORD = process.env.DEMO_ADMIN_PASSWORD ?? "admin-changeme";
+
+/**
+ * P0: Login with wrong password — error shown
+ * Issue #927
+ */
+test("login with wrong password shows error and stays on /login", async ({ page }) => {
+  await page.goto("/login");
+  await page.fill("#email", EMAIL);
+  await page.fill("#password", "wrong-password-123");
+  await page.click('button[type="submit"]');
+
+  // Should stay on /login
+  await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
+
+  // Error message should appear
+  await expect(page.locator("span").filter({ hasText: /invalid|incorrect|wrong|failed|credentials|password/i }).first()).toBeVisible({ timeout: 10_000 });
+});
+
+/**
+ * P0: Logout — redirected to /login, protected pages inaccessible
+ * Issue #927
+ */
+test("logout redirects to /login and blocks protected pages", async ({ page }) => {
+  // Login first
+  await page.goto("/login");
+  await page.fill("#email", EMAIL);
+  await page.fill("#password", PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"), { timeout: 15_000 });
+
+  // Open user menu and click Sign out
+  await page.locator("button").filter({ hasText: /demo admin|admin/i }).first().click();
+  await page.locator("text=Sign out").click();
+
+  // Should redirect to /login
+  await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
+
+  // Protected page should redirect back to /login
+  await page.goto("/dashboard");
+  await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
+});


### PR DESCRIPTION
Closes #927

## Changes
Adds `web/e2e/auth.spec.ts` with 2 Playwright P0 tests:

- **P0** — Login with wrong password shows error message and stays on `/login`
- **P0** — Logout redirects to `/login` and blocks access to protected pages (e.g. `/dashboard`)

## Tested
- Both tests pass locally
- `make lint` passes