### PR TITLE
fix(sessions): 404 denied agent bind

### DIFF
--- a/observal-server/api/routes/sessions.py
+++ b/observal-server/api/routes/sessions.py
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com>
 # SPDX-FileCopyrightText: 2026 SrihariLegend <sriharilegend23@gmail.com>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Session listing and detail endpoints - backed by session_events table.
@@ -19,7 +20,7 @@ import asyncio
 import logging
 import uuid as _uuid
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi_cache.decorator import cache
 from loguru import logger as optic
 from sqlalchemy import select
@@ -394,7 +395,7 @@ async def bind_session_agent(
             params,
         )
         if not ownership:
-            return {"error": "Session not found or access denied"}
+            raise HTTPException(status_code=404, detail="Session not found or access denied")
 
     from redis.exceptions import RedisError
 

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _user(role="user"):
+    from models.user import User, UserRole
+
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.role = getattr(UserRole, role)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_bind_session_agent_denied_raises_404():
+    """Mutation access failures should use HTTP errors, matching other ownership checks."""
+    from api.routes.sessions import bind_session_agent
+
+    with (
+        patch("api.routes.sessions._ch_json", new=AsyncMock(return_value=[])),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await bind_session_agent("session-123", agent_name="agent", current_user=_user())
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Session not found or access denied"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description

`POST /api/v1/sessions/{session_id}/bind-agent` returned `200 OK` with an error body when a non-admin user tried to bind an agent to a session they did not own.

That made a failed mutation look successful at the HTTP layer. Clients that rely on `response.ok`, status codes, or generic API error handling could incorrectly treat the bind as successful even though no agent was bound.

This change makes denied session agent binding return an HTTP error instead.

## Fixes

N/A

## Approach

When a non-admin user tries to bind an agent to a session, the endpoint already checks ClickHouse for a matching `session_id` owned by the current user.

Before this change, failed ownership lookup returned:

`{"error": "Session not found or access denied"}`

with `200 OK`.

After this change, the endpoint raises:

`HTTPException(status_code=404, detail="Session not found or access denied")`

This preserves the existing privacy behavior by not distinguishing between “session does not exist” and “session exists but belongs to someone else.”

This also aligns the endpoint with the rest of the backend. Other ownership and access-control failures in mutation-style routes use FastAPI `HTTPException` responses instead of returning successful `200 OK` responses with an error object.

A focused regression test was added for the denied non-admin path.

## How Has This Been Tested?

Ran the focused session API test from `observal-server`:

`uv run pytest tests/test_sessions_api.py -q`

Result:

`1 passed`

Ran Ruff on the changed backend route and new test from the repository root:

`uv run ruff check observal-server/api/routes/sessions.py observal-server/tests/test_sessions_api.py`

Result:

`All checks passed`

The commit hooks also ran successfully during commit, including Ruff, formatting, SPDX header validation, merge-conflict checks, secret checks, and Dockerfile linting during push.

## Learning (optional, can help others)

I checked first-party callers before making the change.

I did not find any web or CLI code calling `POST /api/v1/sessions/{session_id}/bind-agent`, and I did not find existing tests depending on the old `200 OK` soft-error behavior.

The main compatibility risk would be an external client depending on the old response shape. Within this repository, the change is consistent with the existing API error-handling style and safer for clients that use HTTP status codes to detect failed mutations.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)