### PR TITLE
fix(ee): fix SAML SSO

### DIFF
--- a/ee/README.md
+++ b/ee/README.md
@@ -12,7 +12,7 @@ Source-available enterprise features for Observal. This module is loaded only wh
 | Feature | Status | Description |
 |---------|--------|-------------|
 | Audit Logging | Implemented | Writes all admin and auth events to a ClickHouse `audit_log` table. Queryable and exportable as CSV. |
-| SAML 2.0 SSO | Stub (501) | Routes defined for SAML login, ACS callback, and SP metadata. Not yet implemented. |
+| SAML 2.0 SSO |Implemented | Working SAML SSO tested with Entra ID and Okta as IDPs|
 | SCIM 2.0 Provisioning | Stub (501) | Routes defined for user sync from an identity provider. Not yet implemented. |
 | Plugin Registry | Placeholder | Future home for Grafana, Prometheus, Datadog, and SIEM integrations. |
 

--- a/ee/docs/saml-setup.md
+++ b/ee/docs/saml-setup.md
@@ -49,7 +49,7 @@ table below lists every supported variable.
 
 | Variable | Description | Default |
 |---|---|---|
-| `SAML_SP_ENTITY_ID` | The entity ID that Observal uses to identify itself to the IdP. | Auto-derived from `FRONTEND_URL` |
+| `SAML_SP_ENTITY_ID` | The entity ID that Observal uses to identify itself to the IdP. | Auto-derived from `FRONTEND_URL` (appends `api/v1/sso/saml/metadata`)|
 | `SAML_SP_ACS_URL` | The Assertion Consumer Service URL where the IdP posts SAML responses. | Auto-derived from `FRONTEND_URL` (appends `/api/v1/sso/saml/acs`) |
 | `SAML_SP_KEY_ENCRYPTION_PASSWORD` | Password protecting the SP's private key, used for encrypted assertions. Only required if your IdP sends encrypted SAML assertions. | (none) |
 

--- a/ee/observal_server/routes/sso_saml.py
+++ b/ee/observal_server/routes/sso_saml.py
@@ -11,6 +11,7 @@ import json
 import logging
 import secrets
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse, Response
@@ -111,10 +112,12 @@ def _decrypt_sp_key(config) -> str:
 
 
 def _prepare_saml_request(request: Request) -> dict:
+    parsed = urlparse(settings.FRONTEND_URL)
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
     return {
-        "https": "on" if request.url.scheme == "https" else "off",
-        "http_host": request.headers.get("host", request.url.hostname or "localhost"),
-        "server_port": str(request.url.port or (443 if request.url.scheme == "https" else 80)),
+        "https": "on" if parsed.scheme == "https" else "off",
+        "http_host": f"{parsed.hostname}:{port}" if port not in (80, 443) else parsed.hostname,
+        "server_port": str(port),
         "script_name": request.url.path,
         "get_data": dict(request.query_params),
         "post_data": {},

--- a/ee/observal_server/services/saml.py
+++ b/ee/observal_server/services/saml.py
@@ -120,7 +120,7 @@ def build_saml_settings(
             },
             "x509cert": sp_cert_clean,
             "privateKey": sp_key_clean,
-            "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress",
+            "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
         },
         "idp": {
             "entityId": idp_entity_id,
@@ -137,6 +137,7 @@ def build_saml_settings(
             "wantAssertionsEncrypted": False,
             "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
+            "requestedAuthnContext": False,
         },
     }
     if sp_slo_url:

--- a/observal-server/api/middleware/content_type.py
+++ b/observal-server/api/middleware/content_type.py
@@ -35,7 +35,10 @@ _SKIP_PATHS: set[str] = {
     "/v1/metrics",
 }
 
-_SKIP_PREFIXES: tuple[str, ...] = ("/api/v1/graphql",)
+_SKIP_PREFIXES: tuple[str, ...] = (
+    "/api/v1/graphql",
+    "/api/v1/sso/saml",
+)
 
 # Accepted content types for normal endpoints.
 _ALLOWED_TYPES = {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
SAML SSO: Okta & Azure AD (Entra ID) Compatibility

## Fixes

**Content-Type middleware exemption** (`observal-server/api/middleware/content_type.py`)
- Exempt `/api/v1/sso/saml` prefix from strict JSON content-type enforcement
- Required because the SAML ACS endpoint receives `application/x-www-form-urlencoded` POST from the IdP

**SAML settings corrections** (`ee/observal_server/services/saml.py`)
- Fix NameIDFormat to use the correct `SAML:1.1` URN for email format (the `2.0` variant doesn't exist in the spec)
- Disable `requestedAuthnContext` to avoid IdP rejection when the SP demands an AuthnContext the IdP doesn't support

**Request preparation fix** (`ee/observal_server/routes/sso_saml.py`)
- Derive scheme/host/port from `FRONTEND_URL` instead of the raw request object
- Fixes ACS URL mismatch when running behind a reverse proxy (nginx) where the container sees `localhost:8001` but the IdP expects the public URL
## Approach
Both Okta and Azure AD were rejecting SAML assertions due to:
1. ACS URL mismatch (container port vs public URL)
2. Invalid NameIDFormat URN
3. Unsupported AuthnContext requirement

## How Has This Been Tested?


- Tested against Okta developer tenant
- Tested against Azure AD (Entra ID) enterprise app
- Existing SAML tests pass (`make test`)

