### PR TITLE
docs: rewrite AGENTS.md files to reflect current architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,57 +5,191 @@
 
 # AGENTS.md
 
-Internal context for contributors and AI coding agents. Use `README.md` as the public source of truth for API endpoints and CLI usage. Use `SETUP.md` for environment setup.
+Internal context for contributors and AI coding agents. Use `README.md` for the public API reference, `SETUP.md` for environment setup, and `docs/adding-an-ide.md` for IDE integration.
 
-## Current state
+## What Observal is
 
-Observal is an agent-centric registry and observability platform for AI coding agents. Agents are the primary entity, bundling 5 component types: MCP servers, skills, hooks, prompts, and sandboxes. All components have CRUD, CLI commands, admin review, feedback, and telemetry collection. Agents bundle components via a polymorphic junction table (`agent_components`).
+Observal is an agent-centric registry and observability platform for AI coding agents. Users interact with it three ways:
 
-All API routes accept either UUID or name for path parameters. Admin review controls public registry visibility only. Submitters can install and use their own items immediately without approval.
+1. **CLI** (`observal`): pull agents, scan IDEs, submit components, manage the server
+2. **Web UI** (`web/`): browse the registry, view traces, manage users, admin dashboard
+3. **Observal skill** (bundled, auto-installed on login): lets the LLM inside any IDE drive Observal commands directly (e.g. "create an agent that uses the github MCP")
 
-The MCP validator supports multiple frameworks: FastMCP, standard MCP SDK (Python), TypeScript SDK (`@modelcontextprotocol/sdk`), and Go SDK (`mcp-go`). There is no framework enforcement - all MCP implementations are accepted.
+Agents are the primary entity. Each agent bundles 5 component types: MCP servers, skills, hooks, prompts, and sandboxes. When a user runs `observal pull <agent>`, the platform resolves all components and writes IDE-specific config files.
 
-The platform generates portable agent configs for 8 IDEs: Claude Code, Cursor, Gemini CLI, Kiro, VS Code, Codex CLI, GitHub Copilot, and OpenCode. The agent builder (`services/agent_builder.py`) and agent resolver (`services/agent_resolver.py`) compose and validate component bundles into IDE-specific output formats.
+## IDE support tiers
 
-The web frontend is a Next.js 16 / React 19 app in `web/`. It uses four route groups: `(auth)` for login and device authorization, `(registry)` for the public-facing agent browser, component library, leaderboard, and agent builder, `(admin)` for the admin dashboard, eval, review, alerts, insights, diagnostics, SSO, audit log, security events, user management, and settings, and `(user)` for user-scoped trace views. The frontend has a custom OKLCH design system with 5 themes (light, dark, midnight, forest, sunset), three typefaces (Archivo for display, Albert Sans for body, JetBrains Mono for code), and a 4pt spacing scale. It uses shadcn/ui components, Recharts for charts, TanStack Query for data fetching, and TanStack Table for sortable/filterable tables. Shared API response types live in `web/src/lib/types.ts`. The GraphQL API at `/api/v1/graphql` is the read layer for telemetry data; REST endpoints serve everything else.
+**First-class** (full session parsing, hooks, scanning, config gen, tested e2e):
+- Claude Code
+- Kiro
+- Cursor
+- Pi
+
+**Functional** (config gen and scanning work, but no session parser or hook spec):
+- Gemini CLI, Codex CLI, Copilot, Copilot CLI, OpenCode
+
+See `docs/adding-an-ide.md` for the complete guide to adding or promoting an IDE.
+
+## Architecture at a glance
+
+```
+observal_cli/          Python CLI (Typer)
+  ide/                 CLI-side IDE adapters (protocol.py, base.py, 9 adapters)
+  ide_specs/           Hook specs (claude_code, kiro, pi only)
+  skills/              Bundled skills installed on login (observal, observal-admin, etc.)
+
+observal-server/       FastAPI server
+  api/routes/          REST endpoints (agent/, admin/ are sub-packages)
+  api/middleware/      Audit, request-id, content-type
+  models/              SQLAlchemy models (PostgreSQL)
+  schemas/             Pydantic request/response schemas
+  services/            Business logic
+    clickhouse/        ClickHouse subpackage (client, schema, insert, query)
+    ide/               Server-side IDE adapters (config generation)
+    session_parsers/   Per-IDE JSONL parsers (claude_code, kiro, cursor, pi)
+    audit/             HIPAA audit system (loguru-based)
+    config/            Config generation helpers (mcp_builder, skill_builder)
+    insights/          Open-source insight stub (full impl in ee/)
+    shared/            Cross-service utilities
+  jobs/                Background job definitions (catalog, maintenance)
+
+ee/                    Enterprise (source-available, separate license)
+  license.py           JWT license validation
+  observal_insights/   Full insight pipeline (~20 modules)
+  observal_server/     EE routes + services (audit, SAML, SCIM, exec dashboard)
+
+web/                   Next.js 16 / React 19 frontend
+packages/pi-extension/ Pi telemetry extension (npm: observal-pi)
+docker/                Docker Compose stack (10 services)
+tests/                 pytest (123 files)
+tests/e2e/             Playwright (19 specs)
+```
+
+## How the modularisation works
+
+The codebase follows a strict adapter pattern for IDE-specific logic. This is the most important architectural decision:
+
+**One adapter per IDE, on both sides.** CLI adapters handle scanning and hook detection (`observal_cli/ide/<name>.py`). Server adapters handle config file generation (`observal-server/services/ide/<name>.py`). The IDE registry (`ide_registry.py`, mirrored on both sides) defines paths, keys, features, and event maps.
+
+**No if/elif chains for IDE logic.** If you need IDE-specific behavior, it goes in the adapter. The orchestrators (`cmd_scan.py`, `agent_builder.py`, `cmd_doctor.py`) call adapters via the registry, never with conditionals.
+
+**Feature-flag gating.** Each adapter method maps to a feature (`hooks`, `mcp_servers`, `skills`). The `BaseAdapter` raises `NotSupportedError` if the IDE's registry entry lacks the required feature. This means stubs are safe: they exist but can't be called for unsupported operations.
+
+**Session parsers are separate from adapters.** They live in `services/session_parsers/` (server-side) and handle converting raw JSONL into normalized trace events. Only first-class IDEs have parsers.
+
+### What "first-class" means concretely
+
+A first-class IDE has all of:
+- A hook spec in `ide_specs/` (defines what `doctor patch --hook` installs)
+- A session parser in `services/session_parsers/` (enables `observal reconcile`)
+- Full scanning implementation in its CLI adapter (discovers MCPs, skills, hooks, agents)
+- E2E test coverage in `tests/e2e/`
+
+A stub IDE has:
+- A registry entry with correct paths
+- A CLI adapter that handles basic MCP scanning
+- A server adapter that generates config files
+- No hook spec, no session parser, no e2e tests
+
+## Coding patterns we prefer
+
+### Python (server + CLI)
+
+- **Ruff** for lint and format. Line length 120. Pre-commit enforces it.
+- **Loguru for dev logging** (`from loguru import logger as optic`). Positional args only: `optic.debug("x={}", x)`. Never f-strings in log calls.
+- **Typer for CLI.** `B008` suppressed because Typer requires function calls in argument defaults.
+- **Dynamic settings** for runtime config: `from services.dynamic_settings import get, get_int, get_bool`. Non-boot settings live in the DB, not env vars.
+- **SSRF guard** for all outbound network: `from services.ssrf_guard import check_url`. Used in webhooks, git clone, MCP analysis.
+- **Feature gating via license**: `from ee.license import is_feature_licensed`. Never import other `ee/` modules from core.
+- **Conventional Commits**: `feat`, `fix`, `docs`, `refactor`, `test`, `build`, `ci`, `chore`. Scope in parens. No fixup commits (amend instead).
+
+### TypeScript (web)
+
+- **sessionStorage** for auth state (API key, user role). Never localStorage.
+- **TanStack Query hooks** from `use-api.ts` for all data fetching. No raw `fetch` in components.
+- **Types centralized** in `src/lib/types.ts`. No inline API response types.
+- **Feature gating** is server-side: API returns 403 for unlicensed features. Frontend shows upgrade prompts.
+- **IDE list from server** (`/api/v1/config/ides`), never hardcoded in frontend.
+- **OKLCH color tokens** in `globals.css`. No raw hex/rgb in components.
+
+### General
+
+- **No OTLP env vars.** Telemetry flows through `observal-shim` (stdio proxy) and session push hooks. Never generate `OTEL_*` or `CLAUDE_CODE_ENABLE_TELEMETRY` vars.
+- **Owner fallback on install.** Submitters can install their own items without admin approval. Approved items are preferred, but pending/rejected items are accessible to the submitter.
+- **UUID or name** everywhere. All API path params accept either. Server resolves via `resolve_listing()`.
+- **Hard rewrite policy.** No deprecation wrappers. When code moves, callers update in the same PR. Dead code is deleted immediately.
+- **Tests mock externals.** No Docker needed to run the test suite. E2E specs in `tests/e2e/` are the exception (require running stack).
 
 ## CLI structure
 
