### PR TITLE
test(e2e): add Playwright tests for SSO and device auth (#929)

### DIFF
--- a/tests/test_admin_sso_routes.py
+++ b/tests/test_admin_sso_routes.py
@@ -1,0 +1,974 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy <tanvi.reddy330@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused coverage for admin SSO configuration and diagnostics routes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+import api.deps as deps
+from api.routes import admin_sso as sso
+from models.user import UserRole
+from schemas.sso_health import make_check
+from services.security_events import EventType, Severity
+
+FRONTEND_URL = "https://app.example.test"
+CONFIG_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+TOKEN_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+ADMIN_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+SESSION_ID = "diagnostic_session_1"
+IDP_CERT = "fake-idp-certificate"
+PRIVATE_KEY = "fake-sp-private-key"
+ENCRYPTED_KEY = "encrypted-fake-sp-private-key"
+SP_CERT = "fake-sp-certificate"
+CLIENT_SECRET = "fake-oidc-client-secret"
+
+
+def _result(value):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+def _list_result(values):
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = values
+    return result
+
+
+def _db(*results):
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=list(results) if results else [_result(None)])
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.delete = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+def _user(role=UserRole.admin):
+    return SimpleNamespace(
+        id=ADMIN_ID,
+        email="admin@example.test",
+        role=role,
+        auth_provider="local",
+    )
+
+
+def _config(**overrides):
+    values = {
+        "id": CONFIG_ID,
+        "idp_entity_id": "https://idp.example.test/entity",
+        "idp_sso_url": "https://idp.example.test/sso",
+        "idp_slo_url": "https://idp.example.test/slo",
+        "idp_x509_cert": IDP_CERT,
+        "sp_entity_id": f"{FRONTEND_URL}/api/v1/sso/saml/metadata",
+        "sp_acs_url": f"{FRONTEND_URL}/api/v1/sso/saml/acs",
+        "sp_private_key_enc": ENCRYPTED_KEY,
+        "sp_x509_cert": SP_CERT,
+        "external_sp_private_key": None,
+        "jit_provisioning": True,
+        "default_role": "user",
+        "active": True,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "updated_at": datetime(2026, 1, 2, tzinfo=UTC),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.fixture(autouse=True)
+def disable_rate_limiter(monkeypatch):
+    monkeypatch.setattr(sso.limiter, "enabled", False)
+
+
+@pytest.fixture
+def dynamic_settings(monkeypatch):
+    state = SimpleNamespace(
+        values={"deployment.frontend_url": FRONTEND_URL},
+        external=set(),
+    )
+
+    def get_sync(key, default=None):
+        return state.values.get(key, default)
+
+    def get_sync_bool(key, default=False):
+        value = state.values.get(key, default)
+        return value if isinstance(value, bool) else str(value).lower() in {"1", "true", "yes"}
+
+    monkeypatch.setattr(sso.ds, "get_sync", get_sync)
+    monkeypatch.setattr(sso.ds, "get_sync_bool", get_sync_bool)
+    monkeypatch.setattr(sso.ds, "external_setting_keys", lambda: set(state.external))
+    monkeypatch.setattr(sso.ds, "is_externally_managed", lambda key: key in state.external)
+    monkeypatch.setattr(
+        sso.ds,
+        "has_external_saml_material",
+        lambda: "saml.sp_private_key" in state.external,
+    )
+    return state
+
+
+class _RedisStore:
+    def __init__(self):
+        self.values: dict[str, str] = {}
+        self.writes: list[tuple[str, int, str]] = []
+
+    async def setex(self, key: str, ttl: int, value: str):
+        self.values[key] = value
+        self.writes.append((key, ttl, value))
+
+    async def get(self, key: str):
+        return self.values.get(key)
+
+
+@pytest.fixture
+def diagnostic_store(monkeypatch):
+    redis = _RedisStore()
+    monkeypatch.setattr(sso.sso_diagnostics, "get_redis", lambda: redis)
+    monkeypatch.setattr(sso.sso_diagnostics, "new_session_id", lambda: SESSION_ID)
+    monkeypatch.setattr(sso.sso_diagnostics, "time", SimpleNamespace(time=lambda: 1_000.0))
+    return redis
+
+
+def _mock_http_client(monkeypatch):
+    client = MagicMock(name="health-client")
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=client)
+    monkeypatch.setattr(sso.httpx, "AsyncClient", factory)
+    return client, factory
+
+
+async def _http_get_saml_config(user, db):
+    app = FastAPI()
+    app.include_router(sso.router)
+
+    async def override_db():
+        yield db
+
+    app.dependency_overrides[deps.get_db] = override_db
+    if user is not None:
+        app.dependency_overrides[deps.get_current_user] = lambda: user
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as client:
+        return await client.get("/api/v1/admin/saml-config")
+
+
+@pytest.mark.asyncio
+async def test_saml_config_read_masks_material_and_reports_sources(dynamic_settings):
+    dynamic_settings.values.update(
+        {
+            "saml.idp_entity_id": "https://dynamic-idp.example.test/entity",
+            "saml.idp_sso_url": "https://dynamic-idp.example.test/sso",
+            "saml.idp_slo_url": "https://dynamic-idp.example.test/slo",
+            "saml.sp_entity_id": "https://sp.example.test/metadata",
+            "saml.sp_acs_url": "https://sp.example.test/acs",
+            "saml.jit_provisioning": False,
+            "saml.default_role": "reviewer",
+            "saml.idp_x509_cert": IDP_CERT,
+            "saml.sp_private_key": PRIVATE_KEY,
+        }
+    )
+    dynamic_settings.external.update({"saml.idp_x509_cert", "saml.sp_private_key", "saml.sp_x509_cert"})
+    dynamic_db = _db(_result(None))
+
+    response = await sso.get_saml_config(db=dynamic_db, current_user=_user())
+
+    assert response == {
+        "configured": True,
+        "source": "dynamic",
+        "idp_entity_id": "https://dynamic-idp.example.test/entity",
+        "idp_sso_url": "https://dynamic-idp.example.test/sso",
+        "idp_slo_url": "https://dynamic-idp.example.test/slo",
+        "sp_entity_id": "https://sp.example.test/metadata",
+        "sp_acs_url": "https://sp.example.test/acs",
+        "jit_provisioning": False,
+        "default_role": "reviewer",
+        "has_idp_cert": True,
+        "has_sp_key": True,
+        "externally_managed": ["saml.idp_x509_cert", "saml.sp_private_key", "saml.sp_x509_cert"],
+    }
+    assert IDP_CERT not in json.dumps(response)
+    assert PRIVATE_KEY not in json.dumps(response)
+
+    stored = _config(idp_x509_cert="", sp_private_key_enc="")
+    database_db = _db(_result(stored))
+    database_response = await sso.get_saml_config(db=database_db, current_user=_user())
+
+    assert database_response["source"] == "database+files"
+    assert database_response["has_idp_cert"] is True
+    assert database_response["has_sp_key"] is True
+    assert database_response["created_at"] == "2026-01-01T00:00:00+00:00"
+    assert database_response["updated_at"] == "2026-01-02T00:00:00+00:00"
+    statement = str(database_db.execute.await_args.args[0]).lower()
+    assert "saml_configs.active is true" in statement
+
+
+@pytest.mark.asyncio
+async def test_saml_config_read_reports_unconfigured_without_leaking_defaults(dynamic_settings):
+    response = await sso.get_saml_config(db=_db(_result(None)), current_user=_user())
+
+    assert response["configured"] is False
+    assert response["source"] == "none"
+    assert response["idp_entity_id"] is None
+    assert response["has_idp_cert"] is False
+    assert response["has_sp_key"] is False
+
+
+@pytest.mark.parametrize(
+    ("external", "body", "detail"),
+    [
+        (
+            {"saml.idp_x509_cert"},
+            {"idp_entity_id": "entity", "idp_sso_url": "https://idp.example.test/sso", "idp_x509_cert": IDP_CERT},
+            "SAML IdP certificate is externally managed by a secret file",
+        ),
+        (
+            {"saml.sp_private_key"},
+            {
+                "idp_entity_id": "entity",
+                "idp_sso_url": "https://idp.example.test/sso",
+                "idp_x509_cert": IDP_CERT,
+                "regenerate_sp_key": True,
+            },
+            "SAML SP key and certificate are externally managed by secret files",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_saml_update_rejects_external_file_managed_material(dynamic_settings, external, body, detail):
+    dynamic_settings.external.update(external)
+    db = _db()
+
+    with pytest.raises(HTTPException) as error:
+        await sso.upsert_saml_config(body, db=db, current_user=_user())
+
+    assert error.value.status_code == 409
+    assert error.value.detail == detail
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},
+        {"idp_entity_id": "entity", "idp_sso_url": "https://idp.example.test/sso"},
+        {"idp_entity_id": "entity", "idp_x509_cert": IDP_CERT},
+    ],
+)
+@pytest.mark.asyncio
+async def test_saml_update_validates_required_fields(dynamic_settings, body):
+    with pytest.raises(HTTPException) as error:
+        await sso.upsert_saml_config(body, db=_db(), current_user=_user())
+
+    assert error.value.status_code == 422
+    assert error.value.detail == "idp_entity_id, idp_sso_url, and idp_x509_cert are required"
+
+
+@pytest.mark.asyncio
+async def test_saml_create_generates_encrypts_persists_and_audits(monkeypatch, dynamic_settings):
+    dynamic_settings.values["saml.sp_key_encryption_password"] = "fake-encryption-password"
+    db = _db(_result(None))
+
+    async def refresh(config):
+        config.id = CONFIG_ID
+
+    db.refresh.side_effect = refresh
+    generate = MagicMock(return_value=(PRIVATE_KEY, SP_CERT))
+    encrypt = MagicMock(return_value=ENCRYPTED_KEY)
+    emit = AsyncMock()
+    monkeypatch.setattr(sso, "generate_sp_key_pair", generate)
+    monkeypatch.setattr(sso, "encrypt_private_key", encrypt)
+    monkeypatch.setattr(sso, "emit_security_event", emit)
+
+    response = await sso.upsert_saml_config(
+        {
+            "idp_entity_id": "https://idp.example.test/entity",
+            "idp_sso_url": "https://idp.example.test/sso",
+            "idp_x509_cert": IDP_CERT,
+        },
+        db=db,
+        current_user=_user(),
+    )
+
+    expected_entity = f"{FRONTEND_URL}/api/v1/sso/saml/metadata"
+    expected_acs = f"{FRONTEND_URL}/api/v1/sso/saml/acs"
+    generate.assert_called_once_with(common_name=expected_entity)
+    encrypt.assert_called_once_with(PRIVATE_KEY, "fake-encryption-password")
+    config = db.add.call_args.args[0]
+    assert config.idp_x509_cert == IDP_CERT
+    assert config.sp_private_key_enc == ENCRYPTED_KEY
+    assert config.sp_x509_cert == SP_CERT
+    assert config.sp_entity_id == expected_entity
+    assert config.sp_acs_url == expected_acs
+    assert config.jit_provisioning is True
+    assert config.default_role == "user"
+    assert config.active is True
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once_with(config)
+    assert PRIVATE_KEY not in json.dumps(response)
+    assert IDP_CERT not in json.dumps(response)
+    assert response["message"] == "SAML configuration saved"
+
+    event = emit.await_args.args[0]
+    assert event.event_type == EventType.SETTING_CHANGED
+    assert event.severity == Severity.WARNING
+    assert event.actor_id == str(ADMIN_ID)
+    assert event.actor_role == "admin"
+    assert event.target_id == str(CONFIG_ID)
+    assert event.target_type == "saml_config"
+    assert event.detail == "SAML configuration updated"
+
+
+@pytest.mark.asyncio
+async def test_saml_update_preserves_key_and_applies_activation_fields(monkeypatch, dynamic_settings):
+    existing = _config(idp_slo_url=None, default_role="reviewer")
+    original_key = existing.sp_private_key_enc
+    original_cert = existing.sp_x509_cert
+    db = _db(_result(existing))
+    generate = MagicMock()
+    emit = AsyncMock()
+    monkeypatch.setattr(sso, "generate_sp_key_pair", generate)
+    monkeypatch.setattr(sso, "emit_security_event", emit)
+
+    response = await sso.upsert_saml_config(
+        {
+            "idp_entity_id": "https://new-idp.example.test/entity",
+            "idp_sso_url": "https://new-idp.example.test/sso",
+            "idp_x509_cert": "replacement-fake-certificate",
+            "jit_provisioning": False,
+            "default_role": "user",
+            "active": False,
+        },
+        db=db,
+        current_user=_user(),
+    )
+
+    assert existing.idp_slo_url == ""
+    assert existing.sp_private_key_enc == original_key
+    assert existing.sp_x509_cert == original_cert
+    assert existing.jit_provisioning is False
+    assert existing.default_role == "user"
+    assert existing.active is False
+    assert response["active"] is False
+    generate.assert_not_called()
+    db.add.assert_not_called()
+    db.commit.assert_awaited_once()
+    emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_saml_update_regenerates_encrypted_key(monkeypatch, dynamic_settings):
+    dynamic_settings.values["saml.sp_key_encryption_password"] = "fake-encryption-password"
+    existing = _config()
+    db = _db(_result(existing))
+    generate = MagicMock(return_value=("replacement-fake-private-key", "replacement-fake-sp-cert"))
+    encrypt = MagicMock(return_value="replacement-encrypted-key")
+    monkeypatch.setattr(sso, "generate_sp_key_pair", generate)
+    monkeypatch.setattr(sso, "encrypt_private_key", encrypt)
+    monkeypatch.setattr(sso, "emit_security_event", AsyncMock())
+
+    await sso.upsert_saml_config(
+        {
+            "idp_entity_id": existing.idp_entity_id,
+            "idp_sso_url": existing.idp_sso_url,
+            "idp_x509_cert": IDP_CERT,
+            "sp_entity_id": "https://custom-sp.example.test/metadata",
+            "sp_acs_url": "https://custom-sp.example.test/acs",
+            "regenerate_sp_key": True,
+        },
+        db=db,
+        current_user=_user(),
+    )
+
+    generate.assert_called_once_with(common_name="https://custom-sp.example.test/metadata")
+    encrypt.assert_called_once_with("replacement-fake-private-key", "fake-encryption-password")
+    assert existing.sp_private_key_enc == "replacement-encrypted-key"
+    assert existing.sp_x509_cert == "replacement-fake-sp-cert"
+
+
+@pytest.mark.asyncio
+async def test_saml_delete_handles_missing_and_audits_success(monkeypatch, dynamic_settings):
+    with pytest.raises(HTTPException) as error:
+        await sso.delete_saml_config(db=_db(_result(None)), current_user=_user())
+    assert error.value.status_code == 404
+
+    config = _config()
+    db = _db(_result(config))
+    emit = AsyncMock()
+    monkeypatch.setattr(sso, "emit_security_event", emit)
+
+    response = await sso.delete_saml_config(db=db, current_user=_user())
+
+    assert response == {"deleted": str(CONFIG_ID)}
+    db.delete.assert_awaited_once_with(config)
+    db.commit.assert_awaited_once()
+    event = emit.await_args.args[0]
+    assert event.severity == Severity.WARNING
+    assert event.target_id == str(CONFIG_ID)
+    assert event.detail == "SAML configuration deleted"
+
+
+@pytest.mark.parametrize(
+    ("values", "error"),
+    [
+        ({}, "oauth.client_id or oauth.client_secret not configured"),
+        (
+            {"oauth.client_id": "client", "oauth.client_secret": CLIENT_SECRET},
+            "oauth.server_metadata_url not configured",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_validate_oidc_configuration_gates(dynamic_settings, values, error):
+    dynamic_settings.values.update(values)
+
+    response = await sso.validate_oidc(current_user=_user())
+
+    assert response["success"] is False
+    assert response["error"] == error
+    assert response["checks"] == []
+    assert CLIENT_SECRET not in json.dumps(response)
+
+
+@pytest.mark.parametrize("passes", [True, False])
+@pytest.mark.asyncio
+async def test_validate_oidc_returns_deterministic_health_report(monkeypatch, dynamic_settings, passes):
+    metadata_url = "https://idp.example.test/.well-known/openid-configuration"
+    dynamic_settings.values.update(
+        {
+            "oauth.client_id": "client-id",
+            "oauth.client_secret": CLIENT_SECRET,
+            "oauth.server_metadata_url": metadata_url,
+            "deployment.frontend_url": f"{FRONTEND_URL}/",
+        }
+    )
+    checks = [
+        make_check(
+            "discovery_doc",
+            "OIDC discovery",
+            "pass" if passes else "fail",
+            None if passes else "Discovery failed safely.",
+            None if passes else "Check the configured URL.",
+        )
+    ]
+    run_checks = AsyncMock(return_value=(checks, {"issuer": "https://idp.example.test"}))
+    monkeypatch.setattr(sso, "run_oidc_checks", run_checks)
+    monkeypatch.setattr(sso, "time", SimpleNamespace(monotonic=MagicMock(side_effect=[10.0, 10.012])))
+
+    response = await sso.validate_oidc(current_user=_user())
+
+    assert response["success"] is passes
+    assert response["issuer"] == "https://idp.example.test"
+    assert response["checks"] == checks
+    assert response["latency_ms"] == 12
+    if passes:
+        assert "error" not in response
+    else:
+        assert response["error"] == "Discovery failed safely."
+        assert response["hint"] == "Check the configured URL."
+    run_checks.assert_awaited_once_with(
+        metadata_url,
+        "client-id",
+        CLIENT_SECRET,
+        f"{FRONTEND_URL}/api/v1/auth/oauth/callback",
+    )
+    assert CLIENT_SECRET not in json.dumps(response)
+
+
+@pytest.mark.asyncio
+async def test_runtime_and_required_field_checks_report_login_gates(monkeypatch):
+    validator = AsyncMock(side_effect=[[], ["frontend origin invalid", "encryption password missing"]])
+    monkeypatch.setattr(sso, "validate_runtime_config_async", validator)
+
+    passed = await sso._runtime_config_check()
+    failed = await sso._runtime_config_check()
+
+    assert passed["status"] == "pass"
+    assert failed["status"] == "fail"
+    assert failed["message"] == "frontend origin invalid; encryption password missing"
+    assert "503" in failed["hint"]
+
+    missing = sso._required_field_check(
+        _config(idp_entity_id="", sp_private_key_enc="", external_sp_private_key="external-fake-key")
+    )
+    assert missing["status"] == "fail"
+    assert missing["message"] == "Missing: IdP Entity ID."
+    assert (
+        sso._required_field_check(_config(sp_private_key_enc="", external_sp_private_key="external-fake-key")) is None
+    )
+    assert sso._first_failure([make_check("ok", "Healthy", "pass")]) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_validate_saml_handles_absent_incomplete_and_undecryptable_config(monkeypatch, dynamic_settings):
+    get_config = AsyncMock(return_value=None)
+    monkeypatch.setattr(sso, "_get_saml_config", get_config)
+    missing = await sso.validate_saml(db=_db(), current_user=_user())
+    assert missing["error"] == "SAML is not configured"
+
+    get_config.return_value = _config(sp_acs_url="")
+    incomplete = await sso.validate_saml(db=_db(), current_user=_user())
+    assert incomplete["error"] == "Missing: SP ACS URL."
+    assert incomplete["checks"][0]["name"] == "required_fields"
+
+    leaked_detail = "fake decryption detail that must stay private"
+    get_config.return_value = _config()
+    monkeypatch.setattr(sso, "_decrypt_sp_key", MagicMock(side_effect=ValueError(leaked_detail)))
+    failed = await sso.validate_saml(db=_db(), current_user=_user())
+    assert failed["error"] == "Failed to decrypt SP private key"
+    assert leaked_detail not in json.dumps(failed)
+    assert failed["checks"][0]["name"] == "sp_key_decrypt"
+
+
+@pytest.mark.parametrize("passes", [True, False])
+@pytest.mark.asyncio
+async def test_validate_saml_runs_runtime_and_protocol_health(monkeypatch, dynamic_settings, passes):
+    config = _config()
+    suite = [
+        make_check(
+            "idp_reachable",
+            "IdP reachable",
+            "pass" if passes else "fail",
+            None if passes else "IdP did not respond.",
+            None if passes else "Check IdP networking.",
+        )
+    ]
+    monkeypatch.setattr(sso, "_get_saml_config", AsyncMock(return_value=config))
+    monkeypatch.setattr(sso, "_decrypt_sp_key", MagicMock(return_value=PRIVATE_KEY))
+    monkeypatch.setattr(sso, "_run_saml_check_suite", AsyncMock(return_value=suite))
+    monkeypatch.setattr(
+        sso,
+        "_runtime_config_check",
+        AsyncMock(return_value=make_check("runtime_config", "Runtime config", "pass")),
+    )
+    monkeypatch.setattr(sso, "time", SimpleNamespace(monotonic=MagicMock(side_effect=[20.0, 20.009])))
+    client, factory = _mock_http_client(monkeypatch)
+
+    response = await sso.validate_saml(db=_db(), current_user=_user())
+
+    assert response["success"] is passes
+    assert response["idp_entity_id"] == config.idp_entity_id
+    assert response["latency_ms"] == 9
+    assert [check["name"] for check in response["checks"][:2]] == ["runtime_config", "sp_key_decrypt"]
+    if passes:
+        assert "error" not in response
+    else:
+        assert response["error"] == "IdP did not respond."
+        assert response["hint"] == "Check IdP networking."
+    factory.assert_called_once_with(timeout=10.0, follow_redirects=False)
+    sso._run_saml_check_suite.assert_awaited_once_with(config, PRIVATE_KEY, FRONTEND_URL, client)
+
+
+@pytest.mark.asyncio
+async def test_oidc_e2e_start_reports_preflight_failures_without_staging(monkeypatch, dynamic_settings):
+    dynamic_settings.values.update(
+        {
+            "oauth.client_id": "client-id",
+            "oauth.client_secret": CLIENT_SECRET,
+            "oauth.server_metadata_url": "https://idp.example.test/discovery",
+        }
+    )
+    failure = make_check("authorization_endpoint", "Authorization", "fail", "Redirect rejected.", "Fix redirect URI.")
+    monkeypatch.setattr(sso, "run_oidc_checks", AsyncMock(return_value=([failure], {})))
+    create = AsyncMock()
+    monkeypatch.setattr(sso.sso_diagnostics, "create_session", create)
+
+    response = await sso.e2e_oidc_start(request=MagicMock(), current_user=_user())
+
+    assert response["success"] is False
+    assert response["error"] == "Redirect rejected."
+    assert response["hint"] == "Fix redirect URI."
+    create.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("settings", "metadata", "error"),
+    [
+        ({}, None, "OIDC is not configured on the server"),
+        (
+            {
+                "oauth.client_id": "client-id",
+                "oauth.server_metadata_url": "https://idp.example.test/discovery",
+            },
+            None,
+            "OIDC discovery document missing despite passing probes",
+        ),
+        (
+            {
+                "oauth.client_id": "client-id",
+                "oauth.server_metadata_url": "https://idp.example.test/discovery",
+            },
+            {"issuer": "https://idp.example.test"},
+            "Discovery document is missing authorization_endpoint",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_oidc_e2e_start_handles_configuration_and_discovery_gates(
+    monkeypatch,
+    dynamic_settings,
+    settings,
+    metadata,
+    error,
+):
+    dynamic_settings.values.update(settings)
+    checks = [make_check("discovery", "Discovery", "pass")]
+    run_checks = AsyncMock(return_value=(checks, metadata))
+    monkeypatch.setattr(sso, "run_oidc_checks", run_checks)
+
+    response = await sso.e2e_oidc_start(request=MagicMock(), current_user=_user())
+
+    assert response["success"] is False
+    assert response["error"] == error
+    if not settings:
+        run_checks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oidc_e2e_start_persists_redis_session_and_returns_safe_status(
+    monkeypatch,
+    dynamic_settings,
+    diagnostic_store,
+):
+    metadata_url = "https://idp.example.test/discovery"
+    authorization_endpoint = "https://idp.example.test/authorize"
+    dynamic_settings.values.update(
+        {
+            "oauth.client_id": "client-id",
+            "oauth.client_secret": CLIENT_SECRET,
+            "oauth.server_metadata_url": metadata_url,
+            "deployment.frontend_url": f"{FRONTEND_URL}/",
+        }
+    )
+    checks = [make_check("discovery", "Discovery", "pass")]
+    metadata = {
+        "authorization_endpoint": authorization_endpoint,
+        "token_endpoint": "https://idp.example.test/token",
+        "jwks_uri": "https://idp.example.test/jwks",
+        "issuer": "https://idp.example.test",
+    }
+    monkeypatch.setattr(sso, "run_oidc_checks", AsyncMock(return_value=(checks, metadata)))
+    monkeypatch.setattr(sso, "secrets", SimpleNamespace(token_urlsafe=lambda _size: "fake-diagnostic-nonce"))
+
+    response = await sso.e2e_oidc_start(request=MagicMock(), current_user=_user())
+
+    assert response["success"] is True
+    assert response["session_id"] == SESSION_ID
+    assert response["issuer"] == metadata["issuer"]
+    query = parse_qs(urlparse(response["login_url"]).query)
+    assert query == {
+        "response_type": ["code"],
+        "client_id": ["client-id"],
+        "redirect_uri": [f"{FRONTEND_URL}/api/v1/auth/oauth/callback"],
+        "scope": ["openid email profile groups"],
+        "state": [f"__e2e:{SESSION_ID}"],
+        "nonce": ["fake-diagnostic-nonce"],
+    }
+    assert CLIENT_SECRET not in json.dumps(response)
+
+    redis_key = f"sso_diag:{SESSION_ID}"
+    stored = json.loads(diagnostic_store.values[redis_key])
+    assert stored["nonce"] == "fake-diagnostic-nonce"
+    assert stored["finished_at"] is None
+    assert stored["ok"] is None
+    assert diagnostic_store.writes
+
+    public = await sso.e2e_status(SESSION_ID, current_user=_user())
+    assert public["session_id"] == SESSION_ID
+    assert "nonce" not in public
+    assert "token_endpoint" not in public
+    assert CLIENT_SECRET not in json.dumps(public)
+
+
+@pytest.mark.asyncio
+async def test_saml_e2e_start_handles_config_field_and_key_gates(monkeypatch, dynamic_settings):
+    get_config = AsyncMock(return_value=None)
+    monkeypatch.setattr(sso, "_get_saml_config", get_config)
+
+    missing = await sso.e2e_saml_start(request=MagicMock(), db=_db(), current_user=_user())
+    assert missing["error"] == "SAML is not configured"
+
+    get_config.return_value = _config(idp_x509_cert="")
+    incomplete = await sso.e2e_saml_start(request=MagicMock(), db=_db(), current_user=_user())
+    assert incomplete["error"] == "Missing: IdP X.509 certificate."
+
+    leaked_detail = "fake private decryption failure"
+    get_config.return_value = _config()
+    monkeypatch.setattr(sso, "_decrypt_sp_key", MagicMock(side_effect=ValueError(leaked_detail)))
+    decrypt_failure = await sso.e2e_saml_start(request=MagicMock(), db=_db(), current_user=_user())
+    assert decrypt_failure["error"] == "Failed to decrypt SP private key"
+    assert leaked_detail not in json.dumps(decrypt_failure)
+
+
+@pytest.mark.asyncio
+async def test_saml_e2e_start_stops_on_preflight_failure(monkeypatch, dynamic_settings):
+    failure = make_check("runtime_config", "Runtime config", "fail", "Login gate is closed.", "Fix config.")
+    monkeypatch.setattr(sso, "_get_saml_config", AsyncMock(return_value=_config()))
+    monkeypatch.setattr(sso, "_decrypt_sp_key", MagicMock(return_value=PRIVATE_KEY))
+    monkeypatch.setattr(sso, "_run_saml_check_suite", AsyncMock(return_value=[]))
+    monkeypatch.setattr(sso, "_runtime_config_check", AsyncMock(return_value=failure))
+    create = AsyncMock()
+    monkeypatch.setattr(sso.sso_diagnostics, "create_session", create)
+    _mock_http_client(monkeypatch)
+
+    response = await sso.e2e_saml_start(request=MagicMock(), db=_db(), current_user=_user())
+
+    assert response["success"] is False
+    assert response["error"] == "Login gate is closed."
+    assert response["hint"] == "Fix config."
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_saml_e2e_start_persists_session_and_builds_controlled_login_url(
+    monkeypatch,
+    dynamic_settings,
+    diagnostic_store,
+):
+    config = _config()
+    protocol_checks = [make_check("idp_reachable", "IdP reachable", "pass")]
+    monkeypatch.setattr(sso, "_get_saml_config", AsyncMock(return_value=config))
+    monkeypatch.setattr(sso, "_decrypt_sp_key", MagicMock(return_value=PRIVATE_KEY))
+    monkeypatch.setattr(sso, "_run_saml_check_suite", AsyncMock(return_value=protocol_checks))
+    monkeypatch.setattr(
+        sso,
+        "_runtime_config_check",
+        AsyncMock(return_value=make_check("runtime_config", "Runtime config", "pass")),
+    )
+    client, factory = _mock_http_client(monkeypatch)
+    dynamic_settings.values["deployment.frontend_url"] = f"{FRONTEND_URL}/"
+
+    response = await sso.e2e_saml_start(request=MagicMock(), db=_db(), current_user=_user())
+
+    assert response["success"] is True
+    assert response["session_id"] == SESSION_ID
+    assert response["login_url"] == f"{FRONTEND_URL}/api/v1/sso/saml/login?e2e={SESSION_ID}"
+    assert response["idp_entity_id"] == config.idp_entity_id
+    factory.assert_called_once_with(timeout=10.0, follow_redirects=False)
+    sso._run_saml_check_suite.assert_awaited_once_with(config, PRIVATE_KEY, f"{FRONTEND_URL}/", client)
+
+    stored = json.loads(diagnostic_store.values[f"sso_diag:{SESSION_ID}"])
+    assert stored["finished_at"] is None
+    assert stored["ok"] is None
+    assert [check["name"] for check in stored["checks"]] == [
+        "runtime_config",
+        "sp_key_decrypt",
+        "idp_reachable",
+        "e2e_started",
+    ]
+
+
+@pytest.mark.parametrize("provider", ["oidc", "saml"])
+@pytest.mark.asyncio
+async def test_e2e_start_tolerates_session_expiry_before_enrichment(
+    monkeypatch,
+    dynamic_settings,
+    provider,
+):
+    create = AsyncMock(return_value=(SESSION_ID, {}))
+    finalize = AsyncMock()
+    get_session = AsyncMock(return_value=None)
+    save_session = AsyncMock()
+    monkeypatch.setattr(sso.sso_diagnostics, "create_session", create)
+    monkeypatch.setattr(sso.sso_diagnostics, "finalize", finalize)
+    monkeypatch.setattr(sso.sso_diagnostics, "get_session", get_session)
+    monkeypatch.setattr(sso.sso_diagnostics, "save_session", save_session)
+
+    if provider == "oidc":
+        dynamic_settings.values.update(
+            {
+                "oauth.client_id": "client-id",
+                "oauth.client_secret": CLIENT_SECRET,
+                "oauth.server_metadata_url": "https://idp.example.test/discovery",
+            }
+        )
+        metadata = {
+            "authorization_endpoint": "https://idp.example.test/authorize",
+            "issuer": "https://idp.example.test",
+        }
+        monkeypatch.setattr(
+            sso,
+            "run_oidc_checks",
+            AsyncMock(return_value=([make_check("discovery", "Discovery", "pass")], metadata)),
+        )
+        monkeypatch.setattr(sso, "secrets", SimpleNamespace(token_urlsafe=lambda _size: "fake-nonce"))
+        response = await sso.e2e_oidc_start(request=MagicMock(), current_user=_user())
+    else:
+        monkeypatch.setattr(sso, "_get_saml_config", AsyncMock(return_value=_config()))
+        monkeypatch.setattr(sso, "_decrypt_sp_key", MagicMock(return_value=PRIVATE_KEY))
+        monkeypatch.setattr(sso, "_run_saml_check_suite", AsyncMock(return_value=[]))
+        monkeypatch.setattr(
+            sso,
+            "_runtime_config_check",
+            AsyncMock(return_value=make_check("runtime_config", "Runtime config", "pass")),
+        )
+        _mock_http_client(monkeypatch)
+        response = await sso.e2e_saml_start(request=MagicMock(), db=_db(), current_user=_user())
+
+    assert response["success"] is True
+    finalize.assert_awaited_once()
+    get_session.assert_awaited_once_with(SESSION_ID)
+    save_session.assert_not_awaited()
+
+
+@pytest.mark.parametrize("session_id", ["", "bad/id", "bad id", "a" * 65])
+@pytest.mark.asyncio
+async def test_e2e_status_rejects_invalid_ids(session_id):
+    with pytest.raises(HTTPException) as error:
+        await sso.e2e_status(session_id, current_user=_user())
+    assert error.value.status_code == 400
+    assert error.value.detail == "Invalid session id"
+
+
+@pytest.mark.asyncio
+async def test_e2e_status_returns_safe_not_found(monkeypatch):
+    monkeypatch.setattr(sso.sso_diagnostics, "get_session", AsyncMock(return_value=None))
+
+    with pytest.raises(HTTPException) as error:
+        await sso.e2e_status("missing_session", current_user=_user())
+
+    assert error.value.status_code == 404
+    assert error.value.detail == "Session not found or expired"
+
+
+@pytest.mark.asyncio
+async def test_scim_token_list_masks_hash_and_handles_missing_timestamp(dynamic_settings):
+    tokens = [
+        SimpleNamespace(
+            id=TOKEN_ID,
+            description="Primary provisioning token",
+            active=True,
+            created_at=datetime(2026, 2, 1, tzinfo=UTC),
+            token_hash="abcdef1234567890",
+        ),
+        SimpleNamespace(
+            id=uuid.UUID("44444444-4444-4444-4444-444444444444"),
+            description="Pending token",
+            active=False,
+            created_at=None,
+            token_hash="1234567890abcdef",
+        ),
+    ]
+
+    response = await sso.list_scim_tokens(db=_db(_list_result(tokens)), current_user=_user())
+
+    assert response[0]["token_prefix"] == "abcdef12..."
+    assert response[0]["created_at"] == "2026-02-01T00:00:00+00:00"
+    assert response[1]["created_at"] is None
+    assert all("token" not in item for item in response)
+    assert "abcdef1234567890" not in json.dumps(response)
+
+
+@pytest.mark.asyncio
+async def test_scim_token_create_hashes_persists_and_audits(monkeypatch, dynamic_settings):
+    raw_token = "fake-one-time-scim-token"
+    db = _db()
+
+    async def refresh(token):
+        token.id = TOKEN_ID
+
+    db.refresh.side_effect = refresh
+    emit = AsyncMock()
+    monkeypatch.setattr(sso, "secrets", SimpleNamespace(token_urlsafe=lambda _size: raw_token))
+    monkeypatch.setattr(sso, "emit_security_event", emit)
+
+    response = await sso.create_scim_token(
+        {"description": "Identity provider provisioning"},
+        db=db,
+        current_user=_user(),
+    )
+
+    stored = db.add.call_args.args[0]
+    assert stored.token_hash == hashlib.sha256(raw_token.encode()).hexdigest()
+    assert raw_token not in stored.token_hash
+    assert stored.description == "Identity provider provisioning"
+    assert stored.active is True
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once_with(stored)
+    assert response["token"] == raw_token
+    assert response["message"] == "Save this token now. It will not be shown again."
+
+    event = emit.await_args.args[0]
+    assert event.event_type == EventType.SETTING_CHANGED
+    assert event.severity == Severity.INFO
+    assert event.target_id == str(TOKEN_ID)
+    assert event.target_type == "scim_token"
+    assert event.detail == "SCIM token created"
+
+
+@pytest.mark.asyncio
+async def test_scim_token_revoke_validates_id_and_audits(monkeypatch, dynamic_settings):
+    invalid_db = _db()
+    with pytest.raises(HTTPException) as error:
+        await sso.revoke_scim_token("not-a-uuid", db=invalid_db, current_user=_user())
+    assert error.value.status_code == 404
+    invalid_db.execute.assert_not_awaited()
+
+    with pytest.raises(HTTPException) as error:
+        await sso.revoke_scim_token(str(TOKEN_ID), db=_db(_result(None)), current_user=_user())
+    assert error.value.status_code == 404
+
+    token = SimpleNamespace(id=TOKEN_ID, active=True)
+    db = _db(_result(token))
+    emit = AsyncMock()
+    monkeypatch.setattr(sso, "emit_security_event", emit)
+
+    response = await sso.revoke_scim_token(str(TOKEN_ID), db=db, current_user=_user())
+
+    assert response == {"revoked": str(TOKEN_ID)}
+    assert token.active is False
+    db.commit.assert_awaited_once()
+    event = emit.await_args.args[0]
+    assert event.severity == Severity.WARNING
+    assert event.target_id == str(TOKEN_ID)
+    assert event.detail == "SCIM token revoked"
+
+
+@pytest.mark.parametrize(
+    ("role", "status"),
+    [
+        (UserRole.super_admin, 200),
+        (UserRole.admin, 200),
+        (UserRole.reviewer, 403),
+        (UserRole.user, 403),
+    ],
+)
+@pytest.mark.asyncio
+async def test_admin_sso_routes_enforce_role_hierarchy(monkeypatch, dynamic_settings, role, status):
+    denied = AsyncMock()
+    monkeypatch.setattr(deps, "emit_security_event", denied)
+
+    response = await _http_get_saml_config(_user(role), _db(_result(None)))
+
+    assert response.status_code == status
+    if status == 403:
+        assert response.json()["detail"] == "Insufficient permissions"
+        event = denied.await_args.args[0]
+        assert event.event_type == EventType.PERMISSION_DENIED
+        assert event.actor_role == role.value
+    else:
+        denied.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_admin_sso_routes_require_authentication(dynamic_settings):
+    response = await _http_get_saml_config(None, _db(_result(None)))
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing credentials"

--- a/tests/test_oidc_health.py
+++ b/tests/test_oidc_health.py
@@ -1,0 +1,735 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy <tanvi.reddy330@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic coverage for OIDC health checks and their diagnostic records."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from email.utils import format_datetime, parsedate_to_datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+from redis.exceptions import RedisError
+
+from schemas.sso_health import all_pass, make_check
+from services import oidc_health as oidc
+from services import sso_diagnostics as diagnostics
+
+METADATA_URL = "https://idp.example.test/.well-known/openid-configuration"
+AUTHORIZATION_ENDPOINT = "https://idp.example.test/authorize"
+TOKEN_ENDPOINT = "https://idp.example.test/token"
+JWKS_URI = "https://idp.example.test/jwks"
+REDIRECT_URI = "https://app.example.test/api/v1/auth/oauth/callback"
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), follow_redirects=False)
+
+
+def _check_text(check: dict) -> str:
+    return json.dumps(check, sort_keys=True)
+
+
+@pytest.mark.asyncio
+async def test_bounded_get_streams_body_and_rejects_oversized_response():
+    async def ok_handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == METADATA_URL
+        return httpx.Response(200, content=b"metadata", request=request)
+
+    async with _client(ok_handler) as client:
+        response, body = await oidc._bounded_get(client, METADATA_URL)
+
+    assert response.status_code == 200
+    assert body == b"metadata"
+
+    async def large_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"x" * (oidc._MAX_BODY_BYTES + 1), request=request)
+
+    async with _client(large_handler) as client:
+        with pytest.raises(httpx.ReadError, match="Response exceeded"):
+            await oidc._bounded_get(client, METADATA_URL)
+
+
+@pytest.mark.asyncio
+async def test_fetch_discovery_returns_object_and_server_clock():
+    server_date = "Wed, 01 Jan 2025 12:00:00 GMT"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url == METADATA_URL
+        return httpx.Response(
+            200,
+            json={"issuer": "https://idp.example.test"},
+            headers={"date": server_date},
+            request=request,
+        )
+
+    async with _client(handler) as client:
+        metadata, date_header, check = await oidc.fetch_discovery(client, METADATA_URL)
+
+    assert metadata == {"issuer": "https://idp.example.test"}
+    assert date_header == server_date
+    assert check == {
+        "name": "discovery_doc",
+        "label": "OIDC discovery document",
+        "status": "pass",
+    }
+
+
+@pytest.mark.parametrize(
+    ("failure", "message", "hint"),
+    [
+        ("timeout", "Timed out fetching OIDC metadata", "within 10 seconds"),
+        ("status", "returned HTTP 503", "correct and accessible"),
+        ("malformed", "Failed to fetch OIDC metadata", "reachable URL"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_fetch_discovery_reports_sanitized_transport_and_json_failures(failure, message, hint):
+    secret = "provider-secret-value"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if failure == "timeout":
+            raise httpx.ReadTimeout(secret, request=request)
+        if failure == "status":
+            return httpx.Response(503, text=secret, request=request)
+        return httpx.Response(200, content=b"{not-json", request=request)
+
+    async with _client(handler) as client:
+        metadata, date_header, check = await oidc.fetch_discovery(client, METADATA_URL)
+
+    assert metadata is None
+    assert date_header is None
+    assert message in check["message"]
+    assert hint in check["hint"]
+    assert secret not in _check_text(check)
+
+
+@pytest.mark.asyncio
+async def test_fetch_discovery_rejects_non_object_metadata_without_losing_date():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=["not", "an", "object"],
+            headers={"date": "Wed, 01 Jan 2025 12:00:00 GMT"},
+            request=request,
+        )
+
+    async with _client(handler) as client:
+        metadata, date_header, check = await oidc.fetch_discovery(client, METADATA_URL)
+
+    assert metadata is None
+    assert date_header == "Wed, 01 Jan 2025 12:00:00 GMT"
+    assert check["status"] == "fail"
+    assert "JSON object" in check["message"]
+
+
+@pytest.mark.parametrize(
+    ("status", "location", "body", "expected_status", "message"),
+    [
+        (302, "https://idp.example.test/login", b"", "pass", None),
+        (302, "https://app.example.test/callback?error=invalid_request", b"", "fail", "error redirect"),
+        (200, "", b"login form", "pass", None),
+        (400, "", b"redirect_uri is invalid", "fail", "rejected the redirect_uri"),
+        (401, "", b"invalid_client", "fail", "recognize this client_id"),
+        (403, "", b"unauthorized_client", "fail", "not authorized"),
+        (418, "", b"teapot", "fail", "returned HTTP 418"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_authorization_probe_sends_exact_client_and_redirect_parameters(
+    status,
+    location,
+    body,
+    expected_status,
+    message,
+):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert f"{request.url.scheme}://{request.url.host}{request.url.path}" == AUTHORIZATION_ENDPOINT
+        assert parse_qs(request.url.query.decode()) == {
+            "client_id": ["client-123"],
+            "redirect_uri": [REDIRECT_URI],
+            "response_type": ["code"],
+            "scope": ["openid email profile groups"],
+            "state": ["observal_validate_probe"],
+            "nonce": ["observal_validate_nonce"],
+        }
+        return httpx.Response(status, content=body, headers={"location": location}, request=request)
+
+    async with _client(handler) as client:
+        check = await oidc.probe_authorization_endpoint(
+            client,
+            AUTHORIZATION_ENDPOINT,
+            "client-123",
+            REDIRECT_URI,
+        )
+
+    assert check["status"] == expected_status
+    if message:
+        assert message in check["message"]
+    else:
+        assert "message" not in check
+
+
+@pytest.mark.parametrize("failure", ["timeout", "network"])
+@pytest.mark.asyncio
+async def test_authorization_probe_handles_timeout_and_network_failure_without_details(failure):
+    secret = "socket-secret"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if failure == "timeout":
+            raise httpx.ReadTimeout(secret, request=request)
+        raise httpx.ConnectError(secret, request=request)
+
+    async with _client(handler) as client:
+        check = await oidc.probe_authorization_endpoint(
+            client,
+            AUTHORIZATION_ENDPOINT,
+            "client-123",
+            REDIRECT_URI,
+        )
+
+    assert check["status"] == "fail"
+    assert secret not in _check_text(check)
+    expected = "Timed out" if failure == "timeout" else "Failed to reach"
+    assert expected in check["message"]
+
+
+@pytest.mark.asyncio
+async def test_authorization_probe_stops_buffering_at_body_limit():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, content=b"x" * (oidc._MAX_BODY_BYTES + 1), request=request)
+
+    async with _client(handler) as client:
+        check = await oidc.probe_authorization_endpoint(
+            client,
+            AUTHORIZATION_ENDPOINT,
+            "client-123",
+            REDIRECT_URI,
+        )
+
+    assert check["status"] == "fail"
+    assert check["message"] == "IdP authorization endpoint returned HTTP 400."
+
+
+@pytest.mark.parametrize(
+    ("status", "payload", "expected"),
+    [
+        (401, {"error": "invalid_grant"}, "fail"),
+        (400, {"error": "INVALID_CLIENT"}, "fail"),
+        (400, {"error": "unauthorized_client"}, "fail"),
+        (400, {"error": "invalid_grant"}, "pass"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_client_secret_probe_posts_configuration_without_leaking_secret(status, payload, expected):
+    client_secret = "never-render-this-client-secret"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url == TOKEN_ENDPOINT
+        assert parse_qs(request.content.decode()) == {
+            "grant_type": ["authorization_code"],
+            "code": ["observal_validate_invalid_code"],
+            "redirect_uri": [REDIRECT_URI],
+            "client_id": ["client-123"],
+            "client_secret": [client_secret],
+        }
+        return httpx.Response(status, json=payload, request=request)
+
+    async with _client(handler) as client:
+        check = await oidc.probe_client_secret(
+            client,
+            TOKEN_ENDPOINT,
+            "client-123",
+            client_secret,
+            REDIRECT_URI,
+        )
+
+    assert check["status"] == expected
+    assert client_secret not in _check_text(check)
+
+
+@pytest.mark.asyncio
+async def test_client_secret_probe_skips_absent_secret_and_unreachable_endpoint():
+    unused_client = MagicMock()
+    unused_client.post = AsyncMock()
+    assert await oidc.probe_client_secret(unused_client, TOKEN_ENDPOINT, "client", "", REDIRECT_URI) is None
+    unused_client.post.assert_not_awaited()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("token endpoint unavailable", request=request)
+
+    async with _client(handler) as client:
+        assert await oidc.probe_client_secret(client, TOKEN_ENDPOINT, "client", "secret", REDIRECT_URI) is None
+
+
+@pytest.mark.asyncio
+async def test_client_secret_probe_treats_non_json_non_auth_rejection_as_reachable():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, content=b"not-json", request=request)
+
+    async with _client(handler) as client:
+        check = await oidc.probe_client_secret(client, TOKEN_ENDPOINT, "client", "secret", REDIRECT_URI)
+
+    assert check["status"] == "pass"
+
+
+@pytest.mark.asyncio
+async def test_jwks_probe_requires_uri_and_active_signing_keys():
+    missing = await oidc.probe_jwks(MagicMock(), {})
+    assert missing["status"] == "fail"
+    assert "jwks_uri" in missing["message"]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == JWKS_URI
+        return httpx.Response(200, json={"keys": [{"kid": "key-1", "use": "sig"}]}, request=request)
+
+    async with _client(handler) as client:
+        passed = await oidc.probe_jwks(client, {"jwks_uri": JWKS_URI})
+
+    assert passed["status"] == "pass"
+
+
+@pytest.mark.parametrize("payload", [{}, {"keys": []}, {"keys": "not-a-list"}, ["not-an-object"]])
+@pytest.mark.asyncio
+async def test_jwks_probe_rejects_missing_or_malformed_key_sets(payload):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload, request=request)
+
+    async with _client(handler) as client:
+        check = await oidc.probe_jwks(client, {"jwks_uri": JWKS_URI})
+
+    assert check["status"] == "fail"
+    assert "signing keys" in check["message"]
+
+
+@pytest.mark.parametrize("failure", ["invalid-json", "timeout"])
+@pytest.mark.asyncio
+async def test_jwks_probe_sanitizes_unreachable_or_invalid_responses(failure):
+    secret = "jwks-provider-secret"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if failure == "timeout":
+            raise httpx.ReadTimeout(secret, request=request)
+        return httpx.Response(200, content=b"invalid-json", request=request)
+
+    async with _client(handler) as client:
+        check = await oidc.probe_jwks(client, {"jwks_uri": JWKS_URI})
+
+    assert check["status"] == "fail"
+    assert "unreachable or returned invalid JSON" in check["message"]
+    assert secret not in _check_text(check)
+
+
+@pytest.mark.parametrize(
+    ("metadata", "url", "expected", "message"),
+    [
+        ({}, METADATA_URL, None, None),
+        ({"issuer": "https://idp.example.test/"}, METADATA_URL, "pass", None),
+        (
+            {"issuer": "https://other.example.test/tenant"},
+            METADATA_URL,
+            "fail",
+            "other.example.test",
+        ),
+        ({"issuer": "urn:issuer:value"}, METADATA_URL, "pass", None),
+    ],
+)
+def test_issuer_consistency(metadata, url, expected, message):
+    check = oidc.check_issuer_consistency(metadata, url)
+    if expected is None:
+        assert check is None
+        return
+    assert check["status"] == expected
+    if message:
+        assert message in check["message"]
+
+
+@pytest.mark.parametrize(
+    ("methods", "expected"),
+    [
+        (None, None),
+        ([], None),
+        (["CLIENT_SECRET_BASIC"], "pass"),
+        (["client_secret_post", "private_key_jwt"], "fail"),
+    ],
+)
+def test_token_endpoint_auth_method_support(methods, expected):
+    check = oidc.check_token_endpoint_auth_methods({"token_endpoint_auth_methods_supported": methods})
+    if expected is None:
+        assert check is None
+    else:
+        assert check["status"] == expected
+
+
+@pytest.mark.parametrize(
+    ("algorithms", "expected"),
+    [
+        (None, None),
+        ([None, 123], None),
+        (["none"], "fail"),
+        (["HS512"], "fail"),
+        (["none", "RS256"], "pass"),
+        (["EdDSA"], "pass"),
+    ],
+)
+def test_id_token_signing_algorithm_support(algorithms, expected):
+    check = oidc.check_id_token_signing_alg({"id_token_signing_alg_values_supported": algorithms})
+    if expected is None:
+        assert check is None
+    else:
+        assert check["status"] == expected
+        if algorithms == ["none"]:
+            assert "unsigned tokens" in check["message"]
+
+
+@pytest.mark.parametrize(
+    ("grants", "expected"),
+    [
+        (None, None),
+        ([None, 1], None),
+        (["authorization_code"], "skip"),
+        (["AUTHORIZATION_CODE", "REFRESH_TOKEN"], "pass"),
+    ],
+)
+def test_refresh_token_grant(grants, expected):
+    check = oidc.check_refresh_token_grant({"grant_types_supported": grants})
+    if expected is None:
+        assert check is None
+    else:
+        assert check["status"] == expected
+
+
+def test_logout_pkce_and_email_metadata_checks():
+    assert (
+        oidc.check_end_session_endpoint({"end_session_endpoint": "https://idp.example.test/logout"})["status"] == "pass"
+    )
+    assert oidc.check_end_session_endpoint({})["status"] == "skip"
+
+    assert oidc.check_pkce_methods({})["status"] == "pass"
+    pkce = oidc.check_pkce_methods({"code_challenge_methods_supported": [None, "S256", 1]})
+    assert pkce["status"] == "skip"
+    assert "s256" in pkce["message"]
+
+    assert oidc.check_email_scope({})["status"] == "pass"
+    assert oidc.check_email_scope({"scopes_supported": ["OPENID"], "claims_supported": ["sub"]})["status"] == "fail"
+    assert oidc.check_email_scope({"scopes_supported": ["OPENID", "EMAIL"]})["status"] == "pass"
+    assert oidc.check_email_scope({"scopes_supported": ["openid"], "claims_supported": ["EMAIL"]})["status"] == "pass"
+
+
+class _FrozenDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        value = cls(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        return value if tz is not None else value.replace(tzinfo=None)
+
+
+def test_clock_skew_handles_absent_malformed_naive_and_boundary_values(monkeypatch):
+    monkeypatch.setattr(oidc, "datetime", _FrozenDateTime)
+
+    assert oidc.check_clock_skew(None) is None
+    assert oidc.check_clock_skew("not-a-date") is None
+
+    monkeypatch.setattr(oidc, "parsedate_to_datetime", lambda _value: datetime(2025, 1, 1, 11, 59, 59))
+    assert oidc.check_clock_skew("naive-date")["status"] == "pass"
+
+    monkeypatch.setattr(oidc, "parsedate_to_datetime", parsedate_to_datetime)
+    boundary = format_datetime(datetime(2025, 1, 1, 11, 58, 0, tzinfo=UTC), usegmt=True)
+    outside = format_datetime(datetime(2025, 1, 1, 11, 57, 59, tzinfo=UTC), usegmt=True)
+    assert oidc.check_clock_skew(boundary)["status"] == "pass"
+    failed = oidc.check_clock_skew(outside)
+    assert failed["status"] == "fail"
+    assert "121s" in failed["message"]
+
+
+def _mock_async_client(monkeypatch):
+    client = MagicMock(name="oidc-client")
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=client)
+    monkeypatch.setattr(oidc.httpx, "AsyncClient", factory)
+    return client, factory
+
+
+@pytest.mark.asyncio
+async def test_run_oidc_checks_uses_one_bounded_non_redirecting_client_and_aggregates(monkeypatch):
+    client, factory = _mock_async_client(monkeypatch)
+    metadata = {
+        "issuer": "https://idp.example.test",
+        "authorization_endpoint": AUTHORIZATION_ENDPOINT,
+        "token_endpoint": TOKEN_ENDPOINT,
+        "jwks_uri": JWKS_URI,
+        "scopes_supported": ["openid", "email"],
+        "token_endpoint_auth_methods_supported": ["client_secret_basic"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "end_session_endpoint": "https://idp.example.test/logout",
+    }
+    discovery = make_check("discovery_doc", "Discovery", "pass")
+    fetch = AsyncMock(return_value=(metadata, None, discovery))
+    authz = AsyncMock(return_value=make_check("authorization_endpoint", "Authorization", "pass"))
+    secret = AsyncMock(return_value=make_check("client_secret", "Secret", "pass"))
+    jwks = AsyncMock(return_value=make_check("jwks_reachable", "JWKS", "pass"))
+    monkeypatch.setattr(oidc, "fetch_discovery", fetch)
+    monkeypatch.setattr(oidc, "probe_authorization_endpoint", authz)
+    monkeypatch.setattr(oidc, "probe_client_secret", secret)
+    monkeypatch.setattr(oidc, "probe_jwks", jwks)
+
+    checks, returned_metadata = await oidc.run_oidc_checks(
+        METADATA_URL,
+        "client-123",
+        "client-secret",
+        REDIRECT_URI,
+    )
+
+    assert returned_metadata is metadata
+    assert all_pass(checks) is True
+    assert [check["name"] for check in checks] == [
+        "discovery_doc",
+        "authorization_endpoint",
+        "client_secret",
+        "jwks_reachable",
+        "email_scope",
+        "issuer_host_matches",
+        "token_auth_method_supported",
+        "id_token_alg",
+        "refresh_token_grant",
+        "end_session_endpoint",
+        "pkce_supported",
+    ]
+    factory.assert_called_once_with(timeout=10.0, follow_redirects=False)
+    fetch.assert_awaited_once_with(client, METADATA_URL)
+    authz.assert_awaited_once_with(client, AUTHORIZATION_ENDPOINT, "client-123", REDIRECT_URI)
+    secret.assert_awaited_once_with(client, TOKEN_ENDPOINT, "client-123", "client-secret", REDIRECT_URI)
+    jwks.assert_awaited_once_with(client, metadata)
+
+
+@pytest.mark.asyncio
+async def test_run_oidc_checks_stops_after_failed_discovery(monkeypatch):
+    _client_mock, factory = _mock_async_client(monkeypatch)
+    failure = make_check("discovery_doc", "Discovery", "fail", "unreachable")
+    monkeypatch.setattr(oidc, "fetch_discovery", AsyncMock(return_value=(None, None, failure)))
+    authorization = AsyncMock()
+    monkeypatch.setattr(oidc, "probe_authorization_endpoint", authorization)
+
+    checks, metadata = await oidc.run_oidc_checks(METADATA_URL, "client", "secret", REDIRECT_URI)
+
+    assert checks == [failure]
+    assert metadata is None
+    factory.assert_called_once_with(timeout=10.0, follow_redirects=False)
+    authorization.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_oidc_checks_reports_missing_endpoints_and_omits_skipped_secret(monkeypatch):
+    _mock_async_client(monkeypatch)
+    metadata = {"jwks_uri": JWKS_URI}
+    monkeypatch.setattr(
+        oidc,
+        "fetch_discovery",
+        AsyncMock(return_value=(metadata, None, make_check("discovery_doc", "Discovery", "pass"))),
+    )
+    secret_probe = AsyncMock(return_value=None)
+    jwks_probe = AsyncMock(return_value=make_check("jwks_reachable", "JWKS", "pass"))
+    monkeypatch.setattr(oidc, "probe_client_secret", secret_probe)
+    monkeypatch.setattr(oidc, "probe_jwks", jwks_probe)
+
+    checks, _ = await oidc.run_oidc_checks(METADATA_URL, "client", "", REDIRECT_URI)
+
+    by_name = {check["name"]: check for check in checks}
+    assert by_name["authorization_endpoint"]["status"] == "fail"
+    assert by_name["client_secret"]["status"] == "fail"
+    assert by_name["jwks_reachable"]["status"] == "pass"
+    secret_probe.assert_not_awaited()
+
+    metadata["authorization_endpoint"] = AUTHORIZATION_ENDPOINT
+    metadata["token_endpoint"] = TOKEN_ENDPOINT
+    authorization_probe = AsyncMock(return_value=make_check("authorization_endpoint", "Authorization", "pass"))
+    monkeypatch.setattr(oidc, "probe_authorization_endpoint", authorization_probe)
+
+    checks, _ = await oidc.run_oidc_checks(METADATA_URL, "client", "", REDIRECT_URI)
+
+    assert not any(check["name"] == "client_secret" for check in checks)
+    secret_probe.assert_awaited_once()
+
+
+class _ExpiringRedis:
+    def __init__(self, clock):
+        self.clock = clock
+        self.entries: dict[str, tuple[float, str]] = {}
+        self.setex_calls: list[tuple[str, int, str]] = []
+
+    async def setex(self, key: str, ttl: int, value: str):
+        self.entries[key] = (self.clock() + ttl, value)
+        self.setex_calls.append((key, ttl, value))
+
+    async def get(self, key: str):
+        entry = self.entries.get(key)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if self.clock() >= expires_at:
+            self.entries.pop(key, None)
+            return None
+        return value
+
+
+def _diagnostic_store(monkeypatch):
+    now = {"value": 1_000.0}
+    redis = _ExpiringRedis(lambda: now["value"])
+    monkeypatch.setattr(diagnostics, "get_redis", lambda: redis)
+    monkeypatch.setattr(diagnostics, "time", SimpleNamespace(time=lambda: now["value"]))
+    monkeypatch.setattr(diagnostics, "new_session_id", lambda: "diagnostic-session-1")
+    return now, redis
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_session_persists_updates_and_expires(monkeypatch):
+    now, redis = _diagnostic_store(monkeypatch)
+
+    session_id, created = await diagnostics.create_session("oidc", "e2e")
+    assert session_id == "diagnostic-session-1"
+    assert created["started_at"] == 1_000.0
+    assert redis.setex_calls[-1][0:2] == ("sso_diag:diagnostic-session-1", 600)
+
+    check = make_check("token_exchange", "Token exchange", "fail", "invalid grant")
+    await diagnostics.append_check(session_id, check)
+    await diagnostics.record_actor(session_id, "operator@example.test")
+    now["value"] = 1_025.0
+    await diagnostics.finalize(session_id, summary="login failed")
+
+    stored = await diagnostics.get_session(session_id)
+    assert stored["checks"] == [check]
+    assert stored["actor_email"] == "operator@example.test"
+    assert stored["summary"] == "login failed"
+    assert stored["ok"] is False
+    assert stored["finished_at"] == 1_025.0
+
+    stored["nonce"] = "private-nonce"
+    assert "nonce" not in diagnostics.public_view(stored)
+
+    now["value"] = 1_626.0
+    assert await diagnostics.get_session(session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_session_handles_missing_corrupt_and_failed_redis(monkeypatch):
+    now, redis = _diagnostic_store(monkeypatch)
+    await diagnostics.append_check("missing", make_check("x", "X", "pass"))
+    await diagnostics.record_actor("missing", "nobody@example.test")
+    await diagnostics.record_actor("missing", None)
+
+    redis.entries["sso_diag:corrupt"] = (now["value"] + 600, "not-json")
+    assert await diagnostics.get_session("corrupt") is None
+
+    broken = MagicMock()
+    broken.get = AsyncMock(side_effect=RedisError("redis contains a secret"))
+    broken.setex = AsyncMock(side_effect=RedisError("redis contains a secret"))
+    monkeypatch.setattr(diagnostics, "get_redis", lambda: broken)
+    assert await diagnostics.get_session("safe-id") is None
+    await diagnostics.save_session({"session_id": "safe-id"})
+    with pytest.raises(RedisError):
+        await diagnostics.create_session("oidc", "real")
+
+
+@pytest.mark.asyncio
+async def test_finalize_reconstructs_real_oidc_session_and_replaces_checks(monkeypatch):
+    now, _redis = _diagnostic_store(monkeypatch)
+    now["value"] = 2_000.0
+    checks = [make_check("callback", "Callback", "pass")]
+
+    await diagnostics.finalize(
+        "new-real-session",
+        checks=checks,
+        summary="complete",
+        actor_email="person@example.test",
+    )
+
+    stored = await diagnostics.get_session("new-real-session")
+    assert stored["provider"] == "oidc"
+    assert stored["mode"] == "real"
+    assert stored["checks"] == checks
+    assert stored["ok"] is True
+    assert stored["actor_email"] == "person@example.test"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("safe_ID-123", True),
+        ("bad/id", False),
+        ("a" * 65, False),
+    ],
+)
+def test_diagnostic_session_id_validation(value, expected):
+    assert diagnostics.is_safe_session_id(value) is expected
+
+
+def test_result_pages_escape_untrusted_diagnostic_values():
+    hostile = '<script>alert("secret")</script>'
+    checks = [
+        {"name": "fallback", "status": "pass"},
+        {"name": "failed", "label": hostile, "status": "fail", "message": hostile},
+        {"name": "unknown", "label": "Unknown", "status": "unexpected"},
+    ]
+    page = diagnostics.render_result_page(
+        session_id=hostile,
+        provider="oidc",
+        ok=False,
+        checks=checks,
+        actor_email=hostile,
+        summary=hostile,
+        admin_url='https://app.example.test/admin/sso?next=" onclick="alert(1)',
+    )
+
+    assert hostile not in page
+    assert "&lt;script&gt;" in page
+    assert "<code>invalid</code>" in page
+    assert "OIDC / OAuth 2.0" in page
+    assert "Issues detected" in page
+    css_prefix = "var(" + chr(45) * 2
+    assert css_prefix + "pass)" in page
+    assert css_prefix + "fail)" in page
+    assert css_prefix + "skip)" in page
+    assert 'onclick="alert(1)' not in page
+
+    passed = diagnostics.render_result_page(
+        session_id="safe-id",
+        provider="saml",
+        ok=True,
+        checks=[],
+        actor_email=None,
+        summary=None,
+        admin_url="https://app.example.test/admin/sso",
+    )
+    assert "End-to-end test passed" in passed
+    assert "SAML 2.0" in passed
+    assert "No checks recorded" in passed
+    assert "(not returned)" in passed
+
+    error = diagnostics.render_error_page(hostile, hostile, 'https://app.example.test/"bad')
+    assert hostile not in error
+    assert "Could not run" in error
+    assert "&lt;script&gt;" in error
+
+
+def test_check_rendering_and_status_aggregation_fail_safely():
+    assert make_check("ok", "Healthy", "pass") == {"name": "ok", "label": "Healthy", "status": "pass"}
+    detailed = make_check("bad", "Unhealthy", "fail", "message", "hint")
+    assert detailed["message"] == "message"
+    assert detailed["hint"] == "hint"
+
+    invalid = make_check("typo", "Typo", "unknown")
+    assert invalid["status"] == "fail"
+    assert all_pass([make_check("skip", "Skipped", "skip"), {"name": "odd", "status": "unknown"}]) is True
+    assert all_pass([make_check("pass", "Passed", "pass"), detailed]) is False

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -4,109 +4,671 @@
 
 """Tests for SAML service layer."""
 
+import base64
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from cryptography import x509
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
 from httpx import ASGITransport, AsyncClient
+from lxml import etree
+
+from services import saml
+
+_NOW = datetime(2030, 1, 1, 12, 0, tzinfo=UTC)
+_METADATA_URL = "https://idp.example.test/metadata"
+_SAML_NAMESPACES = 'xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"'
 
 
-class TestSamlKeyGeneration:
-    def test_generate_sp_key_pair_returns_pem_strings(self):
-        from services.saml import generate_sp_key_pair
+class _FrozenDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return _NOW.replace(tzinfo=None)
+        return _NOW.astimezone(tz)
 
-        private_key_pem, cert_pem = generate_sp_key_pair(common_name="test-sp.example.com")
-        assert "BEGIN RSA PRIVATE KEY" in private_key_pem or "BEGIN PRIVATE KEY" in private_key_pem
-        assert "BEGIN CERTIFICATE" in cert_pem
 
-    def test_encrypt_decrypt_private_key_roundtrip(self):
-        from services.saml import (
-            decrypt_private_key,
-            encrypt_private_key,
-            generate_sp_key_pair,
+def _certificate_pem(private_key, not_after: datetime, common_name: str = "test.example") -> str:
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(private_key.public_key())
+        .serial_number(42)
+        .not_valid_before(_NOW - timedelta(days=365))
+        .not_valid_after(not_after)
+        .sign(private_key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _private_key_pem(private_key) -> str:
+    return private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _metadata_xml(certs: tuple[str, ...] = (), formats: tuple[str, ...] = ()) -> str:
+    cert_nodes = "".join(f"<ds:X509Certificate>{cert}</ds:X509Certificate>" for cert in certs)
+    format_nodes = "".join(f"<md:NameIDFormat>{name_id}</md:NameIDFormat>" for name_id in formats)
+    return f"<md:EntityDescriptor {_SAML_NAMESPACES}>{cert_nodes}{format_nodes}</md:EntityDescriptor>"
+
+
+def _stream_response(chunks: list[bytes], *, status_error=None, iteration_error=None):
+    response = MagicMock()
+    response.raise_for_status.side_effect = status_error
+
+    async def aiter_bytes():
+        for chunk in chunks:
+            yield chunk
+        if iteration_error:
+            raise iteration_error
+
+    response.aiter_bytes = aiter_bytes
+    return response
+
+
+def _stream_client(response, *, enter_error=None):
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=response, side_effect=enter_error)
+    context.__aexit__ = AsyncMock(return_value=False)
+    client = MagicMock()
+    client.stream.return_value = context
+    return client, context
+
+
+class TestSamlServiceKeyMaterial:
+    def test_generated_pair_has_expected_identity_validity_and_rsa_parameters(self):
+        private_pem, cert_pem = saml.generate_sp_key_pair(common_name="sp.example.test", validity_days=31)
+
+        private_key = serialization.load_pem_private_key(private_pem.encode(), password=None)
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        assert isinstance(private_key, rsa.RSAPrivateKey)
+        assert private_key.key_size == 2048
+        assert private_key.private_numbers().public_numbers.e == 65537
+        assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == "sp.example.test"
+        assert cert.subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)[0].value == "Observal"
+        assert cert.issuer == cert.subject
+        assert cert.signature_hash_algorithm.name == "sha256"
+        assert cert.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ) == private_key.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        validity = cert.not_valid_after_utc - cert.not_valid_before_utc
+        assert timedelta(days=31) <= validity < timedelta(days=31, seconds=2)
+
+    def test_private_key_encryption_round_trip_uses_authenticated_ciphertext(self):
+        private_pem, _ = saml.generate_sp_key_pair(common_name="roundtrip.example.test")
+
+        encrypted = saml.encrypt_private_key(private_pem, "correct-password")
+
+        assert encrypted.startswith(saml._ENCRYPTION_PREFIX)
+        assert encrypted != private_pem
+        assert saml.decrypt_private_key(encrypted, "correct-password") == private_pem
+
+    def test_key_generation_propagates_crypto_library_failure(self, monkeypatch):
+        failure = RuntimeError("entropy unavailable")
+        generate = MagicMock(side_effect=failure)
+        monkeypatch.setattr(saml.rsa, "generate_private_key", generate)
+
+        with pytest.raises(RuntimeError, match="entropy unavailable"):
+            saml.generate_sp_key_pair()
+
+        generate.assert_called_once_with(public_exponent=65537, key_size=2048)
+
+    def test_derive_key_uses_exact_pbkdf2_parameters(self, monkeypatch):
+        derived = b"d" * 32
+        kdf = MagicMock()
+        kdf.derive.return_value = derived
+        constructor = MagicMock(return_value=kdf)
+        monkeypatch.setattr(saml, "PBKDF2HMAC", constructor)
+
+        assert saml._derive_key("pässword", b"fixed-salt") == derived
+        kwargs = constructor.call_args.kwargs
+        assert isinstance(kwargs["algorithm"], hashes.SHA256)
+        assert kwargs["length"] == 32
+        assert kwargs["salt"] == b"fixed-salt"
+        assert kwargs["iterations"] == 600_000
+        kdf.derive.assert_called_once_with("pässword".encode())
+
+    def test_encrypt_private_key_assembles_deterministic_aesgcm_payload(self, monkeypatch):
+        salt = bytes(range(16))
+        nonce = bytes(range(16, 28))
+        ciphertext = b"ciphertext-and-tag"
+        random_bytes = MagicMock(side_effect=[salt, nonce])
+        derive = MagicMock(return_value=b"k" * 32)
+        cipher = MagicMock()
+        cipher.encrypt.return_value = ciphertext
+        aesgcm = MagicMock(return_value=cipher)
+        monkeypatch.setattr(saml.os, "urandom", random_bytes)
+        monkeypatch.setattr(saml, "_derive_key", derive)
+        monkeypatch.setattr(saml, "AESGCM", aesgcm)
+
+        encrypted = saml.encrypt_private_key("private-key-pem", "secret")
+
+        expected = saml._ENCRYPTION_PREFIX + base64.b64encode(salt + nonce + ciphertext).decode()
+        assert encrypted == expected
+        assert random_bytes.call_args_list[0].args == (16,)
+        assert random_bytes.call_args_list[1].args == (12,)
+        derive.assert_called_once_with("secret", salt)
+        aesgcm.assert_called_once_with(b"k" * 32)
+        cipher.encrypt.assert_called_once_with(nonce, b"private-key-pem", None)
+
+    def test_decrypt_private_key_splits_deterministic_aesgcm_payload(self, monkeypatch):
+        salt = bytes(range(16))
+        nonce = bytes(range(16, 28))
+        ciphertext = b"ciphertext-and-tag"
+        encrypted = saml._ENCRYPTION_PREFIX + base64.b64encode(salt + nonce + ciphertext).decode()
+        derive = MagicMock(return_value=b"k" * 32)
+        cipher = MagicMock()
+        cipher.decrypt.return_value = b"private-key-pem"
+        aesgcm = MagicMock(return_value=cipher)
+        monkeypatch.setattr(saml, "_derive_key", derive)
+        monkeypatch.setattr(saml, "AESGCM", aesgcm)
+
+        assert saml.decrypt_private_key(encrypted, "secret") == "private-key-pem"
+        derive.assert_called_once_with("secret", salt)
+        aesgcm.assert_called_once_with(b"k" * 32)
+        cipher.decrypt.assert_called_once_with(nonce, ciphertext, None)
+
+    def test_empty_password_contracts_preserve_plaintext_or_encrypted_value(self, monkeypatch):
+        warning = MagicMock()
+        monkeypatch.setattr(saml.optic, "warning", warning)
+        encrypted = saml._ENCRYPTION_PREFIX + base64.b64encode(b"payload").decode()
+
+        assert saml.encrypt_private_key("plain-key", "") == "plain-key"
+        assert saml.decrypt_private_key(encrypted, "") == encrypted
+        assert warning.call_count == 2
+        assert "empty password" in warning.call_args_list[0].args[0]
+        assert "without password" in warning.call_args_list[1].args[0]
+
+    def test_wrong_password_and_truncated_payload_fail_loudly(self, monkeypatch):
+        private_pem, _ = saml.generate_sp_key_pair()
+        encrypted = saml.encrypt_private_key(private_pem, "correct-password")
+
+        with pytest.raises(InvalidTag):
+            saml.decrypt_private_key(encrypted, "wrong-password")
+
+        monkeypatch.setattr(saml, "_derive_key", MagicMock(return_value=b"k" * 32))
+        truncated = saml._ENCRYPTION_PREFIX + base64.b64encode(b"short").decode()
+        with pytest.raises(ValueError):
+            saml.decrypt_private_key(truncated, "password")
+
+    def test_unencrypted_private_key_is_returned_without_crypto_calls(self, monkeypatch):
+        derive = MagicMock()
+        monkeypatch.setattr(saml, "_derive_key", derive)
+
+        assert saml.decrypt_private_key("legacy-plaintext-key", "password") == "legacy-plaintext-key"
+        derive.assert_not_called()
+
+
+class TestSamlServiceSettingsAndPem:
+    def test_build_settings_normalizes_pem_and_selects_protocol_bindings(self):
+        settings = saml.build_saml_settings(
+            idp_entity_id="https://idp.example.test/entity",
+            idp_sso_url="https://idp.example.test/sso",
+            idp_slo_url="https://idp.example.test/slo",
+            idp_x509_cert="-----BEGIN CERTIFICATE-----\n IDP CERT \n-----END CERTIFICATE-----",
+            sp_entity_id="https://sp.example.test/metadata",
+            sp_acs_url="https://sp.example.test/acs",
+            sp_slo_url="https://sp.example.test/sls",
+            sp_private_key="-----BEGIN RSA PRIVATE KEY-----\n SP KEY \n-----END RSA PRIVATE KEY-----",
+            sp_x509_cert="-----BEGIN CERTIFICATE-----\n SP CERT \n-----END CERTIFICATE-----",
+            strict=False,
         )
 
-        private_key_pem, _ = generate_sp_key_pair(common_name="test.example.com")
-        password = "test-encryption-password"
-        encrypted = encrypt_private_key(private_key_pem, password)
-        assert encrypted != private_key_pem
-        assert encrypted.startswith("enc:aesgcm:")
-        decrypted = decrypt_private_key(encrypted, password)
-        assert decrypted == private_key_pem
+        assert settings == {
+            "strict": False,
+            "debug": False,
+            "sp": {
+                "entityId": "https://sp.example.test/metadata",
+                "assertionConsumerService": {
+                    "url": "https://sp.example.test/acs",
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                },
+                "x509cert": "SPCERT",
+                "privateKey": "SPKEY",
+                "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+                "singleLogoutService": {
+                    "url": "https://sp.example.test/sls",
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                },
+            },
+            "idp": {
+                "entityId": "https://idp.example.test/entity",
+                "singleSignOnService": {
+                    "url": "https://idp.example.test/sso",
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                },
+                "x509cert": "IDPCERT",
+                "singleLogoutService": {
+                    "url": "https://idp.example.test/slo",
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                },
+            },
+            "security": {
+                "authnRequestsSigned": True,
+                "wantAssertionsSigned": True,
+                "wantMessagesSigned": False,
+                "wantResponsesSigned": True,
+                "wantNameIdEncrypted": False,
+                "wantAssertionsEncrypted": False,
+                "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+                "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
+                "requestedAuthnContext": False,
+                "relaxDestinationValidation": False,
+                "wantNameId": True,
+            },
+        }
 
-    def test_encrypt_decrypt_with_empty_password_is_noop(self):
-        from services.saml import (
-            decrypt_private_key,
-            encrypt_private_key,
-            generate_sp_key_pair,
+    def test_build_settings_omits_logout_services_when_urls_are_empty(self):
+        settings = saml.build_saml_settings(
+            idp_entity_id="idp",
+            idp_sso_url="sso",
+            idp_x509_cert="idp-cert",
+            sp_entity_id="sp",
+            sp_acs_url="acs",
+            sp_private_key="sp-key",
+            sp_x509_cert="sp-cert",
         )
 
-        private_key_pem, _ = generate_sp_key_pair(common_name="test.example.com")
-        encrypted = encrypt_private_key(private_key_pem, "")
-        assert encrypted == private_key_pem
-        decrypted = decrypt_private_key(encrypted, "")
-        assert decrypted == private_key_pem
+        assert "singleLogoutService" not in settings["sp"]
+        assert "singleLogoutService" not in settings["idp"]
+        assert settings["strict"] is True
 
-    def test_build_saml_settings_returns_valid_dict(self):
-        from services.saml import build_saml_settings, generate_sp_key_pair
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("", ""),
+            ("bare-base64", "bare-base64"),
+            ("-----BEGIN CERTIFICATE----- MIIC mzCC -----END CERTIFICATE-----", "MIICmzCC"),
+            ("-----BEGIN PRIVATE KEY-----\r\nAA\tBB\n-----END PRIVATE KEY-----", "AABB"),
+        ],
+    )
+    def test_strip_pem_headers_handles_empty_bare_and_single_line_material(self, value, expected):
+        assert saml._strip_pem_headers(value) == expected
 
-        private_key_pem, cert_pem = generate_sp_key_pair(common_name="test.example.com")
-        result = build_saml_settings(
-            idp_entity_id="https://idp.example.com",
-            idp_sso_url="https://idp.example.com/sso",
-            idp_x509_cert="MIICmzCCAYMCBgGN...",
-            sp_entity_id="https://app.example.com/api/v1/sso/saml/metadata",
-            sp_acs_url="https://app.example.com/api/v1/sso/saml/acs",
-            sp_private_key=private_key_pem,
-            sp_x509_cert=cert_pem,
+
+class TestSamlServiceCertificatesAndMetadata:
+    def test_safe_xml_parser_does_not_expand_entities_and_rejects_malformed_xml(self):
+        xml = '<!DOCTYPE root [<!ENTITY secret "expanded">]><root>&secret;</root>'
+        root = saml._safe_xml_parse(xml)
+
+        assert root.text is None
+        assert len(root) == 1
+        assert root[0].text == "&secret;"
+        with pytest.raises(etree.XMLSyntaxError):
+            saml._safe_xml_parse(b"<broken>")
+
+    def test_metadata_extractors_return_nonempty_raw_values(self):
+        xml = _metadata_xml(
+            certs=("  CERT-A\n", "", "CERT-B"),
+            formats=("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", " "),
         )
-        assert result["idp"]["entityId"] == "https://idp.example.com"
-        assert result["sp"]["entityId"] == "https://app.example.com/api/v1/sso/saml/metadata"
-        assert "x509cert" in result["sp"]
-        assert "privateKey" in result["sp"]
-        assert result["strict"] is True
-        assert result["security"]["authnRequestsSigned"] is True
-        assert result["security"]["wantAssertionsSigned"] is True
-        assert result["security"]["wantResponsesSigned"] is True
-        assert result["security"]["relaxDestinationValidation"] is False
+
+        assert saml._extract_metadata_certs(xml) == ["  CERT-A\n", "CERT-B"]
+        assert saml._extract_metadata_nameid_formats(xml) == ["urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"]
+        assert saml._extract_metadata_certs("<broken>") is None
+        assert saml._extract_metadata_nameid_formats("<broken>") is None
+
+    def test_cert_expiry_skips_empty_and_reports_malformed_certificate(self, monkeypatch):
+        monkeypatch.setattr(saml, "datetime", _FrozenDateTime)
+
+        assert saml.check_cert_expiry("", "IdP") is None
+        assert saml.check_cert_expiry("not-a-certificate", "SP") == {
+            "name": "sp_cert_expiry",
+            "label": "SP X.509 certificate expiry",
+            "status": "fail",
+            "message": "SP X.509 certificate is malformed or could not be parsed.",
+            "hint": "Re-import the SP certificate.",
+        }
+
+    @pytest.mark.parametrize(
+        ("days", "expected"),
+        [
+            (
+                -1,
+                {
+                    "name": "idp_cert_expiry",
+                    "label": "IdP X.509 certificate expiry",
+                    "status": "fail",
+                    "message": "IdP X.509 certificate expired on 2029-12-31.",
+                    "hint": "Rotate the IdP certificate immediately.",
+                },
+            ),
+            (
+                6,
+                {
+                    "name": "idp_cert_expiry",
+                    "label": "IdP X.509 certificate expiry",
+                    "status": "fail",
+                    "message": "IdP X.509 certificate expires within 7 days (on 2030-01-07).",
+                    "hint": "Rotate the IdP certificate before it expires.",
+                },
+            ),
+            (
+                7,
+                {
+                    "name": "idp_cert_expiry",
+                    "label": "IdP X.509 certificate expiry",
+                    "status": "pass",
+                },
+            ),
+        ],
+    )
+    def test_cert_expiry_distinguishes_expired_near_expiry_and_boundary(self, monkeypatch, days, expected):
+        monkeypatch.setattr(saml, "datetime", _FrozenDateTime)
+        key = ec.generate_private_key(ec.SECP256R1())
+        cert = _certificate_pem(key, _NOW + timedelta(days=days))
+
+        assert saml.check_cert_expiry(cert, "IdP") == expected
+
+    def test_cert_expiry_supports_legacy_cryptography_datetime_api(self, monkeypatch):
+        monkeypatch.setattr(saml, "datetime", _FrozenDateTime)
+        legacy_cert = SimpleNamespace(not_valid_after=datetime(2031, 1, 1, 12, 0))
+        load = MagicMock(return_value=legacy_cert)
+        monkeypatch.setattr(saml.x509, "load_pem_x509_certificate", load)
+
+        assert saml.check_cert_expiry("BARE-CERT", "SP")["status"] == "pass"
+        load.assert_called_once_with(b"-----BEGIN CERTIFICATE-----\nBARE-CERT\n-----END CERTIFICATE-----")
+
+    @pytest.mark.parametrize(
+        ("acs", "frontend", "status"),
+        [
+            ("https://app.example.test/acs", "https://app.example.test", "pass"),
+            ("https://sp.example.test/acs", "https://app.example.test", "fail"),
+            ("not-a-url", "https://app.example.test", "pass"),
+            ("", "", "pass"),
+        ],
+    )
+    def test_sp_host_consistency_compares_only_present_hostnames(self, acs, frontend, status):
+        check = saml.check_sp_host_consistency(acs, frontend)
+
+        assert check["status"] == status
+        if status == "fail":
+            assert check == {
+                "name": "sp_host_consistency",
+                "label": "SP ACS host matches frontend",
+                "status": "fail",
+                "message": (
+                    "SP ACS host (sp.example.test) does not match deployment.frontend_url host "
+                    f"(app.example.test) {chr(8212)} the IdP will send assertions to sp.example.test but this "
+                    "deployment is reachable as app.example.test."
+                ),
+                "hint": "Either update the SP ACS URL or change deployment.frontend_url so they share the same host.",
+            }
+
+    def test_idp_cert_metadata_check_skips_absent_metadata_and_fails_bad_or_empty_metadata(self):
+        assert saml.check_idp_cert_against_metadata("CERT", None) is None
+        invalid = saml.check_idp_cert_against_metadata("CERT", "<broken>")
+        empty = saml.check_idp_cert_against_metadata("CERT", _metadata_xml())
+
+        assert invalid["status"] == "fail"
+        assert invalid["message"] == "IdP metadata is not valid XML."
+        assert empty["status"] == "fail"
+        assert empty["message"] == "IdP metadata contains no X509Certificate elements."
+
+    def test_idp_cert_metadata_check_normalizes_match_and_reports_mismatch(self):
+        configured = "-----BEGIN CERTIFICATE-----\nCERT-A\n-----END CERTIFICATE-----"
+        metadata = _metadata_xml(certs=(" CERT-A ", "CERT-B"))
+
+        assert saml.check_idp_cert_against_metadata(configured, metadata)["status"] == "pass"
+        mismatch = saml.check_idp_cert_against_metadata("CERT-C", metadata)
+        assert mismatch["status"] == "fail"
+        assert "does not match any signing certificate" in mismatch["message"]
+        assert saml.check_idp_cert_against_metadata("", metadata)["status"] == "pass"
+
+    def test_sp_cert_key_match_skips_missing_material_and_reports_parse_or_pair_failure(self):
+        private_one, cert_one = saml.generate_sp_key_pair(common_name="one")
+        private_two, _ = saml.generate_sp_key_pair(common_name="two")
+
+        assert saml.check_sp_cert_key_match("", private_one) is None
+        assert saml.check_sp_cert_key_match(cert_one, "") is None
+        malformed = saml.check_sp_cert_key_match("not-a-cert", private_one)
+        assert malformed["status"] == "fail"
+        assert malformed["message"] == "SP certificate or private key could not be parsed."
+        mismatch = saml.check_sp_cert_key_match(cert_one, private_two)
+        assert mismatch["status"] == "fail"
+        assert "do not match" in mismatch["message"]
+
+    def test_sp_cert_key_match_accepts_bare_cert_and_non_rsa_key(self):
+        key = ec.generate_private_key(ec.SECP256R1())
+        cert_pem = _certificate_pem(key, _NOW + timedelta(days=30))
+        bare_cert = saml._strip_pem_headers(cert_pem)
+
+        assert saml.check_sp_cert_key_match(bare_cert, _private_key_pem(key)) == {
+            "name": "sp_cert_key_match",
+            "label": "SP cert/key form a valid pair",
+            "status": "pass",
+        }
+
+    @pytest.mark.parametrize(
+        ("metadata", "configured", "expected"),
+        [
+            (None, "emailAddress", None),
+            ("<broken>", "emailAddress", None),
+            (_metadata_xml(), "emailAddress", None),
+            (
+                _metadata_xml(formats=("urn:oasis:names:tc:SAML:1.1:nameid-format:EMAILADDRESS",)),
+                " emailAddress ",
+                "pass",
+            ),
+            (
+                _metadata_xml(formats=("urn:example:emailAddressSuffix",)),
+                "emailAddress",
+                "fail",
+            ),
+        ],
+    )
+    def test_nameid_format_check_handles_missing_malformed_matching_and_unrelated_values(
+        self,
+        metadata,
+        configured,
+        expected,
+    ):
+        check = saml.check_nameid_format(metadata, configured)
+
+        if expected is None:
+            assert check is None
+        else:
+            assert check["status"] == expected
+            if expected == "fail":
+                assert "does not advertise" in check["message"]
+
+    def test_nameid_last_segment_strips_and_normalizes(self):
+        assert saml._nameid_last_segment("  urn:oasis:NameID-Format:EmailAddress  ") == "emailaddress"
 
 
-class TestSamlHelpers:
-    def test_extract_name_id_and_attrs(self):
-        from unittest.mock import MagicMock
+class TestSamlServiceNetworkChecks:
+    @pytest.mark.asyncio
+    async def test_fetch_metadata_streams_exact_request_and_decodes_invalid_utf8(self):
+        response = _stream_response([b"<metadata>", b"\xff", b"</metadata>"])
+        client, context = _stream_client(response)
 
-        from services.saml import extract_name_id_and_attrs
+        result = await saml.fetch_idp_metadata_xml(client, _METADATA_URL)
 
+        assert result == "<metadata>�</metadata>"
+        client.stream.assert_called_once_with("GET", _METADATA_URL)
+        context.__aenter__.assert_awaited_once_with()
+        context.__aexit__.assert_awaited_once()
+        response.raise_for_status.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_fetch_metadata_rejects_oversized_body_without_reading_success(self):
+        response = _stream_response([b"x" * (saml._MAX_METADATA_BYTES + 1)])
+        client, _ = _stream_client(response)
+
+        assert await saml.fetch_idp_metadata_xml(client, _METADATA_URL) is None
+
+    @pytest.mark.parametrize("failure_point", ["enter", "status", "iteration"])
+    @pytest.mark.asyncio
+    async def test_fetch_metadata_fails_soft_on_external_errors(self, failure_point):
+        error = RuntimeError(f"{failure_point} failed")
+        response = _stream_response(
+            [b"partial"],
+            status_error=error if failure_point == "status" else None,
+            iteration_error=error if failure_point == "iteration" else None,
+        )
+        client, _ = _stream_client(response, enter_error=error if failure_point == "enter" else None)
+
+        assert await saml.fetch_idp_metadata_xml(client, _METADATA_URL) is None
+
+    @pytest.mark.asyncio
+    async def test_sso_reachability_skips_missing_url_and_accepts_non_server_status(self):
+        client = MagicMock()
+        client.head = AsyncMock(return_value=SimpleNamespace(status_code=404))
+        client.get = AsyncMock()
+
+        assert await saml.check_idp_sso_url_reachable(client, "") is None
+        assert (await saml.check_idp_sso_url_reachable(client, "https://idp.example.test/sso"))["status"] == "pass"
+        client.head.assert_awaited_once_with("https://idp.example.test/sso", follow_redirects=False)
+        client.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sso_reachability_retries_head_405_and_reports_server_error(self):
+        client = MagicMock()
+        client.head = AsyncMock(return_value=SimpleNamespace(status_code=405))
+        client.get = AsyncMock(return_value=SimpleNamespace(status_code=503))
+
+        check = await saml.check_idp_sso_url_reachable(client, "https://idp.example.test/sso")
+
+        assert check["status"] == "fail"
+        assert check["message"] == "IdP SSO URL returned HTTP 503."
+        client.get.assert_awaited_once_with("https://idp.example.test/sso", follow_redirects=False)
+
+    @pytest.mark.asyncio
+    async def test_sso_reachability_fails_soft_on_network_error(self):
+        client = MagicMock()
+        client.head = AsyncMock(side_effect=RuntimeError("network details"))
+
+        check = await saml.check_idp_sso_url_reachable(client, "https://idp.example.test/sso")
+
+        assert check["status"] == "fail"
+        assert check["message"] == "IdP SSO URL is unreachable from this server."
+        assert "network details" not in str(check)
+
+    @pytest.mark.asyncio
+    async def test_slo_reachability_returns_skip_when_unconfigured(self):
+        client = MagicMock()
+
+        check = await saml.check_idp_slo_url_reachable(client, None)
+
+        assert check["status"] == "skip"
+        assert "No idp_slo_url configured" in check["message"]
+        client.head.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_slo_reachability_retries_head_405_and_accepts_get(self):
+        client = MagicMock()
+        client.head = AsyncMock(return_value=SimpleNamespace(status_code=405))
+        client.get = AsyncMock(return_value=SimpleNamespace(status_code=204))
+
+        check = await saml.check_idp_slo_url_reachable(client, "https://idp.example.test/slo")
+
+        assert check["status"] == "pass"
+        client.head.assert_awaited_once_with("https://idp.example.test/slo", follow_redirects=False)
+        client.get.assert_awaited_once_with("https://idp.example.test/slo", follow_redirects=False)
+
+    @pytest.mark.parametrize("failure", ["server", "network"])
+    @pytest.mark.asyncio
+    async def test_slo_reachability_reports_server_and_network_failures(self, failure):
+        client = MagicMock()
+        if failure == "server":
+            client.head = AsyncMock(return_value=SimpleNamespace(status_code=500))
+        else:
+            client.head = AsyncMock(side_effect=RuntimeError("network details"))
+
+        check = await saml.check_idp_slo_url_reachable(client, "https://idp.example.test/slo")
+
+        assert check["status"] == "fail"
+        expected = "returned HTTP 500" if failure == "server" else "is unreachable"
+        assert expected in check["message"]
+        assert "network details" not in str(check)
+
+    @pytest.mark.asyncio
+    async def test_dynamic_metadata_setting_controls_fetch(self, monkeypatch):
+        get_sync = MagicMock(side_effect=["", _METADATA_URL])
+        fetch = AsyncMock(return_value="<metadata/>")
+        monkeypatch.setattr(saml.ds, "get_sync", get_sync)
+        monkeypatch.setattr(saml, "fetch_idp_metadata_xml", fetch)
+        client = MagicMock()
+
+        assert await saml.get_idp_metadata_xml(client) is None
+        assert await saml.get_idp_metadata_xml(client) == "<metadata/>"
+        assert get_sync.call_args_list[0].args == ("saml.idp_metadata_url", "")
+        assert get_sync.call_args_list[1].args == ("saml.idp_metadata_url", "")
+        fetch.assert_awaited_once_with(client, _METADATA_URL)
+
+    @pytest.mark.asyncio
+    async def test_dynamic_metadata_setting_failure_propagates(self, monkeypatch):
+        monkeypatch.setattr(saml.ds, "get_sync", MagicMock(side_effect=RuntimeError("settings unavailable")))
+
+        with pytest.raises(RuntimeError, match="settings unavailable"):
+            await saml.get_idp_metadata_xml(MagicMock())
+
+
+class TestSamlServiceIdentityHelpers:
+    def test_extract_name_id_normalizes_subject_and_preserves_attributes(self):
         auth = MagicMock()
-        auth.get_nameid.return_value = "User@Example.COM"
-        auth.get_attributes.return_value = {"displayName": ["Test User"]}
+        attributes = {"mail": ["User@Example.TEST"], "groups": ["engineering"]}
+        auth.get_nameid.return_value = "  User@Example.TEST  "
+        auth.get_attributes.return_value = attributes
 
-        email, attrs = extract_name_id_and_attrs(auth)
-        assert email == "user@example.com"
-        assert attrs["displayName"] == ["Test User"]
+        assert saml.extract_name_id_and_attrs(auth) == ("user@example.test", attributes)
+        auth.get_nameid.assert_called_once_with()
+        auth.get_attributes.assert_called_once_with()
 
-    def test_get_display_name_from_display_name_attr(self):
-        from services.saml import get_display_name
+    def test_extract_name_id_defaults_missing_toolkit_values(self):
+        auth = MagicMock()
+        auth.get_nameid.return_value = None
+        auth.get_attributes.return_value = None
 
-        attrs = {"displayName": ["Jane Smith"]}
-        assert get_display_name(attrs) == "Jane Smith"
+        assert saml.extract_name_id_and_attrs(auth) == ("", {})
 
-    def test_get_display_name_fallback(self):
-        from services.saml import get_display_name
+    def test_extract_name_id_propagates_toolkit_failure(self):
+        auth = MagicMock()
+        auth.get_nameid.side_effect = RuntimeError("toolkit unavailable")
 
-        assert get_display_name({}) == "SSO User"
-        assert get_display_name({}, fallback="Unknown") == "Unknown"
+        with pytest.raises(RuntimeError, match="toolkit unavailable"):
+            saml.extract_name_id_and_attrs(auth)
+        auth.get_attributes.assert_not_called()
 
-    def test_get_display_name_tries_multiple_claims(self):
-        from services.saml import get_display_name
+    @pytest.mark.parametrize(
+        "attribute",
+        [
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+            "displayName",
+            "cn",
+            "urn:oid:2.16.840.1.113730.3.1.241",
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+            "givenName",
+            "firstName",
+        ],
+    )
+    def test_display_name_supports_each_claim_alias(self, attribute):
+        assert saml.get_display_name({attribute: ["  Alice Example  "]}) == "Alice Example"
 
-        attrs = {"givenName": ["Jane"]}
-        assert get_display_name(attrs) == "Jane"
+    def test_display_name_obeys_priority_and_skips_blank_values(self):
+        attributes = {
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name": ["   "],
+            "displayName": [],
+            "cn": ["  Common Name  "],
+            "givenName": ["Lower Priority"],
+        }
 
-    def test_strip_pem_headers(self):
-        from services.saml import _strip_pem_headers
-
-        pem = "-----BEGIN CERTIFICATE-----\nMIIC\nmzCC\n-----END CERTIFICATE-----\n"
-        assert _strip_pem_headers(pem) == "MIICmzCC"
+        assert saml.get_display_name(attributes, fallback="Fallback") == "Common Name"
+        assert saml.get_display_name({}, fallback="Fallback") == "Fallback"
 
 
 class TestSamlEndpoints:

--- a/tests/test_sso_saml_routes.py
+++ b/tests/test_sso_saml_routes.py
@@ -1,0 +1,1293 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy <tanvi.reddy330@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic route tests for the SAML service provider endpoints."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request
+
+from api.deps import get_db
+from api.routes import sso_saml as saml
+from models.user import UserRole
+from services.security_events import EventType, Severity
+
+FRONTEND_URL = "https://app.example.test"
+IDP_URL = "https://idp.example.test/sso"
+USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+TOKEN_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _result(value):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+def _config(**overrides):
+    values = {
+        "idp_entity_id": "https://idp.example.test/entity",
+        "idp_sso_url": IDP_URL,
+        "idp_slo_url": "",
+        "idp_x509_cert": "idp-cert",
+        "sp_entity_id": f"{FRONTEND_URL}/api/v1/sso/saml/metadata",
+        "sp_acs_url": f"{FRONTEND_URL}/api/v1/sso/saml/acs",
+        "sp_private_key_enc": "encrypted-key",
+        "sp_x509_cert": "sp-cert",
+        "external_sp_private_key": None,
+        "jit_provisioning": True,
+        "default_role": "user",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _user(**overrides):
+    values = {
+        "id": USER_ID,
+        "email": "alice@example.test",
+        "username": "alice",
+        "name": "Alice Example",
+        "role": UserRole.user,
+        "auth_provider": "saml",
+        "sso_subject_id": "subject-alice",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _auth():
+    auth = MagicMock()
+    auth.process_response.return_value = None
+    auth.get_errors.return_value = []
+    auth.get_last_error_reason.return_value = None
+    auth.is_authenticated.return_value = True
+    auth.get_last_message_id.return_value = "response-123"
+    auth.get_last_response_xml.return_value = None
+    auth.get_nameid.return_value = "subject-alice"
+    return auth
+
+
+def _request(
+    path: str = "/api/v1/sso/saml/login",
+    *,
+    query: bytes = b"",
+    body: bytes = b"",
+    content_type: bytes | None = None,
+) -> Request:
+    headers = [] if content_type is None else [(b"content-type", content_type)]
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST" if body else "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query,
+        "headers": headers,
+        "client": ("203.0.113.10", 1234),
+        "server": ("test", 80),
+    }
+    delivered = False
+
+    async def receive():
+        nonlocal delivered
+        if delivered:
+            return {"type": "http.disconnect"}
+        delivered = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+@pytest.fixture(autouse=True)
+def reset_dynamic_saml_cache():
+    old_cache = saml._dynamic_saml_config_cache
+    old_signature = saml._dynamic_saml_config_signature
+    saml._dynamic_saml_config_cache = None
+    saml._dynamic_saml_config_signature = None
+    yield
+    saml._dynamic_saml_config_cache = old_cache
+    saml._dynamic_saml_config_signature = old_signature
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    values = {"deployment.frontend_url": FRONTEND_URL}
+    flags = {"external_sp": False, "external_idp": False}
+
+    def get_sync(key, default=""):
+        return values.get(key, default)
+
+    def get_sync_bool(key, default=False):
+        return values.get(key, default)
+
+    def get_sync_int(key, default=0):
+        return int(values.get(key, default))
+
+    monkeypatch.setattr(saml.ds, "get_sync", get_sync)
+    monkeypatch.setattr(saml.ds, "get_sync_bool", get_sync_bool)
+    monkeypatch.setattr(saml.ds, "get_sync_int", get_sync_int)
+    monkeypatch.setattr(saml.ds, "has_external_saml_material", lambda: flags["external_sp"])
+    monkeypatch.setattr(
+        saml.ds,
+        "is_externally_managed",
+        lambda key: key == "saml.idp_x509_cert" and flags["external_idp"],
+    )
+    return SimpleNamespace(values=values, flags=flags)
+
+
+@pytest.fixture
+def db():
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_result(None))
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.add = MagicMock()
+    return session
+
+
+@pytest.fixture
+def app(db):
+    route_app = FastAPI()
+    route_app.include_router(saml.router)
+
+    async def override_db():
+        yield db
+
+    route_app.dependency_overrides[get_db] = override_db
+    return route_app
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as http:
+        yield http
+
+
+@pytest.fixture
+def acs_env(monkeypatch, db, settings):
+    config = _config()
+    auth = _auth()
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=None)
+    redis.setex = AsyncMock()
+    redis.delete = AsyncMock()
+    redis.incr = AsyncMock(return_value=1)
+    redis.expire = AsyncMock()
+    redis.getdel = AsyncMock()
+
+    existing_user = _user()
+    db.execute.return_value = _result(existing_user)
+
+    get_config = AsyncMock(return_value=config)
+    decrypt = MagicMock(return_value="sp-private-key")
+    build_auth = MagicMock(return_value=auth)
+    extract = MagicMock(
+        return_value=(
+            "alice@example.test",
+            {"displayName": ["Alice Example"]},
+        )
+    )
+    issue_tokens = AsyncMock(return_value=("access-token", "refresh-token", 3600))
+    emit = AsyncMock()
+    username = AsyncMock(return_value="alice")
+
+    sessions = {}
+
+    async def finalize(session_id, *, checks, summary, actor_email):
+        sessions[session_id] = {
+            "checks": checks,
+            "summary": summary,
+            "actor_email": actor_email,
+        }
+
+    async def get_session(session_id):
+        return sessions.get(session_id)
+
+    finalize_mock = AsyncMock(side_effect=finalize)
+    get_session_mock = AsyncMock(side_effect=get_session)
+    render = MagicMock(side_effect=lambda **kwargs: f"<html>{kwargs['ok']}:{kwargs['session_id']}</html>")
+
+    monkeypatch.setattr(saml, "_get_saml_config", get_config)
+    monkeypatch.setattr(saml, "_decrypt_sp_key", decrypt)
+    monkeypatch.setattr(saml, "_build_auth", build_auth)
+    monkeypatch.setattr(saml, "extract_name_id_and_attrs", extract)
+    monkeypatch.setattr(saml, "_issue_tokens", issue_tokens)
+    monkeypatch.setattr(saml, "get_redis", lambda: redis)
+    monkeypatch.setattr(saml, "emit_security_event", emit)
+    monkeypatch.setattr(saml, "generate_unique_username", username)
+    monkeypatch.setattr(saml.secrets, "token_urlsafe", lambda _size: "oauth-code")
+    monkeypatch.setattr(saml.uuid, "uuid4", lambda: TOKEN_ID)
+    monkeypatch.setattr(saml.sso_diagnostics, "new_session_id", lambda: "corr-safe")
+    monkeypatch.setattr(saml.sso_diagnostics, "finalize", finalize_mock)
+    monkeypatch.setattr(saml.sso_diagnostics, "get_session", get_session_mock)
+    monkeypatch.setattr(saml.sso_diagnostics, "render_result_page", render)
+
+    return SimpleNamespace(
+        config=config,
+        auth=auth,
+        redis=redis,
+        user=existing_user,
+        get_config=get_config,
+        decrypt=decrypt,
+        build_auth=build_auth,
+        extract=extract,
+        issue_tokens=issue_tokens,
+        emit=emit,
+        username=username,
+        sessions=sessions,
+        finalize=finalize_mock,
+        get_session=get_session_mock,
+        render=render,
+        db=db,
+    )
+
+
+def _checks(env, session_id="corr-safe"):
+    return env.sessions[session_id]["checks"]
+
+
+def _check(env, name, session_id="corr-safe"):
+    return next(check for check in _checks(env, session_id) if check["name"] == name)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, "/"),
+        ("", "/"),
+        ("dashboard", "/"),
+        ("https://evil.example/path", "/"),
+        ("//evil.example/path", "/"),
+        ("/sessions/abc?tab=trace", "/sessions/abc?tab=trace"),
+    ],
+)
+def test_safe_redirect_path_accepts_only_local_absolute_paths(value, expected):
+    assert saml._safe_redirect_path(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, (None, "/")),
+        ("/dashboard", (None, "/dashboard")),
+        ("https://evil.example", (None, "/")),
+        ("__e2e:session_1", ("session_1", "/")),
+        ("__e2e:session_1:ignored", ("session_1", "/")),
+        ("__e2e:bad/id", (None, "/")),
+        (f"__e2e:{'a' * 65}", (None, "/")),
+    ],
+)
+def test_parse_relay_state_separates_diagnostics_from_redirects(raw, expected):
+    assert saml._parse_relay_state(raw) == expected
+
+
+def test_error_redirect_uses_controlled_origin_and_sanitized_id(settings):
+    response = saml._saml_error_redirect("bad/id?next=https://evil.example")
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{FRONTEND_URL}/login?sso_error=invalid"
+
+
+def test_prepare_saml_request_uses_configured_public_origin(settings):
+    settings.values["deployment.frontend_url"] = "https://sso.example.test:8443"
+    data = saml._prepare_saml_request(_request(query=b"next=%2Fdashboard"))
+    assert data == {
+        "https": "on",
+        "http_host": "sso.example.test:8443",
+        "server_port": "8443",
+        "script_name": "/api/v1/sso/saml/login",
+        "get_data": {"next": "/dashboard"},
+        "post_data": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_prepare_saml_request_with_body_includes_form(settings):
+    request = _request(
+        "/api/v1/sso/saml/acs",
+        body=b"SAMLResponse=assertion&RelayState=%2Ftraces",
+        content_type=b"application/x-www-form-urlencoded",
+    )
+    data = await saml._prepare_saml_request_with_body(request)
+    assert data["post_data"] == {"SAMLResponse": "assertion", "RelayState": "/traces"}
+
+
+@pytest.mark.parametrize(
+    ("slo_url", "expected_sp_slo"), [("", ""), ("https://idp.example.test/slo", f"{FRONTEND_URL}/api/v1/sso/saml/sls")]
+)
+def test_build_auth_passes_strict_settings_to_onelogin(monkeypatch, settings, slo_url, expected_sp_slo):
+    config = _config(idp_slo_url=slo_url)
+    toolkit = MagicMock(return_value="toolkit-auth")
+    build_settings = MagicMock(return_value={"strict": True})
+    monkeypatch.setattr(saml, "OneLogin_Saml2_Auth", toolkit)
+    monkeypatch.setattr(saml, "build_saml_settings", build_settings)
+
+    result = saml._build_auth(config, "private-key", {"post_data": {}})
+
+    assert result == "toolkit-auth"
+    assert build_settings.call_args.kwargs["sp_slo_url"] == expected_sp_slo
+    assert build_settings.call_args.kwargs["idp_slo_url"] == slo_url
+    toolkit.assert_called_once_with({"post_data": {}}, old_settings={"strict": True})
+
+
+@pytest.mark.asyncio
+async def test_get_saml_config_prefers_database_and_applies_external_material(monkeypatch, db, settings):
+    stored = _config(idp_x509_cert="stored-idp", sp_x509_cert="stored-sp")
+    db.execute.return_value = _result(stored)
+    settings.flags.update(external_sp=True, external_idp=True)
+    settings.values.update(
+        {
+            "saml.sp_private_key": "external-private-key",
+            "saml.sp_x509_cert": "external-sp-cert",
+            "saml.idp_x509_cert": "external-idp-cert",
+        }
+    )
+
+    resolved = await saml._get_saml_config(db)
+
+    assert resolved is not stored
+    assert resolved.external_sp_private_key == "external-private-key"
+    assert resolved.sp_x509_cert == "external-sp-cert"
+    assert resolved.idp_x509_cert == "external-idp-cert"
+    assert resolved.sp_entity_id == stored.sp_entity_id
+
+    settings.flags.update(external_sp=False, external_idp=False)
+    assert await saml._get_saml_config(db) is stored
+
+
+@pytest.mark.asyncio
+async def test_get_saml_config_returns_none_when_required_dynamic_settings_are_missing(db, settings):
+    assert await saml._get_saml_config(db) is None
+
+
+@pytest.mark.asyncio
+async def test_get_saml_config_generates_and_caches_dynamic_key_pair(monkeypatch, db, settings):
+    settings.values.update(
+        {
+            "saml.idp_entity_id": "https://idp.example.test/entity",
+            "saml.idp_sso_url": IDP_URL,
+            "saml.idp_slo_url": "https://idp.example.test/slo",
+            "saml.idp_x509_cert": "idp-cert",
+            "saml.jit_provisioning": False,
+            "saml.default_role": "reviewer",
+            "saml.sp_key_encryption_password": "encryption-password",
+        }
+    )
+    generate = MagicMock(return_value=("generated-key", "generated-cert"))
+    encrypt = MagicMock(return_value="encrypted-generated-key")
+    monkeypatch.setattr(saml, "generate_sp_key_pair", generate)
+    monkeypatch.setattr(saml, "encrypt_private_key", encrypt)
+
+    first = await saml._get_saml_config(db)
+    second = await saml._get_saml_config(db)
+
+    assert second is first
+    assert first.sp_entity_id == f"{FRONTEND_URL}/api/v1/sso/saml/metadata"
+    assert first.sp_acs_url == f"{FRONTEND_URL}/api/v1/sso/saml/acs"
+    assert first.sp_private_key_enc == "encrypted-generated-key"
+    assert first.sp_x509_cert == "generated-cert"
+    assert first.jit_provisioning is False
+    assert first.default_role == "reviewer"
+    generate.assert_called_once_with(common_name=first.sp_entity_id)
+    encrypt.assert_called_once_with("generated-key", "encryption-password")
+
+
+@pytest.mark.asyncio
+async def test_get_saml_config_warns_when_generated_key_is_not_encrypted(monkeypatch, db, settings):
+    settings.values.update(
+        {
+            "saml.idp_entity_id": "https://idp.example.test/entity",
+            "saml.idp_sso_url": IDP_URL,
+            "saml.sp_key_encryption_password": "",
+        }
+    )
+    warning = MagicMock()
+    monkeypatch.setattr(saml.optic, "warning", warning)
+    monkeypatch.setattr(saml, "generate_sp_key_pair", MagicMock(return_value=("key", "cert")))
+    monkeypatch.setattr(saml, "encrypt_private_key", MagicMock(return_value="key"))
+
+    config = await saml._get_saml_config(db)
+
+    assert config.sp_private_key_enc == "key"
+    warning.assert_called_once()
+    assert "stored unencrypted" in warning.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_get_saml_config_rechecks_cache_after_waiting_for_lock(monkeypatch, db, settings):
+    settings.values.update(
+        {
+            "saml.idp_entity_id": "https://idp.example.test/entity",
+            "saml.idp_sso_url": IDP_URL,
+        }
+    )
+    cached = object()
+
+    class CacheFilledByFirstRequest:
+        async def __aenter__(self):
+            saml._dynamic_saml_config_cache = cached
+            saml._dynamic_saml_config_signature = saml._dynamic_saml_signature()
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    monkeypatch.setattr(saml, "_dynamic_saml_config_lock", CacheFilledByFirstRequest())
+
+    assert await saml._get_saml_config(db) is cached
+
+
+@pytest.mark.asyncio
+async def test_get_saml_config_uses_external_key_pair_without_generating(monkeypatch, db, settings):
+    settings.values.update(
+        {
+            "saml.idp_entity_id": "https://idp.example.test/entity",
+            "saml.idp_sso_url": IDP_URL,
+            "saml.sp_entity_id": "https://sp.example.test/metadata",
+            "saml.sp_acs_url": "https://sp.example.test/acs",
+            "saml.sp_private_key": "external-key",
+            "saml.sp_x509_cert": "external-cert",
+        }
+    )
+    settings.flags["external_sp"] = True
+    generate = MagicMock()
+    monkeypatch.setattr(saml, "generate_sp_key_pair", generate)
+
+    config = await saml._get_saml_config(db)
+
+    assert config.external_sp_private_key == "external-key"
+    assert config.sp_private_key_enc == ""
+    assert config.sp_x509_cert == "external-cert"
+    generate.assert_not_called()
+
+
+def test_decrypt_sp_key_prefers_external_material(monkeypatch, settings):
+    decrypt = MagicMock(return_value="decrypted")
+    monkeypatch.setattr(saml, "decrypt_private_key", decrypt)
+
+    assert saml._decrypt_sp_key(_config(external_sp_private_key="external-key")) == "external-key"
+    assert saml._decrypt_sp_key(_config()) == "decrypted"
+    decrypt.assert_called_once_with("encrypted-key", "")
+
+
+@pytest.mark.asyncio
+async def test_issue_tokens_persists_refresh_session_and_clears_user_revocation(monkeypatch, settings):
+    settings.values["jwt.refresh_token_expire_days"] = 7
+    redis = MagicMock()
+    redis.setex = AsyncMock()
+    redis.delete = AsyncMock()
+    access = MagicMock(return_value=("access", 900))
+    refresh = MagicMock(return_value=("refresh", "refresh-jti"))
+    monkeypatch.setattr(saml, "create_access_token", access)
+    monkeypatch.setattr(saml, "create_refresh_token", refresh)
+    monkeypatch.setattr(saml, "get_redis", lambda: redis)
+    user = _user(role=UserRole.reviewer)
+
+    assert await saml._issue_tokens(user) == ("access", "refresh", 900)
+    access.assert_called_once_with(USER_ID, UserRole.reviewer)
+    refresh.assert_called_once_with(USER_ID, UserRole.reviewer)
+    redis.setex.assert_awaited_once_with("refresh_jti:refresh-jti", 7 * 86400, str(USER_ID))
+    redis.delete.assert_awaited_once_with(f"revoked_user:{USER_ID}")
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        ("idp_cert malformed", "IdP certificate missing or malformed."),
+        ("sp_cert malformed", "SP key or certificate invalid."),
+        ("idp_sso_url invalid", "IdP SSO URL missing or invalid."),
+        ("unexpected", "SAML configuration error."),
+    ],
+)
+@pytest.mark.asyncio
+async def test_saml_check_suite_reports_toolkit_configuration_failures(monkeypatch, settings, error, message):
+    monkeypatch.setattr(saml, "_build_auth", MagicMock(side_effect=ValueError(error)))
+
+    checks = await saml._run_saml_check_suite(_config(), "key", FRONTEND_URL, MagicMock())
+
+    assert checks == [
+        {
+            "name": "onelogin_build",
+            "label": "OneLogin SAML settings load",
+            "status": "fail",
+            "message": message,
+            "hint": "Open the admin SAML page for full diagnostics.",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_saml_check_suite_runs_all_reachability_and_certificate_checks(monkeypatch, settings):
+    settings.values["saml.idp_metadata_url"] = "https://idp.example.test/metadata"
+    auth = MagicMock()
+    auth.login.return_value = IDP_URL
+    monkeypatch.setattr(saml, "_build_auth", MagicMock(return_value=auth))
+    monkeypatch.setattr(saml, "get_idp_metadata_xml", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        saml,
+        "check_idp_sso_url_reachable",
+        AsyncMock(return_value={"name": "sso", "status": "pass"}),
+    )
+    monkeypatch.setattr(
+        saml,
+        "check_idp_slo_url_reachable",
+        AsyncMock(return_value={"name": "slo", "status": "skip"}),
+    )
+    sync_checks = [
+        "check_idp_cert_against_metadata",
+        "check_cert_expiry",
+        "check_sp_host_consistency",
+        "check_sp_cert_key_match",
+        "check_nameid_format",
+    ]
+    for name in sync_checks:
+        monkeypatch.setattr(saml, name, MagicMock(return_value={"name": name, "status": "pass"}))
+
+    checks = await saml._run_saml_check_suite(
+        _config(idp_slo_url="https://idp.example.test/slo"),
+        "key",
+        FRONTEND_URL,
+        MagicMock(),
+    )
+
+    assert checks[0]["name"] == "onelogin_build"
+    assert checks[1]["name"] == "authn_request"
+    assert any(check["name"] == "idp_metadata_reachable" and check["status"] == "fail" for check in checks)
+    assert {check["name"] for check in checks} >= {"sso", "slo", *sync_checks}
+    auth.login.assert_called_once_with(return_to="/")
+
+
+@pytest.mark.asyncio
+async def test_saml_health_probe_handles_absent_config_and_key_failure(monkeypatch, db, settings):
+    get_config = AsyncMock(return_value=None)
+    monkeypatch.setattr(saml, "_get_saml_config", get_config)
+    assert await saml.saml_health_probe(db) is None
+
+    get_config.return_value = _config()
+    monkeypatch.setattr(saml, "_decrypt_sp_key", MagicMock(side_effect=ValueError("wrong password")))
+    monkeypatch.setattr(saml, "time", SimpleNamespace(monotonic=MagicMock(side_effect=[10.0, 10.004])))
+    result = await saml.saml_health_probe(db)
+    assert result == {
+        "ok": False,
+        "checks": [
+            {
+                "name": "sp_key_decrypt",
+                "label": "SP private key decrypts",
+                "status": "fail",
+                "message": "SP private key could not be decrypted.",
+                "hint": "Check saml.sp_key_encryption_password.",
+            }
+        ],
+        "latency_ms": 4,
+    }
+
+
+@pytest.mark.asyncio
+async def test_saml_health_probe_uses_bounded_non_redirecting_client(monkeypatch, db, settings):
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=_config()))
+    monkeypatch.setattr(saml, "_decrypt_sp_key", MagicMock(return_value="key"))
+    monkeypatch.setattr(
+        saml,
+        "_run_saml_check_suite",
+        AsyncMock(return_value=[{"name": "suite", "status": "pass"}]),
+    )
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client_factory = MagicMock(return_value=client)
+    monkeypatch.setattr(saml.httpx, "AsyncClient", client_factory)
+    monkeypatch.setattr(saml, "time", SimpleNamespace(monotonic=MagicMock(side_effect=[20.0, 20.012])))
+
+    result = await saml.saml_health_probe(db)
+
+    assert result["ok"] is True
+    assert result["latency_ms"] == 12
+    assert [check["name"] for check in result["checks"]] == ["sp_key_decrypt", "suite"]
+    client_factory.assert_called_once_with(timeout=10.0, follow_redirects=False)
+
+
+@pytest.mark.asyncio
+async def test_login_returns_404_when_saml_is_not_configured(monkeypatch, client, settings):
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=None))
+    response = await client.get("/api/v1/sso/saml/login")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "SAML SSO is not configured"
+
+
+@pytest.mark.parametrize(
+    ("next_path", "expected_relay"),
+    [
+        (None, "/"),
+        ("/sessions/abc", "/sessions/abc"),
+        ("https://evil.example/phish", "/"),
+        ("//evil.example/phish", "/"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_login_redirects_to_idp_with_sanitized_relay_state(
+    monkeypatch,
+    client,
+    settings,
+    next_path,
+    expected_relay,
+):
+    auth = MagicMock()
+    auth.login.return_value = f"{IDP_URL}?request=signed"
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=_config()))
+    monkeypatch.setattr(saml, "_decrypt_sp_key", MagicMock(return_value="key"))
+    monkeypatch.setattr(saml, "_build_auth", MagicMock(return_value=auth))
+
+    response = await client.get("/api/v1/sso/saml/login", params={} if next_path is None else {"next": next_path})
+
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(IDP_URL)
+    auth.login.assert_called_once_with(return_to=expected_relay)
+
+
+@pytest.mark.asyncio
+async def test_login_uses_valid_diagnostics_relay_state(monkeypatch, client, settings):
+    auth = MagicMock()
+    auth.login.return_value = IDP_URL
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=_config()))
+    monkeypatch.setattr(saml, "_decrypt_sp_key", MagicMock(return_value="key"))
+    monkeypatch.setattr(saml, "_build_auth", MagicMock(return_value=auth))
+
+    response = await client.get("/api/v1/sso/saml/login", params={"e2e": "session_123"})
+
+    assert response.status_code == 302
+    auth.login.assert_called_once_with(return_to="__e2e:session_123")
+
+
+@pytest.mark.parametrize("session_id", ["bad/id", "bad id", "a" * 65])
+@pytest.mark.asyncio
+async def test_login_rejects_invalid_diagnostics_session_ids(monkeypatch, client, settings, session_id):
+    build_auth = MagicMock()
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=_config()))
+    monkeypatch.setattr(saml, "_decrypt_sp_key", MagicMock(return_value="key"))
+    monkeypatch.setattr(saml, "_build_auth", build_auth)
+
+    response = await client.get("/api/v1/sso/saml/login", params={"e2e": session_id})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid e2e session id"
+    build_auth.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_metadata_is_public_xml_and_reports_toolkit_validation_errors(monkeypatch, client, settings):
+    toolkit_settings = MagicMock()
+    toolkit_settings.get_sp_metadata.return_value = "<EntityDescriptor/>"
+    toolkit_settings.validate_metadata.return_value = []
+    auth = MagicMock()
+    auth.get_settings.return_value = toolkit_settings
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=_config()))
+    monkeypatch.setattr(saml, "_decrypt_sp_key", MagicMock(return_value="key"))
+    monkeypatch.setattr(saml, "_build_auth", MagicMock(return_value=auth))
+
+    response = await client.get("/api/v1/sso/saml/metadata")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/xml"
+    assert response.text == "<EntityDescriptor/>"
+
+    toolkit_settings.validate_metadata.return_value = ["invalid_sp_cert", "invalid_acs"]
+    response = await client.get("/api/v1/sso/saml/metadata")
+    assert response.status_code == 500
+    assert response.json()["detail"] == "SP metadata validation error: invalid_sp_cert, invalid_acs"
+
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=None))
+    response = await client.get("/api/v1/sso/saml/metadata")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_acs_without_configuration_records_diagnostics_and_redirects(monkeypatch, client, acs_env):
+    acs_env.get_config.return_value = None
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{FRONTEND_URL}/login?sso_error=corr-safe"
+    assert _check(acs_env, "saml_configured")["status"] == "fail"
+    assert acs_env.sessions["corr-safe"]["summary"] == "SAML not configured"
+    acs_env.build_auth.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_acs_e2e_failure_returns_result_page_without_session_tokens(client, acs_env):
+    acs_env.get_config.return_value = None
+
+    response = await client.post(
+        "/api/v1/sso/saml/acs",
+        data={"SAMLResponse": "assertion", "RelayState": "__e2e:diag_123"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert response.text == "<html>False:diag_123</html>"
+    assert acs_env.sessions["diag_123"]["summary"] == "SAML not configured"
+    acs_env.issue_tokens.assert_not_awaited()
+    acs_env.db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_continues_redirect_when_diagnostics_storage_fails(client, acs_env):
+    acs_env.get_config.return_value = None
+    acs_env.finalize.side_effect = RuntimeError("redis unavailable")
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{FRONTEND_URL}/login?sso_error=corr-safe"
+
+
+@pytest.mark.asyncio
+async def test_acs_rejects_sp_key_decryption_failure(client, acs_env):
+    acs_env.decrypt.side_effect = ValueError("bad key password")
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "sp_key_decrypt")["message"] == "bad key password"
+    assert acs_env.sessions["corr-safe"]["summary"] == "SP key decrypt failed"
+    acs_env.build_auth.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_acs_handles_malformed_response_from_toolkit(client, acs_env):
+    acs_env.auth.process_response.side_effect = ValueError("malformed assertion XML")
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "not-xml"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "process_response")["status"] == "fail"
+    assert acs_env.sessions["corr-safe"]["summary"] == "process_response crashed"
+    acs_env.redis.get.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("reason", "hint_fragment"),
+    [
+        ("Signature validation failed", "rotated its cert"),
+        ("Audience mismatch", "entityID"),
+        ("Assertion expired at NotOnOrAfter", "Clock skew"),
+        ("Destination mismatch", "ACS URL"),
+        ("Certificate rejected", "IdP cert"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_acs_rejects_toolkit_signature_and_condition_errors(client, acs_env, reason, hint_fragment):
+    acs_env.auth.get_errors.return_value = ["invalid_response"]
+    acs_env.auth.get_last_error_reason.return_value = reason
+
+    response = await client.post(
+        "/api/v1/sso/saml/acs",
+        data={"SAMLResponse": "assertion"},
+        headers={"user-agent": "test-browser"},
+    )
+
+    assert response.status_code == 302
+    check = _check(acs_env, "process_response")
+    assert check["message"] == reason
+    assert hint_fragment in check["hint"]
+    event = acs_env.emit.await_args.args[0]
+    assert event.event_type == EventType.SSO_FAILURE
+    assert event.severity == Severity.WARNING
+    assert event.outcome == "failure"
+    assert event.source_ip == "127.0.0.1"
+    assert event.user_agent == "test-browser"
+    assert reason in event.detail
+
+
+@pytest.mark.asyncio
+async def test_acs_rejects_response_that_did_not_authenticate_subject(client, acs_env):
+    acs_env.auth.is_authenticated.return_value = False
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "is_authenticated")["status"] == "fail"
+    acs_env.redis.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_requires_stable_response_identifier(client, acs_env):
+    acs_env.auth.get_last_message_id.return_value = None
+    acs_env.auth.get_last_response_xml.return_value = None
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "replay_protection")["status"] == "fail"
+    assert acs_env.sessions["corr-safe"]["summary"] == "no response id"
+
+
+@pytest.mark.asyncio
+async def test_acs_hashes_response_xml_when_toolkit_omits_message_id(client, acs_env):
+    acs_env.auth.get_last_message_id.return_value = None
+    acs_env.auth.get_last_response_xml.return_value = "<Response ID='fallback'/>"
+    expected_id = hashlib.sha256(b"<Response ID='fallback'/>").hexdigest()
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    acs_env.redis.get.assert_awaited_once_with(f"saml_assertion:{expected_id}")
+    acs_env.redis.setex.assert_any_await(f"saml_assertion:{expected_id}", 300, "1")
+
+
+@pytest.mark.asyncio
+async def test_acs_rejects_replayed_assertion_and_emits_failure_event(client, acs_env):
+    acs_env.redis.get.return_value = "1"
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "replay_protection")["message"] == "This assertion was already processed."
+    event = acs_env.emit.await_args.args[0]
+    assert event.event_type == EventType.SSO_FAILURE
+    assert event.detail == "SAML assertion replay detected"
+    acs_env.db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_fails_closed_when_replay_redis_is_unavailable(client, acs_env):
+    acs_env.redis.get.side_effect = RuntimeError("redis down")
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    check = _check(acs_env, "replay_protection")
+    assert check["status"] == "fail"
+    assert "Redis unavailable" in check["message"]
+    acs_env.db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_reports_attribute_extraction_failure(client, acs_env):
+    acs_env.extract.side_effect = ValueError("unsupported NameID")
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "nameid_extract")["message"] == "unsupported NameID"
+    acs_env.db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_rejects_assertion_without_email_and_lists_available_attributes(client, acs_env):
+    acs_env.extract.return_value = ("", {"groups": ["developers"], "department": ["engineering"]})
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    check = _check(acs_env, "nameid_extract")
+    assert check["status"] == "fail"
+    assert "department, groups" in check["message"]
+
+
+@pytest.mark.parametrize("lookup", [None, _user(), RuntimeError("database unavailable")])
+@pytest.mark.asyncio
+async def test_acs_e2e_mode_is_read_only_and_records_user_lookup(client, acs_env, lookup):
+    if isinstance(lookup, Exception):
+        acs_env.db.execute.side_effect = lookup
+        expected_status = "fail"
+        expected_ok = False
+    else:
+        acs_env.db.execute.return_value = _result(lookup)
+        expected_status = "skip" if lookup is None else "pass"
+        expected_ok = True
+
+    response = await client.post(
+        "/api/v1/sso/saml/acs",
+        data={"SAMLResponse": "assertion", "RelayState": "__e2e:diag_session"},
+    )
+
+    assert response.status_code == 200
+    assert response.text == f"<html>{expected_ok}:diag_session</html>"
+    assert _check(acs_env, "user_lookup", "diag_session")["status"] == expected_status
+    assert _check(acs_env, "e2e_complete", "diag_session")["status"] == "pass"
+    acs_env.issue_tokens.assert_not_awaited()
+    acs_env.db.add.assert_not_called()
+    acs_env.db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_records_missing_display_name_without_trusting_group_claims(client, acs_env):
+    acs_env.extract.return_value = (
+        "alice@example.test",
+        {"groups": ["super_admin", "admins"]},
+    )
+
+    response = await client.post(
+        "/api/v1/sso/saml/acs",
+        data={"SAMLResponse": "assertion", "RelayState": "__e2e:no_display_name"},
+    )
+
+    assert response.status_code == 200
+    assert _check(acs_env, "name_attribute", "no_display_name")["status"] == "skip"
+    acs_env.issue_tokens.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_redirects_when_user_lookup_fails(client, acs_env):
+    acs_env.db.execute.side_effect = RuntimeError("database unavailable")
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "user_lookup")["message"] == "database unavailable"
+    assert acs_env.sessions["corr-safe"]["actor_email"] == "alice@example.test"
+
+
+@pytest.mark.asyncio
+async def test_acs_rejects_unknown_user_when_jit_is_disabled(client, acs_env):
+    acs_env.db.execute.return_value = _result(None)
+    acs_env.config.jit_provisioning = False
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "jit_provisioning")["status"] == "fail"
+    event = acs_env.emit.await_args.args[0]
+    assert event.event_type == EventType.SSO_FAILURE
+    assert event.actor_email == "alice@example.test"
+    assert event.detail == "JIT provisioning disabled; user does not exist"
+    acs_env.db.add.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("configured_role", "expected_role"),
+    [("reviewer", UserRole.reviewer), ("idp-admin-group", UserRole.user)],
+)
+@pytest.mark.asyncio
+async def test_acs_jit_provisions_with_configured_role_not_untrusted_group_claims(
+    client,
+    acs_env,
+    configured_role,
+    expected_role,
+):
+    acs_env.db.execute.return_value = _result(None)
+    acs_env.config.default_role = configured_role
+    acs_env.extract.return_value = (
+        "new-user@example.test",
+        {"displayName": ["New User"], "groups": ["super_admin", "admins"]},
+    )
+    acs_env.auth.get_nameid.return_value = "idp-subject-42"
+
+    async def assign_id():
+        acs_env.db.add.call_args.args[0].id = USER_ID
+
+    acs_env.db.flush.side_effect = assign_id
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    created = acs_env.db.add.call_args.args[0]
+    assert created.email == "new-user@example.test"
+    assert created.username == "alice"
+    assert created.name == "New User"
+    assert created.auth_provider == "saml"
+    assert created.sso_subject_id == "idp-subject-42"
+    assert created.role == expected_role
+    assert created.role != UserRole.super_admin
+    acs_env.db.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_acs_reports_jit_database_failure(client, acs_env):
+    acs_env.db.execute.return_value = _result(None)
+    acs_env.db.flush.side_effect = RuntimeError("unique constraint")
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "jit_provisioning")["message"] == "unique constraint"
+    acs_env.db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_rejects_deactivated_existing_user(client, acs_env):
+    acs_env.user.auth_provider = "deactivated"
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "account_active")["status"] == "fail"
+    event = acs_env.emit.await_args.args[0]
+    assert event.event_type == EventType.SSO_FAILURE
+    assert event.detail == "Deactivated user attempted SAML login"
+    acs_env.issue_tokens.assert_not_awaited()
+
+
+@pytest.mark.parametrize("failure", ["tokens", "commit"])
+@pytest.mark.asyncio
+async def test_acs_reports_token_or_commit_failure(client, acs_env, failure):
+    if failure == "tokens":
+        acs_env.issue_tokens.side_effect = RuntimeError("signing failed")
+        expected = "signing failed"
+    else:
+        acs_env.db.commit.side_effect = RuntimeError("database commit failed")
+        expected = "database commit failed"
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 302
+    assert _check(acs_env, "issue_tokens")["message"] == expected
+    acs_env.emit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acs_existing_local_user_success_updates_profile_and_persists_one_time_state(client, acs_env):
+    acs_env.user.auth_provider = "local"
+    acs_env.user.sso_subject_id = None
+    acs_env.user.name = "SSO User"
+    acs_env.auth.get_nameid.return_value = "idp-subject-new"
+
+    response = await client.post(
+        "/api/v1/sso/saml/acs",
+        data={"SAMLResponse": "assertion", "RelayState": "/sessions/abc"},
+        headers={"user-agent": "browser/1.0"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == (f"{FRONTEND_URL}/login?saml_token={TOKEN_ID}&next=/sessions/abc")
+    assert acs_env.user.auth_provider == "saml"
+    assert acs_env.user.sso_subject_id == "idp-subject-new"
+    assert acs_env.user.name == "Alice Example"
+    acs_env.db.commit.assert_awaited_once()
+
+    calls = acs_env.redis.setex.await_args_list
+    assert calls[0].args == ("saml_assertion:response-123", 300, "1")
+    assert calls[1].args[:2] == ("oauth_code:oauth-code", 120)
+    oauth_payload = json.loads(calls[1].args[2])
+    assert oauth_payload == {
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+        "expires_in": 3600,
+        "user_id": str(USER_ID),
+        "role": "user",
+    }
+    assert calls[2].args[:2] == (f"saml_login:{TOKEN_ID}", 120)
+    login_payload = json.loads(calls[2].args[2])
+    assert login_payload["email"] == "alice@example.test"
+    assert login_payload["username"] == "alice"
+    assert "access-token" not in response.headers["location"]
+
+    event = acs_env.emit.await_args.args[0]
+    assert event.event_type == EventType.SSO_SUCCESS
+    assert event.severity == Severity.INFO
+    assert event.outcome == "success"
+    assert event.actor_id == str(USER_ID)
+    assert event.actor_email == "alice@example.test"
+    assert event.user_agent == "browser/1.0"
+
+
+@pytest.mark.asyncio
+async def test_acs_sanitizes_hostile_relay_state_on_success(client, acs_env):
+    response = await client.post(
+        "/api/v1/sso/saml/acs",
+        data={"SAMLResponse": "assertion", "RelayState": "https://evil.example/phish"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{FRONTEND_URL}/login?saml_token={TOKEN_ID}"
+    assert "evil.example" not in response.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_acs_surfaces_post_commit_redis_failure_without_emitting_success(client, acs_env):
+    acs_env.redis.setex.side_effect = [None, RuntimeError("redis unavailable")]
+
+    response = await client.post("/api/v1/sso/saml/acs", data={"SAMLResponse": "assertion"})
+
+    assert response.status_code == 500
+    acs_env.db.commit.assert_awaited_once()
+    acs_env.emit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exchange_is_public_single_use_and_resets_rate_state(monkeypatch, client, settings):
+    redis = MagicMock()
+    redis.incr = AsyncMock(return_value=1)
+    redis.expire = AsyncMock()
+    redis.getdel = AsyncMock(
+        return_value=json.dumps(
+            {
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "expires_in": 600,
+                "user_id": str(USER_ID),
+                "role": "reviewer",
+                "name": "Alice",
+                "email": "alice@example.test",
+                "username": "alice",
+            }
+        )
+    )
+    redis.delete = AsyncMock()
+    monkeypatch.setattr(saml, "get_redis", lambda: redis)
+
+    response = await client.post("/api/v1/sso/saml/exchange", params={"token_id": "one-time-token"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "access_token": "access",
+        "refresh_token": "refresh",
+        "expires_in": 600,
+        "user": {
+            "id": str(USER_ID),
+            "role": "reviewer",
+            "name": "Alice",
+            "email": "alice@example.test",
+            "username": "alice",
+        },
+    }
+    redis.expire.assert_awaited_once_with("saml_exchange_rate:127.0.0.1", 60)
+    redis.getdel.assert_awaited_once_with("saml_login:one-time-token")
+    redis.delete.assert_awaited_once_with("saml_exchange_rate:127.0.0.1")
+
+
+@pytest.mark.parametrize(
+    ("attempts", "stored", "status", "detail", "expires"),
+    [
+        (1, None, 400, "Invalid or expired SAML token", True),
+        (2, None, 400, "Invalid or expired SAML token", False),
+        (6, "unused", 429, "Too many attempts", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_exchange_rate_limits_and_rejects_missing_tokens(
+    monkeypatch,
+    client,
+    settings,
+    attempts,
+    stored,
+    status,
+    detail,
+    expires,
+):
+    redis = MagicMock()
+    redis.incr = AsyncMock(return_value=attempts)
+    redis.expire = AsyncMock()
+    redis.getdel = AsyncMock(return_value=stored)
+    redis.delete = AsyncMock()
+    monkeypatch.setattr(saml, "get_redis", lambda: redis)
+
+    response = await client.post("/api/v1/sso/saml/exchange", params={"token_id": "bad-token"})
+
+    assert response.status_code == status
+    assert response.json()["detail"] == detail
+    assert redis.expire.await_count == int(expires)
+    if attempts > 5:
+        redis.getdel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exchange_redis_failure_is_not_silently_accepted(monkeypatch, client, settings):
+    redis = MagicMock()
+    redis.incr = AsyncMock(side_effect=RuntimeError("redis unavailable"))
+    monkeypatch.setattr(saml, "get_redis", lambda: redis)
+
+    response = await client.post("/api/v1/sso/saml/exchange", params={"token_id": "token"})
+    assert response.status_code == 500
+
+
+@pytest.mark.parametrize("config", [None, _config(idp_slo_url="")])
+@pytest.mark.asyncio
+async def test_logout_without_slo_returns_to_controlled_login(monkeypatch, client, settings, config):
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=config))
+
+    response = await client.get("/api/v1/sso/saml/logout")
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{FRONTEND_URL}/login"
+
+
+@pytest.mark.asyncio
+async def test_logout_redirects_to_configured_idp_slo(monkeypatch, client, settings):
+    auth = MagicMock()
+    auth.logout.return_value = "https://idp.example.test/slo?SAMLRequest=signed"
+    monkeypatch.setattr(
+        saml,
+        "_get_saml_config",
+        AsyncMock(return_value=_config(idp_slo_url="https://idp.example.test/slo")),
+    )
+    monkeypatch.setattr(saml, "_decrypt_sp_key", MagicMock(return_value="key"))
+    monkeypatch.setattr(saml, "_build_auth", MagicMock(return_value=auth))
+
+    response = await client.get("/api/v1/sso/saml/logout")
+
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("https://idp.example.test/slo")
+    auth.logout.assert_called_once_with(return_to=f"{FRONTEND_URL}/login")
+
+
+@pytest.mark.parametrize(
+    ("toolkit_url", "errors", "expected"),
+    [
+        (f"{FRONTEND_URL}/signed-out", [], f"{FRONTEND_URL}/signed-out"),
+        ("https://evil.example/steal", ["invalid_logout_response"], f"{FRONTEND_URL}/login"),
+        (None, [], f"{FRONTEND_URL}/login"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_sls_processes_logout_and_allows_only_frontend_redirects(
+    monkeypatch,
+    client,
+    settings,
+    toolkit_url,
+    errors,
+    expected,
+):
+    auth = MagicMock()
+    auth.process_slo.return_value = toolkit_url
+    auth.get_errors.return_value = errors
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=_config()))
+    monkeypatch.setattr(saml, "_decrypt_sp_key", MagicMock(return_value="key"))
+    monkeypatch.setattr(saml, "_build_auth", MagicMock(return_value=auth))
+
+    response = await client.get("/api/v1/sso/saml/sls", params={"SAMLResponse": "logout-response"})
+
+    assert response.status_code == 302
+    assert response.headers["location"] == expected
+    callback = auth.process_slo.call_args.kwargs["delete_session_cb"]
+    assert callback() is None
+
+
+@pytest.mark.asyncio
+async def test_sls_without_configuration_redirects_to_login(monkeypatch, client, settings):
+    monkeypatch.setattr(saml, "_get_saml_config", AsyncMock(return_value=None))
+    response = await client.get("/api/v1/sso/saml/sls")
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{FRONTEND_URL}/login"
+
+
+@pytest.mark.asyncio
+async def test_protocol_routes_enforce_http_methods_not_bearer_auth(client, settings):
+    acs_get = await client.get("/api/v1/sso/saml/acs")
+    exchange_get = await client.get("/api/v1/sso/saml/exchange", params={"token_id": "token"})
+    assert acs_get.status_code == 405
+    assert exchange_get.status_code == 405
+    assert acs_get.status_code not in {401, 403}
+    assert exchange_get.status_code not in {401, 403}
+
+
+def test_error_redirect_preserves_only_a_safe_generated_id(settings):
+    response = saml._saml_error_redirect("safe_id")
+    parsed = urlparse(response.headers["location"])
+    assert parsed.netloc == "app.example.test"
+    assert parse_qs(parsed.query) == {"sso_error": ["safe_id"]}


### PR DESCRIPTION
## Summary

Adds e2e tests for SSO login button visibility and device auth confirmation page as specified in #929.

## Test Cases

| Test | Status | Notes |
|------|--------|-------|
| SSO button visible when configured | ⏭️ Skipped | Requires SSO enabled (enterprise) |
| Device auth shows confirmation UI with code | ✅ | |
| Device auth shows error for invalid code | ✅ | |

## Playwright Recording

https://github.com/user-attachments/assets/d02a5109-e23d-4dd8-b81b-d55df807bde1





## Result

2 passed, 1 skipped (10.3s)

Closes #929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive OIDC health and SSO diagnostic coverage, including discovery, endpoint probes, JWKS validation, clock skew, session handling, and status reporting.
  * Expanded SAML route and service tests for configuration, metadata, authentication flows, replay protection, provisioning, token exchange, redirects, and HTTP method enforcement.
  * Added admin SSO coverage for configuration management, diagnostics, credential lifecycle, audit events, and access controls.
  * Strengthened validation of encryption, certificates, XML, key handling, error scenarios, security events, and input sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->