### PR TITLE
Add ingest bounds and identity-aware rate limits

### DIFF
--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -145,6 +145,8 @@ async def get_current_user(
         except RedisError:
             raise HTTPException(status_code=503, detail="Auth service temporarily unavailable")
 
+    request.state.current_user = user
+    request.state.org_id = user.org_id
     return user
 
 

--- a/observal-server/api/graphql.py
+++ b/observal-server/api/graphql.py
@@ -30,6 +30,7 @@ from services.secrets_redactor import redact_secrets
 logger = structlog.get_logger(__name__)
 
 _DEFAULT_PROJECT = "default"
+MAX_TRACE_PAGE_SIZE = 100
 
 
 # --- Helpers ---
@@ -52,6 +53,17 @@ def _parse_json(val: str | None) -> JSON | None:
         return json.loads(val)
     except (json.JSONDecodeError, TypeError):
         return val
+
+
+def _bounded_trace_limit(limit: int) -> int:
+    return min(max(int(limit), 1), MAX_TRACE_PAGE_SIZE)
+
+
+def _bounded_trace_offset(offset: int) -> int:
+    offset = int(offset)
+    if offset < 0:
+        raise ValueError("offset must be greater than or equal to 0")
+    return offset
 
 
 # --- DataLoaders ---
@@ -344,17 +356,19 @@ class Query:
         ctx = info.context
         project_id = ctx.get("project_id", _DEFAULT_PROJECT)
         uid = None if _is_admin(ctx) else ctx.get("user_id")
+        bounded_limit = _bounded_trace_limit(limit)
+        bounded_offset = _bounded_trace_offset(offset)
         rows = await query_traces(
             project_id,
             trace_type=trace_type,
             mcp_id=mcp_id,
             agent_id=agent_id,
             user_id=uid,
-            limit=limit + 1,
-            offset=offset,
+            limit=bounded_limit + 1,
+            offset=bounded_offset,
         )
-        has_more = len(rows) > limit
-        items = [_row_to_trace(r) for r in rows[:limit]]
+        has_more = len(rows) > bounded_limit
+        items = [_row_to_trace(r) for r in rows[:bounded_limit]]
         return TraceConnection(items=items, total_count=len(items), has_more=has_more)
 
     @strawberry.field

--- a/observal-server/api/ratelimit.py
+++ b/observal-server/api/ratelimit.py
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import hashlib
+
 from slowapi import Limiter
 from starlette.requests import Request
 
@@ -36,8 +38,33 @@ def _get_real_ip(request: Request) -> str:
     return client_ip
 
 
+def _get_rate_limit_key(request: Request) -> str:
+    """Prefer authenticated identity, then token hash, then trusted-proxy-aware IP."""
+    state = getattr(request, "state", None)
+    user = getattr(state, "current_user", None) or getattr(state, "user", None)
+    if user is not None:
+        user_id = getattr(user, "id", None)
+        org_id = getattr(user, "org_id", None)
+        if user_id and org_id:
+            return f"org:{org_id}:user:{user_id}"
+        if user_id:
+            return f"user:{user_id}"
+
+    org_id = getattr(state, "org_id", None)
+    if org_id:
+        return f"org:{org_id}"
+
+    auth = request.headers.get("authorization", "")
+    scheme, _, token = auth.partition(" ")
+    if scheme.lower() == "bearer" and token.strip():
+        digest = hashlib.sha256(token.strip().encode("utf-8")).hexdigest()
+        return f"token:{digest}"
+
+    return f"ip:{_get_real_ip(request)}"
+
+
 limiter = Limiter(
-    key_func=_get_real_ip,
+    key_func=_get_rate_limit_key,
     storage_uri=settings.REDIS_URL or "memory://",
     storage_options={
         "socket_connect_timeout": settings.REDIS_SOCKET_TIMEOUT,

--- a/observal-server/api/routes/alert.py
+++ b/observal-server/api/routes/alert.py
@@ -6,7 +6,7 @@ import secrets
 import uuid
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger as optic
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -139,8 +139,8 @@ async def delete_alert(
 @router.get("/{alert_id}/history", response_model=list[AlertHistoryResponse])
 async def get_alert_history(
     alert_id: uuid.UUID,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):

--- a/observal-server/api/routes/ingest.py
+++ b/observal-server/api/routes/ingest.py
@@ -6,32 +6,43 @@
 
 from fastapi import APIRouter, Depends, Request
 from loguru import logger as optic
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 from api.deps import get_project_id, require_role
 from api.ratelimit import limiter
 from models.user import User, UserRole
+from schemas.telemetry import MAX_SHORT_STRING_LENGTH, MAX_TEXT_LENGTH
 
 router = APIRouter(prefix="/api/v1/ingest", tags=["ingest"])
 
+MAX_SESSION_LINES = 1000
+
 
 class SessionIngestRequest(BaseModel):
-    session_id: str
-    ide: str = "claude-code"
-    agent_id: str | None = None
-    agent_version: str | None = None
-    layer_hash: str | None = None
-    lines: list[str]  # Raw JSONL lines
-    start_offset: int = 0
-    hook_event: str = "UserPromptSubmit"
+    session_id: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    ide: str = Field("claude-code", max_length=MAX_SHORT_STRING_LENGTH)
+    agent_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    agent_version: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    layer_hash: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    lines: list[str] = Field(..., max_length=MAX_SESSION_LINES)  # Raw JSONL lines
+    start_offset: int = Field(0, ge=0)
+    hook_event: str = Field("UserPromptSubmit", max_length=MAX_SHORT_STRING_LENGTH)
     # Sent on Stop for integrity check
     final: bool = False
-    total_line_count: int | None = None
-    total_offset: int | None = None
+    total_line_count: int | None = Field(None, ge=0)
+    total_offset: int | None = Field(None, ge=0)
     # Kiro-specific: total credits consumed this session
-    total_credits: float | None = None
+    total_credits: float | None = Field(None, ge=0)
     # Claude Code subagent attribution: set when this session is a subagent
-    parent_session_id: str | None = None
+    parent_session_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+
+    @field_validator("lines")
+    @classmethod
+    def lines_are_bounded(cls, value: list[str]) -> list[str]:
+        for line in value:
+            if len(line) > MAX_TEXT_LENGTH:
+                raise ValueError(f"session lines must be at most {MAX_TEXT_LENGTH} characters")
+        return value
 
 
 class SessionIngestResponse(BaseModel):
@@ -42,10 +53,10 @@ class SessionIngestResponse(BaseModel):
 
 
 @router.post("/session", response_model=SessionIngestResponse)
-@limiter.limit("300/minute")
+@limiter.limit("60/minute")
 async def ingest_session(
-    request: Request,
     req: SessionIngestRequest,
+    request: Request,
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Ingest raw JSONL transcript lines from an IDE session.

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -14,10 +14,11 @@ removed - session telemetry now flows through /api/v1/ingest/session
 import asyncio
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, Header
+from fastapi import APIRouter, Depends, Header, Request
 from loguru import logger as optic
 
 from api.deps import get_project_id, require_role
+from api.ratelimit import limiter
 from models.user import User, UserRole
 from schemas.telemetry import (
     IngestBatch,
@@ -57,8 +58,10 @@ _SHIM_EVENT_NAMES: dict[str, str] = {
 
 
 @router.post("/ingest", response_model=IngestResponse)
+@limiter.limit("60/minute")
 async def ingest(
     batch: IngestBatch,
+    request: Request,
     current_user: User = Depends(require_role(UserRole.user)),
     x_observal_environment: str = Header("default"),
 ):

--- a/observal-server/schemas/telemetry.py
+++ b/observal-server/schemas/telemetry.py
@@ -2,7 +2,24 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
+
+MAX_INGEST_TRACES = 1000
+MAX_INGEST_SPANS = 1000
+MAX_INGEST_SCORES = 1000
+MAX_METADATA_ENTRIES = 100
+MAX_SHORT_STRING_LENGTH = 512
+MAX_TEXT_LENGTH = 1_048_576
+MAX_TAGS = 50
+
+
+def _validate_metadata(value: dict[str, str]) -> dict[str, str]:
+    for key, item in value.items():
+        if len(str(key)) > MAX_SHORT_STRING_LENGTH:
+            raise ValueError(f"metadata keys must be at most {MAX_SHORT_STRING_LENGTH} characters")
+        if len(str(item)) > MAX_TEXT_LENGTH:
+            raise ValueError(f"metadata values must be at most {MAX_TEXT_LENGTH} characters")
+    return value
 
 
 class TelemetryStatusResponse(BaseModel):
@@ -15,44 +32,57 @@ class TelemetryStatusResponse(BaseModel):
 
 
 class TraceIngest(BaseModel):
-    trace_id: str
-    parent_trace_id: str | None = None
-    trace_type: str = "mcp"
-    mcp_id: str | None = None
-    agent_id: str | None = None
-    session_id: str | None = None
-    ide: str = ""
-    name: str = ""
-    start_time: str
-    end_time: str | None = None
-    input: str | None = None
-    output: str | None = None
-    metadata: dict[str, str] = {}
-    tags: list[str] = []
-    tool_id: str | None = None
-    sandbox_id: str | None = None
-    graphrag_id: str | None = None
-    hook_id: str | None = None
-    skill_id: str | None = None
-    prompt_id: str | None = None
+    trace_id: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    parent_trace_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    trace_type: str = Field("mcp", max_length=MAX_SHORT_STRING_LENGTH)
+    mcp_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    agent_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    session_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    ide: str = Field("", max_length=MAX_SHORT_STRING_LENGTH)
+    name: str = Field("", max_length=MAX_SHORT_STRING_LENGTH)
+    start_time: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    end_time: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    input: str | None = Field(None, max_length=MAX_TEXT_LENGTH)
+    output: str | None = Field(None, max_length=MAX_TEXT_LENGTH)
+    metadata: dict[str, str] = Field(default_factory=dict, max_length=MAX_METADATA_ENTRIES)
+    tags: list[str] = Field(default_factory=list, max_length=MAX_TAGS)
+    tool_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    sandbox_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    graphrag_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    hook_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    skill_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    prompt_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+
+    @field_validator("metadata")
+    @classmethod
+    def metadata_values_are_bounded(cls, value: dict[str, str]) -> dict[str, str]:
+        return _validate_metadata(value)
+
+    @field_validator("tags")
+    @classmethod
+    def tags_are_bounded(cls, value: list[str]) -> list[str]:
+        for tag in value:
+            if len(str(tag)) > MAX_SHORT_STRING_LENGTH:
+                raise ValueError(f"tags must be at most {MAX_SHORT_STRING_LENGTH} characters")
+        return value
 
 
 class SpanIngest(BaseModel):
-    span_id: str
-    trace_id: str
-    parent_span_id: str | None = None
-    type: str
-    name: str
-    method: str = ""
-    input: str | None = None
-    output: str | None = None
-    error: str | None = None
-    start_time: str
-    end_time: str | None = None
+    span_id: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    trace_id: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    parent_span_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    type: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    name: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    method: str = Field("", max_length=MAX_SHORT_STRING_LENGTH)
+    input: str | None = Field(None, max_length=MAX_TEXT_LENGTH)
+    output: str | None = Field(None, max_length=MAX_TEXT_LENGTH)
+    error: str | None = Field(None, max_length=MAX_TEXT_LENGTH)
+    start_time: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    end_time: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
     latency_ms: int | None = None
-    status: str = "success"
-    ide: str = ""
-    metadata: dict[str, str] = {}
+    status: str = Field("success", max_length=MAX_SHORT_STRING_LENGTH)
+    ide: str = Field("", max_length=MAX_SHORT_STRING_LENGTH)
+    metadata: dict[str, str] = Field(default_factory=dict, max_length=MAX_METADATA_ENTRIES)
     token_count_input: int | None = None
     token_count_output: int | None = None
     token_count_total: int | None = None
@@ -66,7 +96,7 @@ class SpanIngest(BaseModel):
     tools_available: int | None = None
     tool_schema_valid: bool | None = None
     # Sandbox
-    container_id: str | None = None
+    container_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
     exit_code: int | None = None
     network_bytes_in: int | None = None
     network_bytes_out: int | None = None
@@ -74,40 +104,50 @@ class SpanIngest(BaseModel):
     disk_write_bytes: int | None = None
     oom_killed: bool | None = None
     # GraphRAG
-    query_interface: str | None = None
+    query_interface: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
     relevance_score: float | None = None
     chunks_returned: int | None = None
     embedding_latency_ms: int | None = None
     # Hook
-    hook_event: str | None = None
-    hook_scope: str | None = None
-    hook_action: str | None = None
+    hook_event: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    hook_scope: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    hook_action: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
     hook_blocked: bool | None = None
     # Prompt
     variables_provided: int | None = None
     template_tokens: int | None = None
     rendered_tokens: int | None = None
 
+    @field_validator("metadata")
+    @classmethod
+    def metadata_values_are_bounded(cls, value: dict[str, str]) -> dict[str, str]:
+        return _validate_metadata(value)
+
 
 class ScoreIngest(BaseModel):
-    score_id: str
-    trace_id: str | None = None
-    span_id: str | None = None
-    mcp_id: str | None = None
-    agent_id: str | None = None
-    name: str
-    source: str = "api"
-    data_type: str = "numeric"
+    score_id: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    trace_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    span_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    mcp_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    agent_id: str | None = Field(None, max_length=MAX_SHORT_STRING_LENGTH)
+    name: str = Field(..., max_length=MAX_SHORT_STRING_LENGTH)
+    source: str = Field("api", max_length=MAX_SHORT_STRING_LENGTH)
+    data_type: str = Field("numeric", max_length=MAX_SHORT_STRING_LENGTH)
     value: float
-    string_value: str | None = None
-    comment: str | None = None
-    metadata: dict[str, str] = {}
+    string_value: str | None = Field(None, max_length=MAX_TEXT_LENGTH)
+    comment: str | None = Field(None, max_length=MAX_TEXT_LENGTH)
+    metadata: dict[str, str] = Field(default_factory=dict, max_length=MAX_METADATA_ENTRIES)
+
+    @field_validator("metadata")
+    @classmethod
+    def metadata_values_are_bounded(cls, value: dict[str, str]) -> dict[str, str]:
+        return _validate_metadata(value)
 
 
 class IngestBatch(BaseModel):
-    traces: list[TraceIngest] = []
-    spans: list[SpanIngest] = []
-    scores: list[ScoreIngest] = []
+    traces: list[TraceIngest] = Field(default_factory=list, max_length=MAX_INGEST_TRACES)
+    spans: list[SpanIngest] = Field(default_factory=list, max_length=MAX_INGEST_SPANS)
+    scores: list[ScoreIngest] = Field(default_factory=list, max_length=MAX_INGEST_SCORES)
 
 
 class IngestResponse(BaseModel):

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -22,7 +22,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from models.mcp import McpListing, McpValidationResult
 from services.ssrf_guard import is_private_url as _ssrf_is_private
 
-ALLOWED_SCHEMES = {"https", "http"}
+ALLOW_HTTP_GIT = os.environ.get("MCP_ALLOW_HTTP_GIT", "").lower() in ("1", "true", "yes")
+ALLOWED_SCHEMES = {"https"} | ({"http"} if ALLOW_HTTP_GIT else set())
 BLOCKED_SCHEMES = {"file", "ftp", "ssh", "git"}
 
 # Self-hosted deployments set ALLOW_INTERNAL_GIT_URLS=true to allow corporate
@@ -61,6 +62,13 @@ def _validate_git_url(url: str) -> str | None:
     if not ALLOW_INTERNAL_URLS and _ssrf_is_private(url):
         return "Internal/private URLs not allowed (set ALLOW_INTERNAL_URLS=true for self-hosted deployments)"
     return None
+
+
+def _git_url_warning(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme == "http" and ALLOW_HTTP_GIT:
+        return "Warning: insecure http:// Git URL accepted because MCP_ALLOW_HTTP_GIT=true."
+    return ""
 
 
 def _build_clone_url(git_url: str) -> str:
@@ -473,6 +481,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
         db.add(McpValidationResult(listing_id=listing.id, stage="clone_and_inspect", passed=False, details=url_err))
         await db.commit()
         return None
+    url_warning = _git_url_warning(listing.git_url)
     clone_url = _build_clone_url(listing.git_url)
     try:
         await _async_clone(clone_url, tmp_dir)
@@ -526,7 +535,11 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
                 listing_id=listing.id,
                 stage="clone_and_inspect",
                 passed=True,
-                details=f"Found MCP entry point: {entry_point.relative_to(tmp_dir)}",
+                details="\n".join(
+                    part
+                    for part in (f"Found MCP entry point: {entry_point.relative_to(tmp_dir)}", url_warning)
+                    if part
+                ),
             )
         )
         await db.commit()
@@ -550,7 +563,9 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
                 listing_id=listing.id,
                 stage="clone_and_inspect",
                 passed=True,
-                details=f"Found non-Python MCP framework: {non_python_framework}",
+                details="\n".join(
+                    part for part in (f"Found non-Python MCP framework: {non_python_framework}", url_warning) if part
+                ),
             )
         )
         await db.commit()
@@ -571,11 +586,16 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
             listing_id=listing.id,
             stage="clone_and_inspect",
             passed=True,
-            details=(
-                "No recognized MCP framework detected. "
-                "Marked as validated with framework: unknown. "
-                "Supported detection: FastMCP, MCP SDK (Python/TypeScript/Go), "
-                "and common MCP patterns."
+            details="\n".join(
+                part
+                for part in (
+                    "No recognized MCP framework detected. "
+                    "Marked as validated with framework: unknown. "
+                    "Supported detection: FastMCP, MCP SDK (Python/TypeScript/Go), "
+                    "and common MCP patterns.",
+                    url_warning,
+                )
+                if part
             ),
         )
     )

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -536,9 +536,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
                 stage="clone_and_inspect",
                 passed=True,
                 details="\n".join(
-                    part
-                    for part in (f"Found MCP entry point: {entry_point.relative_to(tmp_dir)}", url_warning)
-                    if part
+                    part for part in (f"Found MCP entry point: {entry_point.relative_to(tmp_dir)}", url_warning) if part
                 ),
             )
         )

--- a/observal_cli/cmd_reconcile.py
+++ b/observal_cli/cmd_reconcile.py
@@ -281,8 +281,7 @@ def recover_stale_session(
     recovered again.
     """
     from observal_cli.sessions.base import (
-        build_payload,
-        post_to_server,
+        post_lines_chunked,
         read_new_lines,
         write_cursor,
     )
@@ -298,20 +297,17 @@ def recover_stale_session(
         return True
 
     new_offset = cursor_offset + bytes_read
-    payload = build_payload(
+    success = post_lines_chunked(
+        server_url=config["server_url"],
+        access_token=config["access_token"],
         session_id=session_id,
         lines=lines,
         start_offset=cursor_line_count,
         hook_event="Stop",
         line_count_before=cursor_line_count,
         new_offset=new_offset,
-    )
-    payload["crash_recovered"] = True
-
-    success = post_to_server(
-        server_url=config["server_url"],
-        access_token=config["access_token"],
-        payload=payload,
+        config=config,
+        extra_fields={"crash_recovered": True},
     )
 
     if success:

--- a/observal_cli/hooks/_cursor_post_worker.py
+++ b/observal_cli/hooks/_cursor_post_worker.py
@@ -66,20 +66,29 @@ def main() -> None:
         return
 
     try:
-        from observal_cli.sessions.base import log_error, post_to_server
+        from observal_cli.sessions.base import log_error, post_lines_chunked
     except Exception as e:
         _log(f"WORKER_EXIT: import error: {e}")
         return
 
     try:
-        success = post_to_server(
+        lines = payload.get("lines", [])
+        success = post_lines_chunked(
             server_url=server_url,
             access_token=access_token,
-            payload=payload,
+            session_id=payload.get("session_id", session_id),
+            lines=lines,
+            start_offset=payload.get("start_offset", 0),
+            hook_event=payload.get("hook_event", "UserPromptSubmit"),
+            line_count_before=payload.get("start_offset", 0),
+            new_offset=new_offset,
+            cwd=payload.get("cwd", ""),
+            parent_session_id=payload.get("parent_session_id"),
+            ide=payload.get("ide", "cursor"),
             config=config,
         )
     except Exception as e:
-        _log(f"WORKER_EXIT: post_to_server raised: {e}")
+        _log(f"WORKER_EXIT: post_lines_chunked raised: {e}")
         log_error(f"cursor_session_push: POST exception for session {session_id}: {e}")
         return
 

--- a/observal_cli/hooks/kiro_session_push.py
+++ b/observal_cli/hooks/kiro_session_push.py
@@ -21,6 +21,7 @@ from observal_cli.sessions.base import (
     build_payload,
     load_config,
     log_error,
+    post_lines_chunked,
     post_to_server,
     read_cursor,
     read_new_lines,
@@ -133,7 +134,16 @@ def _run(home: Path | None = None) -> None:
     optic.debug("read {} new lines ({} bytes) from Kiro session {}", len(lines), bytes_read, session_id[:12])
 
     new_offset = offset + bytes_read
-    payload = build_payload(
+    is_stop = hook_event.lower() == "stop"
+    credits = _read_credits_with_retry(session_id, home=home) if is_stop else read_kiro_credits(session_id, home=home)
+    extra: dict = {}
+    if credits is not None:
+        extra["total_credits"] = credits
+        optic.trace("attaching credits={} to Kiro payload", credits)
+
+    success = post_lines_chunked(
+        server_url=config["server_url"],
+        access_token=config["access_token"],
         session_id=session_id,
         lines=lines,
         start_offset=line_count,
@@ -141,18 +151,9 @@ def _run(home: Path | None = None) -> None:
         line_count_before=line_count,
         new_offset=new_offset,
         cwd=cwd,
-    )
-    payload["ide"] = "kiro"
-    is_stop = hook_event.lower() == "stop"
-    credits = _read_credits_with_retry(session_id, home=home) if is_stop else read_kiro_credits(session_id, home=home)
-    if credits is not None:
-        payload["total_credits"] = credits
-        optic.trace("attaching credits={} to Kiro payload", credits)
-
-    success = post_to_server(
-        server_url=config["server_url"],
-        access_token=config["access_token"],
-        payload=payload,
+        ide="kiro",
+        config=config,
+        extra_fields=extra or None,
     )
 
     if not success:

--- a/observal_cli/hooks/session_push.py
+++ b/observal_cli/hooks/session_push.py
@@ -19,10 +19,9 @@ from pathlib import Path
 from loguru import logger as optic
 
 from observal_cli.sessions.base import (
-    build_payload,
     load_config,
     log_error,
-    post_to_server,
+    post_lines_chunked,
     read_cursor,
     read_new_lines,
     write_cursor,
@@ -86,7 +85,9 @@ def _run(home: Path | None = None) -> None:
     optic.debug("read {} new lines ({} bytes) from session {}", len(lines), bytes_read, session_id[:12])
 
     new_offset = offset + bytes_read
-    payload = build_payload(
+    success = post_lines_chunked(
+        server_url=config["server_url"],
+        access_token=config["access_token"],
         session_id=session_id,
         lines=lines,
         start_offset=line_count,
@@ -96,12 +97,6 @@ def _run(home: Path | None = None) -> None:
         cwd=cwd,
         parent_session_id=parent_session_id,
         session_jsonl=jsonl_path,
-    )
-
-    success = post_to_server(
-        server_url=config["server_url"],
-        access_token=config["access_token"],
-        payload=payload,
         config=config,
     )
 

--- a/observal_cli/sessions/base.py
+++ b/observal_cli/sessions/base.py
@@ -226,6 +226,76 @@ def post_to_server(server_url: str, access_token: str, payload: dict, config: di
 
 
 # ---------------------------------------------------------------------------
+# Chunked posting
+# ---------------------------------------------------------------------------
+
+MAX_CHUNK_SIZE = 500
+
+
+def post_lines_chunked(
+    server_url: str,
+    access_token: str,
+    session_id: str,
+    lines: list[str],
+    start_offset: int,
+    hook_event: str,
+    line_count_before: int,
+    new_offset: int = 0,
+    cwd: str = "",
+    parent_session_id: str | None = None,
+    session_jsonl: Path | None = None,
+    ide: str = "claude-code",
+    config: dict | None = None,
+    extra_fields: dict | None = None,
+) -> bool:
+    """Post lines to ingest in chunks of MAX_CHUNK_SIZE.
+
+    Returns True if ALL chunks succeed, False on first failure.
+    Callers should only advance the cursor on True.
+    """
+    if not lines:
+        return True
+
+    total_chunks = (len(lines) + MAX_CHUNK_SIZE - 1) // MAX_CHUNK_SIZE
+
+    for i in range(0, len(lines), MAX_CHUNK_SIZE):
+        chunk = lines[i : i + MAX_CHUNK_SIZE]
+        chunk_index = i // MAX_CHUNK_SIZE
+        is_last = chunk_index == total_chunks - 1
+
+        payload = build_payload(
+            session_id=session_id,
+            lines=chunk,
+            start_offset=line_count_before + i,
+            hook_event=hook_event,
+            line_count_before=line_count_before + i,
+            new_offset=new_offset if is_last else 0,
+            cwd=cwd,
+            parent_session_id=parent_session_id,
+            session_jsonl=session_jsonl,
+        )
+        payload["ide"] = ide
+        # Only mark final on the last chunk if the hook_event warrants it
+        if not is_last:
+            payload.pop("final", None)
+            payload.pop("total_line_count", None)
+            payload.pop("total_offset", None)
+        if extra_fields:
+            payload.update(extra_fields)
+
+        success = post_to_server(
+            server_url=server_url,
+            access_token=access_token,
+            payload=payload,
+            config=config,
+        )
+        if not success:
+            return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Payload construction
 # ---------------------------------------------------------------------------
 

--- a/packages/pi-extension/extensions/observal.ts
+++ b/packages/pi-extension/extensions/observal.ts
@@ -348,19 +348,30 @@ export default function (pi: ExtensionAPI) {
           .filter((l) => l.trim());
 
         if (lines.length > 0) {
-          const payload = JSON.stringify({
-            session_id: sessionId,
-            ide: "pi",
-            agent_id: s.config?.agent_id ?? null,
-            agent_version: s.config?.agent_version ?? null,
-            lines,
-            start_offset: entry.line_count,
-            hook_event: "CrashRecovery",
-            final: true,
-            total_line_count: entry.line_count + lines.length,
-            total_offset: fileStat.size,
-          });
-          await postWithTimeout(s.config!, "/api/v1/ingest/session", payload);
+          let pushOk = true;
+          for (let offset = 0; offset < lines.length; offset += MAX_LINES_PER_CHUNK) {
+            const chunk = lines.slice(offset, offset + MAX_LINES_PER_CHUNK);
+            const isLastChunk = offset + MAX_LINES_PER_CHUNK >= lines.length;
+            const payload = JSON.stringify({
+              session_id: sessionId,
+              ide: "pi",
+              agent_id: s.config?.agent_id ?? null,
+              agent_version: s.config?.agent_version ?? null,
+              lines: chunk,
+              start_offset: entry.line_count + offset,
+              hook_event: "CrashRecovery",
+              final: isLastChunk,
+              ...(isLastChunk
+                ? {
+                    total_line_count: entry.line_count + lines.length,
+                    total_offset: fileStat.size,
+                  }
+                : {}),
+            });
+            const ok = await postWithTimeout(s.config!, "/api/v1/ingest/session", payload);
+            if (!ok) { pushOk = false; break; }
+          }
+          if (!pushOk) continue; // skip finalization, retry next startup
         }
 
         writeCursor(sessionId, fileStat.size, entry.line_count + lines.length, true);

--- a/tests/test_audit2_pr1_ingest_bounds.py
+++ b/tests/test_audit2_pr1_ingest_bounds.py
@@ -1,0 +1,430 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Regression coverage for Audit 2 PR1 ingest abuse guardrails."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+
+def _trace(trace_id: str = "trace-1") -> dict:
+    return {
+        "trace_id": trace_id,
+        "start_time": "2026-01-01T00:00:00Z",
+    }
+
+
+def _span(span_id: str = "span-1") -> dict:
+    return {
+        "span_id": span_id,
+        "trace_id": "trace-1",
+        "type": "tool_call",
+        "name": "Read",
+        "start_time": "2026-01-01T00:00:00Z",
+    }
+
+
+def _score(score_id: str = "score-1") -> dict:
+    return {
+        "score_id": score_id,
+        "name": "overall",
+        "value": 1.0,
+    }
+
+
+def _info():
+    info = MagicMock()
+    info.context = {"project_id": "default"}
+    return info
+
+
+def _query_bound(default, name: str):
+    if hasattr(default, name):
+        return getattr(default, name)
+    for item in getattr(default, "metadata", []):
+        if hasattr(item, name):
+            return getattr(item, name)
+    return None
+
+
+def test_telemetry_ingest_batch_rejects_oversized_lists():
+    from schemas.telemetry import MAX_INGEST_SPANS, MAX_INGEST_TRACES, IngestBatch
+
+    with pytest.raises(ValidationError):
+        IngestBatch(traces=[_trace(str(i)) for i in range(MAX_INGEST_TRACES + 1)])
+
+    with pytest.raises(ValidationError):
+        IngestBatch(spans=[_span(str(i)) for i in range(MAX_INGEST_SPANS + 1)])
+
+
+def test_telemetry_ingest_rejects_oversized_strings_and_metadata_values():
+    from schemas.telemetry import MAX_TEXT_LENGTH, ScoreIngest, SpanIngest, TraceIngest
+
+    with pytest.raises(ValidationError):
+        TraceIngest(**_trace(), input="x" * (MAX_TEXT_LENGTH + 1))
+
+    with pytest.raises(ValidationError):
+        SpanIngest(**_span(), error="x" * (MAX_TEXT_LENGTH + 1))
+
+    with pytest.raises(ValidationError):
+        ScoreIngest(**_score(), metadata={"large": "x" * (MAX_TEXT_LENGTH + 1)})
+
+
+def test_telemetry_ingest_rejects_oversized_tags_and_metadata_maps():
+    from schemas.telemetry import MAX_METADATA_ENTRIES, MAX_SHORT_STRING_LENGTH, MAX_TAGS, TraceIngest
+
+    with pytest.raises(ValidationError):
+        TraceIngest(**_trace(), tags=[str(i) for i in range(MAX_TAGS + 1)])
+
+    with pytest.raises(ValidationError):
+        TraceIngest(**_trace(), tags=["x" * (MAX_SHORT_STRING_LENGTH + 1)])
+
+    with pytest.raises(ValidationError):
+        TraceIngest(**_trace(), metadata={str(i): "v" for i in range(MAX_METADATA_ENTRIES + 1)})
+
+
+def test_session_ingest_rejects_oversized_batches_and_lines():
+    from api.routes.ingest import MAX_SESSION_LINES, SessionIngestRequest
+    from schemas.telemetry import MAX_TEXT_LENGTH
+
+    with pytest.raises(ValidationError):
+        SessionIngestRequest(session_id="session-1", lines=["{}"] * (MAX_SESSION_LINES + 1))
+
+    with pytest.raises(ValidationError):
+        SessionIngestRequest(session_id="session-1", lines=["x" * (MAX_TEXT_LENGTH + 1)])
+
+    with pytest.raises(ValidationError):
+        SessionIngestRequest(session_id="session-1", lines=["{}"], start_offset=-1)
+
+
+def test_telemetry_ingest_endpoint_keeps_batch_first_and_requires_request():
+    import inspect
+
+    from api.routes.telemetry import ingest
+
+    signature = inspect.signature(ingest)
+    assert list(signature.parameters)[:2] == ["batch", "request"]
+
+
+@pytest.mark.asyncio
+async def test_graphql_trace_limit_is_clamped_to_max_page_size():
+    from api.graphql import MAX_TRACE_PAGE_SIZE, Query
+
+    rows = [
+        {"trace_id": f"trace-{i}", "user_id": "user-1", "start_time": "2026-01-01"}
+        for i in range(MAX_TRACE_PAGE_SIZE + 1)
+    ]
+    query_traces = AsyncMock(return_value=rows)
+
+    with patch("api.graphql.query_traces", query_traces):
+        result = await Query().traces(info=_info(), limit=1_000_000, offset=5)
+
+    assert len(result.items) == MAX_TRACE_PAGE_SIZE
+    assert result.has_more is True
+    query_traces.assert_awaited_once()
+    assert query_traces.call_args.kwargs["limit"] == MAX_TRACE_PAGE_SIZE + 1
+    assert query_traces.call_args.kwargs["offset"] == 5
+
+
+@pytest.mark.asyncio
+async def test_graphql_trace_negative_offset_is_rejected():
+    from api.graphql import Query
+
+    with pytest.raises(ValueError, match="offset"):
+        await Query().traces(info=_info(), offset=-1)
+
+
+def test_alert_history_query_params_are_bounded():
+    import inspect
+
+    from api.routes.alert import get_alert_history
+
+    signature = inspect.signature(get_alert_history)
+    assert signature.parameters["limit"].default.default == 50
+    assert _query_bound(signature.parameters["limit"].default, "le") == 200
+    assert signature.parameters["offset"].default.default == 0
+    assert _query_bound(signature.parameters["offset"].default, "ge") == 0
+
+
+def test_mcp_validator_rejects_http_git_by_default():
+    import services.mcp_validator as mcp_validator
+
+    with (
+        patch.object(mcp_validator, "ALLOWED_SCHEMES", {"https"}),
+        patch.object(mcp_validator, "ALLOW_HTTP_GIT", False),
+    ):
+        err = mcp_validator._validate_git_url("http://github.com/example/repo")
+
+    assert err is not None
+    assert "scheme" in err.lower()
+    assert "https" in err.lower()
+
+
+def test_mcp_validator_allows_http_only_with_explicit_opt_in():
+    import services.mcp_validator as mcp_validator
+
+    with (
+        patch.object(mcp_validator, "ALLOWED_SCHEMES", {"https", "http"}),
+        patch.object(mcp_validator, "ALLOW_HTTP_GIT", True),
+        patch.object(mcp_validator, "_ssrf_is_private", return_value=False),
+    ):
+        assert mcp_validator._validate_git_url("http://github.com/example/repo") is None
+        assert "MCP_ALLOW_HTTP_GIT" in mcp_validator._git_url_warning("http://github.com/example/repo")
+
+
+def test_mcp_validator_warning_is_empty_for_https_urls():
+    import services.mcp_validator as mcp_validator
+
+    with patch.object(mcp_validator, "ALLOW_HTTP_GIT", True):
+        assert mcp_validator._git_url_warning("https://github.com/example/repo") == ""
+        assert mcp_validator._git_url_warning("https://gitlab.example.com/x.git") == ""
+
+
+def test_mcp_validator_env_var_controls_allowed_schemes_at_import():
+    """Ensure the env-var -> ALLOWED_SCHEMES wiring is exercised, not just patched."""
+    import importlib
+    import os
+
+    import services.mcp_validator as mcp_validator
+
+    original_env = os.environ.get("MCP_ALLOW_HTTP_GIT")
+    try:
+        os.environ["MCP_ALLOW_HTTP_GIT"] = "true"
+        importlib.reload(mcp_validator)
+        assert mcp_validator.ALLOW_HTTP_GIT is True
+        assert "http" in mcp_validator.ALLOWED_SCHEMES
+        assert "https" in mcp_validator.ALLOWED_SCHEMES
+
+        os.environ["MCP_ALLOW_HTTP_GIT"] = "false"
+        importlib.reload(mcp_validator)
+        assert mcp_validator.ALLOW_HTTP_GIT is False
+        assert "http" not in mcp_validator.ALLOWED_SCHEMES
+        assert {"https"} == mcp_validator.ALLOWED_SCHEMES
+    finally:
+        if original_env is None:
+            os.environ.pop("MCP_ALLOW_HTTP_GIT", None)
+        else:
+            os.environ["MCP_ALLOW_HTTP_GIT"] = original_env
+        importlib.reload(mcp_validator)
+
+
+def test_telemetry_ingest_batch_rejects_oversized_scores_list():
+    from schemas.telemetry import MAX_INGEST_SCORES, IngestBatch
+
+    with pytest.raises(ValidationError):
+        IngestBatch(scores=[_score(str(i)) for i in range(MAX_INGEST_SCORES + 1)])
+
+
+def test_telemetry_ingest_rejects_remaining_oversized_string_fields():
+    from schemas.telemetry import MAX_TEXT_LENGTH, ScoreIngest, SpanIngest, TraceIngest
+
+    oversize_text = "x" * (MAX_TEXT_LENGTH + 1)
+
+    with pytest.raises(ValidationError):
+        TraceIngest(**_trace(), output=oversize_text)
+
+    with pytest.raises(ValidationError):
+        SpanIngest(**_span(), input=oversize_text)
+
+    with pytest.raises(ValidationError):
+        SpanIngest(**_span(), output=oversize_text)
+
+    with pytest.raises(ValidationError):
+        ScoreIngest(**_score(), string_value=oversize_text)
+
+    with pytest.raises(ValidationError):
+        ScoreIngest(**_score(), comment=oversize_text)
+
+
+def test_telemetry_ingest_rejects_oversized_span_metadata_and_metadata_keys():
+    from schemas.telemetry import MAX_METADATA_ENTRIES, MAX_SHORT_STRING_LENGTH, SpanIngest, TraceIngest
+
+    with pytest.raises(ValidationError):
+        SpanIngest(**_span(), metadata={str(i): "v" for i in range(MAX_METADATA_ENTRIES + 1)})
+
+    # Metadata keys are bounded by MAX_SHORT_STRING_LENGTH via the validator.
+    long_key = "k" * (MAX_SHORT_STRING_LENGTH + 1)
+    with pytest.raises(ValidationError):
+        TraceIngest(**_trace(), metadata={long_key: "v"})
+
+    with pytest.raises(ValidationError):
+        SpanIngest(**_span(), metadata={long_key: "v"})
+
+
+def test_telemetry_ingest_accepts_maximum_valid_sizes():
+    """Boundary regression: exact-limit payloads must remain accepted."""
+    from schemas.telemetry import (
+        MAX_INGEST_SCORES,
+        MAX_INGEST_SPANS,
+        MAX_INGEST_TRACES,
+        MAX_METADATA_ENTRIES,
+        MAX_TAGS,
+        MAX_TEXT_LENGTH,
+        IngestBatch,
+        ScoreIngest,
+        SpanIngest,
+        TraceIngest,
+    )
+
+    batch = IngestBatch(
+        traces=[_trace(str(i)) for i in range(MAX_INGEST_TRACES)],
+        spans=[_span(str(i)) for i in range(MAX_INGEST_SPANS)],
+        scores=[_score(str(i)) for i in range(MAX_INGEST_SCORES)],
+    )
+    assert len(batch.traces) == MAX_INGEST_TRACES
+    assert len(batch.spans) == MAX_INGEST_SPANS
+    assert len(batch.scores) == MAX_INGEST_SCORES
+
+    edge_text = "x" * MAX_TEXT_LENGTH
+    TraceIngest(**_trace(), input=edge_text, output=edge_text)
+    SpanIngest(**_span(), input=edge_text, output=edge_text, error=edge_text)
+    ScoreIngest(**_score(), string_value=edge_text, comment=edge_text)
+
+    TraceIngest(
+        **_trace(),
+        tags=[str(i) for i in range(MAX_TAGS)],
+        metadata={str(i): "v" for i in range(MAX_METADATA_ENTRIES)},
+    )
+
+
+def test_session_ingest_rejects_oversized_short_string_fields():
+    from api.routes.ingest import MAX_SHORT_STRING_LENGTH, SessionIngestRequest
+
+    long_value = "x" * (MAX_SHORT_STRING_LENGTH + 1)
+
+    with pytest.raises(ValidationError):
+        SessionIngestRequest(session_id=long_value, lines=[])
+
+    with pytest.raises(ValidationError):
+        SessionIngestRequest(session_id="s", ide=long_value, lines=[])
+
+    with pytest.raises(ValidationError):
+        SessionIngestRequest(session_id="s", agent_id=long_value, lines=[])
+
+    with pytest.raises(ValidationError):
+        SessionIngestRequest(session_id="s", parent_session_id=long_value, lines=[])
+
+
+def test_alert_history_endpoint_rejects_oversized_limit_via_query_validation():
+    """Behavior-level guard: FastAPI must reject limit=300 through query validation."""
+    import uuid
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api import deps as deps_module
+    from api.routes import alert as alert_module
+    from models.user import UserRole
+
+    class _FakeDB:
+        async def get(self, *args, **kwargs):
+            return None
+
+    async def _current_user():
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        user.email = "tester@example.com"
+        user.role = UserRole.user
+        user.org_id = None
+        return user
+
+    async def _get_db():
+        yield _FakeDB()
+
+    app = FastAPI()
+    app.dependency_overrides[deps_module.get_current_user] = _current_user
+    app.dependency_overrides[alert_module.get_db] = _get_db
+    app.include_router(alert_module.router)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    alert_id = "00000000-0000-0000-0000-000000000000"
+
+    # limit above bound -> 422
+    resp = client.get(f"/api/v1/alerts/{alert_id}/history?limit=300")
+    assert resp.status_code == 422
+    assert "limit" in resp.text
+
+    # negative offset -> 422
+    resp = client.get(f"/api/v1/alerts/{alert_id}/history?limit=50&offset=-1")
+    assert resp.status_code == 422
+    assert "offset" in resp.text
+
+    # limit at the maximum passes validation and then misses in the fake DB.
+    resp = client.get(f"/api/v1/alerts/{alert_id}/history?limit=200&offset=0")
+    assert resp.status_code == 404
+
+
+def test_telemetry_and_session_ingest_have_rate_limit_decorators_wired():
+    """Smoke-check that slowapi limits are attached to the abuse-prone endpoints."""
+    import inspect
+
+    from api.routes.ingest import ingest_session
+    from api.routes.telemetry import ingest as ingest_telemetry
+
+    # slowapi stores the limit string on the wrapped function via closure or attribute.
+    # Both routes also require `request: Request` to be in the signature for slowapi to work.
+    telemetry_params = list(inspect.signature(ingest_telemetry).parameters)
+    session_params = list(inspect.signature(ingest_session).parameters)
+    assert "request" in telemetry_params, "slowapi requires `request: Request` in the signature"
+    assert "request" in session_params, "slowapi requires `request: Request` in the signature"
+
+
+def test_rate_limit_key_prefers_identity_then_token_then_ip():
+    import hashlib
+
+    from api.ratelimit import _get_rate_limit_key
+
+    user_request = MagicMock()
+    user_request.state = SimpleNamespace(current_user=SimpleNamespace(id="user-1", org_id="org-1"))
+    user_request.headers = {}
+    assert _get_rate_limit_key(user_request) == "org:org-1:user:user-1"
+
+    token_request = MagicMock()
+    token_request.state = SimpleNamespace()
+    token_request.headers = {"authorization": "Bearer secret-token"}
+    digest = hashlib.sha256(b"secret-token").hexdigest()
+    assert _get_rate_limit_key(token_request) == f"token:{digest}"
+
+    ip_request = MagicMock()
+    ip_request.state = SimpleNamespace()
+    ip_request.headers = {}
+    ip_request.client = MagicMock()
+    ip_request.client.host = "203.0.113.10"
+    with patch("api.ratelimit.ds") as mock_ds:
+        mock_ds.get_sync.return_value = ""
+        assert _get_rate_limit_key(ip_request) == "ip:203.0.113.10"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_stores_identity_for_rate_limit_key():
+    import uuid
+
+    from api.deps import get_current_user
+    from models.user import UserRole
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "tester@example.com"
+    user.role = UserRole.user
+    user.org_id = uuid.uuid4()
+    user.auth_provider = "password"
+
+    request = MagicMock()
+    request.url.path = "/api/v1/telemetry/ingest"
+    request.state = SimpleNamespace()
+
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=None)
+
+    with (
+        patch("api.deps._authenticate_via_jwt", AsyncMock(return_value=user)),
+        patch("api.deps.get_redis", return_value=redis),
+    ):
+        result = await get_current_user(request, authorization="Bearer access-token", db=MagicMock())
+
+    assert result is user
+    assert request.state.current_user is user
+    assert request.state.org_id == user.org_id

--- a/tests/test_ingest_phase2.py
+++ b/tests/test_ingest_phase2.py
@@ -17,6 +17,18 @@ from api.routes.telemetry import router
 from models.user import User
 
 
+@pytest.fixture(autouse=True)
+def _disable_rate_limiter():
+    from api.ratelimit import limiter
+
+    old_enabled = limiter.enabled
+    limiter.enabled = False
+    try:
+        yield
+    finally:
+        limiter.enabled = old_enabled
+
+
 def _make_user(**kwargs):
     u = MagicMock(spec=User)
     u.id = kwargs.get("id", uuid.uuid4())


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Adds bounded telemetry/session ingest payloads, clamps query limits, restricts MCP Git URLs to HTTPS by default, and keys rate limits by authenticated identity or token before falling back to IP.

## Fixes
* Fixes security issues related to unbounded ingest/query workloads and insecure MCP Git URL schemes.

## Approach
- Adds Pydantic bounds for telemetry traces, spans, scores, metadata, tags, and session JSONL ingest lines.
- Adds endpoint rate limits to telemetry and session ingest routes.
- Keys rate limits by authenticated org/user when available, then bearer-token hash, then client IP.
- Clamps GraphQL trace pagination and rejects negative offsets.
- Bounds alert history pagination query parameters.
- Changes MCP Git validation to allow only HTTPS by default, with explicit opt-in for HTTP via `MCP_ALLOW_HTTP_GIT=true`.
- Adds regression tests for payload bounds, pagination bounds, MCP URL validation, and rate-limit key precedence.

## How Has This Been Tested?

Tested with tests/test_audit2_pr1_ingest_bounds.py

## Learning (optional, can help others)
This change came from reviewing ingest and registry validation paths for denial-of-service and unsafe transport risks. The main hardening pattern is to reject oversized work at schema/query-validation boundaries before it reaches database or background processing.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->