-The CLI is organized into nested command groups:
-
 ```
 observal
-├── pull                     # install complete agent (primary workflow)
-├── scan                     # discover what's installed across IDEs (read-only)
-├── reconcile                # parse local session files and send enrichment to server
+├── pull                     # install agent into IDE (primary workflow)
+├── scan                     # read-only discovery of what's installed
+├── reconcile                # push local session JSONL to server for rich traces
 ├── use / profile            # swap IDE configs from git-hosted profiles
-├── uninstall                # tear down Docker stack, remove repo and config
-├── auth                     # init, login, logout, whoami, status
+├── uninstall                # tear down Docker stack and config
+├── auth                     # login, register, reset-password, logout, whoami, status
 ├── config                   # show, set, path, alias, aliases
-├── registry                 # component registry parent group
+├── registry                 # component parent group
 │   ├── mcp                  #   submit, list, show, install, delete
 │   ├── skill                #   submit, list, show, install, delete
 │   ├── hook                 #   submit, list, show, install, delete
 │   ├── prompt               #   submit, list, show, install, render, delete
-│   └── sandbox              #   submit, list, show, install, delete
+│   ├── sandbox              #   submit, list, show, install, delete
+│   └── models               #   list (public model catalog)
+├── component                # version commands (list-versions, publish, show-version)
 ├── agent                    # create, list, show, install, delete, init, add, build, publish
-├── ops                      # observability commands
-│   ├── overview, metrics, top, traces, spans
-│   ├── rate, feedback
+├── ops                      # overview, metrics, top, rate, feedback
 │   └── telemetry            #   status, test
-├── admin                    # admin commands
-│   ├── settings, set, users
-│   ├── penalties, penalty-set, weights, weight-set
-│   ├── canaries, canary-add, canary-reports, canary-delete
-│   ├── review               #   list, show, approve, reject
-│   └── eval                 #   run, scorecards, show, compare, aggregate
-├── migrate                  # ClickHouse telemetry migration tools
-├── self                     # upgrade, downgrade
-├── doctor                   # diagnose IDE settings; `doctor patch` applies instrumentation
-└── logs                     # live dev log viewer (--level, --filter, --lines, --no-follow)
+├── admin                    # settings, set, users, review (list/show/approve/reject)
+├── server                   # start, stop, restart, status, logs, install, reset, config
+├── self                     # upgrade, downgrade, rollback, status
+├── support                  # bundle (diagnostic tarball with redaction)
+├── doctor                   # diagnose + patch IDE settings for all 9 IDEs
+├── migrate                  # ClickHouse migration tools
+└── logs                     # live dev log viewer
 ```
 
-Deprecated root-level aliases exist for backward compatibility (e.g. `observal submit` → `observal registry mcp submit`, `observal upgrade` → `observal self upgrade`). These are hidden from `--help` and print deprecation warnings.
+## Server routes
+
+REST at `/api/v1/`. GraphQL at `/api/v1/graphql` (read-only telemetry layer with subscriptions).
+
+Key route files: `auth.py`, `mcp.py`, `skill.py`, `hook.py`, `prompt.py`, `sandbox.py`, `review.py`, `feedback.py`, `dashboard.py`, `insights.py`, `reconcile.py`, `ingest.py`, `telemetry.py`, `alert.py`, `config.py`, `sessions.py`, `device_auth.py`, `jwks.py`, `component_source.py`, `component_versions.py`, `agent_versions.py`, `bulk.py`, `support.py`, `preview.py`, `audit.py`, `registry_models.py`.
+
+Sub-packages: `agent/` (crud, install, draft), `admin/` (enterprise_settings, users, org, retention).
+
+## Database architecture
+
+- **PostgreSQL**: relational data (users, agents, components, feedback, settings). SQLAlchemy async.
+- **ClickHouse**: time-series telemetry (traces, spans, scores, audit events). HTTP interface, ReplacingMergeTree, bloom filter indexes. Split into `services/clickhouse/` (client, schema, insert, query).
+- **Redis**: pub/sub for GraphQL subscriptions, arq job queue, dynamic settings cache, auth token revocation.
+
+## Telemetry pipeline
+
+```
+IDE ──→ observal-shim (stdio proxy) ──→ POST /ingest ──→ ClickHouse
+IDE ──→ session push hooks ──→ POST /hooks ──→ ClickHouse
+CLI ──→ observal reconcile ──→ POST /reconcile ──→ ClickHouse (enrichment)
+```
+
+The shim never modifies messages, only observes. Telemetry is fire-and-forget; offline events queue in `~/.observal/telemetry_buffer.db` (SQLite) and flush on reconnect.
+
+## Auth model
+
+- API key based. Keys are SHA-256 hashed. `X-API-Key` header on every request.
+- JWT signing uses ES256 (not HS256). JWKS endpoint for public key distribution.
+- Device authorization flow for CLI login via browser confirmation.
+- Redis fail-closed: if Redis is down, auth fails (prevents stale token usage).
+- Fresh servers auto-bootstrap admin on first `observal auth login` (localhost-only).
+
+## Enterprise (`ee/`)
+
+Source-available, separate license. Loaded via signed JWT (`OBSERVAL_LICENSE_KEY`). Features gated individually: `is_feature_licensed("insights")`, `is_feature_licensed("saml")`, etc.
+
+**Critical constraint:** Core never imports from `ee/`. The `ee/` code imports core. Open-source is fully functional without a license key.
+
+Contents: `observal_insights/` (full insight pipeline), SAML SSO, SCIM provisioning, exec dashboard, HIPAA audit, license generation script.
 
 ## Commands
 
@@ -70,7 +204,6 @@ make logs                # tail logs
 uv tool install --editable .
 observal auth login      # auto-creates admin on fresh server, or login
 observal auth whoami     # check auth
-observal auth status     # server health check
 
 # Linting
 make lint                # ruff check
@@ -78,465 +211,26 @@ make format              # ruff format + ruff fix
 make check               # pre-commit on all files
 make hooks               # install pre-commit hooks
 
-# Tests (~1500 tests across 96 files: 76 in tests/, 18 in observal-server/tests/, 2 in observal_cli/tests/)
-make test                # quick
+# Tests (all mock externals, no Docker needed)
+make test                # 123 files in tests/ + 22 in observal-server/tests/ + 3 in observal_cli/tests/
 make test-v              # verbose
