### PR TITLE
fix: remove unused imports/component and resolve useMemo warnings

### DIFF
--- a/web/src/components/registry/component-edit-form.tsx
+++ b/web/src/components/registry/component-edit-form.tsx
@@ -111,10 +111,17 @@ function McpEditForm({
 	const itemUrl = (item.url as string) ?? "";
 	const itemTransport = (item.transport as string) ?? "";
 	const itemName = (item.name as string) ?? "";
-	const itemArgs = Array.isArray(item.args) ? (item.args as string[]) : [];
-	const itemEnvVars = Array.isArray(item.environment_variables)
-		? (item.environment_variables as { name: string }[])
-		: [];
+	const itemArgs = useMemo(
+		() => (Array.isArray(item.args) ? (item.args as string[]) : []),
+		[item.args],
+	);
+	const itemEnvVars = useMemo(
+		() =>
+			Array.isArray(item.environment_variables)
+				? (item.environment_variables as { name: string }[])
+				: [],
+		[item.environment_variables],
+	);
 
 	const currentConfigJson = useMemo(() => {
 		const cfg: Record<string, unknown> = {};
@@ -133,14 +140,13 @@ function McpEditForm({
 		if (Object.keys(cfg).length === 0) return "";
 		const wrapper = { mcpServers: { [itemName]: cfg } };
 		return JSON.stringify(wrapper, null, 2);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		itemCommand,
 		itemUrl,
 		itemTransport,
 		itemName,
-		JSON.stringify(itemArgs),
-		JSON.stringify(itemEnvVars),
+		itemArgs,
+		itemEnvVars,
 	]);
 
 	const [jsonInput, setJsonInput] = useState(currentConfigJson);

--- a/web/src/components/review/review-diff-sheet.tsx
+++ b/web/src/components/review/review-diff-sheet.tsx
@@ -36,9 +36,8 @@ import {
 	useComponentVersionDetail,
 	useRegistryItem,
 } from "@/hooks/use-api";
-import { registry } from "@/lib/api";
 import type { RegistryType } from "@/lib/api";
-import type { ReviewItem, ComponentChange } from "@/lib/types";
+import type { ReviewItem } from "@/lib/types";
 
 function pluralizeType(type: string): string {
 	if (type === "agent") return "agents";
@@ -76,41 +75,6 @@ const changeIcon: Record<string, React.ReactNode> = {
 	removed: <Minus className="h-3 w-3" />,
 	updated: <RefreshCw className="h-3 w-3" />,
 };
-
-function ComponentChangesList({ changes }: { changes: ComponentChange[] }) {
-	if (!changes.length) return null;
-
-	return (
-		<div className="space-y-2">
-			{changes.map((c, i) => (
-				<div
-					key={i}
-					className="flex items-start gap-2 text-xs py-1.5 px-2 rounded bg-muted/40"
-				>
-					<Badge
-						variant="outline"
-						className={`text-[10px] shrink-0 flex items-center gap-1 ${changeBadgeClasses[c.change] ?? ""}`}
-					>
-						{changeIcon[c.change]}
-						{c.change}
-					</Badge>
-					<div className="min-w-0 flex-1">
-						<span className="font-medium truncate block">{c.name}</span>
-						<span className="text-muted-foreground">{c.type}</span>
-						{c.from && c.to && (
-							<span className="ml-1 text-muted-foreground">
-								{c.from} <ArrowRight className="h-2.5 w-2.5 inline" /> {c.to}
-							</span>
-						)}
-						{c.version && !c.from && (
-							<span className="ml-1 text-muted-foreground">v{c.version}</span>
-						)}
-					</div>
-				</div>
-			))}
-		</div>
-	);
-}
 
 const DIFF_METADATA_FIELDS = new Set([
 	"id",


### PR DESCRIPTION
### Purpose / Description
This PR addresses two code quality issues:

1. Unused imports and component in review-diff-sheet.tsx : The file contained unused imports ( registry and ComponentChange type) and an entire unused component ( ComponentChangesList ) that were never used, causing lint warnings and dead code.
2. useMemo dependency warnings in component-edit-form.tsx : The itemArgs and itemEnvVars variables were initialized with conditional checks, causing unstable dependencies and useMemo warnings.
### Fixes
Fixes #1220

### Approach
- For review-diff-sheet.tsx : Removed the unused imports and the unused ComponentChangesList component entirely.
- For component-edit-form.tsx : Wrapped itemArgs and itemEnvVars initialization in their own useMemo calls to provide stable references, then updated currentConfigJson useMemo dependencies to use these stable values instead of JSON.stringify() calls.
### How Has This Been Tested?
1. pnpm typecheck : Ran typecheck in web directory - no errors
2. pnpm lint : Ran lint in web directory - the useMemo warnings and unused variable warnings for these files are now resolved
3. Manual verification : The code still compiles and the components should function as expected (no regressions)
### Learning (optional)
- React useMemo best practices : When dealing with complex dependencies (like arrays/objects initialized with conditionals), wrap them in useMemo to ensure stable references
- Dead code removal : Always remove unused imports and components to keep the codebase clean and maintainable
### Checklist
- You have a descriptive commit message with a short title (first line, max 50 chars).
- You have performed a self-review of your own code
- UI changes: include screenshots of all affected screens (in particular showing any new or changed strings) (No UI changes in this PR - just code cleanup)