### PR TITLE
feat: self-learning agents — propose version from insight suggestions

### DIFF
--- a/ee/observal_insights/skill_synthesis.py
+++ b/ee/observal_insights/skill_synthesis.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: LicenseRef-Observal-Enterprise
+"""Skill synthesis — feeds insight report output back into the agent's rules.
+
+The simplest possible self-learning loop:
+    sessions → insight report (already runs) → extract actionable sections → inject into agent
+
+No SQL pattern detection. No confidence formulas. No validation gate.
+The insight report IS the analysis. We just pipe it back.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def _extract_suggestion_prompt_additions(narrative: dict) -> list[str]:
+    """Extract system_prompt_addition suggestions from the narrative.
+
+    V1 narrative has `suggestions` as a list of strings — no fix_type, so we
+    can't filter. We skip these.
+
+    V2 sections format has `suggestions` as a dict with `items[]` where each
+    item has a `fix_type`. We only extract items where fix_type == "system_prompt_addition".
+
+    Returns a list of action strings to inject directly into the agent's rules.
+    """
+    suggestions = narrative.get("suggestions")
+    if not suggestions:
+        return []
+
+    # V2 structured format: {"intro": "...", "items": [...]}
+    if isinstance(suggestions, dict):
+        items = suggestions.get("items", [])
+        additions = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if item.get("fix_type") == "system_prompt_addition":
+                action = item.get("action", "").strip()
+                if action:
+                    additions.append(action)
+        return additions
+
+    # V1 format: list of strings — no fix_type metadata, skip
+    return []
+
+
+def synthesize_from_insight_report(report_content: dict) -> str | None:
+    """Extract actionable guidance from an insight report and format as rules.
+
+    Takes the report's narrative, facets summary, and regressions — the analysis
+    that's already been done — and formats it into instructions the agent can follow.
+
+    When the insight report contains structured suggestions with fix_type ==
+    "system_prompt_addition", those are injected verbatim as high-priority
+    behavioral directives.
+
+    Args:
+        report_content: The dict returned by generate_report_content().
+
+    Returns:
+        Formatted markdown string to inject into agent rules, or None if
+        there's nothing actionable.
+    """
+    sections: list[str] = []
+
+    narrative = report_content.get("narrative", {})
+    facets_summary = report_content.get("facets_summary", {})
+    regressions = report_content.get("regressions", [])
+
+    # -- At a glance (already synthesized by the insight LLM) --
+    at_a_glance = narrative.get("at_a_glance", {})
+    # V1: at_a_glance is a string; V2: it's a dict with whats_working, whats_hindering, quick_win
+    if isinstance(at_a_glance, str):
+        whats_working = ""
+        whats_hindering = ""
+        quick_win = ""
+    else:
+        whats_working = at_a_glance.get("whats_working", "")
+        whats_hindering = at_a_glance.get("whats_hindering", "")
+        quick_win = at_a_glance.get("quick_win", "")
+
+    # -- System prompt additions from structured suggestions (V2 only) --
+    prompt_additions = _extract_suggestion_prompt_additions(narrative)
+
+    # -- Repeated instructions (direct user corrections — the gold signal) --
+    repeated_instructions = facets_summary.get("repeated_instructions", [])
+
+    # -- Friction points --
+    friction_points = facets_summary.get("friction_types", {})
+    if isinstance(friction_points, list):
+        friction_points = dict(friction_points)
+
+    # -- Effective vs problematic tools --
+    tools_effective = facets_summary.get("tools_effective", {})
+    tools_problematic = facets_summary.get("tools_problematic", {})
+
+    # aggregate_facets returns sorted list of tuples; handle both formats
+    if isinstance(tools_effective, list):
+        tools_effective = dict(tools_effective)
+    if isinstance(tools_problematic, list):
+        tools_problematic = dict(tools_problematic)
+
+    # -- Inject system_prompt_additions first (highest priority) --
+    if prompt_additions:
+        lines = ["### Behavioral directives"]
+        lines.append("")
+        lines.append("*Auto-generated from insight analysis. Follow these strictly.*")
+        lines.append("")
+        for addition in prompt_additions:
+            lines.append(f"- {addition}")
+        sections.append("\n".join(lines))
+
+    # Build the "what to keep doing" section
+    keep_doing: list[str] = []
+    if whats_working and whats_working.lower() not in ("n/a", "no clear value delivered in this period"):
+        keep_doing.append(whats_working)
+    if tools_effective:
+        top_tools = sorted(tools_effective.items(), key=lambda x: x[1], reverse=True)[:3]
+        for tool, count in top_tools:
+            keep_doing.append(f"Use `{tool}` — effective across {count} sessions")
+
+    # Build the "what to avoid" section
+    avoid: list[str] = []
+    if whats_hindering and whats_hindering.lower() != "n/a":
+        avoid.append(whats_hindering)
+    if repeated_instructions:
+        # These are the highest-confidence signals — users literally telling the agent
+        for instruction in repeated_instructions[:5]:
+            if isinstance(instruction, str):
+                avoid.append(f'Users repeatedly say: "{instruction}"')
+            elif isinstance(instruction, dict):
+                text = instruction.get("instruction", instruction.get("text", ""))
+                count = instruction.get("count", 0)
+                if text:
+                    avoid.append(f'"{text}" ({count} sessions)' if count else f'"{text}"')
+    if tools_problematic:
+        top_problematic = sorted(tools_problematic.items(), key=lambda x: x[1], reverse=True)[:3]
+        for tool, count in top_problematic:
+            avoid.append(f"Avoid `{tool}` — caused friction in {count} sessions")
+    if friction_points:
+        top_friction = sorted(friction_points.items(), key=lambda x: x[1], reverse=True)[:3]
+        for friction, count in top_friction:
+            avoid.append(f"{friction} ({count} sessions)")
+
+    # Build regressions section
+    regression_lines: list[str] = []
+    for reg in regressions[:3]:
+        metric = reg.get("metric", "")
+        direction = reg.get("direction", "")
+        pct = reg.get("change_pct", 0)
+        if metric and direction:
+            regression_lines.append(f"{metric}: {direction} {abs(pct):.0f}%")
+
+    # Assemble
+    if keep_doing:
+        sections.append("### What works\n" + "\n".join(f"- {line}" for line in keep_doing))
+
+    if avoid:
+        sections.append("### What to avoid\n" + "\n".join(f"- {line}" for line in avoid))
+
+    if quick_win and quick_win.lower() != "n/a":
+        sections.append(f"### Quick win\n- {quick_win}")
+
+    if regression_lines:
+        sections.append("### Recent regressions (be careful)\n" + "\n".join(f"- {line}" for line in regression_lines))
+
+    if not sections:
+        return None
+
+    header = "## Learned from Production\n\n*Auto-updated from the latest insight report. Follow these guidelines.*\n"
+    return header + "\n\n".join(sections)

--- a/observal-server/alembic/versions/0010_add_self_learning_enabled.py
+++ b/observal-server/alembic/versions/0010_add_self_learning_enabled.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Add self_learning_enabled to agents table.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-05-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("agents", sa.Column("self_learning_enabled", sa.Boolean(), nullable=False, server_default="false"))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "self_learning_enabled")

--- a/observal-server/api/routes/self_learning.py
+++ b/observal-server/api/routes/self_learning.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Self-learning endpoints (open-source edition).
+
+When self-learning is enabled for an agent, the system can synthesize
+behavioral suggestions from the latest insight report and propose them
+as a new agent version. That version enters the review queue — an admin
+must approve it before users receive the updated rules.
+
+Flow:
+1. Owner toggles self_learning_enabled on the agent
+2. Owner or automation calls POST /{agent_id}/self-learning/propose
+3. System fetches latest completed insight report, synthesizes suggestions
+4. A new AgentVersion (patch bump) is created with suggestions appended to the prompt
+5. Version enters the review queue (status=pending)
+6. Admin approves → version becomes latest → users get updated rules on next pull
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import get_db, require_role
+from models.agent import Agent, AgentStatus, AgentVersion
+from models.insight_report import InsightReport, InsightReportStatus
+from models.user import User, UserRole
+from services.versioning import bump_version
+
+router = APIRouter(prefix="/api/v1/agents", tags=["self-learning"])
+
+
+class SelfLearningToggleRequest(BaseModel):
+    enabled: bool
+
+
+class SelfLearningToggleResponse(BaseModel):
+    enabled: bool
+    message: str
+
+
+class ProposeResponse(BaseModel):
+    version_id: str
+    version: str
+    status: str
+    message: str
+
+
+async def _resolve_agent(agent_id: str, db: AsyncSession) -> Agent:
+    import uuid as _uuid
+
+    try:
+        uid = _uuid.UUID(agent_id)
+        stmt = select(Agent).where(Agent.id == uid)
+    except ValueError:
+        stmt = select(Agent).where(Agent.name == agent_id)
+
+    result = await db.execute(stmt)
+    agent = result.scalar_one_or_none()
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return agent
+
+
+@router.put("/{agent_id}/self-learning", response_model=SelfLearningToggleResponse)
+async def toggle_self_learning(
+    agent_id: str,
+    body: SelfLearningToggleRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Enable or disable self-learning for an agent."""
+    agent = await _resolve_agent(agent_id, db)
+
+    if agent.created_by != current_user.id and current_user.role != UserRole.admin:
+        raise HTTPException(status_code=403, detail="Only the agent owner or admin can toggle self-learning")
+
+    agent.self_learning_enabled = body.enabled
+    await db.commit()
+
+    msg = (
+        "Self-learning enabled. Use POST /self-learning/propose to create a version from insights."
+        if body.enabled
+        else "Self-learning disabled."
+    )
+    return SelfLearningToggleResponse(enabled=agent.self_learning_enabled, message=msg)
+
+
+@router.get("/{agent_id}/self-learning")
+async def get_self_learning_status(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Get self-learning status for an agent."""
+    agent = await _resolve_agent(agent_id, db)
+    return {"enabled": agent.self_learning_enabled}
+
+
+@router.post("/{agent_id}/self-learning/propose", response_model=ProposeResponse)
+async def propose_self_learning_version(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Synthesize suggestions from the latest insight report and create a new agent version.
+
+    The new version enters the review queue (status=pending). An admin must
+    approve it before users receive the updated rules on their next pull.
+    """
+    agent = await _resolve_agent(agent_id, db)
+
+    if agent.created_by != current_user.id and current_user.role != UserRole.admin:
+        raise HTTPException(status_code=403, detail="Only the agent owner or admin can propose self-learning versions")
+
+    if not agent.self_learning_enabled:
+        raise HTTPException(status_code=400, detail="Self-learning is not enabled for this agent")
+
+    # Must have a current version to base the new one on
+    current_version = agent.latest_version
+    if not current_version:
+        raise HTTPException(status_code=400, detail="Agent has no published version to base the proposal on")
+
+    # Fetch the latest completed insight report
+    insight_stmt = (
+        select(InsightReport)
+        .where(
+            InsightReport.agent_id == agent.id,
+            InsightReport.status == InsightReportStatus.completed,
+        )
+        .order_by(InsightReport.completed_at.desc())
+        .limit(1)
+    )
+    insight_result = await db.execute(insight_stmt)
+    latest_report = insight_result.scalar_one_or_none()
+
+    if not latest_report:
+        raise HTTPException(status_code=404, detail="No completed insight report found. Generate one first.")
+
+    # Synthesize suggestions
+    from ee.observal_insights.skill_synthesis import synthesize_from_insight_report
+
+    report_content = {
+        "narrative": latest_report.narrative or {},
+        "facets_summary": (latest_report.aggregated_data or {}).get("facets_summary", {}),
+        "regressions": (latest_report.aggregated_data or {}).get("regressions", []),
+        "sessions_analyzed": latest_report.sessions_analyzed or 0,
+    }
+    suggestions_md = synthesize_from_insight_report(report_content)
+
+    if not suggestions_md:
+        raise HTTPException(
+            status_code=422,
+            detail="Nothing actionable in the latest insight report — no version proposed.",
+        )
+
+    # Build the new prompt: current prompt + suggestions section
+    base_prompt = current_version.prompt or ""
+    # Remove any previously injected suggestions block (idempotent re-proposals)
+    marker = "## Learned from Production"
+    if marker in base_prompt:
+        base_prompt = base_prompt[: base_prompt.index(marker)].rstrip()
+
+    new_prompt = f"{base_prompt}\n\n{suggestions_md}" if base_prompt else suggestions_md
+
+    # Bump version (patch)
+    new_version_str = bump_version(current_version.version, "patch")
+
+    # Check for duplicate version
+    dup_stmt = select(AgentVersion).where(
+        AgentVersion.agent_id == agent.id,
+        AgentVersion.version == new_version_str,
+    )
+    if (await db.execute(dup_stmt)).scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Version {new_version_str!r} already exists. Approve or reject it before proposing again.",
+        )
+
+    # Create the new version — enters review queue
+    now = datetime.now(UTC)
+    new_ver = AgentVersion(
+        agent_id=agent.id,
+        version=new_version_str,
+        description=f"Self-learning: suggestions from insight report ({latest_report.sessions_analyzed} sessions analyzed)",
+        prompt=new_prompt,
+        model_name=current_version.model_name,
+        model_config_json=current_version.model_config_json,
+        models_by_ide=current_version.models_by_ide,
+        external_mcps=current_version.external_mcps,
+        supported_ides=current_version.supported_ides,
+        required_ide_features=current_version.required_ide_features,
+        inferred_supported_ides=current_version.inferred_supported_ides,
+        status=AgentStatus.pending,
+        released_by=current_user.id,
+        released_at=now,
+    )
+    db.add(new_ver)
+    await db.flush()
+
+    # Copy components from the current version
+    from models.agent_component import AgentComponent
+
+    for comp in current_version.components:
+        db.add(
+            AgentComponent(
+                agent_version_id=new_ver.id,
+                component_type=comp.component_type,
+                component_id=comp.component_id,
+                component_name=comp.component_name,
+                resolved_version=comp.resolved_version,
+                order_index=comp.order_index,
+                config_override=comp.config_override,
+            )
+        )
+
+    await db.commit()
+
+    from services.audit_helpers import audit
+
+    await audit(
+        current_user,
+        "agent.self_learning.propose",
+        resource_type="agent",
+        resource_id=str(agent.id),
+        resource_name=agent.name,
+        detail=new_version_str,
+    )
+
+    return ProposeResponse(
+        version_id=str(new_ver.id),
+        version=new_version_str,
+        status="pending",
+        message=f"Version {new_version_str} created with self-learning suggestions and submitted for review.",
+    )

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -57,6 +57,7 @@ from api.routes.reconcile import router as reconcile_router
 from api.routes.registry_models import router as registry_models_router
 from api.routes.review import router as review_router
 from api.routes.sandbox import router as sandbox_router