-# or manually:
-cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with docker pytest ../tests/ tests/ ../observal_cli/tests/ -q
+# E2E (requires running stack):
+cd tests/e2e && pnpm test   # 19 Playwright specs
 ```
 
-## Important files
+## Optic (dev logging)
 
-### API Server (`observal-server/`)
+Loguru-based. `observal logs` streams `~/.observal/logs/dev.log`.
 
-- `main.py` : FastAPI app entrypoint; mounts REST routes + GraphQL at `/api/v1/graphql`; middleware stack includes CORS (env-var origins), security headers, request size limit, rate limiting (slowapi), and session management
-- `config.py` : pydantic-settings: DATABASE_URL, CLICKHOUSE_URL, REDIS_URL, SECRET_KEY, eval model config, OAuth settings (all default to None/disabled), rate limit settings
-- `worker.py` : arq WorkerSettings; background eval jobs consume from Redis queue
-- `api/deps.py` : auth dependency (`get_current_user` via X-API-Key header), DB session injection, `resolve_listing` (name-or-UUID resolver used by all routes)
-- `api/graphql.py` : Strawberry schema: Query (traces, spans, metrics) + Subscription (traceCreated, spanCreated); DataLoaders for ClickHouse batch queries
-- `api/ratelimit.py` : shared slowapi Limiter instance, backed by Redis
-- `api/routes/auth.py` : bootstrap (auto-admin, localhost-only), login, whoami, OAuth code exchange, password reset; all endpoints rate-limited via slowapi
-- `api/routes/mcp.py` : MCP server CRUD; submit triggers async validation pipeline
-- `api/routes/agent.py` : Agent CRUD with goal templates, component linking via agent_components table
-- `api/routes/skill.py` : Skill CRUD; install generates SessionStart/End hook config
-- `api/routes/hook.py` : Hook CRUD; install generates IDE-specific HTTP hook config
-- `api/routes/prompt.py` : Prompt CRUD + `/render` endpoint that emits prompt_render spans
-- `api/routes/sandbox.py` : Sandbox CRUD; install generates observal-sandbox-run config
-- `api/routes/review.py` : Admin approve/reject workflow (unified across all component types)
-- `api/routes/telemetry.py` : `POST /ingest` (batch traces/spans/scores) + legacy `/events` + `POST /hooks` (raw IDE hook JSON) + OTLP HTTP receiver (`/v1/traces`, `/v1/logs`, `/v1/metrics` → ClickHouse)
-- `api/routes/reconcile.py` : Session reconciliation endpoint - accepts full JSONL records from CLI after parsing local session files; stores assistant messages, user prompts, system messages, tool results, attachments
-- `api/routes/insights.py` : Agent insight report CRUD; triggers batch insight generation; returns per-agent usage analysis
-- `api/routes/dashboard.py` : MCP metrics, agent metrics, overview stats, top items, trends
-- `api/routes/feedback.py` : Ratings with dual-write to PostgreSQL + ClickHouse scores table
-- `api/routes/eval.py` : Run evals, list scorecards, compare versions, aggregate stats
-- `api/routes/admin.py` : Enterprise settings CRUD, user management, role changes, penalty catalog, dimension weights
-- `api/routes/alert.py` : Alert rule CRUD (metric threshold alerts with webhook URLs)
-- `api/routes/bulk.py` : Bulk agent creation from scan results
-- `api/routes/jwks.py` : JWKS discovery endpoint for JWT public key distribution
-- `api/routes/component_source.py` : Component source CRUD and sync endpoints for git mirror origins
-- `api/routes/config.py` : Server endpoint discovery and public config (eliminates hardcoded URLs)
-- `api/routes/component_versions.py` : Factory for component version CRUD (list, get, publish, review, suggestions); shared across all 5 component types
-- `api/routes/agent_versions.py` : Agent-specific version publish, review, and listing endpoints
-- `api/routes/device_auth.py` : Device authorization flow for CLI login (OAuth device code grant)
-- `api/routes/sessions.py` : Session management (list active sessions, revoke)
+- Import: `from loguru import logger as optic`
+- Format: `optic.debug("msg: x={}", x)` (positional only, never f-strings)
+- Never log secrets, tokens, keys, JWT payloads. Log IDs and counts only.
+- Log format (console/json) configured via `observability.log_format` dynamic setting.
 
-### Models (`observal-server/models/`)
+## AI contribution policy
 
-- `user.py` : User with UserRole enum (admin, developer, user); API key is hashed with SHA-256
-- `mcp.py` : McpListing, McpValidationResult, McpDownload; ListingStatus enum (shared by all models)
-- `agent.py` : Agent, AgentStatus enum
-- `alert.py` : AlertRule (metric threshold alerts with webhook URLs)
-- `alert_history.py` : AlertHistory (fired alert records with resolved timestamps)
-- `skill.py` : SkillListing, SkillDownload
-- `hook.py` : HookListing, HookDownload
-- `prompt.py` : PromptListing, PromptDownload
-- `sandbox.py` : SandboxListing, SandboxDownload
-- `submission.py` : Submission (unified pending submissions)
-- `eval.py` : EvalRun, Scorecard, ScoreCardDimension; EvalRunStatus enum
-- `feedback.py` : Feedback (polymorphic on listing_type across all component types)
-- `enterprise_config.py` : Key-value enterprise settings
-- `organization.py` : Organization (id, name, slug, created_at, updated_at)
-- `saml_config.py` : SamlConfig (IDP metadata, certificates, attribute mapping)
-- `scim_token.py` : ScimToken (bearer tokens for SCIM provisioning endpoint)
-- `component_source.py` : ComponentSource, Git mirror origins for component discovery
-- `component_bundle.py` : ComponentBundle, bundled component snapshots for portable sharing
-- `agent_component.py` : AgentComponent, polymorphic junction table (agent_id, component_type, component_id); NO FK on component_id
-- `download.py` : AgentDownloadRecord (deduplicated by user_id + fingerprint), ComponentDownloadRecord (not deduplicated)
-- `exporter_config.py` : ExporterConfig, per-org telemetry export settings (grafana, datadog, loki, otel)
-- `password_reset_token.py` : PasswordResetToken, time-limited reset tokens
-- `sanitization.py` : Sanitization rules for telemetry data scrubbing
-- `scoring.py` : Scoring models for eval dimension weights and composite grades
-- `insight_report.py` : InsightReport, per-agent AI-generated usage analysis with status tracking
-- `insight_session_facets.py` : InsightSessionFacets, aggregated session-level tool/error/model breakdowns
-- `insight_session_meta.py` : InsightSessionMeta, lightweight session metadata for insight queries
+See `AI_POLICY.md`. Key rules: no autonomous PRs without human authorship, every change must be explainable, label AI tool usage, frontend changes need screenshots, no slop.
 
-### Services (`observal-server/services/`)
+## Paths to never commit
 
-- `clickhouse.py` : ClickHouse HTTP client; DDL for 5 tables (2 legacy + 3 new); insert/query helpers with parameterized SQL builder; `INIT_SQL` runs on startup
-- `redis.py` : Redis connection, pub/sub (publish/subscribe), eval job queue (enqueue_eval)
-- `config_generator.py` : Generates IDE config snippets per MCP; wraps commands with `observal-shim`; handles stdio vs HTTP transport
-- `agent_config_generator.py` : Generates bundled agent configs (rules file + MCP configs); injects OBSERVAL_AGENT_ID env var
-- `agent_builder.py` : Composes resolved components into portable agent manifests for 8 IDEs
-- `agent_resolver.py` : Looks up and validates all components for an agent; produces ResolvedAgent
-- `sandbox_config_generator.py` : Wraps sandbox execution with `observal-sandbox-run` entry point
-- `skill_config_generator.py` : Emits SessionStart/End hooks for skill activation telemetry
-- `hook_config_generator.py` : Generates IDE-specific HTTP hook configs (Claude Code, Kiro, Cursor)
-- `hook_materializer.py` : Materializes hook definitions into runnable IDE configs
-- `codex_config_generator.py` : Generates Codex CLI-specific agent and MCP configs
-- `mcp_validator.py` : 2-stage validation: clone+inspect (git clone, find entry point, detect framework) + manifest validation. Detects FastMCP, standard MCP SDK (Python), TypeScript SDK, and Go SDK. No framework enforcement.
-- `anti_gaming.py` : Scans agent system prompts for eval-manipulation patterns; flags for reviewer warning badge; never auto-rejects
-- `username_generator.py` : Auto-generates unique usernames from email addresses
-- `alert_evaluator.py` : Periodic metric threshold checks against ClickHouse; fires webhooks on breach
-- `cache.py` : Caching layer for frequently accessed registry data
-- `crypto.py` : Cryptographic utilities (payload encryption, key derivation)
-- `demo_accounts.py` : Demo/seed account provisioning
-- `download_tracker.py` : Tracks agent and component download metrics
-- `events.py` : Internal event bus for cross-service coordination
-- `git_mirror_service.py` : Git mirroring for component source synchronization
-- `ide_feature_inference.py` : Detects IDE capabilities from config files for smart config generation
-- `jwt_service.py` : JWT signing and verification for token-based auth
-- `registry_telemetry.py` : Telemetry collection for registry operations (installs, searches, etc.)
-- `secrets_redactor.py` : Redacts secrets from telemetry spans before storage
-- `security_events.py` : Security event logging and audit trail
-- `versioning.py` : Component versioning and compatibility checks
-- `webhook_delivery.py` : Webhook HTTP delivery with retry logic and SSRF protection
-- `webhook_signer.py` : HMAC signing for outbound webhook payloads
-- `component_version_extras.py` : Type-aware validation and field extraction for component version `extra` payloads
-- `editing_lock.py` : Optimistic locking for concurrent component editing (lock acquire, release, timeout)
-- `audit_helpers.py` : Lightweight audit logging utility (writes to security events)
-- `agent_lock_file.py` : Agent lock file generation for reproducible installs
-- `agent_registry_cache.py` : Registry query cache for agent resolution
-- `request_context.py` : Request-scoped context (current user, request ID) for services
-
-**Eval pipeline (`services/eval/`)** - all eval services live in this subpackage:
-
-- `eval_engine.py` : `EvalBackend` ABC; `LLMJudgeBackend` (Bedrock/OpenAI); `FallbackBackend` (deterministic); managed prompt templates
-- `eval_service.py` : Orchestrates eval runs: fetch traces, run backend, create scorecards
-- `eval_watchdog.py` : Meta-checker - detects dimensions that return perfect scores without evidence or skip dimensions entirely
-- `sanitizer.py` : `TraceSanitizer` - strips prompt injection attempts before they reach the LLM judge
-- `adversarial_scorer.py` : Rule-based scoring for adversarial robustness dimension
-- `canary.py` : `CanaryDetector` - injects synthetic tokens, checks whether agents parrot them back
-- `score_aggregator.py` : Weighted aggregation, penalty application, letter grade mapping
-- `slm_scorer.py` : LLM-as-judge scoring for goal completion, factual grounding, thought process
-- `structural_scorer.py` : Rule-based scoring for tool efficiency and tool failures; `MatchingEngine` with fuzzy comparison
-- `ragas_eval.py` : RAGAS metrics for GraphRAG retrieval spans (faithfulness, answer relevancy, context precision, context recall)
-- `kernel.py` : Kernel-level session analysis for deeper behavioral insights
-- `kernel_bridge.py` : Converts OTLP log hook events to kernel analysis format
-- `kernel_scorer.py` : Scores sessions using kernel analysis output
-
-**Insights pipeline (`services/insights/`):**
-
-- `batch.py` : Discovers agents needing insight reports, queues generation jobs
-- `trace_dedup.py` : Trace-level deduplication for the UI trace viewer
-
-### Schemas (`observal-server/schemas/`)
-
-- Pydantic request/response models mirroring the API surface
-- `telemetry.py` : TraceIngest, SpanIngest, ScoreIngest, IngestBatch, IngestResponse
-- `ide_registry.py` : IDE registry schema - canonical source of IDE capabilities, config paths, hook specs; mirrored in `observal_cli/ide_registry.py`
-- `insights.py` : InsightReport request/response schemas
-- `judge_output.py` : Structured output schemas for the LLM judge
-
-### CLI (`observal_cli/`)
-
-- `main.py` : Typer app wiring; creates `registry_app` parent group (mcp, skill, hook, prompt, sandbox), registers all command modules
-- `branding.py` : ASCII banner (`BANNER`) and `welcome_banner()` helper; used by `auth login`
-- `ide_registry.py` : Client-side mirror of `observal-server/schemas/ide_registry.py`; kept in sync by `tests/test_constants_sync.py`
-- `prompts.py` : Interactive prompt helpers using `questionary` for TTY arrow-key selection; falls back to `typer.prompt` in CI
-- `analyzer.py` : Local repo analysis for MCP submissions - clones with system git (inherits SSH keys, credential helpers), runs same AST/pattern detection as the server
-- `telemetry_buffer.py` : SQLite buffer (`~/.observal/telemetry_buffer.db`) for offline telemetry; stores events when server is unreachable and flushes on reconnect
-- `settings_reconciler.py` : Non-destructive reconciler for Claude Code `settings.json`; Terraform-style declarative reconciliation - reads current state, diffs against desired, applies only deltas
-- `cmd_auth.py` : `auth_app` subgroup: login (smart - auto-bootstrap on fresh server, supports --key for API keys, email+password), register, reset-password, logout, whoami, status. Also `config_app` subgroup: show, set, path, alias, aliases
-- `cmd_mcp.py` : `mcp_app` subgroup: submit (JSON paste default, --git for repo analysis, --draft, --yes for non-interactive), list (--sort, --limit, --output), show, install (--raw), delete
-- `cmd_agent.py` : `agent_app` subgroup: create (--from-file), list, show, install, delete; authoring: init, add, build, publish
-- `cmd_skill.py` : `skill_app` subgroup: submit, list, show, install, delete
-- `cmd_hook.py` : `hook_app` subgroup: submit, list, show, install, delete
-- `cmd_prompt.py` : `prompt_app` subgroup: submit, list, show, install, render, delete
-- `cmd_sandbox.py` : `sandbox_app` subgroup: submit, list, show, install, delete
-- `cmd_component.py` : `component_app` subgroup: version commands (list-versions, publish, show-version) shared across all component types
-- `cmd_scan.py` : `observal scan`: read-only discovery of IDE configs (Claude Code, Cursor, Kiro, VS Code, Gemini CLI, Codex CLI, Copilot CLI, OpenCode); `--ide` filter flag
-- `cmd_pull.py` : `observal pull`: fetch agent config from server, write IDE files (rules, MCP config, agent files) to disk; `--dry-run`, `--dir` flags; merges MCP configs with existing files
-- `cmd_reconcile.py` : `observal reconcile`: parse local session JSONL files and send enrichment to server; `--latest` flag for most recent session
-- `cmd_profile.py` : `observal use` + `observal profile`: swap IDE configs from git-hosted profiles; clones/caches profiles, backs up current config, restores via `observal use default`
-- `cmd_ops.py` : `ops_app` subgroup: overview, metrics (--watch), top, traces, spans, rate, feedback, sync. Contains `telemetry_app` (status, test). Also `admin_app` subgroup: settings, set, users, penalties, penalty-set, weights, weight-set, canaries, canary-add, canary-reports, canary-delete. Contains `review_app` (list, show, approve, reject) and `eval_app` (run, scorecards, show, compare, aggregate). Also `self_app` subgroup: upgrade, downgrade
-- `cmd_doctor.py` : `doctor_app`: diagnose IDE settings for Observal compatibility; checks all 8 IDEs; `--ide` to target specific IDE, `--fix` to auto-repair. `doctor patch` subcommand: `--hook` (install telemetry hooks), `--shim` (wrap MCP servers), `--all` (hooks + shims + OTel), `--all-ides` / `--ide <name>`, `--dry-run` (preview)
-- `cmd_migrate.py` : `migrate_app`: ClickHouse telemetry migration tools for PostgreSQL shallow-copy migrations
-- `cmd_uninstall.py` : `observal uninstall`: tear down Docker stack, remove repo and config files
-- `client.py` : httpx wrapper with get/post/put/delete/health; contextual error messages per status code
-- `config.py` : `~/.observal/config.json` management; alias system (@name → UUID resolution)
-- `render.py` : Shared Rich rendering: status badges, relative timestamps, IDE color tags, star ratings, kv panels, spinners
-- `shim.py` : `observal-shim`: transparent stdio JSON-RPC proxy; pairs requests/responses into spans; caches tools/list for schema compliance; buffered async telemetry flush via `telemetry_buffer.py`
-- `proxy.py` : `observal-proxy`: HTTP reverse proxy reusing ShimState; same telemetry pipeline
-- `sandbox_runner.py` : `observal-sandbox-run`: Docker SDK executor; captures stdout/stderr via container.logs(); reports exit code, OOM, container ID
-
-**IDE hook specs (`observal_cli/ide_specs/`)** - one module per IDE, each exporting hook generation helpers:
-
-- `claude_code_hooks_spec.py`, `kiro_hooks_spec.py`, `cursor_hooks_spec.py`, `gemini_hooks_spec.py`, `vscode_hooks_spec.py`, `copilot_cli_hooks_spec.py`, `opencode_hooks_spec.py`
-
-### Docker (`docker/`)
-
-- `docker-compose.yml` : Primary stack - 10 services: init (migrations), api, db (PostgreSQL 16), clickhouse, redis, worker (arq), web (Next.js), lb (nginx reverse proxy on port 8000), prometheus (9090), grafana (3001)
-- `docker-compose.dev.yml` : Development overrides (hot reload, bind mounts)
-- `docker-compose.production.yml` : Production overrides (resource limits, restart policies)
-- `docker-compose.enterprise.yml` : Enterprise stack additions (SAML, SCIM, SSO)
-- `Dockerfile.api` : uv-based Python build
-- `Dockerfile.web` : Node 24-alpine, multi-stage build with standalone output
-- `entrypoint.sh` : Init container entrypoint - runs Alembic migrations then exits
-- `nginx.conf`, `nginx.dev.conf`, `nginx.production.conf` : Nginx reverse proxy configs
-
-### Tests (`tests/`)
-
-96 test files total; all mock external services (no Docker needed to run).
-
-**`tests/` (64 files):**
-
-- `test_clickhouse_phase1.py` : DDL, SQL helpers, insert/query functions
-- `test_ingest_phase2.py` : Ingestion schemas, endpoint, partial failure
-- `test_shim_phase3.py` : JSON-RPC parsing, schema compliance, ShimState, config gen
-- `test_proxy_phase4.py` : Proxy, HTTP transport config
-- `test_worker_phase5.py` : Redis, arq, docker-compose validation
-- `test_graphql_phase6.py` : Strawberry types, DataLoaders, resolvers
-- `test_phase9_10.py` : Dual-write, CLI commands
-- `test_registry_types.py` : Models, schemas, routes, review, feedback, CLI for all 6 types
-- `test_telemetry_collection.py` : Sandbox runner, config generators, install route wiring
-- `test_schema_redesign.py` : Organization, ComponentSource, AgentComponent, downloads, ExporterConfig, feedback/submission updates
-- `test_agent_composition.py` : Agent composition resolver and multi-component support
-- `test_pull_and_agent_cli.py` : Pull command and agent CLI commands
-- `test_git_mirror.py` : Git mirroring service
-- `test_agent_config_generator.py` : Agent config generation for all IDEs
-- `test_agent_name_lookup.py` : Agent name resolution
-- `test_agent_review.py` : Agent review workflow
-- `test_agent_rbac.py` : Agent-level RBAC enforcement
-- `test_alert_evaluator.py` : Alert threshold evaluation and webhook firing
-- `test_audit_logging.py` : Audit log creation and queries
-- `test_auth2_security.py` : Auth security hardening tests
-- `test_auth_redis_down.py` : Auth resilience when Redis is unavailable
-- `test_bulk.py` : Bulk agent creation
-- `test_bundles.py` : Component bundle packaging
-- `test_clickhouse_resource_tuning.py` : ClickHouse resource configuration
-- `test_clickhouse_retention.py` : ClickHouse data retention policies
-- `test_cli_errors.py` : CLI error handling and messages
-- `test_component_version_extras.py` : Version extras validation
-- `test_config_generator_utils.py` : Config generation utilities
-- `test_constants_sync.py` : Constant synchronization between frontend and backend; validates `ide_registry.py` mirrors
-- `test_demo_accounts.py` : Demo account provisioning
-- `test_deployment_guards.py` : Deployment safety checks
-- `test_device_auth.py` : Device authorization flow
-- `test_docker_detection.py` : Docker availability detection
-- `test_draft_workflow.py` : Draft submission workflow
-- `test_endpoint_discovery.py` : Server endpoint discovery
-- `test_enterprise.py` : Enterprise feature gates
-- `test_env_detection_and_config.py` : Environment detection
-- `test_events.py` : Internal event bus
-- `test_field_validation.py` : Input field validation
-- `test_health.py` : Health endpoint behavior
-- `test_ide_config_e2e.py` : End-to-end IDE config generation
-- `test_ide_registry.py` : IDE registry schema and CLI mirror sync
-- `test_listing_detail_access.py` : Listing detail access control
-- `test_migrate.py` : Migration tooling
-- `test_migrate_telemetry.py` : Telemetry migration
-- `test_payload_crypto.py` : Payload encryption
-- `test_reconcile_subagent.py` : Session reconciliation for subagent flows
-- `test_resilience.py` : Service resilience under failure
-- `test_review_queue.py` : Review queue operations
-- `test_saml.py` : SAML SSO flow
-- `test_saml_scim_integration.py` : SAML + SCIM integration
-- `test_sanitize.py` : Telemetry sanitization
-- `test_scan_kiro_home.py` : Kiro home directory scanning
-- `test_scim.py` : SCIM provisioning endpoint
-- `test_schema_redesign.py` : Schema migration tests
-- `test_secrets_redactor.py` : Secret redaction in telemetry
-- `test_settings_reconciler.py` : Claude Code settings reconciler
-- `test_skill_config_generator.py` : Skill config generation
-- `test_uninstall.py` : Uninstall command
-- `test_uninstall_windows.py` : Windows uninstall paths
-- `test_username_generator.py` : Username auto-generation
-- `test_versioning.py` : Component versioning
-- `test_webhook_delivery.py` : Webhook delivery and retry
-- `test_webhook_signer_properties.py` : Webhook signer property tests
-- `test_webhook_signer.py` : Webhook HMAC signing
-
-**`tests/eval/` (12 files):**
-
-- `test_eval_phase8.py` : Templates, backends, run_eval_on_trace
-- `test_phase8a_sanitizer.py` : TraceSanitizer
-- `test_phase8b_matching.py` : MatchingEngine fuzzy comparison
-- `test_phase8d_adversarial.py` : AdversarialScorer
-- `test_phase8e_canary.py` : CanaryDetector
-- `test_phase8g_pipeline.py` : Full eval pipeline integration
-- `test_ragas_eval.py` : RAGAS evaluation metrics
-- `test_structural_scorer.py` : Rule-based structural scoring
-- `test_slm_scorer.py` : LLM-based SLM scoring
-- `test_score_aggregator.py` : Score aggregation and composite grading
-- `test_adversarial_self.py` : BenchJack self-attacks against Observal's own eval pipeline
-- `test_eval_completeness.py` : Meta-tests validating the scorers actually score
-
-**`observal-server/tests/` (18 files):**
-
-- `test_component_versions_api.py` : Component version API route tests
-- `test_component_version_extras.py` : Version extras validation
-- `test_agent_versions_api.py` : Agent version API route tests
-- `test_agent_config_gen_versioned.py` : Versioned agent config generation
-- `test_agent_delete.py` : Agent deletion cascade
-- `test_agent_pull.py` : Agent pull command logic
-- `test_anti_gaming.py` : Anti-gaming prompt scanner
-- `test_config.py` : Config service tests
-- `test_cross_user.py` : Cross-user data isolation
-- `test_crypto.py` : Crypto utilities tests
-- `test_dedup.py` : General deduplication logic
-- `test_jwt.py` : JWT service tests
-- `test_multi_tenancy.py` : Multi-tenancy isolation tests
-- `test_payload_protection.py` : Payload protection tests
-- `test_rbac.py` : RBAC enforcement tests
-- `test_security_events.py` : Security event logging tests
-- `test_shim_enrichment.py` : Shim span enrichment
-- `test_trace_dedup.py` : Trace-level deduplication
-
-**`observal_cli/tests/` (2 files):**
-
-- `test_cmd_component_versions.py` : Component version CLI commands
-- `test_cmd_agent_versions.py` : Agent version CLI commands
-
-### Web Frontend (`web/`)
-
-**Design system:** OKLCH color space with 5 themes (light, dark, midnight, forest, sunset). Typography: Archivo (display/headings), Albert Sans (body), JetBrains Mono (code). 4pt base spacing scale. Motion tokens for animations. Defined in `globals.css`.
-
-Four route groups organize the UI by access level:
-
-**`(auth)/`** - Login and device authorization
-
-- `login/page.tsx` : Email/name login and first-run admin init
-- `device/page.tsx` : Device authorization confirmation page (OAuth device flow)
-
-**`(registry)/`** - Public agent browser (requires auth)
-
-- `page.tsx` : Registry home with search, trending agents, top rated
-- `agents/page.tsx` : Agent list table with search and filters
-- `agents/[id]/page.tsx` : Agent detail with pull command box
-- `components/page.tsx` : Tabbed component browser (MCPs, skills, hooks, prompts, sandboxes)
-- `components/[id]/page.tsx` : Component detail view
-- `leaderboard/page.tsx` : Agent leaderboard ranked by eval score
-
-**`(admin)/`** - Admin dashboard (requires admin role)
-
-- `dashboard/page.tsx` : Overview stats, recent agents, latest traces, agent scores
-- `review/page.tsx` : Admin review queue with detail sheet
-- `insights/page.tsx` : Insight report list across all agents
-- `insights/[reportId]/page.tsx` : Individual insight report detail
-- `eval/page.tsx` : Eval overview with agent scores
-- `eval/[agentId]/page.tsx` : Eval detail with aggregate chart, dimension radar, penalty accordion
-- `errors/page.tsx` : Error log viewer with Tool Failure / API Error classification
-- `users/page.tsx` : User management
-- `settings/page.tsx` : Enterprise settings
-- `sso/page.tsx` : SSO / SAML / OIDC configuration
-- `audit-log/page.tsx` : Audit log viewer
-- `security-events/page.tsx` : Security event log
-- `diagnostics/page.tsx` : System diagnostics and health
-
-**`(user)/`** - User-scoped views (requires auth)
-
-- `traces/page.tsx` : Session trace list with filtering and token sort
-- `traces/[id]/page.tsx` : Trace detail with turn grouping, event list, session info tab
-
-**Shared components:**
-
-- `src/lib/api.ts` : Typed fetch wrapper; all REST + GraphQL calls; auth via localStorage API key
-- `src/lib/types.ts` : Shared TypeScript interfaces for all API responses
-- `src/lib/graphql-ws.ts` : GraphQL WebSocket subscription client
-- `src/lib/ide-features.ts` : IDE capability detection utilities
-- `src/hooks/use-api.ts` : TanStack Query hooks for every endpoint (queries + mutations)
-- `src/hooks/use-auth.ts` : Auth guard hook (checks API key exists)
-- `src/hooks/use-admin-guard.ts` : Admin role check hook
-- `src/hooks/use-role-guard.ts` : Generic role check hook
-- `src/hooks/use-deployment-config.ts` : Deployment config fetcher (endpoint discovery)
-- `src/hooks/use-mobile.ts` : Mobile viewport detection
-- `src/components/layouts/auth-guard.tsx` : Auth guard wrapper
-- `src/components/layouts/admin-guard.tsx` : Admin guard wrapper
-- `src/components/layouts/role-guard.tsx` : Generic role guard wrapper
-- `src/components/layouts/dashboard-shell.tsx` : Dashboard layout shell
-- `src/components/layouts/page-header.tsx` : Page header with breadcrumbs
-- `src/components/nav/registry-sidebar.tsx` : Unified sidebar with conditional admin section
-- `src/components/nav/command-menu.tsx` : Command palette (Cmd+K)
-- `src/components/nav/nav-user.tsx` : User profile menu
-- `src/components/nav/github-star-banner.tsx` : GitHub star call-to-action banner
-- `src/components/shared/skeleton-layouts.tsx` : Reusable skeletons (TableSkeleton, CardSkeleton, DetailSkeleton, ChartSkeleton)
-- `src/components/shared/error-state.tsx` : Reusable error display with retry
-- `src/components/shared/empty-state.tsx` : Icon + title + description + CTA
-- `src/components/builder/` : Agent builder components (preview panel, sortable component list, validation panel)
-- `src/components/dashboard/` : Stat cards, trend charts, bar lists, heatmap, time range select, no-data/error states
-- `src/components/traces/` : Trace list, trace detail, span tree with collapsible thread lines
-- `src/components/registry/` : Agent card, component card, pull command with IDE selector, install dialog, metrics panel, feedback list, status badge, submit component dialog, registry detail, registry table
-- `src/components/review/` : Review detail sheet, validation badges
-
-### Demo (`demo/`)
-
-- `test_all_types.sh` : Full e2e test - submit, approve, install, and test all component types with real Docker containers and ClickHouse verification
-- `run_demo.sh` : Automated demo script
-
-### Enterprise (`ee/`)
-
-The `ee/` directory contains proprietary enterprise features licensed under the Observal Enterprise License (see `ee/LICENSE`). This code is source-available but requires a commercial license for production use. Community contributions are not accepted into this directory.
-
-**Critical constraint:** The open-source core must never import from `ee/`. The dependency is strictly one-way: `ee/` code can import from the open-source core, but not the reverse. The open-source edition must be fully functional without `ee/`.
-
-## Implementation notes
-
-### Library Documentation Lookup (MANDATORY)
-
-**ALWAYS lookup library documentation before implementing library-specific code.** Use `/docs <library-name>` or the `docs-lookup` skill (via Context7 MCP) to fetch current API documentation. This is REQUIRED for:
-
-- Adding new dependencies or imports
-- Framework-specific patterns (FastAPI, Strawberry, Typer, SQLAlchemy, Alembic, pytest, Next.js, React, TanStack Query, etc.)
-- Library APIs you're not 100% certain about
-- Version-specific features
-
-NEVER guess or hallucinate library APIs. Lookup docs first to ensure code matches the installed version and prevent breaking changes. Examples: `/docs fastapi`, `/docs sqlalchemy`, `/docs nextjs`, `/docs strawberry-graphql`, `/docs pytest`.
-
-### Database Architecture
-
-- Two databases: PostgreSQL for relational data (users, MCPs, agents, feedback, eval runs), ClickHouse for time-series telemetry (traces, spans, scores). They are not interchangeable.
-- ClickHouse uses ReplacingMergeTree with bloom filter indexes. Queries go through the HTTP interface, not a native driver. The `_query` helper in `clickhouse.py` handles parameterized queries.
-- The shim is the core telemetry collection mechanism. It sits between the IDE and the MCP server, completely transparent. It never modifies messages: only observes. Telemetry is fire-and-forget via async POST; if the server is down, events are queued in `~/.observal/telemetry_buffer.db` (SQLite) and flushed on reconnect via `telemetry_buffer.py`.
-- Config generators automatically wrap MCP commands with `observal-shim` for stdio transport or point to `observal-proxy` for HTTP transport. This is how telemetry collection is opt-in per install.
-- **Never generate or seed OTLP/OTEL environment variables** (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_METRICS_EXPORTER`, `CLAUDE_CODE_ENABLE_TELEMETRY`) into IDE settings, config snippets, or API responses. Telemetry flows exclusively through the observal-shim and session push hooks. The `MANAGED_ENV_KEYS` set in `claude_code_hooks_spec.py` exists solely so `observal doctor cleanup` can strip stale vars from users who had them previously; it must not be used to seed new values.
-- The `observal scan` command is read-only: it discovers IDE config files and lists MCP servers, hooks, and OTel configuration without modifying anything. The `observal doctor patch` command does the actual instrumentation: `--shim` wraps MCP commands with `observal-shim`, `--hook` installs telemetry hooks, `--all` does both plus OTel config. It creates timestamped backups before modifying any file. Supports all 8 IDEs. Registration of components is manual via `observal registry <type> submit`.
-- GraphQL is the read layer for telemetry data. REST still exists for auth, CRUD, feedback, eval, admin. The GraphQL layer uses DataLoaders to batch ClickHouse queries.
-- Redis serves two purposes: pub/sub for GraphQL subscriptions (live trace/span events) and arq job queue for background eval runs.
-- The eval engine is pluggable. `LLMJudgeBackend` calls Bedrock or OpenAI-compatible endpoints. `FallbackBackend` returns deterministic scores when no LLM is configured. All eval services live in `services/eval/`. The kernel scorer (`kernel.py`, `kernel_bridge.py`, `kernel_scorer.py`) provides deeper behavioral analysis from OTLP log events.
-- Feedback dual-writes: when a user rates an MCP/agent, it writes to PostgreSQL (for the feedback API) AND ClickHouse scores table (for unified analytics). The ClickHouse write is best-effort.
-- Auth is API key based. Keys are SHA-256 hashed before storage. The `X-API-Key` header is checked on every authenticated request via `get_current_user` dependency. User onboarding uses self-registration (`observal auth register`) or SSO. Fresh servers auto-bootstrap an admin account on first `observal auth login` (zero prompts, localhost-only). The `/health` endpoint returns `initialized: bool` so the CLI knows whether to bootstrap or prompt for credentials. All auth endpoints are rate-limited via slowapi (backed by Redis). OAuth uses a one-time auth code exchange pattern: the callback stores credentials in Redis with a 30s TTL and redirects with an opaque code instead of the raw API key. JWT signing and verification available via `jwt_service.py` with JWKS endpoint for public key distribution. Device authorization flow (`device_auth.py`) supports CLI login via browser confirmation.
-- Install routes use an owner fallback: try approved first, then allow the submitter to install their own pending/rejected items. Items are registered via `observal registry <type> submit` and immediately usable by the submitter.
-- The CLI stores config in `~/.observal/config.json`. Aliases are in `~/.observal/aliases.json`. Both are plain JSON. All API path parameters accept UUID or name; the server resolves names via `resolve_listing()` in `deps.py`.
-- All CLI list/show commands support `--output table|json|plain`. Use `--output json` for scripting. Use `--raw` on install commands to pipe config directly to files.
-- The CLI uses nested Typer subgroups: `auth`, `registry` (mcp/skill/hook/prompt/sandbox), `agent`, `ops` (telemetry), `admin` (review/eval), `self`, `config`, `doctor`, `migrate`. Root-level convenience commands: `pull`, `scan`, `reconcile`, `uninstall`, `use`, `profile`.
-- The IDE registry (`schemas/ide_registry.py` server-side, `observal_cli/ide_registry.py` client-side) is the canonical source of truth for IDE capabilities, config file paths, agent file paths, MCP config paths, and skill paths. `tests/test_constants_sync.py` enforces they stay in sync.
-- Ruff is the Python linter and formatter. Line length is 120. Pre-commit hooks enforce it.
-- The `B008` ruff rule is suppressed because Typer requires function calls in argument defaults (`typer.Option(...)`, `typer.Argument(...)`).
-- No em-dashes (-) anywhere: not in code, comments, commit messages, PR descriptions, or documentation. Use hyphens (-) or rewrite the sentence.
-- The data model is agent-centric. Agents bundle components (MCPs, skills, hooks, prompts, sandboxes) via `agent_components`, a polymorphic junction table with NO foreign key on `component_id` (allows cross-type references). Agent downloads are deduplicated by `(user_id)` and `(fingerprint)` unique constraints; component downloads are not deduplicated. All components support organization ownership via `is_private` + `owner_org_id` fields. Git-based versioning: components require `git_url` + `git_ref` for reproducible installs.
-- The web frontend uses OKLCH color space for perceptually uniform theming. 5 themes are defined in `globals.css` using CSS custom properties. Theme switching is handled by `theme-switcher.tsx`. The design system uses a 4pt spacing scale, semantic color tokens (background, foreground, card, border, primary, secondary, accent, destructive, success, warning, info), and motion tokens for animations.
-- The web frontend proxies all API calls through Next.js rewrites (`/api/v1/*` → backend). The backend URL is configured via `NEXT_PUBLIC_API_URL` env var (defaults to `http://localhost:8000`). Auth state (API key, user role) is stored in localStorage. Role-based access is enforced client-side via AuthGuard, AdminGuard, and RoleGuard components, not Next.js middleware.
-- Alert rules support metric threshold monitoring with webhook delivery. The `alert_evaluator.py` service runs periodic checks against ClickHouse metrics and fires webhooks (with HMAC signing via `webhook_signer.py` and delivery retries via `webhook_delivery.py`) when thresholds are breached. SSRF protection prevents webhooks to private IP ranges.
-- Telemetry data is scrubbed by `secrets_redactor.py` before ClickHouse storage. Security events are logged via `security_events.py` for audit trails.
-- Server endpoint discovery (`api/routes/config.py`) eliminates hardcoded URLs - clients derive endpoints from server config at runtime.
-- The `observal reconcile` command parses local Claude Code session JSONL files and uploads enrichment data to the server - this is the mechanism for populating traces with full conversation context (assistant messages, thinking blocks, tool results) rather than just hook-captured metadata.
-
-### Optic dev logging
-
-- Optic is Observal's developer logging system built on loguru. It provides real-time visibility into what the server and CLI are doing, viewable via `observal logs`.
-- **Server config:** `observal-server/services/optic.py` - file sink (DEBUG+) to `~/.observal/logs/dev.log`, console sink (INFO+). Called from `main.py` on startup.
-- **CLI config:** `observal_cli/optic.py` - file sink only when `--debug` or `--verbose` flags are passed. Called from `observal_cli/main.py`.
-- **Log file:** `~/.observal/logs/dev.log` - rotated at 10MB, 5 backups kept (~50MB max disk). Docker containers access this via a volume mount.
-- **Viewing:** `observal logs` streams the log file with `--level` (filter by severity), `--filter` (text search), `--lines N` (show last N), `--no-follow` (exit after showing history).
-- **Import convention:** Files that already have `structlog` use `from loguru import logger as optic` to avoid shadowing. New files without structlog also use the `as optic` alias for consistency.
-- **Security rules:** NEVER log passwords, tokens, secrets, API keys, JWT payloads, or full request bodies that may contain credentials. Log only safe identifiers (email, listing_id, name). For large content (file bodies, configs), log `len()` not the content itself.
-- **Formatting:** Always use loguru positional style: `optic.debug("msg: x={}", x)`. Never use f-strings or `{name}` without kwargs (loguru will log an error instead of the value).
-- **Context:** Every log call should include at least one useful argument from the function scope (an id, name, or count). Bare `optic.debug("X called")` without context is only acceptable when no safe arguments exist (e.g., the only params are db/request/self).
-
-### AI contribution policy
-
-This repository has an explicit [AI Policy](AI_POLICY.md). Key rules that apply to AI coding agents working in this codebase:
-
-- **Autonomous agent submissions are prohibited.** Do not open PRs on behalf of a user without meaningful human authorship of the code. The US Copyright Office (January 2025) confirms purely AI-generated code has no copyright owner, which breaks the project CLA and AGPL licensing chain.
-- **Every contribution must be explainable.** If a reviewer asks about a change, the human contributor must be able to explain it. Do not generate code the contributor cannot defend.
-- **Do not use AI tools to fill in the PR template or write GitHub comments.** The PR template must be completed by the human contributor.
-- **Label AI use.** If a contribution makes nontrivial use of AI tools, the PR description must state the tool name and version.
-- **Frontend changes require screenshots** attached to the PR body.
-- **No slop.** Do not generate low-effort, unreviewed output. Tests must pass, the diff must compile, and the contributor must have read through it.
-
-### Paths to never commit
-
-The following paths are developer-local AI agent and IDE configurations. They are gitignored but listed here so agents don't try to remove the gitignore entries or create these files in PRs:
-
-- `.claude/`, `CLAUDE.md` - Claude Code
-- `.kiro/` - Kiro
-- `.cursor/`, `.cursorignore`, `.cursorindexingignore` - Cursor
-- `.gemini/`, `GEMINI.md` - Gemini CLI
-- `.opencode/` - OpenCode
-- `.github/copilot-instructions.md`, `.copilot/` - GitHub Copilot
-- `.vscode/` - VS Code
-- `.worktrees/` - Git worktree scratch area
-
-### Branch workflow
-
-When a new feature is requested that is unrelated to the current branch, always create a new branch (with a git worktree if needed) rather than mixing unrelated changes. Each feature gets its own branch off `main`.
+`.claude/`, `CLAUDE.md`, `.kiro/`, `.cursor/`, `.gemini/`, `GEMINI.md`, `.opencode/`, `.github/copilot-instructions.md`, `.copilot/`, `.vscode/`, `.worktrees/`

