### PR TITLE
feat: version enforcement - hard block on CLI/server mismatch & auto-update

### DIFF
--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -19,14 +19,16 @@ router = APIRouter(prefix="/api/v1/config", tags=["config"])
 
 @router.get("/version")
 async def get_version():
-    """Server version and compatibility info. No auth required."""
+    """Server version and compatibility info. No auth required.
+
+    The server_version is the canonical target: CLI and frontend must match it.
+    """
     optic.debug("config.get_version called")
     import services.dynamic_settings as ds
 
     max_cli = await ds.get("misc.max_cli_version")
     api_version = await ds.get("misc.api_version")
     frontend_version = await ds.get("misc.frontend_version")
-    recommended_cli = await ds.get("misc.recommended_cli_version")
 
     server_ver = get_server_version()
     return {
@@ -34,7 +36,8 @@ async def get_version():
         "max_cli_version": max_cli or None,
         "api_version": api_version or None,
         "frontend_version": frontend_version or server_ver,
-        "recommended_cli_version": recommended_cli or server_ver,
+        # Deprecated: kept for backward compat with CLIs < 1.0.0. Will be removed in 1.2.0.
+        "recommended_cli_version": server_ver,
     }
 
 

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -223,7 +223,6 @@ DEFAULTS: dict[str, str] = {
     "misc.max_cli_version": "",  # empty = no upper bound
     "misc.api_version": "2026-05-01",  # date-based, bumped on breaking changes
     "misc.frontend_version": "",  # expected frontend build version (empty = same as server)
-    "misc.recommended_cli_version": "",  # empty = same as server_version
     "misc.git_mirror_base_path": "",
 }
 

--- a/observal_cli/__main__.py
+++ b/observal_cli/__main__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Allow running observal_cli as a module: python -m observal_cli."""
+
+from observal_cli.main import app
+
+app()

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -22,6 +22,11 @@ logger = logging.getLogger(__name__)
 
 # Cached server version for the process lifetime
 _server_version_cache: str | None = None
+# Whether version enforcement has already run this session
+_version_enforced: bool = False
+
+# Subcommands exempt from version enforcement (user needs these to fix mismatches)
+_EXEMPT_SUBCOMMANDS = frozenset({"self", "server"})
 
 
 def _get_cli_version() -> str:
@@ -38,10 +43,37 @@ def _get_cli_version() -> str:
 def _client() -> tuple[str, dict]:
     optic.debug("_client called")
     cfg = config.get_or_exit()
-    return cfg["server_url"].rstrip("/"), {
+    base_url = cfg["server_url"].rstrip("/")
+    headers = {
         "Authorization": f"Bearer {cfg['access_token']}",
         "X-Observal-CLI-Version": _get_cli_version(),
     }
+    # Run version enforcement once per session (unless exempt subcommand)
+    _enforce_version_once(base_url)
+    return base_url, headers
+
+
+def _enforce_version_once(server_url: str) -> None:
+    """Run version enforcement exactly once per CLI session.
+
+    Checks if CLI major.minor matches server. Hard exits on mismatch.
+    Exempt: `observal self` and `observal server` subcommands.
+    """
+    global _version_enforced
+    if _version_enforced:
+        return
+    _version_enforced = True
+
+    # Check if current subcommand is exempt (handle flags before subcommand)
+    import sys
+
+    positional_args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    if positional_args and positional_args[0] in _EXEMPT_SUBCOMMANDS:
+        return
+
+    from observal_cli.version_check import check_version_compatibility
+
+    check_version_compatibility(server_url)
 
 
 def _handle_error(e: httpx.HTTPStatusError, path: str = ""):

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -1649,6 +1649,15 @@ def downgrade(
         rprint(f"[red]Invalid version: {version}[/red]")
         raise typer.Exit(1)
 
+    # Enforce version floor - cannot go below 1.0.0
+    if target < Version(version_check.VERSION_FLOOR):
+        rprint(
+            f"[bold red]\u2716 Cannot downgrade below v{version_check.VERSION_FLOOR}.[/bold red]\n"
+            f"  Versioning is not supported on earlier releases.\n"
+            f"  Minimum allowed version: [cyan]v{version_check.VERSION_FLOOR}[/cyan]"
+        )
+        raise typer.Exit(1)
+
     try:
         if target >= Version(current):
             rprint(f"[yellow]v{version} is not older than current v{current}.[/yellow]")

--- a/observal_cli/features.py
+++ b/observal_cli/features.py
@@ -35,8 +35,13 @@ FEATURE_VERSIONS: dict[str, str] = {
     "skills": "0.7.0",
     # v0.8.0
     "agent_builder": "0.8.0",
-    "version_negotiation": "0.8.0",
-    "self_upgrade": "0.8.0",
+    # v1.0.0
+    "version_check": "1.0.0",
+    "version_enforcement": "1.0.0",
+    "self_upgrade": "1.0.0",
+    "server_upgrade": "1.0.0",
+    "auto_update": "1.0.0",
+    "version_negotiation": "1.0.0",
 }
 
 

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -94,6 +94,36 @@ def main(
     elif verbose:
         logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
+    # Auto-update on minor/patch releases (non-blocking, exempt self/server commands)
+    _try_auto_update()
+
+
+def _try_auto_update() -> None:
+    """Attempt auto-update for minor/patch releases on startup.
+
+    Runs silently. Logs a message on success so the user knows the next
+    invocation will use the new version.
+    Exempt: self/server subcommands, CI, non-TTY.
+    """
+    # Skip exempt subcommands (check positional args, not flags)
+    positional_args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    if positional_args and positional_args[0] in ("self", "server"):
+        return
+    if os.environ.get("CI") or os.environ.get("OBSERVAL_NO_UPDATE_CHECK"):
+        return
+    if not sys.stdout.isatty():
+        return  # Never auto-update in non-interactive environments
+
+    try:
+        from observal_cli.version_check import auto_update_if_needed
+
+        if auto_update_if_needed():
+            from rich import print as _rprint
+
+            _rprint("[dim]Updated. The new version will be used on your next command.[/dim]")
+    except Exception:
+        pass  # Never crash the CLI for auto-update
+
 
 # ── Register command groups ──────────────────────────────
 
@@ -175,11 +205,11 @@ except ImportError:
 
 
 def _show_update_banner() -> None:
-    """Post-command hook: show update notification if available.
+    """Post-command hook: show major version notification only.
 
-    Only on interactive TTY, never during self/server commands, never in CI.
-    If connected to a server (enterprise): targets the server's version.
-    Otherwise: targets the latest GitHub release.
+    Minor/patch mismatches are handled by auto-update.
+    Major.minor mismatches are hard-blocked by the version enforcement gate.
+    This banner only fires for major upgrades available in community mode.
     """
     import sys as _sys
 
