### PR TITLE
refactor(worker): split job definitions into jobs/ subpackage

### DIFF
--- a/observal-server/jobs/__init__.py
+++ b/observal-server/jobs/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Background job modules for the arq worker."""

--- a/observal-server/jobs/catalog.py
+++ b/observal-server/jobs/catalog.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Catalog and insights background jobs."""
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+async def generate_insight_report(ctx: dict, report_id: str):
+    """Background job: generate an insight report for an agent."""
+    from services.insights import INSIGHTS_AVAILABLE
+
+    if not INSIGHTS_AVAILABLE:
+        logger.warning("insight_report_skipped", reason="package not installed")
+        return
+
+    logger.info("insight_report_started", report_id=report_id)
+    try:
+        from services.insights import _run_single_report
+
+        if _run_single_report is None:
+            logger.warning("insight_report_skipped", reason="license not valid")
+            return
+        await _run_single_report(report_id)
+    except Exception as e:
+        logger.exception("insight_report_job_failed", report_id=report_id, error=str(e))
+
+
+async def batch_generate_insights(ctx: dict):
+    """Cron job: discover agents needing reports and queue generation."""
+    from services.insights import INSIGHTS_AVAILABLE
+
+    if not INSIGHTS_AVAILABLE:
+        return
+
+    from services.insights import _discover_and_queue
+
+    if _discover_and_queue is None:
+        return
+
+    try:
+        queued = await _discover_and_queue()
+        if queued > 0:
+            logger.info("insight_batch_queued_reports", count=queued)
+    except Exception as e:
+        logger.exception("insight_batch_failed", error=str(e))
+
+
+async def refresh_model_catalog(ctx: dict):
+    """Cron job: pre-warm the model catalog so user requests never hit a cold cache."""
+    from services.model_catalog import get_catalog
+
+    try:
+        cat = await get_catalog(force_refresh=True)
+        logger.info(
+            "model_catalog_prewarm",
+            source=cat.source,
+            count=cat.model_count,
+            degraded=cat.degraded,
+        )
+    except Exception as e:
+        logger.warning("model_catalog_prewarm_failed", error=str(e))

--- a/observal-server/jobs/eval.py
+++ b/observal-server/jobs/eval.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Eval-related background jobs."""
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+async def run_eval(ctx: dict, agent_id: str, trace_id: str | None = None, project_id: str = "default"):
+    """Background job: run eval on an agent's traces."""
+    logger.info("eval_started", agent_id=agent_id, trace_id=trace_id, project_id=project_id)
+    try:
+        from services.clickhouse import query_traces
+        from services.eval.eval_engine import run_eval_on_trace
+        from services.redis import publish
+
+        if trace_id:
+            scores = await run_eval_on_trace(agent_id, trace_id, project_id=project_id)
+            await publish(
+                f"eval:{agent_id}",
+                {
+                    "agent_id": agent_id,
+                    "trace_id": trace_id,
+                    "scores_written": len(scores),
+                },
+            )
+        else:
+            traces = await query_traces(project_id, agent_id=agent_id, limit=20)
+            for t in traces:
+                tid = t.get("trace_id", "")
+                scores = await run_eval_on_trace(agent_id, tid, project_id=project_id)
+                await publish(
+                    f"eval:{agent_id}",
+                    {
+                        "agent_id": agent_id,
+                        "trace_id": tid,
+                        "scores_written": len(scores),
+                    },
+                )
+    except Exception as e:
+        logger.exception("eval_failed", error=str(e))

