### PR TITLE
fix: `make test` fails due to missing `pyarrow` dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ check:  ## Full pre-commit check on all files
 # ── Testing ──────────────────────────────────────────────
 
 test:  ## Run Python tests
-	cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis pytest ../tests/ -q
+	cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis --with pyarrow pytest ../tests/ -q
 
 test-v:  ## Run Python tests (verbose)
-	cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis pytest ../tests/ -v
+	cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis --with pyarrow pytest ../tests/ -v
 
 test-adversarial:  ## Run BenchJack self-test suite
 	cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich pytest ../tests/test_adversarial_self.py -v --tb=short


### PR DESCRIPTION
Fixes #1043

Adds `--with pyarrow` to the `test` and `test-v` targets in the Makefile so that `pytest` can correctly resolve `pyarrow` when importing `tests/test_migrate_telemetry.py`.