@@ -197,25 +227,19 @@ def _show_update_banner() -> None:
         if not update:
             return
 
+        from packaging.version import Version
         from rich import print as _rprint
 
-        if update.source == "server":
-            if update.direction == "downgrade":
+        # Only show banner for major version upgrades (community mode)
+        # Hard block already handles minor mismatches; auto-update handles patches
+        if update.source == "github":
+            current_v = Version(update.current)
+            latest_v = Version(update.latest)
+            if latest_v.major > current_v.major:
                 _rprint(
-                    f"\n[yellow]Your server recommends v{update.latest}. "
-                    f"Downgrade: [bold]observal self downgrade --version {update.latest}[/bold][/yellow]"
+                    f"\n[yellow]Major update available: v{update.current} \u2192 v{update.latest}[/yellow]\n"
+                    f"  Run: [bold cyan]observal self upgrade --version {update.latest}[/bold cyan]"
                 )
-            else:
-                _rprint(
-                    f"\n[dim]Your server is v{update.latest}. "
-                    f"Match it: [bold]observal self upgrade --version {update.latest}[/bold][/dim]"
-                )
-        else:
-            _rprint(
-                f"\n[dim]Update available: v{update.current} \u2192 "
-                f"[green]v{update.latest}[/green] \u2022 "
-                f"[bold]observal self upgrade[/bold][/dim]"
-            )
     except Exception:
         pass  # Never crash the CLI for a version check
 

--- a/observal_cli/upgrade_executor.py
+++ b/observal_cli/upgrade_executor.py
@@ -229,3 +229,29 @@ def _verify_install(direction: str) -> None:
         rprint(f"[green]{direction.capitalize()}d to v{new_version}[/green]")
     except (subprocess.TimeoutExpired, OSError, IndexError):
         rprint(f"[green]{direction.capitalize()} complete. Restart your shell to use the new version.[/green]")