--- a/ee/AGENTS.md
+++ b/ee/AGENTS.md
@@ -3,106 +3,97 @@
 
 # Enterprise Edition
 
-Source-available enterprise features for Observal. Loaded only when `DEPLOYMENT_MODE=enterprise`.
+Source-available enterprise features. Loaded when `OBSERVAL_LICENSE_KEY` is set and contains a valid signed JWT. Features are individually gated: the JWT's `features` array controls which capabilities activate.
 
-**License:** Separate enterprise license (`ee/LICENSE`). Commercial license required for production. Community contributions NOT accepted into this directory.
+**License:** `ee/LICENSE`. Commercial license required for production. No community contributions accepted here.
 
-**Critical constraint:** Core must NEVER import from `ee/`. Dependency is strictly one-way: `ee/` imports core, never the reverse. The open-source edition must be fully functional without `ee/`.
+**Critical constraint:** Core never imports from `ee/`. One-way dependency only. Open-source edition is fully functional without this directory.
 
 ## How it loads
 
-`observal-server/main.py` calls `register_enterprise(app, settings)` from `ee/__init__.py` which:
+`observal-server/main.py` calls `register_enterprise(app, settings)` from `ee/__init__.py`:
 
-1. Validates enterprise config via `config_validator.py`
-2. Mounts EE routes (`/api/v1/sso/saml/*`, `/api/v1/scim/*`, `/api/v1/admin/audit-log*`)
-3. Adds `EnterpriseGuardMiddleware` (returns 503 on EE routes if config is invalid)
-4. Registers audit event bus handlers on `services.events.bus`
-5. Stores config issues in `app.state.enterprise_issues`
+1. Validates license JWT via `ee/license.py` (checks signature, expiry, org_id, features)
+2. Mounts EE routes (SAML, SCIM, audit, SSO admin, exec dashboard)
+3. Adds `EnterpriseGuardMiddleware` (503 on EE routes if license invalid/expired)
 
