### PR TITLE
fix: restrict migrate commands to super admin

### DIFF
--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -10,7 +10,7 @@ Portable migration tools for moving an Observal instance between environments. T
 
 Phase 2 depends on Phase 1. You must complete the shallow copy export and import before running the deep copy.
 
-All migrate commands require **admin** or **super_admin** role.
+All migrate commands require **super_admin** role.
 
 ### Prerequisites
 
@@ -480,5 +480,5 @@ If you encounter a permission error during import, ask your DBA to grant the app
 
 ## Related
 
-* [`observal admin`](admin.md) — admin commands (required role for migrate)
-* [`observal auth`](auth.md) — authentication (must be logged in as admin)
+* [`observal admin`](admin.md) — admin commands
+* [`observal auth`](auth.md) — authentication (must be logged in as super_admin)

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -256,7 +256,7 @@ class TelemetryValidationResult:
 
 
 def _require_admin() -> None:
-    """Verify the current user has admin or super_admin role. Exit if not."""
+    """Verify the current super_admin role. Exit if not."""
     try:
         user = client.get("/api/v1/auth/whoami")
     except SystemExit as exc:
@@ -264,8 +264,8 @@ def _require_admin() -> None:
         rprint("[dim]  Run [bold]observal auth login[/bold] first.[/dim]")
         raise typer.Exit(1) from exc
     role = user.get("role", "")
-    if role not in ("admin", "super_admin"):
-        rprint("[red]Permission denied.[/red] The migrate command requires admin or super_admin role.")
+    if role not in ("super_admin"):
+        rprint("[red]Permission denied.[/red] The migrate command requires super_admin role.")
         rprint(f"[dim]  Current role: {role}[/dim]")
         raise typer.Exit(1)
 

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -256,7 +256,7 @@ class TelemetryValidationResult:
 
 
 def _require_admin() -> None:
-    """Verify the current super_admin role. Exit if not."""
+    """Verify the current user has super_admin role. Exit if not."""
     try:
         user = client.get("/api/v1/auth/whoami")
     except SystemExit as exc:
@@ -264,7 +264,7 @@ def _require_admin() -> None:
         rprint("[dim]  Run [bold]observal auth login[/bold] first.[/dim]")
         raise typer.Exit(1) from exc
     role = user.get("role", "")
-    if role not in ("super_admin"):
+    if role != "super_admin":
         rprint("[red]Permission denied.[/red] The migrate command requires super_admin role.")
         rprint(f"[dim]  Current role: {role}[/dim]")
         raise typer.Exit(1)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -237,9 +237,10 @@ class TestBuildSelect:
 
 class TestRequireAdmin:
     @patch("observal_cli.cmd_migrate.client")
-    def test_admin_role_allowed(self, mock_client):
+    def test_admin_role_rejected(self, mock_client):
         mock_client.get.return_value = {"role": "admin"}
-        _require_admin()  # Should not raise
+        with pytest.raises((SystemExit, click.exceptions.Exit)):
+            _require_admin()
 
     @patch("observal_cli.cmd_migrate.client")
     def test_super_admin_role_allowed(self, mock_client):
@@ -988,9 +989,9 @@ class TestMigrationIdConsistencyProperty:
 
 
 class TestAdminRoleGateProperty:
-    """Property 10: Only admin and super_admin roles pass the gate."""
+    """Property 10: Only super_admin role passes the gate."""
 
-    ALLOWED_ROLES = {"admin", "super_admin"}
+    ALLOWED_ROLES = {"super_admin"}
 
     @given(role=st.sampled_from(["admin", "super_admin", "user", "reviewer", "", "moderator", "guest", "operator"]))
     @hsettings(max_examples=100)

--- a/tests/test_migrate_telemetry.py
+++ b/tests/test_migrate_telemetry.py
@@ -633,12 +633,12 @@ class TestSecurity:
 
 
 class TestAdminRoleGateProperty:
-    """Property 1: Only admin and super_admin roles pass the gate.
+    """Property 1: Only super_admin role passes the gate.
 
     **Validates: Requirements 1.5**
     """
 
-    ALLOWED_ROLES = {"admin", "super_admin"}
+    ALLOWED_ROLES = {"super_admin"}
 
     @given(
         role=st.text(


### PR DESCRIPTION
## Purpose / Description
Restrict all `observal migrate` commands to **super_admin** role only. Previously, both `admin` and `super_admin` could run migrate commands (export, import, validate, export-telemetry, import-telemetry, validate-telemetry). Since these are destructive database-level operations, access should be limited to super admins.


## Approach
- Updated the `_require_admin()` gate function in `observal_cli/cmd_migrate.py` to reject `admin` role and only allow `super_admin`.
- Updated the error message to reflect the new requirement.
- Updated unit tests and property-based tests in both `test_migrate.py` and `test_migrate_telemetry.py` to assert that `admin` is now rejected.
- Updated `docs/cli/migrate.md` to document the new requirement.

## How Has This Been Tested?

- Ran `TestRequireAdmin` (5 tests) — all pass, including the new `test_admin_role_rejected` case.
- Ran `TestAdminRoleGateProperty` property-based test (100 examples via Hypothesis) — passes with `ALLOWED_ROLES = {"super_admin"}`.
- Ran the same property test in `test_migrate_telemetry.py` — passes.
- Ran `ruff check` on all modified files — no lint issues.
- Manually verified `observal migrate --help` and subcommand help output works while logged in as super_admin.

## Learning (optional, can help others)
All 6 migrate subcommands funnel through a single `_require_admin()` helper, so the fix is a one-line logic change with test/doc updates.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
