### PR TITLE
feat(cli): add Cursor crash-recovery sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 SrihariLegend <sriharilegend23@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 DoomsCoder <vedantkakade05@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Add Cursor session crash-recovery sweep in `cmd_reconcile` (#831)
 
 ## [1.2.0] - 2026-05-26
 
@@ -1644,4 +1651,3 @@ All notable changes to this project will be documented in this file.
 ### Ui
 
 - brighter borders, responsive text scaling, observal favicon ([909a9b6](https://github.com/BlazeUp-AI/Observal/commit/909a9b6dd7cedc9ddaff31b208f09ace9d35be7e))
-

--- a/observal_cli/cmd_reconcile.py
+++ b/observal_cli/cmd_reconcile.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Crash recovery and session reconciliation for Observal CLI.
@@ -27,11 +28,17 @@ from pathlib import Path
 from loguru import logger
 
 from observal_cli.sessions.claude_code import find_sessions_dir as _find_claude_sessions_dir_impl
+from observal_cli.sessions.cursor import find_sessions_dir as _find_cursor_sessions_dir_impl
 from observal_cli.sessions.kiro import find_sessions_dir as _find_kiro_sessions_dir_impl
 
 # ---------------------------------------------------------------------------
 # Discovery
 # ---------------------------------------------------------------------------
+
+
+def _find_cursor_sessions_dir(home: Path | None = None) -> Path:
+    """Return ~/.cursor/projects/ (the root of all Cursor session JSONL files)."""
+    return _find_cursor_sessions_dir_impl(home)
 
 
 def _find_claude_sessions_dir(home: Path | None = None) -> Path:
@@ -51,14 +58,35 @@ def _find_recent_sessions(
     """Return (jsonl_path, session_id) pairs for recently-modified session files.
 
     Discovers:
-    - Top-level files:  ~/.claude/projects/<project>/<session_id>.jsonl
-    - Subagent files:   ~/.claude/projects/<project>/<session_id>/subagents/<agent_id>.jsonl
-    - Kiro files:       ~/.kiro/sessions/cli/<session_id>.jsonl
+    - Cursor:       ~/.cursor/projects/<project>/agent-transcripts/<session_id>/<session_id>.jsonl
+    - Claude Code:  ~/.claude/projects/<project>/<session_id>.jsonl
+    - Claude Code subagent: ~/.claude/projects/<project>/<session_id>/subagents/<agent_id>.jsonl
+    - Kiro:         ~/.kiro/sessions/cli/<session_id>.jsonl
 
     Files older than *since_hours* are excluded.
     """
     cutoff = time.time() - since_hours * 3600
     results: list[tuple[Path, str]] = []
+
+    # Cursor sessions
+    cursor_dir = _find_cursor_sessions_dir(home)
+    if cursor_dir.exists():
+        for project_dir in cursor_dir.iterdir():
+            if not project_dir.is_dir():
+                continue
+            transcripts_dir = project_dir / "agent-transcripts"
+            if not transcripts_dir.is_dir():
+                continue
+            for session_dir in transcripts_dir.iterdir():
+                if not session_dir.is_dir():
+                    continue
+                jsonl_file = session_dir / f"{session_dir.name}.jsonl"
+                if jsonl_file.exists():
+                    try:
+                        if jsonl_file.stat().st_mtime >= cutoff:
+                            results.append((jsonl_file, jsonl_file.stem))
+                    except OSError:
+                        pass
 
     # Claude Code sessions
     sessions_dir = _find_claude_sessions_dir(home)
@@ -107,10 +135,21 @@ def _find_session_file(
     """Return the Path for *session_id*.jsonl across all supported IDEs.
 
     Search order:
-    1. Claude Code top-level: ~/.claude/projects/<project>/<session_id>.jsonl
-    2. Claude Code subagent:  ~/.claude/projects/<project>/<id>/subagents/<session_id>.jsonl
-    3. Kiro:                  ~/.kiro/sessions/cli/<session_id>.jsonl
+    1. Cursor:                ~/.cursor/projects/<project>/agent-transcripts/<session_id>/<session_id>.jsonl
+    2. Claude Code top-level: ~/.claude/projects/<project>/<session_id>.jsonl
+    3. Claude Code subagent:  ~/.claude/projects/<project>/<id>/subagents/<session_id>.jsonl
+    4. Kiro:                  ~/.kiro/sessions/cli/<session_id>.jsonl
     """
+    # --- Cursor ---
+    cursor_dir = _find_cursor_sessions_dir(home)
+    if cursor_dir.exists():
+        for project_dir in cursor_dir.iterdir():
+            if not project_dir.is_dir():
+                continue
+            candidate = project_dir / "agent-transcripts" / session_id / f"{session_id}.jsonl"
+            if candidate.exists():
+                return candidate
+
     # --- Claude Code ---
     claude_dir = _find_claude_sessions_dir(home)
     if claude_dir.exists():

--- a/observal_cli/sessions/cursor.py
+++ b/observal_cli/sessions/cursor.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Cursor session file helpers.
@@ -11,6 +12,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+
+
+def find_sessions_dir(home: Path | None = None) -> Path:
+    """Return ~/.cursor/projects/ (the root of all Cursor session JSONL files)."""
+    if home is None:
+        home = Path.home()
+    return home / ".cursor" / "projects"
 
 
 def project_key_from_cwd(cwd: str) -> str:

--- a/tests/test_reconcile_cursor.py
+++ b/tests/test_reconcile_cursor.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 Yash Gadgil <yashgadgil08@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for Cursor crash-recovery sweep in cmd_reconcile."""
+
+import json
+import os
+import time
+
+from observal_cli.cmd_reconcile import find_stale_sessions
+
+
+def _create_cursor_session(tmp_path, session_id, content, age_secs=300):
+    """Create a Cursor JSONL file at the expected path and backdate its mtime."""
+    jsonl_dir = tmp_path / ".cursor" / "projects" / "test-project" / "agent-transcripts" / session_id
+    jsonl_dir.mkdir(parents=True)
+    jsonl_file = jsonl_dir / f"{session_id}.jsonl"
+    jsonl_file.write_text(content)
+    mtime = time.time() - age_secs
+    os.utime(jsonl_file, (mtime, mtime))
+    return jsonl_file
+
+
+def _create_sync_state(tmp_path, session_id, offset=0, line_count=0, finalized=False):
+    """Write a sync_state.json entry for the given session."""
+    state_dir = tmp_path / ".observal"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state_file = state_dir / "sync_state.json"
+    entry = {"offset": offset, "line_count": line_count, "finalized": finalized}
+    data = json.loads(state_file.read_text()) if state_file.exists() else {}
+    data[session_id] = entry
+    state_file.write_text(json.dumps(data))
+
+
+class TestCursorStaleDetection:
+    def test_stale_cursor_session_detected(self, tmp_path):
+        session_id = "cursor-sess-001"
+        content = '{"type": "user", "message": "hello"}\n'
+        _create_cursor_session(tmp_path, session_id, content)
+        _create_sync_state(tmp_path, session_id, offset=0, line_count=0)
+
+        stale = find_stale_sessions(home=tmp_path)
+
+        assert len(stale) == 1
+        assert stale[0]["session_id"] == session_id
+        assert stale[0]["file_size"] > 0
+        assert stale[0]["cursor_offset"] == 0
+
+    def test_finalized_cursor_session_skipped(self, tmp_path):
+        session_id = "cursor-sess-002"
+        content = '{"type": "user", "message": "hello"}\n'
+        _create_cursor_session(tmp_path, session_id, content)
+        _create_sync_state(tmp_path, session_id, offset=0, line_count=0, finalized=True)
+
+        stale = find_stale_sessions(home=tmp_path)
+
+        assert stale == []


### PR DESCRIPTION
## Purpose / Description
`cmd_reconcile` sweeps for IDE sessions whose `Stop` hook never fired and pushes their remaining tail, previously only Claude Code and Kiro sessions were swept, so any crashed Cursor session would silently lose its unsynchronized tail.

## Fixes
* Fixes #831

## Approach
Add Cursor session discovery to the reconcile scanner, ensuring crashed Cursor sessions are detected and recovered alongside the existing Claude Code and Kiro paths

1. `observal_cli/sessions/cursor.py`: added a `find_sessions_dir(home)` helper that returns `~/.cursor/projects/`, mirroring the existing `find_sessions_dir` in the Claude Code and Kiro session modules

2. `observal_cli/cmd_reconcile.py`: imported the new helper and added a `_find_cursor_sessions_dir` wrapper. Extended `_find_recent_sessions` to glob Cursor JSONL files at `~/.cursor/projects/<project>/agent-transcripts/<session_id>/<session_id>.jsonl`, and extended `_find_session_file` to resolve a session ID to the corresponding Cursor path. Both follow the same pattern used for Claude Code and Kiro

3. `tests/test_reconcile_cursor.py` two new unit tests:
   - `test_stale_cursor_session_detected` creates a Cursor JSONL file with a sync offset behind the file size and asserts it is returned as stale
   - `test_finalized_cursor_session_skipped` marks the sync state as finalized and asserts the session is excluded

## How Has This Been Tested?

- `make test`: 3670 passed, 1 failed, 22 skipped (pre-existing, unrelated to these changes)
- `make format` and `make lint`: no new warnings
- The two new tests verify correct detection of stale Cursor sessions and correct skipping of finalized ones

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code