-## Config validation
+## License key format
 
-Five settings checked on startup. If any fail, issues are stored and the guard middleware blocks EE routes with 503.
+Signed JWT containing:
 
-| Setting | Requirement |
-|---------|------------|
-| `SECRET_KEY` | Not the default `"change-me-to-a-random-string"` |
-| `OAUTH_CLIENT_ID` | Must be set |
-| `OAUTH_CLIENT_SECRET` | Must be set |
-| `OAUTH_SERVER_METADATA_URL` | Must be set (OIDC discovery) |
-| `FRONTEND_URL` | Not localhost or empty |
+```json
+{
+  "org_id": "uuid",
+  "features": ["insights", "saml", "scim", "audit", "exec_dashboard"],
+  "exp": 1750000000
+}
+```
 
-## Features
+Usage in code: `from ee.license import is_feature_licensed`. Returns bool. Generate keys with `ee/scripts/generate_license.py`.
 
-### Audit logging (implemented)
+## Feature inventory
 
-Listens to 8 event types on the core event bus (`services/events.py`):
-- `UserCreated`, `UserDeleted`
-- `LoginSuccess`, `LoginFailure`
-- `RoleChanged`, `SettingsChanged`
-- `AlertRuleChanged`, `AgentLifecycleEvent`
+### Insights (`ee/observal_insights/`)
 