+
+
+def execute_silent(install_info: InstallInfo, target_version: str, direction: str) -> bool:
+    """Non-interactive auto-update path. Returns True on success, False on failure.
+
+    Unlike execute(), this never prints to stdout/stderr and never raises typer.Exit.
+    Used by auto_update_if_needed() for background minor/patch updates.
+    """
+    try:
+        if install_info.method == InstallMethod.UV_TOOL:
+            result = subprocess.run(
+                ["uv", "tool", "install", f"observal-cli=={target_version}", "--force"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return result.returncode == 0
+        elif install_info.method == InstallMethod.PIP:
+            pip_cmd = [sys.executable, "-m", "pip", "install", f"observal-cli=={target_version}", "--quiet"]
+            result = subprocess.run(pip_cmd, capture_output=True, text=True, timeout=30)
+            return result.returncode == 0
+        else:
+            # Binary and other methods are too complex for silent update
+            return False
+    except (subprocess.TimeoutExpired, OSError):
+        return False

--- a/observal_cli/version_check.py
+++ b/observal_cli/version_check.py
@@ -5,14 +5,15 @@
 
 Used by:
   - CLI post-command hook (notification banner)
-  - server start/status (notification)
+  - Version enforcement gate (hard block on mismatch)
   - `observal self upgrade` (resolve latest)
   - `observal server upgrade` (resolve latest)
+  - Auto-update on startup (minor/patch only)
 
 Two check modes:
-  - Server mode: CLI is connected to a server → check server's /api/v1/config/version
-    for recommended_cli_version (enterprise employees should match their server)
-  - GitHub mode: no server configured → check GitHub Releases API for latest
+  - Server mode: CLI is connected to a server. The server_version from
+    /api/v1/config/version is the canonical target. CLI must match it.
+  - GitHub mode: no server configured. Check GitHub Releases API for latest.
 """
 
 from __future__ import annotations
@@ -50,6 +51,9 @@ REDIRECT_ALLOWLIST = frozenset(
     ]
 )
 
+# Hard floor: versioning didn't exist before 1.0.0, never allow going below this.
+VERSION_FLOOR = "1.0.0"
+
 
 @dataclass(frozen=True)
 class UpdateAvailable:
@@ -71,6 +75,19 @@ def get_current_version() -> str:
         return version("observal-cli")
     except Exception:
         return "0.0.0"
+
+
+def check_version_floor(target: str) -> bool:
+    """Return True if target version is at or above the version floor.
+
+    Rejects any version below 1.0.0 since versioning didn't exist before that.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        return Version(target) >= Version(VERSION_FLOOR)
+    except InvalidVersion:
+        return False
 
 
 def _github_repo() -> str:
@@ -195,9 +212,10 @@ def _should_check(cache: dict | None, interval: int) -> bool:
 
 
 def _fetch_from_server(server_url: str, token: str) -> dict | None:
-    """Check connected server for recommended CLI version.
+    """Check connected server for its version (the canonical target for CLI).
 
     Returns dict with latest_version, release_url, source="server" or None.
+    The server_version IS the target - CLI must match it.
     """
     try:
         resp = httpx.get(
@@ -214,24 +232,24 @@ def _fetch_from_server(server_url: str, token: str) -> dict | None:
         if not isinstance(data, dict):
             return None
 
-        # Use recommended_cli_version if set, otherwise server_version
-        recommended = data.get("recommended_cli_version") or data.get("server_version")
-        if not recommended:
+        # Server version is the canonical target - CLI must match it
+        server_ver = data.get("server_version")
+        if not server_ver:
             return None
 
         from packaging.version import InvalidVersion, Version
 
         try:
-            Version(recommended)
+            Version(server_ver)
         except InvalidVersion:
             return None
 
         return {
-            "latest_version": recommended,
+            "latest_version": server_ver,
             "release_url": "",
             "published_at": "",
             "source": "server",
-            "server_version": data.get("server_version", ""),
+            "server_version": server_ver,
         }
     except (httpx.HTTPError, json.JSONDecodeError, KeyError):
         return None
@@ -527,3 +545,155 @@ def fetch_all_releases(include_pre: bool = False) -> list[dict]:
         except Exception:
             break
     return results
+
+
+# ── Version enforcement ─────────────────────────────────────────────
+
+
+def check_version_compatibility(server_url: str) -> None:
+    """Enforce CLI/server version match. Hard exit on major.minor mismatch.
+
+    The server version is the canonical target. CLI must match its major.minor.
+    Patch differences are tolerated (e.g. CLI 1.0.1 vs server 1.0.0 is fine).
+
+    Reads from the local version cache first (populated by auto-update check)
+    to avoid a duplicate network call. Falls back to a fresh fetch if needed.
+    """
+    import typer
+    from packaging.version import InvalidVersion, Version
+    from rich import print as rprint
+
+    cli_ver_str = get_current_version()
+    if cli_ver_str == "0.0.0":
+        return  # dev install, skip check
+
+    # Try reading server version from cache first (populated by auto-update)
+    server_ver = None
+    cache = _read_cache()
+    if cache and cache.get("server_version") and cache.get("source") == "server":
+        server_ver = cache["server_version"]
+
+    # Fall back to a fresh fetch if cache doesn't have it
+    if not server_ver:
+        try:
+            resp = httpx.get(f"{server_url.rstrip('/')}/api/v1/config/version", timeout=5)
+            if resp.status_code != 200:
+                return
+            data = resp.json()
+            server_ver = data.get("server_version")
+        except Exception:
+            return  # server unreachable or doesn't support this endpoint
+
+    if not server_ver or server_ver == "dev":
+        return  # dev server, skip enforcement
+
+    try:
+        cli_v = Version(cli_ver_str)
+        srv_v = Version(server_ver)
+    except InvalidVersion:
+        return
+
+    # Compare major.minor only - patch differences are tolerated
+    cli_major_minor = (cli_v.major, cli_v.minor)
+    srv_major_minor = (srv_v.major, srv_v.minor)
+
+    if cli_major_minor == srv_major_minor:
+        return  # versions match, all good
+
+    # Mismatch - hard block
+    if cli_major_minor > srv_major_minor:
+        rprint(
+            f"\n[bold red]\u2716 CLI version {cli_ver_str} is ahead of server {server_ver}.[/bold red]\n"
+            f"  The server is the source of truth for versioning.\n"
+            f"  Downgrade your CLI to match the server:\n\n"
+            f"    [cyan]observal self downgrade --version {server_ver}[/cyan]\n"
+        )
+    else:
+        rprint(
+            f"\n[bold red]\u2716 CLI version {cli_ver_str} is behind server {server_ver}.[/bold red]\n"
+            f"  The server is the source of truth for versioning.\n"
+            f"  Upgrade your CLI to match the server:\n\n"
+            f"    [cyan]observal self upgrade --version {server_ver}[/cyan]\n"
+        )
+    raise typer.Exit(1)
+
+
+# ── Auto-update logic ─────────────────────────────────────────────
+
+
+def auto_update_if_needed() -> bool:
+    """Auto-update CLI if a minor/patch update is available. Returns True if update applied.
+
+    Behavior:
+    - Enterprise (server connected): match server version exactly.
+    - Community (GitHub): update to latest minor/patch, prompt for major.
+    - Respects `auto_update` config (default: true).
+    - Never auto-updates across major versions without explicit consent.
+    - Enforces VERSION_FLOOR.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    cfg = load_config()
+    if not cfg.get("auto_update", True):
+        return False
+    if os.environ.get("OBSERVAL_NO_UPDATE_CHECK") or os.environ.get("CI"):
+        return False
+
+    current_str = get_current_version()
+    if current_str == "0.0.0":
+        return False  # dev install
+
+    try:
+        current = Version(current_str)
+    except InvalidVersion:
+        return False
+
+    # Determine target version
+    release = _resolve_update_source()
+    if release is None:
+        return False
+
+    target_str = release["latest_version"]
+    try:
+        target = Version(target_str)
+    except InvalidVersion:
+        return False
+
+    # No update needed if already at target
+    if target == current:
+        return False
+
+    # Enforce version floor
+    if target < Version(VERSION_FLOOR):
+        return False
+
+    # Determine if this is a major version jump
+    is_major_jump = target.major != current.major
+
+    if is_major_jump:
+        # Major version changes require explicit action
+        import sys
+
+        if sys.stdout.isatty():
+            from rich import print as _rprint
+
+            _rprint(
+                f"\n[yellow]Major update available: v{current_str} \u2192 v{target_str}[/yellow]\n"
+                f"  This may include breaking changes.\n"
+                f"  Run: [bold cyan]observal self upgrade --version {target_str}[/bold cyan]\n"
+            )
+        return False
+
+    # Minor/patch - auto-update silently
+    try:
+        from observal_cli.install_detector import InstallMethod, detect
+        from observal_cli.upgrade_executor import execute_silent
+
+        install_info = detect()
+        if install_info.method in (InstallMethod.HOMEBREW, InstallMethod.SYSTEM_PACKAGE):
+            return False  # managed installs can't be auto-updated
+
+        direction = "upgrade" if target > current else "downgrade"
+        return execute_silent(install_info, target_str, direction)
+    except Exception:
+        return False  # Never crash CLI for auto-update failures

--- a/scripts/sync_features.py
+++ b/scripts/sync_features.py
@@ -43,25 +43,28 @@ export const FEATURE_VERSIONS: Record<string, string> = {{
  * Check if a feature is available at the given effective version.
  * effective = min(cli_version, server_version)
  */
-export function isFeatureAvailable(feature: string, effectiveVersion: string): boolean {{
-  const minVersion = FEATURE_VERSIONS[feature];
-  if (!minVersion) return true; // Unknown features assumed available
-  return semverGte(effectiveVersion, minVersion);
+export function isFeatureAvailable(
+\tfeature: string,
+\teffectiveVersion: string,
+): boolean {{
+\tconst minVersion = FEATURE_VERSIONS[feature];
+\tif (!minVersion) return true; // Unknown features assumed available
+\treturn semverGte(effectiveVersion, minVersion);
 }}
 
 /**
  * Simple semver >= comparison (major.minor.patch only).
  */
 function semverGte(a: string, b: string): boolean {{
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {{
-    const av = pa[i] || 0;
-    const bv = pb[i] || 0;
-    if (av > bv) return true;
-    if (av < bv) return false;
-  }}
-  return true; // equal
+\tconst pa = a.split(".").map(Number);
+\tconst pb = b.split(".").map(Number);
+\tfor (let i = 0; i < 3; i++) {{
+\t\tconst av = pa[i] || 0;
+\t\tconst bv = pb[i] || 0;
+\t\tif (av > bv) return true;
+\t\tif (av < bv) return false;
+\t}}
+\treturn true; // equal
 }}
 """
 
@@ -72,7 +75,7 @@ def generate() -> str:
     for name, version in sorted(FEATURE_VERSIONS.items()):
         # Convert snake_case to camelCase for TS convention
         camel = _to_camel_case(name)
-        entries.append(f'  {camel}: "{version}",')
+        entries.append(f'\t{camel}: "{version}",')
     return TEMPLATE.format(entries="\n".join(entries))
 
 

--- a/tests/test_self_commands.py
+++ b/tests/test_self_commands.py
@@ -13,10 +13,16 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def disable_auto_update(monkeypatch):
+    """Disable auto-update and version checks in all self-command tests."""
+    monkeypatch.setenv("OBSERVAL_NO_UPDATE_CHECK", "1")
+
+
 @pytest.fixture
 def mock_version(monkeypatch):
     """Mock current CLI version."""
-    monkeypatch.setattr("observal_cli.version_check.get_current_version", lambda: "0.7.0")
+    monkeypatch.setattr("observal_cli.version_check.get_current_version", lambda: "1.2.0")
 
 
 @pytest.fixture
@@ -68,11 +74,11 @@ class TestSelfUpgrade:
     def test_upgrade_already_latest(self, mock_version, mock_install_uv, mock_lock, monkeypatch):
         monkeypatch.setattr(
             "observal_cli.version_check._fetch_from_github",
-            lambda include_pre=False: {"latest_version": "0.7.0", "source": "github"},
+            lambda include_pre=False: {"latest_version": "1.2.0", "source": "github"},
         )
         app = _get_app()
         result = runner.invoke(app, ["self", "upgrade", "--force"])
-        assert "Already on v0.7.0" in result.output
+        assert "Already on v1.2.0" in result.output
 
     def test_upgrade_managed_install_blocked(self, mock_version, mock_install_brew, monkeypatch):
         app = _get_app()
@@ -80,7 +86,7 @@ class TestSelfUpgrade:
         assert "managed by brew" in result.output.lower() or "brew" in result.output
 
     def test_upgrade_specific_version(self, mock_version, mock_install_uv, mock_lock, monkeypatch):
-        """--version 0.8.0 should attempt install of that version."""
+        """--version 1.3.0 should attempt install of that version."""
         install_called = {"version": None}
 
         def mock_do_install(info, target, direction):
@@ -88,13 +94,13 @@ class TestSelfUpgrade:
 
         monkeypatch.setattr("observal_cli.cmd_ops._do_install", mock_do_install)
         app = _get_app()
-        result = runner.invoke(app, ["self", "upgrade", "--version", "0.8.0", "--force"])
-        assert install_called["version"] == "0.8.0"
+        result = runner.invoke(app, ["self", "upgrade", "--version", "1.3.0", "--force"])
+        assert install_called["version"] == "1.3.0"
 
     def test_upgrade_older_version_rejected(self, mock_version, mock_install_uv, mock_lock, monkeypatch):
         """Attempting to 'upgrade' to an older version should fail."""
         app = _get_app()
-        result = runner.invoke(app, ["self", "upgrade", "--version", "0.5.0", "--force"])
+        result = runner.invoke(app, ["self", "upgrade", "--version", "1.0.0", "--force"])
         assert "older" in result.output.lower() or "downgrade" in result.output.lower()
 
 
@@ -108,19 +114,19 @@ class TestSelfDowngrade:
         monkeypatch.setattr(
             "observal_cli.version_check.fetch_all_releases",
             lambda include_pre=False: [
-                {"version": "0.7.0", "published_at": "2026-05-20", "prerelease": False},
-                {"version": "0.6.0", "published_at": "2026-05-10", "prerelease": False},
+                {"version": "1.1.0", "published_at": "2026-05-20", "prerelease": False},
+                {"version": "1.0.0", "published_at": "2026-05-10", "prerelease": False},
             ],
         )
         app = _get_app()
         result = runner.invoke(app, ["self", "downgrade", "--list"])
-        assert "0.7.0" in result.output
-        assert "0.6.0" in result.output
+        assert "1.1.0" in result.output
+        assert "1.0.0" in result.output
 
     def test_downgrade_target_is_newer(self, mock_version, monkeypatch):
         """Downgrade to a newer version should error."""
         app = _get_app()
-        result = runner.invoke(app, ["self", "downgrade", "--version", "0.9.0"])
+        result = runner.invoke(app, ["self", "downgrade", "--version", "1.3.0"])
         assert "not older" in result.output.lower() or "upgrade" in result.output.lower()
 
 
@@ -142,8 +148,8 @@ class TestSelfStatus:
     def test_status_shows_version(self, mock_version, mock_install_uv, monkeypatch):
         monkeypatch.setattr(
             "observal_cli.version_check._fetch_from_github",
-            lambda include_pre=False: {"latest_version": "0.8.0", "source": "github"},
+            lambda include_pre=False: {"latest_version": "1.3.0", "source": "github"},
         )
         app = _get_app()
         result = runner.invoke(app, ["self", "status"])
-        assert "0.7.0" in result.output
+        assert "1.2.0" in result.output

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -272,3 +272,230 @@ class TestFetchAllReleases:
         assert len(results) == 2
         assert results[0]["version"] == "0.8.0"
         assert results[1]["version"] == "0.7.0"
+
+
+# ── Version floor tests ─────────────────────────────────────────
+
+
+class TestVersionFloor:
+    def test_floor_constant_exists(self):
+        assert version_check.VERSION_FLOOR == "1.0.0"
+
+    def test_check_version_floor_above(self):
+        assert version_check.check_version_floor("1.0.0") is True
+        assert version_check.check_version_floor("1.0.1") is True
+        assert version_check.check_version_floor("2.0.0") is True
+
+    def test_check_version_floor_below(self):
+        assert version_check.check_version_floor("0.9.0") is False
+        assert version_check.check_version_floor("0.8.0") is False
+        assert version_check.check_version_floor("0.0.1") is False
+
+    def test_check_version_floor_invalid(self):
+        assert version_check.check_version_floor("not-a-version") is False
+
+
+# ── check_version_compatibility tests ────────────────────────────
+
+
+class TestCheckVersionCompatibility:
+    def test_dev_install_skipped(self, monkeypatch):
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "0.0.0")
+        version_check.check_version_compatibility("http://localhost:8000")
+
+    def test_server_unreachable_skipped(self, monkeypatch):
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(version_check, "_read_cache", lambda: None)
+
+        def mock_get(*args, **kwargs):
+            raise httpx.ConnectError("unreachable")
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+        version_check.check_version_compatibility("http://localhost:8000")
+
+    def test_dev_server_skipped(self, monkeypatch):
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(version_check, "_read_cache", lambda: None)
+
+        def mock_get(*args, **kwargs):
+            return httpx.Response(200, json={"server_version": "dev"})
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+        version_check.check_version_compatibility("http://localhost:8000")
+
+    def test_versions_match_no_exit(self, monkeypatch):
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(version_check, "_read_cache", lambda: None)
+
+        def mock_get(*args, **kwargs):
+            return httpx.Response(200, json={"server_version": "1.0.3"})
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+        version_check.check_version_compatibility("http://localhost:8000")
+
+    def test_cli_ahead_exits(self, monkeypatch):
+        from click.exceptions import Exit
+
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.2.0")
+        monkeypatch.setattr(version_check, "_read_cache", lambda: None)
+
+        def mock_get(*args, **kwargs):
+            return httpx.Response(200, json={"server_version": "1.0.0"})
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+        with pytest.raises(Exit):
+            version_check.check_version_compatibility("http://localhost:8000")
+
+    def test_cli_behind_exits(self, monkeypatch):
+        from click.exceptions import Exit
+
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(version_check, "_read_cache", lambda: None)
+
+        def mock_get(*args, **kwargs):
+            return httpx.Response(200, json={"server_version": "1.2.0"})
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+        with pytest.raises(Exit):
+            version_check.check_version_compatibility("http://localhost:8000")
+
+    def test_uses_cache_to_avoid_network_call(self, monkeypatch):
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(version_check, "_read_cache", lambda: {"server_version": "1.0.5", "source": "server"})
+        network_called = {"hit": False}
+
+        def mock_get(*args, **kwargs):
+            network_called["hit"] = True
+            return httpx.Response(200, json={"server_version": "1.0.5"})
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+        version_check.check_version_compatibility("http://localhost:8000")
+        assert network_called["hit"] is False
+
+
+# ── Auto-update tests ───────────────────────────────────────────
+
+
+class TestAutoUpdate:
+    def test_disabled_via_config(self, monkeypatch):
+        monkeypatch.setattr(version_check, "load_config", lambda: {"auto_update": False})
+        assert version_check.auto_update_if_needed() is False
+
+    def test_disabled_via_env(self, monkeypatch):
+        monkeypatch.setattr(version_check, "load_config", lambda: {})
+        monkeypatch.setenv("OBSERVAL_NO_UPDATE_CHECK", "1")
+        assert version_check.auto_update_if_needed() is False
+
+    def test_disabled_in_ci(self, monkeypatch):
+        monkeypatch.setattr(version_check, "load_config", lambda: {})
+        monkeypatch.setenv("CI", "true")
+        assert version_check.auto_update_if_needed() is False
+
+    def test_no_update_when_current(self, monkeypatch):
+        monkeypatch.setattr(version_check, "load_config", lambda: {})
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(
+            version_check, "_resolve_update_source", lambda: {"latest_version": "1.0.0", "source": "github"}
+        )
+        assert version_check.auto_update_if_needed() is False
+
+    def test_major_jump_not_auto_applied(self, monkeypatch):
+        import sys
+
+        monkeypatch.setattr(version_check, "load_config", lambda: {})
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(
+            version_check, "_resolve_update_source", lambda: {"latest_version": "2.0.0", "source": "github"}
+        )
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+        assert version_check.auto_update_if_needed() is False
+
+    def test_below_floor_not_applied(self, monkeypatch):
+        monkeypatch.setattr(version_check, "load_config", lambda: {})
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(
+            version_check, "_resolve_update_source", lambda: {"latest_version": "0.9.0", "source": "server"}
+        )
+        assert version_check.auto_update_if_needed() is False
+
+    def test_minor_update_triggers_silent_install(self, monkeypatch):
+        monkeypatch.setattr(version_check, "load_config", lambda: {})
+        monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
+        monkeypatch.setattr(
+            version_check, "_resolve_update_source", lambda: {"latest_version": "1.1.0", "source": "github"}
+        )
+        # Ensure CI env var doesn't block the test
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("OBSERVAL_NO_UPDATE_CHECK", raising=False)
+
+        import observal_cli.install_detector as id_mod
+        import observal_cli.upgrade_executor as ue_mod
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+
+        fake_info = InstallInfo(method=InstallMethod.UV_TOOL, path="/fake", writable=True, managed_by=None)
+        monkeypatch.setattr(id_mod, "detect", lambda: fake_info)
+        monkeypatch.setattr(ue_mod, "execute_silent", lambda info, ver, direction: True)
+        assert version_check.auto_update_if_needed() is True
+
+
+# ── execute_silent tests ────────────────────────────────────────
+
+
+class TestExecuteSilent:
+    def test_uv_tool_success(self, monkeypatch):
+        import subprocess
+
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+        from observal_cli.upgrade_executor import execute_silent
+
+        info = InstallInfo(method=InstallMethod.UV_TOOL, path="/fake", writable=True, managed_by=None)
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
+        assert execute_silent(info, "1.1.0", "upgrade") is True
+
+    def test_pip_success(self, monkeypatch):
+        import subprocess
+
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+        from observal_cli.upgrade_executor import execute_silent
+
+        info = InstallInfo(method=InstallMethod.PIP, path="/fake", writable=True, managed_by=None)
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
+        assert execute_silent(info, "1.1.0", "upgrade") is True
+
+    def test_binary_skipped(self):
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+        from observal_cli.upgrade_executor import execute_silent
+
+        info = InstallInfo(method=InstallMethod.BINARY, path="/fake", writable=True, managed_by=None)
+        assert execute_silent(info, "1.1.0", "upgrade") is False
+
+    def test_timeout_returns_false(self, monkeypatch):
+        import subprocess
+
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+        from observal_cli.upgrade_executor import execute_silent
+
+        info = InstallInfo(method=InstallMethod.UV_TOOL, path="/fake", writable=True, managed_by=None)
+
+        def mock_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired("uv", 120)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        assert execute_silent(info, "1.1.0", "upgrade") is False
+
+
+# ── Downgrade floor guard test ──────────────────────────────────
+
+
+class TestDowngradeFloorGuard:
+    def test_downgrade_below_floor_rejected(self, monkeypatch):
+        monkeypatch.setenv("OBSERVAL_NO_UPDATE_CHECK", "1")
+        monkeypatch.setattr("observal_cli.version_check.get_current_version", lambda: "1.2.0")
+        from typer.testing import CliRunner
+
+        from observal_cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["self", "downgrade", "--version", "0.9.0"])
+        assert result.exit_code == 1
+        assert "Cannot downgrade below" in result.output or "1.0.0" in result.output

--- a/web/src/components/shared/version-mismatch-banner.tsx
+++ b/web/src/components/shared/version-mismatch-banner.tsx
@@ -6,49 +6,165 @@
 import { useEffect, useState } from "react";
 
 /**
- * Displays a non-intrusive banner when the frontend build version
- * doesn't match the server version (stale browser tab after server upgrade).
+ * Simple semver comparison. Returns:
+ *   1 if a > b
+ *  -1 if a < b
+ *   0 if equal
+ */
+function semverCompare(a: string, b: string): number {
+	const pa = a.split(".").map(Number);
+	const pb = b.split(".").map(Number);
+	for (let i = 0; i < 3; i++) {
+		const av = pa[i] || 0;
+		const bv = pb[i] || 0;
+		if (av > bv) return 1;
+		if (av < bv) return -1;
+	}
+	return 0;
+}
+
+type MismatchState = {
+	server: string;
+	frontend: string;
+	direction: "ahead" | "behind";
+};
+
+/**
+ * Version gate component. Enforces frontend/server version alignment.
  *
- * Fetches /api/v1/config/version on mount and compares server_version
- * against NEXT_PUBLIC_APP_VERSION.
+ * - Frontend AHEAD of server: Full-page blocking overlay (cannot dismiss).
+ *   This happens when a cached browser tab has a newer build than the server.
+ *   User must hard-refresh to load the correct frontend version.
+ *
+ * - Frontend BEHIND server: Soft refresh banner (dismissable).
+ *   Server was upgraded; refreshing will pull the new frontend.
  */
 export function VersionMismatchBanner() {
-	const [mismatch, setMismatch] = useState<{
-		server: string;
-		frontend: string;
-	} | null>(null);
+	const [mismatch, setMismatch] = useState<MismatchState | null>(null);
 	const [dismissed, setDismissed] = useState(false);
+	const [refreshAttempts, setRefreshAttempts] = useState(0);
+
+	// Hydrate refresh attempts from sessionStorage on mount
+	useEffect(() => {
+		const stored = sessionStorage.getItem(
+			"observal:version-refresh-attempts",
+		);
+		if (stored) setRefreshAttempts(parseInt(stored, 10));
+	}, []);
 
 	useEffect(() => {
-		if (sessionStorage.getItem("observal:version-mismatch-dismissed")) {
-			return;
-		}
-
 		const buildVersion = process.env.NEXT_PUBLIC_APP_VERSION;
 		if (!buildVersion) return;
 
-		// Fetch server version directly
 		fetch("/api/v1/config/version")
 			.then((res) => (res.ok ? res.json() : null))
 			.then((data) => {
 				if (!data?.server_version) return;
 				const serverVersion = data.server_version;
-				if (serverVersion !== buildVersion && serverVersion !== "dev") {
-					setMismatch({ server: serverVersion, frontend: buildVersion });
-				}
+				if (serverVersion === "dev") return;
+
+				const cmp = semverCompare(buildVersion, serverVersion);
+				if (cmp === 0) return; // versions match
+
+				setMismatch({
+					server: serverVersion,
+					frontend: buildVersion,
+					direction: cmp > 0 ? "ahead" : "behind",
+				});
 			})
 			.catch(() => {}); // Silently ignore failures
 	}, []);
 
-	if (!mismatch || dismissed) return null;
+	if (!mismatch) return null;
+
+	// Frontend AHEAD of server: full-page blocking overlay (no dismiss)
+	if (mismatch.direction === "ahead") {
+		return (
+			<div className="fixed inset-0 z-[9999] flex items-center justify-center bg-background/95 backdrop-blur-sm">
+				<div className="mx-4 max-w-md rounded-xl border bg-card p-8 text-center shadow-2xl">
+					<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+						<svg
+							className="h-6 w-6 text-destructive"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							strokeWidth={2}
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+							/>
+						</svg>
+					</div>
+					<h2 className="mb-2 text-lg font-semibold">
+						Version Mismatch
+					</h2>
+					<p className="mb-4 text-sm text-muted-foreground">
+						Your app (v{mismatch.frontend}) is ahead of the server
+						(v{mismatch.server}). This can cause compatibility
+						issues.
+					</p>
+					<p className="mb-6 text-xs text-muted-foreground">
+						Hard refresh to load the correct version:
+					</p>
+					<div className="space-y-2">
+						<button
+							type="button"
+							onClick={() => {
+								const next = refreshAttempts + 1;
+								sessionStorage.setItem(
+									"observal:version-refresh-attempts",
+									String(next),
+								);
+								setRefreshAttempts(next);
+								window.location.reload();
+							}}
+							className="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+						>
+							Refresh Now
+						</button>
+						<p className="text-xs text-muted-foreground">
+							<kbd className="rounded border px-1.5 py-0.5 font-mono text-xs">
+								Ctrl+Shift+R
+							</kbd>{" "}
+							/{" "}
+							<kbd className="rounded border px-1.5 py-0.5 font-mono text-xs">
+								Cmd+Shift+R
+							</kbd>
+						</p>
+						{refreshAttempts >= 2 && (
+							<button
+								type="button"
+								onClick={() => {
+									sessionStorage.removeItem(
+										"observal:version-refresh-attempts",
+									);
+									setMismatch(null);
+								}}
+								className="w-full rounded-md border px-4 py-2 text-xs text-muted-foreground hover:text-foreground"
+							>
+								Dismiss (split deployment?)
+							</button>
+						)}
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	// Frontend BEHIND server: soft dismissable banner
+	if (dismissed) return null;
+	if (
+		typeof window !== "undefined" &&
+		sessionStorage.getItem("observal:version-mismatch-dismissed")
+	) {
+		return null;
+	}
 
 	const handleDismiss = () => {
 		setDismissed(true);
 		sessionStorage.setItem("observal:version-mismatch-dismissed", "1");
-	};
-
-	const handleRefresh = () => {
-		window.location.reload();
 	};
 
 	return (
@@ -56,12 +172,13 @@ export function VersionMismatchBanner() {
 			<div className="text-sm">
 				<p className="font-medium">New version available</p>
 				<p className="text-muted-foreground text-xs">
-					v{mismatch.frontend} → v{mismatch.server}
+					Server updated to v{mismatch.server} - refresh to get the
+					latest.
 				</p>
 			</div>
 			<button
 				type="button"
-				onClick={handleRefresh}
+				onClick={() => window.location.reload()}
 				className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
 			>
 				Refresh

--- a/web/src/lib/features.ts
+++ b/web/src/lib/features.ts
@@ -13,15 +13,19 @@ export const FEATURE_VERSIONS: Record<string, string> = {
 	agentBuilder: "0.8.0",
 	agentInsights: "0.7.0",
 	agentSnapshots: "0.6.0",
+	autoUpdate: "1.0.0",
 	basicAgents: "0.5.0",
 	bulkAgents: "0.6.0",
 	componentVersions: "0.6.0",
 	deviceAuth: "0.7.0",
 	mcpRegistry: "0.5.0",
 	reconcile: "0.7.0",
-	selfUpgrade: "0.8.0",
+	selfUpgrade: "1.0.0",
+	serverUpgrade: "1.0.0",
 	skills: "0.7.0",
-	versionNegotiation: "0.8.0",
+	versionCheck: "1.0.0",
+	versionEnforcement: "1.0.0",
+	versionNegotiation: "1.0.0",
 };
 
 /**


### PR DESCRIPTION
## Purpose / Description

Enforce strict version alignment between CLI, server, and frontend. The server is the single source of truth - CLI must match its major.minor version to operate.

**What this adds:**
- Hard version floor at 1.0.0 (pre-versioning releases cannot be targeted)
- Bidirectional enforcement: CLI ahead OR behind server = hard exit with actionable fix
- Auto-update for minor/patch releases (silent, non-interactive)
- Major release upgrades require explicit consent
- Frontend: full-page blocking overlay when ahead of server; soft refresh banner when behind
- Enterprise mode: server version dictates what all connected CLIs must run
- Community mode: auto-updates CLI + suggests server upgrade on minor/patch

## Fixes

* Fixes version drift issues from #1181 (merged at 0.8.0 semantics, needs 1.0.0 enforcement)

## Approach

1. `VERSION_FLOOR = "1.0.0"` constant - reject any downgrade below this
2. `check_version_compatibility()` rewritten - compares major.minor, hard exits on mismatch
3. `_enforce_version_once()` gate - runs once per CLI session on first authenticated API call
4. `auto_update_if_needed()` - detects minor/patch drift, calls `execute_silent()`
5. CLI startup calls `_try_auto_update()` with re-exec on success
6. `observal self` and `observal server` exempt from enforcement (user needs these to fix mismatches)
7. Removed `recommended_cli_version` - server_version itself is the canonical target
8. Frontend `VersionMismatchBanner` now shows blocking overlay (z-9999, no dismiss) when ahead

## How Has This Been Tested?

```bash
uv run ruff check && uv run ruff format --check   # all passed
uv run pytest tests/ --ignore=tests/test_phase9_10.py -q   # 3601 passed, 0 failed
```

Key test scenarios:
- `test_version_floor`: Floor constant exists, above/below/invalid checks
- `test_auto_update`: Disabled via config/env/CI, major jump not applied, floor enforced, minor triggers silent install
- `test_enterprise_vs_community`: Server version used directly (no pinning), community falls back to GitHub
- `test_downgrade_below_floor_rejected`: `--version 0.9.0` rejected
- `test_downgrade_target_is_newer`: Can't "downgrade" to a newer version

## Checklist

- [x] Descriptive commit message with short title
- [x] Code commented in hard-to-understand areas
- [x] Self-review performed
- [ ] No UI screenshots needed (CLI changes + one frontend component with no visual regression beyond the blocking overlay behavior)