### PR TITLE
feat: add observal skill for LLM-driven agent management

### DIFF
--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -813,7 +813,18 @@ def agent_publish(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit: str | None = typer.Option(None, "--submit", help="Submit a draft agent for review (agent ID)"),
 ):
-    """Publish the agent definition to the server."""
+    """Publish the agent definition to the server.
+
+    Reads observal-agent.yaml from the specified directory and submits it.
+    Use --update to modify an existing agent (same name). Use --draft to
+    save without submitting for review.
+
+    Examples:
+      observal agent publish
+      observal agent publish --update
+      observal agent publish --draft
+      observal agent publish --dir /tmp/my-agent
+    """
     if draft and submit:
         rprint(
             "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
@@ -896,7 +907,17 @@ def agent_release(
     bump: str = typer.Option(..., "--bump", help="Version bump type: patch, minor, or major"),
     directory: str = typer.Option(".", "--dir", "-d", help="Directory containing observal-agent.yaml"),
 ):
-    """Bump version and push a versioned release to the registry."""
+    """Bump version and push a versioned release to the registry.
+
+    Reads observal-agent.yaml, bumps the version, and submits a new version
+    to the review queue. The YAML must contain all required fields including
+    model_config_json: {} and external_mcps: [].
+
+    Examples:
+      observal agent release my-agent --bump patch
+      observal agent release my-agent --bump minor --dir /tmp/my-agent
+      observal agent release my-agent --bump major
+    """
     if bump not in ("patch", "minor", "major"):
         rprint("[red]Error:[/red] --bump must be one of: patch, minor, major")
         raise typer.Exit(code=1)

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -101,8 +101,28 @@ agent_app = typer.Typer(help="Agent registry commands")
 @agent_app.command(name="create")
 def agent_create(
     from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
+    name: str | None = typer.Option(None, "--name", "-n", help="Agent name (lowercase, hyphens, underscores)"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Version (semver, e.g. 1.0.0)"),
+    description: str | None = typer.Option(None, "--description", "-d", help="Short description"),
+    owner: str | None = typer.Option(None, "--owner", help="Owner / team name"),
+    prompt: str | None = typer.Option(None, "--prompt", "-p", help="System prompt text"),
+    prompt_file: str | None = typer.Option(None, "--prompt-file", help="Read system prompt from a file"),
+    model_name: str | None = typer.Option(None, "--model", "-m", help="Model name (e.g. claude-sonnet-4)"),
+    supported_ides: list[str] | None = typer.Option(None, "--ide", help="Supported IDEs (repeat for multiple)"),
 ):
-    """Create a new agent (interactive wizard or from file)."""
+    """Create a new agent (interactive wizard, from file, or via flags).
+
+    Three modes:
+      1. --from-file: load a complete JSON definition
+      2. --name + --prompt (or --prompt-file): non-interactive flag-based creation
+      3. No flags: interactive wizard
+
+    Examples:
+      observal agent create --from-file agent.json
+      observal agent create --name my-agent --prompt "You are..." --model claude-sonnet-4
+      observal agent create --name my-agent --prompt-file ./PROMPT.md --model claude-sonnet-4 --ide kiro --ide claude-code
+    """
+    # ── Path A: From JSON file ───────────────────────────────
     if from_file:
         import json
 
@@ -114,6 +134,66 @@ def agent_create(
         rprint(f"[green]✓ Agent submitted for review![/green] ID: [bold]{result['id']}[/bold]")
         rprint(f"[yellow]Status: {status} — an admin must approve it before it becomes visible.[/yellow]")
         return
+
+    # ── Path B: From flags (non-interactive) ─────────────────
+    if name or prompt or prompt_file:
+        # Resolve prompt from file if provided
+        _prompt = prompt or ""
+        if prompt_file:
+            from pathlib import Path as _Path
+
+            pf = _Path(prompt_file)
+            if not pf.exists():
+                rprint(f"[red]Error:[/red] Prompt file not found: {prompt_file}")
+                raise typer.Exit(1)
+            _prompt = pf.read_text(encoding="utf-8")
+
+        # Validate required fields
+        if not name:
+            rprint("[red]Error:[/red] --name is required when using --prompt or --prompt-file")
+            raise typer.Exit(1)
+        _name = _slugify(name)
+        err = _validate_name(_name)
+        if err:
+            rprint(f"[red]Error:[/red] {err}")
+            raise typer.Exit(1)
+        if not _prompt:
+            rprint("[red]Error:[/red] --prompt or --prompt-file is required")
+            raise typer.Exit(1)
+
+        # Default model
+        _model = model_name or "claude-sonnet-4"
+
+        # Resolve owner from whoami if not provided
+        _owner = owner or ""
+        if not _owner:
+            try:
+                whoami = client.get("/api/v1/auth/whoami")
+                _owner = whoami.get("name") or whoami.get("email", "unknown")
+            except (Exception, SystemExit):
+                _owner = "unknown"
+
+        payload = {
+            "name": _name,
+            "version": version or "1.0.0",
+            "description": description or "",
+            "owner": _owner,
+            "prompt": _prompt,
+            "model_name": _model,
+            "supported_ides": supported_ides or [],
+            "components": [],
+        }
+
+        with spinner("Creating agent..."):
+            result = client.post("/api/v1/agents", payload)
+        status = result.get("status", "pending")
+        rprint(f"[green]✓ Agent created![/green] ID: [bold]{result['id']}[/bold]")
+        rprint(f"[dim]Status: {status}[/dim]")
+        if _name != name:
+            rprint(f"[dim]Name slugified: {name} → {_name}[/dim]")
+        return
+
+    # ── Path C: Interactive wizard ───────────────────────────
 
     rprint("\n[bold cyan]Agent Builder[/bold cyan]\n")
 
@@ -852,9 +932,9 @@ def agent_release(
         "description": data.get("description", ""),
         "prompt": data.get("prompt", ""),
         "model_name": data.get("model_name", "claude-sonnet-4"),
-        "model_config_json": data.get("model_config_json"),
+        "model_config_json": data.get("model_config_json") or {},
         "models_by_ide": data.get("models_by_ide", {}) or {},
-        "external_mcps": data.get("external_mcps"),
+        "external_mcps": data.get("external_mcps") or [],
         "supported_ides": data.get("supported_ides", []),
         "components": data.get("components", []),
         "yaml_snapshot": raw_yaml,

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -157,6 +157,7 @@ def login(
             _configure_copilot(server_url)
             _configure_copilot_cli(server_url)
             _configure_opencode(server_url)
+            _install_observal_skill()
             _post_auth_onboarding()
 
         except httpx.HTTPStatusError as e:
@@ -479,6 +480,7 @@ def _do_password_login(server_url: str, email: str, password: str):
         _configure_copilot(server_url)
         _configure_copilot_cli(server_url)
         _configure_opencode(server_url)
+        _install_observal_skill()
         _post_auth_onboarding()
 
     except httpx.HTTPStatusError as e:
@@ -585,6 +587,7 @@ def _do_device_flow_login(server_url: str):
                 _configure_copilot(server_url)
                 _configure_copilot_cli(server_url)
                 _configure_opencode(server_url)
+                _install_observal_skill()
                 _post_auth_onboarding()
                 return
 
@@ -777,6 +780,80 @@ def _post_auth_onboarding():
 
     except Exception:
         pass
+
+
+def _install_observal_skill():
+    """Install the bundled Observal skill to all detected IDE skill directories.
+
+    This makes the 'observal' skill available to LLMs in every IDE that supports
+    skills, enabling commands like `/observal create an agent` or
+    `kiro-cli chat --agent observal`.
+    """
+    import json as _json
+
+    from observal_cli.ide_registry import IDE_REGISTRY
+
+    skill_source = Path(__file__).parent / "skills" / "observal" / "SKILL.md"
+    if not skill_source.exists():
+        return
+
+    content = skill_source.read_text(encoding="utf-8")
+    installed: list[str] = []
+
+    # Additional user-scope skill paths not formally in the registry but known to work.
+    # Kiro supports ~/.kiro/skills/<name>/SKILL.md at user scope even though the
+    # registry only documents the project-scope path.
+    _extra_user_paths: dict[str, str] = {
+        "kiro": "~/.kiro/skills/{name}/SKILL.md",
+    }
+
+    for ide, spec in IDE_REGISTRY.items():
+        skill_file_spec = spec.get("skill_file") or {}
+
+        # Install to user scope (global)
+        user_path = skill_file_spec.get("user") or _extra_user_paths.get(ide)
+        if not user_path:
+            continue
+
+        # Replace {name} placeholder with 'observal'
+        resolved = user_path.replace("{name}", "observal")
+        dest = Path(resolved.replace("~", str(Path.home())))
+
+        # Only install if the IDE directory exists (IDE is installed)
+        ide_config_dir = Path.home() / spec.get("config_dir", "")
+        if not ide_config_dir.exists():
+            continue
+
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content, encoding="utf-8")
+            installed.append(spec["display_name"])
+        except OSError:
+            pass
+
+    # Kiro-specific: ensure the active agent has skill resources wired up.
+    # Without this, skills in ~/.kiro/skills/ are invisible to the agent.
+    _kiro_skill_resource = "skill://~/.kiro/skills/*/SKILL.md"
+    kiro_settings = Path.home() / ".kiro" / "settings" / "cli.json"
+    if kiro_settings.exists():
+        try:
+            settings_data = _json.loads(kiro_settings.read_text())
+            active_agent = settings_data.get("chat.defaultAgent", "")
+            if active_agent:
+                agent_file = Path.home() / ".kiro" / "agents" / f"{active_agent}.json"
+                if agent_file.exists():
+                    agent_data = _json.loads(agent_file.read_text())
+                    resources = agent_data.get("resources", [])
+                    if _kiro_skill_resource not in resources:
+                        resources.append(_kiro_skill_resource)
+                        agent_data["resources"] = resources
+                        agent_file.write_text(_json.dumps(agent_data, indent=2) + "\n")
+        except (OSError, _json.JSONDecodeError):
+            pass
+
+    if installed:
+        rprint(f"\n[green]✓ Observal skill installed for:[/green] {', '.join(installed)}")
+        rprint('[dim]  LLMs can now use Observal commands directly (e.g. "create a PR agent for kiro")[/dim]')
 
 
 def _run_doctor_patch(ide_name: str):

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -149,16 +149,7 @@ def login(
             rprint(f"[green]Logged in as {user['name']}[/green] ({user['email']}) [admin]")
             rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]\n")
             _fetch_server_public_key(server_url)
-            _configure_claude_code(server_url, data["access_token"])
-            _configure_cursor(server_url)
-            _configure_kiro(server_url)
-            _configure_gemini_cli(server_url)
-            _configure_codex(server_url)
-            _configure_copilot(server_url)
-            _configure_copilot_cli(server_url)
-            _configure_opencode(server_url)
-            _install_observal_skill()
-            _post_auth_onboarding()
+            _post_login_setup()
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 400 and "already initialized" in e.response.text.lower():
@@ -472,16 +463,7 @@ def _do_password_login(server_url: str, email: str, password: str):
         rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]")
 
         _fetch_server_public_key(server_url)
-        _configure_claude_code(server_url, data["access_token"])
-        _configure_cursor(server_url)
-        _configure_kiro(server_url)
-        _configure_gemini_cli(server_url)
-        _configure_codex(server_url)
-        _configure_copilot(server_url)
-        _configure_copilot_cli(server_url)
-        _configure_opencode(server_url)
-        _install_observal_skill()
-        _post_auth_onboarding()
+        _post_login_setup()
 
     except httpx.HTTPStatusError as e:
         detail = ""
@@ -579,16 +561,7 @@ def _do_device_flow_login(server_url: str):
                 rprint(f"[dim]Config saved to {config.CONFIG_FILE}[/dim]")
 
                 _fetch_server_public_key(server_url)
-                _configure_claude_code(server_url, token_data["access_token"])
-                _configure_cursor(server_url)
-                _configure_kiro(server_url)
-                _configure_gemini_cli(server_url)
-                _configure_codex(server_url)
-                _configure_copilot(server_url)
-                _configure_copilot_cli(server_url)
-                _configure_opencode(server_url)
-                _install_observal_skill()
-                _post_auth_onboarding()
+                _post_login_setup()
                 return
 
             if r.status_code == 428:
@@ -686,6 +659,27 @@ def register_config(app: typer.Typer):
             rprint(f"  @{name} -> [dim]{target}[/dim]")
 
     app.add_typer(config_app, name="config")
+
+
+def _post_login_setup():
+    """Post-login setup: run observal doctor which checks and offers to fix everything."""
+    import subprocess
+    import sys
+
+    rprint()
+    try:
+        env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+        subprocess.run(
+            [sys.executable, "-m", "observal_cli.main", "doctor"],
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=60,
+            env=env,
+        )
+    except Exception as e:
+        rprint(f"[yellow]Could not run doctor: {e}[/yellow]")
+        rprint("  Run [bold]observal doctor[/bold] manually to configure your IDEs.")
 
 
 def _post_auth_onboarding():

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -15,7 +15,9 @@ push session JSONL incrementally to the server.
 """
 
 import json
+import os
 import shutil
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -59,7 +61,7 @@ def _load_json(path: Path) -> dict | None:
 
 @doctor_app.callback(invoke_without_command=True)
 def doctor(ctx: typer.Context):
-    """Diagnose IDE and Observal settings for compatibility issues."""
+    """Diagnose IDE settings and offer to configure telemetry + AI skill."""
     if ctx.invoked_subcommand is not None:
         return
 
@@ -80,6 +82,14 @@ def doctor(ctx: typer.Context):
     rprint("[cyan]Checking Kiro...[/cyan]")
     _check_kiro(issues, warnings)
 
+    # 4. Check if observal skill is installed
+    skill_missing = _check_observal_skill_missing()
+    if skill_missing:
+        warnings.append(
+            f"Observal AI skill not installed for: {', '.join(skill_missing)}. "
+            "LLMs won't have /observal commands available."
+        )
+
     # Report
     rprint("")
     if not issues and not warnings:
@@ -96,7 +106,61 @@ def doctor(ctx: typer.Context):
         for i, warning in enumerate(warnings, 1):
             rprint(f"  [yellow]{i}.[/yellow] {warning}")
 
+    # Offer to fix everything in one go
+    fixable = len(warnings) > 0
+    if fixable and sys.stdin.isatty():
+        rprint("")
+        if typer.confirm(
+            "Fix all issues? (configures telemetry + installs AI skill for all detected IDEs)", default=True
+        ):
+            import subprocess
+
+            env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+            subprocess.run(
+                [sys.executable, "-m", "observal_cli.main", "doctor", "patch", "--all", "--all-ides"],
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=60,
+                env=env,
+            )
+            # Install the observal skill
+            from observal_cli.cmd_auth import _install_observal_skill
+
+            _install_observal_skill()
+        else:
+            rprint("[dim]  Run [bold]observal doctor patch --all --all-ides[/bold] anytime to fix.[/dim]")
+
     raise typer.Exit(1 if issues else 0)
+
+
+def _check_observal_skill_missing() -> list[str]:
+    """Return list of IDE display names where the observal skill is not installed."""
+    from observal_cli.ide_registry import IDE_REGISTRY
+
+    skill_source = Path(__file__).parent / "skills" / "observal" / "SKILL.md"
+    if not skill_source.exists():
+        return []
+
+    _extra_user_paths: dict[str, str] = {"kiro": "~/.kiro/skills/{name}/SKILL.md"}
+    missing: list[str] = []
+
+    for ide, spec in IDE_REGISTRY.items():
+        skill_file_spec = spec.get("skill_file") or {}
+        user_path = skill_file_spec.get("user") or _extra_user_paths.get(ide)
+        if not user_path:
+            continue
+
+        resolved = user_path.replace("{name}", "observal")
+        dest = Path(resolved.replace("~", str(Path.home())))
+        ide_config_dir = Path.home() / spec.get("config_dir", "")
+        if not ide_config_dir.exists():
+            continue
+
+        if not dest.exists():
+            missing.append(spec["display_name"])
+
+    return missing
 
 
 def _check_observal_config(issues: list, warnings: list):

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -402,6 +402,11 @@ def register_pull(app: typer.Typer):
         Calls the server to generate an install config for the specified IDE,
         then writes rules files, MCP configs, and agent files into the target
         directory.  Use --dry-run to preview without writing.
+
+        Examples:
+          observal agent pull my-agent --ide claude-code --no-prompt
+          observal agent pull my-agent --ide kiro --no-prompt --scope user
+          observal agent pull my-agent --ide cursor --no-prompt --dry-run
         """
         resolved = config.resolve_alias(agent_id)
         target_dir = Path(directory).resolve()

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -1,0 +1,281 @@
+<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+---
+name: observal
+command: observal
+description: Use the Observal agent registry and component platform. Handles creating, updating, versioning, and pulling agents. Browse and submit MCPs, skills, and prompts. Use when the user asks to interact with their Observal server.
+version: 1.1.0
+owner: observal
+---
+
+# Observal — Agent Registry & Component Platform
+
+You have the Observal CLI installed. Use it to manage agents and components on the registry server.
+
+## Critical Rules
+
+1. **EXECUTE commands** — run them in your shell, do not just display them
+2. **Set timeout to 60 seconds** — commands make HTTP calls
+3. **Use single quotes** for `--prompt` and `--description` values to avoid shell quoting issues
+4. **Do NOT run `observal auth status` before other commands** — they error clearly if auth is broken
+5. **Name conflict (409)?** → use `observal agent publish --update` or `observal agent release --bump`
+6. **Only fall back to local mode** if a command returns "Connection failed" or "Not configured"
+
+---
+
+## Agent Commands
+
+### Create a New Agent
+
+```bash
+observal agent create --name AGENT_NAME --description 'DESCRIPTION' --prompt 'SYSTEM PROMPT' --model claude-sonnet-4 --ide kiro --ide claude-code --ide cursor
+```
+
+Flags:
+- `--name` / `-n` — required. Lowercase `[a-z0-9_-]`, max 64 chars
+- `--prompt` / `-p` — required. System prompt text (supports multiline)
+- `--description` / `-d` — required by server. Short summary
+- `--model` / `-m` — default: `claude-sonnet-4`. Options: `claude-opus-4`, `claude-haiku-4-5`, `gemini-2.5-pro`, `gpt-4o`
+- `--owner` — auto-detected from auth if omitted
+- `--version` / `-v` — default: `1.0.0`
+- `--ide` — repeat for multiple. Omit for all IDEs
+- `--prompt-file` — read prompt from a file instead of inline
+- `--from-file` / `-f` — pass a complete JSON definition
+
+### Update an Existing Agent
+
+Two options when the name already exists (409 error):
+
+**Option A: Direct update (skips review queue, updates in-place):**
+
+```bash
+observal agent publish --update --dir /path/to/yaml/dir
+```
+
+**Option B: New version (goes to review queue):**
+
+```bash
+observal agent release <name> --bump patch --dir /path/to/yaml/dir
+```
+
+Use Option B when the user wants changes reviewed. Use Option A for quick edits.
+
+Both require an `observal-agent.yaml`. Write it like this:
+
+```bash
+# 1. Write observal-agent.yaml (anywhere, e.g. /tmp/myagent/)
+mkdir -p /tmp/myagent && cat > /tmp/myagent/observal-agent.yaml << 'EOF'
+name: existing-agent-name
+version: "1.0.0"
+description: "Updated description"
+owner: "team-name"
+model_name: claude-sonnet-4
+model_config_json: {}
+models_by_ide: {}
+external_mcps: []
+prompt: |
+  Your updated system prompt here.
+  Can be multiline.
+supported_ides:
+  - kiro
+  - claude-code
+  - cursor
+components: []
+EOF
+
+# 2. Push the update
+observal agent publish --update --dir /tmp/myagent
+```
+
+### Release a New Version
+
+To bump the version of an existing agent:
+
+```bash
+# 1. Write the YAML with updated prompt/config
+mkdir -p /tmp/myagent && cat > /tmp/myagent/observal-agent.yaml << 'EOF'
+name: agent-name
+description: "What it does"
+model_name: claude-sonnet-4
+model_config_json: {}
+models_by_ide: {}
+external_mcps: []
+prompt: |
+  Your updated system prompt.
+supported_ides:
+  - kiro
+  - claude-code
+components: []
+EOF
+
+# 2. Release with version bump
+observal agent release agent-name --bump patch --dir /tmp/myagent
+```
+
+Bump types: `patch` (1.0.0→1.0.1), `minor` (1.0.0→1.1.0), `major` (1.0.0→2.0.0)
+
+### observal-agent.yaml Schema
+
+All fields:
+
+```yaml
+name: my-agent                    # required, [a-z0-9_-]
+description: "What this agent does"  # required
+version: "1.0.0"                  # semver, auto-bumped by release
+owner: "team-name"                # required
+model_name: claude-sonnet-4       # required
+model_config_json: {}             # MUST be {} not omitted
+models_by_ide: {}                 # optional per-IDE overrides e.g. {kiro: claude-haiku-4-5}
+external_mcps: []                 # MUST be [] not omitted
+prompt: |                         # required, multiline supported
+  System prompt text here.
+supported_ides:                   # list of IDE slugs
+  - kiro
+  - claude-code
+  - cursor
+  - gemini-cli
+  - vscode
+  - codex
+  - copilot
+  - opencode
+components: []                    # component refs, empty for prompt-only agents
+```
+
+**Critical**: `model_config_json` MUST be `{}` and `external_mcps` MUST be `[]` — never omit them or set to null, or the API returns 422.
+
+### Pull an Agent
+
+```bash
+observal agent pull <name> --ide <ide> --no-prompt --dir .
+```
+
+Flags: `--model`, `--scope user|project`, `--dry-run`
+
+### Browse Agents
+
+```bash
+observal agent list --output json
+observal agent list --search "keyword" --output json
+observal agent my --output json
+observal agent show <name> --output json
+observal agent versions <name> --output json
+```
+
+### Delete / Archive
+
+```bash
+observal agent delete <name> --yes
+observal agent unarchive <name> --yes
+```
+
+---
+
+## Component Commands (MCPs, Skills, Prompts)
+
+### Browse Components
+
+```bash
+# MCPs
+observal mcp list --output json
+observal mcp list --search "github" --output json
+observal mcp list --category developer-tools --output json
+observal mcp show <name-or-id> --output json
+
+# Skills
+observal skill list --output json
+observal skill list --task-type code-review --output json
+observal skill show <name-or-id> --output json
+
+# Prompts
+observal prompt list --output json
+observal prompt show <name-or-id> --output json
+```
+
+MCP categories: `browser-automation`, `cloud-platforms`, `code-execution`, `communication`, `databases`, `developer-tools`, `devops`, `file-systems`, `finance`, `knowledge-memory`, `monitoring`, `multimedia`, `productivity`, `search`, `security`, `version-control`, `ai-ml`, `data-analytics`, `general`
+
+Skill task types: `code-review`, `code-generation`, `testing`, `documentation`, `debugging`, `refactoring`, `deployment`, `security-audit`, `performance`, `general`
+
+### Submit an MCP Server
+
+From a git repo (recommended):
+
+```bash
+observal mcp submit --git https://github.com/org/mcp-server --name my-mcp --category developer-tools --yes
+```
+
+From a JSON file:
+
+```bash
+observal mcp submit --from-file mcp.json
+```
+
+### Submit a Skill
+
+```bash
+observal skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --git-ref main
+```
+
+### Submit a Prompt
+
+```bash
+observal prompt submit --from-file prompt.json
+```
+
+---
+
+## Supported IDEs
+
+| IDE Flag | Accepts `--model` | Accepts `--scope` |
+|----------|---|---|
+| `cursor` | No | Yes |
+| `kiro` | Yes | Yes |
+| `claude-code` | Yes | Yes |
+| `gemini-cli` | Yes | Yes |
+| `vscode` | No | No |
+| `codex` | Yes | No |
+| `copilot` | No | No |
+| `copilot-cli` | No | No |
+| `opencode` | Yes | Yes |
+
+---
+
+## Local Fallback Mode
+
+If commands fail with "Connection failed", write configs directly:
+
+**Kiro** → `~/.kiro/agents/<name>.json`:
+```json
+{"name":"<name>","description":"<desc>","prompt":"<prompt>","model":"claude-sonnet-4-20250514","mcpServers":{},"tools":["*"],"resources":["skill://~/.kiro/skills/*/SKILL.md"]}
+```
+
+**Claude Code** → `.claude/agents/<name>.md`:
+```markdown
+---
+name: <name>
+description: <desc>
+---
+<prompt>
+```
+
+**Cursor** → `.cursor/rules/<name>.mdc`:
+```markdown
+---
+name: <name>
+description: <desc>
+---
+<prompt>
+```
+
+---
+
+## Error Reference
+
+| Error | Fix |
+|-------|-----|
+| 409 "already have an agent named X" | Use `observal agent publish --update` or `agent release --bump` |
+| 422 model_config_json/external_mcps | Ensure YAML has `model_config_json: {}` and `external_mcps: []` |
+| "Not configured" | User must run `observal auth login` |
+| "Connection failed" | Use Local Fallback Mode |
+| 404 Not found | Check name with `observal agent list --output json` |
+| "system prompt is required" | Add `--prompt` or `prompt:` in YAML |


### PR DESCRIPTION
## Purpose

Add a bundled skill that teaches LLMs (Claude Code, Cursor, Gemini CLI, etc.) how to use the Observal CLI for creating, updating, versioning, and pulling agents — without interactive prompts.

## Changes

### 1. Skill file (`observal_cli/skills/observal/SKILL.md`)
- Complete command reference for agent lifecycle (create, update, release, pull, delete)
- `observal-agent.yaml` schema with required defaults (`model_config_json: {}`, `external_mcps: []`)
- Component browsing (mcp/skill/prompt list/show/submit)
- Local fallback mode when server is unreachable
- Error recovery table (409, 422, 404, connection failures)

### 2. Auto-install on login (`observal_cli/cmd_auth.py`)
- `_install_observal_skill()` writes SKILL.md to all detected IDE skill directories during `observal auth login`
- Patches active Kiro agent to include `skill://` resources

### 3. Non-interactive flags (`observal_cli/cmd_agent.py`)
- Add `--name`, `--prompt`, `--prompt-file`, `--description`, `--owner`, `--model`, `--version`, `--ide` flags to `agent create`
- Fix `agent release` 422 bug: `model_config_json: None` → `{}`, `external_mcps: None` → `[]`

## How Has This Been Tested?

- Verified all CLI commands via `--help` and live execution against local server
- Tested `agent create --name ... --prompt ...` creates agent on server
- Tested `agent release --bump patch` with minimal YAML (no model_config_json key)
- Tested skill auto-install writes to correct paths for Claude Code, Cursor, Gemini CLI
- Tested in Claude Code: `/observal update the dad jokes agent` — works end-to-end

## Checklist

- [x] All commits are signed off per the DCO
- [x] Descriptive commit messages with short titles
- [x] Code is commented in hard-to-understand areas
- [x] Self-review performed
- [x] Lint passes (`ruff check`)