-Each event → row in ClickHouse `audit_log` table with actor info, resource details, HTTP metadata, and freeform detail JSON.
+Full agent usage analysis pipeline. The open-source `services/insights/` returns empty stubs; this provides the real implementation.
 
-**API endpoints (admin-only):**
-- `GET /api/v1/admin/audit-log` — query with filters (actor, action, resource_type, date range), paginated
-- `GET /api/v1/admin/audit-log/export` — CSV download (max 10k rows)
+Key modules: `batch.py` (job orchestration), `generator.py` (LLM narrative), `sections.py` (report builders), `metrics.py` (aggregation), `facets.py` (session analysis), `enrichment.py` (trace enrichment), `reconcile.py` (session reconciliation), `shim_enrichment.py` (shim data), `trace_dedup.py` / `dedup.py` (deduplication), `cross_user.py` (pattern analysis), `session_cache.py` (caching), `transcript.py` (session transcripts), `html_export.py` (export), `pricing.py` (token costs), `regression.py` (performance regression), `anonymize.py` (data anonymization).
 
-### SAML 2.0 SSO (stub — returns 501)
+### Audit (HIPAA-compliant)
 
-- `POST /api/v1/sso/saml/login` — initiate SAML login
-- `POST /api/v1/sso/saml/acs` — Assertion Consumer Service callback
-- `GET /api/v1/sso/saml/metadata` — SP metadata
+Loguru-based middleware captures every API request. Events classified for HIPAA compliance.
 