--- a/observal-server/jobs/maintenance.py
+++ b/observal-server/jobs/maintenance.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Maintenance background jobs: ClickHouse optimization, component source sync, retention."""
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+async def sync_component_sources(ctx: dict):
+    """Background job: sync component sources that are due for re-sync."""
+    from datetime import UTC, datetime
+
+    from sqlalchemy import or_, select
+
+    from database import async_session
+    from models.component_source import ComponentSource
+    from services.git_mirror_service import sync_source
+
+    async with async_session() as db:
+        # Find sources due for sync
+        now = datetime.now(UTC)
+        stmt = select(ComponentSource).where(
+            ComponentSource.auto_sync_interval.isnot(None),
+            or_(
+                ComponentSource.last_synced_at.is_(None),
+                ComponentSource.last_synced_at + ComponentSource.auto_sync_interval < now,
+            ),
+        )
+        result = await db.execute(stmt)
+        sources = result.scalars().all()
+
+        for source in sources:
+            logger.info("Syncing component source %s (%s)", source.id, source.url)
+            source.sync_status = "syncing"
+            await db.commit()
+
+            sync_result = sync_source(source.url, source.component_type)
+
+            source.last_synced_at = now
+            source.sync_status = "success" if sync_result.success else "failed"
+            source.sync_error = sync_result.error if not sync_result.success else None
+            await db.commit()
+            logger.info(
+                "Sync %s: %s (%d components)",
+                source.url,
+                source.sync_status,
+                len(sync_result.components),
+            )
+
+
+async def maintain_clickhouse(ctx: dict):
+    """Periodic ClickHouse maintenance: compact parts to prevent OOM on long-running agents.
+
+    OPTIMIZE TABLE (without FINAL) merges small parts into larger ones.
+    This is lightweight and safe to run frequently.  Without it, a
+    month-long agent session accumulates thousands of tiny parts that
+    bloat memory during merges and FINAL queries.
+    """
+    from services.clickhouse.client import _query
+
+    tables = ["traces", "spans", "scores", "session_events", "session_stats_agg"]
+    for table in tables:
+        try:
+            await _query(f"OPTIMIZE TABLE {table}")
+        except Exception as e:
+            logger.warning("ClickHouse OPTIMIZE %s failed: %s", table, e)
+
+    # Check part health: warn before things get critical
+    try:
+        resp = await _query(
+            "SELECT table, count() as parts, sum(rows) as total_rows "
+            "FROM system.parts WHERE database = currentDatabase() AND active "
+            "GROUP BY table FORMAT JSON"
+        )
+        if resp.status_code == 200:
+            for row in resp.json().get("data", []):
+                parts = int(row.get("parts", 0))
+                if parts > 300:
+                    logger.warning(
+                        "ClickHouse table %s has %s active parts, merges may be falling behind",
+                        row["table"],
+                        parts,
+                    )
+    except Exception as e:
+        logger.debug("Part health check failed: %s", e)

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -7,187 +7,21 @@
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-"""arq background worker for eval jobs and async tasks."""
+"""arq background worker: startup/shutdown hooks, job registration, and cron scheduling."""
 
 import structlog
 from arq.cron import cron
 
+from jobs.catalog import batch_generate_insights, generate_insight_report, refresh_model_catalog
+from jobs.eval import run_eval
+from jobs.maintenance import maintain_clickhouse, sync_component_sources
 from logging_config import setup_logging
 from services.alert_evaluator import evaluate_alerts
-from services.redis import parse_redis_settings, publish
+from services.redis import parse_redis_settings
 from services.retention import run_retention_purge
 
 setup_logging()
 logger = structlog.get_logger(__name__)
-
-
-async def run_eval(ctx: dict, agent_id: str, trace_id: str | None = None, project_id: str = "default"):
-    """Background job: run eval on an agent's traces."""
-    logger.info("eval_started", agent_id=agent_id, trace_id=trace_id, project_id=project_id)
-    try:
-        from services.clickhouse import query_traces
-        from services.eval.eval_engine import run_eval_on_trace
-
-        if trace_id:
-            scores = await run_eval_on_trace(agent_id, trace_id, project_id=project_id)
-            await publish(
-                f"eval:{agent_id}",
-                {
-                    "agent_id": agent_id,
-                    "trace_id": trace_id,
-                    "scores_written": len(scores),
-                },
-            )
-        else:
-            traces = await query_traces(project_id, agent_id=agent_id, limit=20)
-            for t in traces:
-                tid = t.get("trace_id", "")
-                scores = await run_eval_on_trace(agent_id, tid, project_id=project_id)
-                await publish(
-                    f"eval:{agent_id}",
-                    {
-                        "agent_id": agent_id,
-                        "trace_id": tid,
-                        "scores_written": len(scores),
-                    },
-                )
-    except Exception as e:
-        logger.exception("eval_failed", error=str(e))
-
-
-async def sync_component_sources(ctx: dict):
-    """Background job: sync component sources that are due for re-sync."""
-    from datetime import UTC, datetime
-
-    from sqlalchemy import or_, select
-
-    from database import async_session
-    from models.component_source import ComponentSource
-    from services.git_mirror_service import sync_source
-
-    async with async_session() as db:
-        # Find sources due for sync
-        now = datetime.now(UTC)
-        stmt = select(ComponentSource).where(
-            ComponentSource.auto_sync_interval.isnot(None),
-            or_(
-                ComponentSource.last_synced_at.is_(None),
-                ComponentSource.last_synced_at + ComponentSource.auto_sync_interval < now,
-            ),
-        )
-        result = await db.execute(stmt)
-        sources = result.scalars().all()
-
-        for source in sources:
-            logger.info("Syncing component source %s (%s)", source.id, source.url)
-            source.sync_status = "syncing"
-            await db.commit()
-
-            sync_result = sync_source(source.url, source.component_type)
-
-            source.last_synced_at = now
-            source.sync_status = "success" if sync_result.success else "failed"
-            source.sync_error = sync_result.error if not sync_result.success else None
-            await db.commit()
-            logger.info(
-                "Sync %s: %s (%d components)",
-                source.url,
-                source.sync_status,
-                len(sync_result.components),
-            )
-
-
-async def maintain_clickhouse(ctx: dict):
-    """Periodic ClickHouse maintenance: compact parts to prevent OOM on long-running agents.
-
-    OPTIMIZE TABLE (without FINAL) merges small parts into larger ones.
-    This is lightweight and safe to run frequently.  Without it, a
-    month-long agent session accumulates thousands of tiny parts that
-    bloat memory during merges and FINAL queries.
-    """
-    from services.clickhouse.client import _query
-
-    tables = ["traces", "spans", "scores", "session_events", "session_stats_agg"]
-    for table in tables:
-        try:
-            await _query(f"OPTIMIZE TABLE {table}")
-        except Exception as e:
-            logger.warning("ClickHouse OPTIMIZE %s failed: %s", table, e)
-
-    # Check part health — warn before things get critical
-    try:
-        resp = await _query(
-            "SELECT table, count() as parts, sum(rows) as total_rows "
-            "FROM system.parts WHERE database = currentDatabase() AND active "
-            "GROUP BY table FORMAT JSON"
-        )
-        if resp.status_code == 200:
-            for row in resp.json().get("data", []):
-                parts = int(row.get("parts", 0))
-                if parts > 300:
-                    logger.warning(
-                        "ClickHouse table %s has %s active parts — merges may be falling behind",
-                        row["table"],
-                        parts,
-                    )
-    except Exception as e:
-        logger.debug("Part health check failed: %s", e)
-
-
-async def generate_insight_report(ctx: dict, report_id: str):
-    """Background job: generate an insight report for an agent."""
-    from services.insights import INSIGHTS_AVAILABLE
-
-    if not INSIGHTS_AVAILABLE:
-        logger.warning("insight_report_skipped", reason="package not installed")
-        return
-
-    logger.info("insight_report_started", report_id=report_id)
-    try:
-        from services.insights import _run_single_report
-
-        if _run_single_report is None:
-            logger.warning("insight_report_skipped", reason="license not valid")
-            return
-        await _run_single_report(report_id)
-    except Exception as e:
-        logger.exception("insight_report_job_failed", report_id=report_id, error=str(e))
-
-
-async def batch_generate_insights(ctx: dict):
-    """Cron job: discover agents needing reports and queue generation."""
-    from services.insights import INSIGHTS_AVAILABLE
-
-    if not INSIGHTS_AVAILABLE:
-        return
-
-    from services.insights import _discover_and_queue
-
-    if _discover_and_queue is None:
-        return
-
-    try:
-        queued = await _discover_and_queue()
-        if queued > 0:
-            logger.info("insight_batch_queued_reports", count=queued)
-    except Exception as e:
-        logger.exception("insight_batch_failed", error=str(e))
-
-
-async def refresh_model_catalog(ctx: dict):
-    """Cron job: pre-warm the model catalog so user requests never hit a cold cache."""
-    from services.model_catalog import get_catalog
-
-    try:
-        cat = await get_catalog(force_refresh=True)
-        logger.info(
-            "model_catalog_prewarm",
-            source=cat.source,
-            count=cat.model_count,
-            degraded=cat.degraded,
-        )
-    except Exception as e:
-        logger.warning("model_catalog_prewarm_failed", error=str(e))
 
 
 async def startup(ctx: dict):

