### PR TITLE
fix(web): handle non-JSON login error responses

### DIFF
--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -48,22 +48,8 @@ function LoginContent() {
       setLoading(true);
       window.history.replaceState({}, "", "/login");
 
-      fetch("/api/v1/auth/exchange", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code: ssoCode }),
-      })
-        .then(async (res) => {
-          if (!res.ok) {
-            const text = await res.text().catch(() => res.statusText);
-            const msg = (res.status >= 500 || text.trim().startsWith("<"))
-              ? "Unable to reach the server. Please try again later."
-              : text;
-            throw new Error(msg);
-          }
-          return res.json();
-        })
-        .then((data: { access_token: string; refresh_token: string; user: { role: string; name: string; email: string; username?: string; avatar_url?: string | null } }) => {
+      auth.exchangeCode({ code: ssoCode })
+        .then((data) => {
           setTokens(data.access_token, data.refresh_token);
           setUserRole(data.user.role);
           setUserName(data.user.name);

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -56,7 +56,10 @@ function LoginContent() {
         .then(async (res) => {
           if (!res.ok) {
             const text = await res.text().catch(() => res.statusText);
-            throw new Error(text);
+            const msg = (res.status >= 500 || text.trim().startsWith("<"))
+              ? "Unable to reach the server. Please try again later."
+              : text;
+            throw new Error(msg);
           }
           return res.json();
         })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,4 @@
+
 // SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
 // SPDX-FileCopyrightText: 2026 Harishankar <harishankar0301@gmail.com>
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -263,7 +263,10 @@ async function request<T = unknown>(
 						: JSON.stringify(parsed.error);
 			}
 		} catch {
-			// not JSON, use raw text
+			// not JSON, use raw text unless it's HTML or a 5xx error
+			if (response.status >= 500 || text.trim().startsWith("<")) {
+				detail = "Unable to reach the server. Please try again later.";
+			}
 		}
 		const err = new Error(detail);
 		(err as Error & { status: number }).status = response.status;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes the login page rendering raw HTML when the API server is unavailable.

When the API container is unhealthy/down, nginx returns an HTML 502 Bad Gateway response. The frontend previously displayed this raw HTML directly inside the login error banner.

This change adds guards for non-JSON/HTML error responses and replaces them with a user-friendly message:

"Unable to reach the server. Please try again later."

## Fixes
* Fixes #1238

## Approach
Added minimal frontend-side guards for login-related API error handling.

## How Has This Been Tested?
Reproduction:
1. Start the stack
2. Stop the API container:
       docker stop docker-observal-api-1
3. Open the login page
4. Attempt login

Before:
Raw nginx HTML (502 Bad Gateway) was rendered inside the login error banner

After:
A user-friendly error message is displayed:
"Unable to reach the server. Please try again later."

## Learning (optional, can help others)
This issue was caused by frontend error handling assuming API responses were always valid JSON/text responses intended for UI display. When nginx returned an HTML error page, the raw HTML was propagated directly into the UI.

The fix demonstrates a simple defensive pattern for handling unexpected non-JSON server responses in frontend fetch logic.

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->