-### SCIM 2.0 provisioning (stub — returns 501)
+- `ee/observal_server/routes/audit.py`: query + export (CSV/JSON, max 10k rows)
+- `ee/observal_server/services/audit.py`: sink to ClickHouse `audit_log` table
+- `api/middleware/audit.py` (core): the middleware itself
+- `services/audit/classification.py` (core): event classification rules
+- `observal_cli/audit.py`: CLI-side audit event emission
 
-- `GET /api/v1/scim/Users` — list users
-- `POST /api/v1/scim/Users` — create user
-- `GET /api/v1/scim/Users/{user_id}` — get user
-- `PUT /api/v1/scim/Users/{user_id}` — update user
-- `DELETE /api/v1/scim/Users/{user_id}` — delete user
+### SAML 2.0 SSO
 
-### Plugin registry (placeholder)
+Full implementation: login initiation, ACS callback, SP metadata, admin configuration.
 
-`ee/plugins/__init__.py` — future home for Grafana, Prometheus, Datadog, and SIEM integrations.
+- Routes: `sso_saml.py`, `admin_sso.py`
+- Service: `services/saml.py`
+
+### SCIM 2.0
+
+User provisioning: list, create, get, update, delete.
+
+- Route: `scim.py`
+- Service: `services/scim_service.py`
+
+### Exec dashboard
+
+Executive analytics dashboard. Route: `exec_dashboard.py`.
 
 ## Frontend architecture
 
-There is NO separate `web/ee/` directory. Enterprise frontend code lives in `web/src/` alongside core code, gated by `useDeploymentConfig()`.
-
-This follows the industry-standard pattern (Langfuse, PostHog, Infisical, Lago all do this). The `ee/` boundary is for backend licensing — the frontend is AGPL and gates features server-side, not by directory.
-
-**How enterprise features are gated in the frontend:**
-- `useDeploymentConfig()` hook returns `{ deploymentMode, ssoEnabled, samlEnabled }`
-- Pages check `deploymentMode === "enterprise"` and show upgrade prompts if not
-- SSO button in login page: conditional on `ssoEnabled`
-- Enterprise settings section: conditional on `deploymentMode`
-- API filters results server-side — frontend reads what it's given
-
-**Enterprise-only admin pages** (audit log viewer, diagnostics, SCIM config) should be regular pages in `web/src/app/(admin)/` that check deployment mode and show an upgrade prompt when not enterprise. Do NOT create a `web/ee/` directory.
-
-**Future resource-based access control** will follow PostHog's annotation pattern: include `user_access_level` on every API response object. The API filters results by team membership; the frontend reads the annotation. No CASL or client-side policy engine needed initially.
+NO `web/ee/` directory. Enterprise pages live in `web/src/app/(admin)/` and call license-gated endpoints. Server returns 403 for unlicensed features. Frontend shows upgrade prompts.
 
 ## Directory layout
 
 ```
 ee/
-├── __init__.py                         # register_enterprise() entrypoint
-├── LICENSE                             # Enterprise license
-├── AGENTS.md                           # This file
-├── README.md                           # Public-facing description
-├── docs/
-│   └── cli.md                          # EE configuration reference
+├── __init__.py                    # register_enterprise() entrypoint
+├── LICENSE
+├── license.py                     # is_feature_licensed(), require_license(), get_license_info()
+├── AGENTS.md
+├── README.md
+├── docs/cli.md
+├── scripts/generate_license.py
 ├── observal_server/
-│   ├── middleware/
-│   │   └── enterprise_guard.py         # 503 guard for misconfigured EE routes
-│   ├── routes/
-│   │   ├── __init__.py                 # mount_ee_routes() — mounts all EE routers
-│   │   ├── audit.py                    # Audit log query + CSV export
-│   │   ├── scim.py                     # SCIM 2.0 stubs
-│   │   └── sso_saml.py                # SAML 2.0 stubs
-│   └── services/
-│       ├── audit.py                    # Event bus handlers → ClickHouse audit_log writes
-│       └── config_validator.py         # Startup config validation
-└── plugins/
-    └── __init__.py                     # Future integrations placeholder
+│   ├── middleware/enterprise_guard.py
+│   ├── routes/ (audit, admin_sso, exec_dashboard, scim, sso_saml)
+│   └── services/ (audit, config_validator, saml, scim_service)
+├── observal_insights/ (~20 modules, see above)
+└── plugins/__init__.py            # Future integrations placeholder
 ```
+
+## Coding patterns for EE code
+
+- Import core freely: `from services.clickhouse.query import query`, `from models.user import User`
+- Never expose EE imports to core: if core needs to call EE functionality, use a stub pattern (core defines the interface, EE provides the implementation, loaded at runtime)
+- Gate routes with `require_license("feature_name")` dependency
+- All EE tests live in `ee/` or use `pytest.importorskip("ee")`
+- The `EnterpriseGuardMiddleware` is the last line of defense: even if a route is mounted, requests fail with 503 if the license is invalid

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -5,77 +5,116 @@
 
 Next.js 16 / React 19 / TypeScript 6 / Tailwind CSS 4 / Playwright 1.59
 
-## Stack
+## How users interact with it
 
-- **Framework:** Next.js 16 with `output: "standalone"` for Docker
-- **UI:** shadcn/ui (`src/components/ui/`), Recharts 3 for charts, TanStack Query for data fetching, TanStack Table for sortable/filterable tables
-- **Design system:** OKLCH color space with 5 themes (light, dark, midnight, forest, sunset). Typography: Archivo (display), Albert Sans (body), JetBrains Mono (code). 4pt spacing scale. Defined in `globals.css`.
-- **API proxy:** Next.js rewrites (`/api/v1/*` → backend). Backend URL via `NEXT_PUBLIC_API_URL` (defaults `http://localhost:8000`).
-- **Auth:** API key + user role in localStorage. Client-side guards (AuthGuard, AdminGuard, RoleGuard), not middleware.
-- **GraphQL:** `/api/v1/graphql` is the read layer for telemetry. REST for everything else. WebSocket subscriptions via `src/lib/graphql-ws.ts`.
+The web UI is one of three ways to interact with Observal (alongside the CLI and the bundled observal skill). It covers:
+
+- **Browsing and installing agents** from the registry
+- **Viewing session traces** (conversation replay, span tree, token counts)
+- **Admin operations** (review queue, user management, insights, audit logs)
+- **Agent building** (drag-and-drop component assembly with live YAML preview)
+
+## Stack decisions
+
+| Concern | Choice | Why |
+|---------|--------|-----|
+| Framework | Next.js 16 (`output: "standalone"`) | Docker-friendly, RSC-ready |
+| UI primitives | shadcn/ui | Composable, accessible, themeable |
+| Data fetching | TanStack Query via `use-api.ts` | Caching, deduplication, mutations |
+| Tables | TanStack Table | Sort, filter, pagination built-in |
+| Charts | Recharts 3 | Simple, works with OKLCH tokens |
+| Auth | sessionStorage (API key + role) | Not localStorage. Guards are client-side. |
+| API proxy | Next.js rewrites (`/api/v1/*` → backend) | Single origin, no CORS in prod |
+| Fonts | Local files only | No Google Fonts CDN calls |
+| Design tokens | OKLCH in `globals.css` | Perceptually uniform, 5 themes |
+| IDE list | Server-fetched (`/api/v1/config/ides`) | Never hardcoded in frontend |
+
+## Design system
+
+OKLCH color space with semantic tokens: `background`, `foreground`, `card`, `border`, `primary`, `secondary`, `accent`, `destructive`, `success`, `warning`, `info`.
+
+5 themes: light, dark, midnight, forest, sunset. Defined in `globals.css` via CSS custom properties. Switched by `theme-switcher.tsx`.
+
+Typography: Archivo (display/headings), Albert Sans (body), JetBrains Mono (code). 4pt spacing scale. Motion tokens for animations.
+
+No Tailwind config file: Tailwind CSS 4 reads tokens directly from `globals.css`.
 
 ## Route groups
 
 ```
 src/app/
-├── (auth)/login/               # Login + first-run admin init
-├── (registry)/                 # Public agent browser (requires auth)
-│   ├── page.tsx                #   Registry home (search, trending, top rated)
-│   ├── agents/page.tsx         #   Agent list with search + filters
-│   ├── agents/[id]/page.tsx    #   Agent detail with pull command box
-│   ├── agents/builder/page.tsx #   Agent builder (two-column, component selector, YAML preview)
-│   ├── agents/leaderboard/page.tsx #   Agent leaderboard rankings
-│   ├── components/page.tsx     #   Tabbed component browser (MCPs, skills, hooks, prompts, sandboxes)
-│   └── components/[id]/page.tsx#   Component detail
-├── (admin)/                    # Admin dashboard (requires admin role)
-│   ├── dashboard/page.tsx      #   Overview stats, recent agents, latest traces
-│   ├── review/page.tsx         #   Review queue with detail sheet
-│   ├── users/page.tsx          #   User management
-│   ├── settings/page.tsx       #   Enterprise settings
-│   ├── eval/page.tsx           #   Eval overview with agent scores
-│   ├── eval/[agentId]/page.tsx #   Eval detail (aggregate chart, dimension radar, penalty accordion)
-│   └── errors/page.tsx         #   Error log viewer
-└── (user)/                     # User-scoped views (requires auth)
-    ├── traces/page.tsx         #   User trace list with filtering
-    └── traces/[id]/page.tsx    #   Trace detail (resizable span tree + JSON viewer)
+├── (auth)/                         # Unauthenticated
+│   ├── login/page.tsx              #   Login + first-run admin init
+│   └── device/page.tsx             #   Device authorization (OAuth device flow)
+├── (registry)/                     # Authenticated, any role
+│   ├── page.tsx                    #   Registry home (search, trending, top rated)
+│   ├── agents/page.tsx             #   Agent list with search + filters
+│   ├── agents/[id]/page.tsx        #   Agent detail with pull command box
+│   ├── agents/builder/page.tsx     #   Agent builder (component selector, YAML preview)
+│   ├── components/page.tsx         #   Tabbed component browser (all 5 types)
+│   ├── components/[id]/page.tsx    #   Component detail
+│   └── leaderboard/page.tsx        #   Agent leaderboard rankings
+├── (admin)/                        # Admin role required
+│   ├── dashboard/page.tsx          #   Overview stats, recent agents, latest traces
+│   ├── review/page.tsx             #   Review queue with detail sheet
+│   ├── insights/page.tsx           #   Insight reports (license-gated)
+│   ├── insights/[reportId]/page.tsx#   Individual insight report
+│   ├── users/page.tsx              #   User management
+│   ├── settings/page.tsx           #   Settings (sections gated by feature flags)
+│   ├── sso/page.tsx                #   SSO / SAML / OIDC config (license-gated)
+│   ├── audit-log/page.tsx          #   HIPAA audit log with parameterized search
+│   ├── security-events/page.tsx    #   Security event log
+│   ├── diagnostics/page.tsx        #   System diagnostics
+│   └── errors/page.tsx             #   Error log (stubbed, pending rework)
+└── (user)/                         # Authenticated, own data
+    ├── traces/page.tsx             #   Session trace list
+    ├── traces/[id]/page.tsx        #   Trace detail (span tree + JSON viewer)
+    └── account/page.tsx            #   Account settings
 ```
 
