### PR TITLE
feat(skills): add registry_direct delivery mode for inline skill submission

### DIFF
--- a/ee/observal_server/routes/exec_dashboard.py
+++ b/ee/observal_server/routes/exec_dashboard.py
@@ -724,11 +724,7 @@ async def get_departments(
     if all_dept_user_ids:
         from models.agent import Agent
 
-        agent_rows = (
-            await db.execute(
-                select(Agent.created_by, func.count(Agent.id)).group_by(Agent.created_by)
-            )
-        ).all()
+        agent_rows = (await db.execute(select(Agent.created_by, func.count(Agent.id)).group_by(Agent.created_by))).all()
         user_agent_count: dict[str, int] = {str(r[0]): r[1] for r in agent_rows}
         for dept_name, user_ids in dept_map.items():
             agent_count_by_dept[dept_name] = sum(user_agent_count.get(uid, 0) for uid in user_ids)

--- a/observal-server/alembic/versions/003_skill_registry_direct.py
+++ b/observal-server/alembic/versions/003_skill_registry_direct.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Add registry_direct delivery mode fields to skill_versions.
+
+Revision ID: 003_skill_registry_direct
+Revises: 002_drop_visibility
+Create Date: 2026-05-26
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "003_skill_registry_direct"
+down_revision = "002_drop_visibility"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "skill_versions", sa.Column("delivery_mode", sa.String(20), server_default="git_fetch", nullable=False)
+    )
+    op.add_column("skill_versions", sa.Column("script_content", sa.Text(), nullable=True))
+    op.add_column("skill_versions", sa.Column("script_filename", sa.String(255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("skill_versions", "script_filename")
+    op.drop_column("skill_versions", "script_content")
+    op.drop_column("skill_versions", "delivery_mode")

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -186,7 +186,6 @@ def require_role(min_role: UserRole):
     return _check
 
 
-
 def get_effective_agent_permission(agent: "Agent", user: User | None) -> str:  # noqa: F821
     """Evaluate effective permission for an agent: 'owner', 'edit', 'view', or 'none'."""
     if not user:

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -250,11 +250,7 @@ async def list_agents(
     total = (await db.execute(count_stmt)).scalar_one()
     response.headers["X-Total-Count"] = str(total)
 
-    stmt = (
-        select(Agent)
-        .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
-        .where(base_filter)
-    )
+    stmt = select(Agent).join(AgentVersion, Agent.latest_version_id == AgentVersion.id).where(base_filter)
     if search_filter is not None:
         stmt = stmt.where(search_filter)
     if org_filter is not None:
@@ -315,11 +311,7 @@ async def my_agents(
     optic.debug("my_agents called")
     from models.feedback import Feedback
 
-    stmt = (
-        select(Agent)
-        .where(Agent.created_by == current_user.id)
-        .order_by(Agent.created_at.desc())
-    )
+    stmt = select(Agent).where(Agent.created_by == current_user.id).order_by(Agent.created_at.desc())
     agents = (await db.execute(stmt)).scalars().all()
 
     agent_ids = [a.id for a in agents]

--- a/observal-server/api/routes/agent/helpers.py
+++ b/observal-server/api/routes/agent/helpers.py
@@ -39,18 +39,13 @@ async def _load_agent(
     (needed for unarchive, delete, etc.).
     """
     try:
-        return await resolve_prefix_id(
-            Agent, agent_id, db, extra_conditions=extra_conditions
-        )
+        return await resolve_prefix_id(Agent, agent_id, db, extra_conditions=extra_conditions)
     except HTTPException:
         pass
 
     # Try the caller's own agent first
     if prefer_user_id is not None:
-        stmt = (
-            select(Agent)
-            .where(Agent.name == agent_id, Agent.created_by == prefer_user_id)
-        )
+        stmt = select(Agent).where(Agent.name == agent_id, Agent.created_by == prefer_user_id)
         if extra_conditions:
             stmt = stmt.where(*extra_conditions)
         mine = (await db.execute(stmt)).scalar_one_or_none()
@@ -58,11 +53,7 @@ async def _load_agent(
             return mine
 
     # Fall back to global name lookup
-    stmt = (
-        select(Agent)
-        .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
-        .where(Agent.name == agent_id)
-    )
+    stmt = select(Agent).join(AgentVersion, Agent.latest_version_id == AgentVersion.id).where(Agent.name == agent_id)
     if not include_all_statuses:
         stmt = stmt.where(AgentVersion.status == AgentStatus.approved)
     if extra_conditions:

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -61,8 +61,32 @@ async def submit_skill(
     description = req.description
     slash_command = req.slash_command
     skill_path = req.skill_path
+    delivery_mode = req.delivery_mode or "git_fetch"
+    script_content = req.script_content
+    script_filename = req.script_filename
 
-    if req.git_url:
+    if delivery_mode == "registry_direct":
+        # Registry direct: skill_md_content is required, no git validation
+        if not skill_md_content:
+            raise HTTPException(status_code=422, detail="skill_md_content is required for registry_direct delivery")
+        # Parse frontmatter for auto-fill using simple string ops (no regex on user data)
+        import re as _re
+
+        fm_match = _re.match(r"^---\r?\n([\s\S]*?)\r?\n---", skill_md_content)
+        if fm_match:
+            for line in fm_match.group(1).split("\n"):
+                if line.startswith("name:") and not name:
+                    name = line[5:].strip()
+                elif line.startswith("description:") and not description:
+                    val = line[12:].strip()
+                    # Strip surrounding quotes
+                    if len(val) >= 2 and val[0] in ("'", '"') and val[-1] == val[0]:
+                        val = val[1:-1]
+                    description = val
+                elif line.startswith("command:") and slash_command is None:
+                    slash_command = line[8:].strip().lstrip("/")
+        validated = True  # Content is inline, no need to fetch from git
+    elif req.git_url:
         try:
             analysis = await validate_skill_md(
                 req.git_url,
@@ -113,6 +137,9 @@ async def submit_skill(
         git_url=req.git_url,
         git_ref=req.git_ref,
         skill_md_content=skill_md_content,
+        delivery_mode=delivery_mode,
+        script_content=script_content,
+        script_filename=script_filename,
         validated=validated,
         target_agents=req.target_agents,
         task_type=req.task_type,
@@ -245,6 +272,9 @@ async def save_skill_draft(
         git_url=req.git_url,
         git_ref=req.git_ref,
         skill_md_content=req.skill_md_content,
+        delivery_mode=req.delivery_mode or "git_fetch",
+        script_content=req.script_content,
+        script_filename=req.script_filename,
         target_agents=req.target_agents,
         task_type=req.task_type,
         slash_command=req.slash_command,
@@ -289,6 +319,9 @@ async def update_skill_draft(
         "git_url",
         "git_ref",
         "skill_md_content",
+        "delivery_mode",
+        "script_content",
+        "script_filename",
         "target_agents",
         "task_type",
         "slash_command",

--- a/observal-server/models/skill.py
+++ b/observal-server/models/skill.py
@@ -151,6 +151,36 @@ class SkillListing(Base):
         self.latest_version.skill_md_content = value
 
     @property
+    def delivery_mode(self) -> str:
+        return self.latest_version.delivery_mode if self.latest_version else "git_fetch"
+
+    @delivery_mode.setter
+    def delivery_mode(self, value: str) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set delivery_mode")
+        self.latest_version.delivery_mode = value
+
+    @property
+    def script_content(self) -> str | None:
+        return self.latest_version.script_content if self.latest_version else None
+
+    @script_content.setter
+    def script_content(self, value: str | None) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set script_content")
+        self.latest_version.script_content = value
+
+    @property
+    def script_filename(self) -> str | None:
+        return self.latest_version.script_filename if self.latest_version else None
+
+    @script_filename.setter
+    def script_filename(self, value: str | None) -> None:
+        if not self.latest_version:
+            raise RuntimeError(f"{type(self).__name__} has no latest_version; cannot set script_filename")
+        self.latest_version.script_filename = value
+
+    @property
     def validated(self) -> bool:
         return self.latest_version.validated if self.latest_version else False
 
@@ -229,6 +259,9 @@ class SkillVersion(Base):
     git_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     git_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
     skill_md_content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    delivery_mode: Mapped[str] = mapped_column(String(20), server_default="git_fetch", nullable=False)
+    script_content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    script_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
     validated: Mapped[bool] = mapped_column(Boolean, default=False)
     target_agents: Mapped[list] = mapped_column(JSON, default=list)
     task_type: Mapped[str] = mapped_column(String(100), nullable=False)

--- a/observal-server/schemas/skill.py
+++ b/observal-server/schemas/skill.py
@@ -21,6 +21,9 @@ class SkillSubmitRequest(BaseModel):
     git_url: str | None = None
     git_ref: str | None = None
     skill_md_content: str | None = None
+    delivery_mode: str = "git_fetch"
+    script_content: str | None = None
+    script_filename: str | None = None
     target_agents: list[str] = []
     task_type: str
     slash_command: str | None = None
@@ -39,6 +42,9 @@ class SkillDraftRequest(BaseModel):
     git_url: str | None = None
     git_ref: str | None = None
     skill_md_content: str | None = None
+    delivery_mode: str = "git_fetch"
+    script_content: str | None = None
+    script_filename: str | None = None
     target_agents: list[str] = []
     task_type: str = "general"
     slash_command: str | None = None
@@ -56,6 +62,9 @@ class SkillUpdateRequest(BaseModel):
     git_url: str | None = None
     git_ref: str | None = None
     skill_md_content: str | None = None
+    delivery_mode: str | None = None
+    script_content: str | None = None
+    script_filename: str | None = None
     target_agents: list[str] | None = None
     task_type: str | None = None
     slash_command: str | None = None
@@ -75,6 +84,9 @@ class SkillListingResponse(BaseModel):
     git_url: str | None = None
     git_ref: str | None = None
     skill_md_content: str | None = None
+    delivery_mode: str = "git_fetch"
+    script_content: str | None = None
+    script_filename: str | None = None
     validated: bool = False
     slash_command: str | None = None
     status: ListingStatus

--- a/observal-server/services/skill_config_generator.py
+++ b/observal-server/services/skill_config_generator.py
@@ -121,6 +121,17 @@ def generate_skill_config(
     if skill_md_content:
         config["skill"]["skill_md_content"] = skill_md_content
 
+    # Delivery mode and registry-direct script
+    delivery_mode = getattr(skill_listing, "delivery_mode", "git_fetch")
+    config["skill"]["delivery_mode"] = delivery_mode
+    if delivery_mode == "registry_direct":
+        script_content = getattr(skill_listing, "script_content", None)
+        script_filename = getattr(skill_listing, "script_filename", None)
+        if script_content:
+            config["skill"]["script_content"] = script_content
+        if script_filename:
+            config["skill"]["script_filename"] = script_filename
+
     # Generate IDE-specific skill file
     skill_file = _generate_skill_file(skill_listing, ide, scope)
     if skill_file:

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -75,6 +75,8 @@ def skill_submit(
     skill_md: str | None = typer.Option(None, "--skill-md", help="Path to SKILL.md to paste (auto-fills fields)"),
     git_url: str | None = typer.Option(None, "--git-url", help="Git repository URL"),
     git_ref: str | None = typer.Option(None, "--git-ref", help="Branch or tag (default: main)"),
+    script: str | None = typer.Option(None, "--script", help="Path to script file (registry_direct mode)"),
+    delivery_mode: str | None = typer.Option(None, "--delivery-mode", help="Delivery: git_fetch or registry_direct"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (skill ID)"),
 ):
@@ -86,7 +88,11 @@ def skill_submit(
 
     Shortcut: provide --skill-md PATH to paste the SKILL.md content directly
     (fields are auto-filled from frontmatter; --git-url is still required
-    for install).
+    for install unless using --delivery-mode registry_direct).
+
+    Registry direct: use --delivery-mode registry_direct with --skill-md and
+    optionally --script to submit a skill with inline content (no git repo
+    needed). On install, the SKILL.md and script are written directly.
 
     Only submit skills you created or are the point-of-contact for.
 
@@ -94,6 +100,7 @@ def skill_submit(
         observal registry skill submit --git-url https://github.com/org/repo
         observal registry skill submit --from-file skill.json
         observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo
+        observal registry skill submit --skill-md ./SKILL.md --script ./run.sh --delivery-mode registry_direct
         observal registry skill submit --draft
         observal registry skill submit --submit abc123
     """
@@ -126,6 +133,9 @@ def skill_submit(
         # --- Paste-first: parse SKILL.md locally if provided ---
         prefill: dict = {}
         skill_md_content: str | None = None
+        script_content: str | None = None
+        script_filename: str | None = None
+
         if skill_md:
             try:
                 raw = Path(skill_md).read_text(encoding="utf-8")
@@ -145,22 +155,41 @@ def skill_submit(
                     f"description={str(prefill.get('description', ''))[:60]!r}"
                 )
 
+        if script:
+            script_path_obj = Path(script)
+            if not script_path_obj.exists():
+                rprint(f"[red]Script file not found:[/red] {script}")
+                raise typer.Exit(code=1)
+            script_content = script_path_obj.read_text(encoding="utf-8")
+            script_filename = script_path_obj.name
+            rprint(f"[green]✓ Read script:[/green] {script_filename}")
+
+        # Auto-detect delivery mode
+        effective_delivery_mode = delivery_mode or (
+            "registry_direct" if (skill_md_content and not git_url) else "git_fetch"
+        )
+
         agents_input = text_input("Target agents (comma-separated)", default="")
         payload = {
             "name": text_input("Skill name", default=prefill.get("name", "")),
             "version": text_input("Version", default="1.0.0"),
             "description": text_input("Description", default=prefill.get("description", "")),
             "owner": text_input("Owner", default=config.load().get("user_name", "")),
-            "git_url": git_url or text_input("Git URL"),
-            "skill_path": text_input("Skill path in repo", default="/"),
-            "git_ref": git_ref or text_input("Git ref (branch/tag)", default="main"),
             "task_type": select_one("Task type", VALID_SKILL_TASK_TYPES),
             "target_agents": [a.strip() for a in agents_input.split(",") if a.strip()],
+            "delivery_mode": effective_delivery_mode,
         }
+        if effective_delivery_mode == "git_fetch":
+            payload["git_url"] = git_url or text_input("Git URL")
+            payload["skill_path"] = text_input("Skill path in repo", default="/")
+            payload["git_ref"] = git_ref or text_input("Git ref (branch/tag)", default="main")
         if prefill.get("slash_command"):
             payload["slash_command"] = prefill["slash_command"]
         if skill_md_content:
             payload["skill_md_content"] = skill_md_content
+        if script_content:
+            payload["script_content"] = script_content
+            payload["script_filename"] = script_filename
 
     endpoint = "/api/v1/skills/draft" if draft else "/api/v1/skills/submit"
     label = "draft" if draft else "skill"
@@ -309,10 +338,12 @@ def skill_show(
                 ("Status", status_badge(item.get("status", ""))),
                 ("Validated", "✓" if item.get("validated") else "✗"),
                 ("Task Type", item.get("task_type", "N/A")),
+                ("Delivery Mode", item.get("delivery_mode", "git_fetch")),
                 ("Owner", item.get("owner", "N/A")),
                 ("Git URL", item.get("git_url", "N/A")),
                 ("Git Ref", item.get("git_ref") or "N/A"),
                 ("Skill Path", item.get("skill_path", "/")),
+                ("Script", item.get("script_filename") or "N/A"),
                 ("Slash Command", f"/{item['slash_command']}" if item.get("slash_command") else "N/A"),
                 ("Description", item.get("description", "")),
                 ("Target Agents", ", ".join(item.get("target_agents", [])) or "N/A"),
@@ -408,15 +439,26 @@ def skill_install(
     skill_info = snippet.get("skill", {})
 
     if not no_write:
-        install_skill_from_git(
-            name=skill_info.get("name", "skill"),
-            git_url=skill_info.get("git_url"),
-            skill_path=skill_info.get("skill_path", "/"),
-            git_ref=skill_info.get("git_ref", "main"),
-            ide=ide,
-            scope=scope,
-            skill_md_content=skill_info.get("skill_md_content"),
-        )
+        delivery_mode = skill_info.get("delivery_mode", "git_fetch")
+        if delivery_mode == "registry_direct":
+            install_skill_registry_direct(
+                name=skill_info.get("name", "skill"),
+                skill_md_content=skill_info.get("skill_md_content"),
+                script_content=skill_info.get("script_content"),
+                script_filename=skill_info.get("script_filename"),
+                ide=ide,
+                scope=scope,
+            )
+        else:
+            install_skill_from_git(
+                name=skill_info.get("name", "skill"),
+                git_url=skill_info.get("git_url"),
+                skill_path=skill_info.get("skill_path", "/"),
+                git_ref=skill_info.get("git_ref", "main"),
+                ide=ide,
+                scope=scope,
+                skill_md_content=skill_info.get("skill_md_content"),
+            )
     else:
         rprint("[dim]Skill install skipped (--no-write)[/dim]")
 
@@ -451,6 +493,61 @@ def _user_skill_dest(ide: str, skill_name: str) -> Path:
     base = _USER_SKILL_DIRS.get(ide_key, "~/.agents/skills")
     expanded = Path(base.replace("~", str(Path.home())))
     return expanded / skill_name
+
+
+def install_skill_registry_direct(
+    *,
+    name: str,
+    skill_md_content: str | None,
+    script_content: str | None = None,
+    script_filename: str | None = None,
+    ide: str = "claude-code",
+    scope: str = "user",
+    cwd: Path | None = None,
+) -> Path | None:
+    """Install a registry_direct skill: write SKILL.md and optional script.
+
+    Writes to <dest>/<name>/SKILL.md and <dest>/<name>/scripts/<script_filename>.
+    Returns the destination Path on success, None on failure.
+    """
+    skill_name = _sanitize_name(name)
+
+    if scope == "user":
+        dest = _user_skill_dest(ide, skill_name)
+    else:
+        base = (cwd or Path.cwd()) / ".agents" / "skills"
+        dest = base / skill_name
+        if not _is_path_safe(dest, base):
+            rprint(f"[red]\u2717 Unsafe skill name (path traversal detected):[/red] {skill_name!r}")
+            return None
+
+    if not skill_md_content:
+        rprint("[yellow]\u26a0 No SKILL.md content available to write.[/yellow]")
+        return None
+
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "SKILL.md").write_text(skill_md_content, encoding="utf-8")
+    rprint(f"[green]\u2713 Wrote skill file:[/green] {dest / 'SKILL.md'}")
+
+    if script_content and script_filename:
+        scripts_dir = dest / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        script_path = scripts_dir / script_filename
+        if not _is_path_safe(script_path, scripts_dir):
+            rprint(f"[red]\u2717 Unsafe script filename (path traversal):[/red] {script_filename!r}")
+        else:
+            script_path.write_text(script_content, encoding="utf-8")
+            # Make executable if it looks like a script
+            if script_filename.endswith((".sh", ".bash", ".py", ".rb")):
+                import os
+
+                os.chmod(script_path, 0o755)
+            rprint(f"[green]\u2713 Wrote script:[/green] {script_path}")
+
+    if scope == "project":
+        _symlink_for_ides(cwd or Path.cwd(), dest, skill_name)
+
+    return dest
 
 
 def install_skill_from_git(

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -57,9 +57,17 @@ Without `--git`, opens interactive JSON paste (accepts IDE config block, named c
 
 ### Skill
 
+Git-based (server validates SKILL.md from repo):
 ```bash
 observal skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --git-ref main
 ```
+
+Registry direct (inline SKILL.md + optional script, no git repo needed):
+```bash
+observal skill submit --skill-md ./SKILL.md --script ./run.sh --delivery-mode registry_direct
+```
+
+On install, registry_direct skills write `<skill-name>/SKILL.md` and `<skill-name>/scripts/<filename>` into the IDE skills directory.
 
 ### Hook
 

--- a/tests/test_listing_detail_access.py
+++ b/tests/test_listing_detail_access.py
@@ -100,6 +100,9 @@ def _listing_mock(status=ListingStatus.approved, submitted_by=None):
     m.skill_path = "/"
     m.git_ref = None
     m.skill_md_content = None
+    m.delivery_mode = "git_fetch"
+    m.script_content = None
+    m.script_filename = None
     m.validated = False
     m.slash_command = None
     m.event = "PreToolUse"

--- a/tests/test_sec027_registry_sc.py
+++ b/tests/test_sec027_registry_sc.py
@@ -192,7 +192,8 @@ class TestInstallAgentStatusGating:
     @pytest.mark.asyncio
     @patch("api.routes.agent.install._load_agent")
     @patch("api.routes.agent.install._ds")
-    async def test_approved_agent_always_installable(self, mock_settings, mock_load):
+    @patch("services.download_tracker.record_agent_download", new_callable=AsyncMock)
+    async def test_approved_agent_always_installable(self, mock_download, mock_settings, mock_load):
         """Approved agents install regardless of ALLOW_DRAFT_INSTALL flag."""
         mock_settings.get_sync_bool.return_value = False
 

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -23,6 +23,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Check, Info, Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
 import type { RegistryType } from "@/lib/api";
@@ -181,6 +182,12 @@ export function SubmitComponentDialog({
 	const [skillGitRef, setSkillGitRef] = useState((d?.git_ref as string) ?? "");
 	const [skillMdContent, setSkillMdContent] = useState(
 		(d?.skill_md_content as string) ?? "",
+	);
+	const [skillScriptContent, setSkillScriptContent] = useState(
+		(d?.script_content as string) ?? "",
+	);
+	const [skillScriptFilename, setSkillScriptFilename] = useState(
+		(d?.script_filename as string) ?? "",
 	);
 	const [skillMode, setSkillMode] = useState<"git" | "paste">("git");
 
@@ -369,6 +376,8 @@ export function SubmitComponentDialog({
 		setSkillPathHint(null);
 		setSkillGitRef("");
 		setSkillMdContent("");
+		setSkillScriptContent("");
+		setSkillScriptFilename("");
 		setSkillMode("git");
 		setEvent("PreToolUse");
 		setHandlerType("command");
@@ -416,11 +425,17 @@ export function SubmitComponentDialog({
 				const skillBody: Record<string, unknown> = {
 					...base,
 					task_type: taskType,
-					git_url: skillGitUrl || undefined,
-					skill_path: skillPath || "/",
+					delivery_mode: skillMode === "paste" ? "registry_direct" : "git_fetch",
 				};
-				if (skillGitRef) skillBody.git_ref = skillGitRef;
-				if (skillMdContent) skillBody.skill_md_content = skillMdContent;
+				if (skillMode === "git") {
+					skillBody.git_url = skillGitUrl || undefined;
+					skillBody.skill_path = skillPath || "/";
+					if (skillGitRef) skillBody.git_ref = skillGitRef;
+				} else {
+					if (skillMdContent) skillBody.skill_md_content = skillMdContent;
+					if (skillScriptContent) skillBody.script_content = skillScriptContent;
+					if (skillScriptFilename) skillBody.script_filename = skillScriptFilename;
+				}
 				return skillBody;
 			}
 			case "hooks": {
@@ -869,116 +884,122 @@ export function SubmitComponentDialog({
 								</Select>
 							</div>
 
-							{/* Toggle: git-ref mode vs paste SKILL.md */}
-							<div className="flex items-center gap-2 text-xs">
-								<button
-									type="button"
-									onClick={() => setSkillMode("git")}
-									className={`px-2.5 py-1 rounded-md font-medium transition-colors ${
-										skillMode === "git"
-											? "bg-primary text-primary-foreground"
-											: "bg-muted/50 text-muted-foreground hover:bg-muted"
-									}`}
-								>
-									Git URL
-								</button>
-								<button
-									type="button"
-									onClick={() => setSkillMode("paste")}
-									className={`px-2.5 py-1 rounded-md font-medium transition-colors ${
-										skillMode === "paste"
-											? "bg-primary text-primary-foreground"
-											: "bg-muted/50 text-muted-foreground hover:bg-muted"
-									}`}
-								>
-									Paste SKILL.md
-								</button>
-							</div>
+							<Tabs value={skillMode} onValueChange={(v) => setSkillMode(v as "git" | "paste")} className="w-full">
+								<TabsList className="grid w-full grid-cols-2">
+									<TabsTrigger value="git">Git Submit</TabsTrigger>
+									<TabsTrigger value="paste">Registry Submit</TabsTrigger>
+								</TabsList>
 
-							{skillMode === "paste" && (
-								<div className="space-y-1.5">
-									<Label htmlFor="skill-md-content">SKILL.md content</Label>
-									<Textarea
-										id="skill-md-content"
-										value={skillMdContent}
-										onChange={(e) => {
-											const raw = e.target.value;
-											setSkillMdContent(raw);
-											// Auto-fill name/description from frontmatter
-											const fmMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-											if (fmMatch) {
-												const lines = fmMatch[1].split(/\r?\n/);
-												for (const line of lines) {
-													const nm = line.match(/^name:\s*(.+)$/);
-													if (nm && !name) setName(nm[1].trim());
-													const dm = line.match(
-														/^description:\s*["']?(.+?)["']?$/,
-													);
-													if (dm && !description) setDescription(dm[1].trim());
-												}
-											}
-										}}
-										placeholder={`---\nname: my-skill\ndescription: What this skill does\ncommand: /my-skill\n---\n\n## Instructions\n...`}
-										rows={10}
-										className="font-mono text-xs"
-									/>
-									<p className="text-xs text-muted-foreground">
-										Frontmatter auto-fills name and description above. Git URL
-										is still required for install.
-									</p>
-								</div>
-							)}
-
-							<div className="grid grid-cols-2 gap-3">
-								<div className="space-y-1.5">
-									<Label htmlFor="skill-git-url">
-										Git URL{" "}
-										{skillMode === "git" ? "*" : "(required for install)"}
-									</Label>
-									<Input
-										id="skill-git-url"
-										value={skillGitUrl}
-										onChange={(e) => handleSkillGitUrl(e.target.value)}
-										placeholder="https://github.com/org/skills"
-									/>
-									{skillDiscovering && (
-										<p className="text-xs text-muted-foreground flex items-center gap-1">
-											<Loader2 className="h-3 w-3 animate-spin" />
-											Looking for SKILL.md…
-										</p>
-									)}
-									{skillPathHint && !skillDiscovering && (
-										<p
-											className={`text-xs ${skillPathAuto ? "text-green-600" : "text-amber-600"}`}
-										>
-											{skillPathHint}
-										</p>
-									)}
-								</div>
-								{!skillPathAuto && (
+								<TabsContent value="git" className="space-y-3 pt-3">
+									<div className="grid grid-cols-2 gap-3">
+										<div className="space-y-1.5">
+											<Label htmlFor="skill-git-url">Git URL *</Label>
+											<Input
+												id="skill-git-url"
+												value={skillGitUrl}
+												onChange={(e) => handleSkillGitUrl(e.target.value)}
+												placeholder="https://github.com/org/skills"
+											/>
+											{skillDiscovering && (
+												<p className="text-xs text-muted-foreground flex items-center gap-1">
+													<Loader2 className="h-3 w-3 animate-spin" />
+													Looking for SKILL.md…
+												</p>
+											)}
+											{skillPathHint && !skillDiscovering && (
+												<p
+													className={`text-xs ${skillPathAuto ? "text-green-600" : "text-amber-600"}`}
+												>
+													{skillPathHint}
+												</p>
+											)}
+										</div>
+										{!skillPathAuto && (
+											<div className="space-y-1.5">
+												<Label htmlFor="skill-path">Skill Path</Label>
+												<Input
+													id="skill-path"
+													value={skillPath}
+													onChange={(e) => {
+														setSkillPath(e.target.value);
+														setSkillPathAuto(false);
+													}}
+													placeholder="skills/my-skill"
+												/>
+											</div>
+										)}
+									</div>
 									<div className="space-y-1.5">
-										<Label htmlFor="skill-path">Skill Path</Label>
+										<Label htmlFor="skill-git-ref">Git Ref (branch / tag)</Label>
 										<Input
-											id="skill-path"
-											value={skillPath}
-											onChange={(e) => {
-												setSkillPath(e.target.value);
-												setSkillPathAuto(false);
-											}}
-											placeholder="skills/my-skill"
+											id="skill-git-ref"
+											value={skillGitRef}
+											onChange={(e) => setSkillGitRef(e.target.value)}
+											placeholder="main"
 										/>
 									</div>
-								)}
-							</div>
-							<div className="space-y-1.5">
-								<Label htmlFor="skill-git-ref">Git Ref (branch / tag)</Label>
-								<Input
-									id="skill-git-ref"
-									value={skillGitRef}
-									onChange={(e) => setSkillGitRef(e.target.value)}
-									placeholder="main"
-								/>
-							</div>
+								</TabsContent>
+
+								<TabsContent value="paste" className="space-y-3 pt-3">
+									<div className="space-y-1.5">
+										<Label htmlFor="skill-md-content">SKILL.md *</Label>
+										<Textarea
+											id="skill-md-content"
+											value={skillMdContent}
+											onChange={(e) => {
+												const raw = e.target.value;
+												setSkillMdContent(raw);
+												// Auto-fill name/description from frontmatter
+												const fmMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+												if (fmMatch) {
+													const lines = fmMatch[1].split(/\r?\n/);
+													for (const line of lines) {
+														const nm = line.match(/^name:\s*(.+)$/);
+														if (nm && !name) setName(nm[1].trim());
+														const dm = line.match(
+															/^description:\s*["']?(.+?)["']?$/,
+														);
+														if (dm && !description) setDescription(dm[1].trim());
+													}
+												}
+											}}
+											placeholder={`---\nname: my-skill\ndescription: What this skill does\ncommand: /my-skill\n---\n\n## Instructions\n\nYour skill instructions here...`}
+											rows={10}
+											className="font-mono text-xs"
+										/>
+										<p className="text-xs text-muted-foreground">
+											Frontmatter auto-fills name and description above.
+										</p>
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="skill-script-filename">Script Filename (optional)</Label>
+										<Input
+											id="skill-script-filename"
+											value={skillScriptFilename}
+											onChange={(e) => setSkillScriptFilename(e.target.value)}
+											placeholder="run.sh"
+											className="font-mono"
+										/>
+										<p className="text-xs text-muted-foreground">
+											Name of the script file that will be written on install.
+										</p>
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="skill-script-content">Script (optional)</Label>
+										<Textarea
+											id="skill-script-content"
+											value={skillScriptContent}
+											onChange={(e) => setSkillScriptContent(e.target.value)}
+											placeholder={"#!/bin/bash\n# Script that the skill can invoke\n# Stored in the registry and delivered on install"}
+											rows={8}
+											className="font-mono text-xs"
+										/>
+										<p className="text-xs text-muted-foreground">
+											Script content stored in the registry and delivered on install. Similar to hook scripts.
+										</p>
+									</div>
+								</TabsContent>
+							</Tabs>
 						</>
 					)}
 


### PR DESCRIPTION
## Purpose / Description
Add a `registry_direct` delivery mode for skills, allowing users to submit a SKILL.md and an optional script directly to the registry without needing a git repository. On install, the CLI writes the skill into the IDE skills directory with the expected structure.

## Fixes
* Closes the gap between hooks (which support inline script submission) and skills (which previously required a git repo).

## Approach
1. **Database**: new alembic migration adds `delivery_mode`, `script_content`, `script_filename` columns to `skill_versions`.
2. **Server**: the submit route checks `delivery_mode`. For `registry_direct`, it skips git validation, parses frontmatter from the inline content, and marks the skill as validated. The config generator includes script data in the install response.
3. **CLI**: new `--delivery-mode` and `--script` flags on `skill submit`. Auto-detects `registry_direct` when `--skill-md` is given without `--git-url`. New `install_skill_registry_direct()` writes `<name>/SKILL.md` and `<name>/scripts/<filename>`.
4. **Web**: replaced the old pill toggle with a proper Tabs component ("Git Submit" / "Registry Submit"). The registry tab has fields for SKILL.md content, script filename, and script body (mirrors the hooks form).
5. **Skill docs**: updated observal-registry skill with registry_direct examples.

## How Has This Been Tested?

1. Ran `make rebuild`, confirmed migration applied (`003_skill_registry_direct`).
2. Submitted a test skill via curl with `delivery_mode: registry_direct`, `skill_md_content`, `script_content`, and `script_filename`.
3. Approved via `observal admin review approve`.
4. Ran `observal skill install test-registry-direct --ide claude-code --scope user`.
5. Verified the file structure:
   ```
   ~/.claude/skills/test-registry-direct/
   \u251c\u2500\u2500 SKILL.md
   \u2514\u2500\u2500 scripts/
       \u2514\u2500\u2500 test-script.sh  (executable, 755)
   ```
6. TypeScript builds clean (`tsc --noEmit`), ruff lint passes.
<img width="488" height="809" alt="image" src="https://github.com/user-attachments/assets/d029118a-77b8-4cb7-8132-6174ec09bd4b" />

<img width="493" height="889" alt="image" src="https://github.com/user-attachments/assets/d3e39314-5e67-4e8b-a2a8-5e545127cf27" />


## Learning (optional, can help others)
The hooks pattern of storing `script_content` + `script_filename` inline in the DB and writing them on install translates cleanly to skills. The key difference is skills write to a `scripts/` subdirectory within the skill directory rather than alongside config files.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)