--- a/tests/test_clickhouse_resource_tuning.py
+++ b/tests/test_clickhouse_resource_tuning.py
@@ -427,7 +427,7 @@ class TestMaintainClickhouse:
 
         with (
             patch("services.clickhouse.client._query", side_effect=_parts_query),
-            patch("worker.logger") as mock_logger,
+            patch("jobs.maintenance.logger") as mock_logger,
         ):
             from worker import maintain_clickhouse
 

--- a/tests/test_worker_phase5.py
+++ b/tests/test_worker_phase5.py
@@ -120,7 +120,7 @@ class TestRunEval:
         with (
             patch("services.eval.eval_service.fetch_traces", new_callable=AsyncMock, return_value=mock_traces),
             patch("services.eval.eval_service.evaluate_trace", new_callable=AsyncMock, return_value=mock_result),
-            patch("worker.publish", new_callable=AsyncMock) as mock_pub,
+            patch("services.redis.publish", new_callable=AsyncMock) as mock_pub,
         ):
             await run_eval({}, "agent-1", "t1")
             mock_pub.assert_called_once()


### PR DESCRIPTION
## Purpose / Description

Split the monolithic `worker.py` (231 lines) into domain-specific job modules under `jobs/`. This is Phase S2 of the codebase refactoring plan (`refactor.md`).