-## Component directories
+## Key directories
 
 ```
 src/components/
-├── builder/       # Agent builder (preview panel, sortable component list, validation panel)
+├── builder/       # model-picker, preview-panel, sortable-component-list, validation-panel
 ├── dashboard/     # Stat cards, trend charts, bar lists, heatmap, time range select
 ├── layouts/       # AuthGuard, AdminGuard, RoleGuard, DashboardShell, PageHeader
 ├── nav/           # RegistrySidebar, CommandMenu (Cmd+K), NavUser, GitHubStarBanner
-├── registry/      # AgentCard, AgentEditForm, ComponentCard, ComponentEditForm, PullCommand, InstallDialog, StatusBadge, SubmitComponentDialog, RegistryTable, RegistryDetail, ReviewForm, MetricsPanel, FeedbackList, IdeBadges, VersionBumpDialog, VersionDropdown
+├── registry/      # AgentCard, AgentEditForm, ComponentCard, ComponentEditForm, PullCommand,
+│                  # InstallDialog, StatusBadge, SubmitComponentDialog, RegistryTable,
+│                  # RegistryDetail, ReviewForm, FeedbackList, IdeBadges, VersionBumpDialog,
+│                  # VersionDropdown
 ├── review/        # ReviewDetailSheet, ValidationBadges
 ├── shared/        # SkeletonLayouts, ErrorState, EmptyState
 ├── traces/        # TraceList, TraceDetail, SpanTree
-└── ui/            # shadcn/ui primitives (27 components)
+└── ui/            # shadcn/ui primitives
 ```
 
 ## Key files
 
-- `src/lib/api.ts` : Typed fetch wrapper; all REST + GraphQL calls; auth via localStorage
-- `src/lib/types.ts` : Shared TypeScript interfaces for all API responses
+- `src/lib/api.ts` : Typed fetch wrapper, auth via sessionStorage
+- `src/lib/types.ts` : ALL shared TypeScript interfaces for API responses
 - `src/lib/graphql-ws.ts` : GraphQL WebSocket subscription client
-- `src/lib/ide-features.ts` : IDE feature detection utilities
-- `src/lib/query-client.ts` : TanStack Query client configuration
-- `src/lib/utils.ts` : Shared utility functions
-- `src/lib/export.ts` : Data export utilities
-- `src/hooks/use-api.ts` : TanStack Query hooks for every endpoint (queries + mutations)
-- `src/hooks/use-auth.ts` : Auth guard hook (checks API key exists)
-- `src/hooks/use-admin-guard.ts` : Admin role check hook
-- `src/hooks/use-role-guard.ts` : Generic role check hook
-- `src/hooks/use-deployment-config.ts` : Deployment config fetcher (endpoint discovery)
-- `src/hooks/use-mobile.ts` : Mobile viewport detection
-- `src/components/registry/component-edit-form.tsx` : Unified component editor (hook, skill, prompt, MCP, sandbox type-specific forms)
-- `src/components/registry/version-bump-dialog.tsx` : Semver version bump dialog for publishing new versions
-- `src/components/registry/version-dropdown.tsx` : Version selector dropdown with status badges
-- `src/components/registry/agent-edit-form.tsx` : Agent editor with goal template and component selector
-- `next.config.ts` : API rewrites, standalone output
-- `playwright.config.ts` : E2E test config (Chromium, port 3000)
+- `src/lib/ide-features.ts` : IDE capability detection
+- `src/lib/query-client.ts` : TanStack Query client config
+- `src/hooks/use-api.ts` : TanStack Query hooks for every endpoint
+- `src/hooks/use-auth.ts` : Auth guard (checks sessionStorage)
+- `src/hooks/use-deployment-config.ts` : Feature flags and license status
+- `src/hooks/use-ides.ts` : IDE list from server
+
+## Coding patterns
+
+**Data fetching:** Always use hooks from `use-api.ts`. Never call `fetch` directly in components. The hooks handle caching, error states, loading states, and refetching.
+
+**Types:** All API response types live in `src/lib/types.ts`. Do not define inline types for data that comes from the API. If a new endpoint is added, add its types there.
+
+**Feature gating:** Enterprise features are gated server-side. The API returns 403 for unlicensed features. The frontend reads `useDeploymentConfig()` for display decisions (show/hide sections, upgrade prompts) but never trusts the client to enforce access.
+
+**IDE list:** Fetched from `/api/v1/config/ides` via `useIdes()`. Never hardcode IDE names or capabilities in the frontend. The server is the single source of truth.
+
+**Auth state:** Stored in sessionStorage (not localStorage). `useAuth()` hook checks for presence. Three guard components: `AuthGuard` (any logged-in user), `AdminGuard` (admin role), `RoleGuard` (configurable role check).
+
+**Theming:** Use semantic tokens (`var(--primary)`, `var(--destructive)`, etc.). Never use raw color values. All 5 themes are defined in one `globals.css` block.
 
 ## Commands
 
@@ -83,27 +122,15 @@ src/components/
 pnpm dev          # dev server on :3000
 pnpm build        # production build
 pnpm lint         # ESLint
-pnpm test:e2e     # Playwright e2e tests (requires running API + Docker stack)
-# E2E specs live in web/e2e/*.spec.ts (16 spec files)
+pnpm e2e          # Playwright (requires running Docker stack)
+pnpm e2e:kiro     # Kiro-specific e2e tests
+pnpm e2e:ui       # Playwright UI mode
 ```
 
-## Enterprise feature gating
+E2E specs live in `tests/e2e/*.spec.ts` (19 files, separate pnpm workspace at repo root).
 
-There is NO `web/ee/` directory. Enterprise frontend code lives here in `web/src/`, gated server-side via `useDeploymentConfig()`. This follows the Langfuse/PostHog/Infisical pattern — the `ee/` boundary is backend-only.
+## Enterprise in the frontend
 
-**Current enterprise conditionals:**
-- `src/app/(auth)/login/page.tsx` — SSO button shown when `ssoEnabled`
-- `src/app/(admin)/settings/page.tsx` — enterprise settings section shown when `deploymentMode === "enterprise"`
-- `src/hooks/use-deployment-config.ts` — fetches `{ deploymentMode, ssoEnabled, samlEnabled }` from `/api/v1/config/public`
+There is NO `web/ee/` directory. Enterprise pages live in `src/app/(admin)/` alongside core pages. They call license-gated API endpoints. If the feature isn't licensed, the server returns 403 and the frontend shows an upgrade prompt.
 
-**Pattern for new enterprise pages:** Add regular pages in `src/app/(admin)/` that check deployment mode and show an upgrade prompt when not enterprise. Don't duplicate pages or create separate directories.
-
-**Future resource-based access control:** API will include `user_access_level` on response objects (PostHog annotation pattern). Frontend reads the annotation — no client-side policy engine needed.
-
-## Conventions
-
-- No Tailwind config file — Tailwind CSS 4 uses `globals.css` for all design tokens
-- Theme switching via `src/components/ui/theme-switcher.tsx`
-- All API response types are centralized in `src/lib/types.ts` — don't define inline types for API data
-- Use TanStack Query hooks from `src/hooks/use-api.ts` for data fetching — don't call `fetch` directly in components
-- Semantic color tokens: background, foreground, card, border, primary, secondary, accent, destructive, success, warning, info
+This follows the Langfuse/PostHog pattern: the `ee/` boundary is backend-only. The frontend is AGPL and gates features server-side.


### PR DESCRIPTION
## Purpose / Description

All AGENTS.md files were stale (last edited 162 commits ago). They described removed systems (eval pipeline, DEPLOYMENT_MODE, VS Code adapter, event-bus audit), missed new systems (Pi IDE, HIPAA audit, dynamic settings, version enforcement, server commands), and read like a changelog rather than living architectural context.

Rewrote all three committed files (root, ee/, web/) plus the gitignored .pi/AGENTS.md to be:
- Architecture-focused, not changelog-shaped
- Clear about IDE support tiers (first-class: Claude Code, Kiro, Cursor, Pi; stubs: rest)
- Explicit about coding patterns and conventions
- Descriptive of the three interaction modes (CLI, Web UI, Observal skill)
- References `docs/adding-an-ide.md` for the IDE integration guide

## Fixes

* No linked issue (maintenance)

## Approach

- Ran `git log` on all 162 commits since last edit
- Inspected actual directory structure, adapter line counts, feature sets
- Rewrote from scratch with architectural framing rather than file-by-file inventory
- Root AGENTS.md went from 34KB to 12.6KB (more useful, less noise per token)

## How Has This Been Tested?

Documentation-only change. Verified file paths and claims against the actual codebase via inspection.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)