### PR TITLE
fix: pin redis>=5.2.1 to address CVE-2023-28858 and CVE-2023-28859

### DIFF
--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "httpx",
     "gitpython>=3.1.50",
     "boto3",
-    "redis[hiredis]",
+    "redis[hiredis]>=5.2.1",
     "arq",
     "strawberry-graphql[fastapi]>=0.315.4",
     "authlib>=1.6.11",


### PR DESCRIPTION
## Summary

The  Python package dependency in  was unpinned, allowing installation of versions vulnerable to:

- **CVE-2023-28858**: Async connection information disclosure
- **CVE-2023-28859**: Connection data leak during connection reuse

## Changes

- Pin `redis[hiredis]>=5.2.1` in `observal-server/pyproject.toml` to ensure only patched versions are installed.

## References

- Closes #896