### PR TITLE
fix: unify loading skeletons via shared canonical layouts

### DIFF
--- a/web/src/components/review/review-detail-sheet.tsx
+++ b/web/src/components/review/review-detail-sheet.tsx
@@ -24,7 +24,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Skeleton } from "@/components/ui/skeleton";
+import { DetailSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
 import {
 	Tooltip,
 	TooltipContent,
@@ -265,12 +265,7 @@ function RelatedSkillsSection({
 	);
 
 	if (isLoading) {
-		return (
-			<div className="space-y-2">
-				<Skeleton className="h-4 w-40" />
-				<Skeleton className="h-8 w-full" />
-			</div>
-		);
+		return <TableSkeleton rows={1} cols={2} />;
 	}
 
 	if (!skills?.length) return null;
@@ -355,10 +350,8 @@ export function ReviewDetailSheet({
 						onDelete={onDelete}
 					/>
 				) : (
-					<div className="space-y-4 pt-6">
-						<Skeleton className="h-6 w-48" />
-						<Skeleton className="h-4 w-full" />
-						<Skeleton className="h-4 w-3/4" />
+					<div className="pt-6">
+            <DetailSkeleton />
 					</div>
 				)}
 			</SheetContent>
@@ -519,10 +512,7 @@ function SheetBody({
 
 			{/* Type-specific config */}
 			{isLoading ? (
-				<div className="space-y-2">
-					<Skeleton className="h-4 w-32" />
-					<Skeleton className="h-20 w-full" />
-				</div>
+				<DetailSkeleton />
 			) : (
 				<div className="space-y-3">
 					<h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">

--- a/web/src/components/traces/trace-list.tsx
+++ b/web/src/components/traces/trace-list.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/ui/table";
 import { StatusBadge } from "@/components/registry/status-badge";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
+import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { QueryError } from "@/components/dashboard/query-error";
 import { ListTree } from "lucide-react";
 
@@ -138,12 +138,7 @@ export function TraceList() {
       {isError ? (
         <QueryError message={error?.message} onRetry={refetch} />
       ) : isLoading ? (
-        <div className="space-y-2">
-          <Skeleton className="h-8 w-full" />
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton key={i} className="h-9 w-full" />
-          ))}
-        </div>
+      <TableSkeleton rows={8} cols={6} />
       ) : !filtered?.length ? (
         <div className="flex flex-col items-center justify-center rounded-md border border-dashed py-16">
           <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">


### PR DESCRIPTION
Closes #878

## What I did
- Replaced inline `<Skeleton>` usage in `trace-list.tsx` with `TableSkeleton`
- Replaced inline `<Skeleton>` usage in `review-detail-sheet.tsx` with `DetailSkeleton` and `TableSkeleton`
- Removed direct `@/components/ui/skeleton` imports from both files
- `skeleton-layouts.tsx` already had all 4 canonical layouts defined, no changes needed there

No visual changes to dark mode or existing behavior.