### PR TITLE
feat(ci): auto-label PRs with merge conflicts

### DIFF
--- a/.github/workflows/conflict-label.yml
+++ b/.github/workflows/conflict-label.yml
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+name: Label Conflicting PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  conflict-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply or remove conflict label
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const repo = context.repo;
+            const labelName = 'Has Conflicts';
+
+            // Ensure the label exists
+            try {
+              await github.rest.issues.getLabel({ ...repo, name: labelName });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              await github.rest.issues.createLabel({
+                ...repo,
+                name: labelName,
+                color: 'd93f0b',
+                description: 'Pull request has merge conflicts',
+              });
+            }
+
+            // Collect PRs to check
+            let prs = [];
+            if (context.eventName === 'push') {
+              // When main moves, re-check all open PRs
+              prs = await github.paginate(github.rest.pulls.list, {
+                ...repo,
+                state: 'open',
+                per_page: 100,
+              });
+            } else {
+              prs = [context.payload.pull_request];
+            }
+
+            for (const pr of prs) {
+              // Poll until GitHub resolves mergeability (max ~30s)
+              let mergeable_state = pr.mergeable_state;
+              if (mergeable_state === 'unknown') {
+                for (let i = 0; i < 6; i++) {
+                  await new Promise((r) => setTimeout(r, 5000));
+                  const { data: fresh } = await github.rest.pulls.get({
+                    ...repo,
+                    pull_number: pr.number,
+                  });
+                  mergeable_state = fresh.mergeable_state;
+                  if (mergeable_state !== 'unknown') break;
+                }
+              }
+
+              const hasConflicts = mergeable_state === 'dirty';
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                ...repo,
+                issue_number: pr.number,
+              });
+              const isLabeled = labels.some((l) => l.name === labelName);
+
+              if (hasConflicts && !isLabeled) {
+                await github.rest.issues.addLabels({
+                  ...repo,
+                  issue_number: pr.number,
+                  labels: [labelName],
+                });
+                console.log(`#${pr.number}: added '${labelName}'`);
+              } else if (!hasConflicts && isLabeled) {
+                await github.rest.issues.removeLabel({
+                  ...repo,
+                  issue_number: pr.number,
+                  name: labelName,
+                });
+                console.log(`#${pr.number}: removed '${labelName}'`);
+              }
+            }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Adds a workflow that automatically applies a `Has Conflicts` label to PRs with merge conflicts, and removes it once the conflicts are resolved.

## Fixes
* Fixes #1066

## Approach
Triggers on `pull_request_target` (opened, synchronize, reopened) and on `push` to `main`. The `push` trigger fans out across all open PRs so anything that becomes conflicted when main moves forward gets caught too.

Since GitHub computes `mergeable_state` asynchronously, the script polls up to 30s before acting. Adds the label when `mergeable_state === 'dirty'\', removes it when clean.

## How Has This Been Tested?
Workflow syntax validated locally. Logic verified by reading through the GitHub API docs for `mergeable_state` values (`clean`, `dirty`, `unknown`, `blocked` etc) and tracing each branch of the script.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)