### PR TITLE
fix(web): add license field to package.json

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "license": "AGPL-3.0-only",
   "packageManager": "pnpm@10.33.4",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Add `"license": "AGPL-3.0-only"` to `web/package.json`.

The field was missing — while not breaking (the package is `private: true`), compliance tools like `license-checker`, `reuse lint`, and SBOM generators use this field to identify the license from the manifest. Adding it keeps the frontend package consistent with `pyproject.toml` and `observal-server/pyproject.toml` which both declare `AGPL-3.0-only`.