### PR TITLE
fix(settings): remove Minimum CLI Version setting

### DIFF
--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -21,7 +21,6 @@ async def get_version():
     """Server version and compatibility info. No auth required."""
     import services.dynamic_settings as ds
 
-    min_cli = await ds.get("misc.min_cli_version")
     max_cli = await ds.get("misc.max_cli_version")
     api_version = await ds.get("misc.api_version")
     frontend_version = await ds.get("misc.frontend_version")
@@ -30,7 +29,6 @@ async def get_version():
     server_ver = get_server_version()
     return {
         "server_version": server_ver,
-        "min_cli_version": min_cli,
         "max_cli_version": max_cli or None,
         "api_version": api_version or None,
         "frontend_version": frontend_version or server_ver,

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -221,7 +221,6 @@ DEFAULTS: dict[str, str] = {
     "observability.enable_openapi": "false",
     "observability.enable_metrics": "false",
     # Misc
-    "misc.min_cli_version": "0.4.0",
     "misc.max_cli_version": "",  # empty = no upper bound
     "misc.api_version": "2026-05-01",  # date-based, bumped on breaking changes
     "misc.frontend_version": "",  # expected frontend build version (empty = same as server)

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -361,44 +361,6 @@ def health() -> tuple[bool, float]:
         return False, 0
 
 
-def check_version_compatibility(server_url: str) -> None:
-    """Warn if CLI version is older than server's minimum requirement."""
-    from importlib.metadata import version as pkg_version
-
-    try:
-        cli_ver_str = pkg_version("observal-cli")
-    except Exception:
-        return  # dev install, skip check
-
-    try:
-        r = httpx.get(f"{server_url.rstrip('/')}/api/v1/config/version", timeout=5)
-        if r.status_code != 200:
-            return
-        data = r.json()
-    except Exception:
-        return  # server doesn't support this endpoint yet, skip
-
-    min_cli = data.get("min_cli_version")
-    server_ver = data.get("server_version", "unknown")
-    if not min_cli:
-        return
-
-    try:
-        cli_tuple = tuple(int(x) for x in cli_ver_str.split("."))
-        min_tuple = tuple(int(x) for x in min_cli.split("."))
-        if cli_tuple < min_tuple:
-            rprint(
-                f"\n[bold yellow]⚠ CLI version {cli_ver_str} is older than the server requires "
-                f"(minimum {min_cli}).[/bold yellow]\n"
-                f"  Server version: {server_ver}\n"
-                f"  Please upgrade:\n\n"
-                f"    [cyan]uv tool upgrade observal-cli[/cyan]    "
-                f"[dim]# or: pip install --upgrade observal-cli[/dim]\n"
-            )
-    except (ValueError, TypeError):
-        pass
-
-
 def server_supports(feature: str) -> bool:
     """Check if the connected server supports a given feature.
 

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -113,9 +113,6 @@ def login(
 
     initialized = health_data.get("initialized", True)
 
-    # Check CLI/server version compatibility
-    client.check_version_compatibility(server_url)
-
     # 2. Fresh server → prompt for admin credentials and initialize
     if not initialized:
         rprint("[green]Connected.[/green] No users yet — let's set up your admin account.\n")
@@ -331,7 +328,6 @@ def status():
     if ok:
         color = "green" if latency < 200 else "yellow" if latency < 1000 else "red"
         rprint(f"  Health:  [{color}]ok[/{color}] ({latency:.0f}ms)")
-        client.check_version_compatibility(url)
     else:
         rprint("  Health:  [red]unreachable[/red]")
 

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -2108,28 +2108,6 @@ self_app = typer.Typer(
 )
 
 
-def _get_server_min_version() -> str | None:
-    """Fetch MIN_CLI_VERSION from connected server (if configured)."""
-    try:
-        cfg = config.load()
-        server_url = cfg.get("server_url", "").rstrip("/")
-        token = cfg.get("access_token", "")
-        if not server_url or not token:
-            return None
-        import httpx as _httpx
-
-        resp = _httpx.get(
-            f"{server_url}/api/v1/config/version",
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=5,
-        )
-        if resp.status_code == 200:
-            return resp.json().get("min_cli_version")
-    except Exception:
-        pass
-    return None
-
-
 def _do_install(install_info, target_version: str, direction: str) -> None:
     """Execute the actual version change. Delegates to upgrade_executor module."""
     # Lazy import to avoid circular dependency (upgrade_executor imports from version_check)
@@ -2231,15 +2209,11 @@ def downgrade(
     list_versions: bool = typer.Option(
         False, "--list", "-l", help="List all available versions with compatibility status"
     ),
-    force: bool = typer.Option(
-        False, "--force", "-f", help="Skip confirmation and MIN_CLI_VERSION compatibility warning"
-    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt"),
 ):
     """Downgrade the observal CLI to a previous version.
 
     Downloads and installs a specific older version from GitHub releases.
-    Warns if the target version is below the server's minimum supported
-    CLI version (API calls may fail).
 
     Use --list to see all available versions with their publication dates
     and compatibility status.
@@ -2263,7 +2237,6 @@ def downgrade(
             rprint("[red]Failed to fetch releases from GitHub.[/red]")
             raise typer.Exit(1)
 
-        min_ver = _get_server_min_version()
         table = Table(title="Available Versions")
         table.add_column("Version", style="bold")
         table.add_column("Published")
@@ -2273,14 +2246,6 @@ def downgrade(
             status = ""
             if r["version"] == current:
                 status = "← current"
-            elif min_ver:
-                try:
-                    if Version(r["version"]) < Version(min_ver):
-                        status = "⚠ below server minimum"
-                    elif r["version"] == min_ver:
-                        status = "(server minimum)"
-                except InvalidVersion:
-                    pass
             table.add_row(r["version"], r.get("published_at", "")[:10], status)
 
         from rich.console import Console
@@ -2312,18 +2277,6 @@ def downgrade(
         mgr = install.managed_by or "your package manager"
         rprint(f"[yellow]Observal is managed by {mgr}.[/yellow]")
         raise typer.Exit(1)
-
-    # MIN_CLI_VERSION check
-    min_ver = _get_server_min_version()
-    if min_ver:
-        try:
-            if target < Version(min_ver):
-                rprint(f"[red]⚠ Warning: v{version} is below server minimum (v{min_ver}).[/red]")
-                rprint("[red]API calls may fail with this version.[/red]")
-                if not force and not typer.confirm("Downgrade anyway?", default=False):
-                    raise typer.Abort()
-        except InvalidVersion:
-            pass
 
     if not force:
         rprint(f"  Current: [dim]v{current}[/dim]")
@@ -2414,11 +2367,6 @@ def status():
             rprint(f"  Latest:   [green]v{latest}[/green] (up to date)")
     else:
         rprint("  Latest:   [dim]could not reach GitHub[/dim]")
-
-    # Server version if connected
-    min_ver = _get_server_min_version()
-    if min_ver:
-        rprint(f"  Server minimum: [dim]v{min_ver}[/dim]")
 
 
 # ═══════════════════════════════════════════════════════════

--- a/tests/test_self_commands.py
+++ b/tests/test_self_commands.py
@@ -112,25 +112,10 @@ class TestSelfDowngrade:
                 {"version": "0.6.0", "published_at": "2026-05-10", "prerelease": False},
             ],
         )
-        monkeypatch.setattr("observal_cli.cmd_ops._get_server_min_version", lambda: None)
         app = _get_app()
         result = runner.invoke(app, ["self", "downgrade", "--list"])
         assert "0.7.0" in result.output
         assert "0.6.0" in result.output
-
-    def test_downgrade_below_minimum_warns(self, mock_version, mock_install_uv, mock_lock, monkeypatch):
-        """Downgrading below MIN_CLI_VERSION should warn."""
-        monkeypatch.setattr("observal_cli.cmd_ops._get_server_min_version", lambda: "0.6.0")
-
-        def mock_do_install(info, target, direction):
-            pass
-
-        monkeypatch.setattr("observal_cli.cmd_ops._do_install", mock_do_install)
-        app = _get_app()
-        # Without --force, prompt appears. With --force, it bypasses.
-        result = runner.invoke(app, ["self", "downgrade", "--version", "0.4.0", "--force"])
-        # Should still proceed with --force (no error exit)
-        assert result.exit_code == 0 or "below server minimum" in result.output
 
     def test_downgrade_target_is_newer(self, mock_version, monkeypatch):
         """Downgrade to a newer version should error."""
@@ -159,7 +144,6 @@ class TestSelfStatus:
             "observal_cli.version_check._fetch_from_github",
             lambda include_pre=False: {"latest_version": "0.8.0", "source": "github"},
         )
-        monkeypatch.setattr("observal_cli.cmd_ops._get_server_min_version", lambda: None)
         app = _get_app()
         result = runner.invoke(app, ["self", "status"])
         assert "0.7.0" in result.output

--- a/web/src/app/(admin)/settings/page.tsx
+++ b/web/src/app/(admin)/settings/page.tsx
@@ -146,7 +146,6 @@ function getPlaceholder(key: string): string {
 		"observability.enable_openapi": "true | false",
 		"observability.enable_metrics": "true | false",
 		// Misc
-		"misc.min_cli_version": "0.4.0",
 		"misc.git_mirror_base_path": "/var/lib/observal/mirrors",
 	};
 	return placeholders[key] || "Enter value...";
@@ -670,13 +669,6 @@ const SETTING_SECTIONS: SettingSection[] = [
 		icon: <Settings className="h-3.5 w-3.5" />,
 		description: "Other system settings.",
 		settings: [
-			{
-				key: "misc.min_cli_version",
-				label: "Minimum CLI Version",
-				subtitle: "Warn users with older CLI versions to upgrade",
-				tooltip:
-					"The Observal CLI checks this on startup and shows an upgrade warning if the user's version is older. Useful to enforce breaking changes or required features in new CLI releases.",
-			},
 			{
 				key: "misc.git_mirror_base_path",
 				label: "Git Mirror Path",


### PR DESCRIPTION
## Purpose / Description

Remove the "Minimum CLI Version" (`misc.min_cli_version`) dynamic setting entirely. It added friction (startup warnings, downgrade blocks) without real value. Version negotiation for feature gating (`effective = min(cli, server)`) remains intact as the proper compatibility mechanism.

## Fixes

* Removes the Minimum CLI Version card from the admin settings MISCELLANEOUS section

## Approach

- Server: removed `min_cli_version` from `/api/v1/config/version` response and from `DEFAULTS` in `dynamic_settings.py`
- CLI: removed `_get_server_min_version()` helper, gutted `check_version_compatibility()` to a no-op, removed min version warnings from `self downgrade --list`, `self downgrade`, and `self status`
- Frontend: removed the setting card from the admin settings page
- Tests: removed `test_downgrade_below_minimum_warns` and related `_get_server_min_version` mocks

## How Has This Been Tested?

- Full test suite: 3806 passed (4 pre-existing pyarrow failures unrelated)
- `ruff check` and `ruff format` clean

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (setting card removed from MISCELLANEOUS section)