### PR TITLE
fix(cli): default installation scope to user for agent pull

### DIFF
--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -321,10 +321,10 @@ def _collect_install_options(
             opts["scope"] = scope
         elif interactive:
             project_label, user_label = _SCOPE_AWARE_IDES[ide]
-            choice = select_one("  Scope", [project_label, user_label], default=project_label)
+            choice = select_one("  Scope", [user_label, project_label], default=user_label)
             opts["scope"] = "user" if choice.startswith("user") else "project"
         else:
-            opts["scope"] = "project"
+            opts["scope"] = "user"
 
     if accepts_model_choice(ide):
         explicit = model_overrides.get(ide) or model_default

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -907,7 +907,19 @@ class TestPullOpenCode:
         }
         with _patch_config(), _patch_get_agent(), _patch_post(snippet):
             result = runner.invoke(
-                cli_app, ["agent", "pull", "abc123", "--ide", "opencode", "--dir", str(tmp_path), "--no-prompt"]
+                cli_app,
+                [
+                    "agent",
+                    "pull",
+                    "abc123",
+                    "--ide",
+                    "opencode",
+                    "--dir",
+                    str(tmp_path),
+                    "--no-prompt",
+                    "--scope",
+                    "project",
+                ],
             )
         assert result.exit_code == 0, result.output
         rules = tmp_path / "AGENTS.md"

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -323,7 +323,19 @@ class TestPullKiro:
     def test_writes_agent_file(self, tmp_path: Path):
         with _patch_config(), _patch_get_agent(), _patch_post(_kiro_snippet()):
             result = runner.invoke(
-                cli_app, ["agent", "pull", "abc123", "--ide", "kiro", "--dir", str(tmp_path), "--no-prompt"]
+                cli_app,
+                [
+                    "agent",
+                    "pull",
+                    "abc123",
+                    "--ide",
+                    "kiro",
+                    "--dir",
+                    str(tmp_path),
+                    "--no-prompt",
+                    "--scope",
+                    "project",
+                ],
             )
 
         assert result.exit_code == 0, result.output
@@ -352,7 +364,19 @@ class TestPullKiro:
         }
         with _patch_config(), _patch_get_agent(), _patch_post(snippet):
             result = runner.invoke(
-                cli_app, ["agent", "pull", "abc123", "--ide", "kiro", "--dir", str(tmp_path), "--no-prompt"]
+                cli_app,
+                [
+                    "agent",
+                    "pull",
+                    "abc123",
+                    "--ide",
+                    "kiro",
+                    "--dir",
+                    str(tmp_path),
+                    "--no-prompt",
+                    "--scope",
+                    "project",
+                ],
             )
 
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Purpose / Description

Changes the default installation scope for `observal pull` from project to user. User scope is the correct default: most users want an agent available globally across all their projects, not just the current directory.

## Fixes

* Fixes #1077

## Approach

Single change in `_collect_install_options` in `observal_cli/cmd_pull.py`:

- Interactive selector now lists User first and pre-selects it (was Project first)
- Non-interactive path (`--no-prompt` or CI) defaults to `user` instead of `project`
- `--scope project` still works as an explicit opt-in for project-local installs

`cmd_skill.py` already defaults to `user` and was not touched.

Two Kiro tests that specifically test project-directory writing now pass `--scope project` explicitly to preserve their original intent.

## How Has This Been Tested?

All 39 pull and agent CLI tests pass locally across the affected test class.

<img width="809" height="226" alt="image" src="https://github.com/user-attachments/assets/d279d345-28ec-44fc-9837-c1b568e55490" />


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)