## Fixes

* Addresses Phase S2 requirements from the refactoring plan

## Approach

Extract job functions from `worker.py` into three domain modules:

- `jobs/eval.py`: `run_eval` (background eval job)
- `jobs/maintenance.py`: `sync_component_sources`, `maintain_clickhouse` (periodic maintenance)
- `jobs/catalog.py`: `generate_insight_report`, `batch_generate_insights`, `refresh_model_catalog` (catalog and insights jobs)

`worker.py` retains only:
- arq `WorkerSettings` (functions list, cron schedule)
- `startup`/`shutdown` hooks
- Job registration imports

Each job module is independently importable and testable. No module imports from `ee/` directly.

## How Has This Been Tested?

- `pytest tests/test_worker_phase5.py`: 18 passed
- Full test suite (excluding hypothesis/click optional deps): 2556 passed, 24 skipped
- The 2 failures are pre-existing (unrelated to this change): one from local `.env` polluting enterprise mode, one from a moved logger patch target (fixed in this PR)

## Learning

Python `mock.patch` targets a name binding on a specific module. When functions move between modules, patch targets must follow. Two test patch targets updated:
- `worker.publish` to `services.redis.publish`
- `worker.logger` to `jobs.maintenance.logger`

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

**AI tool used:** Claude (Anthropic) for mechanical code extraction and test verification.