### PR TITLE
fix(security): prevent rate-limit bypass via X-Forwarded-For spoofing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 SrihariLegend <sriharilegend23@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 DoomsCoder <vedantkakade05@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Security
+
+- Prevent rate-limit bypass via X-Forwarded-For spoofing (SEC-003, #894). Uvicorn `--proxy-headers` removed; new `TrustedProxyMiddleware` resolves client IP at the app layer using the `security.trusted_proxy_ips` dynamic setting.
 
 ## [1.1.1] - 2026-05-25
 
@@ -1723,4 +1730,3 @@ All notable changes to this project will be documented in this file.
 ### Ui
 
 - brighter borders, responsive text scaling, observal favicon ([909a9b6](https://github.com/BlazeUp-AI/Observal/commit/909a9b6dd7cedc9ddaff31b208f09ace9d35be7e))
-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com>
 # SPDX-FileCopyrightText: 2026 Swathi Saravanan <ss4522@cornell.edu>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 services:
@@ -50,9 +51,6 @@ services:
         "0.0.0.0",
         "--port",
         "8000",
-        "--proxy-headers",
-        "--forwarded-allow-ips",
-        "*",
       ]
     env_file:
       - ../.env

--- a/docker/server-package/docker-compose.yml
+++ b/docker/server-package/docker-compose.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # Standalone Observal deployment — uses pre-built images from GHCR.
@@ -30,7 +31,7 @@ services:
 
   observal-api:
     image: ghcr.io/blazeup-ai/observal-api:${OBSERVAL_VERSION:-latest}
-    command: ["/app/.venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]
+    command: ["/app/.venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
     env_file:
       - ./.env
     environment:

--- a/observal-server/api/middleware/audit.py
+++ b/observal-server/api/middleware/audit.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Audit middleware: captures every request lifecycle via loguru."""
@@ -30,9 +31,8 @@ class AuditMiddleware(BaseHTTPMiddleware):
         if sensitivity == "skip":
             return await call_next(request)
 
-        ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip()
-        if not ip:
-            ip = request.client.host if request.client else "127.0.0.1"
+        # Real IP is resolved by TrustedProxyMiddleware into request.scope["client"]
+        ip = request.client.host if request.client else "127.0.0.1"
 
         response = await call_next(request)
         duration_ms = (time.perf_counter() - start) * 1000

--- a/observal-server/api/middleware/trusted_proxy.py
+++ b/observal-server/api/middleware/trusted_proxy.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Trusted proxy middleware (SEC-003).
+
+Replaces Uvicorn's --proxy-headers flag with app-layer proxy handling
+that uses the same trust config (security.trusted_proxy_ips) as the
+rate limiter.
+
+When the TCP peer is a trusted proxy this middleware:
+  1. Resolves the real client IP from X-Forwarded-For (rightmost non-trusted)
+     and overwrites request.scope["client"] so that ALL downstream consumers
+     (audit, download tracker, rate limiter, etc.) see the correct IP.
+  2. Reads X-Forwarded-Proto and sets request.scope["scheme"].
+
+Unlike Uvicorn's --proxy-headers (which takes the leftmost XFF entry and
+is trivially spoofable), this walks the header right-to-left and skips
+trusted proxy IPs — the same algorithm used by _get_real_ip() in
+api/ratelimit.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from starlette.middleware.base import BaseHTTPMiddleware
+
+import services.dynamic_settings as ds
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+
+class TrustedProxyMiddleware(BaseHTTPMiddleware):
+    """Resolve real client IP and scheme from proxy headers when the TCP peer is trusted."""
+
+    async def dispatch(self, request: Request, call_next):
+        client_ip = request.client.host if request.client else None
+        trusted_str = ds.get_sync("security.trusted_proxy_ips")
+        trusted = {ip.strip() for ip in trusted_str.split(",") if ip.strip()} if trusted_str else set()
+
+        if client_ip and client_ip in trusted:
+            # Resolve real client IP from X-Forwarded-For (rightmost non-trusted)
+            forwarded = request.headers.get("x-forwarded-for", "")
+            if forwarded:
+                ips = [ip.strip() for ip in forwarded.split(",")]
+                for ip in reversed(ips):
+                    if ip not in trusted:
+                        # Overwrite scope so all downstream sees the real IP
+                        request.scope["client"] = (ip, request.scope["client"][1])
+                        break
+
+            # Set scheme from X-Forwarded-Proto
+            proto = request.headers.get("x-forwarded-proto")
+            if proto in ("http", "https"):
+                request.scope["scheme"] = proto
+
+        return await call_next(request)

--- a/observal-server/api/middleware/trusted_proxy.py
+++ b/observal-server/api/middleware/trusted_proxy.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Trusted proxy middleware (SEC-003).
@@ -15,8 +16,12 @@ When the TCP peer is a trusted proxy this middleware:
 
 Unlike Uvicorn's --proxy-headers (which takes the leftmost XFF entry and
 is trivially spoofable), this walks the header right-to-left and skips
-trusted proxy IPs — the same algorithm used by _get_real_ip() in
+trusted proxy IPs, using the same algorithm as _get_real_ip() in
 api/ratelimit.py.
+
+The setting supports both plain IPs and CIDR notation (e.g.
+"172.16.0.0/12,10.0.0.0/8") so Docker-internal networks are matched
+regardless of the container IP assigned at runtime.
 """
 
 from __future__ import annotations
@@ -26,6 +31,7 @@ from typing import TYPE_CHECKING
 from starlette.middleware.base import BaseHTTPMiddleware
 
 import services.dynamic_settings as ds
+from services.shared.ip_utils import is_trusted, parse_trusted
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -37,15 +43,19 @@ class TrustedProxyMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         client_ip = request.client.host if request.client else None
         trusted_str = ds.get_sync("security.trusted_proxy_ips")
-        trusted = {ip.strip() for ip in trusted_str.split(",") if ip.strip()} if trusted_str else set()
 
-        if client_ip and client_ip in trusted:
+        if not trusted_str or not client_ip:
+            return await call_next(request)
+
+        exact, networks = parse_trusted(trusted_str)
+
+        if is_trusted(client_ip, exact, networks):
             # Resolve real client IP from X-Forwarded-For (rightmost non-trusted)
             forwarded = request.headers.get("x-forwarded-for", "")
             if forwarded:
                 ips = [ip.strip() for ip in forwarded.split(",")]
                 for ip in reversed(ips):
-                    if ip not in trusted:
+                    if not is_trusted(ip, exact, networks):
                         # Overwrite scope so all downstream sees the real IP
                         request.scope["client"] = (ip, request.scope["client"][1])
                         break

--- a/observal-server/api/ratelimit.py
+++ b/observal-server/api/ratelimit.py
@@ -12,20 +12,26 @@ from config import settings
 
 def _get_real_ip(request: Request) -> str:
     """Return the real client IP.
+
     Only trusts X-Forwarded-For when the direct TCP peer is in TRUSTED_PROXY_IPS.
     Without configured trusted proxies, uses the socket IP directly.
+    Supports both plain IPs and CIDR notation in the setting.
     """
+    from services.shared.ip_utils import is_trusted, parse_trusted
+
     client_ip = request.client.host if request.client else "127.0.0.1"
     trusted_str = ds.get_sync("security.trusted_proxy_ips")
-    trusted = [ip.strip() for ip in trusted_str.split(",") if ip.strip()] if trusted_str else []
-    if not trusted or client_ip not in trusted:
+    if not trusted_str:
+        return client_ip
+    exact, networks = parse_trusted(trusted_str)
+    if not is_trusted(client_ip, exact, networks):
         return client_ip
     forwarded = request.headers.get("x-forwarded-for", "")
     if not forwarded:
         return client_ip
     ips = [ip.strip() for ip in forwarded.split(",")]
     for ip in reversed(ips):
-        if ip not in trusted:
+        if not is_trusted(ip, exact, networks):
             return ip
     return client_ip
 

--- a/observal-server/api/routes/audit.py
+++ b/observal-server/api/routes/audit.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """CLI audit event ingestion endpoint."""
@@ -45,9 +46,8 @@ async def receive_cli_audit_event(
 
     from services.clickhouse import insert_audit_log
 
-    ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip()
-    if not ip:
-        ip = request.client.host if request.client else "127.0.0.1"
+    # Real IP is resolved by TrustedProxyMiddleware into request.scope["client"]
+    ip = request.client.host if request.client else "127.0.0.1"
 
     row = {
         "event_id": event.event_id,

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com>
 # SPDX-FileCopyrightText: 2026 Swathi Saravanan <ss4522@cornell.edu>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import os
@@ -36,6 +37,7 @@ from api.graphql import get_context_dep, schema
 from api.middleware.audit import AuditMiddleware
 from api.middleware.content_type import ContentTypeMiddleware
 from api.middleware.request_id import RequestIDMiddleware
+from api.middleware.trusted_proxy import TrustedProxyMiddleware
 from api.ratelimit import limiter
 from api.routes.admin import router as admin_router
 from api.routes.agent import router as agent_router
@@ -327,6 +329,11 @@ if AUDIT_LICENSED:
 
 # --- GZip compression for responses >= 500 bytes ---
 app.add_middleware(GZipMiddleware, minimum_size=500)
+
+# --- Trusted proxy: resolve real client IP + scheme (SEC-003) ---
+# Replaces Uvicorn --proxy-headers so proxy trust is controlled by a single
+# dynamic setting (security.trusted_proxy_ips) shared with the rate limiter.
+app.add_middleware(TrustedProxyMiddleware)
 
 
 class CacheControlMiddleware(BaseHTTPMiddleware):

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -183,7 +183,12 @@ DEFAULTS: dict[str, str] = {
     "security.allow_draft_install": "false",
     "security.rate_limit_auth": "10/minute",
     "security.rate_limit_auth_strict": "5/minute",
-    "security.trusted_proxy_ips": "",
+    # NOTE: Defaults to RFC 1918 private ranges so the Docker compose stack
+    # works out of the box (nginx LB connects from a Docker-bridge IP).
+    # Tradeoff: any process on the same private network can inject XFF headers
+    # that the middleware will trust. For hardened deployments where the API is
+    # directly exposed, narrow this to only the actual proxy IP(s).
+    "security.trusted_proxy_ips": "172.16.0.0/12,10.0.0.0/8,192.168.0.0/16,127.0.0.1",
     # SAML
     "saml.idp_entity_id": "",
     "saml.idp_sso_url": "",

--- a/observal-server/services/request_context.py
+++ b/observal-server/services/request_context.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Per-request context propagation via contextvars.
@@ -27,9 +28,12 @@ class RequestContext(NamedTuple):
 
 
 def set_request_context(request) -> None:
-    """Populate contextvars from a Starlette/FastAPI Request."""
-    forwarded = request.headers.get("x-forwarded-for")
-    ip = forwarded.split(",")[0].strip() if forwarded else (request.client.host if request.client else "127.0.0.1")
+    """Populate contextvars from a Starlette/FastAPI Request.
+
+    NOTE: relies on TrustedProxyMiddleware having already resolved the real
+    client IP into request.scope["client"].  Do not parse X-Forwarded-For here.
+    """
+    ip = request.client.host if request.client else "127.0.0.1"
 
     _request_ip.set(ip)
     _request_user_agent.set(request.headers.get("user-agent", ""))

--- a/observal-server/services/shared/ip_utils.py
+++ b/observal-server/services/shared/ip_utils.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""IP parsing and trust utilities for proxy-aware IP resolution.
+
+Used by both TrustedProxyMiddleware and the rate limiter to determine
+whether a peer IP is a trusted proxy and to resolve the real client IP
+from X-Forwarded-For headers.
+
+Supports both plain IPs and CIDR notation (e.g. "172.16.0.0/12,10.0.0.1").
+Results are cached per unique setting string to avoid re-parsing on every request.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from functools import lru_cache
+
+from loguru import logger as optic
+
+
+@lru_cache(maxsize=4)
+def parse_trusted(raw: str) -> tuple[frozenset[str], tuple]:
+    """Parse the trusted proxy setting into exact IPs and CIDR networks.
+
+    Returns a tuple of (exact_ips_frozenset, networks_tuple) for hashability.
+    Cached by the raw string value so repeated calls within the same config
+    epoch are essentially free.
+    """
+    exact: set[str] = set()
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "/" in entry:
+            try:
+                networks.append(ipaddress.ip_network(entry, strict=False))
+            except ValueError:
+                optic.warning("invalid CIDR in security.trusted_proxy_ips: {}", entry)
+        else:
+            exact.add(entry)
+    return frozenset(exact), tuple(networks)
+
+
+def is_trusted(ip: str, exact: frozenset[str], networks: tuple) -> bool:
+    """Check if an IP is trusted (exact match or within a CIDR range)."""
+    if ip in exact:
+        return True
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return any(addr in net for net in networks)

--- a/scripts/test_xff_spoofing.sh
+++ b/scripts/test_xff_spoofing.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# SEC-003 integration test: verify that X-Forwarded-For spoofing
+# cannot bypass rate limiting.
+#
+# Run against a live docker-compose stack:
+#   docker compose -f docker/docker-compose.yml up -d
+#   bash scripts/test_xff_spoofing.sh
+#
+# Before the fix (--forwarded-allow-ips "*"):
+#   All requests return 401 — rate limit bypassed via XFF rotation.
+#
+# After the fix (--proxy-headers removed, TrustedProxyMiddleware added):
+#   Requests 6+ return 429 — rate limiter sees the real IP regardless of XFF.
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost}"
+ENDPOINT="$BASE_URL/api/v1/auth/login"
+RATE_LIMIT=5        # the login endpoint allows 5/minute
+TOTAL_REQUESTS=8    # send more than the limit to trigger 429
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # no color
+
+echo ""
+echo "======================================"
+echo " SEC-003: XFF Spoofing Rate Limit Test"
+echo "======================================"
+echo ""
+echo "Target:   $ENDPOINT"
+echo "Limit:    $RATE_LIMIT/minute"
+echo "Requests: $TOTAL_REQUESTS (with rotating X-Forwarded-For)"
+echo ""
+
+# Check that the endpoint is reachable (/health is exposed through nginx;
+# /readyz is only available in the dev nginx config).
+if ! curl -sf -o /dev/null "$BASE_URL/health" 2>/dev/null; then
+    echo -e "${RED}ERROR: Server not reachable at $BASE_URL${NC}"
+    echo "Start the stack first: docker compose -f docker/docker-compose.yml up -d"
+    exit 1
+fi
+
+# Send requests with a different spoofed XFF on each one.
+# If the rate limiter is fooled, every request gets a unique "client IP"
+# and none of them hit the 5/minute cap.
+got_429=false
+results=()
+
+for i in $(seq 1 "$TOTAL_REQUESTS"); do
+    code=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "$ENDPOINT" \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-For: 99.99.99.$i" \
+        -d '{"email":"xff-test@example.com","password":"wrong"}')
+    results+=("$code")
+    if [ "$code" = "429" ]; then
+        got_429=true
+    fi
+    echo "  Request $i  →  HTTP $code  (XFF: 99.99.99.$i)"
+done
+
+echo ""
+echo "--------------------------------------"
+
+if $got_429; then
+    echo -e "${GREEN}PASS${NC}: Rate limiter returned 429 despite XFF rotation."
+    echo "XFF spoofing does NOT bypass rate limiting."
+    exit 0
+else
+    echo -e "${RED}FAIL${NC}: All $TOTAL_REQUESTS requests returned without rate limiting."
+    echo "XFF spoofing bypasses the rate limiter — the attacker can rotate"
+    echo "X-Forwarded-For to get unlimited login attempts."
+    exit 1
+fi

--- a/tests/test_hipaa_audit.py
+++ b/tests/test_hipaa_audit.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Tests for the HIPAA audit logging system."""
@@ -283,7 +284,7 @@ class TestMiddleware:
             assert kwargs["audit"] is True
             assert kwargs["outcome"] == "success"
             assert kwargs["sensitivity"] == "high"
-            assert kwargs["ip_address"] == "10.0.0.1"
+            assert kwargs["ip_address"] == "127.0.0.1"
             mock_bound.info.assert_called_once_with("audit")
 
     @pytest.mark.asyncio

--- a/tests/test_sec003_trusted_proxy_middleware.py
+++ b/tests/test_sec003_trusted_proxy_middleware.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for SEC-003: TrustedProxyMiddleware.
+
+The middleware replaces Uvicorn's --proxy-headers flag so that both
+X-Forwarded-For (client IP) and X-Forwarded-Proto (scheme) are only
+honoured from IPs listed in ``security.trusted_proxy_ips``.
+
+Unlike Uvicorn (which takes the leftmost XFF entry), this middleware
+walks XFF right-to-left and skips trusted proxy IPs — making it
+resistant to spoofing.
+"""
+
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from api.middleware.trusted_proxy import TrustedProxyMiddleware
+
+
+def _make_app():
+    """Build a minimal Starlette app with only TrustedProxyMiddleware."""
+
+    async def info(request: Request):
+        return JSONResponse(
+            {
+                "ip": request.client.host,  # pyright: ignore[reportOptionalMemberAccess]
+                "scheme": request.scope["scheme"],
+            }
+        )
+
+    app = Starlette(routes=[Route("/info", info)])
+    app.add_middleware(TrustedProxyMiddleware)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# X-Forwarded-Proto tests
+# ---------------------------------------------------------------------------
+
+
+class TestProtoHandling:
+    def test_untrusted_peer_proto_ignored(self):
+        """X-Forwarded-Proto from a non-trusted peer is ignored."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "10.0.0.1"
+            resp = client.get("/info", headers={"X-Forwarded-Proto": "https"})
+        assert resp.json()["scheme"] == "http"
+
+    def test_trusted_peer_proto_applied(self):
+        """X-Forwarded-Proto from a trusted peer sets the scheme to https."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "testclient"
+            resp = client.get("/info", headers={"X-Forwarded-Proto": "https"})
+        assert resp.json()["scheme"] == "https"
+
+    def test_no_trusted_proxies_proto_ignored(self):
+        """When trusted proxy list is empty, X-Forwarded-Proto is always ignored."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = ""
+            resp = client.get("/info", headers={"X-Forwarded-Proto": "https"})
+        assert resp.json()["scheme"] == "http"
+
+    def test_invalid_proto_value_rejected(self):
+        """Only 'http' and 'https' are accepted; other values are ignored."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "testclient"
+            resp = client.get("/info", headers={"X-Forwarded-Proto": "ftp"})
+        assert resp.json()["scheme"] == "http"
+
+
+# ---------------------------------------------------------------------------
+# X-Forwarded-For (client IP resolution) tests
+# ---------------------------------------------------------------------------
+
+
+class TestClientIpResolution:
+    def test_untrusted_peer_xff_ignored(self):
+        """XFF from a non-trusted peer does not change client IP."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "10.0.0.1"
+            resp = client.get("/info", headers={"X-Forwarded-For": "99.99.99.1"})
+        # testclient is not trusted, XFF ignored
+        assert resp.json()["ip"] == "testclient"
+
+    def test_trusted_peer_rightmost_non_trusted_ip_used(self):
+        """When peer is trusted, rightmost non-trusted IP from XFF is used."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "testclient,10.0.0.2"
+            resp = client.get(
+                "/info",
+                headers={"X-Forwarded-For": "5.5.5.5, 8.8.8.8, 10.0.0.2"},
+            )
+        # Reversed: 10.0.0.2 (trusted, skip), 8.8.8.8 (not trusted, use it)
+        assert resp.json()["ip"] == "8.8.8.8"
+
+    def test_spoofed_leftmost_ignored(self):
+        """Attacker-controlled leftmost XFF entry is never used."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "testclient"
+            resp = client.get(
+                "/info",
+                headers={"X-Forwarded-For": "spoofed.ip, real.client.ip"},
+            )
+        # Reversed: real.client.ip (not trusted) -> used
+        assert resp.json()["ip"] == "real.client.ip"
+
+    def test_all_xff_trusted_keeps_peer_ip(self):
+        """When all XFF IPs are trusted, client IP stays as the TCP peer."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "testclient,10.0.0.1,10.0.0.2"
+            resp = client.get(
+                "/info",
+                headers={"X-Forwarded-For": "10.0.0.1, 10.0.0.2"},
+            )
+        # All XFF IPs are trusted, no override happens
+        assert resp.json()["ip"] == "testclient"
+
+    def test_no_xff_header_keeps_peer_ip(self):
+        """When no XFF header is sent, client IP is the TCP peer."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "testclient"
+            resp = client.get("/info")
+        assert resp.json()["ip"] == "testclient"
+
+    def test_empty_trusted_list_xff_ignored(self):
+        """When no proxies are trusted, XFF cannot change client IP."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = ""
+            resp = client.get(
+                "/info",
+                headers={"X-Forwarded-For": "99.99.99.1"},
+            )
+        assert resp.json()["ip"] == "testclient"
+
+    def test_multiple_trusted_proxies_parsed(self):
+        """Comma-separated trusted proxy list is parsed and whitespace trimmed."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = " testclient , 10.0.0.1 "
+            resp = client.get(
+                "/info",
+                headers={"X-Forwarded-For": "203.0.113.50, 10.0.0.1"},
+            )
+        # Reversed: 10.0.0.1 (trusted, skip), 203.0.113.50 (not trusted, use)
+        assert resp.json()["ip"] == "203.0.113.50"

--- a/tests/test_sec003_trusted_proxy_middleware.py
+++ b/tests/test_sec003_trusted_proxy_middleware.py
@@ -8,8 +8,8 @@ X-Forwarded-For (client IP) and X-Forwarded-Proto (scheme) are only
 honoured from IPs listed in ``security.trusted_proxy_ips``.
 
 Unlike Uvicorn (which takes the leftmost XFF entry), this middleware
-walks XFF right-to-left and skips trusted proxy IPs — making it
-resistant to spoofing.
+walks XFF right-to-left and skips trusted proxy IPs, making it
+resistant to spoofing. Supports both plain IPs and CIDR notation.
 """
 
 from unittest.mock import patch
@@ -170,3 +170,66 @@ class TestClientIpResolution:
             )
         # Reversed: 10.0.0.1 (trusted, skip), 203.0.113.50 (not trusted, use)
         assert resp.json()["ip"] == "203.0.113.50"
+
+
+# ---------------------------------------------------------------------------
+# CIDR notation support
+# ---------------------------------------------------------------------------
+
+
+class TestCidrSupport:
+    def test_cidr_matches_peer_ip(self):
+        """A peer IP within a trusted CIDR range is recognized as trusted."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            # testclient is not a real IP, so trust the Docker-style subnet
+            # that contains 127.0.0.1 (TestClient uses 'testclient' as host)
+            mock_ds.get_sync.return_value = "testclient,172.16.0.0/12"
+            resp = client.get(
+                "/info",
+                headers={"X-Forwarded-For": "203.0.113.99, 172.18.0.5"},
+            )
+        # 172.18.0.5 is in 172.16.0.0/12 (trusted, skip), 203.0.113.99 used
+        assert resp.json()["ip"] == "203.0.113.99"
+
+    def test_cidr_skips_xff_entries_in_range(self):
+        """XFF entries within a trusted CIDR are skipped during right-to-left walk."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            mock_ds.get_sync.return_value = "testclient,10.0.0.0/8"
+            resp = client.get(
+                "/info",
+                headers={"X-Forwarded-For": "82.1.2.3, 10.0.0.1, 10.0.0.2"},
+            )
+        # 10.0.0.2 trusted, 10.0.0.1 trusted, 82.1.2.3 not trusted
+        assert resp.json()["ip"] == "82.1.2.3"
+
+    def test_cidr_does_not_match_outside_range(self):
+        """IPs outside the CIDR range are not considered trusted."""
+        app = _make_app()
+        client = TestClient(app)
+        with patch("api.middleware.trusted_proxy.ds") as mock_ds:
+            # Only 192.168.0.0/16 is trusted; testclient is not in that range
+            mock_ds.get_sync.return_value = "192.168.0.0/16"
+            resp = client.get(
+                "/info",
+                headers={"X-Forwarded-For": "1.2.3.4"},
+            )
+        # testclient not trusted, XFF ignored
+        assert resp.json()["ip"] == "testclient"
+
+    def test_default_docker_cidr_trusts_nginx(self):
+        """The default setting (172.16.0.0/12) matches typical Docker bridge IPs."""
+        from services.shared.ip_utils import is_trusted, parse_trusted
+
+        exact, networks = parse_trusted("172.16.0.0/12,10.0.0.0/8,192.168.0.0/16,127.0.0.1")
+        # Typical Docker-assigned nginx IPs
+        assert is_trusted("172.18.0.2", exact, networks)
+        assert is_trusted("172.20.0.5", exact, networks)
+        assert is_trusted("10.0.2.1", exact, networks)
+        assert is_trusted("127.0.0.1", exact, networks)
+        # Public IPs should NOT be trusted
+        assert not is_trusted("8.8.8.8", exact, networks)
+        assert not is_trusted("203.0.113.1", exact, networks)


### PR DESCRIPTION
## Purpose / Description

Uvicorn's `--proxy-headers --forwarded-allow-ips "*"` overwrites `request.client.host` with the **leftmost** (attacker-controlled) X-Forwarded-For entry before any app code runs. An attacker rotating XFF on each request gets a unique "client IP" every time, completely bypassing per-IP rate limiting on login and other sensitive endpoints.

### Reproduction

```bash
# With spoofed XFF rotation every request sees a different "client"
for i in {1..8}; do
  curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost/api/v1/auth/login \
    -H "Content-Type: application/json" \
    -H "X-Forwarded-For: 99.99.99.$i" \
    -d '{"email":"xff-test@example.com","password":"wrong"}'
done
# Before fix: all return 401 (rate limit never triggers)
# After fix: 429 appears at request 6
```

## Fixes

* Fixes #894

## Approach

1. **Remove `--proxy-headers --forwarded-allow-ips "*"`** from both docker-compose files so Uvicorn no longer blindly trusts XFF.

2. **Add `TrustedProxyMiddleware`** at the app layer which:
   - Only processes XFF when the TCP peer is in `security.trusted_proxy_ips`
   - Walks XFF **right-to-left**, skipping trusted proxy IPs (resistant to leftmost spoofing)
   - Writes the resolved IP into `request.scope["client"]` so all downstream (rate limiter, audit, etc.) sees it
   - Also handles `X-Forwarded-Proto` for scheme detection

3. **Remove broken leftmost-XFF parsing** from three other call sites (AuditMiddleware, CLI audit route, request_context) — they now read from `request.client.host` which the middleware already resolved.

4. Uses the **same trust config** (`security.trusted_proxy_ips` dynamic setting) as the rate limiter, single source of truth, changeable at runtime via admin UI.

### Deployment note

Deployments behind a reverse proxy must set `security.trusted_proxy_ips` (via admin UI) to the proxy's IP for per-client rate limiting to work correctly. Without it, all requests appear to come from the proxy's IP (fails closed).

## How Has This Been Tested?

- `make test` — 3676 passed, 22 skipped (pre-existing, unrelated)
- New unit tests: `tests/test_sec003_trusted_proxy_middleware.py` (11 tests covering trusted/untrusted peers, XFF walk, spoofed leftmost ignored, empty config, proto handling)
- Integration test: `scripts/test_xff_spoofing.sh` (hits real docker stack with rotating XFF, verifies 429 appears)

## Learning

- Uvicorn's `--proxy-headers` takes the **leftmost** XFF entry, the one the client controls. This is fundamentally broken for security when `--forwarded-allow-ips "*"`.
- The correct algorithm is rightmost-non-trusted (walk XFF from right to left, skip known proxy IPs, first unknown IP is the real client). This is what nginx `realip_module`, Cloudflare, and AWS ALB all use.
- Unit tests can't catch this class of bug because they mock `request.client.host` directly, bypassing the Uvicorn layer. Only integration tests against the real stack prove the fix.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
