### PR TITLE
feat: add Pi as supported IDE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,13 @@ jobs:
             exit 1
           fi
 
+          # Validate version matches packages/pi-extension/package.json
+          NPM_VERSION=$(python3 -c "import json, pathlib; print(json.loads(pathlib.Path('packages/pi-extension/package.json').read_text())['version'])")
+          if [ "$VERSION" != "$NPM_VERSION" ]; then
+            echo "::error::Release version v$VERSION does not match packages/pi-extension/package.json ($NPM_VERSION)"
+            exit 1
+          fi
+
           # Detect bump type by comparing to previous tag
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "v0.0.0")
           PREV="${PREV_TAG#v}"
@@ -330,10 +337,38 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  # ── Job 5: npm publish (after approval) ────────────────────
+  npm:
+    name: Publish to npm
+    needs: [preflight, approve]
+    if: needs.approve.result == 'success'
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Sync version from release
+        run: |
+          VERSION="${{ needs.preflight.outputs.version }}"
+          cd packages/pi-extension
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Publish observal-pi
+        run: |
+          cd packages/pi-extension
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   # ── Final: Create GitHub Release with all artifacts ────────
   release:
     name: GitHub Release
-    needs: [preflight, cli-binaries, docker-merge, server-package, pypi, approve]
+    needs: [preflight, cli-binaries, docker-merge, server-package, pypi, npm, approve]
     if: needs.approve.result == 'success'
     runs-on: ubuntu-latest
     steps:

--- a/observal-server/schemas/ide_registry.py
+++ b/observal-server/schemas/ide_registry.py
@@ -316,6 +316,39 @@ IDE_REGISTRY: dict[str, dict] = {
         "accepts_model_choice": True,
         "auto_sentinel": {"omit_field": True},
     },
+    "pi": {
+        "display_name": "Pi",
+        "features": {"skills", "hooks", "mcp_servers"},
+        "session_parser": "pi",
+        "scopes": ["project", "user"],
+        "default_scope": "user",
+        "scope_labels": ("project (.pi/)", "user (~/.pi/agent/)"),
+        "rules_file": {
+            "project": "AGENTS.md",
+            "user": "~/.pi/agent/AGENTS.md",
+        },
+        "rules_format": "markdown",
+        "mcp_config_path": {
+            "project": ".pi/mcp.json",
+            "user": "~/.pi/agent/mcp.json",
+        },
+        "mcp_servers_key": "mcpServers",
+        "skill_file": {
+            "project": ".pi/skills/{name}/SKILL.md",
+            "user": "~/.pi/agent/skills/{name}/SKILL.md",
+        },
+        "skill_format": "yaml_frontmatter",
+        "home_mcp_config": "~/.pi/agent/mcp.json",
+        "hook_type": "extension",
+        "hook_config_path": {
+            "user": "~/.pi/agent/settings.json",
+        },
+        "hook_scripts_dir": None,
+        "hook_events_map": {},
+        "config_dir": ".pi",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_field": True},
+    },
 }
 
 

--- a/observal-server/services/ide/load_all.py
+++ b/observal-server/services/ide/load_all.py
@@ -15,3 +15,4 @@ from services.ide import cursor as _cursor  # noqa: F401
 from services.ide import gemini_cli as _gemini_cli  # noqa: F401
 from services.ide import kiro as _kiro  # noqa: F401
 from services.ide import opencode as _opencode  # noqa: F401
+from services.ide import pi as _pi  # noqa: F401

--- a/observal-server/services/ide/pi.py
+++ b/observal-server/services/ide/pi.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Pi IDE adapter for agent config generation.
+
+Pi is harness-centric: `observal pull` writes AGENTS.md which becomes pi's
+entire system prompt, effectively reconfiguring the whole agent runtime.
+MCP servers are written to ~/.pi/agent/mcp.json (read by pi-mcp-adapter).
+Skills go to .pi/skills/ or ~/.pi/agent/skills/.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from schemas.ide_registry import IDE_REGISTRY
+from services.ide import ConfigContext, register_adapter
+from services.ide.helpers import _generate_skill_file
+
+
+class PiAdapter:
+    """Pi IDE adapter - harness-centric config generation."""
+
+    @property
+    def ide_name(self) -> str:
+        logger.debug("PiAdapter.ide_name called")
+        return "pi"
+
+    def format_config(self, ctx: ConfigContext) -> dict:
+        """Format config for Pi.
+
+        Pi uses:
+        - AGENTS.md (project) or ~/.pi/agent/AGENTS.md (user) for the system prompt
+        - .pi/mcp.json or ~/.pi/agent/mcp.json for MCP servers (pi-mcp-adapter)
+        - .pi/skills/{name}/SKILL.md for skills
+        """
+        logger.debug("PiAdapter.format_config: agent={}", ctx.safe_name)
+        options = ctx.options
+        scope = options.get("scope", IDE_REGISTRY["pi"]["default_scope"])
+
+        result: dict = {}
+
+        # ── Rules / Agent file (AGENTS.md) ──
+        if ctx.rules_content:
+            rules_spec = IDE_REGISTRY["pi"]["rules_file"]
+            rules_path = rules_spec.get(scope, rules_spec.get("user", "AGENTS.md"))
+            result["rules_file"] = {
+                "path": rules_path,
+                "content": ctx.rules_content,
+            }
+
+        # ── MCP config (for pi-mcp-adapter) ──
+        if ctx.mcp_configs:
+            mcp_path_spec = IDE_REGISTRY["pi"]["mcp_config_path"]
+            mcp_path = mcp_path_spec.get(scope, mcp_path_spec.get("user"))
+            if mcp_path:
+                result["mcp_config"] = {
+                    "path": mcp_path,
+                    "content": {"mcpServers": ctx.mcp_configs},
+                }
+
+        # ── Skills ──
+        skill_files = []
+        for skill in ctx.skill_configs:
+            entry = _generate_skill_file(skill, "pi")
+            if entry:
+                skill_files.append(entry)
+        if skill_files:
+            result["skill_files"] = skill_files
+
+        # Pi doesn't use command-based hooks - telemetry is via observal-pi
+        # No hook files to generate.
+
+        return result
+
+
+register_adapter(PiAdapter())

--- a/observal-server/services/session_ingest.py
+++ b/observal-server/services/session_ingest.py
@@ -14,6 +14,7 @@ default fallback.  Passing an unknown ``ide`` value raises ``KeyError``.
 
 import hashlib
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import structlog
@@ -23,15 +24,13 @@ from services.clickhouse import insert_session_events, query_existing_for_dedup,
 from services.secrets_redactor import redact_secrets
 from services.session_parsers.ingest_classify import extract_timestamp, get_classifier, get_extra_rows
 
+# ---------------------------------------------------------------------------
+# Per-IDE token usage extraction (dispatch pattern)
+# ---------------------------------------------------------------------------
 
-def _extract_usage_tokens(parsed: dict) -> dict:
-    """Extract input/output/cache token counts and model from a parsed JSONL line.
 
-    Claude Code embeds per-turn token counts in ``message.usage``.
-    Cursor injects a synthetic usage line from the hook payload on stop events.
-    All other IDEs (Kiro, etc.) have no per-line token data and default to 0.
-    """
-    optic.debug("_extract_usage_tokens: parsed={}", parsed)
+def _usage_claude_code(parsed: dict) -> dict:
+    """Claude Code / Cursor / Kiro: usage.input_tokens, usage.output_tokens, etc."""
     msg = parsed.get("message", {})
     usage = msg.get("usage") or {}
     return {
@@ -41,6 +40,72 @@ def _extract_usage_tokens(parsed: dict) -> dict:
         "cache_write_tokens": int(usage.get("cache_creation_input_tokens") or 0),
         "model": str(msg.get("model") or parsed.get("model") or ""),
     }
