### PR TITLE
chore(packaging): prep CLI for Homebrew

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Updates the BlazeUp-AI/homebrew-observal tap after every published release.
+#
+# Fires when a GitHub release is published (the release.yml workflow flips a
+# draft to published as its final step). Downloads the just-published binaries
+# from the release, reads their sha256s from checksums.txt, rewrites
+# Formula/observal-cli.rb in the tap, and pushes a commit.
+
+name: Update Homebrew tap
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish to the tap (e.g. 0.6.0). Must match an existing GitHub release."
+        required: true
+        type: string
+
+concurrency:
+  group: update-homebrew-tap
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  update-tap:
+    name: Bump observal-cli.rb in homebrew-observal
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    steps:
+      - name: Resolve release version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download checksums from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ steps.version.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern checksums.txt \
+            --output checksums.txt
+
+      - name: Extract sha256 values
+        id: sha
+        run: |
+          MACOS_ARM=$(grep " observal-macos-arm64$" checksums.txt | awk '{print $1}')
+          LINUX_ARM=$(grep " observal-linux-arm64$" checksums.txt | awk '{print $1}')
+          LINUX_X64=$(grep " observal-linux-x64$" checksums.txt | awk '{print $1}')
+
+          for var in MACOS_ARM LINUX_ARM LINUX_X64; do
+            val="${!var}"
+            if [ -z "$val" ]; then
+              echo "::error::Missing sha256 for $var in checksums.txt"
+              exit 1
+            fi
+          done
+
+          echo "macos_arm=$MACOS_ARM" >> "$GITHUB_OUTPUT"
+          echo "linux_arm=$LINUX_ARM" >> "$GITHUB_OUTPUT"
+          echo "linux_x64=$LINUX_X64" >> "$GITHUB_OUTPUT"
+
+      - name: Generate tap app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: BlazeUp-AI
+          repositories: homebrew-observal
+
+      - name: Checkout homebrew-observal
+        uses: actions/checkout@v6
+        with:
+          repository: BlazeUp-AI/homebrew-observal
+          token: ${{ steps.app-token.outputs.token }}
+          path: homebrew-observal
+
+      - name: Rewrite Formula/observal-cli.rb
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          MACOS_ARM: ${{ steps.sha.outputs.macos_arm }}
+          LINUX_ARM: ${{ steps.sha.outputs.linux_arm }}
+          LINUX_X64: ${{ steps.sha.outputs.linux_x64 }}
+        run: |
+          FORMULA=homebrew-observal/Formula/observal-cli.rb
+
+          python3 - <<'PY'
+          import os, re, pathlib
+          path = pathlib.Path("homebrew-observal/Formula/observal-cli.rb")
+          text = path.read_text()
+
+          version = os.environ["VERSION"]
+          shas = {
+              "observal-macos-arm64": os.environ["MACOS_ARM"],
+              "observal-linux-arm64": os.environ["LINUX_ARM"],
+              "observal-linux-x64":   os.environ["LINUX_X64"],
+          }
+
+          text = re.sub(r'^(\s*version\s+)"[^"]+"', rf'\1"{version}"', text, count=1, flags=re.M)
+          text = re.sub(
+              r'(releases/download/)v[0-9][0-9A-Za-z.\-]*(/observal-[^"]+)',
+              rf'\1v{version}\2',
+              text,
+          )
+
+          def replace_sha(match):
+              url_line, sha_indent = match.group(1), match.group(2)
+              binary = re.search(r'/(observal-[a-z0-9\-]+)"', url_line).group(1)
+              new_sha = shas[binary]
+              return f'{url_line}\n{sha_indent}sha256 "{new_sha}"'
+
+          text = re.sub(
+              r'(url "https://github\.com/BlazeUp-AI/Observal/releases/download/v[^"]+")\n(\s*)sha256 "[0-9a-f]{64}"',
+              replace_sha,
+              text,
+          )
+
+          path.write_text(text)
+          PY
+
+          echo "--- Updated formula ---"
+          cat "$FORMULA"
+
+      - name: Commit and push
+        working-directory: homebrew-observal
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "observal-release[bot]"
+          git config user.email "observal-release[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "Formula already up-to-date for v${VERSION} — nothing to push."
+            exit 0
+          fi
+
+          git add Formula/observal-cli.rb
+          git commit -m "observal-cli ${VERSION}"
+          git push

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 <p>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python">
-  <img src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" alt="Status">
+  <img src="https://img.shields.io/badge/status-beta-yellow?style=flat-square" alt="Status">
   <a href="https://github.com/BlazeUp-AI/Observal/stargazers"><img src="https://img.shields.io/github/stars/BlazeUp-AI/Observal?style=flat-square" alt="Stars"></a>
   <a href="https://codecov.io/gh/BlazeUp-AI/Observal"><img src="https://img.shields.io/codecov/c/github/BlazeUp-AI/Observal?style=flat-square&logo=codecov" alt="Coverage"></a>
 </p>
