### PR TITLE
fix: add fork detection to GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'BlazeUp-AI/Observal'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/e2e-frontend.yml
+++ b/.github/workflows/e2e-frontend.yml
@@ -1,4 +1,4 @@
-okaokay# SPDX-FileCopyrightText: 2025 Observal Contributors
+# SPDX-FileCopyrightText: 2025 Observal Contributors
 # SPDX-License-Identifier: AGPL-3.0-only
 
 name: E2E Frontend
@@ -37,13 +37,21 @@ jobs:
 
       - name: Wait for API health
         run: |
+          echo "Waiting for API health check..."
           for i in $(seq 1 30); do
-            curl -sf http://localhost:8000/health && exit 0
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "✓ API is healthy"
+              exit 0
+            fi
+            echo "[$i/30] Waiting for API to be ready..."
             sleep 2
           done
-          echo "API not healthy" && exit 1
+          echo "::error::API failed health check"
+          echo "Docker logs:"
+          cd docker && docker compose logs --tail 50 observal-api observal-init observal-db || true
+          exit 1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
   # ── Preflight: detect release commit and create tag ────────
   preflight:
     name: Preflight checks
+    if: github.repository == 'BlazeUp-AI/Observal'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -66,6 +66,7 @@ jobs:
         run: uv run --no-project scripts/check_vulnerabilities.py sbom-python.cdx.json sbom-node.cdx.json
 
       - name: Ensure labels exist
+        if: github.repository == 'BlazeUp-AI/Observal'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -73,7 +74,7 @@ jobs:
           gh label create "automated" --color "0E8A16" --description "Created by CI automation" 2>/dev/null || true
 
       - name: Post vulnerability summary
-        if: hashFiles('vulnerability-report.md') != ''
+        if: github.repository == 'BlazeUp-AI/Observal' && hashFiles('vulnerability-report.md') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -95,7 +96,7 @@ jobs:
 
       # ── Attach to release ────────────────────────────────────
       - name: Attach SBOMs to release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && github.repository == 'BlazeUp-AI/Observal'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Overview
This PR fixes GitHub Actions workflow failures on forked repositories by adding proper fork detection and graceful skipping of secret-dependent jobs.

## What This PR Fixes
- ✅ Deploy workflow failing with "EC2_HOST secret missing"
- ✅ Release workflow failing with "RELEASE_APP_PRIVATE_KEY secret missing"  
- ✅ SBOM workflow failing with "Permission denied on GitHub operations"
- ✅ E2E frontend failing with shell syntax error in health check

## Changes Made
- `.github/workflows/deploy.yml`: Added fork detection (`if: github.repository == 'BlazeUp-AI/Observal'`)
- `.github/workflows/release.yml`: Added fork detection to preflight job
- `.github/workflows/sbom.yml`: Added fork-safe step conditions
- `.github/workflows/e2e-frontend.yml`: Fixed shell syntax, improved diagnostics, updated pnpm action v4→v6

## Testing
✅ Tested on fork (d-kavinraja/Observal):
- All jobs skip gracefully on fork
- CI passes on fork
- No breaking changes to main repo workflows

## Note
This PR does NOT address Issue #964 (frontend acceptance tests), which requires a separate implementation.