+
+
+def _usage_pi(parsed: dict) -> dict:
+    """Pi: usage.input, usage.output, usage.cacheRead, usage.cacheWrite."""
+    msg = parsed.get("message", {})
+    usage = msg.get("usage") or {}
+    return {
+        "input_tokens": int(usage.get("input") or 0),
+        "output_tokens": int(usage.get("output") or 0),
+        "cache_read_tokens": int(usage.get("cacheRead") or 0),
+        "cache_write_tokens": int(usage.get("cacheWrite") or 0),
+        "model": str(msg.get("model") or ""),
+    }
+
+
+_UsageFn = Callable[[dict], dict]
+
+_USAGE_EXTRACTORS: dict[str, _UsageFn] = {
+    "claude-code": _usage_claude_code,
+    "kiro": _usage_claude_code,
+    "cursor": _usage_claude_code,
+    "pi": _usage_pi,
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-IDE UUID extraction (dispatch pattern)
+# ---------------------------------------------------------------------------
+
+
+def _uuid_default(parsed: dict) -> tuple[str | None, str | None]:
+    """Claude Code / Kiro / Cursor: uuid, parentUuid."""
+    return parsed.get("uuid"), parsed.get("parentUuid")
+
+
+def _uuid_pi(parsed: dict) -> tuple[str | None, str | None]:
+    """Pi: id, parentId (at entry level)."""
+    return parsed.get("id"), parsed.get("parentId")
+
+
+_UuidFn = Callable[[dict], "tuple[str | None, str | None]"]
+
+_UUID_EXTRACTORS: dict[str, _UuidFn] = {
+    "claude-code": _uuid_default,
+    "kiro": _uuid_default,
+    "cursor": _uuid_default,
+    "pi": _uuid_pi,
+}
+
+
+def _extract_usage_tokens(parsed: dict, ide: str = "claude-code") -> dict:
+    """Extract input/output/cache token counts and model from a parsed JSONL line.
+
+    Dispatches to per-IDE extractor. Falls back to Claude Code format.
+    """
+    extractor = _USAGE_EXTRACTORS.get(ide, _usage_claude_code)
+    return extractor(parsed)
+
+
+def _extract_uuid(parsed: dict, ide: str = "claude-code") -> tuple[str | None, str | None]:
+    """Extract (uuid, parent_uuid) from a parsed JSONL line.
+
+    Dispatches to per-IDE extractor. Falls back to Claude Code format.
+    """
+    extractor = _UUID_EXTRACTORS.get(ide, _uuid_default)
+    return extractor(parsed)
 
 
 logger = structlog.get_logger(__name__)
@@ -147,6 +212,7 @@ async def ingest_session_lines(
         redacted_line = redact_secrets(raw_line)
         preview = preview_fn(parsed, event_type)
         tool_name, tool_id = tool_info_fn(parsed)
+        uuid, parent_uuid = _extract_uuid(parsed, ide)
 
         ts = extract_timestamp(ide, parsed)
         if ts is not None:
@@ -173,8 +239,8 @@ async def ingest_session_lines(
                 "line_hash": line_hash,
                 "event_type": event_type,
                 "timestamp": timestamp,
-                "uuid": parsed.get("uuid"),
-                "parent_uuid": parsed.get("parentUuid"),
+                "uuid": uuid,
+                "parent_uuid": parent_uuid,
                 "tool_name": tool_name,
                 "tool_id": tool_id,
                 "content_preview": preview,
@@ -182,8 +248,8 @@ async def ingest_session_lines(
                 "raw_line": redacted_line,
                 "credits": 0.0,
                 "parent_session_id": parent_session_id,
-                # Token counts from the JSONL line (Claude Code: message.usage).
-                **_extract_usage_tokens(parsed),
+                # Token counts from the JSONL line (IDE-specific field names).
+                **_extract_usage_tokens(parsed, ide),
             }
         )
         ingested += 1

--- a/observal-server/services/session_parsers/__init__.py
+++ b/observal-server/services/session_parsers/__init__.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from .claude_code import parse_rows as _parse_claude_code
 from .cursor import parse_rows as _parse_cursor
 from .kiro import parse_rows as _parse_kiro
+from .pi import parse_rows as _parse_pi
 
 # Maps session_parser ID -> parse_rows callable.
 # Add new entries here when implementing a new JSONL format.
@@ -34,6 +35,7 @@ _PARSERS: dict[str, _ParseFn] = {
     "claude-code": _parse_claude_code,
     "cursor": _parse_cursor,
     "kiro": _parse_kiro,
+    "pi": _parse_pi,
 }
 
 

--- a/observal-server/services/session_parsers/ingest_classify.py
+++ b/observal-server/services/session_parsers/ingest_classify.py
@@ -329,6 +329,146 @@ def _tool_info_cursor(parsed: dict) -> tuple[str | None, str | None]:
 
 
 # ---------------------------------------------------------------------------
+# Pi classifier
+# ---------------------------------------------------------------------------
+
+_PI_SKIP_TYPES = frozenset({"session", "label", "session_info", "custom"})
+
+
+def _classify_pi(parsed: dict) -> str | None:
+    """Classify one Pi JSONL line.
+
+    Pi uses ``type: "toolCall"`` (not ``tool_use``) in content blocks, and
+    ``message.role: "toolResult"`` as a top-level message role (not a content
+    block inside user messages like Claude Code).
+    """
+    line_type = parsed.get("type", "")
+
+    if line_type in _PI_SKIP_TYPES:
+        return None
+
+    if line_type in ("model_change", "thinking_level_change", "custom_message"):
+        return "system"
+
+    if line_type in ("compaction", "branch_summary"):
+        return "meta"
+
+    if line_type == "message":
+        msg = parsed.get("message", {})
+        role = msg.get("role", "")
+
+        if role == "user":
+            content = msg.get("content", [])
+            if not content:
+                return None
+            return "user_prompt"
+
+        if role == "assistant":
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        btype = block.get("type", "")
+                        if btype == "thinking":
+                            return "thinking"
+                        if btype == "toolCall":
+                            return "tool_call"
+                        if btype == "text":
+                            return "assistant_text"
+            return "assistant_text"
+
+        if role == "toolResult":
+            return "tool_result"
+
+        if role == "bashExecution":
+            return "tool_result"
+
+        if role in ("custom", "branchSummary", "compactionSummary"):
+            return "system"
+
+    # Unknown type -- store as system so nothing is silently dropped
+    return "system"
+
+
+def _preview_pi(parsed: dict, event_type: str) -> str:
+    """Extract preview text from a Pi JSONL line."""
+    try:
+        line_type = parsed.get("type", "")
+
+        if line_type == "message":
+            msg = parsed.get("message", {})
+            role = msg.get("role", "")
+            content = msg.get("content", [])
+
+            if role in ("user", "assistant"):
+                if isinstance(content, str):
+                    return content[:_PREVIEW_MAX]
+                if isinstance(content, list):
+                    parts: list[str] = []
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        btype = block.get("type", "")
+                        if btype == "text":
+                            parts.append(block.get("text", "")[:_PREVIEW_MAX])
+                        elif btype == "thinking":
+                            parts.append(block.get("thinking", "")[:_PREVIEW_MAX])
+                        elif btype == "toolCall":
+                            parts.append(f"[tool_call: {block.get('name', '')}]")
+                    return " ".join(parts)[:_PREVIEW_MAX]
+
+            if role == "toolResult":
+                tool_name = msg.get("toolName", "")
+                inner = msg.get("content", [])
+                if isinstance(inner, list):
+                    for item in inner:
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            return f"[{tool_name}] {item.get('text', '')}"[:_PREVIEW_MAX]
+                return f"[{tool_name}]"[:_PREVIEW_MAX]
+
+            if role == "bashExecution":
+                return f"$ {msg.get('command', '')}"[:_PREVIEW_MAX]
+
+        if line_type == "model_change":
+            return f"Model: {parsed.get('provider', '')}/{parsed.get('modelId', '')}"[:_PREVIEW_MAX]
+
+        if line_type == "thinking_level_change":
+            return f"Thinking: {parsed.get('thinkingLevel', '')}"[:_PREVIEW_MAX]
+
+        if line_type in ("compaction", "branch_summary"):
+            return parsed.get("summary", "")[:_PREVIEW_MAX]
+
+        if line_type == "custom_message":
+            c = parsed.get("content", "")
+            if isinstance(c, str):
+                return c[:_PREVIEW_MAX]
+
+    except Exception:
+        pass
+    return ""
+
+
+def _tool_info_pi(parsed: dict) -> tuple[str | None, str | None]:
+    """Extract (tool_name, tool_id) from a Pi JSONL line."""
+    if parsed.get("type") != "message":
+        return None, None
+    msg = parsed.get("message", {})
+    role = msg.get("role", "")
+
+    if role == "assistant":
+        content = msg.get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "toolCall":
+                    return block.get("name"), block.get("id")
+
+    if role == "toolResult":
+        return msg.get("toolName"), msg.get("toolCallId")
+
+    return None, None
+
+
+# ---------------------------------------------------------------------------
 # Registry  -- add new parsers here, update ide_registry.py session_parser key
 # ---------------------------------------------------------------------------
 
@@ -342,6 +482,7 @@ _CLASSIFIERS: dict[str, _Classifier] = {
     "claude-code": (_classify_claude_code, _preview_claude_code, _tool_info_claude_code),
     "kiro": (_classify_kiro, _preview_kiro, _tool_info_kiro),
     "cursor": (_classify_cursor, _preview_cursor, _tool_info_cursor),
+    "pi": (_classify_pi, _preview_pi, _tool_info_pi),
 }
 
 
@@ -427,10 +568,25 @@ def _ts_cursor(parsed: dict) -> str | None:
     return None
 
 
+def _ts_pi(parsed: dict) -> str | None:
+    """Return ClickHouse timestamp string from a Pi JSONL line, or None.
+
+    Pi uses ISO timestamps at the entry level (``parsed["timestamp"]``).
+    """
+    raw = parsed.get("timestamp")
+    if not raw:
+        return None
+    ts = str(raw).replace("T", " ").rstrip("Z")
+    if "." not in ts:
+        ts += ".000"
+    return ts
+
+
 _TS_EXTRACTORS: dict[str, object] = {
     "claude-code": _ts_claude_code,
     "kiro": _ts_kiro,
     "cursor": _ts_cursor,
+    "pi": _ts_pi,
 }
 
 
@@ -468,6 +624,7 @@ _EXTRA_ROWS_HANDLERS: dict[str, _ExtraRowsFn] = {
     "kiro": _kiro_extra_rows,
     "claude-code": _no_extra_rows,
     "cursor": _no_extra_rows,
+    "pi": _no_extra_rows,
 }
 
 

--- a/observal-server/services/session_parsers/pi.py
+++ b/observal-server/services/session_parsers/pi.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Pi session parser -- READ path (raw ClickHouse rows -> frontend events).
+
+Pi's JSONL format uses entry-level ``type`` + ``message.role`` structure.
+Tool calls use ``type: "toolCall"`` and tool results are ``role: "toolResult"``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from .base import basic_event, pick_timestamp
+
+
+def parse_rows(rows: list[dict]) -> list[dict]:
+    """Parse Pi session rows into normalised frontend events."""
+    events: list[dict] = []
+    # Maps toolCallId -> index in events for merge-on-result
+    tool_call_index: dict[str, int] = {}
+
+    for row in rows:
+        raw_line = row.get("raw_line", "")
+        ingested_at = row.get("ingested_at", "")
+        row_ts = row.get("timestamp", "")
+        ide = row.get("ide", "pi")
+
+        if not raw_line:
+            events.append(basic_event(row))
+            continue
+
+        try:
+            parsed = json.loads(raw_line)
+        except (json.JSONDecodeError, ValueError):
+            events.append(basic_event(row))
+            continue
+
+        line_type = parsed.get("type", "")
+        ts = pick_timestamp(parsed.get("timestamp"), row_ts, ingested_at)
+
+        if line_type == "message":
+            _handle_message(parsed, ts, ide, events, tool_call_index)
+        elif line_type == "model_change":
+            events.append(
+                {
+                    "timestamp": ts,
+                    "event_name": "hook_sessionstart",
+                    "body": f"Model: {parsed.get('provider', '')}/{parsed.get('modelId', '')}",
+                    "attributes": {
+                        "provider": parsed.get("provider", ""),
+                        "model": parsed.get("modelId", ""),
+                    },
+                    "service_name": ide,
+                }
+            )
+        elif line_type == "thinking_level_change":
+            events.append(
+                {
+                    "timestamp": ts,
+                    "event_name": "hook_sessionstart",
+                    "body": f"Thinking level: {parsed.get('thinkingLevel', '')}",
+                    "attributes": {"thinking_level": parsed.get("thinkingLevel", "")},
+                    "service_name": ide,
+                }
+            )
+        elif line_type in ("compaction", "branch_summary"):
+            events.append(
+                {
+                    "timestamp": ts,
+                    "event_name": "hook_assistant_response",
+                    "body": parsed.get("summary", "")[:100],
+                    "attributes": {"tool_response": parsed.get("summary", "")},
+                    "service_name": ide,
+                }
+            )
+        elif line_type == "custom_message":
+            content = parsed.get("content", "")
+            if isinstance(content, list):
+                content = "\n".join(
+                    b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text"
+                )
+            events.append(
+                {
+                    "timestamp": ts,
+                    "event_name": "hook_assistant_response",
+                    "body": str(content)[:100],
+                    "attributes": {"tool_response": str(content)},
+                    "service_name": ide,
+                }
+            )
+
+    return events
+
+
+def _handle_message(
+    parsed: dict,
+    ts: str,
+    ide: str,
+    events: list[dict],
+    tool_call_index: dict[str, int],
+) -> None:
+    msg = parsed.get("message", {})
+    role = msg.get("role", "")
+
+    if role == "user":
+        _handle_user(msg, ts, ide, events)
+    elif role == "assistant":
+        _handle_assistant(msg, ts, ide, events, tool_call_index)
+    elif role == "toolResult":
+        _handle_tool_result(msg, ts, ide, events, tool_call_index)
+    elif role == "bashExecution":
+        _handle_bash(msg, ts, ide, events)
+
+
+def _handle_user(msg: dict, ts: str, ide: str, events: list[dict]) -> None:
+    content = msg.get("content", [])
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        text = "\n".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
+    else:
+        text = str(content)
+
+    if text.strip():
+        events.append(
+            {
+                "timestamp": ts,
+                "event_name": "hook_userpromptsubmit",
+                "body": text[:100],
+                "attributes": {"tool_input": text},
+                "service_name": ide,
+            }
+        )
+
+
+def _handle_assistant(
+    msg: dict,
+    ts: str,
+    ide: str,
+    events: list[dict],
+    tool_call_index: dict[str, int],
+) -> None:
+    content = msg.get("content", [])
+    if not isinstance(content, list):
+        return
+
+    usage = msg.get("usage") or {}
+    token_attrs: dict = {}
+    if usage:
+        if usage.get("input"):
+            token_attrs["input_tokens"] = str(usage["input"])
+        if usage.get("output"):
+            token_attrs["output_tokens"] = str(usage["output"])
+        if usage.get("cacheRead"):
+            token_attrs["cache_read_tokens"] = str(usage["cacheRead"])
+        if usage.get("cacheWrite"):
+            token_attrs["cache_creation_tokens"] = str(usage["cacheWrite"])
+        if msg.get("model"):
+            token_attrs["model"] = msg["model"]
+        if msg.get("provider"):
+            token_attrs["provider"] = msg["provider"]
+        if msg.get("stopReason"):
+            token_attrs["stop_reason"] = msg["stopReason"]
+        # Pi-unique: cost data
+        cost = usage.get("cost", {})
+        if cost and cost.get("total"):
+            token_attrs["cost_usd"] = str(cost["total"])
+
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type", "")
+
+        if block_type == "thinking":
+            thinking_text = block.get("thinking", "")
+            events.append(
+                {
+                    "timestamp": ts,
+                    "event_name": "hook_assistant_thinking",
+                    "body": thinking_text[:100],
+                    "attributes": {"tool_response": thinking_text},
+                    "service_name": ide,
+                }
+            )
+
+        elif block_type == "text":
+            response_text = block.get("text", "")
+            attrs: dict = {"tool_response": response_text}
+            if token_attrs:
+                attrs.update(token_attrs)
+                token_attrs = {}  # consumed
+            events.append(
+                {
+                    "timestamp": ts,
+                    "event_name": "hook_assistant_response",
+                    "body": response_text[:100],
+                    "attributes": attrs,
+                    "service_name": ide,
+                }
+            )
+
+        elif block_type == "toolCall":
+            tool_call_id = block.get("id", "")
+            tool_name = block.get("name", "")
+            tool_input = block.get("arguments", {})
+            idx = len(events)
+            events.append(
+                {
+                    "timestamp": ts,
+                    "event_name": "hook_posttooluse",
+                    "body": tool_name,
+                    "attributes": {
+                        "tool_name": tool_name,
+                        "tool_input": json.dumps(tool_input),
+                        "tool_use_id": tool_call_id,
+                    },
+                    "service_name": ide,
+                }
+            )
+            if tool_call_id:
+                tool_call_index[tool_call_id] = idx
+
+    # Emit standalone token usage if not consumed by text block
+    if token_attrs:
+        events.append(
+            {
+                "timestamp": ts,
+                "event_name": "hook_token_usage",
+                "body": "",
+                "attributes": token_attrs,
+                "service_name": ide,
+            }
+        )
+
+
+def _handle_tool_result(
+    msg: dict,
+    ts: str,
+    ide: str,
+    events: list[dict],
+    tool_call_index: dict[str, int],
+) -> None:
+    tool_call_id = msg.get("toolCallId", "")
+    tool_name = msg.get("toolName", "")
+    content = msg.get("content", [])
+    is_error = msg.get("isError", False)
+
+    if isinstance(content, list):
+        result_text = "\n".join(c.get("text", "") for c in content if isinstance(c, dict) and c.get("type") == "text")
+    elif isinstance(content, str):
+        result_text = content
+    else:
+        result_text = str(content)
+
+    # Merge into preceding tool_call event if possible
+    if tool_call_id and tool_call_id in tool_call_index:
+        existing = events[tool_call_index[tool_call_id]]
+        existing["attributes"]["tool_response"] = result_text
+        if is_error:
+            existing["attributes"]["is_error"] = "true"
+    else:
+        # Standalone tool result (orphan or no matching call)
+        events.append(
+            {
+                "timestamp": ts,
+                "event_name": "hook_posttooluse",
+                "body": tool_name,
+                "attributes": {
+                    "tool_name": tool_name,
+                    "tool_response": result_text,
+                    "tool_use_id": tool_call_id,
+                    **({"is_error": "true"} if is_error else {}),
+                },
+                "service_name": ide,
+            }
+        )
+
+
+def _handle_bash(msg: dict, ts: str, ide: str, events: list[dict]) -> None:
+    command = msg.get("command", "")
+    output = msg.get("output", "")
+    exit_code = msg.get("exitCode")
+
+    events.append(
+        {
+            "timestamp": ts,
+            "event_name": "hook_posttooluse",
+            "body": "bash",
+            "attributes": {
+                "tool_name": "bash",
+                "tool_input": command,
+                "tool_response": output,
+                **({"exit_code": str(exit_code)} if exit_code is not None else {}),
+            },
+            "service_name": ide,
+        }
+    )

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -810,6 +810,7 @@ def _post_auth_onboarding():
             "Codex": (Path.home() / ".codex", "codex"),
             "Copilot": (Path.home() / ".vscode", "copilot"),
             "OpenCode": (Path.home() / ".config" / "opencode", "opencode"),
+            "Pi": (Path.home() / ".pi" / "agent", "pi"),
         }
 
         found: list[tuple[str, str, int, int]] = []  # (label, ide_key, agents, mcps)

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -26,7 +26,7 @@ from loguru import logger as optic
 from rich import print as rprint
 
 from observal_cli import config
-from observal_cli.ide_registry import get_home_mcp_configs, get_mcp_servers_key
+from observal_cli.ide_registry import get_home_mcp_configs, get_mcp_servers_key, get_valid_ides
 from observal_cli.ide_specs.claude_code_hooks_spec import (
     MANAGED_ENV_KEYS,
     get_desired_hooks,
@@ -87,7 +87,11 @@ def doctor(
     rprint("[cyan]Checking Kiro...[/cyan]")
     _check_kiro(issues, warnings)
 
-    # 4. Check if observal skill is installed
+    # 4. Check Pi
+    rprint("[cyan]Checking Pi...[/cyan]")
+    _check_pi(issues, warnings)
+
+    # 5. Check if observal skill is installed
     skill_missing = _check_observal_skill_missing()
     if skill_missing:
         warnings.append(
@@ -283,6 +287,33 @@ def _check_kiro(issues: list, warnings: list):
         warnings.append(
             "Kiro session push hooks not installed in any agent config. "
             "Run `observal doctor patch --all --ide kiro` to inject them."
+        )
+
+
+def _check_pi(issues: list, warnings: list):
+    """Check if Observal pi extension is installed."""
+    optic.debug("_check_pi")
+    pi_dir = Path.home() / ".pi" / "agent"
+    if not pi_dir.exists():
+        rprint("  [dim]Pi not detected[/dim]")
+        return
+
+    settings_path = pi_dir / "settings.json"
+    if not settings_path.exists():
+        rprint("  [dim]No ~/.pi/agent/settings.json found[/dim]")
+        return
+
+    data = _load_json(settings_path)
+    if data is None:
+        issues.append(f"{settings_path}: not valid JSON.")
+        return
+
+    packages = data.get("packages", [])
+    has_observal = any("observal-pi" in (p if isinstance(p, str) else p.get("source", "")) for p in packages)
+
+    if not has_observal:
+        warnings.append(
+            "Observal pi extension not installed. Run `pi install npm:observal-pi` to enable session telemetry."
         )
 
 
@@ -512,7 +543,7 @@ def _shim_config_file(config_path: Path, ide: str, dry_run: bool) -> int:
 
 
 _SHIM_TARGETS: dict[str, Path] = {ide: Path(path).expanduser() for ide, path in get_home_mcp_configs().items() if path}
-_VALID_IDES = list(_SHIM_TARGETS.keys())
+_VALID_IDES = get_valid_ides()
 
 
 # ── Patch command ────────────────────────────────────────────
@@ -579,6 +610,9 @@ def doctor_patch(
                 any_changes = any_changes or changed
             elif target == "cursor":
                 changed = _patch_cursor(dry_run)
+                any_changes = any_changes or changed
+            elif target == "pi":
+                changed = _patch_pi(dry_run)
                 any_changes = any_changes or changed
 
         # ── Shims (all IDEs with home MCP config) ──
@@ -753,4 +787,51 @@ def _patch_cursor(dry_run: bool) -> bool:
 
     verb = "Would install" if dry_run else "Installed"
     rprint(f"  {verb} hooks in {hooks_path}")
+    return True
+
+
+def _patch_pi(dry_run: bool) -> bool:
+    """Install observal-pi into ~/.pi/agent/settings.json packages."""
+    optic.debug("_patch_pi: dry_run={}", dry_run)
+
+    rprint("[cyan]Pi - session telemetry extension[/cyan]")
+
+    pi_dir = Path.home() / ".pi" / "agent"
+    if not pi_dir.is_dir():
+        rprint("  [dim]No ~/.pi/agent/ directory - skipping[/dim]")
+        return False
+
+    settings_path = pi_dir / "settings.json"
+    package_spec = "npm:observal-pi"
+
+    # Load existing settings
+    data: dict = {}
+    if settings_path.exists():
+        try:
+            data = json.loads(settings_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            data = {}
+
+    packages = data.get("packages", [])
+
+    # Check if already installed
+    already_installed = any(package_spec in (p if isinstance(p, str) else p.get("source", "")) for p in packages)
+
+    if already_installed:
+        rprint("  [dim]Already installed[/dim]")
+        return False
+
+    # Add the package
+    packages.append(package_spec)
+    data["packages"] = packages
+
+    if not dry_run:
+        if settings_path.exists():
+            _backup_config(settings_path)
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps(data, indent=2) + "\n")
+
+    verb = "Would install" if dry_run else "Installed"
+    rprint(f"  {verb} {package_spec} in {settings_path}")
+    rprint("  [dim]Restart pi or run /reload to activate[/dim]")
     return True

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -118,6 +118,7 @@ _IDE_HOME_DIRS: dict[str, str] = {
     "copilot-cli": "~/.copilot",
     "opencode": "~/.config/opencode",
     "cursor": "~/.cursor",
+    "pi": "~/.pi/agent",
 }
 
 

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -441,6 +441,7 @@ _USER_SKILL_DIRS: dict[str, str] = {
     "opencode": "~/.config/opencode/skills",
     "cursor": "~/.cursor/rules",
     "copilot": "~/.copilot/skills",
+    "pi": "~/.pi/agent/skills",
 }
 
 

--- a/observal_cli/ide/__init__.py
+++ b/observal_cli/ide/__init__.py
@@ -92,7 +92,7 @@ def get_all_adapters() -> dict[str, IdeAdapter]:
 
 
 # Expected number of adapters (updated when new IDEs are added)
-_EXPECTED_ADAPTER_COUNT = 8
+_EXPECTED_ADAPTER_COUNT = 9
 
 
 def ensure_loaded() -> None:

--- a/observal_cli/ide/load_all.py
+++ b/observal_cli/ide/load_all.py
@@ -11,3 +11,4 @@ from observal_cli.ide import cursor as _cursor  # noqa: F401
 from observal_cli.ide import gemini_cli as _gemini_cli  # noqa: F401
 from observal_cli.ide import kiro as _kiro  # noqa: F401
 from observal_cli.ide import opencode as _opencode  # noqa: F401
+from observal_cli.ide import pi as _pi  # noqa: F401

--- a/observal_cli/ide/pi.py
+++ b/observal_cli/ide/pi.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Pi IDE adapter - scanning, hook detection, shim status."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from observal_cli.ide import (
+    DiscoveredMcp,
+    DiscoveredSkill,
+    HookSpec,
+    ScanResult,
+    register_adapter,
+)
+from observal_cli.ide.base import BaseAdapter
+from observal_cli.shared.utils import extract_mcp_servers, first_content_line, parse_frontmatter_field
+
+
+class PiAdapter(BaseAdapter):
+    """Adapter for Pi.
+
+    Pi is harness-centric: the entirety of pi IS one agent.
+    MCP servers are managed via pi-mcp-adapter (reads ~/.pi/agent/mcp.json).
+    Hooks are delivered as the observal-pi package.
+    """
+
+    @property
+    def ide_name(self) -> str:
+        return "pi"
+
+    # ── Scanning ──────────────────────────────────────────────
+
+    def scan_home(self, home: Path | None = None) -> ScanResult:
+        """Discover MCPs from ~/.pi/agent/mcp.json, skills from ~/.pi/agent/skills/."""
+        home = home or Path.home()
+        pi_dir = home / ".pi" / "agent"
+        if not pi_dir.exists():
+            return ScanResult()
+
+        mcps = self._scan_mcps(pi_dir / "mcp.json", "pi:global")
+        skills = self._scan_skills(pi_dir / "skills")
+        return ScanResult(mcps=mcps, skills=skills)
+
+    def scan_project(self, project_dir: Path) -> ScanResult:
+        """Discover MCPs from .pi/mcp.json, skills from .pi/skills/."""
+        pi_dir = project_dir / ".pi"
+        if not pi_dir.exists():
+            return ScanResult()
+
+        mcps = self._scan_mcps(pi_dir / "mcp.json", "pi:project")
+        skills = self._scan_skills(pi_dir / "skills")
+        return ScanResult(mcps=mcps, skills=skills)
+
+    # ── Hook detection ────────────────────────────────────────
+
+    def get_hook_spec(self) -> HookSpec:
+        return HookSpec(
+            events=[],
+            format="extension",
+            markers=["observal-pi"],
+        )
+
+    def detect_hooks(self, config_dir: Path) -> str:
+        """Check if observal-pi is in settings.json packages."""
+        settings = config_dir / "settings.json"
+        if not settings.exists():
+            return "missing"
+        try:
+            data = json.loads(settings.read_text())
+        except (json.JSONDecodeError, OSError):
+            return "missing"
+
+        packages = data.get("packages", [])
+        has_observal = any(
+            "observal-pi" in (p if isinstance(p, str) else p.get("source", ""))
+            or "pi-extension" in (p if isinstance(p, str) else p.get("source", ""))
+            for p in packages
+        )
+        return "installed" if has_observal else "missing"
+
+    # ── Private helpers ───────────────────────────────────────
+
+    def _scan_mcps(self, mcp_file: Path, source: str) -> list[DiscoveredMcp]:
+        if not mcp_file.exists():
+            return []
+        try:
+            data = json.loads(mcp_file.read_text())
+            servers = extract_mcp_servers(data)
+            return [
+                DiscoveredMcp(
+                    name=name,
+                    command=cfg.get("command"),
+                    args=cfg.get("args", []),
+                    url=cfg.get("url"),
+                    description=f"Pi MCP: {name}",
+                    source=source,
+                )
+                for name, cfg in servers.items()
+                if isinstance(cfg, dict)
+            ]
+        except (json.JSONDecodeError, OSError):
+            return []
+
+    def _scan_skills(self, skills_dir: Path) -> list[DiscoveredSkill]:
+        if not skills_dir.is_dir():
+            return []
+        skills = []
+        for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+            name = skill_md.parent.name
+            desc = ""
+            try:
+                content = skill_md.read_text()
+                desc = parse_frontmatter_field(content, "description") or ""
+                if not desc:
+                    desc = first_content_line(content)
+            except OSError:
+                pass
+            skills.append(
+                DiscoveredSkill(
+                    name=name,
+                    description=desc or f"Skill: {name}",
+                    source="pi:skills",
+                )
+            )
+        return skills
+
+
+register_adapter(PiAdapter())

--- a/observal_cli/ide_registry.py
+++ b/observal_cli/ide_registry.py
@@ -316,6 +316,39 @@ IDE_REGISTRY: dict[str, dict] = {
         "accepts_model_choice": True,
         "auto_sentinel": {"omit_field": True},
     },
+    "pi": {
+        "display_name": "Pi",
+        "features": {"skills", "hooks", "mcp_servers"},
+        "session_parser": "pi",
+        "scopes": ["project", "user"],
+        "default_scope": "user",
+        "scope_labels": ("project (.pi/)", "user (~/.pi/agent/)"),
+        "rules_file": {
+            "project": "AGENTS.md",
+            "user": "~/.pi/agent/AGENTS.md",
+        },
+        "rules_format": "markdown",
+        "mcp_config_path": {
+            "project": ".pi/mcp.json",
+            "user": "~/.pi/agent/mcp.json",
+        },
+        "mcp_servers_key": "mcpServers",
+        "skill_file": {
+            "project": ".pi/skills/{name}/SKILL.md",
+            "user": "~/.pi/agent/skills/{name}/SKILL.md",
+        },
+        "skill_format": "yaml_frontmatter",
+        "home_mcp_config": "~/.pi/agent/mcp.json",
+        "hook_type": "extension",
+        "hook_config_path": {
+            "user": "~/.pi/agent/settings.json",
+        },
+        "hook_scripts_dir": None,
+        "hook_events_map": {},
+        "config_dir": ".pi",
+        "accepts_model_choice": True,
+        "auto_sentinel": {"omit_field": True},
+    },
 }
 
 

--- a/observal_cli/ide_specs/pi_hooks_spec.py
+++ b/observal_cli/ide_specs/pi_hooks_spec.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Hook specification for Pi.
+
+Pi uses in-process extensions for session telemetry, not command-based hooks.
+This module provides metadata for `observal doctor patch` to display guidance.
+"""
+
+from __future__ import annotations
+
+
+def build_hooks() -> dict:
+    """Return hook metadata for Pi.
+
+    Pi's hooks are delivered as the observal-pi npm package.
+    There is no settings.json injection - users install via `pi install`.
+    """
+    return {
+        "hook_type": "extension",
+        "install_command": "pi install npm:observal-pi",
+        "package": "observal-pi",
+    }

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -1,8 +1,9 @@
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
-
 ---
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
 name: observal
 command: observal
 description: "Core Observal CLI operations: pull agents into your IDE, scan installed components, diagnose and patch IDE configs, authenticate, and manage CLI settings. Use when the user wants to install an agent, check their IDE setup, login, or configure the CLI."

--- a/packages/pi-extension/LICENSE
+++ b/packages/pi-extension/LICENSE
@@ -1,0 +1,727 @@
+Copyright (c) 2026-present Observal (BlazeUp AI LLP)
+Registered Office: Chennai, Tamil Nadu, India
+Contact: contact@observal.io
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DUAL LICENSE STRUCTURE
+━━━━━━━━━━━━━━━━━━━━━━
+
+This repository uses a dual-license structure:
+
+  1. All content in this repository is licensed under the GNU Affero
+     General Public License v3.0 ("AGPL"), as published by the Free
+     Software Foundation - EXCEPT content residing under the "ee/"
+     directory.
+
+  2. Content under the "ee/" directory is licensed under the Observal
+     Enterprise License defined in "ee/LICENSE". That code is
+     source-available but requires a paid commercial license for any
+     production, internal enterprise, or commercial use.
+
+The open-source core (everything outside "ee/") is fully functional
+on its own and does not require any code in the "ee/" directory to
+operate.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+IMPORTANT — AGPL SECTION 7 NOTICE (ee/ boundary)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Pursuant to AGPL Section 7, the following additional permissions
+apply to the AGPL-licensed core (code outside "ee/"):
+
+  (a) You may combine or link the AGPL-licensed core with the
+      "ee/" directory code ONLY if you hold a valid Observal
+      Commercial License. Using the "ee/" features without a
+      commercial license, even if you have built the project
+      successfully, constitutes a violation of the "ee/LICENSE".
+
+  (b) The "ee/" directory code is NOT covered by the AGPL and
+      does NOT grant you any AGPL rights. The AGPL Section 7
+      additional permissions here apply only to the core code
+      (outside "ee/") and do not extend any license to "ee/".
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+COMMERCIAL LICENSE
+━━━━━━━━━━━━━━━━━━
+
+If you or your organization:
+
+  • Cannot comply with the AGPL (e.g., cannot open-source your
+    internal modifications or network-facing deployments),
+  • Want to use Observal in a proprietary product or internal
+    enterprise deployment without AGPL obligations,
+  • Want access to the enterprise features in the "ee/" directory,
+  • Require an SLA, IP indemnification, or compliance documentation,
+
+→ A commercial license is available from BlazeUp AI LLP.
+
+  Website : https://observal.io/
+  Email   : contact@observal.io
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+
+    Copyright (C) <year>  <organization>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/packages/pi-extension/README.md
+++ b/packages/pi-extension/README.md
@@ -1,0 +1,59 @@
+<!--
+SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# observal-pi
+
+Session telemetry extension for [Pi](https://pi.dev) that pushes conversation traces to your [Observal](https://obs-sync.dev) server.
+
+## Install
+
+```bash
+pi install npm:observal-pi
+```
+
+## Prerequisites
+
+1. An Observal account - run `observal auth login` to authenticate
+2. Pi installed (`>=0.74.0`)
+
+## What it does
+
+- **Incremental push:** After each user prompt (`agent_end`), reads new JSONL lines from the session file and POSTs them to your Observal server
+- **Final push:** On session exit, sends remaining lines with integrity metadata
+- **Crash recovery:** On startup, detects sessions that weren't cleanly finalized and pushes their remaining data
+- **Status indicator:** Shows `● observal` in the footer with line count
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/obs-sync` | Show sync status (lines pushed, server URL) |
+| `/obs-sync flush` | Force push pending lines now |
+| `/obs-sync config` | Show config file path and server URL |
+
+## Design
+
+- **Zero dependencies** - only `node:*` built-ins
+- **Fail-open** - never throws, never crashes pi. If the server is unreachable, pi continues normally
+- **5s timeout** - all HTTP calls abort after 5 seconds
+- **Chunked uploads** - batches of 500 lines max per request
+- **Dedup-safe** - server deduplicates by `(session_id, line_offset, line_hash)`
+
+## Configuration
+
+The extension reads credentials from `~/.observal/config.json` (written by `observal auth login`):
+
+```json
+{
+  "server_url": "https://your-server.observal.dev",
+  "access_token": "..."
+}
+```
+
+Sync state is tracked in `~/.observal/sync_state.json` (per-session byte offsets).
+
+## License
+
+AGPL-3.0-only - see [LICENSE](./LICENSE)

--- a/packages/pi-extension/extensions/observal.ts
+++ b/packages/pi-extension/extensions/observal.ts
@@ -1,0 +1,383 @@
+// SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Observal session telemetry extension for Pi.
+ *
+ * Reads the session JSONL file incrementally on lifecycle events and POSTs
+ * raw lines to the Observal ingest API. Zero runtime dependencies - uses
+ * only node:* built-ins.
+ *
+ * Design principles:
+ * - Fail-open: never throw, never crash pi
+ * - 5s timeout on all HTTP calls
+ * - Generation counter for async safety
+ * - Byte offset tracking (same model as CLI hooks)
+ * - Chunk at 500 lines per POST to avoid 413
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as https from "node:https";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface ObservalConfig {
+  server_url: string;
+  access_token: string;
+}
+
+interface CursorEntry {
+  offset: number;
+  line_count: number;
+  finalized?: boolean;
+}
+
+interface ObservalState {
+  config: ObservalConfig | null;
+  sessionFile: string | null;
+  sessionId: string;
+  byteOffset: number;
+  lineCount: number;
+  generation: number;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const OBSERVAL_DIR = path.join(os.homedir(), ".observal");
+const CONFIG_PATH = path.join(OBSERVAL_DIR, "config.json");
+const SYNC_STATE_PATH = path.join(OBSERVAL_DIR, "sync_state.json");
+const TIMEOUT_MS = 5_000;
+const MAX_LINES_PER_CHUNK = 500;
+const RECOVERY_MAX_SESSIONS = 5;
+const RECOVERY_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+// ─── Extension Entry ─────────────────────────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+  let state: ObservalState | null = null;
+
+  pi.on("session_start", async (event, ctx) => {
+    state = initState(ctx);
+
+    // On fresh startup, attempt crash recovery (fire-and-forget)
+    if (event.reason === "startup" && state.config) {
+      recoverStaleSessions(state, ctx).catch(() => {});
+    }
+
+    if (state.config && ctx.hasUI) {
+      const theme = ctx.ui.theme;
+      ctx.ui.setStatus("observal", theme.fg("dim", "● observal"));
+    }
+  });
+
+  pi.on("agent_end", async (_event, _ctx) => {
+    if (!state?.config || !state.sessionFile) return;
+    await pushNewLines(state, { final: false });
+  });
+
+  pi.on("session_shutdown", async (_event, _ctx) => {
+    if (!state?.config || !state.sessionFile) return;
+    await pushNewLines(state, { final: true });
+    state = null;
+  });
+
+  // ─── /obs-sync command ─────────────────────────────────────────────────
+
+  pi.registerCommand("obs-sync", {
+    description: "Observal telemetry sync status",
+    handler: async (args, ctx) => {
+      const sub = args.trim();
+      if (sub === "flush") {
+        if (!state?.config || !state.sessionFile) {
+          ctx.ui.notify("No active session or config", "warning");
+          return;
+        }
+        await pushNewLines(state, { final: false });
+        ctx.ui.notify(`Flushed (${state.lineCount} lines total)`, "info");
+      } else if (sub === "config") {
+        ctx.ui.notify(
+          `Config: ${CONFIG_PATH}\nServer: ${state?.config?.server_url ?? "not configured"}`,
+          "info",
+        );
+      } else {
+        const synced = state?.lineCount ?? 0;
+        const server = state?.config?.server_url ?? "not configured";
+        ctx.ui.notify(`Observal: ${synced} lines pushed\nServer: ${server}`, "info");
+      }
+    },
+  });
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────
+
+  function initState(ctx: ExtensionContext): ObservalState {
+    const config = loadConfig();
+    const sessionFile = ctx.sessionManager.getSessionFile() ?? null;
+    const sessionId = ctx.sessionManager.getSessionId();
+
+    let byteOffset = 0;
+    let lineCount = 0;
+
+    if (sessionId) {
+      const cursor = readCursor(sessionId);
+      byteOffset = cursor.offset;
+      lineCount = cursor.line_count;
+    }
+
+    return { config, sessionFile, sessionId, byteOffset, lineCount, generation: 0 };
+  }
+
+  function loadConfig(): ObservalConfig | null {
+    try {
+      if (!fs.existsSync(CONFIG_PATH)) return null;
+      const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+      const data = JSON.parse(raw);
+      if (!data.server_url || !data.access_token) return null;
+      return { server_url: data.server_url, access_token: data.access_token };
+    } catch {
+      return null;
+    }
+  }
+
+  function readCursor(sessionId: string): CursorEntry {
+    try {
+      if (!fs.existsSync(SYNC_STATE_PATH)) return { offset: 0, line_count: 0 };
+      const data = JSON.parse(fs.readFileSync(SYNC_STATE_PATH, "utf-8"));
+      return data[sessionId] ?? { offset: 0, line_count: 0 };
+    } catch {
+      return { offset: 0, line_count: 0 };
+    }
+  }
+
+  function writeCursor(sessionId: string, offset: number, lineCount: number, finalized = false): void {
+    try {
+      fs.mkdirSync(OBSERVAL_DIR, { recursive: true });
+      let data: Record<string, CursorEntry> = {};
+      if (fs.existsSync(SYNC_STATE_PATH)) {
+        data = JSON.parse(fs.readFileSync(SYNC_STATE_PATH, "utf-8"));
+      }
+      data[sessionId] = { offset, line_count: lineCount, finalized };
+      fs.writeFileSync(SYNC_STATE_PATH, JSON.stringify(data, null, 2));
+    } catch {
+      // Fail-open
+    }
+  }
+
+  async function pushNewLines(s: ObservalState, opts: { final: boolean }): Promise<void> {
+    if (!s.config || !s.sessionFile) return;
+
+    const gen = ++s.generation;
+
+    try {
+      const stat = fs.statSync(s.sessionFile);
+      const newBytes = stat.size - s.byteOffset;
+
+      if (newBytes <= 0) {
+        if (opts.final) writeCursor(s.sessionId, s.byteOffset, s.lineCount, true);
+        return;
+      }
+
+      const buffer = Buffer.alloc(newBytes);
+      const fd = fs.openSync(s.sessionFile, "r");
+      fs.readSync(fd, buffer, 0, newBytes, s.byteOffset);
+      fs.closeSync(fd);
+
+      if (s.generation !== gen) return; // stale
+
+      const text = buffer.toString("utf-8");
+      const rawLines = text.split("\n");
+
+      // Only consume complete lines (discard partial last line)
+      const lines: string[] = [];
+      let consumedBytes = 0;
+      for (let i = 0; i < rawLines.length; i++) {
+        const line = rawLines[i]!;
+        if (i === rawLines.length - 1 && !text.endsWith("\n")) {
+          break; // incomplete line
+        }
+        if (line.trim()) {
+          lines.push(line);
+        }
+        consumedBytes += Buffer.byteLength(line, "utf-8") + 1; // +1 for \n
+      }
+
+      if (lines.length === 0 && !opts.final) return;
+
+      // Chunk large batches
+      for (let offset = 0; offset < lines.length; offset += MAX_LINES_PER_CHUNK) {
+        if (s.generation !== gen) return; // stale
+
+        const chunk = lines.slice(offset, offset + MAX_LINES_PER_CHUNK);
+        const isLastChunk = offset + MAX_LINES_PER_CHUNK >= lines.length;
+
+        const payload = JSON.stringify({
+          session_id: s.sessionId,
+          ide: "pi",
+          lines: chunk,
+          start_offset: s.lineCount + offset,
+          hook_event: opts.final && isLastChunk ? "SessionShutdown" : "AgentEnd",
+          final: opts.final && isLastChunk,
+          ...(opts.final && isLastChunk
+            ? {
+                total_line_count: s.lineCount + lines.length,
+                total_offset: s.byteOffset + consumedBytes,
+              }
+            : {}),
+        });
+
+        const ok = await postWithTimeout(s.config!, "/api/v1/ingest/session", payload);
+        if (!ok) break; // stop chunking on failure, retry next time
+      }
+
+      if (s.generation !== gen) return; // stale
+
+      // Update state
+      s.byteOffset += consumedBytes;
+      s.lineCount += lines.length;
+      writeCursor(s.sessionId, s.byteOffset, s.lineCount, opts.final);
+    } catch {
+      // Fail-open
+    }
+  }
+
+  function postWithTimeout(config: ObservalConfig, urlPath: string, body: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      try {
+        const url = new URL(urlPath, config.server_url);
+        const mod = url.protocol === "https:" ? https : http;
+        const timer = setTimeout(() => {
+          req.destroy();
+          resolve(false);
+        }, TIMEOUT_MS);
+
+        const req = mod.request(
+          url,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${config.access_token}`,
+              "Content-Length": String(Buffer.byteLength(body)),
+            },
+          },
+          (res) => {
+            clearTimeout(timer);
+            res.resume(); // drain response
+            resolve(res.statusCode === 200);
+          },
+        );
+
+        req.on("error", () => {
+          clearTimeout(timer);
+          resolve(false);
+        });
+
+        req.write(body);
+        req.end();
+      } catch {
+        resolve(false);
+      }
+    });
+  }
+
+  async function recoverStaleSessions(s: ObservalState, ctx: ExtensionContext): Promise<void> {
+    try {
+      if (!fs.existsSync(SYNC_STATE_PATH) || !s.config) return;
+      const data: Record<string, CursorEntry> = JSON.parse(
+        fs.readFileSync(SYNC_STATE_PATH, "utf-8"),
+      );
+
+      const cwd = ctx.cwd;
+      const projectKey = cwd.replace(/\//g, "-");
+      const sessionsDir = path.join(os.homedir(), ".pi", "agent", "sessions");
+      // Pi uses --<path>-- format for directory names
+      const fullDir = path.join(sessionsDir, `-${projectKey}-`);
+
+      if (!fs.existsSync(fullDir)) return;
+
+      let recovered = 0;
+      const now = Date.now();
+
+      for (const [sessionId, entry] of Object.entries(data)) {
+        if (entry.finalized) continue;
+        if (sessionId === s.sessionId) continue; // current session
+        if (recovered >= RECOVERY_MAX_SESSIONS) break;
+
+        // Find the JSONL file for this session
+        const files = fs.readdirSync(fullDir).filter((f) => f.includes(sessionId));
+        if (files.length === 0) continue;
+
+        const filePath = path.join(fullDir, files[0]!);
+        if (!fs.existsSync(filePath)) continue;
+
+        // Skip sessions older than 7 days
+        const fileStat = fs.statSync(filePath);
+        if (now - fileStat.mtimeMs > RECOVERY_MAX_AGE_MS) {
+          writeCursor(sessionId, entry.offset, entry.line_count, true);
+          continue;
+        }
+
+        if (fileStat.size <= entry.offset) {
+          writeCursor(sessionId, entry.offset, entry.line_count, true);
+          continue;
+        }
+
+        const fd = fs.openSync(filePath, "r");
+        const buffer = Buffer.alloc(fileStat.size - entry.offset);
+        fs.readSync(fd, buffer, 0, buffer.length, entry.offset);
+        fs.closeSync(fd);
+
+        const lines = buffer
+          .toString("utf-8")
+          .split("\n")
+          .filter((l) => l.trim());
+
+        if (lines.length > 0) {
+          const payload = JSON.stringify({
+            session_id: sessionId,
+            ide: "pi",
+            lines,
+            start_offset: entry.line_count,
+            hook_event: "CrashRecovery",
+            final: true,
+            total_line_count: entry.line_count + lines.length,
+            total_offset: fileStat.size,
+          });
+          await postWithTimeout(s.config!, "/api/v1/ingest/session", payload);
+        }
+
+        writeCursor(sessionId, fileStat.size, entry.line_count + lines.length, true);
+        recovered++;
+      }
+
+      // Prune old finalized entries from sync_state.json
+      pruneSyncState();
+    } catch {
+      // Fail-open
+    }
+  }
+
+  function pruneSyncState(): void {
+    try {
+      if (!fs.existsSync(SYNC_STATE_PATH)) return;
+      const data: Record<string, CursorEntry> = JSON.parse(
+        fs.readFileSync(SYNC_STATE_PATH, "utf-8"),
+      );
+      const entries = Object.entries(data);
+      if (entries.length <= 50) return; // No pruning needed
+
+      // Keep only the 50 most recent entries (by offset as proxy for recency)
+      const sorted = entries.sort((a, b) => b[1].offset - a[1].offset);
+      const pruned: Record<string, CursorEntry> = {};
+      for (const [key, value] of sorted.slice(0, 50)) {
+        pruned[key] = value;
+      }
+      fs.writeFileSync(SYNC_STATE_PATH, JSON.stringify(pruned, null, 2));
+    } catch {
+      // Fail-open
+    }
+  }
+}

--- a/packages/pi-extension/extensions/observal.ts
+++ b/packages/pi-extension/extensions/observal.ts
@@ -34,6 +34,7 @@ interface CursorEntry {
   offset: number;
   line_count: number;
   finalized?: boolean;
+  last_pushed_at?: number;
 }
 
 interface ObservalState {
@@ -159,7 +160,7 @@ export default function (pi: ExtensionAPI) {
       if (fs.existsSync(SYNC_STATE_PATH)) {
         data = JSON.parse(fs.readFileSync(SYNC_STATE_PATH, "utf-8"));
       }
-      data[sessionId] = { offset, line_count: lineCount, finalized };
+      data[sessionId] = { offset, line_count: lineCount, finalized, last_pushed_at: Date.now() };
       fs.writeFileSync(SYNC_STATE_PATH, JSON.stringify(data, null, 2));
     } catch {
       // Fail-open
@@ -266,7 +267,7 @@ export default function (pi: ExtensionAPI) {
           (res) => {
             clearTimeout(timer);
             res.resume(); // drain response
-            resolve(res.statusCode === 200);
+            resolve(res.statusCode! >= 200 && res.statusCode! < 300);
           },
         );
 
@@ -290,10 +291,12 @@ export default function (pi: ExtensionAPI) {
         fs.readFileSync(SYNC_STATE_PATH, "utf-8"),
       );
 
+      // Use sessionManager to resolve session directory when available,
+      // falling back to the conventional path layout.
+      const sessionsDir = ctx.sessionManager.getSessionsDir?.()
+        ?? path.join(os.homedir(), ".pi", "agent", "sessions");
       const cwd = ctx.cwd;
       const projectKey = cwd.replace(/\//g, "-");
-      const sessionsDir = path.join(os.homedir(), ".pi", "agent", "sessions");
-      // Pi uses --<path>-- format for directory names
       const fullDir = path.join(sessionsDir, `-${projectKey}-`);
 
       if (!fs.existsSync(fullDir)) return;
@@ -369,8 +372,8 @@ export default function (pi: ExtensionAPI) {
       const entries = Object.entries(data);
       if (entries.length <= 50) return; // No pruning needed
 
-      // Keep only the 50 most recent entries (by offset as proxy for recency)
-      const sorted = entries.sort((a, b) => b[1].offset - a[1].offset);
+      // Keep only the 50 most recent entries (by last push time, falling back to offset)
+      const sorted = entries.sort((a, b) => (b[1].last_pushed_at ?? 0) - (a[1].last_pushed_at ?? 0));
       const pruned: Record<string, CursorEntry> = {};
       for (const [key, value] of sorted.slice(0, 50)) {
         pruned[key] = value;

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "observal-pi",
+  "version": "1.0.0",
+  "description": "Observal session telemetry for Pi — zero-dependency extension that pushes session traces to your Observal server",
+  "keywords": ["pi-package", "pi-extension", "observal", "telemetry", "tracing"],
+  "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BlazeUp-AI/Observal.git",
+    "directory": "packages/pi-extension"
+  },
+  "pi": {
+    "extensions": ["./extensions/observal.ts"]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "files": [
+    "extensions/",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/packages/pi-extension/package.json.license
+++ b/packages/pi-extension/package.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-only

--- a/tests/test_cli_ide_adapters.py
+++ b/tests/test_cli_ide_adapters.py
@@ -38,6 +38,7 @@ class TestAdapterRegistry:
             "copilot",
             "copilot-cli",
             "opencode",
+            "pi",
         }
         assert set(adapters.keys()) == expected
 

--- a/tests/test_constants_sync.py
+++ b/tests/test_constants_sync.py
@@ -79,6 +79,7 @@ def test_ide_registry_model_choice_fields():
         "codex": True,
         "gemini-cli": True,
         "opencode": True,
+        "pi": True,
         "cursor": False,
         "copilot": False,
         "copilot-cli": False,

--- a/tests/test_pi_session_parser.py
+++ b/tests/test_pi_session_parser.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for Pi session parser and classifiers."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "observal-server"))
+
+from services.session_ingest import _usage_pi, _uuid_pi
+from services.session_parsers.ingest_classify import (
+    _classify_pi,
+    _preview_pi,
+    _tool_info_pi,
+    _ts_pi,
+)
+
+# ── Sample Pi JSONL lines ─────────────────────────────────────────────────────
+
+SESSION_HEADER = (
+    '{"type":"session","version":3,"id":"019e5adf-dd81","timestamp":"2026-05-24T16:44:41.217Z","cwd":"/Users/test"}'
+)
+MODEL_CHANGE = '{"type":"model_change","id":"d6ec41d1","parentId":null,"timestamp":"2026-05-24T09:04:17.964Z","provider":"amazon-bedrock","modelId":"eu.anthropic.claude-opus-4-6-v1"}'
+THINKING_LEVEL = '{"type":"thinking_level_change","id":"8bc16d27","parentId":"d6ec41d1","timestamp":"2026-05-24T09:04:17.964Z","thinkingLevel":"high"}'
+USER_PROMPT = '{"type":"message","id":"e67e72b6","parentId":"8bc16d27","timestamp":"2026-05-24T09:04:17.968Z","message":{"role":"user","content":[{"type":"text","text":"what is 2+2"}],"timestamp":1779624000000}}'
+ASSISTANT_THINKING = '{"type":"message","id":"e91018f9","parentId":"e67e72b6","timestamp":"2026-05-24T09:04:23.288Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"4."},{"type":"text","text":"The answer is 4."}],"api":"bedrock-converse-stream","provider":"amazon-bedrock","model":"eu.anthropic.claude-opus-4-6-v1","usage":{"input":3,"output":4,"cacheRead":100,"cacheWrite":200,"totalTokens":307,"cost":{"input":0.00001,"output":0.00006,"cacheRead":0.0001,"cacheWrite":0.001,"total":0.00117}},"stopReason":"stop","timestamp":1779624005000}}'
+TOOL_CALL = '{"type":"message","id":"cba220e0","parentId":"075da560","timestamp":"2026-05-24T13:35:54.577Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"tooluse_abc123","name":"read","arguments":{"path":"/tmp/test.txt"}}],"model":"eu.anthropic.claude-opus-4-6-v1","usage":{"input":10,"output":20,"cacheRead":0,"cacheWrite":0},"stopReason":"toolUse","timestamp":1779629754577}}'
+TOOL_RESULT = '{"type":"message","id":"075da560","parentId":"cba220e0","timestamp":"2026-05-24T13:35:49.253Z","message":{"role":"toolResult","toolCallId":"tooluse_abc123","toolName":"read","content":[{"type":"text","text":"file contents here"}],"isError":false,"timestamp":1779629749253}}'
+BASH_EXECUTION = '{"type":"message","id":"bash1","parentId":"prev1","timestamp":"2026-05-24T10:00:00.000Z","message":{"role":"bashExecution","command":"ls -la","output":"total 0\\ndrwxr-xr-x 2 user staff 64 May 24 10:00 .","exitCode":0,"cancelled":false,"truncated":false,"timestamp":1779624000000}}'
+CUSTOM_ENTRY = '{"type":"custom","id":"h8i9j0k1","parentId":"g7h8i9j0","timestamp":"2026-05-24T14:20:00.000Z","customType":"my-extension","data":{"count":42}}'
+COMPACTION = '{"type":"compaction","id":"f6g7h8i9","parentId":"e5f6g7h8","timestamp":"2026-05-24T14:10:00.000Z","summary":"User discussed project setup and configuration.","firstKeptEntryId":"c3d4e5f6","tokensBefore":50000}'
+EMPTY_USER = '{"type":"message","id":"empty1","parentId":"prev1","timestamp":"2026-05-24T10:00:00.000Z","message":{"role":"user","content":[],"timestamp":1779624000000}}'
+
+
+class TestClassifyPi:
+    def test_session_header_skipped(self):
+        assert _classify_pi(json.loads(SESSION_HEADER)) is None
+
+    def test_model_change_is_system(self):
+        assert _classify_pi(json.loads(MODEL_CHANGE)) == "system"
+
+    def test_thinking_level_is_system(self):
+        assert _classify_pi(json.loads(THINKING_LEVEL)) == "system"
+
+    def test_user_prompt(self):
+        assert _classify_pi(json.loads(USER_PROMPT)) == "user_prompt"
+
+    def test_empty_user_prompt_skipped(self):
+        assert _classify_pi(json.loads(EMPTY_USER)) is None
+
+    def test_assistant_with_thinking_is_thinking(self):
+        assert _classify_pi(json.loads(ASSISTANT_THINKING)) == "thinking"
+
+    def test_tool_call(self):
+        assert _classify_pi(json.loads(TOOL_CALL)) == "tool_call"
+
+    def test_tool_result(self):
+        assert _classify_pi(json.loads(TOOL_RESULT)) == "tool_result"
+
+    def test_bash_execution_is_tool_result(self):
+        assert _classify_pi(json.loads(BASH_EXECUTION)) == "tool_result"
+
+    def test_custom_entry_skipped(self):
+        assert _classify_pi(json.loads(CUSTOM_ENTRY)) is None
+
+    def test_compaction_is_meta(self):
+        assert _classify_pi(json.loads(COMPACTION)) == "meta"
+
+
+class TestPreviewPi:
+    def test_user_prompt_preview(self):
+        parsed = json.loads(USER_PROMPT)
+        assert _preview_pi(parsed, "user_prompt") == "what is 2+2"
+
+    def test_assistant_text_preview(self):
+        parsed = json.loads(ASSISTANT_THINKING)
+        # First block is thinking, so preview picks that
+        preview = _preview_pi(parsed, "thinking")
+        assert "4." in preview
+
+    def test_tool_call_preview(self):
+        parsed = json.loads(TOOL_CALL)
+        preview = _preview_pi(parsed, "tool_call")
+        assert "[tool_call: read]" in preview
+
+    def test_tool_result_preview(self):
+        parsed = json.loads(TOOL_RESULT)
+        preview = _preview_pi(parsed, "tool_result")
+        assert "[read]" in preview
+        assert "file contents" in preview
+
+    def test_bash_preview(self):
+        parsed = json.loads(BASH_EXECUTION)
+        preview = _preview_pi(parsed, "tool_result")
+        assert preview == "$ ls -la"
+
+    def test_model_change_preview(self):
+        parsed = json.loads(MODEL_CHANGE)
+        preview = _preview_pi(parsed, "system")
+        assert "amazon-bedrock" in preview
+        assert "claude-opus" in preview
+
+    def test_compaction_preview(self):
+        parsed = json.loads(COMPACTION)
+        preview = _preview_pi(parsed, "meta")
+        assert "project setup" in preview
+
+
+class TestToolInfoPi:
+    def test_tool_call_extracts_name_and_id(self):
+        parsed = json.loads(TOOL_CALL)
+        name, tool_id = _tool_info_pi(parsed)
+        assert name == "read"
+        assert tool_id == "tooluse_abc123"
+
+    def test_tool_result_extracts_name_and_id(self):
+        parsed = json.loads(TOOL_RESULT)
+        name, tool_id = _tool_info_pi(parsed)
+        assert name == "read"
+        assert tool_id == "tooluse_abc123"
+
+    def test_user_prompt_returns_none(self):
+        parsed = json.loads(USER_PROMPT)
+        name, tool_id = _tool_info_pi(parsed)
+        assert name is None
+        assert tool_id is None
+
+    def test_non_message_returns_none(self):
+        parsed = json.loads(MODEL_CHANGE)
+        name, tool_id = _tool_info_pi(parsed)
+        assert name is None
+        assert tool_id is None
+
+
+class TestTimestampPi:
+    def test_extracts_iso_timestamp(self):
+        parsed = json.loads(USER_PROMPT)
+        ts = _ts_pi(parsed)
+        assert ts == "2026-05-24 09:04:17.968"
+
+    def test_no_timestamp_returns_none(self):
+        assert _ts_pi({}) is None
+
+    def test_adds_millis_if_missing(self):
+        parsed = {"timestamp": "2026-05-24T10:00:00Z"}
+        ts = _ts_pi(parsed)
+        assert ts == "2026-05-24 10:00:00.000"
+
+
+class TestUsagePi:
+    def test_extracts_pi_usage_fields(self):
+        parsed = json.loads(ASSISTANT_THINKING)
+        result = _usage_pi(parsed)
+        assert result["input_tokens"] == 3
+        assert result["output_tokens"] == 4
+        assert result["cache_read_tokens"] == 100
+        assert result["cache_write_tokens"] == 200
+        assert result["model"] == "eu.anthropic.claude-opus-4-6-v1"
+
+    def test_missing_usage_returns_zeros(self):
+        parsed = json.loads(USER_PROMPT)
+        result = _usage_pi(parsed)
+        assert result["input_tokens"] == 0
+        assert result["output_tokens"] == 0
+
+
+class TestUuidPi:
+    def test_extracts_id_and_parent_id(self):
+        parsed = json.loads(USER_PROMPT)
+        uuid, parent_uuid = _uuid_pi(parsed)
+        assert uuid == "e67e72b6"
+        assert parent_uuid == "8bc16d27"
+
+    def test_null_parent_id(self):
+        parsed = json.loads(MODEL_CHANGE)
+        uuid, parent_uuid = _uuid_pi(parsed)
+        assert uuid == "d6ec41d1"
+        assert parent_uuid is None

--- a/web/src/lib/ide-features.ts
+++ b/web/src/lib/ide-features.ts
@@ -21,6 +21,7 @@ export const VALID_IDES = [
   "gemini-cli",
   "kiro",
   "opencode",
+  "pi",
 ] as const;
 
 export type IdeName = (typeof VALID_IDES)[number];
@@ -46,6 +47,7 @@ export const IDE_FEATURE_MATRIX: Record<IdeName, ReadonlySet<IdeFeature>> = {
   copilot: new Set(["mcp_servers", "rules"]),
   "copilot-cli": new Set(["mcp_servers", "rules", "hook_bridge", "skills"]),
   opencode: new Set(["mcp_servers", "rules"]),
+  pi: new Set(["skills", "hook_bridge", "mcp_servers", "rules"]),
 };
 
 export const IDE_DISPLAY_NAMES: Record<IdeName, string> = {
@@ -57,6 +59,7 @@ export const IDE_DISPLAY_NAMES: Record<IdeName, string> = {
   copilot: "Copilot",
   "copilot-cli": "Copilot CLI",
   opencode: "OpenCode",
+  pi: "Pi",
 };
 
 export const FEATURE_LABELS: Record<IdeFeature, string> = {
@@ -80,6 +83,7 @@ export const IDE_ACCEPTS_MODEL_CHOICE: Record<IdeName, boolean> = {
   "gemini-cli": true,
   codex: true,
   opencode: true,
+  pi: true,
   cursor: false,
   copilot: false,
   "copilot-cli": false,


### PR DESCRIPTION
## Purpose / Description

Add full IDE support for Pi (https://pi.dev) — our first harness-centric IDE integration. Pi is different from Claude Code/Kiro/Cursor: the entirety of pi IS one agent, and `observal pull` writes `AGENTS.md` which becomes the whole system prompt (harness pivot).

This PR adds:
1. Server-side session parser - classifies Pi JSONL format (toolCall/toolResult/bashExecution)
2. CLI adapter - scanning, hook detection, doctor patch support
3. Extension package (`packages/pi-extension/`) - zero-dep TypeScript extension that pushes session traces to Observal
4. Full `doctor patch` support - auto-installs the extension into Pi settings.json

## Fixes

* New feature (no existing issue)

## Approach

Follows [docs/adding-an-ide.md](https://github.com/BlazeUp-AI/Observal/blob/main/docs/adding-an-ide.md) checklist:

- IDE Registry entry with `hook_type: "extension"` (novel - Pi uses in-process extensions, not command hooks)
- Session parser handles Pi format differences: `toolCall` (not `tool_use`), `toolResult` as message role, `bashExecution`, `id`/`parentId` at entry level
- `_USAGE_EXTRACTORS` dispatch dict (Pi uses `usage.input`/`output`/`cacheRead`/`cacheWrite`)
- `_UUID_EXTRACTORS` dispatch dict (Pi uses `id`/`parentId` not `uuid`/`parentUuid`)
- MCP config at `~/.pi/agent/mcp.json` (read by pi-mcp-adapter) - enables shims + sandboxes
- `_patch_pi()` writes `npm:@observal/pi-extension` to `~/.pi/agent/settings.json` packages array

The extension (`packages/pi-extension/extensions/observal.ts`):
- Hooks `session_start`, `agent_end`, `session_shutdown` lifecycle
- Reads JSONL from byte offset, POSTs raw lines to `/api/v1/ingest/session`
- Chunked at 500 lines, 5s timeout, fail-open, generation counter
- Crash recovery on startup (5 sessions, 7 day cap, async)
- `/observal` command for status/flush/config

## How Has This Been Tested?

1. Installed extension locally: `pi install /path/to/packages/pi-extension`
2. Ran pi sessions - traces appeared in Observal frontend (thinking, tool calls, assistant responses all visible)
3. Verified classifier with real Pi JSONL data (all event types: user_prompt, thinking, tool_call, tool_result, assistant_text, system, meta)
4. Verified token extraction maps Pi `usage.input`/`output` correctly
5. Verified UUID extraction maps Pi `id`/`parentId` correctly
6. `observal doctor patch --hook --ide pi` correctly writes to settings.json
7. Syntax-checked all 24 modified/new files

## Learning

- Pi session format is similar to Claude Code but with key differences: `toolCall` vs `tool_use`, `toolResult` as a message role, `bashExecution` for shell commands, ISO timestamps at entry level
- Pi extension API provides `session_start`/`agent_end`/`session_shutdown` lifecycle hooks + `ctx.sessionManager.getSessionFile()`/`getSessionId()`
- Pi package system uses `~/.pi/agent/settings.json` `packages` array with `npm:` or local path references
- Pi-mcp-adapter reads MCP config from `~/.pi/agent/mcp.json` - this enables Observal MCP shims and sandboxes

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)