### PR TITLE
docs(env): add OBSERVAL_LICENSE_KEY to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -265,3 +265,12 @@ DEMO_USER_PASSWORD=user-changeme
 # Grafana admin credentials (Grafana container only)
 # GRAFANA_ADMIN_USER=admin
 # GRAFANA_ADMIN_PASSWORD=admin
+
+
+# -----------------------------------------------------------------------------
+# Enterprise License
+# Required for ee/ features (exec dashboard, SAML SSO, SCIM provisioning).
+# Leave blank for open-source core only.
+# -----------------------------------------------------------------------------
+
+# OBSERVAL_LICENSE_KEY=


### PR DESCRIPTION
## Purpose / Description

Add the `OBSERVAL_LICENSE_KEY` variable to `.env.example` so contributors know where to configure their enterprise license.

## Fixes

N/A

## Approach

Appended a documented, commented-out entry at the bottom of `.env.example`.

## How Has This Been Tested?

Documentation-only change, no runtime impact.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)