### PR TITLE
feat(builder): create and submit new components from agent builder

### DIFF
--- a/observal-server/api/routes/agent.py
+++ b/observal-server/api/routes/agent.py
@@ -259,6 +259,7 @@ async def create_agent(
         errors = await validate_component_ids(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
             db,
+            require_approved=False,
         )
         if errors:
             raise HTTPException(
@@ -769,6 +770,7 @@ async def update_agent(
         errors = await validate_component_ids(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
             db,
+            require_approved=False,
         )
         if errors:
             raise HTTPException(
@@ -1173,6 +1175,7 @@ async def validate_agent_composition(
     errors = await validate_component_ids(
         [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
         db,
+        require_approved=False,
     )
     issues = [
         ValidationIssue(
@@ -1651,6 +1654,7 @@ async def submit_draft(
         errors = await validate_component_ids(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in agent.components],
             db,
+            require_approved=False,
         )
         if errors:
             raise HTTPException(

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -168,7 +168,14 @@ async def _get_agent_version(
     if not ver:
         raise HTTPException(status_code=404, detail="Version not found")
 
-    return _version_to_detail(ver)
+    from api.routes.agent import _resolve_component_names
+
+    name_map = await _resolve_component_names(ver.components or [], db)
+    detail = _version_to_detail(ver)
+    for comp in detail.get("components", []):
+        if not comp.get("name"):
+            comp["name"] = name_map.get(comp["component_id"], "")
+    return detail
 
 
 async def _create_agent_version(

--- a/web/src/app/(admin)/review/page.tsx
+++ b/web/src/app/(admin)/review/page.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useCallback, useMemo } from "react";
 import { CheckCircle2, X, Trash2, LayoutGrid, TableProperties, Eye } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useReviewAgents, useReviewComponents, useReviewAction, useReviewDelete } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import type { ReviewItem } from "@/lib/types";
@@ -348,6 +349,7 @@ export default function ReviewPage() {
   const [activeTab, setActiveTab] = useState("agents");
   const [selectedItem, setSelectedItem] = useState<ReviewItem | null>(null);
   const [diffItem, setDiffItem] = useState<ReviewItem | null>(null);
+  const [nestedDiffItem, setNestedDiffItem] = useState<ReviewItem | null>(null);
 
   const agentCount = (agents ?? []).length;
   const componentCount = (components ?? []).length;
@@ -368,11 +370,46 @@ export default function ReviewPage() {
     [reviewDelete],
   );
 
+  const queryClient = useQueryClient();
+
   const handleItemClick = useCallback(
     (item: ReviewItem) => {
       setDiffItem(item);
     },
     [],
+  );
+
+  const handleOpenComponentReview = useCallback(
+    async (id: string, type: string) => {
+      const singularType = type.replace(/s$/, "");
+      let list = components ?? [];
+      // If not found yet, refetch first (component may have just been submitted)
+      if (!list.find((c) => c.id === id)) {
+        const result = await refetchComponents();
+        list = result.data ?? list;
+      }
+      const found = list.find((c) => c.id === id || (c.type === singularType && c.id === id));
+      if (found) setNestedDiffItem(found);
+    },
+    [components, refetchComponents],
+  );
+
+  const handleApproveWithRefetch = useCallback(
+    (id: string, type?: string) => {
+      reviewAction.mutate({ id, type, action: "approve" }, {
+        onSuccess: async () => {
+          setNestedDiffItem(null);
+          const [freshAgents] = await Promise.all([refetchAgents(), refetchComponents()]);
+          // Update diffItem in-place with fresh blocking_components so the sheet reflects the change
+          setDiffItem((prev) => {
+            if (!prev) return prev;
+            const updated = (freshAgents.data ?? []).find((a) => a.id === prev.id);
+            return updated ?? prev;
+          });
+        },
+      });
+    },
+    [reviewAction, refetchAgents, refetchComponents],
   );
 
   return (
@@ -492,6 +529,14 @@ export default function ReviewPage() {
         open={!!diffItem}
         onOpenChange={(open) => { if (!open) setDiffItem(null); }}
         onApprove={handleApprove}
+        onReject={handleReject}
+        onOpenComponentReview={handleOpenComponentReview}
+      />
+      <ReviewDiffSheet
+        item={nestedDiffItem}
+        open={!!nestedDiffItem}
+        onOpenChange={(open) => { if (!open) setNestedDiffItem(null); }}
+        onApprove={handleApproveWithRefetch}
         onReject={handleReject}
       />
     </>

--- a/web/src/app/(registry)/agents/builder/page.tsx
+++ b/web/src/app/(registry)/agents/builder/page.tsx
@@ -51,6 +51,7 @@ import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 const DRAFT_STORAGE_KEY = "observal_agent_draft";
 
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
+import { SubmitComponentDialog } from "@/components/registry/submit-component-dialog";
 import { ValidationPanel } from "@/components/builder/validation-panel";
 import { PreviewPanel } from "@/components/builder/preview-panel";
 import { ModelPicker } from "@/components/builder/model-picker";
@@ -345,6 +346,14 @@ function AgentBuilderInner() {
   const [draftId, setDraftId] = useState<string | null>(null);
   const [savingDraft, setSavingDraft] = useState(false);
   const [showRestoreBanner, setShowRestoreBanner] = useState(false);
+  // Components created in-builder, held in memory until agent submit
+  const [pendingComponents, setPendingComponents] = useState<Array<{
+    id: string; // local temp id
+    type: RegistryType;
+    name: string;
+    body: Record<string, unknown>;
+  }>>([]);
+  const [createDialogType, setCreateDialogType] = useState<RegistryType | null>(null);
   const saveDraft = useSaveDraft();
   const updateDraft = useUpdateDraft();
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -713,6 +722,26 @@ function AgentBuilderInner() {
 
     setPublishing(true);
     try {
+      // Flush in-memory components to registry first, collect real IDs
+      const flushedIds: { type: RegistryType; id: string; name: string }[] = [];
+      for (const pc of pendingComponents) {
+        const created = await registry.submit(pc.type, pc.body);
+        flushedIds.push({ type: pc.type, id: created.id, name: created.name });
+      }
+      if (flushedIds.length) {
+        // Merge flushed IDs into selectedComponents
+        const next = { ...selectedComponents };
+        for (const { type, id, name } of flushedIds) {
+          const plural = type as string;
+          next[plural] = [...(next[plural] ?? []), { id, name }];
+        }
+        // Update selected components synchronously via ref trick — rebuild body after
+        for (const { type, id, name } of flushedIds) {
+          const plural = type as string;
+          selectedComponents[plural] = [...(selectedComponents[plural] ?? []), { id, name }];
+        }
+        setPendingComponents([]);
+      }
       const body = buildRequestBody();
       if (draftId) {
         await updateDraft.mutateAsync({ id: draftId, body });
@@ -921,6 +950,28 @@ function AgentBuilderInner() {
                       selected={selectedIds}
                       onToggle={handleToggle(ct.value)}
                     />
+                    {/* In-memory components not yet submitted */}
+                    {pendingComponents.filter((p) => p.type === ct.value).map((p) => (
+                      <div key={p.id} className="mt-2 flex items-center gap-2 rounded border border-dashed border-border px-3 py-1.5 text-xs">
+                        <span className="font-medium">{p.name}</span>
+                        <span className="text-muted-foreground italic">not yet submitted</span>
+                        <button
+                          type="button"
+                          className="ml-auto text-muted-foreground hover:text-destructive"
+                          onClick={() => setPendingComponents((prev) => prev.filter((x) => x.id !== p.id))}
+                        >✕</button>
+                      </div>
+                    ))}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="mt-2 h-7 text-xs text-muted-foreground hover:text-foreground"
+                      onClick={() => setCreateDialogType(ct.value)}
+                    >
+                      <Plus className="mr-1 h-3 w-3" />
+                      Create new {ct.value.replace(/s$/, "")}
+                    </Button>
 
                     {/* Sortable selected list */}
                     {(selectedComponents[ct.value] ?? []).length > 0 && (
@@ -1088,17 +1139,54 @@ function AgentBuilderInner() {
                 description={description}
                 modelName={modelName}
                 selectedComponents={Object.fromEntries(
-                  Object.entries(selectedComponents).map(([k, v]) =>
-                    [k, v.map((item) => ({ id: item.id, name: item.name }))]
-                  ),
+                  Object.entries({
+                    ...Object.fromEntries(
+                      Object.entries(selectedComponents).map(([k, v]) =>
+                        [k, v.map((item) => ({ id: item.id, name: item.name }))]
+                      )
+                    ),
+                    // Merge in-memory pending components so they show in preview
+                    ...pendingComponents.reduce((acc, pc) => {
+                      acc[pc.type as string] = [...(acc[pc.type as string] ?? []), { id: pc.id, name: `${pc.name} (pending)` }];
+                      return acc;
+                    }, {} as Record<string, { id: string; name: string }[]>),
+                  }).map(([k, v]) => [k, v])
                 )}
                 prompt={systemPrompt}
+                pendingComponentBodies={Object.fromEntries(pendingComponents.map((pc) => [pc.id, pc.body]))}
                 validationResult={validationResult}
               />
             </div>
           </aside>
         </div>
       </div>
+
+      {/* Create in-memory component dialog */}
+      {createDialogType && (
+        <SubmitComponentDialog
+          key={createDialogType}
+          open={!!createDialogType}
+          onOpenChange={(v) => { if (!v) setCreateDialogType(null); }}
+          type={createDialogType}
+          editItem={null}
+          onSubmit={(body) => {
+            const tempId = Math.random().toString(36).slice(2);
+            const name = (body.name as string) || createDialogType.replace(/s$/, "");
+            setPendingComponents((prev) => [...prev, { id: tempId, type: createDialogType!, name, body }]);
+            setCreateDialogType(null);
+            toast.success(`${name} added — will be submitted with the agent.`);
+          }}
+          onSaveDraft={(body) => {
+            const tempId = Math.random().toString(36).slice(2);
+            const name = (body.name as string) || createDialogType.replace(/s$/, "");
+            setPendingComponents((prev) => [...prev, { id: tempId, type: createDialogType!, name, body }]);
+            setCreateDialogType(null);
+            toast.success(`${name} added — will be submitted with the agent.`);
+          }}
+          isSubmitting={false}
+          isSavingDraft={false}
+        />
+      )}
 
       {/* Version Bump Dialog — shown when updating an existing agent */}
       <VersionBumpDialog

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -39,6 +39,7 @@ interface PreviewPanelProps {
   modelName?: string;
   selectedComponents: Record<string, { id: string; name: string }[]>;
   prompt?: string;
+  pendingComponentBodies?: Record<string, Record<string, unknown>>; // tempId -> body
   validationResult: ValidationResult | null;
 }
 
@@ -48,6 +49,7 @@ function buildMarkdownBody(
   description: string,
   selectedComponents: Record<string, { id: string; name: string }[]>,
   prompt?: string,
+  pendingBodies?: Record<string, Record<string, unknown>>,
 ): string {
   const lines: string[] = [];
 
@@ -60,7 +62,18 @@ function buildMarkdownBody(
     lines.push("");
     lines.push(`## ${heading}`);
     lines.push("");
-    items.forEach((item) => lines.push(`- **${item.name}**`));
+    items.forEach((item) => {
+      lines.push(`- **${item.name}**`);
+      // Inject content for in-memory pending components
+      const body = pendingBodies?.[item.id];
+      if (body) {
+        const content = (body.template ?? body.skill_md_content ?? body.handler_config) as string | undefined;
+        if (content && typeof content === "string") {
+          lines.push("");
+          lines.push(content.split("\n").map(l => `  ${l}`).join("\n"));
+        }
+      }
+    });
   }
 
   if (prompt?.trim()) {
@@ -320,6 +333,7 @@ export function PreviewPanel({
   modelName,
   selectedComponents,
   prompt,
+  pendingComponentBodies,
   validationResult,
 }: PreviewPanelProps) {
   const [ide, setIde] = useState<Ide>("claude-code");
@@ -331,7 +345,7 @@ export function PreviewPanel({
   const modalScrollRef = useRef<HTMLDivElement>(null);
 
   const mcps = selectedComponents.mcps ?? [];
-  const body = buildMarkdownBody(description, selectedComponents, prompt);
+  const body = buildMarkdownBody(description, selectedComponents, prompt, pendingComponentBodies);
 
   // Simplified mode: client-side generators
   let files: PreviewFile[];

--- a/web/src/components/review/review-diff-sheet.tsx
+++ b/web/src/components/review/review-diff-sheet.tsx
@@ -26,9 +26,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import Link from "next/link";
+import { useQueryClient } from "@tanstack/react-query";
 import yaml from "js-yaml";
 import { YamlDiffView } from "./yaml-diff-view";
 import { useAgentVersions, useAgentVersionDetail, useComponentVersions, useComponentVersionDetail, useRegistryItem } from "@/hooks/use-api";
+import { registry } from "@/lib/api";
 import type { RegistryType } from "@/lib/api";
 import type { ReviewItem, ComponentChange } from "@/lib/types";
 
@@ -123,7 +125,29 @@ function toReviewYaml(obj: Record<string, unknown>): string {
 
 const COMPONENT_CONTENT_KEYS = ["template", "skill_md_content", "handler_config", "input_schema", "output_schema", "source_url", "git_url", "config_json", "event", "execution_mode", "task_type", "slash_command"];
 
-function buildCleanYaml(detail: Record<string, unknown>): string {
+// For non-agent component submissions — include all content fields
+const COMPONENT_SNAPSHOT_META = new Set([
+  "id", "listing_id", "download_count", "released_by", "released_at",
+  "created_at", "status", "rejection_reason", "is_prerelease",
+]);
+
+function buildComponentYaml(detail: Record<string, unknown>): string {
+  const obj = Object.fromEntries(
+    Object.entries(detail).filter(([k, v]) =>
+      !COMPONENT_SNAPSHOT_META.has(k) && v !== null && v !== undefined && v !== "" &&
+      !(Array.isArray(v) && (v as unknown[]).length === 0) &&
+      !(typeof v === "object" && !Array.isArray(v) && Object.keys(v as object).length === 0)
+    )
+  );
+  try {
+    return yaml.dump(obj, { lineWidth: 120, indent: 2, noRefs: true }).trimEnd();
+  } catch {
+    return JSON.stringify(obj, null, 2);
+  }
+}
+
+
+function buildCleanYaml(detail: Record<string, unknown>, componentDataMap?: Map<string, Record<string, unknown>>): string {
   const comps = (detail.components as Array<Record<string, unknown>> | undefined) ?? [];
   const obj: Record<string, unknown> = {};
   if (detail.version) obj.version = detail.version;
@@ -135,13 +159,16 @@ function buildCleanYaml(detail: Record<string, unknown>): string {
   if (ides?.length) obj.supported_ides = ides;
   if (comps.length) {
     obj.components = comps.map((c) => {
+      const cached = componentDataMap?.get(String(c.component_id ?? "")) as Record<string, unknown> | undefined;
+      const merged = cached ? { ...cached, ...c } : c;
       const entry: Record<string, unknown> = {};
-      if (c.component_type) entry.type = c.component_type;
-      if (c.name) entry.name = c.name;
-      if (c.description) entry.description = c.description;
-      if (c.version) entry.version = c.version;
+      if (merged.component_type) entry.type = merged.component_type;
+      entry.name = merged.name || merged.component_name || c.name || c.component_name || "(pending)";
+      const desc = merged.description ?? merged.component_description;
+      if (desc) entry.description = desc;
+      if (merged.version) entry.version = merged.version;
       for (const k of COMPONENT_CONTENT_KEYS) {
-        if (c[k]) entry[k] = c[k];
+        if (merged[k]) entry[k] = merged[k];
       }
       return entry;
     });
@@ -158,7 +185,7 @@ function buildCleanYaml(detail: Record<string, unknown>): string {
 const CONTENT_KEYS = ["template", "skill_md_content", "handler_config", "input_schema", "output_schema", "source_url", "config_json"] as const;
 const TYPE_MAP: Record<string, string> = { mcp: "mcps", skill: "skills", hook: "hooks", prompt: "prompts", sandbox: "sandboxes" };
 
-function LinkedComponentDetail({ componentType, componentId }: { componentType: string; componentId: string }) {
+function LinkedComponentDetail({ componentType, componentId, onPendingClick, isPending }: { componentType: string; componentId: string; onPendingClick?: (id: string, type: string) => void; isPending?: boolean }) {
   const registryType = (TYPE_MAP[componentType] ?? `${componentType}s`) as import("@/lib/api").RegistryType;
   const { data: item } = useRegistryItem(registryType, componentId);
   const name = item?.name ?? componentType;
@@ -175,7 +202,14 @@ function LinkedComponentDetail({ componentType, componentId }: { componentType: 
     <div className="rounded border border-border overflow-hidden text-xs">
       <div className="flex items-center gap-2 px-3 py-2 bg-muted/50">
         <Badge variant="outline" className="text-[10px] shrink-0">{componentType}</Badge>
-        <Link href={href} className="font-medium hover:underline text-primary">{name}</Link>
+        {isPending && onPendingClick ? (
+          <button type="button" onClick={() => onPendingClick(componentId, componentType)} className="font-medium hover:underline text-amber-500 text-left">
+            {name}
+            <span className="ml-1 text-[9px] opacity-70">(pending)</span>
+          </button>
+        ) : (
+          <Link href={href} className="font-medium hover:underline text-primary">{name}</Link>
+        )}
       </div>
       {description && (
         <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-b border-border/50">{description}</p>
@@ -196,12 +230,14 @@ function LinkedComponentDetail({ componentType, componentId }: { componentType: 
 }
 
 
+
 interface ReviewDiffSheetProps {
   item: ReviewItem | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onApprove: (id: string, type?: string) => void;
   onReject: (id: string, reason: string, type?: string) => void;
+  onOpenComponentReview?: (id: string, type: string) => void;
 }
 
 export function ReviewDiffSheet({
@@ -210,6 +246,7 @@ export function ReviewDiffSheet({
   onOpenChange,
   onApprove,
   onReject,
+  onOpenComponentReview,
 }: ReviewDiffSheetProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -221,6 +258,7 @@ export function ReviewDiffSheet({
             onOpenChange={onOpenChange}
             onApprove={onApprove}
             onReject={onReject}
+            onOpenComponentReview={onOpenComponentReview}
           />
         ) : (
           <div className="p-6 space-y-4">
@@ -238,11 +276,13 @@ function DiffDialogBody({
   onOpenChange,
   onApprove,
   onReject,
+  onOpenComponentReview,
 }: {
   item: ReviewItem;
   onOpenChange: (open: boolean) => void;
   onApprove: (id: string, type?: string) => void;
   onReject: (id: string, reason: string, type?: string) => void;
+  onOpenComponentReview?: (id: string, type: string) => void;
 }) {
   const [showRejectDialog, setShowRejectDialog] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
@@ -300,32 +340,6 @@ function DiffDialogBody({
 
   const detailLoading = isAgent ? agentDetailLoading : compDetailLoading;
 
-  // Build client-side diff for agents using clean YAML (no UUIDs, no metadata)
-  const agentDiff = useMemo(() => {
-    if (!isAgent || !agentDetail) return null;
-    const curr = buildCleanYaml(agentDetail as unknown as Record<string, unknown>);
-    if (!agentPrevDetail) return null;
-    const prev = buildCleanYaml(agentPrevDetail as unknown as Record<string, unknown>);
-    if (prev === curr) return "";
-    const prevLines = prev.split("\n");
-    const currLines = curr.split("\n");
-    const lines: string[] = [`--- v${previousVersion}`, `+++ v${item.version}`];
-    const hunks: string[] = [];
-    const maxLen = Math.max(prevLines.length, currLines.length);
-    let inHunk = false;
-    for (let i = 0; i < maxLen; i++) {
-      const pl = prevLines[i] ?? "";
-      const cl = currLines[i] ?? "";
-      if (pl !== cl) {
-        if (!inHunk) { hunks.push(`@@ -${i + 1} +${i + 1} @@`); inHunk = true; }
-        if (pl) hunks.push(`-${pl}`);
-        if (cl) hunks.push(`+${cl}`);
-      } else {
-        if (inHunk) { hunks.push(` ${cl}`); inHunk = false; }
-      }
-    }
-    return [...lines, ...hunks].join("\n");
-  }, [isAgent, agentDetail, agentPrevDetail, previousVersion, item.version]);
 
   const bumpType = useMemo(() => {
     if (!previousVersion || !item.version) return null;
@@ -334,8 +348,8 @@ function DiffDialogBody({
 
   const componentDiff = useMemo(() => {
     if (isAgent || !compDetail || !compPrevDetail || !previousVersion) return null;
-    const prev = buildCleanYaml(compPrevDetail as unknown as Record<string, unknown>);
-    const curr = buildCleanYaml(compDetail as unknown as Record<string, unknown>);
+    const prev = buildComponentYaml(compPrevDetail as unknown as Record<string, unknown>);
+    const curr = buildComponentYaml(compDetail as unknown as Record<string, unknown>);
     if (prev === curr) return "";
     const prevLines = prev.split("\n");
     const currLines = curr.split("\n");
@@ -381,7 +395,6 @@ function DiffDialogBody({
   const isLoading = versionsLoading || detailLoading;
 
   const detail = (isAgent ? agentDetail : compDetail) as Record<string, unknown> | undefined;
-  const yamlSnapshot = detail ? buildCleanYaml(detail) : null;
   // Prefer version detail fields over the sparse review item fields
   const prompt = (detail?.prompt as string) || item.prompt || "";
   const modelName = (detail?.model_name as string) || item.model_name || "";
@@ -395,6 +408,46 @@ function DiffDialogBody({
   );
   const supportedIdes = (detail?.supported_ides as string[]) || item.supported_ides || [];
   const components = (detail?.components as { component_type: string; component_id: string; name?: string; template?: string; description?: string; category?: string }[]) || item.components || [];
+  const queryClient = useQueryClient();
+  const componentKey = components.map((c) => c.component_id).join(",");
+  const cachedComponentData = useMemo(() => {
+    const dataMap = new Map<string, Record<string, unknown>>();
+    components.forEach((comp) => {
+      const pluralType = TYPE_MAP[comp.component_type] ?? `${comp.component_type}s`;
+      const cached = queryClient.getQueryData(["registry", pluralType, comp.component_id]);
+      if (cached) dataMap.set(comp.component_id, cached as Record<string, unknown>);
+    });
+    return dataMap;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [componentKey, queryClient]);
+
+  // Build client-side diff for agents using clean YAML (no UUIDs, no metadata)
+  const agentDiff = useMemo(() => {
+    if (!isAgent || !agentDetail) return null;
+    const curr = buildCleanYaml(agentDetail as unknown as Record<string, unknown>, cachedComponentData);
+    if (!agentPrevDetail) return null;
+    const prev = buildCleanYaml(agentPrevDetail as unknown as Record<string, unknown>, cachedComponentData);
+    if (prev === curr) return "";
+    const prevLines = prev.split("\n");
+    const currLines = curr.split("\n");
+    const lines: string[] = [`--- v${previousVersion}`, `+++ v${item.version}`];
+    const hunks: string[] = [];
+    const maxLen = Math.max(prevLines.length, currLines.length);
+    let inHunk = false;
+    for (let i = 0; i < maxLen; i++) {
+      const pl = prevLines[i] ?? "";
+      const cl = currLines[i] ?? "";
+      if (pl !== cl) {
+        if (!inHunk) { hunks.push(`@@ -${i + 1} +${i + 1} @@`); inHunk = true; }
+        if (pl) hunks.push(`-${pl}`);
+        if (cl) hunks.push(`+${cl}`);
+      } else {
+        if (inHunk) { hunks.push(` ${cl}`); inHunk = false; }
+      }
+    }
+    return [...lines, ...hunks].join("\n");
+  }, [isAgent, agentDetail, agentPrevDetail, previousVersion, item.version]);
+  const yamlSnapshot = detail ? (isAgent ? buildCleanYaml(detail, cachedComponentData) : buildComponentYaml(detail)) : null;
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -627,6 +680,10 @@ function DiffDialogBody({
                           <LinkedComponentDetail
                             componentType={(ch as {component_type?: string; type?: string}).component_type ?? (ch as {type?: string}).type ?? ""}
                             componentId={(ch as {component_id?: string}).component_id ?? ""}
+                            onPendingClick={onOpenComponentReview}
+                            isPending={(item.blocking_components as Array<{component_id: string}> | undefined)?.some(
+                              (b) => b.component_id === (ch as {component_id?: string}).component_id
+                            ) ?? false}
                           />
                         </div>
                       );

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -302,6 +302,7 @@ export interface ReviewItem {
 	mcp_validated?: boolean;
 	validation_results?: McpValidationResult[];
 	components_ready?: boolean;
+	blocking_components?: Array<{ component_id: string; component_type: string; name: string; status: string }>;
 	component_blockers?: {
 		component_type: string;
 		component_id: string;


### PR DESCRIPTION
## Purpose / Description

Components created from the agent builder are held in memory only — nothing is written to the registry until the user hits Submit. When the agent is submitted, all in-memory components are POSTed to the registry first (getting real IDs), then the agent is submitted with those IDs linked.

## Fixes

* Closes #1090

## Approach

Single file change in `builder/page.tsx`:

- `pendingComponents` state: array of `{ id (temp), type, name, body }` held in memory only
- `createDialogType` state: which component tab's Create dialog is open
- `SubmitComponentDialog` rendered; `onSubmit`/`onSaveDraft` both store locally instead of calling the API
- Each tab shows pending items with a dashed border and 'not yet submitted' label, removable with x
- `handlePublish` flushes pending components to the registry first, merges real IDs into `selectedComponents`, then builds and submits the agent

## How Has This Been Tested?

Tested locally: created a prompt from the builder, saw it appear as 'not yet submitted', submitted the agent, confirmed the prompt appeared in the registry and was linked.
<img width="1501" height="1032" alt="submit" src="https://github.com/user-attachments/assets/69ad9d80-b341-4b2f-bcb0-5d869db9d4a2" />


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens