### PR TITLE
docs: add cli/skill.md reference

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,5 +1,6 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Nithin-Bhargav-07 <gaddamnithinbhargav@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Summary
@@ -37,6 +38,7 @@
 * [observal profile](cli/profile.md)
 * [observal self](cli/self.md)
 * [observal server](cli/server.md)
+* [observal skill](cli/skill.md)
 * [observal uninstall](cli/uninstall.md)
 
 ## Self-Hosting

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -2,6 +2,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Naraen Rammoorthi <naraen13@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Nithin-Bhargav-07 <gaddamnithinbhargav@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # CLI Reference
@@ -30,6 +31,7 @@ Complete reference for the `observal` CLI. Every subcommand has its own page; th
 | [`observal profile`](profile.md) | Switch IDE configs to a git-hosted profile |
 | [`observal self`](self.md) | Upgrade or downgrade the CLI |
 | [`observal server`](server.md) | Manage the embedded server (start, stop, upgrade, rollback) |
+| [`observal skill`](skill.md) | Submit, browse, and install portable skill packages |
 | [`observal uninstall`](uninstall.md) | Completely remove Observal from the system |
 
 ## Global options

--- a/docs/cli/skill.md
+++ b/docs/cli/skill.md
@@ -1,0 +1,196 @@
+<!-- SPDX-FileCopyrightText: 2026 Nithin-Bhargav-07 <gaddamnithinbhargav@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# observal skill
+
+Submit, browse, and install portable skill packages. A skill is a `SKILL.md`
+instruction file that agents load on demand to handle a specific task.
+
+## Subcommands
+
+| Command | Description |
+| --- | --- |
+| [`skill submit`](#observal-skill-submit) | Submit a skill to the registry |
+| [`skill list`](#observal-skill-list) | List approved skills |
+| [`skill my`](#observal-skill-my) | List your own skills (all statuses) |
+| [`skill show`](#observal-skill-show) | Show detailed information about a skill |
+| [`skill install`](#observal-skill-install) | Install a skill into an IDE |
+| [`skill edit`](#observal-skill-edit) | Edit a draft, rejected, or pending skill |
+| [`skill delete`](#observal-skill-delete) | Delete a skill from the registry |
+
+---
+
+## `observal skill submit`
+
+Submit a skill to the registry. There are two delivery modes:
+
+- **git_fetch** (default): provide `--git-url` and the server clones the
+  `SKILL.md` from the repo on install.
+- **registry_direct**: provide `--skill-md` (and optionally `--script`) with
+  `--delivery-mode registry_direct`. The content is stored inline in the
+  registry and written directly on install, no git repo needed.
+
+You can also provide `--skill-md` alongside `--git-url` to auto-fill
+frontmatter fields while still using git_fetch delivery.
+
+```bash
+# Git-based submission
+observal skill submit --git-url https://github.com/your-org/your-skill
+observal skill submit --skill-md ./SKILL.md --git-url https://github.com/your-org/your-skill
+observal skill submit --git-url https://github.com/your-org/your-skill --draft
+
+# Registry direct (no git repo required)
+observal skill submit --skill-md ./SKILL.md --delivery-mode registry_direct
+observal skill submit --skill-md ./SKILL.md --script ./run.sh --delivery-mode registry_direct
+
+# From JSON file
+observal skill submit --from-file skill.json
+
+# Submit a saved draft
+observal skill submit --submit abc123
+```
+
+| Option | Description |
+| --- | --- |
+| `--from-file`, `-f` | Create from a JSON file |
+| `--skill-md` | Path to `SKILL.md` to paste (auto-fills fields from frontmatter) |
+| `--git-url` | Git repository URL |
+| `--git-ref` | Branch or tag (default: main) |
+| `--script` | Path to script file (registry_direct mode only) |
+| `--delivery-mode` | Delivery mode: `git_fetch` (default) or `registry_direct` |
+| `--draft` | Save as draft instead of submitting for review |
+| `--submit` | Submit a draft for review (skill ID) |
+
+---
+
+## `observal skill list`
+
+List approved skills in the registry. Use `--task-type`, `--target-agent`, or
+`--search` to filter results. Row numbers from the output can be used as
+references in subsequent commands.
+
+```bash
+observal skill list
+observal skill list --task-type coding
+observal skill list --target-agent claude-code --output json
+observal skill list --search "refactor"
+```
+
+| Option | Description |
+| --- | --- |
+| `--task-type`, `-t` | Filter by task type |
+| `--target-agent` | Filter by target agent |
+| `--search`, `-s` | Filter by search term |
+| `--output`, `-o` | Output format: table, json, plain (default: table) |
+
+---
+
+## `observal skill my`
+
+List your own skills across all statuses: drafts, pending, approved, and
+rejected. Useful for tracking the review status of your submissions.
+
+```bash
+observal skill my
+observal skill my --output json
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output format: table, json, plain (default: table) |
+
+---
+
+## `observal skill show`
+
+Show detailed information about a skill including validation status, task type,
+git source, slash command, target agents, and timestamps. Accepts a UUID, name,
+row number from a previous list, or @alias.
+
+```bash
+observal skill show my-skill
+observal skill show 1
+observal skill show @refactor-skill --output json
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output format (default: table) |
+
+---
+
+## `observal skill install`
+
+Install a skill into an IDE. For git_fetch skills, clones the skill directory
+from the configured `git_url`. For registry_direct skills, writes the stored
+`SKILL.md` (and script, if present) directly. Falls back to cached content if
+git clone fails.
+
+Two scopes are supported:
+
+- `--scope user` (default): writes to `~/.<ide>/skills/<name>/` globally.
+- `--scope project`: writes to `.agents/skills/<name>/` in the current
+  directory, then symlinks into each IDE config dir found in the project.
+
+```bash
+observal skill install my-skill --ide claude-code
+observal skill install @sk --ide kiro --scope project
+observal skill install 2 --ide cursor --raw > config.json
+observal skill install my-skill --ide gemini-cli --no-write
+```
+
+| Option | Description |
+| --- | --- |
+| `--ide`, `-i` | Target IDE (required) |
+| `--scope`, `-s` | Install scope: user (default) or project |
+| `--raw` | Output raw JSON only |
+| `--no-write` | Print config without writing files |
+
+---
+
+## `observal skill edit`
+
+Edit a draft, rejected, or pending skill submission. You can provide individual
+field options or load all updates from a JSON file. Acquires an edit lock to
+prevent concurrent modifications.
+
+```bash
+observal skill edit my-skill --description "Better desc"
+observal skill edit abc123 --from-file updates.json
+observal skill edit @sk --git-url https://github.com/org/new-repo
+observal skill edit 2 --version 2.0.0 --task-type debugging
+```
+
+| Option | Description |
+| --- | --- |
+| `--from-file`, `-f` | Load updates from a JSON file |
+| `--name`, `-n` | New listing name |
+| `--description`, `-d` | New description |
+| `--version`, `-v` | New version string |
+| `--task-type`, `-t` | New task type |
+| `--git-url` | New git URL |
+| `--git-ref` | New git ref |
+
+---
+
+## `observal skill delete`
+
+Permanently delete a skill from the registry. Skills you own can be deleted
+regardless of status. Prompts for confirmation unless `--yes` is provided.
+
+```bash
+observal skill delete my-skill
+observal skill delete abc123 --yes
+observal skill delete @old-skill -y
+```
+
+| Option | Description |
+| --- | --- |
+| `--yes`, `-y` | Skip confirmation |
+
+---
+
+## Related
+
+* [`observal agent`](agent.md): bundle skills into a full agent config
+* [`observal registry`](registry.md): manage other registry component types


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description
Adds a missing documentation page for the `observal skill` CLI command group.

## Fixes
* Fixes #860

## Approach
Created docs/cli/skill.md documenting all subcommands (submit, list, my, show, install, edit, delete) following the style of docs/cli/agent.md. Added links in docs/SUMMARY.md and docs/cli/README.md.

## How Has This Been Tested?

Verified all subcommands and flags match the CLI reference in the README.
Confirmed links in SUMMARY.md and cli/README.md point to the correct file.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)


