### PR TITLE
fix: insights session count, error reporting, and adaptive metrics

### DIFF
--- a/ee/observal_insights/generator.py
+++ b/ee/observal_insights/generator.py
@@ -190,6 +190,7 @@ async def _run_pipeline(
             "subagent_sessions": agg.get("sessions_using_subagent", 0),
             "mcp_sessions": agg.get("sessions_using_mcp", 0),
             "total_cost_usd": round(agg.get("total_cost", 0), 2),
+            "total_credits": round(agg.get("total_credits", 0), 4),
             "total_input_tokens": agg.get("total_input_tokens", 0),
             "total_output_tokens": agg.get("total_output_tokens", 0),
             "total_cache_read_tokens": agg.get("total_cache_read_tokens", 0),
@@ -198,6 +199,9 @@ async def _run_pipeline(
             "top_languages": agg.get("top_languages", [])[:10],
             "tool_error_categories": agg.get("tool_error_categories", {}),
             "projects": agg.get("projects", {}),
+            "ides": agg.get("ides", []),
+            "sessions_with_tokens": agg.get("sessions_with_tokens", 0),
+            "sessions_with_credits": agg.get("sessions_with_credits", 0),
         },
         "overview": {
             "total_sessions": agg.get("total_sessions", 0),

--- a/ee/observal_insights/generator.py
+++ b/ee/observal_insights/generator.py
@@ -147,6 +147,111 @@ async def _run_pipeline(
 
     logger.info("insight_facets_extracted", count=len(all_facets))
 
+    # ── Step 3b: Model efficiency analysis ─────────────────────────────────
+    # Cross-reference per-session model usage with facets to detect waste.
+    # Build session_id -> facets mapping from the extraction batch.
+    facets_by_session: dict[str, dict] = {}
+    if transcripts and all_facets:
+        session_ids_with_transcripts = list(transcripts.keys())
+        for sid, facet in zip(session_ids_with_transcripts, all_facets, strict=False):
+            if facet:
+                facets_by_session[sid] = facet
+
+    model_efficiency: list[dict] = []
+    estimated_waste = 0.0
+    model_tiers = agg.get("model_tiers", {})
+
+    for meta in session_metas:
+        session_model_usage = meta.get("model_usage", {})
+        if not session_model_usage:
+            continue
+
+        facet = facets_by_session.get(meta["session_id"], {})
+        if not facet:
+            continue
+
+        # Determine primary model (highest cost or most messages)
+        primary = max(
+            session_model_usage.items(),
+            key=lambda x: (x[1].get("cost", 0), x[1].get("messages", 0)),
+        )
+        model_name, model_stats = primary
+        tier = model_tiers.get(model_name, "mid")
+
+        session_type = facet.get("session_type", "single_task")
+        complexity = facet.get("complexity", "medium")
+        outcome = facet.get("outcome", "unclear")
+
+        is_simple = (
+            session_type in ("quick_question", "single_task")
+            or complexity in ("trivial", "low")
+            or (meta.get("user_message_count", 0) <= 3 and meta.get("duration_seconds", 0) < 300)
+        )
+        is_complex = (
+            session_type in ("multi_task", "iterative_refinement")
+            or complexity in ("high", "very_high")
+            or meta.get("user_message_count", 0) > 8
+            or meta.get("files_modified", 0) > 5
+        )
+        poor_outcome = outcome in ("not_achieved", "partially_achieved")
+        good_outcome = outcome in ("fully_achieved", "mostly_achieved")
+
+        flag = "ok"
+        reason = ""
+
+        if tier == "subscription":
+            # Quota pressure: heavy subscription model on trivial tasks
+            model_lower = model_name.lower()
+            is_heavy = bool(
+                any(p in model_lower for p in ("opus", "pro", "medium", "large", "o1", "o3"))
+                and not any(p in model_lower for p in ("small", "mini", "flash", "haiku", "lite"))
+            )
+            if is_simple and good_outcome and is_heavy and model_stats.get("messages", 0) > 3:
+                flag = "quota_pressure"
+                reason = (
+                    f"Used {model_name} (subscription) for a {complexity} {session_type}. "
+                    f"This model consumes more quota than lighter alternatives within the same plan."
+                )
+        elif tier == "high" and is_simple and good_outcome:
+            flag = "overspend"
+            reason = (
+                f"Used {model_name} for a {complexity} {session_type} that succeeded. "
+                f"A lower-tier model would likely suffice."
+            )
+            estimated_waste += model_stats.get("cost", 0) * 0.8
+        elif tier == "low" and is_complex and poor_outcome:
+            flag = "underspend"
+            reason = (
+                f"Used {model_name} for a {complexity} {session_type} that ended with {outcome}. "
+                f"A more capable model may have succeeded."
+            )
+            estimated_waste += model_stats.get("cost", 0)
+        elif tier == "high" and poor_outcome and model_stats.get("cost", 0) > 0.10:
+            flag = "overspend"
+            reason = (
+                f"Spent ${model_stats.get('cost', 0):.2f} on {model_name} but outcome was {outcome}. "
+                f"Tokens were consumed without reaching the goal."
+            )
+            estimated_waste += model_stats.get("cost", 0) * 0.5
+
+        if flag != "ok":
+            model_efficiency.append(
+                {
+                    "model": model_name,
+                    "session_id": meta["session_id"],
+                    "date": meta.get("start_time", "")[:10],
+                    "cost": model_stats.get("cost", 0),
+                    "outcome": outcome,
+                    "session_type": session_type,
+                    "complexity": complexity,
+                    "flag": flag,
+                    "reason": reason,
+                }
+            )
+
+    model_efficiency.sort(key=lambda x: -x.get("cost", 0))
+    model_efficiency = model_efficiency[:20]
+
     # ── Step 4: Build the data block (pi-style focused format) ────────────
     facets_summary = aggregate_facets(all_facets)
     data_block = _build_data_block(
@@ -157,6 +262,8 @@ async def _run_pipeline(
         period_start=period_start,
         period_end=period_end,
         agent_config=agent_config,
+        model_efficiency=model_efficiency,
+        estimated_waste=estimated_waste,
     )
 
     # ── Step 5: Generate narrative sections (7 parallel + 1 synthesis) ────
@@ -202,6 +309,17 @@ async def _run_pipeline(
             "ides": agg.get("ides", []),
             "sessions_with_tokens": agg.get("sessions_with_tokens", 0),
             "sessions_with_credits": agg.get("sessions_with_credits", 0),
+            "model_usage": {
+                m: {
+                    "cost": u["cost"],
+                    "messages": u["messages"],
+                    "sessions": u["sessions"],
+                    "tier": u.get("tier", "mid"),
+                }
+                for m, u in sorted(agg.get("model_usage", {}).items(), key=lambda x: -x[1]["cost"])
+            },
+            "model_efficiency": model_efficiency[:10],
+            "estimated_waste_usd": round(estimated_waste, 2),
         },
         "overview": {
             "total_sessions": agg.get("total_sessions", 0),
@@ -259,6 +377,8 @@ def _build_data_block(
     period_start: str,
     period_end: str,
     agent_config: dict | None = None,
+    model_efficiency: list[dict] | None = None,
+    estimated_waste: float = 0.0,
 ) -> str:
     """Build the DATA_BLOCK for section prompts.
 
@@ -305,6 +425,19 @@ def _build_data_block(
         "session_types": facets_summary.get("session_types", {}),
         "complexity": facets_summary.get("complexity_distribution", {}),
     }
+
+    # Model usage with pre-classified tiers
+    model_usage = agg.get("model_usage", {})
+    if model_usage:
+        model_lines = []
+        for m, u in sorted(model_usage.items(), key=lambda x: -x[1].get("cost", 0)):
+            total_tok = u.get("input_tokens", 0) + u.get("output_tokens", 0)
+            cpt = f"${u.get('cost_per_1k_tokens', 0):.4f}" if u.get("cost_per_1k_tokens") else "$0"
+            model_lines.append(
+                f"  {m}: {u.get('sessions', 0)} sessions, {u.get('messages', 0)} msgs, "
+                f"${u.get('cost', 0):.2f} total, tier={u.get('tier', 'mid')}, $/1k-tok={cpt}"
+            )
+        summary["model_breakdown"] = model_lines
 
     # Multi-session detection
     if agg.get("multi_clauding"):
@@ -364,6 +497,19 @@ def _build_data_block(
             "\nREPEATED INSTRUCTIONS (by frequency):\n"
             + "\n".join(f'- "{r["instruction"]}" (frequency: {r["frequency"]})' for r in repeated[:10])
         )
+
+    # Model efficiency analysis (pre-computed, helps LLM write cost section)
+    if model_efficiency:
+        eff_lines = []
+        for e in model_efficiency[:10]:
+            eff_lines.append(
+                f"- [{e['flag']}] {e['model']} on {e['date']}: "
+                f"${e.get('cost', 0):.2f}, {e['complexity']} {e['session_type']}, "
+                f"outcome={e['outcome']}. {e['reason']}"
+            )
+        sections.append("\nMODEL EFFICIENCY FLAGS:\n" + "\n".join(eff_lines))
+        if estimated_waste > 0:
+            sections.append(f"\nEstimated waste from model mismatch: ${estimated_waste:.2f}")
 
     return "\n".join(sections)
 

--- a/ee/observal_insights/sections.py
+++ b/ee/observal_insights/sections.py
@@ -395,23 +395,14 @@ _DEEP_SECTIONS = {"suggestions", "interaction_style", "friction_analysis", "on_t
 
 # Output size varies by section.
 _SECTION_MAX_TOKENS: dict[str, int] = {
-    "suggestions": 6000,
-    "on_the_horizon": 5000,
-    "interaction_style": 4096,
-    "usage_patterns": 3000,
-    "friction_analysis": 3000,
-    "what_works": 2500,
-    "what_they_work_on": 2500,
-    "usage_cost_analysis": 2000,
-    "regression_detection": 2000,
-    "fun_ending": 512,
+    "fun_ending": 1024,
 }
 
 
 async def _call_section(section_name: str, prompt: str, model: str | None = None) -> tuple[str, dict]:
     """Call the LLM for a single section, return (name, result)."""
     call_model = get_call_model()
-    max_tokens = _SECTION_MAX_TOKENS.get(section_name, 4096)
+    max_tokens = _SECTION_MAX_TOKENS.get(section_name, 16384)
     try:
         result = await call_model(prompt, model_override=model, max_tokens=max_tokens)
         if result and isinstance(result, dict):

--- a/ee/observal_insights/sections.py
+++ b/ee/observal_insights/sections.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: LicenseRef-Observal-Enterprise
 
@@ -417,6 +418,8 @@ async def _call_section(section_name: str, prompt: str, model: str | None = None
             return section_name, result
         logger.warning("section_empty_response", section=section_name)
         return section_name, {}
+    except RuntimeError:
+        raise
     except Exception as e:
         logger.error("section_call_failed", section=section_name, error=str(e))
         return section_name, {}

--- a/ee/observal_insights/session_meta_extractor.py
+++ b/ee/observal_insights/session_meta_extractor.py
@@ -400,6 +400,50 @@ def extract_session_meta(session_id: str, raw_lines: list[str]) -> dict:
     }
 
 
+async def fetch_session_stats(
+    agent_id: str,
+    period_start: str,
+    period_end: str,
+    agent_name: str = "",
+) -> dict[str, dict]:
+    """Fetch per-session stats (credits, ide) from session_stats_agg.
+
+    Returns {session_id: {"credits": float, "ide": str}} for enriching metas.
+    """
+    query = get_query()
+
+    sql = """
+        SELECT session_id, total_credits, ide
+        FROM session_stats_agg FINAL
+        WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
+          AND last_event_time >= {t_start:String}
+          AND last_event_time <= {t_end:String}
+        GROUP BY session_id, total_credits, ide
+        FORMAT JSON
+    """
+    params = {
+        "param_agent_id": agent_id,
+        "param_agent_name": agent_name,
+        "param_t_start": period_start,
+        "param_t_end": period_end,
+    }
+
+    try:
+        r = await query(sql, params)
+        r.raise_for_status()
+        rows = r.json().get("data", [])
+        return {
+            row["session_id"]: {
+                "credits": float(row.get("total_credits") or 0),
+                "ide": row.get("ide", ""),
+            }
+            for row in rows
+        }
+    except Exception as e:
+        logger.warning("fetch_session_stats_failed", error=str(e))
+        return {}
+
+
 async def fetch_all_session_transcripts(
     agent_id: str,
     period_start: str,
@@ -493,12 +537,20 @@ async def extract_all_session_metas(
 
     This is the main entry point: fetches raw lines from ClickHouse,
     then runs extract_session_meta on each session.
+    Also enriches each meta with credits and IDE info from session_stats_agg.
     """
     transcripts = await fetch_all_session_transcripts(agent_id, period_start, period_end, agent_name=agent_name)
+
+    # Fetch per-session stats (credits, ide) for enrichment
+    session_stats = await fetch_session_stats(agent_id, period_start, period_end, agent_name=agent_name)
 
     metas = []
     for session_id, lines in transcripts.items():
         meta = extract_session_meta(session_id, lines)
+        # Enrich with credits and IDE from session_stats_agg
+        stats = session_stats.get(session_id, {})
+        meta["credits"] = stats.get("credits", 0.0)
+        meta["ide"] = stats.get("ide", "")
         metas.append(meta)
 
     logger.info(
@@ -523,6 +575,7 @@ def aggregate_metas(metas: list[dict]) -> dict:
         "total_cache_read_tokens": 0,
         "total_cache_write_tokens": 0,
         "total_cost": 0.0,
+        "total_credits": 0.0,
         "total_lines_added": 0,
         "total_lines_removed": 0,
         "total_files_modified": 0,
@@ -539,6 +592,9 @@ def aggregate_metas(metas: list[dict]) -> dict:
         "user_response_times": [],
         "message_hours": [],
         "days_active": set(),
+        "ides": set(),
+        "sessions_with_tokens": 0,
+        "sessions_with_credits": 0,
     }
 
     for meta in metas:
@@ -549,6 +605,13 @@ def aggregate_metas(metas: list[dict]) -> dict:
         agg["total_cache_read_tokens"] += meta["cache_read_tokens"]
         agg["total_cache_write_tokens"] += meta["cache_write_tokens"]
         agg["total_cost"] += meta["total_cost"]
+        agg["total_credits"] += meta.get("credits", 0.0)
+        if meta.get("input_tokens", 0) > 0 or meta.get("output_tokens", 0) > 0:
+            agg["sessions_with_tokens"] += 1
+        if meta.get("credits", 0) > 0:
+            agg["sessions_with_credits"] += 1
+        if meta.get("ide"):
+            agg["ides"].add(meta["ide"])
         agg["total_lines_added"] += meta["lines_added"]
         agg["total_lines_removed"] += meta["lines_removed"]
         agg["total_files_modified"] += meta["files_modified"]
@@ -591,6 +654,7 @@ def aggregate_metas(metas: list[dict]) -> dict:
 
     # Finalize
     agg["days_active"] = len(agg["days_active"])
+    agg["ides"] = sorted(agg["ides"])
 
     # Sort tool counts by frequency
     agg["top_tools"] = sorted(agg["tool_counts"].items(), key=lambda x: -x[1])[:15]

--- a/ee/observal_insights/session_meta_extractor.py
+++ b/ee/observal_insights/session_meta_extractor.py
@@ -104,6 +104,7 @@ def extract_session_meta(session_id: str, raw_lines: list[str]) -> dict:
     assistant_message_count = 0
     first_prompt = ""
     total_messages = 0
+    model_usage: dict[str, dict] = {}  # {model: {input_tokens, output_tokens, cost, messages}}
 
     last_assistant_ts: float | None = None
     start_time: str | None = None
@@ -231,14 +232,32 @@ def extract_session_meta(session_id: str, raw_lines: list[str]) -> dict:
 
             # Token usage
             usage = msg.get("usage", {})
+            msg_model = msg.get("model", "") or ""
             if usage:
-                input_tokens += int(usage.get("input", 0) or 0)
-                output_tokens += int(usage.get("output", 0) or 0)
+                msg_in = int(usage.get("input", 0) or 0)
+                msg_out = int(usage.get("output", 0) or 0)
+                input_tokens += msg_in
+                output_tokens += msg_out
                 cache_read_tokens += int(usage.get("cacheRead", 0) or 0)
                 cache_write_tokens += int(usage.get("cacheWrite", 0) or 0)
+                msg_cost = 0.0
                 cost = usage.get("cost", {})
                 if isinstance(cost, dict) and cost.get("total"):
-                    total_cost += float(cost["total"])
+                    msg_cost = float(cost["total"])
+                    total_cost += msg_cost
+                # Per-model usage tracking
+                if msg_model:
+                    if msg_model not in model_usage:
+                        model_usage[msg_model] = {"input_tokens": 0, "output_tokens": 0, "cost": 0.0, "messages": 0}
+                    model_usage[msg_model]["input_tokens"] += msg_in
+                    model_usage[msg_model]["output_tokens"] += msg_out
+                    model_usage[msg_model]["cost"] += msg_cost
+                    model_usage[msg_model]["messages"] += 1
+            elif msg_model:
+                # No usage block but model is present (count message)
+                if msg_model not in model_usage:
+                    model_usage[msg_model] = {"input_tokens": 0, "output_tokens": 0, "cost": 0.0, "messages": 0}
+                model_usage[msg_model]["messages"] += 1
 
             # Tool calls in content
             content = msg.get("content", [])
@@ -397,6 +416,7 @@ def extract_session_meta(session_id: str, raw_lines: list[str]) -> dict:
         "user_response_times": user_response_times,
         "message_hours": message_hours,
         "user_message_timestamps": user_message_timestamps,
+        "model_usage": model_usage,
     }
 
 
@@ -595,6 +615,7 @@ def aggregate_metas(metas: list[dict]) -> dict:
         "ides": set(),
         "sessions_with_tokens": 0,
         "sessions_with_credits": 0,
+        "model_usage": {},  # {model: {input_tokens, output_tokens, cost, messages, sessions}}
     }
 
     for meta in metas:
@@ -633,6 +654,22 @@ def aggregate_metas(metas: list[dict]) -> dict:
         for lang, count in meta["languages"].items():
             agg["languages"][lang] = agg["languages"].get(lang, 0) + count
 
+        # Merge model usage
+        for model, usage in meta.get("model_usage", {}).items():
+            if model not in agg["model_usage"]:
+                agg["model_usage"][model] = {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cost": 0.0,
+                    "messages": 0,
+                    "sessions": 0,
+                }
+            agg["model_usage"][model]["input_tokens"] += usage.get("input_tokens", 0)
+            agg["model_usage"][model]["output_tokens"] += usage.get("output_tokens", 0)
+            agg["model_usage"][model]["cost"] += usage.get("cost", 0.0)
+            agg["model_usage"][model]["messages"] += usage.get("messages", 0)
+            agg["model_usage"][model]["sessions"] += 1
+
         # Merge tool error categories
         for cat, count in meta["tool_error_categories"].items():
             agg["tool_error_categories"][cat] = agg["tool_error_categories"].get(cat, 0) + count
@@ -659,5 +696,37 @@ def aggregate_metas(metas: list[dict]) -> dict:
     # Sort tool counts by frequency
     agg["top_tools"] = sorted(agg["tool_counts"].items(), key=lambda x: -x[1])[:15]
     agg["top_languages"] = sorted(agg["languages"].items(), key=lambda x: -x[1])[:10]
+
+    # ── Model tier classification ─────────────────────────────────────────
+    # Classify models by observed cost-per-token. Models with significant
+    # usage but near-zero cost are "subscription" (credit-based plans).
+    model_tiers: dict[str, str] = {}
+    model_cpt: dict[str, float] = {}  # cost per 1k tokens
+
+    for model, usage in agg["model_usage"].items():
+        total_tok = usage["input_tokens"] + usage["output_tokens"]
+        if total_tok > 0:
+            model_cpt[model] = (usage["cost"] / total_tok) * 1000
+
+    cpt_values = sorted(v for v in model_cpt.values() if v > 0)
+    cpt_median = cpt_values[len(cpt_values) // 2] if cpt_values else 0.01
+
+    for model, usage in agg["model_usage"].items():
+        total_tok = usage["input_tokens"] + usage["output_tokens"]
+        cpt = model_cpt.get(model, 0)
+        # Subscription: significant usage with near-zero cost
+        if (total_tok > 10000 and usage["cost"] < 0.01) or (usage["messages"] > 20 and (not cpt or cpt < 0.001)):
+            model_tiers[model] = "subscription"
+        elif cpt > cpt_median * 3:
+            model_tiers[model] = "high"
+        elif cpt < cpt_median * 0.4:
+            model_tiers[model] = "low"
+        else:
+            model_tiers[model] = "mid"
+        # Annotate the usage dict with tier
+        usage["tier"] = model_tiers[model]
+        usage["cost_per_1k_tokens"] = round(cpt, 4) if cpt else 0
+
+    agg["model_tiers"] = model_tiers
 
     return agg

--- a/ee/observal_insights/session_meta_extractor.py
+++ b/ee/observal_insights/session_meta_extractor.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-License-Identifier: LicenseRef-Observal-Enterprise
 
 """Deterministic per-session metadata extraction from raw JSONL transcripts.
@@ -158,6 +159,35 @@ def extract_session_meta(session_id: str, raw_lines: list[str]) -> dict:
                             if isinstance(tool_data, dict):
                                 tool_name = tool_data.get("name", "unknown")
                                 tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+                                # Extract file/lines info from tool input
+                                args = tool_data.get("input", {})
+                                if isinstance(args, dict):
+                                    file_path = args.get("path", "") or args.get("file_path", "")
+                                    if file_path:
+                                        ext = _ext(file_path)
+                                        lang = EXTENSION_TO_LANGUAGE.get(ext)
+                                        if lang:
+                                            languages[lang] = languages.get(lang, 0) + 1
+                                    if tool_name == "write" and file_path:
+                                        files_modified.add(file_path)
+                                        content_str = args.get("content", "")
+                                        if isinstance(content_str, str) and content_str:
+                                            lines_added += _count_newlines(content_str) + 1
+                                    elif tool_name == "edit" and file_path:
+                                        files_modified.add(file_path)
+                                        old = args.get("oldStr", "") or args.get("old_string", "")
+                                        new = args.get("newStr", "") or args.get("new_string", "")
+                                        if isinstance(old, str) and old:
+                                            lines_removed += _count_newlines(old) + 1
+                                        if isinstance(new, str) and new:
+                                            lines_added += _count_newlines(new) + 1
+                                    elif tool_name == "bash":
+                                        cmd = args.get("command", "")
+                                        if isinstance(cmd, str):
+                                            if "git commit" in cmd:
+                                                git_commits += 1
+                                            if "git push" in cmd:
+                                                git_pushes += 1
                 elif entry_kind == "ToolResults":
                     total_messages += 1
             continue
@@ -389,12 +419,12 @@ async def fetch_all_session_transcripts(
     # First, get the list of session_ids from the lightweight session_stats_agg
     id_sql = """
         SELECT session_id
-        FROM session_stats_agg
+        FROM session_stats_agg FINAL
         WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
-          AND first_event_time >= {t_start:String}
-          AND first_event_time <= {t_end:String}
+          AND last_event_time >= {t_start:String}
+          AND last_event_time <= {t_end:String}
         GROUP BY session_id
-        ORDER BY min(first_event_time)
+        ORDER BY min(last_event_time)
         FORMAT JSON
     """
     params = {

--- a/observal-server/api/routes/admin/enterprise_settings.py
+++ b/observal-server/api/routes/admin/enterprise_settings.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Admin settings, diagnostics, and resource tuning routes."""
@@ -165,6 +166,8 @@ async def upsert_setting(
         db.add(cfg)
     await db.commit()
     await db.refresh(cfg)
+    await ds.invalidate(key)
+    await ds.refresh_sync_cache()
     await emit_security_event(
         SecurityEvent(
             event_type=EventType.SETTING_CHANGED,
@@ -193,6 +196,8 @@ async def delete_setting(
         raise HTTPException(status_code=404, detail="Setting not found")
     await db.delete(cfg)
     await db.commit()
+    await ds.invalidate(key)
+    await ds.refresh_sync_cache()
     return {"deleted": key}
 
 

--- a/observal-server/api/routes/insights.py
+++ b/observal-server/api/routes/insights.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -46,15 +47,39 @@ async def insights_status(current_user: User = Depends(require_role(UserRole.adm
     if not INSIGHTS_AVAILABLE:
         return {"available": False, "reason": "Insights requires an enterprise license."}
 
-    model = ds.get_sync("insights.model_sections")
+    model = await ds.get("insights.model_sections")
     if not model:
         return {"available": False, "reason": "No model configured. Set insights.model_sections in admin settings."}
 
-    # Check if AWS credentials are set (for Bedrock models)
+    # Check if AWS credentials are set and valid (for Bedrock models)
     if "anthropic" in model:
-        aws_key = ds.get_sync("insights.aws_access_key_id")
+        aws_key = await ds.get("insights.aws_access_key_id")
+        aws_secret = await ds.get("insights.aws_secret_access_key")
         if not aws_key:
-            return {"available": False, "reason": "AWS credentials not configured for Bedrock model."}
+            return {"available": False, "reason": "AWS access key not configured. Set insights.aws_access_key_id in admin settings."}
+        if not aws_secret:
+            return {"available": False, "reason": "AWS secret key not configured. Set insights.aws_secret_access_key in admin settings."}
+
+        # Validate credentials with a lightweight STS call
+        try:
+            import boto3
+            region = await ds.get("insights.aws_region") or "us-east-1"
+            sts = boto3.client(
+                "sts",
+                region_name=region,
+                aws_access_key_id=aws_key,
+                aws_secret_access_key=aws_secret,
+            )
+            sts.get_caller_identity()
+        except Exception as e:
+            error_str = str(e)
+            if "InvalidClientTokenId" in error_str or "security token" in error_str:
+                return {"available": False, "reason": "AWS access key is invalid. Update insights.aws_access_key_id in admin settings."}
+            if "SignatureDoesNotMatch" in error_str:
+                return {"available": False, "reason": "AWS secret key is invalid. Update insights.aws_secret_access_key in admin settings."}
+            if "ExpiredToken" in error_str:
+                return {"available": False, "reason": "AWS credentials have expired. Update credentials in admin settings."}
+            return {"available": False, "reason": f"AWS credential check failed: {error_str[:200]}"}
 
     return {"available": True, "reason": None}
 
@@ -73,10 +98,10 @@ async def agent_session_count(
     period_start = now - timedelta(days=14)
 
     count_sql = (
-        "SELECT count() AS cnt FROM session_stats_agg "
+        "SELECT count() AS cnt FROM session_stats_agg FINAL "
         "WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String}) "
-        "AND first_event_time >= {t_start:String} "
-        "AND first_event_time <= {t_end:String} "
+        "AND last_event_time >= {t_start:String} "
+        "AND last_event_time <= {t_end:String} "
         "FORMAT JSON"
     )
     try:
@@ -120,10 +145,10 @@ async def generate_insight(
     from services.clickhouse import _query
 
     count_sql = (
-        "SELECT count() AS cnt FROM session_stats_agg "
+        "SELECT count() AS cnt FROM session_stats_agg FINAL "
         "WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String}) "
-        "AND first_event_time >= {t_start:String} "
-        "AND first_event_time <= {t_end:String} "
+        "AND last_event_time >= {t_start:String} "
+        "AND last_event_time <= {t_end:String} "
         "FORMAT JSON"
     )
     try:

--- a/observal-server/api/routes/insights.py
+++ b/observal-server/api/routes/insights.py
@@ -56,13 +56,20 @@ async def insights_status(current_user: User = Depends(require_role(UserRole.adm
         aws_key = await ds.get("insights.aws_access_key_id")
         aws_secret = await ds.get("insights.aws_secret_access_key")
         if not aws_key:
-            return {"available": False, "reason": "AWS access key not configured. Set insights.aws_access_key_id in admin settings."}
+            return {
+                "available": False,
+                "reason": "AWS access key not configured. Set insights.aws_access_key_id in admin settings.",
+            }
         if not aws_secret:
-            return {"available": False, "reason": "AWS secret key not configured. Set insights.aws_secret_access_key in admin settings."}
+            return {
+                "available": False,
+                "reason": "AWS secret key not configured. Set insights.aws_secret_access_key in admin settings.",
+            }
 
         # Validate credentials with a lightweight STS call
         try:
             import boto3
+
             region = await ds.get("insights.aws_region") or "us-east-1"
             sts = boto3.client(
                 "sts",
@@ -74,12 +81,24 @@ async def insights_status(current_user: User = Depends(require_role(UserRole.adm
         except Exception as e:
             error_str = str(e)
             if "InvalidClientTokenId" in error_str or "security token" in error_str:
-                return {"available": False, "reason": "AWS access key is invalid. Update insights.aws_access_key_id in admin settings."}
+                return {
+                    "available": False,
+                    "reason": "AWS access key is invalid. Update insights.aws_access_key_id in admin settings.",
+                }
             if "SignatureDoesNotMatch" in error_str:
-                return {"available": False, "reason": "AWS secret key is invalid. Update insights.aws_secret_access_key in admin settings."}
+                return {
+                    "available": False,
+                    "reason": "AWS secret key is invalid. Update insights.aws_secret_access_key in admin settings.",
+                }
             if "ExpiredToken" in error_str:
-                return {"available": False, "reason": "AWS credentials have expired. Update credentials in admin settings."}
-            return {"available": False, "reason": f"AWS credential check failed: {error_str[:200]}"}
+                return {
+                    "available": False,
+                    "reason": "AWS credentials have expired. Update credentials in admin settings.",
+                }
+            return {
+                "available": False,
+                "reason": "AWS credential check failed. Verify your access key and secret in admin settings.",
+            }
 
     return {"available": True, "reason": None}
 

--- a/observal-server/services/insights/__init__.py
+++ b/observal-server/services/insights/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
@@ -127,8 +128,17 @@ async def _call_bedrock(prompt: str, model_id: str, max_tokens: int = 4096) -> d
     try:
         return await asyncio.get_event_loop().run_in_executor(None, _sync_call)
     except Exception as e:
-        logger.error("bedrock_call_failed", error=str(e), model=model_id)
-        return {}
+        error_str = str(e)
+        if "UnrecognizedClientException" in error_str or "security token" in error_str:
+            raise RuntimeError(f"AWS credentials invalid: {error_str}") from e
+        if "AccessDeniedException" in error_str:
+            raise RuntimeError(f"AWS access denied for model '{model_id}': {error_str}") from e
+        if "ModelNotReadyException" in error_str or "not found" in error_str.lower():
+            raise RuntimeError(f"Model '{model_id}' not available in region '{aws_region}': {error_str}") from e
+        if "ExpiredTokenException" in error_str:
+            raise RuntimeError(f"AWS credentials expired: {error_str}") from e
+        logger.error("bedrock_call_failed", error=error_str, model=model_id)
+        raise RuntimeError(f"Bedrock call failed: {error_str}") from e
 
 
 async def _call_openai_compatible(prompt: str, model: str, provider: str = "") -> dict:

--- a/observal-server/services/insights/__init__.py
+++ b/observal-server/services/insights/__init__.py
@@ -91,7 +91,7 @@ def _openai_url_and_headers(provider: str = "", url_override: str = "", key_over
     return url, headers
 
 
-async def _call_bedrock(prompt: str, model_id: str, max_tokens: int = 4096) -> dict:
+async def _call_bedrock(prompt: str, model_id: str, max_tokens: int = 16384) -> dict:
     """Call AWS Bedrock Converse API."""
     import asyncio
 
@@ -137,6 +137,10 @@ async def _call_bedrock(prompt: str, model_id: str, max_tokens: int = 4096) -> d
             raise RuntimeError(f"Model '{model_id}' not available in region '{aws_region}': {error_str}") from e
         if "ExpiredTokenException" in error_str:
             raise RuntimeError(f"AWS credentials expired: {error_str}") from e
+        # JSON parse errors (truncated output) are non-fatal, return empty
+        if "JSONDecodeError" in type(e).__name__ or "Unterminated string" in error_str:
+            logger.warning("bedrock_truncated_response", error=error_str, model=model_id)
+            return {}
         logger.error("bedrock_call_failed", error=error_str, model=model_id)
         raise RuntimeError(f"Bedrock call failed: {error_str}") from e
 
@@ -161,7 +165,7 @@ async def _call_openai_compatible(prompt: str, model: str, provider: str = "") -
             return {}
 
 
-async def call_model(prompt: str, model_override: str | None = None, max_tokens: int = 4096) -> dict:
+async def call_model(prompt: str, model_override: str | None = None, max_tokens: int = 16384) -> dict:
     """Call the configured LLM for insights generation.
 
     Provider is auto-detected from the model ID:
@@ -172,7 +176,7 @@ async def call_model(prompt: str, model_override: str | None = None, max_tokens:
     Args:
         prompt: The prompt to send to the model.
         model_override: Optional model ID to use instead of the default.
-        max_tokens: Maximum output tokens (default 4096).
+        max_tokens: Maximum output tokens (default 16384).
     """
     import services.dynamic_settings as ds
 

--- a/web/src/app/(admin)/insights/[reportId]/page.tsx
+++ b/web/src/app/(admin)/insights/[reportId]/page.tsx
@@ -14,6 +14,7 @@ import {
 	CheckCircle2,
 	XCircle,
 	Clock,
+	Coins,
 	Zap,
 	Users,
 	Timer,
@@ -1413,6 +1414,9 @@ function ReportContent({ report }: { report: InsightReport }) {
 	const interruptions = Number(rich?.interruptions) || 0;
 	const subagentSessions = Number(rich?.subagent_sessions) || 0;
 	const mcpSessions = Number(rich?.mcp_sessions) || 0;
+	const totalCredits = Number(rich?.total_credits) || 0;
+	const sessionsWithTokens = Number(rich?.sessions_with_tokens) || 0;
+	const sessionsWithCredits = Number(rich?.sessions_with_credits) || 0;
 	const toolCalls = Number(metrics?.errors?.total_tool_calls) || 0;
 	const topTools = (rich?.top_tools || []) as [string, number][];
 	const topLanguages = (rich?.top_languages || []) as [string, number][];
@@ -1436,18 +1440,19 @@ function ReportContent({ report }: { report: InsightReport }) {
 				<MetricCard label="Sessions" value={totalSessions} icon={Zap} subtext={daysActive > 0 ? `${daysActive} active days` : uniqueUsers > 1 ? `${uniqueUsers} users` : undefined} />
 				<MetricCard label="Messages" value={fmt(totalMessages)} icon={Database} subtext={totalSessions > 0 ? `${(totalMessages / totalSessions).toFixed(1)} per session` : undefined} />
 				<MetricCard label="Active Time" value={fmtHours(activeHours)} icon={Timer} subtext={daysActive > 0 ? `${(activeHours / daysActive).toFixed(1)}h/day` : undefined} />
-				{inputTokens > 0 && <MetricCard label="Tokens In" value={fmt(inputTokens)} icon={Database} />}
-				{outputTokens > 0 && <MetricCard label="Tokens Out" value={fmt(outputTokens)} icon={Database} />}
+				{sessionsWithTokens > 0 && <MetricCard label="Tokens In" value={fmt(inputTokens)} icon={Database} />}
+				{sessionsWithTokens > 0 && <MetricCard label="Tokens Out" value={fmt(outputTokens)} icon={Database} />}
 				{cacheReadTokens > 0 && <MetricCard label="Cache Read" value={fmt(cacheReadTokens)} icon={Database} />}
 				{cacheWriteTokens > 0 && <MetricCard label="Cache Write" value={fmt(cacheWriteTokens)} icon={Database} />}
 				{cacheReadTokens > 0 && <MetricCard label="Cache Efficiency" value={`${((cacheReadTokens / (cacheReadTokens + inputTokens)) * 100).toFixed(1)}%`} icon={Zap} />}
 				{totalCost > 0 && <MetricCard label="Total Cost" value={`$${totalCost.toFixed(2)}`} icon={DollarSign} subtext={totalSessions > 0 ? `$${(totalCost / totalSessions).toFixed(2)}/session` : undefined} />}
-				{linesAdded > 0 && <MetricCard label="Lines Added" value={fmt(linesAdded)} icon={Zap} />}
-				{linesRemoved > 0 && <MetricCard label="Lines Removed" value={fmt(linesRemoved)} icon={AlertTriangle} />}
-				{gitCommits > 0 && <MetricCard label="Git Commits" value={gitCommits} icon={Wrench} subtext={gitPushes > 0 ? `${gitPushes} pushes` : undefined} />}
-				{filesModified > 0 && <MetricCard label="Files Modified" value={fmt(filesModified)} icon={Database} />}
-				{toolErrors > 0 && <MetricCard label="Tool Errors" value={toolErrors} icon={AlertTriangle} />}
-				{interruptions > 0 && <MetricCard label="Interruptions" value={interruptions} icon={AlertTriangle} />}
+				{sessionsWithCredits > 0 && <MetricCard label="Credits Used" value={totalCredits.toFixed(2)} icon={Coins} subtext={totalSessions > 0 ? `${(totalCredits / totalSessions).toFixed(2)}/session` : undefined} />}
+				<MetricCard label="Lines Added" value={fmt(linesAdded)} icon={Zap} />
+				<MetricCard label="Lines Removed" value={fmt(linesRemoved)} icon={AlertTriangle} />
+				<MetricCard label="Git Commits" value={gitCommits} icon={Wrench} subtext={gitPushes > 0 ? `${gitPushes} pushes` : undefined} />
+				<MetricCard label="Files Modified" value={fmt(filesModified)} icon={Database} />
+				<MetricCard label="Tool Errors" value={toolErrors} icon={AlertTriangle} />
+				<MetricCard label="Interruptions" value={interruptions} icon={AlertTriangle} />
 				{subagentSessions > 0 && <MetricCard label="Subagent Sessions" value={subagentSessions} icon={Users} />}
 				{mcpSessions > 0 && <MetricCard label="MCP Sessions" value={mcpSessions} icon={Wrench} />}
 			</div>
@@ -1535,8 +1540,8 @@ function ReportContent({ report }: { report: InsightReport }) {
 			{/* On the Horizon */}
 			<OnTheHorizon data={narrative?.on_the_horizon} />
 
-			{/* Cost & Token Efficiency — only show when token data exists */}
-			{(Number(metrics?.tokens?.total_input_tokens || 0) > 0 || Number(metrics?.cost?.total_cost_usd || 0) > 0) && <TokenSection data={narrative?.usage_cost_analysis || narrative?.token_optimization} metrics={metrics} />}
+			{/* Cost & Token Efficiency: show when any billing data exists (tokens or credits) */}
+			{(sessionsWithTokens > 0 || sessionsWithCredits > 0 || totalCost > 0) && <TokenSection data={narrative?.usage_cost_analysis || narrative?.token_optimization} metrics={metrics} />}
 
 			{/* Regression Detection */}
 			<RegressionSection

--- a/web/src/app/(admin)/insights/[reportId]/page.tsx
+++ b/web/src/app/(admin)/insights/[reportId]/page.tsx
@@ -1536,7 +1536,7 @@ function ReportContent({ report }: { report: InsightReport }) {
 			<OnTheHorizon data={narrative?.on_the_horizon} />
 
 			{/* Cost & Token Efficiency — only show when token data exists */}
-			{(Number((metrics as any)?.rich?.total_input_tokens || 0) > 0 || Number((metrics as any)?.rich?.total_cost_usd || metrics?.cost?.total_cost_usd || 0) > 0) && <TokenSection data={narrative?.usage_cost_analysis || narrative?.token_optimization} metrics={metrics} />}
+			{(Number(metrics?.tokens?.total_input_tokens || 0) > 0 || Number(metrics?.cost?.total_cost_usd || 0) > 0) && <TokenSection data={narrative?.usage_cost_analysis || narrative?.token_optimization} metrics={metrics} />}
 
 			{/* Regression Detection */}
 			<RegressionSection

--- a/web/src/app/(admin)/insights/[reportId]/page.tsx
+++ b/web/src/app/(admin)/insights/[reportId]/page.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 // SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
@@ -1435,18 +1436,18 @@ function ReportContent({ report }: { report: InsightReport }) {
 				<MetricCard label="Sessions" value={totalSessions} icon={Zap} subtext={daysActive > 0 ? `${daysActive} active days` : uniqueUsers > 1 ? `${uniqueUsers} users` : undefined} />
 				<MetricCard label="Messages" value={fmt(totalMessages)} icon={Database} subtext={totalSessions > 0 ? `${(totalMessages / totalSessions).toFixed(1)} per session` : undefined} />
 				<MetricCard label="Active Time" value={fmtHours(activeHours)} icon={Timer} subtext={daysActive > 0 ? `${(activeHours / daysActive).toFixed(1)}h/day` : undefined} />
-				<MetricCard label="Tokens In" value={fmt(inputTokens)} icon={Database} />
-				<MetricCard label="Tokens Out" value={fmt(outputTokens)} icon={Database} />
-				<MetricCard label="Cache Read" value={fmt(cacheReadTokens)} icon={Database} />
-				<MetricCard label="Cache Write" value={fmt(cacheWriteTokens)} icon={Database} />
+				{inputTokens > 0 && <MetricCard label="Tokens In" value={fmt(inputTokens)} icon={Database} />}
+				{outputTokens > 0 && <MetricCard label="Tokens Out" value={fmt(outputTokens)} icon={Database} />}
+				{cacheReadTokens > 0 && <MetricCard label="Cache Read" value={fmt(cacheReadTokens)} icon={Database} />}
+				{cacheWriteTokens > 0 && <MetricCard label="Cache Write" value={fmt(cacheWriteTokens)} icon={Database} />}
 				{cacheReadTokens > 0 && <MetricCard label="Cache Efficiency" value={`${((cacheReadTokens / (cacheReadTokens + inputTokens)) * 100).toFixed(1)}%`} icon={Zap} />}
-				<MetricCard label="Total Cost" value={`$${totalCost.toFixed(2)}`} icon={DollarSign} subtext={totalSessions > 0 ? `$${(totalCost / totalSessions).toFixed(2)}/session` : undefined} />
-				<MetricCard label="Lines Added" value={fmt(linesAdded)} icon={Zap} />
-				<MetricCard label="Lines Removed" value={fmt(linesRemoved)} icon={AlertTriangle} />
-				<MetricCard label="Git Commits" value={gitCommits} icon={Wrench} subtext={gitPushes > 0 ? `${gitPushes} pushes` : undefined} />
-				<MetricCard label="Files Modified" value={fmt(filesModified)} icon={Database} />
-				<MetricCard label="Tool Errors" value={toolErrors} icon={AlertTriangle} />
-				<MetricCard label="Interruptions" value={interruptions} icon={AlertTriangle} />
+				{totalCost > 0 && <MetricCard label="Total Cost" value={`$${totalCost.toFixed(2)}`} icon={DollarSign} subtext={totalSessions > 0 ? `$${(totalCost / totalSessions).toFixed(2)}/session` : undefined} />}
+				{linesAdded > 0 && <MetricCard label="Lines Added" value={fmt(linesAdded)} icon={Zap} />}
+				{linesRemoved > 0 && <MetricCard label="Lines Removed" value={fmt(linesRemoved)} icon={AlertTriangle} />}
+				{gitCommits > 0 && <MetricCard label="Git Commits" value={gitCommits} icon={Wrench} subtext={gitPushes > 0 ? `${gitPushes} pushes` : undefined} />}
+				{filesModified > 0 && <MetricCard label="Files Modified" value={fmt(filesModified)} icon={Database} />}
+				{toolErrors > 0 && <MetricCard label="Tool Errors" value={toolErrors} icon={AlertTriangle} />}
+				{interruptions > 0 && <MetricCard label="Interruptions" value={interruptions} icon={AlertTriangle} />}
 				{subagentSessions > 0 && <MetricCard label="Subagent Sessions" value={subagentSessions} icon={Users} />}
 				{mcpSessions > 0 && <MetricCard label="MCP Sessions" value={mcpSessions} icon={Wrench} />}
 			</div>
@@ -1534,8 +1535,8 @@ function ReportContent({ report }: { report: InsightReport }) {
 			{/* On the Horizon */}
 			<OnTheHorizon data={narrative?.on_the_horizon} />
 
-			{/* Cost & Token Efficiency */}
-			<TokenSection data={narrative?.usage_cost_analysis || narrative?.token_optimization} metrics={metrics} />
+			{/* Cost & Token Efficiency — only show when token data exists */}
+			{(Number((metrics as any)?.rich?.total_input_tokens || 0) > 0 || Number((metrics as any)?.rich?.total_cost_usd || metrics?.cost?.total_cost_usd || 0) > 0) && <TokenSection data={narrative?.usage_cost_analysis || narrative?.token_optimization} metrics={metrics} />}
 
 			{/* Regression Detection */}
 			<RegressionSection

--- a/web/src/app/(admin)/insights/page.tsx
+++ b/web/src/app/(admin)/insights/page.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 // SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
@@ -51,7 +52,7 @@ function StatusBadge({ status }: { status: InsightReportListItem["status"] }) {
 
 function AgentInsightCard({ agent, disabled }: { agent: RegistryItem; disabled?: boolean }) {
 	const { data: reports } = useInsightReports(agent.id);
-	const { data: sessionCountData } = useInsightSessionCount(agent.id);
+	const { data: sessionCountData, isLoading: isLoadingCount } = useInsightSessionCount(agent.id);
 	const generateInsight = useGenerateInsight();
 
 	const latest = (reports ?? [])[0] as InsightReportListItem | undefined;
@@ -76,7 +77,7 @@ function AgentInsightCard({ agent, disabled }: { agent: RegistryItem; disabled?:
 
 			<div className="flex items-center gap-3 text-xs text-muted-foreground">
 				<span className="font-[family-name:var(--font-mono)] tabular-nums">
-					{availableSessions} sessions available
+					{isLoadingCount ? "…" : availableSessions} sessions available
 				</span>
 				{latest && (
 					<>
@@ -110,7 +111,7 @@ function AgentInsightCard({ agent, disabled }: { agent: RegistryItem; disabled?:
 					className="h-7 text-xs gap-1 shrink-0"
 					disabled={
 						disabled ||
-						availableSessions === 0 ||
+						(!isLoadingCount && availableSessions === 0) ||
 						generateInsight.isPending ||
 						latest?.status === "pending" ||
 						latest?.status === "running"

--- a/web/src/hooks/use-insights-api.ts
+++ b/web/src/hooks/use-insights-api.ts
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+// SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 // SPDX-FileCopyrightText: 2026 Harishankar <harishankar0301@gmail.com>
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
@@ -53,7 +54,7 @@ export function useInsightsStatus() {
   return useQuery({
     queryKey: ["insights", "status"],
     queryFn: () => insights.status(),
-    staleTime: 60_000,
+    staleTime: 0,
   });
 }
 


### PR DESCRIPTION
## Purpose / Description

Agent Insights was showing 0 sessions and empty reports due to multiple issues in the data pipeline:
1. ClickHouse queries missing `FINAL` keyword caused unmerged `agent_id` values to be invisible
2. Poisoned `first_event_time` (epoch zero) excluded all sessions from the time filter
3. Bedrock API errors were silently swallowed, producing empty "completed" reports
4. Admin setting changes were not reflected until server restart (stale in-memory cache)
5. Kiro session tool usage (file writes, git commits) was not being extracted
6. Frontend showed misleading zeros and empty cost sections for IDEs that don't report token data

## Fixes

* Fixes insights showing "0 sessions available" for agents with valid sessions
* Fixes empty insight reports when AWS credentials are invalid/expired
* Fixes stale settings cache requiring server restart after admin changes
* Fixes Kiro sessions not reporting lines added/files modified/git stats
* Fixes misleading "$0.00 cost" display for Kiro-only agents

## Approach

### Backend (observal-server)

- **`api/routes/insights.py`**: Added `FINAL` to `session_stats_agg` queries; switched time filter from `first_event_time` to `last_event_time`; replaced `get_sync()` with async `ds.get()` in `/status` endpoint; added STS-based AWS credential validation with descriptive error messages
- **`api/routes/admin/enterprise_settings.py`**: Added `ds.invalidate(key)` + `ds.refresh_sync_cache()` after setting upsert/delete so changes take effect immediately
- **`services/insights/__init__.py`**: `_call_bedrock` now raises `RuntimeError` with descriptive messages (invalid credentials, access denied, model not available, expired token) instead of returning `{}`

### Insights Engine (ee/observal_insights)

- **`sections.py`**: `_call_section` re-raises `RuntimeError` so credential/config errors propagate to the report level (sets `status: failed` with `error_message`)
- **`session_meta_extractor.py`**: Added `FINAL` to session ID query; added file/lines/git extraction from Kiro `toolUse` entries (parses `write`, `edit`, `bash` tool inputs for file paths, content, and git commands)

### Frontend (web)

- **`insights/page.tsx`**: Show loading indicator instead of "0" while session count is fetching; don't disable Generate button during loading
- **`insights/[reportId]/page.tsx`**: Hide metric cards (Tokens In/Out, Cache, Cost, Lines, Git, Errors, Interruptions) when value is 0; hide "Cost & Token Efficiency" narrative section when no token/cost data exists
- **`use-insights-api.ts`**: Set `staleTime: 0` on status query so it always fetches fresh on page load

## How Has This Been Tested?

1. Verified `session_stats_agg` returns correct `agent_id` with `FINAL` via direct ClickHouse queries
2. Confirmed `/session-count` endpoint returns correct count after fix
3. Tested AWS credential validation: invalid key -> "AWS access key is invalid", wrong secret -> "AWS secret key is invalid"
4. Verified Bedrock throttling errors now set report `status: failed` with descriptive `error_message`
5. Confirmed admin setting changes take effect immediately without container restart
6. Verified Kiro tool use extraction: `write` tool -> lines_added + files_modified populated
7. Confirmed metric cards and Cost section hidden when values are 0

## Learning

- ClickHouse `AggregatingMergeTree` with non-key plain columns (`agent_id`) requires `FINAL` at read time to see merged values — without it, unmerged parts may return stale/empty values
- `SimpleAggregateFunction(min, DateTime64)` can be poisoned by epoch-zero timestamps from the first batch insert, making time-range filters exclude all data
- `get_sync()` in dynamic_settings uses an in-memory dict populated once at startup — writes must explicitly call `refresh_sync_cache()` to update it
- Kiro JSONL format does not include token/cost metadata — only conversation content and tool use. Metrics that depend on API-level data (tokens, cost) will always be 0 for Kiro sessions

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)