### PR TITLE
fix(web): handle non-JSON API error responses

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -240,7 +240,7 @@ async function request<T = unknown>(
 		}
 
 		const text = await response.text().catch(() => response.statusText);
-		let detail = text;
+		let detail = "Unable to reach the server. Please try again later.";
 		try {
 			const parsed = JSON.parse(text);
 			if (parsed.detail) {
@@ -263,7 +263,8 @@ async function request<T = unknown>(
 						: JSON.stringify(parsed.error);
 			}
 		} catch {
-			// not JSON, use raw text
+			// Non-JSON response (e.g. nginx 502 html page)
+			detail = "Unable to reach the server. Please try again later.";
 		}
 		const err = new Error(detail);
 		(err as Error & { status: number }).status = response.status;


### PR DESCRIPTION
## Purpose / Description

Fix frontend handling for non-JSON API error responses.

When the API container is unavailable or unhealthy, nginx returns an HTML 502 response. Previously, the frontend rendered the raw HTML inside the login error banner instead of showing a user-friendly message.

## Fixes

* Fixes #1238
## Approach

Updated the shared API request error handling in `web/src/lib/api.ts`.

The change:

* catches JSON parse failures
* prevents rendering raw HTML responses
* displays a generic connectivity error message instead

Now users see:
"Unable to reach the server. Please try again later."

instead of raw HTML from nginx.

## How Has This Been Tested?

Tested locally using Docker.

Steps:

1. Started the frontend stack
2. Stopped the API container using:
   `docker stop docker-observal-api-1`
3. Opened the login page
4. Attempted sign in

### Before fix

The frontend displayed raw HTML from the nginx 502 response.

### After fix

The frontend now shows:
"Unable to reach the server. Please try again later."

Screenshots attached below show both behaviors.
<img width="1920" height="1080" alt="Screenshot (21)" src="https://github.com/user-attachments/assets/e166caa6-afe8-4383-9f65-3f7e89b2ade4" />

<img width="1920" height="1080" alt="Screenshot (22)" src="https://github.com/user-attachments/assets/4f3f397e-04b3-4390-92d8-74f0e60e6e29" />

## Checklist

* [x] You have a descriptive commit message with a short title (first line, max 50 chars).
* [ ] You have commented your code, particularly in hard-to-understand areas
* [x] You have performed a self-review of your own code
* [x] UI changes: include screenshots of all affected screens
