### PR TITLE
chore: add .clabot to allowlist renovate and dependabot

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,0 +1,3 @@
+{
+  "allowlist": ["renovate[bot]", "dependabot[bot]"]
+}

--- a/.clabot.license
+++ b/.clabot.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
## Purpose / Description
Adds a `.clabot` configuration file so that automated bot accounts (renovate[bot], dependabot[bot]) can bypass the CLA signature requirement. Without this, every dependency update PR is blocked by the CLA check.

## Fixes
* Fixes the CLA check blocking renovate[bot] PRs

## Approach
Added a `.clabot` file at the repo root with an allowlist array. CLA Assistant (and clabot-compatible tools) read this file and skip the signature requirement for listed accounts.

## How Has This Been Tested?
Will be validated once a renovate PR triggers the CLA check again - it should pass without manual intervention.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)