### PR TITLE
feat(ci): add cli, server, and web area labels to PR auto-labeler

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -90,9 +90,18 @@ jobs:
 
             const isEnterprise = paths.some((p) => /^ee\//.test(p));
 
+            const isCli = paths.some((p) => /^observal_cli\//.test(p));
+
+            const isServer = paths.some((p) => /^observal-server\//.test(p));
+
+            const isWeb = paths.some((p) => /^web\//.test(p));
+
             const labelsToApply = [
               ...(isTest ? ['tests'] : []),
               ...(isEnterprise ? ['enterprise'] : []),
+              ...(isCli ? ['cli'] : []),
+              ...(isServer ? ['server'] : []),
+              ...(isWeb ? ['web'] : []),
             ];
 
             if (labelsToApply.length === 0) return;
@@ -100,6 +109,9 @@ jobs:
             const labelDefs = {
               tests: { color: '0075ca', description: 'Pull request adds or modifies tests' },
               enterprise: { color: 'e11d48', description: 'Pull request touches enterprise (ee/) code' },
+              cli: { color: '1d76db', description: 'Pull request touches CLI code' },
+              server: { color: 'fbca04', description: 'Pull request touches server code' },
+              web: { color: '0e8a16', description: 'Pull request touches web frontend code' },
             };
 
             for (const name of labelsToApply) {


### PR DESCRIPTION
## Purpose / Description
Extends the PR auto-labeler to apply area labels (`cli`, `server`, `web`) based on which directories a PR touches. This makes it easy to filter PRs by component at a glance.

## Fixes
* N/A - new feature

## Approach
Added three new path matchers to the existing `auto-label` job in `pr-labels.yml`:
- `observal_cli/` -> `cli` label (blue)
- `observal-server/` -> `server` label (yellow)
- `web/` -> `web` label (green)

The job already gates on `github.event_name == 'pull_request_target'` so labels are only applied to PRs automatically on open/synchronize/reopen.

## How Has This Been Tested?
Verified the regex patterns match the expected directory prefixes. The workflow uses the same proven pattern as the existing `tests` and `enterprise` labels.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)