@@ -141,7 +141,12 @@ make up
 ### Connect your IDE
 
 ```bash
-uv tool install observal-cli
+# Homebrew (macOS Apple Silicon, Linux)
+brew install BlazeUp-AI/observal/observal-cli
+
+# Or via Python tooling (all platforms)
+uv tool install observal-cli   # or: pipx install observal-cli
+
 observal auth login
 ```
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -103,6 +103,12 @@ uv tool install observal-cli
 # or: pipx install observal-cli
 ```
 
+**Via Homebrew** (macOS Apple Silicon, Linux x64/arm64):
+
+```bash
+brew install BlazeUp-AI/observal/observal-cli
+```
+
 Verify: `observal --version`
 
 ---

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -1722,6 +1722,21 @@ async def _validate_telemetry(
 migrate_app = typer.Typer(help="PostgreSQL shallow-copy migration tools")
 
 
+def _require_pyarrow() -> None:
+    """pyarrow is an optional dependency; tell the user how to install it."""
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError as exc:
+        raise typer.BadParameter(
+            "The migrate commands require pyarrow. Install with: pip install 'observal-cli[migrate]'"
+        ) from exc
+
+
+@migrate_app.callback()
+def _migrate_callback() -> None:
+    _require_pyarrow()
+
+
 @migrate_app.command("export")
 def export_cmd(
     db_url: str = typer.Option(..., "--db-url", help="Source PostgreSQL connection string"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,11 @@ dependencies = [
     "questionary>=2.0.0",
     "docker>=7.0.0",
     "asyncpg>=0.29.0",
-    "hypothesis",
-    "pyarrow",
 ]
-
 
 keywords = ["mcp", "model-context-protocol", "registry", "cli", "agents", "observability"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
@@ -41,6 +38,12 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
+
+# Optional extras: only required for specific commands.
+# Install with `pip install observal-cli[migrate]` if you need the
+# `observal migrate` Parquet export/import pipeline.
+[project.optional-dependencies]
+migrate = ["pyarrow>=15.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/BlazeUp-AI/Observal"
@@ -140,4 +143,6 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=6.0",
+    "hypothesis>=6.0",
+    "pyarrow>=15.0.0",
 ]

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -33,6 +33,7 @@ from observal_cli.cmd_migrate import (
     _build_select,
     _coerce_value,
     _require_admin,
+    _require_pyarrow,
     _sha256_file,
 )
 from observal_cli.main import app as cli_app
@@ -79,6 +80,34 @@ class TestCLIRegistration:
         result = runner.invoke(cli_app, ["migrate", "validate", "--help"])
         assert result.exit_code == 0
         assert "--archive" in _plain(result.output)
+
+
+class TestPyarrowRequirement:
+    def test_passes_when_pyarrow_importable(self):
+        # pyarrow is installed in the dev environment, so the guard is a no-op.
+        _require_pyarrow()
+
+    def test_raises_install_hint_when_missing(self):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "pyarrow":
+                raise ImportError("simulated missing pyarrow")
+            return real_import(name, *args, **kwargs)
+
+        import typer
+
+        with (
+            patch.object(builtins, "__import__", side_effect=fake_import),
+            pytest.raises(typer.BadParameter) as excinfo,
+        ):
+            _require_pyarrow()
+
+        msg = str(excinfo.value)
+        assert "pyarrow" in msg
+        assert "observal-cli[migrate]" in msg
 
 
 # ── 2. PGEncoder Tests ───────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -477,17 +477,22 @@ dependencies = [
     { name = "asyncpg" },
     { name = "docker" },
     { name = "httpx" },
-    { name = "hypothesis" },
-    { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "rich" },
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+migrate = [
+    { name = "pyarrow" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "fastapi" },
+    { name = "hypothesis" },
+    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pytest" },
@@ -502,17 +507,19 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "docker", specifier = ">=7.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "hypothesis" },
-    { name = "pyarrow" },
+    { name = "pyarrow", marker = "extra == 'migrate'", specifier = ">=15.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
+provides-extras = ["migrate"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "hypothesis", specifier = ">=6.0" },
+    { name = "pyarrow", specifier = ">=15.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pytest", specifier = ">=9.0.3" },


### PR DESCRIPTION
## Purpose / Description

Get `observal-cli` ready for distribution through Homebrew — both our own `BlazeUp-AI/homebrew-observal` tap and the upstream `Homebrew/homebrew-core` registry. Three packaging fixes that Homebrew Core's [Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae) policy effectively requires, plus the supporting tap-bump workflow and user-facing docs.

## Fixes

* No tracking issue; this is enablement work for the Homebrew distribution effort discussed offline.

## Approach

**Packaging (`pyproject.toml`, `README.md`)**

- `Development Status :: 3 - Alpha` → `Development Status :: 4 - Beta`. Homebrew Core rejects formulae upstream declares as alpha. The CLI has shipped on PyPI since 0.2.0 and runs in production for users, so the alpha label is stale anyway. Status badge in `README.md` mirrors the change.
- Drop `hypothesis` from runtime dependencies — it's a property-testing framework only used under `tests/`. Moved into `[dependency-groups].dev`. Every `pip install observal-cli` was pulling it for no reason.
- Move `pyarrow` from runtime deps into a new `[project.optional-dependencies].migrate` extra. `pyarrow` is only imported inside `observal_cli/cmd_migrate.py` (Parquet export/import). Default installs shed roughly 80 MB of native binaries. Users who need migration tooling run `pip install 'observal-cli[migrate]'`.

**Friendly gate (`observal_cli/cmd_migrate.py`)**

- New `_require_pyarrow` typer callback on `migrate_app`. Without the extra installed, running any `observal migrate <...>` subcommand now exits with:
  ```
  The migrate commands require pyarrow. Install with: pip install 'observal-cli[migrate]'
  ```
  instead of a raw `ImportError`.

**Docs (`README.md`, `SETUP.md`)**

- Both files now show `brew install BlazeUp-AI/observal/observal-cli` alongside the existing `uv tool install` / `pipx install` paths so users see all three options in one place.

**Tap automation (`.github/workflows/update-homebrew-tap.yml`)**

- New release-triggered workflow. On every published GitHub release it pulls `checksums.txt` from the release, extracts the SHAs for `observal-macos-arm64`, `observal-linux-arm64`, and `observal-linux-x64`, rewrites `Formula/observal-cli.rb` in `BlazeUp-AI/homebrew-observal`, and commits + pushes. Reuses the existing `RELEASE_APP_CLIENT_ID` / `RELEASE_APP_PRIVATE_KEY` GitHub App credentials, so the app needs Contents: write granted on `homebrew-observal` before the first post-merge release.

## How Has This Been Tested?

- `make lint` — clean.
- `uv lock` regenerated; resolution went from 50 → 49 packages (hypothesis is no longer in the runtime resolver path).
- Manually tested the `_require_pyarrow` callback path in a clean venv: subcommand exits cleanly with the install hint, no traceback.
- The tap formula was authored in `BlazeUp-AI/homebrew-observal` and verified end-to-end on this machine: `brew tap … && brew audit --strict --new observal-cli && brew install observal-cli` succeeds; the installed binary runs.
- The auto-bump workflow's rewrite step was simulated locally with a dummy `0.9.99` version and synthetic SHAs — `ruby -c` on the rewritten formula stays valid.

## Learning (optional, can help others)

- Homebrew Core acceptance criteria: <https://docs.brew.sh/Acceptable-Formulae>.
- Python virtualenv formula pattern: <https://docs.brew.sh/Python-for-Formula-Authors>.
- These docs are what drove the Alpha → Beta classifier change and the dependency cleanup, both of which are de-facto requirements for a homebrew-core submission to be reviewed.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings) — N/A (no UI changes).

## Follow-ups (not in this PR)

- After this merges and a 0.7.0 release is cut to PyPI (so the published sdist carries the Beta classifier and the slim runtime deps), the homebrew-core PR adding `observal-cli` can be opened pointing at that sdist.