### PR TITLE
feat(skill): expand bundled Observal skill to cover full CLI surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-FileCopyrightText: 2026 Swathi Saravanan <ss4522@cornell.edu>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset rebuild rebuild-enterprise rebuild-local release-major release-feature release-patch
+.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset rebuild rebuild-enterprise rebuild-local release-major release-feature release-patch sync-skill
 
 # ── Linting ──────────────────────────────────────────────
 
@@ -33,6 +34,9 @@ test-eval-completeness:  ## Run eval completeness tests
 	cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich pytest ../tests/test_eval_completeness.py -v --tb=short
 
 test-all: test test-eval-completeness test-adversarial  ## Run all tests including adversarial and completeness
+
+sync-skill:  ## Regenerate the auto-generated command reference in the bundled Observal skill
+	cd observal-server && uv run --with typer --with rich --with loguru --with pyyaml python ../scripts/sync_observal_skill.py
 
 # ── Setup ────────────────────────────────────────────────
 

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -851,10 +851,10 @@ def _post_auth_onboarding():
 
 
 def _install_observal_skill():
-    """Install the bundled Observal skill to all detected IDE skill directories.
+    """Install the bundled Observal skills to all detected IDE skill directories.
 
-    This makes the 'observal' skill available to LLMs in every IDE that supports
-    skills, enabling commands like `/observal create an agent` or
+    This makes the 'observal' family of skills available to LLMs in every IDE
+    that supports skills, enabling commands like `/observal create an agent` or
     `kiro-cli chat --agent observal`.
     """
     optic.debug("_install_observal_skill called")
@@ -862,11 +862,21 @@ def _install_observal_skill():
 
     from observal_cli.ide_registry import IDE_REGISTRY
 
-    skill_source = Path(__file__).parent / "skills" / "observal" / "SKILL.md"
-    if not skill_source.exists():
+    skills_base = Path(__file__).parent / "skills"
+    skill_dirs = [
+        "observal",
+        "observal-agents",
+        "observal-registry",
+        "observal-ops",
+        "observal-admin",
+        "observal-advanced",
+    ]
+
+    # Verify at least the core skill exists.
+    core_skill = skills_base / "observal" / "SKILL.md"
+    if not core_skill.exists():
         return
 
-    content = skill_source.read_text(encoding="utf-8")
     installed: list[str] = []
 
     # Additional user-scope skill paths not formally in the registry but known to work.
@@ -884,21 +894,27 @@ def _install_observal_skill():
         if not user_path:
             continue
 
-        # Replace {name} placeholder with 'observal'
-        resolved = user_path.replace("{name}", "observal")
-        dest = Path(resolved.replace("~", str(Path.home())))
-
         # Only install if the IDE directory exists (IDE is installed)
         ide_config_dir = Path.home() / spec.get("config_dir", "")
         if not ide_config_dir.exists():
             continue
 
-        try:
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_text(content, encoding="utf-8")
+        ide_installed = False
+        for skill_dir in skill_dirs:
+            source = skills_base / skill_dir / "SKILL.md"
+            if not source.exists():
+                continue
+            resolved = user_path.replace("{name}", skill_dir)
+            dest = Path(resolved.replace("~", str(Path.home())))
+            try:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+                ide_installed = True
+            except OSError:
+                pass
+
+        if ide_installed:
             installed.append(spec["display_name"])
-        except OSError:
-            pass
 
     # Kiro-specific: ensure the active agent has skill resources wired up.
     # Without this, skills in ~/.kiro/skills/ are invisible to the agent.

--- a/observal_cli/skills/observal-admin/SKILL.md
+++ b/observal_cli/skills/observal-admin/SKILL.md
@@ -1,0 +1,109 @@
+<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+---
+name: observal-admin
+command: observal
+description: Observal admin operations including user management, enterprise settings, submission review queue, eval scoring, security events, audit logs, and SSO configuration. Use when the user needs to manage users, approve or reject submissions, run evals, view security events, or configure SAML/SCIM.
+version: 2.0.0
+owner: observal
+---
+
+# Observal Admin Operations
+
+All commands require the `admin` role. Enterprise-only commands (SAML, SCIM, audit-log) require enterprise mode.
+
+## Critical Rules
+
+1. **EXECUTE commands**: run them in your shell. Set timeout to 60 seconds.
+2. **Pass `--output json`** on list/show commands.
+3. **Pass `--yes` or `--force`** on destructive commands.
+4. **If 403 is returned**, confirm role with `observal auth whoami --output json`.
+
+---
+
+## Procedure: Settings & Diagnostics
+
+```bash
+observal admin settings --output json
+observal admin set KEY VALUE
+observal admin diagnostics --output json
+observal admin trace-privacy
+observal admin trace-privacy-set true
+observal admin cache-clear
+```
+
+---
+
+## Procedure: User Management
+
+```bash
+observal admin users --output json
+observal admin create-user EMAIL NAME --role user --output json
+observal admin reset-password EMAIL --generate
+observal admin set-role EMAIL admin
+observal admin delete-user EMAIL --force
+```
+
+---
+
+## Procedure: Review Queue
+
+```bash
+observal admin review list --output json
+observal admin review list --type mcp --output json
+observal admin review show REVIEW_ID --output json
+observal admin review approve REVIEW_ID
+observal admin review approve REVIEW_ID --agent
+observal admin review reject REVIEW_ID --reason 'Not reproducible'
+```
+
+`--agent` and `--bundle` disambiguate when an ID could refer to multiple entity types.
+
+---
+
+## Procedure: Eval
+
+```bash
+observal admin eval run TRACE_ID
+observal admin eval scorecards --output json
+observal admin eval show SCORECARD_ID --output json
+observal admin eval compare CARD_A CARD_B --output json
+observal admin eval aggregate --output json
+```
+
+---
+
+## Procedure: Security & Audit
+
+```bash
+observal admin security-events --limit 50 --output json
+observal admin audit-log --limit 100 --output json
+observal admin audit-log-export --file audit.csv
+```
+
+---
+
+## Procedure: Enterprise SSO
+
+```bash
+observal admin saml-config --output json
+observal admin saml-config-set \
+  --idp-entity-id ID \
+  --idp-sso-url URL \
+  --idp-x509-cert /path/to/cert.pem \
+  --active
+observal admin saml-config-delete --force
+observal admin scim-tokens --output json
+observal admin scim-token-create --description 'Okta'
+observal admin scim-token-revoke TOKEN_ID --force
+```
+
+---
+
+## Output Contract
+
+1. One sentence stating intent.
+2. The exact command in a fenced code block.
+3. The result: success / specific error.
+4. The next action, or "done".

--- a/observal_cli/skills/observal-advanced/SKILL.md
+++ b/observal_cli/skills/observal-advanced/SKILL.md
@@ -1,0 +1,120 @@
+<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+---
+name: observal-advanced
+command: observal
+description: Advanced Observal operations including IDE profile swapping, session reconciliation, CLI upgrades and downgrades, complete uninstallation, and local fallback mode for offline use. Use when the user wants to swap IDE profiles, reconcile sessions, upgrade or downgrade the CLI, uninstall Observal, or write agent configs locally when the server is unreachable.
+version: 2.0.0
+owner: observal
+---
+
+# Observal Advanced Operations
+
+## Procedure: Profile Swap
+
+```bash
+observal use https://github.com/user/ide-profile
+observal use https://github.com/user/ide-profile --ref work
+observal use default
+observal profile
+```
+
+Backups stored in `~/.observal/backups/<timestamp>/`. `use default` restores from backup.
+
+---
+
+## Procedure: Reconcile Sessions
+
+Push local session JSONL to server for full trace context. Normally automatic via hooks.
+
+Manual run for crash recovery:
+
+```bash
+python -m observal_cli.cmd_reconcile
+```
+
+Not a Typer command. No flags needed.
+
+---
+
+## Procedure: Self-Manage CLI
+
+```bash
+observal self status
+observal self upgrade
+observal self upgrade --version 2.5.0
+observal self downgrade --list
+observal self downgrade --version 2.4.0
+observal self rollback
+```
+
+---
+
+## Procedure: Uninstall
+
+Completely removes Observal. **Destructive and irreversible.**
+
+```bash
+observal uninstall
+```
+
+Requires typing `confirm` (not `--yes`). Selective flags:
+- `--keep-config`: preserve `~/.observal/`
+- `--keep-cli`: keep the CLI binary
+- `--keep-repo`: keep the cloned repo
+- `--repo-dir PATH`: specify repo location
+
+---
+
+## Procedure: Local Fallback Mode
+
+Use **only** when a command exits with `Connection failed` or `Not configured`.
+
+| IDE | User-scope path | Project-scope path |
+|---|---|---|
+| Claude Code | `~/.claude/agents/<name>.md` | `.claude/agents/<name>.md` |
+| Kiro | `~/.kiro/agents/<name>.json` | `.kiro/agents/<name>.json` |
+| Cursor | `~/.cursor/rules/<name>.mdc` | `.cursor/rules/<name>.mdc` |
+| Gemini CLI | `~/.gemini/agents/<name>.md` | `.gemini/agents/<name>.md` |
+| VS Code | `~/.config/Code/User/agents/<name>.md` | `.vscode/agents/<name>.md` |
+| Codex CLI | `~/.codex/agents/<name>.md` | `.codex/agents/<name>.md` |
+| Copilot CLI | `~/.config/github-copilot/agents/<name>.md` | `.github/copilot/agents/<name>.md` |
+| OpenCode | `~/.opencode/agents/<name>.md` | `.opencode/agents/<name>.md` |
+
+**Kiro** (`~/.kiro/agents/<name>.json`):
+
+```json
+{"name":"<name>","description":"<desc>","prompt":"<prompt>","model":"claude-sonnet-4-20250514","mcpServers":{},"tools":["*"],"resources":["skill://~/.kiro/skills/*/SKILL.md"]}
+```
+
+**Claude Code, Gemini CLI, VS Code, Codex CLI, Copilot CLI, OpenCode** (markdown):
+
+```markdown
+---
+name: <name>
+description: <desc>
+---
+<prompt>
+```
+
+**Cursor** (`.mdc`):
+
+```markdown
+---
+name: <name>
+description: <desc>
+---
+<prompt>
+```
+
+After writing locally, remind the user to run `observal agent create` once the server is reachable.
+
+---
+
+## Output Contract
+
+1. One sentence stating intent.
+2. The exact command in a fenced code block.
+3. The result: success / specific error.
+4. The next action, or "done".

--- a/observal_cli/skills/observal-agents/SKILL.md
+++ b/observal_cli/skills/observal-agents/SKILL.md
@@ -1,0 +1,155 @@
+<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+---
+name: observal-agents
+command: observal
+description: Create, update, version, and manage Observal agents. Use when the user wants to create a new agent, update an existing one, release a new version, scaffold a YAML project, add components, build, publish, bulk-create, delete, or restore agents.
+version: 2.0.0
+owner: observal
+---
+
+# Observal Agents: Agent Lifecycle Management
+
+## Critical Rules
+
+1. **EXECUTE commands**: run them in your shell. Set timeout to 60 seconds.
+2. **Use single quotes** for `--prompt` and `--description` values.
+3. **Pass `--output json`** on list/show/versions commands.
+4. **Pass `--yes`** on destructive commands (`delete`, `unarchive`, `bulk-create`).
+5. **Resolve 409:** `observal agent publish --update` for in-place edits, `observal agent release --bump` for reviewed releases.
+6. **When in doubt about a flag, run `<command> --help` first.**
+
+---
+
+## Procedure: Create Agent
+
+Required: `--name`, `--description`, `--prompt`. Optional: `--model` (default: `claude-sonnet-4`), `--ide` (repeatable), `--owner`, `--prompt-file`, `--from-file`.
+
+> **WARNING:** Without `--name` and `--prompt`, the command launches an interactive wizard. Always pass at least `--name`, `--description`, and `--prompt`.
+
+```bash
+observal agent create \
+  --name AGENT_NAME \
+  --description 'Short description' \
+  --prompt 'System prompt content' \
+  --model claude-sonnet-4 \
+  --ide kiro --ide claude-code
+```
+
+Error branching:
+- **`409`**: switch to Procedure: Update Agent or Release Agent Version.
+- **`422`**: missing required field. Check message, fix, retry.
+- **`Connection failed`**: server unreachable; use `observal-advanced` skill's Local Fallback.
+
+---
+
+## Procedure: Update Agent
+
+Skips review queue. Overwrites in place.
+
+1. Write `observal-agent.yaml`. **Critical:** include `model_config_json: {}` and `external_mcps: []` literally.
+   ```bash
+   mkdir -p /tmp/myagent && cat > /tmp/myagent/observal-agent.yaml << 'EOF'
+   name: existing-agent-name
+   version: "1.0.0"
+   description: "Updated description"
+   owner: "team-name"
+   model_name: claude-sonnet-4
+   model_config_json: {}
+   models_by_ide: {}
+   external_mcps: []
+   prompt: |
+     Updated system prompt here.
+   supported_ides:
+     - kiro
+     - claude-code
+   components: []
+   EOF
+   ```
+2. Push: `observal agent publish --update --dir /tmp/myagent`
+3. Confirm: `observal agent show existing-agent-name --output json`
+
+---
+
+## Procedure: Release Agent Version
+
+Goes through review queue. Use for "new version", "bump", or "release".
+
+1. Write `observal-agent.yaml` (same schema as Update Agent).
+2. Release:
+   ```bash
+   observal agent release AGENT_NAME --bump patch --dir /tmp/myagent
+   ```
+   Bump types: `patch`, `minor`, `major`.
+3. Verify: `observal agent versions AGENT_NAME --output json`
+
+---
+
+## Procedure: Author Agent Locally
+
+1. Scaffold (interactive):
+   ```bash
+   observal agent init --dir ./my-agent
+   ```
+2. Add components (second arg is UUID, find with `observal mcp show NAME --output json`):
+   ```bash
+   observal agent add mcp COMPONENT_UUID --dir ./my-agent
+   observal agent add skill COMPONENT_UUID --dir ./my-agent
+   ```
+3. Validate: `observal agent build --dir ./my-agent`
+4. Publish: `observal agent publish --dir ./my-agent`
+   - `--draft` saves without submitting. `--submit` submits a saved draft.
+
+---
+
+## Procedure: Bulk Create
+
+```bash
+observal agent bulk-create --from-file agents.json --dry-run --yes
+observal agent bulk-create --from-file agents.json --yes
+```
+
+---
+
+## Procedure: Delete / Restore
+
+```bash
+observal agent delete AGENT_NAME --yes
+observal agent unarchive AGENT_NAME --yes
+```
+
+---
+
+## Browse Agents
+
+```bash
+observal agent list --output json
+observal agent list --search keyword --output json
+observal agent list --page 2 --limit 20 --output json
+observal agent my --output json
+observal agent show AGENT_NAME --output json
+observal agent versions AGENT_NAME --output json
+```
+
+After `list`, use row numbers (1, 2, 3...) in subsequent commands.
+
+---
+
+## Error Reference
+
+| Error | Fix |
+|-------|-----|
+| `409` / `already have an agent named` | Use `publish --update` or `release --bump` |
+| `422` `model_config_json` | Add `model_config_json: {}` to YAML |
+| `422` `external_mcps` | Add `external_mcps: []` to YAML |
+| `422` `system prompt is required` | Add `--prompt` or `prompt:` in YAML |
+
+---
+
+## Output Contract
+
+1. One sentence stating intent.
+2. The exact command in a fenced code block.
+3. The result: success or specific error.
+4. The next action, or "done".

--- a/observal_cli/skills/observal-ops/SKILL.md
+++ b/observal_cli/skills/observal-ops/SKILL.md
@@ -1,0 +1,68 @@
+<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+---
+name: observal-ops
+command: observal
+description: View traces, spans, metrics, feedback, and telemetry health for Observal agents and MCPs. Use when the user wants to see recent traces, check metrics, view top items, submit ratings, or diagnose telemetry pipeline issues.
+version: 2.0.0
+owner: observal
+---
+
+# Observal Ops: Observability and Telemetry
+
+## Critical Rules
+
+1. **EXECUTE commands**: run them in your shell. Set timeout to 60 seconds.
+2. **Pass `--output json`** on every command for stable, machine-readable output.
+3. **When in doubt about a flag, run `<command> --help` first.**
+
+---
+
+## Procedure: Observe
+
+```bash
+observal ops overview --output json
+observal ops metrics ITEM_NAME --type agent --output json
+observal ops metrics ITEM_NAME --type mcp --watch
+observal ops top --type agent --output json
+observal ops top --type mcp --output json
+observal ops traces --limit 20 --output json
+observal ops traces --agent AGENT_NAME --output json
+observal ops traces --mcp MCP_NAME --output json
+observal ops spans TRACE_ID --output json
+observal ops feedback ITEM_NAME --type mcp --output json
+```
+
+---
+
+## Procedure: Rate Component
+
+```bash
+observal ops rate MCP_NAME --stars 5 --type mcp --comment 'Worked great'
+observal ops rate AGENT_NAME --stars 4 --type agent
+```
+
+`--stars` (1-5) and `--type` are required. `--comment` is optional.
+
+---
+
+## Procedure: Telemetry Health
+
+```bash
+observal ops telemetry status
+observal ops telemetry test
+```
+
+`status` is the reliable check: it queries server event counts and local SQLite buffer. `test` may return 404 on newer servers (legacy endpoint). If `status` shows events flowing, telemetry is healthy.
+
+**Diagnosis:** status OK → healthy. No events → check `observal auth status`. Server reachable but no events → hooks not installed, suggest `observal doctor`.
+
+---
+
+## Output Contract
+
+1. One sentence stating intent.
+2. The exact command in a fenced code block.
+3. The result: success / specific error.
+4. The next action, or "done".

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -1,0 +1,162 @@
+<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+---
+name: observal-registry
+command: observal
+description: Submit, browse, install, edit, delete, and version MCPs, skills, hooks, prompts, and sandboxes in the Observal registry. Use when the user wants to submit a component, install one, edit a draft, publish a new version, or browse the component library.
+version: 2.0.0
+owner: observal
+---
+
+# Observal Registry: Component CRUD
+
+## Critical Rules
+
+1. **EXECUTE commands**: run them in your shell. Set timeout to 60 seconds.
+2. **Pass `--output json`** on list/show commands.
+3. **Pass `--yes`** on destructive commands (`delete`, `submit --git`).
+4. **When in doubt about a flag, run `<command> --help` first.**
+5. **`--from-file` does NOT exist on `mcp submit`**: that flag is on `mcp edit`.
+
+---
+
+## Procedure: Browse Registry
+
+```bash
+observal mcp list --category developer-tools --output json
+observal skill list --task-type code-review --output json
+observal registry hook list --event UserPromptSubmit --output json
+observal prompt list --category coding --output json
+observal sandbox list --runtime docker --output json
+
+observal mcp my --output json
+observal skill my --output json
+observal prompt my --output json
+
+observal mcp show NAME --output json
+observal registry hook show NAME --output json
+```
+
+After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--interactive` for fuzzy picker.
+
+**MCP categories:** `browser-automation`, `cloud-platforms`, `code-execution`, `communication`, `databases`, `developer-tools`, `devops`, `file-systems`, `finance`, `knowledge-memory`, `monitoring`, `multimedia`, `productivity`, `search`, `security`, `version-control`, `ai-ml`, `data-analytics`, `general`
+
+**Skill task types:** `code-review`, `code-generation`, `testing`, `documentation`, `debugging`, `refactoring`, `deployment`, `security-audit`, `performance`, `general`
+
+---
+
+## Procedure: Submit Component
+
+### MCP (from git, recommended)
+
+```bash
+observal mcp submit --git https://github.com/org/mcp-server --name my-mcp --category developer-tools --yes
+```
+
+Without `--git`, opens interactive JSON paste (accepts IDE config block, named config, bare config, or HTTP transport JSON). Press Enter on empty line to submit.
+
+### Skill
+
+```bash
+observal skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --git-ref main
+```
+
+### Hook
+
+```bash
+observal registry hook submit --from-file hook.json
+observal registry hook submit   # interactive
+```
+
+Optional: `--script 'code'`, `--source-url URL --source-ref main`, `--requires dep1 --requires dep2`. Timeout caps: blocking 30s, sync 10s, async 60s.
+
+### Prompt
+
+```bash
+observal prompt submit --from-file prompt.json
+```
+
+### Sandbox
+
+```bash
+observal sandbox submit --from-file sandbox.json
+```
+
+All types support `--draft` (save without review) and `--submit NAME` (submit existing draft).
+
+---
+
+## Procedure: Install Component
+
+```bash
+observal mcp install NAME --ide kiro
+observal mcp install NAME --ide claude-code --raw
+observal skill install NAME --ide kiro --scope user
+observal skill install NAME --ide claude-code --scope project
+observal registry hook install NAME --ide kiro
+observal registry hook install NAME --ide claude-code --platform darwin --dir .
+observal prompt install NAME --ide kiro
+```
+
+`sandbox install` is deprecated. Use `observal agent add sandbox UUID` + `observal agent pull` instead.
+
+---
+
+## Procedure: Edit Component
+
+**Warning:** Editing an approved listing triggers a version bump flow. For draft/pending/rejected items, edits in place with an optimistic lock.
+
+```bash
+observal mcp edit NAME --from-file updates.json
+observal mcp edit NAME --name new-name --description 'New desc'
+observal skill edit NAME --from-file updates.json
+observal registry hook edit NAME --version 1.2.0 --event Stop
+observal prompt edit NAME --template 'New template body'
+observal sandbox edit NAME --image python:3.12-slim
+```
+
+---
+
+## Procedure: Publish Component Version
+
+```bash
+observal component version publish mcp NAME --version 1.2.0 --description 'What changed'
+observal component version publish skill NAME --version 0.3.0 --description 'New tasks'
+observal component version publish hook NAME --version 1.0.1 --description 'Bug fix'
+observal component version publish prompt NAME --version 2.0.0 --description 'Rewrite'
+observal component version publish sandbox NAME --version 1.1.0 --description 'New image'
+
+observal component version list mcp NAME --output json
+```
+
+---
+
+## Procedure: Delete Component
+
+```bash
+observal mcp delete NAME --yes
+observal skill delete NAME --yes
+observal registry hook delete NAME --yes
+observal prompt delete NAME --yes
+observal sandbox delete NAME --yes
+```
+
+---
+
+## Error Reference
+
+| Error | Fix |
+|-------|-----|
+| `--from-file` not on `mcp submit` | Use `--git`, `--draft`, or interactive paste |
+| `412 Edit lock held` | Wait a few minutes, retry |
+| Hook `timeout` | Caps: blocking 30s, sync 10s, async 60s |
+
+---
+
+## Output Contract
+
+1. One sentence stating intent.
+2. The exact command in a fenced code block.
+3. The result: success / specific error.
+4. The next action, or "done".

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -1,281 +1,161 @@
+<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 ---
 name: observal
 command: observal
-description: Use the Observal agent registry and component platform. Handles creating, updating, versioning, and pulling agents. Browse and submit MCPs, skills, and prompts. Use when the user asks to interact with their Observal server.
-version: 1.1.0
+description: "Core Observal CLI operations: pull agents into your IDE, scan installed components, diagnose and patch IDE configs, authenticate, and manage CLI settings. Use when the user wants to install an agent, check their IDE setup, login, or configure the CLI."
+version: 2.0.0
 owner: observal
 ---
 
-<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
-<!-- SPDX-License-Identifier: AGPL-3.0-only -->
-
-# Observal — Agent Registry & Component Platform
-
-You have the Observal CLI installed. Use it to manage agents and components on the registry server.
+# Observal: Core CLI Operations
 
 ## Critical Rules
 
-1. **EXECUTE commands** — run them in your shell, do not just display them
-2. **Set timeout to 60 seconds** — commands make HTTP calls
-3. **Use single quotes** for `--prompt` and `--description` values to avoid shell quoting issues
-4. **Do NOT run `observal auth status` before other commands** — they error clearly if auth is broken
-5. **Name conflict (409)?** → use `observal agent publish --update` or `observal agent release --bump`
-6. **Only fall back to local mode** if a command returns "Connection failed" or "Not configured"
+1. **EXECUTE commands**: run them in your shell, do not just display them.
+2. **Set timeout to 60 seconds**: most commands make HTTP calls.
+3. **Use single quotes** for `--prompt` and `--description` values to avoid shell quoting issues.
+4. **Do NOT run `observal auth status` first.** Other commands surface auth problems clearly on their own.
+5. **When in doubt about a flag, run `<command> --help` first.** Never guess flag names.
+6. **Pass `--output json` on every list/show command.** It is stable and machine readable.
+7. **Pass `--yes` / `-y` on destructive commands** so they do not block on a confirmation prompt.
+8. **Resolve 409 conflicts deterministically:** `--update` for in-place edits, `--bump` for versioned releases.
+9. **Only fall back to local file writes** if a command exits with `Connection failed` or `Not configured`.
+10. **Never invent `OTEL_*` or `CLAUDE_CODE_ENABLE_TELEMETRY` environment variables.** Telemetry flows through `observal-shim` and session push hooks only.
 
 ---
 
-## Agent Commands
+## Procedure: Pull Agent
 
-### Create a New Agent
-
-```bash
-observal agent create --name AGENT_NAME --description 'DESCRIPTION' --prompt 'SYSTEM PROMPT' --model claude-sonnet-4 --ide kiro --ide claude-code --ide cursor
-```
-
-Flags:
-- `--name` / `-n` — required. Lowercase `[a-z0-9_-]`, max 64 chars
-- `--prompt` / `-p` — required. System prompt text (supports multiline)
-- `--description` / `-d` — required by server. Short summary
-- `--model` / `-m` — default: `claude-sonnet-4`. Options: `claude-opus-4`, `claude-haiku-4-5`, `gemini-2.5-pro`, `gpt-4o`
-- `--owner` — auto-detected from auth if omitted
-- `--version` / `-v` — default: `1.0.0`
-- `--ide` — repeat for multiple. Omit for all IDEs
-- `--prompt-file` — read prompt from a file instead of inline
-- `--from-file` / `-f` — pass a complete JSON definition
-
-### Update an Existing Agent
-
-Two options when the name already exists (409 error):
-
-**Option A: Direct update (skips review queue, updates in-place):**
+Install an agent's full config (rules, MCP servers, hooks, skills) into a local IDE.
 
 ```bash
-observal agent publish --update --dir /path/to/yaml/dir
+observal agent pull AGENT_NAME --ide kiro --no-prompt --dir .
 ```
 
-**Option B: New version (goes to review queue):**
+**Flags:**
+- `--ide` (required): `claude-code`, `kiro`, `cursor`, `gemini-cli`, `vscode`, `codex`, `copilot`, `copilot-cli`, `opencode`
+- `--scope user|project`: install scope (Claude Code, Kiro, Gemini only)
+- `--model <name>` or `--model <ide>=<name>`: override saved model (repeatable)
+- `--tools t1,t2`: Claude Code tool whitelist
+- `--dry-run`: preview file writes without touching disk
+- `--no-prompt`: skip interactive confirmation
+- `--dir <path>`: target directory (default: current)
+
+**Merge behavior:** MCP configs are merged with existing IDE config files, not overwritten. Existing user entries are preserved.
+
+If the user did not specify an IDE, ask which one before running.
+
+---
+
+## Procedure: Scan IDEs
+
+Read-only inventory of installed components across all detected IDEs. **Never modifies any file.**
 
 ```bash
-observal agent release <name> --bump patch --dir /path/to/yaml/dir
+observal scan
+observal scan --ide kiro
+observal scan --ide claude-code
 ```
 
-Use Option B when the user wants changes reviewed. Use Option A for quick edits.
+Reports: detected IDEs, MCP servers (with shimmed status), skills, hooks, agents, and unregistered components.
 
-Both require an `observal-agent.yaml`. Write it like this:
+---
+
+## Procedure: Doctor
+
+Diagnose only. Does not fix anything.
 
 ```bash
-# 1. Write observal-agent.yaml (anywhere, e.g. /tmp/myagent/)
-mkdir -p /tmp/myagent && cat > /tmp/myagent/observal-agent.yaml << 'EOF'
-name: existing-agent-name
-version: "1.0.0"
-description: "Updated description"
-owner: "team-name"
-model_name: claude-sonnet-4
-model_config_json: {}
-models_by_ide: {}
-external_mcps: []
-prompt: |
-  Your updated system prompt here.
-  Can be multiline.
-supported_ides:
-  - kiro
-  - claude-code
-  - cursor
-components: []
-EOF
-
-# 2. Push the update
-observal agent publish --update --dir /tmp/myagent
+observal doctor
 ```
 
-### Release a New Version
+Reports: Observal config validity, server reachability, hook installation status per IDE, skill presence. Exits non-zero if issues found.
 
-To bump the version of an existing agent:
+---
+
+## Procedure: Doctor Patch
+
+Apply instrumentation. Run with `--dry-run` first when the user is unsure.
 
 ```bash
-# 1. Write the YAML with updated prompt/config
-mkdir -p /tmp/myagent && cat > /tmp/myagent/observal-agent.yaml << 'EOF'
-name: agent-name
-description: "What it does"
-model_name: claude-sonnet-4
-model_config_json: {}
-models_by_ide: {}
-external_mcps: []
-prompt: |
-  Your updated system prompt.
-supported_ides:
-  - kiro
-  - claude-code
-components: []
-EOF
-
-# 2. Release with version bump
-observal agent release agent-name --bump patch --dir /tmp/myagent
+observal doctor patch --all --all-ides --dry-run
+observal doctor patch --all --all-ides
+observal doctor patch --hook --shim --ide kiro
+observal doctor patch --all --ide claude-code
+observal doctor patch --hook --all-ides
+observal doctor patch --shim --all-ides
 ```
 
-Bump types: `patch` (1.0.0→1.0.1), `minor` (1.0.0→1.1.0), `major` (1.0.0→2.0.0)
+**Required:** at least one of `--hook` / `--shim` / `--all`, AND at least one of `--all-ides` / `--ide`. Creates timestamped backups before modifying any file.
 
-### observal-agent.yaml Schema
+---
 
-All fields:
+## Procedure: Doctor Cleanup
 
-```yaml
-name: my-agent                    # required, [a-z0-9_-]
-description: "What this agent does"  # required
-version: "1.0.0"                  # semver, auto-bumped by release
-owner: "team-name"                # required
-model_name: claude-sonnet-4       # required
-model_config_json: {}             # MUST be {} not omitted
-models_by_ide: {}                 # optional per-IDE overrides e.g. {kiro: claude-haiku-4-5}
-external_mcps: []                 # MUST be [] not omitted
-prompt: |                         # required, multiline supported
-  System prompt text here.
-supported_ides:                   # list of IDE slugs
-  - kiro
-  - claude-code
-  - cursor
-  - gemini-cli
-  - vscode
-  - codex
-  - copilot
-  - opencode
-components: []                    # component refs, empty for prompt-only agents
-```
-
-**Critical**: `model_config_json` MUST be `{}` and `external_mcps` MUST be `[]` — never omit them or set to null, or the API returns 422.
-
-### Pull an Agent
+Remove Observal-managed hooks and env vars from IDE configs. Leaves user content untouched.
 
 ```bash
-observal agent pull <name> --ide <ide> --no-prompt --dir .
-```
-
-Flags: `--model`, `--scope user|project`, `--dry-run`
-
-### Browse Agents
-
-```bash
-observal agent list --output json
-observal agent list --search "keyword" --output json
-observal agent my --output json
-observal agent show <name> --output json
-observal agent versions <name> --output json
-```
-
-### Delete / Archive
-
-```bash
-observal agent delete <name> --yes
-observal agent unarchive <name> --yes
+observal doctor cleanup --dry-run
+observal doctor cleanup
+observal doctor cleanup --ide kiro
 ```
 
 ---
 
-## Component Commands (MCPs, Skills, Prompts)
-
-### Browse Components
+## Procedure: Auth
 
 ```bash
-# MCPs
-observal mcp list --output json
-observal mcp list --search "github" --output json
-observal mcp list --category developer-tools --output json
-observal mcp show <name-or-id> --output json
-
-# Skills
-observal skill list --output json
-observal skill list --task-type code-review --output json
-observal skill show <name-or-id> --output json
-
-# Prompts
-observal prompt list --output json
-observal prompt show <name-or-id> --output json
+observal auth login
+observal auth login --server https://observal.example.com
+observal auth login --sso
+observal auth login --email me@x.com --password '...'
+observal auth whoami --output json
+observal auth status
+observal auth logout
+observal auth change-password
+observal auth set-username new-handle
 ```
 
-MCP categories: `browser-automation`, `cloud-platforms`, `code-execution`, `communication`, `databases`, `developer-tools`, `devops`, `file-systems`, `finance`, `knowledge-memory`, `monitoring`, `multimedia`, `productivity`, `search`, `security`, `version-control`, `ai-ml`, `data-analytics`, `general`
+On a fresh server, `auth login` auto-bootstraps an admin from localhost (no prompts needed).
 
-Skill task types: `code-review`, `code-generation`, `testing`, `documentation`, `debugging`, `refactoring`, `deployment`, `security-audit`, `performance`, `general`
+---
 
-### Submit an MCP Server
-
-From a git repo (recommended):
+## Procedure: CLI Config
 
 ```bash
-observal mcp submit --git https://github.com/org/mcp-server --name my-mcp --category developer-tools --yes
-```
-
-From a JSON file:
-
-```bash
-observal mcp submit --from-file mcp.json
-```
-
-### Submit a Skill
-
-```bash
-observal skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --git-ref main
-```
-
-### Submit a Prompt
-
-```bash
-observal prompt submit --from-file prompt.json
-```
-
----
-
-## Supported IDEs
-
-| IDE Flag | Accepts `--model` | Accepts `--scope` |
-|----------|---|---|
-| `cursor` | No | Yes |
-| `kiro` | Yes | Yes |
-| `claude-code` | Yes | Yes |
-| `gemini-cli` | Yes | Yes |
-| `vscode` | No | No |
-| `codex` | Yes | No |
-| `copilot` | No | No |
-| `copilot-cli` | No | No |
-| `opencode` | Yes | Yes |
-
----
-
-## Local Fallback Mode
-
-If commands fail with "Connection failed", write configs directly:
-
-**Kiro** → `~/.kiro/agents/<name>.json`:
-```json
-{"name":"<name>","description":"<desc>","prompt":"<prompt>","model":"claude-sonnet-4-20250514","mcpServers":{},"tools":["*"],"resources":["skill://~/.kiro/skills/*/SKILL.md"]}
-```
-
-**Claude Code** → `.claude/agents/<name>.md`:
-```markdown
----
-name: <name>
-description: <desc>
----
-<prompt>
-```
-
-**Cursor** → `.cursor/rules/<name>.mdc`:
-```markdown
----
-name: <name>
-description: <desc>
----
-<prompt>
+observal config show
+observal config path
+observal config set output json
+observal config set server_url https://observal.example.com
+observal config aliases
+observal config alias MY_AGENT abc-123
 ```
 
 ---
 
 ## Error Reference
 
-| Error | Fix |
-|-------|-----|
-| 409 "already have an agent named X" | Use `observal agent publish --update` or `agent release --bump` |
-| 422 model_config_json/external_mcps | Ensure YAML has `model_config_json: {}` and `external_mcps: []` |
-| "Not configured" | User must run `observal auth login` |
-| "Connection failed" | Use Local Fallback Mode |
-| 404 Not found | Check name with `observal agent list --output json` |
-| "system prompt is required" | Add `--prompt` or `prompt:` in YAML |
+| Error | Action |
+|-------|--------|
+| `Connection failed` | Server unreachable. Use the `observal-advanced` skill's Local Fallback procedure |
+| `Not configured` / `No server` | Run `observal auth login` |
+| `403 Forbidden` | Check `observal auth whoami`; user lacks required role |
+| `404 Not found` | Verify name with `observal agent list --output json` |
+
+---
+
+## Output Contract
+
+For every CLI invocation, format your response:
+
+1. One sentence stating intent.
+2. The exact command in a fenced code block.
+3. The result: success / specific error.
+4. The next action, or "done".
+
+---
+
+For full command reference, read `references/commands.md`. For agent creation use the `observal-agents` skill. For registry operations use `observal-registry`. For observability use `observal-ops`. For admin tasks use `observal-admin`.

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -1,0 +1,196 @@
+<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Observal CLI Command Reference
+
+Auto-generated from the Typer app by `scripts/sync_observal_skill.py`. Do not edit manually.
+
+<!-- BEGIN AUTO-GENERATED COMMAND REFERENCE -->
+Every command available in the installed CLI. This block is generated from the Typer app by `scripts/sync_observal_skill.py`. If a flag you need is missing here, run `<command> --help` for full options.
+
+**Root commands**
+
+- `observal profile`: Show active profile and backup info.
+- `observal scan`: Show a read-only inventory of your local IDE setup.
+- `observal uninstall`: Completely uninstall Observal: stop containers, remove volumes, delete repo and config.
+- `observal use`: Swap your IDE configs to a profile. Backs up current config first.
+
+**`observal admin`**: Admin commands
+
+- `observal admin review`: Admin review commands
+  - `observal admin review approve`: Approve a submission (component, agent, or bundle).
+  - `observal admin review list`: List pending submissions awaiting admin review.
+  - `observal admin review reject`: Reject a submission (component, agent, or bundle).
+  - `observal admin review show`: Show review details for a component or agent.
+  - `observal admin audit-log`: Query the audit log. (Enterprise only)
+  - `observal admin audit-log-export`: Export audit log as CSV. (Enterprise only)
+  - `observal admin cache-clear`: Clear all server caches.
+  - `observal admin create-user`: Create a new user account. Requires admin privileges.
+  - `observal admin delete-user`: Delete a user account. Requires admin privileges.
+  - `observal admin diagnostics`: Show system diagnostics and health status.
+  - `observal admin reset-password`: Reset a user's password. Requires admin privileges.
+  - `observal admin saml-config`: View current SAML SSO configuration. (Enterprise only)
+  - `observal admin saml-config-delete`: Delete SAML SSO configuration. Disables SAML SSO. (Enterprise only)
+  - `observal admin saml-config-set`: Create or update SAML SSO configuration.
+  - `observal admin scim-token-create`: Create a new SCIM provisioning token.
+  - `observal admin scim-token-revoke`: Revoke a SCIM provisioning token. (Enterprise only)
+  - `observal admin scim-tokens`: List SCIM provisioning tokens. (Enterprise only)
+  - `observal admin security-events`: View security events log.
+  - `observal admin set`: Set an enterprise setting.
+  - `observal admin set-role`: Change a user's role.
+  - `observal admin settings`: List enterprise settings.
+  - `observal admin trace-privacy`: View trace privacy setting.
+  - `observal admin trace-privacy-set`: Enable or disable trace privacy (redacts sensitive trace data).
+  - `observal admin users`: List all users.
+
+**`observal agent`**: Agent registry commands
+
+  - `observal agent add`: Add a component reference to observal-agent.yaml.
+  - `observal agent build`: Validate agent definition against the server (dry-run).
+  - `observal agent bulk-create`: Bulk-create agents from a JSON file.
+  - `observal agent create`: Create a new agent (interactive wizard, from file, or via flags).
+  - `observal agent delete`: Archive an agent (soft delete).
+  - `observal agent init`: Scaffold an observal-agent.yaml definition file.
+  - `observal agent install`: Get install config for an agent.
+  - `observal agent list`: List active agents (paginated).
+  - `observal agent my`: List your own agents (all statuses).
+  - `observal agent publish`: Publish the agent definition to the server.
+  - `observal agent pull`: Fetch agent config and write IDE files to disk.
+  - `observal agent release`: Bump version and push a versioned release to the registry.
+  - `observal agent show`: Show full agent details.
+  - `observal agent unarchive`: Restore an archived agent back to active status.
+  - `observal agent versions`: List all versions for an agent.
+
+**`observal auth`**: Authentication and account commands
+
+  - `observal auth login`: Connect to Observal.
+  - `observal auth init`: [Removed] Use 'observal auth login' + 'observal agent pull' instead.
+  - `observal auth logout`: Clear saved credentials.
+  - `observal auth whoami`: Show current authenticated user.
+  - `observal auth status`: Check server connectivity and health.
+  - `observal auth change-password`: Change your password.
+  - `observal auth set-username`: Set or update your username.
+
+**`observal component`**: Component version commands
+
+- `observal component version`: Manage component versions
+  - `observal component version list`: List version history for a registry component.
+  - `observal component version publish`: Publish a new version for a registry component.
+
+**`observal config`**: CLI configuration
+
+  - `observal config alias`: Set or remove an alias for an MCP/agent ID.
+  - `observal config aliases`: List all aliases.
+  - `observal config path`: Show config file path.
+  - `observal config set`: Set a CLI config value.
+  - `observal config show`: Show current CLI configuration.
+
+**`observal doctor`**: Diagnose and patch IDE settings for Observal telemetry
+
+  - `observal doctor cleanup`: Remove ALL Observal hooks, env vars, and legacy telemetry config.
+  - `observal doctor patch`: Instrument IDEs with Observal telemetry hooks and shims.
+
+**`observal mcp`**: MCP server registry commands
+
+  - `observal mcp submit`: Submit an MCP server to the registry.
+  - `observal mcp show`: Show full details of an MCP server.
+  - `observal mcp install`: Generate an install config snippet for an MCP server.
+  - `observal mcp delete`: Delete an MCP server from the registry.
+  - `observal mcp edit`: Edit an MCP server submission.
+  - `observal mcp list`: List approved MCP servers in the registry.
+  - `observal mcp my`: List your own MCP servers across all statuses.
+
+**`observal ops`**: Observability and operational commands (traces, telemetry, dashboard, feedback)
+
+- `observal ops telemetry`: Telemetry commands
+  - `observal ops telemetry status`: Check telemetry data flow status.
+  - `observal ops telemetry test`: Send a test telemetry event.
+  - `observal ops feedback`: Show feedback for an MCP server or agent.
+  - `observal ops metrics`: Show metrics for an MCP server or agent.
+  - `observal ops overview`: Show enterprise overview stats.
+  - `observal ops rate`: Rate an MCP server or agent.
+  - `observal ops spans`: List spans for a trace.
+  - `observal ops top`: Show top MCP servers or agents by usage.
+  - `observal ops traces`: List recent traces.
+
+**`observal prompt`**: Prompt registry commands
+
+  - `observal prompt delete`: Delete a prompt from the registry.
+  - `observal prompt edit`: Edit a draft, rejected, or pending prompt submission.
+  - `observal prompt install`: Generate IDE install configuration for a prompt.
+  - `observal prompt list`: List approved prompts in the registry.
+  - `observal prompt my`: List your own prompts across all statuses.
+  - `observal prompt render`: Render a prompt template with variable substitution.
+  - `observal prompt show`: Show detailed information about a prompt.
+  - `observal prompt submit`: Submit a new prompt template for review.
+
+**`observal registry`**: Component registry (MCPs, skills, hooks, prompts, sandboxes)
+
+- `observal registry hook`: Hook registry commands
+  - `observal registry hook delete`: Delete a hook from the registry.
+  - `observal registry hook edit`: Edit a draft, rejected, or pending hook submission.
+  - `observal registry hook install`: Install a hook for a specific IDE.
+  - `observal registry hook list`: List approved hooks from the registry.
+  - `observal registry hook show`: Show detailed information for a single hook.
+  - `observal registry hook submit`: Submit a new hook for review.
+- `observal registry mcp`: MCP server registry commands
+  - `observal registry mcp submit`: Submit an MCP server to the registry.
+  - `observal registry mcp show`: Show full details of an MCP server.
+  - `observal registry mcp install`: Generate an install config snippet for an MCP server.
+  - `observal registry mcp delete`: Delete an MCP server from the registry.
+  - `observal registry mcp edit`: Edit an MCP server submission.
+  - `observal registry mcp list`: List approved MCP servers in the registry.
+  - `observal registry mcp my`: List your own MCP servers across all statuses.
+- `observal registry models`: Inspect the model catalog (live from models.dev with offline fallback).
+  - `observal registry models list`: Show models from the registry.
+- `observal registry prompt`: Prompt registry commands
+  - `observal registry prompt delete`: Delete a prompt from the registry.
+  - `observal registry prompt edit`: Edit a draft, rejected, or pending prompt submission.
+  - `observal registry prompt install`: Generate IDE install configuration for a prompt.
+  - `observal registry prompt list`: List approved prompts in the registry.
+  - `observal registry prompt my`: List your own prompts across all statuses.
+  - `observal registry prompt render`: Render a prompt template with variable substitution.
+  - `observal registry prompt show`: Show detailed information about a prompt.
+  - `observal registry prompt submit`: Submit a new prompt template for review.
+- `observal registry sandbox`: Sandbox registry commands
+  - `observal registry sandbox delete`: Delete a sandbox from the registry.
+  - `observal registry sandbox edit`: Edit a draft, rejected, or pending sandbox submission.
+  - `observal registry sandbox install`: Generate IDE install configuration for a sandbox.
+  - `observal registry sandbox list`: List approved sandboxes in the registry.
+  - `observal registry sandbox show`: Show detailed information about a sandbox.
+  - `observal registry sandbox submit`: Submit a new sandbox environment for review.
+- `observal registry skill`: Skill registry commands
+  - `observal registry skill delete`: Delete a skill from the registry.
+  - `observal registry skill edit`: Edit a draft, rejected, or pending skill submission.
+  - `observal registry skill install`: Install a skill by fetching the full skill directory from git.
+  - `observal registry skill list`: List approved skills in the registry.
+  - `observal registry skill my`: List your own skills across all statuses.
+  - `observal registry skill show`: Show detailed information about a skill.
+  - `observal registry skill submit`: Submit a new skill for review.
+
+**`observal sandbox`**: Sandbox registry commands
+
+  - `observal sandbox delete`: Delete a sandbox from the registry.
+  - `observal sandbox edit`: Edit a draft, rejected, or pending sandbox submission.
+  - `observal sandbox install`: Generate IDE install configuration for a sandbox.
+  - `observal sandbox list`: List approved sandboxes in the registry.
+  - `observal sandbox show`: Show detailed information about a sandbox.
+  - `observal sandbox submit`: Submit a new sandbox environment for review.
+
+**`observal self`**: CLI self-management commands (upgrade, downgrade, rollback, status)
+
+  - `observal self upgrade`: Upgrade the observal CLI to the latest (or specified) version.
+  - `observal self downgrade`: Downgrade the observal CLI to a previous version.
+  - `observal self rollback`: Restore the CLI to the version before the last upgrade/downgrade.
+  - `observal self status`: Show current CLI version, install method, and update availability.
+
+**`observal skill`**: Skill registry commands
+
+  - `observal skill delete`: Delete a skill from the registry.
+  - `observal skill edit`: Edit a draft, rejected, or pending skill submission.
+  - `observal skill install`: Install a skill by fetching the full skill directory from git.
+  - `observal skill list`: List approved skills in the registry.
+  - `observal skill my`: List your own skills across all statuses.
+  - `observal skill show`: Show detailed information about a skill.
+  - `observal skill submit`: Submit a new skill for review.
+<!-- END AUTO-GENERATED COMMAND REFERENCE -->

--- a/scripts/sync_observal_skill.py
+++ b/scripts/sync_observal_skill.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Regenerate the auto-generated command reference block in the Observal skill.
+
+Run: python scripts/sync_observal_skill.py
+
+This walks the Typer command tree exposed by ``observal_cli.main:app`` and
+rewrites the section delimited by ``<!-- BEGIN AUTO-GENERATED ... -->`` and
+``<!-- END AUTO-GENERATED ... -->`` sentinels in
+``observal_cli/skills/observal/SKILL.md`` so the bundled skill stays in sync
+with the actual CLI surface.
+
+Enforced by ``tests/test_observal_skill_sync.py`` in CI. If the test fails,
+run this script to regenerate.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add project root to path so we can import observal_cli without installation.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+import typer  # noqa: E402, TC002
+
+from observal_cli.main import app  # noqa: E402
+
+SKILL_PATH = ROOT / "observal_cli" / "skills" / "observal" / "references" / "commands.md"
+
+BEGIN_SENTINEL = "<!-- BEGIN AUTO-GENERATED COMMAND REFERENCE -->"
+END_SENTINEL = "<!-- END AUTO-GENERATED COMMAND REFERENCE -->"
+
+# Hidden top-level groups: present in the CLI but not useful in the skill.
+# `server` requires extra deps and is dev-only; `migrate` is operator tooling;
+# `logs` is interactive only; `support` is for bug reporting.
+_HIDDEN_GROUPS = {"server", "migrate", "logs", "support"}
+
+
+def _first_line(text: str | None) -> str:
+    """Return the first non-empty line of help text, stripped."""
+    if not text:
+        return ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _command_help(cmd: typer.models.CommandInfo) -> str:
+    """Extract a one-line summary for a Typer command."""
+    if cmd.help:
+        return _first_line(cmd.help)
+    if cmd.callback and cmd.callback.__doc__:
+        return _first_line(cmd.callback.__doc__)
+    return ""
+
+
+def _group_help(group: typer.models.TyperInfo) -> str:
+    """Extract a one-line summary for a Typer group."""
+    inst = group.typer_instance
+    if inst is None:
+        return ""
+    info = inst.info
+    if info and info.help:
+        return _first_line(info.help)
+    return ""
+
+
+def _walk(prefix: str, group_app: typer.Typer, lines: list[str], depth: int = 0) -> None:
+    """Recursively render commands under ``group_app`` into ``lines``."""
+    # Sub-groups first (alphabetical), then commands (alphabetical).
+    for sub in sorted(group_app.registered_groups, key=lambda g: g.name or ""):
+        name = sub.name or ""
+        if depth == 0 and name in _HIDDEN_GROUPS:
+            continue
+        full = f"{prefix} {name}".strip()
+        summary = _group_help(sub)
+        lines.append(f"- `{full}`: {summary}" if summary else f"- `{full}`")
+        if sub.typer_instance is not None:
+            _walk(full, sub.typer_instance, lines, depth + 1)
+
+    for cmd in sorted(group_app.registered_commands, key=lambda c: c.name or ""):
+        name = cmd.name or (cmd.callback.__name__ if cmd.callback else "")
+        full = f"{prefix} {name}".strip()
+        summary = _command_help(cmd)
+        lines.append(f"  - `{full}`: {summary}" if summary else f"  - `{full}`")
+
+
+def generate_reference() -> str:
+    """Produce the markdown block that lives between the sentinels."""
+    lines: list[str] = []
+    lines.append(
+        "Every command available in the installed CLI. This block is generated "
+        "from the Typer app by `scripts/sync_observal_skill.py`. If a flag you "
+        "need is missing here, run `<command> --help` for full options."
+    )
+    lines.append("")
+
+    # Root-level commands (scan, use, profile, uninstall, etc.) come first.
+    root_lines: list[str] = []
+    for cmd in sorted(app.registered_commands, key=lambda c: c.name or ""):
+        name = cmd.name or (cmd.callback.__name__ if cmd.callback else "")
+        summary = _command_help(cmd)
+        root_lines.append(f"- `observal {name}`: {summary}" if summary else f"- `observal {name}`")
+    if root_lines:
+        lines.append("**Root commands**")
+        lines.append("")
+        lines.extend(root_lines)
+        lines.append("")
+
+    # Group sections.
+    for group in sorted(app.registered_groups, key=lambda g: g.name or ""):
+        name = group.name or ""
+        if name in _HIDDEN_GROUPS:
+            continue
+        summary = _group_help(group)
+        header = f"**`observal {name}`**"
+        if summary:
+            header = f"{header}: {summary}"
+        lines.append(header)
+        lines.append("")
+        sub_lines: list[str] = []
+        if group.typer_instance is not None:
+            _walk(f"observal {name}", group.typer_instance, sub_lines)
+        if sub_lines:
+            lines.extend(sub_lines)
+        else:
+            lines.append("- (no subcommands)")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def rewrite_skill(skill_text: str, reference: str) -> str:
+    """Return ``skill_text`` with the auto-gen block replaced by ``reference``."""
+    begin_idx = skill_text.find(BEGIN_SENTINEL)
+    end_idx = skill_text.find(END_SENTINEL)
+
+    block = f"{BEGIN_SENTINEL}\n{reference}{END_SENTINEL}"
+
+    if begin_idx == -1 or end_idx == -1:
+        # First-time setup: append the block to the end if neither sentinel
+        # exists. Callers that want a different placement should add the
+        # sentinels manually before running the script.
+        sep = "" if skill_text.endswith("\n") else "\n"
+        return f"{skill_text}{sep}\n{block}\n"
+
+    if end_idx < begin_idx:
+        raise SystemExit("SKILL.md sentinels are out of order: END appears before BEGIN. Fix the file by hand.")
+
+    head = skill_text[:begin_idx]
+    tail = skill_text[end_idx + len(END_SENTINEL) :]
+    return f"{head}{block}{tail}"
+
+
+def main() -> int:
+    if not SKILL_PATH.exists():
+        print(f"✗ {SKILL_PATH} does not exist", file=sys.stderr)
+        return 1
+
+    reference = generate_reference()
+    original = SKILL_PATH.read_text(encoding="utf-8")
+    updated = rewrite_skill(original, reference)
+
+    if original == updated:
+        print(f"✓ {SKILL_PATH.relative_to(ROOT)} already in sync")
+        return 0
+
+    SKILL_PATH.write_text(updated, encoding="utf-8")
+    print(f"✓ Regenerated {SKILL_PATH.relative_to(ROOT)} ({len(reference)} bytes in reference block)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_observal_skill.py
+++ b/tests/test_observal_skill.py
@@ -1,0 +1,424 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Static validation for the bundled Observal skill.
+
+These tests exercise ``observal_cli/skills/observal/SKILL.md`` without invoking
+an LLM. They guarantee:
+
+- The file exists at the path the installer expects.
+- Frontmatter contains the fields IDE skill loaders rely on.
+- Every fenced ``observal …`` shell command in the skill resolves to a real
+  Typer command path.
+- Every long flag mentioned for a documented command is a real flag on that
+  command.
+- The auto-generated reference block exists between the expected sentinels.
+- The file stays under a sane size budget so it does not blow up LLM context.
+
+If any of these regress, run::
+
+    cd observal-server && uv run --with typer --with rich --with loguru \\
+        --with pyyaml python ../scripts/sync_observal_skill.py
+
+and update the skill copy accordingly.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+import yaml
+
+from observal_cli.main import app
+
+SKILL_PATH = Path(__file__).resolve().parent.parent / "observal_cli" / "skills" / "observal" / "SKILL.md"
+
+SKILLS_DIR = Path(__file__).resolve().parent.parent / "observal_cli" / "skills"
+
+REFERENCE_PATH = SKILLS_DIR / "observal" / "references" / "commands.md"
+
+ALL_SKILL_PATHS = [
+    SKILLS_DIR / "observal" / "SKILL.md",
+    SKILLS_DIR / "observal-agents" / "SKILL.md",
+    SKILLS_DIR / "observal-registry" / "SKILL.md",
+    SKILLS_DIR / "observal-ops" / "SKILL.md",
+    SKILLS_DIR / "observal-admin" / "SKILL.md",
+    SKILLS_DIR / "observal-advanced" / "SKILL.md",
+]
+
+MAX_SKILL_LINES_EACH = 250  # Per-skill budget (split skills should be small)
+
+REQUIRED_FRONTMATTER_FIELDS = ("name", "description", "version")
+EXPECTED_COMMAND = "observal"
+EXPECTED_NAME = "observal"
+
+BEGIN_SENTINEL = "<!-- BEGIN AUTO-GENERATED COMMAND REFERENCE -->"
+END_SENTINEL = "<!-- END AUTO-GENERATED COMMAND REFERENCE -->"
+
+MAX_SKILL_LINES = 1500  # Total budget across all skills combined.
+
+# Top-level groups intentionally hidden from the skill (developer-only tools).
+# Mirrors the ``_HIDDEN_GROUPS`` set in scripts/sync_observal_skill.py.
+_HIDDEN_GROUPS = {"server", "migrate", "logs", "support"}
+
+# A few fenced examples are illustrative output rather than runnable commands
+# (e.g. piped placeholders). Skip those during command resolution.
+_PLACEHOLDER_TOKENS = {"<", ">", "..."}
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _read_skill() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _split_frontmatter(text: str) -> tuple[dict, str]:
+    """Split ``---``-delimited frontmatter from the body."""
+    # Strip leading HTML comments (SPDX headers) line by line.
+    lines = text.splitlines(keepends=True)
+    start = 0
+    for i, line in enumerate(lines):
+        stripped_line = line.strip()
+        if (stripped_line.startswith("<!--") and stripped_line.endswith("-->")) or stripped_line == "":
+            start = i + 1
+        else:
+            break
+    remaining = "".join(lines[start:])
+    match = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n(.*)", remaining, re.DOTALL)
+    if not match:
+        raise AssertionError("SKILL.md is missing YAML frontmatter delimited by '---'. IDE skill loaders need it.")
+    fm = yaml.safe_load(match.group(1)) or {}
+    body = match.group(2)
+    return fm, body
+
+
+def _iter_bash_blocks(body: str):
+    """Yield each fenced ``bash`` code block (sans fences) in order."""
+    pattern = re.compile(r"```(?:bash|shell|sh)\s*\n(.*?)```", re.DOTALL)
+    for m in pattern.finditer(body):
+        yield m.group(1)
+
+
+@dataclass
+class ParsedCommand:
+    full: str  # Complete invocation as written.
+    path: tuple[str, ...]  # ('agent', 'create')
+    flags: tuple[str, ...]  # ('--name', '--description', ...)
+
+
+def _parse_observal_invocations(body: str) -> list[ParsedCommand]:
+    """Pull every ``observal …`` invocation out of fenced bash blocks."""
+    commands: list[ParsedCommand] = []
+    for block in _iter_bash_blocks(body):
+        # Join continuation lines so multi-line commands parse as one.
+        joined = re.sub(r"\\\s*\n\s*", " ", block)
+        for raw_line in joined.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            # Strip leading shell prefixes like '$ ' or 'sudo '.
+            line = re.sub(r"^\$\s+", "", line)
+
+            # Collapse pipes/&&/|| chains into separate invocations so each
+            # gets validated independently.
+            for segment in re.split(r"\s+(?:\|\||&&|;|\|)\s+", line):
+                segment = segment.strip()
+                if not segment.startswith("observal"):
+                    continue
+                tokens = _shell_tokens(segment)
+                if not tokens or tokens[0] != "observal":
+                    continue
+
+                # Walk tokens after `observal` accumulating the command path
+                # until we hit a flag (after which everything is args/values).
+                path: list[str] = []
+                flags: list[str] = []
+                seen_flag = False
+                for tok in tokens[1:]:
+                    if tok.startswith("-"):
+                        seen_flag = True
+                        # Strip ``=value`` from long flags.
+                        flag = tok.split("=", 1)[0]
+                        flags.append(flag)
+                        continue
+                    if seen_flag:
+                        # Positional argument or flag value — never a path token.
+                        continue
+                    if not _is_identifier_token(tok):
+                        # Looks like a placeholder (e.g. NAME, <id>) — stop
+                        # accumulating; subsequent tokens are arguments.
+                        seen_flag = True
+                        continue
+                    path.append(tok)
+
+                if not path:
+                    continue
+                commands.append(ParsedCommand(full=segment, path=tuple(path), flags=tuple(flags)))
+    return commands
+
+
+def _shell_tokens(line: str) -> list[str]:
+    """Cheap tokenizer: split on whitespace, respecting quoted spans loosely."""
+    tokens: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    for ch in line:
+        if quote:
+            if ch == quote:
+                quote = None
+            else:
+                buf.append(ch)
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch.isspace():
+            if buf:
+                tokens.append("".join(buf))
+                buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        tokens.append("".join(buf))
+    return tokens
+
+
+def _is_identifier_token(tok: str) -> bool:
+    """True when the token looks like a Typer command name (kebab-ish)."""
+    if not tok:
+        return False
+    if tok[0] in _PLACEHOLDER_TOKENS:
+        return False
+    # Command paths use [a-z0-9-]; anything else is an argument.
+    return bool(re.fullmatch(r"[a-z][a-z0-9-]*", tok))
+
+
+# ── Typer introspection ────────────────────────────────────────────────────
+
+
+def _resolve_path(path: tuple[str, ...]):
+    """Walk the Typer tree by command path. Returns the leaf command/group or None."""
+    current_app: typer.Typer = app
+    for i, segment in enumerate(path):
+        # Match against subgroups first.
+        for grp in current_app.registered_groups:
+            if grp.name == segment:
+                current_app = grp.typer_instance
+                break
+        else:
+            # Fall through: maybe it's a leaf command.
+            if i != len(path) - 1:
+                return None
+            for cmd in current_app.registered_commands:
+                if cmd.name == segment or (cmd.callback and cmd.callback.__name__ == segment):
+                    return cmd
+            return None
+    return current_app
+
+
+def _flags_for_command(cmd: typer.models.CommandInfo) -> set[str]:
+    """Extract every long flag declared on a Typer command callback."""
+    if cmd.callback is None:
+        return set()
+    flags: set[str] = set()
+    import inspect
+
+    sig = inspect.signature(cmd.callback)
+    for param in sig.parameters.values():
+        default = param.default
+        if isinstance(default, typer.models.OptionInfo):
+            for decl in default.param_decls or ():
+                # Handle Typer boolean pairs like "--active/--inactive"
+                for part in decl.split("/"):
+                    if part.startswith("--"):
+                        flags.add(part.split("=", 1)[0])
+            # Typer derives --param-name from the parameter name when no decl
+            # is given. Mirror that.
+            if not default.param_decls:
+                flags.add(f"--{param.name.replace('_', '-')}")
+        elif isinstance(default, typer.models.ArgumentInfo):
+            # Arguments do not have flags.
+            pass
+        else:
+            # Plain bool/str defaults still get a flag from Typer.
+            if param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY):
+                flags.add(f"--{param.name.replace('_', '-')}")
+    return flags
+
+
+def _all_command_paths() -> set[tuple[str, ...]]:
+    """Return every reachable command path under the root app."""
+    out: set[tuple[str, ...]] = set()
+
+    def walk(prefix: tuple[str, ...], current: typer.Typer) -> None:
+        for cmd in current.registered_commands:
+            name = cmd.name or (cmd.callback.__name__ if cmd.callback else "")
+            if name:
+                out.add((*prefix, name))
+        for grp in current.registered_groups:
+            if not grp.name:
+                continue
+            if not prefix and grp.name in _HIDDEN_GROUPS:
+                continue
+            out.add((*prefix, grp.name))
+            if grp.typer_instance is not None:
+                walk((*prefix, grp.name), grp.typer_instance)
+
+    walk((), app)
+    return out
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+class TestSkillFile:
+    def test_skill_file_exists_at_installer_path(self):
+        """``_install_observal_skill`` reads from this exact path."""
+        assert SKILL_PATH.exists(), f"{SKILL_PATH} is missing"
+        assert SKILL_PATH.is_file()
+
+    def test_all_skill_files_exist(self):
+        """All 6 intent-based skills must exist."""
+        for path in ALL_SKILL_PATHS:
+            assert path.exists(), f"{path} is missing"
+
+    def test_reference_file_exists(self):
+        """The auto-generated command reference must exist."""
+        assert REFERENCE_PATH.exists(), f"{REFERENCE_PATH} is missing"
+
+    def test_skill_file_under_size_budget(self):
+        total = sum(len(p.read_text(encoding="utf-8").splitlines()) for p in ALL_SKILL_PATHS)
+        assert total <= MAX_SKILL_LINES, (
+            f"All skills combined have {total} lines (budget: {MAX_SKILL_LINES}). Tighten procedures or split further."
+        )
+
+    def test_each_skill_under_individual_budget(self):
+        for path in ALL_SKILL_PATHS:
+            lines = len(path.read_text(encoding="utf-8").splitlines())
+            assert lines <= MAX_SKILL_LINES_EACH, (
+                f"{path.parent.name}/SKILL.md has {lines} lines (budget: {MAX_SKILL_LINES_EACH}). "
+                "Split into a smaller skill."
+            )
+
+
+class TestFrontmatter:
+    def setup_method(self):
+        self.frontmatter, self.body = _split_frontmatter(_read_skill())
+
+    def test_required_fields_present(self):
+        for field in REQUIRED_FRONTMATTER_FIELDS:
+            assert field in self.frontmatter, f"frontmatter missing required field: {field}"
+            assert self.frontmatter[field], f"frontmatter field {field!r} is empty"
+
+    def test_name_matches_skill_directory(self):
+        assert self.frontmatter["name"] == EXPECTED_NAME, (
+            f"frontmatter name should be {EXPECTED_NAME!r} so IDE loaders find it"
+        )
+
+    def test_command_field_present_when_set(self):
+        # ``command`` is optional but if present must point at the CLI binary.
+        if "command" in self.frontmatter:
+            assert self.frontmatter["command"] == EXPECTED_COMMAND
+
+    def test_version_is_semverish(self):
+        version = str(self.frontmatter["version"])
+        assert re.fullmatch(r"\d+\.\d+\.\d+(?:[-+].*)?", version), f"version should look like semver, got {version!r}"
+
+
+class TestAutoGenBlock:
+    def test_sentinels_present(self):
+        text = REFERENCE_PATH.read_text(encoding="utf-8")
+        assert BEGIN_SENTINEL in text, (
+            f"missing {BEGIN_SENTINEL!r} in references/commands.md. Run scripts/sync_observal_skill.py."
+        )
+        assert END_SENTINEL in text, (
+            f"missing {END_SENTINEL!r} in references/commands.md. Run scripts/sync_observal_skill.py."
+        )
+        begin = text.index(BEGIN_SENTINEL)
+        end = text.index(END_SENTINEL)
+        assert begin < end, "sentinels are out of order"
+
+    def test_auto_gen_block_lists_every_visible_top_level_group(self):
+        text = REFERENCE_PATH.read_text(encoding="utf-8")
+        block = text[text.index(BEGIN_SENTINEL) : text.index(END_SENTINEL)]
+        for grp in app.registered_groups:
+            if not grp.name or grp.name in _HIDDEN_GROUPS:
+                continue
+            assert f"observal {grp.name}" in block, (
+                f"auto-gen block does not mention top-level group {grp.name!r}. Run scripts/sync_observal_skill.py."
+            )
+
+
+class TestCommandResolution:
+    def setup_method(self):
+        # Collect commands from ALL skill files.
+        self.commands: list[ParsedCommand] = []
+        for path in ALL_SKILL_PATHS:
+            _, body = _split_frontmatter(path.read_text(encoding="utf-8"))
+            self.commands.extend(_parse_observal_invocations(body))
+        self.valid_paths = _all_command_paths()
+
+    def test_at_least_one_command_documented(self):
+        assert self.commands, "skill body has no observal CLI invocations"
+
+    def test_every_command_resolves(self):
+        unresolved: list[str] = []
+        for parsed in self.commands:
+            # Try progressively shorter prefixes; the first that resolves wins.
+            # That handles cases where the parser greedily ate an argument.
+            for length in range(len(parsed.path), 0, -1):
+                candidate = parsed.path[:length]
+                if candidate in self.valid_paths:
+                    break
+                resolved = _resolve_path(candidate)
+                if resolved is not None:
+                    break
+            else:
+                unresolved.append(f"{parsed.full!r} → path={parsed.path}")
+        assert not unresolved, (
+            "skill references commands that do not exist in the CLI:\n  "
+            + "\n  ".join(unresolved)
+            + "\nRun scripts/sync_observal_skill.py and update procedures."
+        )
+
+
+class TestFlagResolution:
+    """Every long flag mentioned in any skill must exist on its command."""
+
+    def setup_method(self):
+        self.commands: list[ParsedCommand] = []
+        for path in ALL_SKILL_PATHS:
+            _, body = _split_frontmatter(path.read_text(encoding="utf-8"))
+            self.commands.extend(_parse_observal_invocations(body))
+
+    def test_documented_flags_exist(self):
+        bad: list[str] = []
+        seen: set[tuple[tuple[str, ...], str]] = set()
+
+        for parsed in self.commands:
+            # Find the command leaf this invocation targets.
+            leaf = None
+            for length in range(len(parsed.path), 0, -1):
+                candidate = parsed.path[:length]
+                resolved = _resolve_path(candidate)
+                if isinstance(resolved, typer.models.CommandInfo):
+                    leaf = resolved
+                    break
+            if leaf is None:
+                continue  # Resolution test will already have flagged this.
+
+            valid_flags = _flags_for_command(leaf)
+            for flag in parsed.flags:
+                if not flag.startswith("--"):
+                    continue  # Skip short flags; they are noisier to validate.
+                key = (parsed.path, flag)
+                if key in seen:
+                    continue
+                seen.add(key)
+                if flag not in valid_flags:
+                    bad.append(f"{' '.join(parsed.path)} {flag} (in: {parsed.full})")
+
+        assert not bad, "skill documents flags that do not exist on the target command:\n  " + "\n  ".join(bad)

--- a/tests/test_observal_skill_sync.py
+++ b/tests/test_observal_skill_sync.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""CI guard: SKILL.md auto-gen block must match what the sync script produces.
+
+If the CLI grows or renames a command and the bundled skill is not regenerated,
+this test fails with a clear instruction to run::
+
+    cd observal-server && uv run --with typer --with rich --with loguru \\
+        --with pyyaml python ../scripts/sync_observal_skill.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Load the sync script as a module so we can call its helpers without
+# triggering the ``__main__`` write path.
+_SYNC_PATH = ROOT / "scripts" / "sync_observal_skill.py"
+_spec = importlib.util.spec_from_file_location("_sync_observal_skill", _SYNC_PATH)
+_sync = importlib.util.module_from_spec(_spec)
+sys.modules["_sync_observal_skill"] = _sync
+_spec.loader.exec_module(_sync)  # type: ignore[union-attr]
+
+
+def test_skill_reference_block_in_sync():
+    """The reference block on disk equals what the sync script would emit."""
+    expected = _sync.generate_reference()
+    on_disk = _sync.SKILL_PATH.read_text(encoding="utf-8")
+
+    begin = on_disk.find(_sync.BEGIN_SENTINEL)
+    end = on_disk.find(_sync.END_SENTINEL)
+    assert begin != -1 and end != -1 and begin < end, (
+        "SKILL.md is missing the BEGIN/END auto-generated sentinels. Run: python scripts/sync_observal_skill.py"
+    )
+
+    actual_block = on_disk[begin + len(_sync.BEGIN_SENTINEL) : end].lstrip("\n")
+    # ``generate_reference`` appends a single trailing newline; mirror that
+    # for the comparison so whitespace alone never causes drift noise.
+    if not actual_block.endswith("\n"):
+        actual_block += "\n"
+
+    assert actual_block == expected, (
+        "SKILL.md auto-generated reference block is stale.\n"
+        "Run: python scripts/sync_observal_skill.py\n\n"
+        f"--- expected (first 400 chars) ---\n{expected[:400]}\n"
+        f"--- actual   (first 400 chars) ---\n{actual_block[:400]}\n"
+    )


### PR DESCRIPTION
## Purpose / Description

The bundled Observal skill (observal_cli/skills/observal/SKILL.md) only covered ~30% of the CLI surface (agents, MCPs, skills, prompts). LLMs using the skill would fail or hallucinate when asked to use hooks, sandboxes, ops/telemetry, doctor, scan, admin, eval, or profile commands. Additionally, the skill had a bug documenting `--from-file` on `mcp submit` (only exists on `mcp edit`).

This PR rewrites the skill to a procedure-based playbook covering ~90% of the CLI, adds an auto-generated command reference that stays in sync with the Typer app, and adds 12 static validation tests as a regression net.

## Fixes

* Fixes incorrect `--from-file` flag documentation on `mcp submit`
* Fixes wrong `component publish`/`list` paths (now correctly `component version publish`/`list`)
* Fixes `agent add` examples showing name instead of required UUID

## Approach

- Restructured SKILL.md from flat command list to decision-tree + procedure-based playbook
- Added `scripts/sync_observal_skill.py` that introspects the Typer app and regenerates a command reference block between sentinel comments
- Added CI guard test that fails when CLI changes without regenerating the skill
- Added static tests validating every command and flag in the skill resolves to a real CLI command

## How Has This Been Tested?

- 12 new automated tests in `tests/test_observal_skill.py` and `tests/test_observal_skill_sync.py` (all pass)
- Full test suite: 3638 passed (5 pre-existing failures unrelated to this PR)
- `make sync-skill` confirms reference block is current
- Manual testing with kiro-cli against a live Observal server using 60+ test prompts

Run the new tests:
```bash
cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis --with pyarrow --with loguru pytest ../tests/test_observal_skill.py ../tests/test_observal_skill_sync.py -v
```

## Learning

- LLMs follow procedure-based instructions ("when X, do Y") far more reliably than reference documentation
- A decision tree at the top of a skill maps user intent to procedures and doubles as a test matrix
- Auto-generating reference blocks from code introspection (same pattern as `scripts/sync_features.py`) prevents drift permanently
- CodeQL flags `(?:<!--.*?-->\s*)*` as exponential backtracking risk; line-by-line stripping is safer

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens - N/A (no UI changes)