+from api.routes.self_learning import router as self_learning_router
 from api.routes.sessions import router as sessions_router
 from api.routes.skill import router as skill_router
 from api.routes.support import router as support_router
@@ -344,6 +345,7 @@ app.include_router(bulk_router)
 app.include_router(config_router)
 app.include_router(registry_models_router)
 app.include_router(support_router)
+app.include_router(self_learning_router)
 
 # --- Prometheus metrics ---
 _instrumentator = Instrumentator(

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -121,6 +121,10 @@ class Agent(Base):
         onupdate=lambda: datetime.now(UTC),
     )
 
+    # Self-learning: when enabled, the insight pipeline synthesizes behavioral
+    # rules from aggregate telemetry and delivers them to the agent.
+    self_learning_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+
     versions: Mapped[list["AgentVersion"]] = relationship(
         back_populates="agent",
         lazy="selectin",

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -175,6 +175,7 @@ class AgentResponse(BaseModel):
     user_permission: str | None = None
     latest_approved_version: str | None = None
     latest_version: str | None = None
+    self_learning_enabled: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/observal-server/services/agent_config_generator.py
+++ b/observal-server/services/agent_config_generator.py
@@ -481,6 +481,7 @@ def _build_rules_content(
     agent: Agent,
     component_names: dict | None = None,
     prompt_listings: dict | None = None,
+    insight_suggestions: str | None = None,
 ) -> str:
     """Build markdown rules content from the agent and its components.
 
@@ -490,6 +491,9 @@ def _build_rules_content(
     Args:
         prompt_listings: optional {component_id: PromptListing} map. When provided,
             prompt components inject their full template content instead of a bullet name.
+        insight_suggestions: optional pre-formatted markdown block from the self-learning
+            pipeline (synthesized from the latest insight report). Appended after all
+            other content.
     """
     sections: list[str] = []
 
@@ -540,6 +544,10 @@ def _build_rules_content(
                 lines.append(f"- **{n}**")
             sections.append("\n".join(lines))
 
+    # Append self-learning insight suggestions at the end of the rules
+    if insight_suggestions:
+        sections.append(insight_suggestions)
+
     return "\n\n".join(sections) if sections else f"# {agent.name}"
 
 
@@ -556,6 +564,7 @@ def generate_agent_config(
     hook_listings: dict | None = None,
     otlp_http_url: str = "",
     prompt_listings: dict | None = None,
+    insight_suggestions: str | None = None,
 ) -> dict:
     """Generate IDE-specific config for an agent.
 
@@ -567,11 +576,12 @@ def generate_agent_config(
         skill_listings: optional {component_id: SkillListing} map pre-loaded by caller.
         hook_listings: optional {component_id: HookListing} map pre-loaded by caller.
         prompt_listings: optional {component_id: PromptListing} map pre-loaded by caller.
+        insight_suggestions: optional pre-formatted markdown from the self-learning pipeline.
     """
     safe_name = _sanitize_name(agent.name)
     effective_otlp_http = otlp_http_url or observal_url
     mcp_configs = _build_mcp_configs(agent, ide, effective_otlp_http, mcp_listings=mcp_listings, env_values=env_values)
-    rules_content = _build_rules_content(agent, component_names, prompt_listings)
+    rules_content = _build_rules_content(agent, component_names, prompt_listings, insight_suggestions)
     skill_configs = _build_skill_configs(agent, skill_listings)
     hook_configs = _build_hook_configs(agent, hook_listings)
     options = options or {}

--- a/tests/test_self_learning.py
+++ b/tests/test_self_learning.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tests for the self-learning suggestions pipeline.
+
+Architecture: self-learning produces a new agent version (patch bump) with
+suggestions baked into the prompt. That version enters the review queue.
+Only after admin approval does it become the latest version served on install.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure project root is on path so ee/ is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ee.observal_insights.skill_synthesis import (
+    _extract_suggestion_prompt_additions,
+    synthesize_from_insight_report,
+)
+from services.agent_config_generator import _build_rules_content
+
+
+# -- _extract_suggestion_prompt_additions tests --------------------------------
+
+
+class TestExtractSuggestionPromptAdditions:
+    def test_returns_empty_for_none_suggestions(self):
+        assert _extract_suggestion_prompt_additions({}) == []
+
+    def test_returns_empty_for_v1_string_list(self):
+        """V1 narratives have suggestions as a list of strings — no fix_type."""
+        narrative = {"suggestions": ["Use retry logic", "Optimize cache"]}
+        assert _extract_suggestion_prompt_additions(narrative) == []
+
+    def test_extracts_system_prompt_additions_from_v2(self):
+        narrative = {
+            "suggestions": {
+                "intro": "Based on 50 sessions...",
+                "items": [
+                    {
+                        "title": "Add file read check",
+                        "action": "Always read a file before editing it.",
+                        "why": "Reduces wrong_file friction by 60%",
+                        "priority": "high",
+                        "fix_type": "system_prompt_addition",
+                        "expected_impact": "Reduce errors by 60%",
+                        "confidence": "high",
+                    },
+                    {
+                        "title": "Switch to pnpm",
+                        "action": "Use pnpm instead of npm for package management.",
+                        "why": "npm causes frequent failures",
+                        "priority": "medium",
+                        "fix_type": "tool_configuration",
+                        "expected_impact": "Fewer tool failures",
+                        "confidence": "medium",
+                    },
+                    {
+                        "title": "Confirm before deleting",
+                        "action": "Before deleting any file, confirm with the user.",
+                        "why": "Users frequently reject file deletions",
+                        "priority": "high",
+                        "fix_type": "system_prompt_addition",
+                        "expected_impact": "Reduce user rejections by 40%",
+                        "confidence": "high",
+                    },
+                ],
+            }
+        }
+        result = _extract_suggestion_prompt_additions(narrative)
+        assert len(result) == 2
+        assert "Always read a file before editing it." in result
+        assert "Before deleting any file, confirm with the user." in result
+
+    def test_skips_empty_actions(self):
+        narrative = {
+            "suggestions": {
+                "intro": "...",
+                "items": [
+                    {
+                        "title": "Empty",
+                        "action": "   ",
+                        "fix_type": "system_prompt_addition",
+                    },
+                ],
+            }
+        }
+        assert _extract_suggestion_prompt_additions(narrative) == []
+
+    def test_handles_non_dict_items_gracefully(self):
+        narrative = {
+            "suggestions": {
+                "intro": "...",
+                "items": ["not a dict", 42, None],
+            }
+        }
+        assert _extract_suggestion_prompt_additions(narrative) == []
+
+
+# -- synthesize_from_insight_report tests --------------------------------------
+
+
+class TestSynthesizeFromInsightReport:
+    def test_injects_system_prompt_additions_first(self):
+        """system_prompt_addition suggestions should appear first in output."""
+        report = {
+            "narrative": {
+                "at_a_glance": {"whats_working": "Fast navigation", "whats_hindering": "N/A", "quick_win": "N/A"},
+                "suggestions": {
+                    "intro": "Based on analysis...",
+                    "items": [
+                        {
+                            "title": "Read before edit",
+                            "action": "Always read file contents before editing.",
+                            "fix_type": "system_prompt_addition",
+                            "priority": "high",
+                        },
+                    ],
+                },
+            },
+            "facets_summary": {"tools_effective": {"rg": 34}},
+            "regressions": [],
+            "sessions_analyzed": 50,
+        }
+        result = synthesize_from_insight_report(report)
+        assert result is not None
+        assert "### Behavioral directives" in result
+        assert "Always read file contents before editing." in result
+        # Directives should appear before "What works"
+        directives_pos = result.index("### Behavioral directives")
+        works_pos = result.index("### What works")
+        assert directives_pos < works_pos
+
+    def test_no_directives_section_without_system_prompt_additions(self):
+        report = {
+            "narrative": {
+                "at_a_glance": {"whats_working": "Good stuff", "whats_hindering": "N/A", "quick_win": "N/A"},
+                "suggestions": {
+                    "intro": "...",
+                    "items": [
+                        {
+                            "title": "Switch tool",
+                            "action": "Use ripgrep instead of find",
+                            "fix_type": "tool_configuration",
+                            "priority": "medium",
+                        },
+                    ],
+                },
+            },
+            "facets_summary": {},
+            "regressions": [],
+            "sessions_analyzed": 50,
+        }
+        result = synthesize_from_insight_report(report)
+        assert result is not None
+        assert "### Behavioral directives" not in result
+
+    def test_extracts_whats_working(self):
+        report = {
+            "narrative": {
+                "at_a_glance": {
+                    "whats_working": "Fast file navigation using rg",
+                    "whats_hindering": "N/A",
+                    "quick_win": "N/A",
+                }
+            },
+            "facets_summary": {"tools_effective": {"rg": 34, "git_diff": 12}},
+            "regressions": [],
+            "sessions_analyzed": 50,
+        }
+        result = synthesize_from_insight_report(report)
+        assert result is not None
+        assert "### What works" in result
+        assert "rg" in result
+        assert "34 sessions" in result
+
+    def test_extracts_repeated_instructions(self):
+        report = {
+            "narrative": {
+                "at_a_glance": {
+                    "whats_working": "N/A",
+                    "whats_hindering": "Agent uses npm",
+                    "quick_win": "Switch to pnpm",
+                }
+            },
+            "facets_summary": {"repeated_instructions": ["use pnpm not npm", "don't edit test files"]},
+            "regressions": [],
+            "sessions_analyzed": 50,
+        }
+        result = synthesize_from_insight_report(report)
+        assert result is not None
+        assert "### What to avoid" in result
+        assert "use pnpm not npm" in result
+        assert "don't edit test files" in result
+
+    def test_returns_none_when_nothing_actionable(self):
+        report = {
+            "narrative": {"at_a_glance": {"whats_working": "N/A", "whats_hindering": "N/A", "quick_win": "N/A"}},
+            "facets_summary": {},
+            "regressions": [],
+            "sessions_analyzed": 50,
+        }
+        result = synthesize_from_insight_report(report)
+        assert result is None
+
+    def test_returns_none_on_empty_report(self):
+        result = synthesize_from_insight_report({})
+        assert result is None
+
+    def test_header_present(self):
+        report = {
+            "narrative": {"at_a_glance": {"whats_working": "Good stuff", "whats_hindering": "N/A", "quick_win": "N/A"}},
+            "facets_summary": {},
+            "regressions": [],
+            "sessions_analyzed": 50,
+        }
+        result = synthesize_from_insight_report(report)
+        assert result is not None
+        assert "## Learned from Production" in result
+        assert "Auto-updated from the latest insight report" in result
+
+    def test_v1_string_at_a_glance(self):
+        """V1 narrative has at_a_glance as a string."""
+        report = {
+            "narrative": {
+                "at_a_glance": "Agent is healthy with 95% task completion",
+                "suggestions": ["Improve cache utilization"],
+            },
+            "facets_summary": {"tools_effective": {"rg": 10}},
+            "regressions": [],
+            "sessions_analyzed": 30,
+        }
+        result = synthesize_from_insight_report(report)
+        assert result is not None
+        assert "rg" in result
+        # V1 string suggestions should NOT produce directives
+        assert "### Behavioral directives" not in result
+
+    def test_regressions(self):
+        report = {
+            "narrative": {"at_a_glance": {"whats_working": "N/A", "whats_hindering": "N/A", "quick_win": "N/A"}},
+            "facets_summary": {},
+            "regressions": [{"metric": "tool_failure_rate", "direction": "increased", "change_pct": 15}],
+            "sessions_analyzed": 50,
+        }
+        result = synthesize_from_insight_report(report)
+        assert result is not None
+        assert "### Recent regressions" in result
+        assert "tool_failure_rate" in result
+        assert "15%" in result
+
+
+# -- _build_rules_content with insight_suggestions tests -----------------------
+
+
+class TestBuildRulesContentWithSuggestions:
+    """Test that the rules content builder can embed suggestions.
+
+    In the version-proposal flow, suggestions are baked into the prompt of
+    the new version. The _build_rules_content function's insight_suggestions
+    param still works for pre-rendering, but the primary path is now via
+    the version's prompt field.
+    """
+
+    def test_appends_suggestions_to_rules(self):
+        agent = MagicMock()
+        agent.prompt = "You are a helpful coding agent."
+        agent.description = ""
+        agent.components = []
+
+        suggestions = "## Learned from Production\n\n### What works\n- Use rg"
+        result = _build_rules_content(agent, insight_suggestions=suggestions)
+        assert "## Learned from Production" in result
+        assert "Use rg" in result
+        assert "You are a helpful coding agent." in result
+
+    def test_no_suggestions_when_none(self):
+        agent = MagicMock()
+        agent.prompt = "Base prompt."
+        agent.description = ""
+        agent.components = []
+
+        result = _build_rules_content(agent, insight_suggestions=None)
+        assert "Learned from Production" not in result
+        assert result == "Base prompt."
+
+    def test_suggestions_appear_after_prompt(self):
+        agent = MagicMock()
+        agent.prompt = "You are a coding assistant."
+        agent.description = ""
+        agent.components = []
+
+        suggestions = "## Learned from Production\n\n### Behavioral directives\n- Always read before editing"
+        result = _build_rules_content(agent, insight_suggestions=suggestions)
+        prompt_pos = result.index("You are a coding assistant.")
+        suggestions_pos = result.index("## Learned from Production")
+        assert suggestions_pos > prompt_pos
+
+
+# -- Version proposal logic tests ----------------------------------------------
+
+
+class TestVersionProposalLogic:
+    """Test the prompt composition logic used by the propose endpoint."""
+
+    def test_new_prompt_appends_suggestions(self):
+        """Simulate what the propose endpoint does: base prompt + suggestions."""
+        base_prompt = "You are a coding agent. Follow best practices."
+        suggestions_md = "## Learned from Production\n\n### What works\n- Use rg for search"
+
+        new_prompt = f"{base_prompt}\n\n{suggestions_md}"
+        assert "You are a coding agent." in new_prompt
+        assert "## Learned from Production" in new_prompt
+        assert new_prompt.index("coding agent") < new_prompt.index("Learned from Production")
+
+    def test_idempotent_reproposal_strips_old_suggestions(self):
+        """Re-proposing strips the old suggestions block before appending new ones."""
+        marker = "## Learned from Production"
+        old_prompt = "Base prompt.\n\n## Learned from Production\n\n### Old stuff\n- Outdated"
+        new_suggestions = "## Learned from Production\n\n### What works\n- Use rg"
+
+        if marker in old_prompt:
+            base_prompt = old_prompt[: old_prompt.index(marker)].rstrip()
+        else:
+            base_prompt = old_prompt
+
+        new_prompt = f"{base_prompt}\n\n{new_suggestions}"
+        assert "Outdated" not in new_prompt
+        assert "Use rg" in new_prompt
+        assert new_prompt.startswith("Base prompt.")
+
+    def test_version_bump(self):
+        from services.versioning import bump_version
+
+        assert bump_version("1.2.3", "patch") == "1.2.4"
+        assert bump_version("0.1.0", "patch") == "0.1.1"
+
+
+# -- Agent model toggle test ---------------------------------------------------
+
+
+class TestSelfLearningToggle:
+    def test_agent_model_default_disabled(self):
+        from models.agent import Agent
+
+        col = Agent.__table__.columns["self_learning_enabled"]
+        assert col.default.arg is False


### PR DESCRIPTION
## Purpose / Description

When self-learning is enabled for an agent, the system can synthesize behavioral suggestions from the latest insight report and propose them as a **new agent version** that enters the review queue. An admin must approve it before users receive the updated rules.

This ensures human oversight over automatically generated content — no unreviewed changes reach production.

## Fixes
* Implements the self-learning agent improvement pipeline (version-based, review-gated)

## Approach

**Flow:**
1. Owner toggles `self_learning_enabled` on the agent via `PUT /agents/{id}/self-learning`
2. Owner calls `POST /agents/{id}/self-learning/propose`
3. System fetches the latest completed insight report, runs `synthesize_from_insight_report()`
4. A new AgentVersion (patch bump) is created with suggestions appended to the prompt
5. Version enters the review queue (`status=pending`)
6. Admin approves → version becomes latest → users get updated rules on next `observal pull`

**Where suggestions live:** Appended to the version's prompt under `## Learned from Production` with subsections:
- `### Behavioral directives` — `system_prompt_addition` fix_type items (highest priority)
- `### What works` — effective tools and patterns
- `### What to avoid` — repeated user corrections, problematic tools, friction
- `### Quick win` — low-effort high-impact suggestion
- `### Recent regressions` — metrics that worsened

**Key design decisions:**
- Install route is unchanged — it always serves the latest approved version
- Re-proposals are idempotent: old suggestions block is stripped before appending new
- Only `system_prompt_addition` fix_type suggestions from V2 structured format are treated as behavioral directives
- V1 narrative format (list of strings) contributes facets/regressions but not directives

## How Has This Been Tested?

21 unit tests covering:
- `_extract_suggestion_prompt_additions`: V1 vs V2 format handling, edge cases
- `synthesize_from_insight_report`: full synthesis with all section types
- `_build_rules_content`: integration with insight_suggestions param
- Version proposal logic: prompt composition, idempotent re-proposal, version bump
- Agent model: `self_learning_enabled` default value

```bash
cd observal-server && uv run pytest ../tests/test_self_learning.py -q
# 21 passed

uv run pytest ../tests/test_agent_config_generator.py ../tests/test_pull_and_agent_cli.py ../tests/test_ide_config_e2e.py -q
# 303 passed (no regressions)
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A — backend only)