### PR TITLE
docs(env): uncomment SAML and license vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,17 +102,17 @@ OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRET=
 OAUTH_SERVER_METADATA_URL=
 
-# SAML 2.0 (enterprise mode only — leave blank to disable)
-# SAML_IDP_ENTITY_ID=
-# SAML_IDP_SSO_URL=
-# SAML_IDP_SLO_URL=
-# SAML_IDP_X509_CERT=
-# SAML_IDP_METADATA_URL=
-# SAML_SP_ENTITY_ID=
-# SAML_SP_ACS_URL=
-# SAML_JIT_PROVISIONING=true
-# SAML_DEFAULT_ROLE=user
-# SAML_SP_KEY_ENCRYPTION_PASSWORD=
+# SAML 2.0 (enterprise mode only, leave blank to disable)
+SAML_IDP_ENTITY_ID=
+SAML_IDP_SSO_URL=
+SAML_IDP_SLO_URL=
+SAML_IDP_X509_CERT=
+SAML_IDP_METADATA_URL=
+SAML_SP_ENTITY_ID=
+SAML_SP_ACS_URL=
+SAML_JIT_PROVISIONING=true
+SAML_DEFAULT_ROLE=user
+SAML_SP_KEY_ENCRYPTION_PASSWORD=
 
 
 # -----------------------------------------------------------------------------
@@ -273,4 +273,4 @@ DEMO_USER_PASSWORD=user-changeme
 # Leave blank for open-source core only.
 # -----------------------------------------------------------------------------
 
-# OBSERVAL_LICENSE_KEY=
+OBSERVAL_LICENSE_KEY=


### PR DESCRIPTION
## Purpose / Description

Commented-out vars are harder to discover and fill in. Uncomment SAML and license key variables with blank values so users can see what is available and fill in directly.

## Fixes

N/A

## Approach

Changed `# SAML_IDP_ENTITY_ID=` style to `SAML_IDP_ENTITY_ID=` (blank but visible). Same for `OBSERVAL_LICENSE_KEY`.

## How Has This Been Tested?

Documentation-only change, no runtime impact. Blank values are equivalent to unset for all affected variables.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)