### PR TITLE
fix(deps): bump gitpython to 3.1.50 and urllib3 to 2.7.0

### DIFF
--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "email-validator",
     "alembic",
     "httpx",
-    "gitpython",
+    "gitpython>=3.1.50",
     "boto3",
     "redis[hiredis]",
     "arq",
@@ -41,6 +41,7 @@ dependencies = [
     "mako>=1.3.11",
     "structlog>=24.1.0",
     "prometheus-fastapi-instrumentator>=7.0.0",
+    "urllib3>=2.7.0",
 ]
 
 [dependency-groups]

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -422,14 +422,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -933,7 +933,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -965,6 +965,7 @@ dependencies = [
     { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "structlog" },
     { name = "tenacity" },
+    { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -990,7 +991,7 @@ requires-dist = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "fastapi-cache2", extras = ["redis"], specifier = ">=0.2.2" },
-    { name = "gitpython" },
+    { name = "gitpython", specifier = ">=3.1.50" },
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "jinja2", specifier = ">=3.1.0" },
@@ -1008,6 +1009,7 @@ requires-dist = [
     { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.314.0" },
     { name = "structlog", specifier = ">=24.1.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"] },
 ]
 
@@ -1640,11 +1642,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose / Description

Bumps two dependencies with known CVEs surfaced after pip-audit was made blocking in #1068.

## Fixes

* Fixes 6 CVEs across gitpython and urllib3

## Approach

Bumped minimum versions in `observal-server/pyproject.toml` and regenerated `uv.lock`. Verified `pip-audit --strict` reports no known vulnerabilities after the bump.

**gitpython 3.1.46 -> 3.1.50**
- CVE-2026-42215: underscore kwargs bypass unsafe-option check, leading to RCE via `upload_pack`/`receive_pack`
- CVE-2026-42284: `multi_options` validation runs on original list but execution uses post-`shlex.split` result, allowing `--config core.hooksPath` injection
- CVE-2026-44244: `set_value()` does not validate newlines in the value parameter, enabling persistent `.git/config` poisoning
- GHSA-mv93-w799-cj2w: incomplete patch for CVE-2026-44244, section and option params also injectable

**urllib3 2.6.3 -> 2.7.0**
- CVE-2026-44431: sensitive headers not stripped on cross-origin redirects via low-level proxy API
- CVE-2026-44432: full decompression of streaming responses in two edge cases, potential DoS

## How Has This Been Tested?

`pip-audit --strict --desc` reports no known vulnerabilities after the bump.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)