### PR TITLE
fix: move SPDX comments inside YAML frontmatter for all skills

### DIFF
--- a/observal_cli/skills/observal-admin/SKILL.md
+++ b/observal_cli/skills/observal-admin/SKILL.md
@@ -1,7 +1,6 @@
-<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
-<!-- SPDX-License-Identifier: AGPL-3.0-only -->
-
 ---
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
 name: observal-admin
 command: observal
 description: Observal admin operations including user management, enterprise settings, submission review queue, eval scoring, security events, audit logs, and SSO configuration. Use when the user needs to manage users, approve or reject submissions, run evals, view security events, or configure SAML/SCIM.

--- a/observal_cli/skills/observal-advanced/SKILL.md
+++ b/observal_cli/skills/observal-advanced/SKILL.md
@@ -1,7 +1,6 @@
-<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
-<!-- SPDX-License-Identifier: AGPL-3.0-only -->
-
 ---
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
 name: observal-advanced
 command: observal
 description: Advanced Observal operations including IDE profile swapping, session reconciliation, CLI upgrades and downgrades, complete uninstallation, and local fallback mode for offline use. Use when the user wants to swap IDE profiles, reconcile sessions, upgrade or downgrade the CLI, uninstall Observal, or write agent configs locally when the server is unreachable.

--- a/observal_cli/skills/observal-agents/SKILL.md
+++ b/observal_cli/skills/observal-agents/SKILL.md
@@ -1,7 +1,6 @@
-<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
-<!-- SPDX-License-Identifier: AGPL-3.0-only -->
-
 ---
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
 name: observal-agents
 command: observal
 description: Create, update, version, and manage Observal agents. Use when the user wants to create a new agent, update an existing one, release a new version, scaffold a YAML project, add components, build, publish, bulk-create, delete, or restore agents.

--- a/observal_cli/skills/observal-ops/SKILL.md
+++ b/observal_cli/skills/observal-ops/SKILL.md
@@ -1,7 +1,6 @@
-<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
-<!-- SPDX-License-Identifier: AGPL-3.0-only -->
-
 ---
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
 name: observal-ops
 command: observal
 description: View traces, spans, metrics, feedback, and telemetry health for Observal agents and MCPs. Use when the user wants to see recent traces, check metrics, view top items, submit ratings, or diagnose telemetry pipeline issues.

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -1,7 +1,6 @@
-<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
-<!-- SPDX-License-Identifier: AGPL-3.0-only -->
-
 ---
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
 name: observal-registry
 command: observal
 description: Submit, browse, install, edit, delete, and version MCPs, skills, hooks, prompts, and sandboxes in the Observal registry. Use when the user wants to submit a component, install one, edit a draft, publish a new version, or browse the component library.

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -1,8 +1,6 @@
-<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
-<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
-<!-- SPDX-License-Identifier: AGPL-3.0-only -->
 ---
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 name: observal
 command: observal


### PR DESCRIPTION
## Purpose / Description

Pi requires `---` to be the very first line of SKILL.md files. HTML comments (`<!-- SPDX... -->`) before the frontmatter break Pi's skill parser with "description is required" error.

## Fixes

* Fixes skill conflicts on Pi after `observal doctor patch --all --all-ides`

## Approach

Move SPDX headers from HTML comments (before `---`) to YAML comments (inside frontmatter). This is valid YAML, REUSE-compliant, and Pi-compatible.

Before:
```markdown
<!-- SPDX-FileCopyrightText: 2026 ... -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

---
name: observal-admin
```

After:
```markdown
---
# SPDX-FileCopyrightText: 2026 ...
# SPDX-License-Identifier: AGPL-3.0-only
name: observal-admin
```

## How Has This Been Tested?

Verified on a Pi install that all 6 skills load without "description is required" errors after this fix.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens