### PR TITLE
fix(agent): description is registry metadata, never inject into agent files

### DIFF
--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -484,8 +484,8 @@ def _build_rules_content(
 ) -> str:
     """Build markdown rules content from the agent and its components.
 
-    Assembles the agent prompt (if any), description, and a summary of
-    all bundled components so the rules file is never empty.
+    Assembles the agent prompt (if any) and a summary of all bundled
+    components. Description is registry metadata and is never injected.
 
     Args:
         prompt_listings: optional {component_id: PromptListing} map. When provided,
@@ -495,8 +495,6 @@ def _build_rules_content(
 
     if agent.prompt:
         sections.append(agent.prompt)
-    elif agent.description:
-        sections.append(agent.description)
 
     # Group components by type and resolve display names
     names = component_names or {}
@@ -542,7 +540,7 @@ def _build_rules_content(
                 lines.append(f"- **{n}**")
             sections.append("\n".join(lines))
 
-    return "\n\n".join(sections) if sections else f"# {agent.name}\n\n{agent.description or ''}"
+    return "\n\n".join(sections) if sections else f"# {agent.name}"
 
 
 def generate_agent_config(
@@ -623,7 +621,6 @@ def generate_agent_config(
                 "path": agent_path,
                 "content": {
                     "name": safe_name,
-                    "description": agent.description[:200] if agent.description else "",
                     "prompt": _wrap_kiro_prompt(agent.prompt, safe_name),
                     "mcpServers": mcp_configs,
                     "tools": ["*"],
@@ -682,11 +679,9 @@ def generate_agent_config(
                 model_choice = _model_name_to_frontmatter(getattr(agent, "model_name", ""))
 
         # Build Claude Code agent file with YAML frontmatter
-        desc_line = (agent.description or safe_name).replace("\n", " ").strip()
         frontmatter_lines = [
             "---",
             f"name: {safe_name}",
-            f'description: "{desc_line}"',
         ]
         if model_choice:
             frontmatter_lines.append(f"model: {model_choice}")
@@ -788,11 +783,9 @@ def generate_agent_config(
         copilot_spec = IDE_REGISTRY["copilot"]
 
         # Build .agent.md with hooks in frontmatter (per-agent hooks)
-        desc_line = (agent.description or safe_name).replace("\n", " ").strip()
         frontmatter_lines = [
             "---",
             f"name: {safe_name}",
-            f'description: "{desc_line}"',
             "tools: ['*']",
         ]
         frontmatter_lines.extend(_vscode_copilot_hooks_frontmatter_lines())
@@ -838,11 +831,9 @@ def generate_agent_config(
         copilot_cli_spec = IDE_REGISTRY["copilot-cli"]
 
         # Build .agent.md with hooks in frontmatter (per-agent hooks)
-        desc_line = (agent.description or safe_name).replace("\n", " ").strip()
         frontmatter_lines = [
             "---",
             f"name: {safe_name}",
-            f'description: "{desc_line}"',
             "tools: ['*']",
         ]
         frontmatter_lines.extend(_vscode_copilot_hooks_frontmatter_lines())

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -146,10 +146,11 @@ class TestBuildRulesContent:
         assert "Custom prompt" in result
         assert "Desc" not in result
 
-    def test_falls_back_to_description_when_no_prompt(self):
-        agent = _make_agent(prompt="", description="Agent description")
+    def test_no_prompt_produces_bare_heading(self):
+        agent = _make_agent(prompt="", description="Registry copy. Must not appear.")
         result = _build_rules_content(agent)
-        assert "Agent description" in result
+        assert "Registry copy" not in result
+        assert result == f"# {agent.name}"
 
     def test_fallback_when_both_empty(self):
         agent = _make_agent(prompt="", description="")
@@ -217,7 +218,7 @@ class TestGenerateClaudeCode:
         assert len(parts) >= 3
         fm = yaml.safe_load(parts[1])
         assert fm["name"] == "test-agent"
-        assert "A test agent" in fm["description"]
+        assert "description" not in fm
 
     def test_frontmatter_includes_mcp_servers(self):
         ext_mcps = [{"name": "my-ext", "command": "npx", "args": ["-y", "ext"]}]
@@ -262,14 +263,6 @@ class TestGenerateClaudeCode:
         agent = _make_agent()
         cfg = generate_agent_config(agent, "claude_code")
         assert ".claude/agents/" in cfg["rules_file"]["path"]
-
-    def test_multiline_description_collapsed(self):
-        agent = _make_agent(description="Line one\nLine two\nLine three")
-        cfg = generate_agent_config(agent, "claude-code")
-        content = cfg["rules_file"]["content"]
-        parts = content.split("---", 2)
-        fm = yaml.safe_load(parts[1])
-        assert "\n" not in fm["description"]
 
     def test_model_fallback_from_agent_when_no_option(self):
         agent = _make_agent(model_name="claude-sonnet-4-6-20250725")
@@ -394,10 +387,10 @@ class TestGenerateKiro:
         cfg = generate_agent_config(agent, "kiro")
         assert "steering_file" not in cfg
 
-    def test_description_truncated_to_200(self):
+    def test_kiro_agent_file_has_no_description(self):
         agent = _make_agent(description="x" * 300)
         cfg = generate_agent_config(agent, "kiro")
-        assert len(cfg["agent_file"]["content"]["description"]) == 200
+        assert "description" not in cfg["agent_file"]["content"]
 
     def test_tools_include_wildcard(self):
         agent = _make_agent()


### PR DESCRIPTION
## Purpose / Description

Stops `agent.description` from leaking into generated IDE agent files. Description is registry copy shown on the agent card, not system prompt content.

## Fixes

* Fixes #1081

## Approach

Four targeted removals in `agent_config_generator.py`:

1. `_build_rules_content`: removed the `elif agent.description` fallback. When `agent.prompt` is empty the rules file now produces a bare `# {name}` heading instead of writing the description as prompt content.
2. `_build_rules_content`: fixed the empty-sections fallback from `# {name}\n\n{description}` to `# {name}`.
3. Claude Code YAML frontmatter: removed the `description:` line.
4. Kiro `agent.json`: removed the `description` field.
5. Copilot and Copilot-CLI frontmatter: removed the `description:` line.

## How Has This Been Tested?

Unit tested all four cases directly against the config generator functions: prompt set with no description leak, no prompt with bare heading output, Claude Code frontmatter without description, Kiro agent.json without description. All pass.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)