### PR TITLE
docs: update agent pull command

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,4 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Summary
@@ -26,7 +27,7 @@
 * [observal auth](cli/auth.md)
 * [observal config](cli/config.md)
 * [observal scan](cli/scan.md)
-* [observal pull](cli/pull.md)
+* [observal agent pull](cli/pull.md)
 * [observal registry](cli/registry.md)
 * [observal agent](cli/agent.md)
 * [observal ops](cli/ops.md)

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,6 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Naraen Rammoorthi <naraen13@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # CLI Reference
@@ -16,7 +17,7 @@ Complete reference for the `observal` CLI. Every subcommand has its own page —
 | [`observal auth`](auth.md) | Authentication and account management |
 | [`observal config`](config.md) | Local CLI configuration, aliases |
 | [`observal scan`](scan.md) | Discover what's installed across your IDEs (read-only) |
-| [`observal pull`](pull.md) | Install a published agent into an IDE |
+| [`observal agent pull`](pull.md) | Install a published agent into an IDE |
 | [`observal registry`](registry.md) | Publish and manage components (MCP / skill / hook / prompt / sandbox) |
 | [`observal agent`](agent.md) | Author and publish agents |
 | [`observal ops`](ops.md) | Observability and operations (traces, spans, metrics, feedback) |

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -1,4 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # observal agent
@@ -12,7 +13,7 @@ Create, author, and publish agents. An agent bundles registry components (MCPs, 
 | [`agent create`](#observal-agent-create) | Interactive agent creation wizard |
 | [`agent list`](#observal-agent-list) | List agents |
 | [`agent show`](#observal-agent-show) | Show an agent's details and components |
-| [`agent install`](#observal-agent-install) | Install an agent into an IDE (see also [`observal pull`](pull.md)) |
+| [`agent pull`](#observal-agent-pull) | Install an agent into an IDE |
 | [`agent delete`](#observal-agent-delete) | Delete an agent |
 | [`agent init`](#observal-agent-init) | Scaffold `observal-agent.yaml` in the current directory |
 | [`agent add`](#observal-agent-add) | Add a component to the local `observal-agent.yaml` |
@@ -49,12 +50,12 @@ Prints the agent's metadata and every bundled component.
 
 ---
 
-## `observal agent install`
+## `observal agent pull`
 
-Install an agent into an IDE. Equivalent to [`observal pull`](pull.md); `pull` is the preferred shorthand.
+Install an agent into an IDE.
 
 ```bash
-observal agent install <id-or-name> --ide <ide>
+observal agent pull <id-or-name> --ide <ide>
 ```
 
 ---
@@ -118,6 +119,6 @@ Invalid: `Code-Reviewer` (uppercase), `-starts-with-hyphen`, `my.agent` (dot)
 
 ## Related
 
-* [`observal pull`](pull.md) — install a published agent
+* [`observal agent pull`](pull.md) — install a published agent
 * [`observal registry`](registry.md) — author the components an agent will bundle
 * [Use Cases → Share agent configs](../use-cases/share-agent-configs.md)

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -13,7 +13,8 @@ Create, author, and publish agents. An agent bundles registry components (MCPs, 
 | [`agent create`](#observal-agent-create) | Interactive agent creation wizard |
 | [`agent list`](#observal-agent-list) | List agents |
 | [`agent show`](#observal-agent-show) | Show an agent's details and components |
-| [`agent pull`](#observal-agent-pull) | Install an agent into an IDE |
+| [`agent install`](#observal-agent-install) | Get install config for an agent |
+| [`agent pull`](#observal-agent-pull) | Write agent config to IDE files |
 | [`agent delete`](#observal-agent-delete) | Delete an agent |
 | [`agent init`](#observal-agent-init) | Scaffold `observal-agent.yaml` in the current directory |
 | [`agent add`](#observal-agent-add) | Add a component to the local `observal-agent.yaml` |
@@ -50,9 +51,19 @@ Prints the agent's metadata and every bundled component.
 
 ---
 
+## `observal agent install`
+
+Get install config for an agent.
+
+```bash
+observal agent install <id-or-name> --ide <ide>
+```
+
+---
+
 ## `observal agent pull`
 
-Install an agent into an IDE.
+Fetch agent config and write IDE files to disk.
 
 ```bash
 observal agent pull <id-or-name> --ide <ide>

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,5 +1,6 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # observal doctor
@@ -207,5 +208,5 @@ mv ~/.claude/settings.json.20260421_143055.bak ~/.claude/settings.json
 ## Related
 
 * [`observal scan`](scan.md) -- read-only discovery of what's installed
-* [`observal pull`](pull.md) -- install a full agent (also wires up MCP servers)
+* [`observal agent pull`](pull.md) -- install a full agent (also wires up MCP servers)
 * [Use Cases -- Observe MCP traffic](../use-cases/observe-mcp-traffic.md) -- narrative walkthrough

--- a/docs/cli/profile.md
+++ b/docs/cli/profile.md
@@ -1,4 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # observal use / observal profile
@@ -12,7 +13,7 @@ Snapshot-style profile management for IDE configs. Swap between configs from a s
 | [`observal use`](#observal-use) | Switch to a git-hosted or local profile |
 | [`observal profile`](#observal-profile) | Show the active profile and backup info |
 
-Unlike `observal pull` (installs one agent), these work at **config-level** — your whole IDE setup.
+Unlike `observal agent pull` (installs one agent), these work at **config-level** — your whole IDE setup.
 
 ---
 
@@ -101,12 +102,12 @@ cp -r ~/.observal/backups/profile-before-20260421_143000/kiro/* .kiro/
 
 | Situation | Use |
 | --- | --- |
-| Install one published agent into my current setup | [`observal pull`](pull.md) |
+| Install one published agent into my current setup | [`observal agent pull`](pull.md) |
 | Switch my whole setup to a known-good team config | `observal use` |
 | Onboard a new machine to match your team's baseline | `observal use` |
 | Swap between "work setup" and "personal setup" | `observal use` |
 
 ## Related
 
-* [`observal pull`](pull.md) — the single-agent equivalent
+* [`observal agent pull`](pull.md) — the single-agent equivalent
 * [Use Cases → Share agent configs](../use-cases/share-agent-configs.md)

--- a/docs/cli/pull.md
+++ b/docs/cli/pull.md
@@ -1,15 +1,16 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
-# observal pull
+# observal agent pull
 
 Install a complete agent — MCP servers, skills, hooks, prompts, sandboxes, and IDE-specific config — into an IDE in one command.
 
 ## Synopsis
 
 ```bash
-observal pull <agent-id-or-name> --ide <ide> [OPTIONS]
+observal agent pull <agent-id-or-name> --ide <ide> [OPTIONS]
 ```
 
 ## Required
@@ -28,7 +29,7 @@ observal pull <agent-id-or-name> --ide <ide> [OPTIONS]
 | `--scope project\|user` | Claude Code / Kiro / Gemini: install at project or user scope |
 | `--model inherit\|sonnet\|opus\|haiku` | Claude Code only: sub-agent model (default: `inherit`) |
 | `--tools <list>` | Claude Code only: comma-separated tool allowlist |
-| `--yes` / `-y` | Skip confirmation prompts |
+| `--no-prompt` / `-y` | Skip confirmation prompts |
 
 ## What gets installed
 
@@ -66,19 +67,19 @@ Values are written into your IDE config (not uploaded to Observal).
 ### Basic
 
 ```bash
-observal pull code-reviewer --ide claude-code
+observal agent pull code-reviewer --ide claude-code
 ```
 
 ### Preview first
 
 ```bash
-observal pull code-reviewer --ide claude-code --dry-run
+observal agent pull code-reviewer --ide claude-code --dry-run
 ```
 
 ### Project-scoped Claude Code install with a specific model and tool allowlist
 
 ```bash
-observal pull code-reviewer --ide claude-code \
+observal agent pull code-reviewer --ide claude-code \
   --scope project \
   --model sonnet \
   --tools "Read,Bash,Grep"
@@ -88,7 +89,7 @@ observal pull code-reviewer --ide claude-code \
 
 ```bash
 export GITHUB_TOKEN=ghp_...
-observal pull code-reviewer --ide claude-code -y
+observal agent pull code-reviewer --ide claude-code -y
 ```
 
 ## Restart your IDE

--- a/docs/cli/scan.md
+++ b/docs/cli/scan.md
@@ -1,5 +1,6 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # observal scan
@@ -90,6 +91,6 @@ observal doctor patch --all --all-ides --dry-run
 ## Related
 
 * [`observal doctor patch`](doctor.md) — instrument your IDEs (hooks, shims, OTel)
-* [`observal pull`](pull.md) — install a full agent (also wires up MCP servers)
+* [`observal agent pull`](pull.md) — install a full agent (also wires up MCP servers)
 * [`observal doctor`](doctor.md) — diagnose instrumentation end-to-end
 * [Use Cases -- Observe MCP traffic](../use-cases/observe-mcp-traffic.md) — narrative walkthrough

--- a/docs/e2e-test-checklist-enterprise.md
+++ b/docs/e2e-test-checklist-enterprise.md
@@ -1,4 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # E2E Test Checklist — Enterprise Mode
@@ -269,7 +270,7 @@ Perform the following actions and verify each generates an audit log entry:
 - [ ] `observal self doctor` — verify diagnostics pass
 - [ ] `observal scan` -- verify IDE discovery works (read-only)
 - [ ] `observal doctor patch --all --all-ides` -- verify instrumentation works
-- [ ] `observal pull <agent>` — verify agent pull works with SSO auth token
+- [ ] `observal agent pull <agent>` — verify agent pull works with SSO auth token
 - [ ] `observal admin review list` — verify review list works (admin only)
 
 ## 16. Eval Engine (Enterprise)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,6 +2,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Quickstart
@@ -175,7 +176,7 @@ observal agent show <agent-name>
 Install one into your IDE:
 
 ```bash
-observal pull agent <agent-name> --ide <ide-name>
+observal agent pull <agent-name> --ide <ide-name>
 ```
 
 This drops agent files, skills, hooks, and MCP configs into the right places for your IDE and wires up telemetry automatically.

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,6 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Claude Code
@@ -29,7 +30,7 @@ observal scan --ide claude-code
 observal doctor patch --all --ide claude-code
 
 # 4. (Optional) pull an agent from the registry
-observal pull <agent-id> --ide claude-code
+observal agent pull <agent-id> --ide claude-code
 
 # 5. Verify
 observal doctor --ide claude-code
@@ -70,12 +71,12 @@ Events captured:
 
 Hook schema and handler types: [Hooks specification](../reference/hooks-spec.md).
 
-## Sub-agents (`observal pull` options)
+## Sub-agents (`observal agent pull` options)
 
 Claude Code supports nested sub-agents, each with their own model and tool allowlist. Control these at pull time:
 
 ```bash
-observal pull code-reviewer --ide claude-code \
+observal agent pull code-reviewer --ide claude-code \
   --scope project \
   --model sonnet \
   --tools "Read,Bash,Grep"
@@ -114,6 +115,6 @@ This drops a directory into `.claude/skills/` that Claude Code loads on demand.
 
 ## Related
 
-* [`observal pull`](../cli/pull.md)
+* [`observal agent pull`](../cli/pull.md)
 * [`observal scan`](../cli/scan.md)
 * [Data model](../concepts/data-model.md)

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -1,4 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Codex CLI
@@ -20,7 +21,7 @@ In practice, Codex CLI is a rules-only target today. Use it to ship `AGENTS.md` 
 ## Install an agent (rules only)
 
 ```bash
-observal pull <agent-id> --ide codex
+observal agent pull <agent-id> --ide codex
 ```
 
 Writes only the rules portion of the agent.
@@ -31,4 +32,4 @@ If Codex CLI adds MCP or hook support upstream, we'll extend Observal accordingl
 
 ## Related
 
-* [`observal pull`](../cli/pull.md)
+* [`observal agent pull`](../cli/pull.md)

--- a/docs/integrations/copilot-cli.md
+++ b/docs/integrations/copilot-cli.md
@@ -1,5 +1,6 @@
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Copilot CLI
@@ -56,7 +57,7 @@ observal doctor patch --all --ide copilot-cli
 
 ```bash
 observal agent list
-observal pull <agent-id> --ide copilot-cli
+observal agent pull <agent-id> --ide copilot-cli
 ```
 
 This writes:
@@ -173,6 +174,6 @@ which observal-shim
 
 ## Related
 
-* [`observal pull`](../cli/pull.md)
+* [`observal agent pull`](../cli/pull.md)
 * [`observal scan`](../cli/scan.md)
 * [`observal doctor`](../cli/doctor.md)

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,6 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Cursor
@@ -39,7 +40,7 @@ Restart Cursor.
 ## Install an agent
 
 ```bash
-observal pull <agent-id> --ide cursor
+observal agent pull <agent-id> --ide cursor
 ```
 
 What gets written:

--- a/docs/integrations/gemini-cli.md
+++ b/docs/integrations/gemini-cli.md
@@ -1,6 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Gemini CLI
@@ -34,7 +35,7 @@ Restart Gemini CLI.
 ## Install an agent
 
 ```bash
-observal pull <agent-id> --ide gemini-cli
+observal agent pull <agent-id> --ide gemini-cli
 ```
 
 Writes MCP config + rules files. OTLP telemetry and hooks are configured automatically by `observal doctor patch --all`.

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -1,6 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Kiro CLI
@@ -79,7 +80,7 @@ Backup saved: .kiro/settings/mcp.json.20260421_143055.bak
 
 ```bash
 observal agent list
-observal pull <agent-id> --ide kiro
+observal agent pull <agent-id> --ide kiro
 ```
 
 This writes:
@@ -133,7 +134,7 @@ Each hook is a `curl` call to `http://localhost:8000/api/v1/telemetry/hooks` (or
 }
 ```
 
-You don't write these by hand — `observal pull` generates them.
+You don't write these by hand — `observal agent pull` generates them.
 
 ## View your traces
 
@@ -202,6 +203,6 @@ For every gap between Kiro and Claude Code (hook event names, missing fields, et
 
 ## Related
 
-* [`observal pull`](../cli/pull.md)
+* [`observal agent pull`](../cli/pull.md)
 * [`observal scan`](../cli/scan.md)
 * [`observal doctor`](../cli/doctor.md)

--- a/docs/integrations/vscode.md
+++ b/docs/integrations/vscode.md
@@ -1,6 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # VS Code
@@ -36,7 +37,7 @@ Reload your VS Code window.
 ## Install an agent
 
 ```bash
-observal pull <agent-id> --ide vscode
+observal agent pull <agent-id> --ide vscode
 ```
 
 ## Note on Copilot and Claude Code extensions

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -1,5 +1,6 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Config files
@@ -101,7 +102,7 @@ Use anywhere that accepts `<id-or-name>` by prefixing with `@`.
 
 ## Backups
 
-Every config modification by `observal doctor patch`, `observal pull`, or `observal use` creates a timestamped `.bak` file next to the original:
+Every config modification by `observal doctor patch`, `observal agent pull`, or `observal use` creates a timestamped `.bak` file next to the original:
 
 ```
 ~/.claude/settings.json.20260421_143055.bak

--- a/docs/reference/hooks-spec.md
+++ b/docs/reference/hooks-spec.md
@@ -1,10 +1,11 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Hooks specification
 
-The schema Observal uses for hook definitions -- both the registry hook type (`observal registry hook`) and hooks wired into IDE configs by `observal pull` / `observal doctor patch`.
+The schema Observal uses for hook definitions -- both the registry hook type (`observal registry hook`) and hooks wired into IDE configs by `observal agent pull` / `observal doctor patch`.
 
 Current version: `HOOKS_SPEC_VERSION = "5"` (see `observal_cli/hooks_spec.py`).
 
@@ -13,7 +14,7 @@ Current version: `HOOKS_SPEC_VERSION = "5"` (see `observal_cli/hooks_spec.py`).
 Two distinct things share the name "hook":
 
 1. **Registry hooks** — packaged, versioned hook definitions in the Observal registry. Install them via `observal registry hook install`.
-2. **IDE hooks** -- entries in `~/.claude/settings.json`, `.kiro/agents/<name>.json`, etc. These are written by `observal pull` and `observal doctor patch --hook`.
+2. **IDE hooks** -- entries in `~/.claude/settings.json`, `.kiro/agents/<name>.json`, etc. These are written by `observal agent pull` and `observal doctor patch --hook`.
 
 Both use the same event vocabulary.
 

--- a/docs/self-hosting/telemetry-pipeline.md
+++ b/docs/self-hosting/telemetry-pipeline.md
@@ -1,5 +1,6 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Telemetry pipeline
@@ -61,7 +62,7 @@ Events sent per lifecycle event:
 
 Full schema and handler types: [Hooks specification](../reference/hooks-spec.md).
 
-`observal pull` and `observal doctor patch --hook` wire hooks into the appropriate file:
+`observal agent pull` and `observal doctor patch --hook` wire hooks into the appropriate file:
 
 * Claude Code: `~/.claude/settings.json`
 * Kiro: agent JSON at `.kiro/agents/<name>.json` or `~/.kiro/agents/<name>.json`

--- a/docs/use-cases/share-agent-configs.md
+++ b/docs/use-cases/share-agent-configs.md
@@ -1,4 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Share agent configs across IDEs
@@ -17,7 +18,7 @@ Every agent is a YAML file that bundles:
 * Prompts (with variables)
 * Sandboxes for code execution
 
-When someone runs `observal pull <agent>`, Observal templates that YAML into the right files for their IDE — `~/.claude/agents/*.json`, `.kiro/agents/*.json`, `.cursor/mcp.json`, and so on.
+When someone runs `observal agent pull <agent>`, Observal templates that YAML into the right files for their IDE — `~/.claude/agents/*.json`, `.kiro/agents/*.json`, `.cursor/mcp.json`, and so on.
 
 ## Publish an agent
 
@@ -56,12 +57,12 @@ observal agent show <agent-id>
 Install — one command, pick the IDE:
 
 ```bash
-observal pull <agent-id> --ide claude-code
-observal pull <agent-id> --ide kiro
-observal pull <agent-id> --ide cursor
-observal pull <agent-id> --ide gemini-cli
-observal pull <agent-id> --ide vscode
-observal pull <agent-id> --ide codex
+observal agent pull <agent-id> --ide claude-code
+observal agent pull <agent-id> --ide kiro
+observal agent pull <agent-id> --ide cursor
+observal agent pull <agent-id> --ide gemini-cli
+observal agent pull <agent-id> --ide vscode
+observal agent pull <agent-id> --ide codex
 ```
 
 The CLI prompts for any environment variables the MCP servers declare as required (GitHub tokens, API keys). These are stored in your IDE config, not uploaded to Observal.
@@ -70,20 +71,20 @@ The CLI prompts for any environment variables the MCP servers declare as require
 
 ```bash
 # Preview without writing anything
-observal pull <agent-id> --ide claude-code --dry-run
+observal agent pull <agent-id> --ide claude-code --dry-run
 
 # Install into a specific directory
-observal pull <agent-id> --ide claude-code --dir ./my-project
+observal agent pull <agent-id> --ide claude-code --dir ./my-project
 
 # Claude Code only: scope (project-local vs user-global)
-observal pull <agent-id> --ide claude-code --scope project
-observal pull <agent-id> --ide claude-code --scope user
+observal agent pull <agent-id> --ide claude-code --scope project
+observal agent pull <agent-id> --ide claude-code --scope user
 
 # Claude Code only: sub-agent model
-observal pull <agent-id> --ide claude-code --model sonnet
+observal agent pull <agent-id> --ide claude-code --model sonnet
 
 # Claude Code only: tool allowlist
-observal pull <agent-id> --ide claude-code --tools Read,Write,Bash
+observal agent pull <agent-id> --ide claude-code --tools Read,Write,Bash
 ```
 
 ## What portability actually means

--- a/docs/use-cases/team-registry.md
+++ b/docs/use-cases/team-registry.md
@@ -1,6 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Run a team-wide agent registry
@@ -75,7 +76,7 @@ After registering, they can:
 
 ```bash
 observal agent list                           # see every agent the team has published
-observal pull team-reviewer --ide claude-code # install one
+observal agent pull team-reviewer --ide claude-code # install one
 observal scan                                 # discover what they have installed
 observal doctor patch --all --all-ides        # instrument everything
 ```

--- a/web/README.md
+++ b/web/README.md
@@ -1,4 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Observal Web UI Reference
@@ -108,7 +109,7 @@ The landing page for the agent registry. Accessible without authentication.
 
 **Sections:**
 
-1. **Hero** -- Branding, tagline, live stats bar (agents, components, engineers count), search bar, terminal snippet with copy button (`observal pull my-agent --ide cursor`)
+1. **Hero** -- Branding, tagline, live stats bar (agents, components, engineers count), search bar, terminal snippet with copy button (`observal agent pull my-agent --ide cursor`)
 2. **Trending** -- Grid of top 6 agents by download count. Uses `AgentCard` components.
 3. **Leaderboard** -- Time-window tabs (24h, 7d, 30d, all time) showing top 10 agents ranked by composite score. Links to full leaderboard.
 4. **Recently Added** -- Grid of 6 newest agents sorted by creation date.
@@ -142,7 +143,7 @@ Comprehensive agent page with five tabs.
 | **Overview** | About section, model name, goal template (structured sections with title + description) |
 | **Components** | Linked MCPs/skills/hooks with type badges. Shows system prompt inline if no components linked. |
 | **Reviews** | Star rating form (1-5) + text comment for authenticated users. Review list with user, date, rating. |
-| **Install** | CLI quick install (`observal pull <name>`), manual IDE config JSON snippet with copy button. |
+| **Install** | CLI quick install (`observal agent pull <name>`), manual IDE config JSON snippet with copy button. |
 | **Analytics** | Admin-only tab. Composite score, standard deviation, 95% CI, drift alert. Dimension averages bar chart, score trend, link to traces. |
 
 <!-- Screenshot: Agent detail page -- overview tab with sidebar (WIP -- needs demo data) -->


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Update the docs to use the current agent pull command.

Several docs referenced the old root-level `observal pull` command, but the CLI now exposes this workflow as `observal agent pull`. This caused the quickstart command to fail with `No such command 'pull'`.

## Fixes
* No linked issue

## Approach
Replaced user-facing references to `observal pull` with `observal agent pull` across the CLI docs, quickstart, integration docs, use-case docs, and related README references.

## How Has This Been Tested?
Verified locally with:
```bash
observal agent pull --help
git diff --check
```

Also reproduced the old documented command failure:
```bash
observal pull agent integ-agent-666b8f6b --ide codex
```
which returns:
```text
No such command 'pull'.
```


## Learning (optional, can help others)
Found this while following the getting started docs as a new contributor. The quickstart showed `observal pull agent <agent-name> --ide <ide-name>`, but the installed CLI help shows the command under `observal agent pull`.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas (N/A, docs-only)
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings (N/A, docs-only)