### PR TITLE
bump(release): v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.1] - 2026-05-27
+
+### Changed
+
+- minimize login error handling fix (**web**) ([6819685](https://github.com/BlazeUp-AI/Observal/commit/68196858e305187825076c400d97179370aa6902))
+
+### Fixed
+
+- prevent auth guard flicker on direct URL access (**web**) ([b7eb425](https://github.com/BlazeUp-AI/Observal/commit/b7eb4252f8dd167ff12067be30f3c1b7431833c1))
+- SSO device flow, skill install, version check, UI (**auth,ide,cli,web**) ([5ef6a67](https://github.com/BlazeUp-AI/Observal/commit/5ef6a67269e31a14ab416b9a65ec6286e39ef9a4))
+- 404 denied agent bind (**sessions**) ([a71ba58](https://github.com/BlazeUp-AI/Observal/commit/a71ba58e9a77df0aeb7b96dc5147c27e0abdc745))
+- handle non-JSON login error responses (**web**) ([e0f79ff](https://github.com/BlazeUp-AI/Observal/commit/e0f79ff6f4fc7159744b8a182189ce637edd3675))
 ## [1.2.0] - 2026-05-26
 
 ### Added

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.2.0"
+version = "1.2.1"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "AGPL-3.0-only"

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -941,7 +941,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.2.0"
+version = "1.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [
     "pi-package",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.2.0"
+version = "1.2.1"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@10.33.4",


### PR DESCRIPTION
## Release v1.2.1 (patch)

Bumps version `1.2.0` → `1.2.1` and regenerates changelog.

**Merging this PR will automatically trigger the release pipeline.**

### What happens after merge
- CLI binaries built for 6 platforms (Linux/macOS/Windows, x64/arm64)
- Docker images pushed to GHCR
- Server deployment tarball packaged
- PyPI package published
- **Approval required** in the `production` environment before GitHub Release publishes