### PR TITLE
fix(saml): enforce strict SAML signature validation

### DIFF
--- a/ee/observal_server/services/saml.py
+++ b/ee/observal_server/services/saml.py
@@ -110,7 +110,7 @@ def build_saml_settings(
     idp_cert_clean = _strip_pem_headers(idp_x509_cert)
 
     settings_dict: dict[str, Any] = {
-        "strict": False,
+        "strict": strict,
         "debug": True,
         "sp": {
             "entityId": sp_entity_id,
@@ -132,15 +132,15 @@ def build_saml_settings(
         },
         "security": {
             "authnRequestsSigned": False,
-            "wantAssertionsSigned": False,
+            "wantAssertionsSigned": True,
             "wantMessagesSigned": False,
-            "wantResponsesSigned": False,
+            "wantResponsesSigned": True,
             "wantNameIdEncrypted": False,
             "wantAssertionsEncrypted": False,
             "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
             "requestedAuthnContext": False,
-            "relaxDestinationValidation": True,
+            "relaxDestinationValidation": False,
             "wantNameId": True,
         },
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description

Enforce strict SAML signature validation that was disabled during initial development. The security settings were relaxed to get the SAML flow working, but now that the ACS URL and audience restriction match correctly, strict mode works without issues.

## Fixes

* Fixes the relaxed SAML security configuration in `ee/observal_server/services/saml.py`

## Approach

- Use the `strict` parameter instead of hardcoding `False`
- Require signed assertions (`wantAssertionsSigned: True`)
- Require signed responses (`wantResponsesSigned: True`)
- Disable relaxed destination validation (`relaxDestinationValidation: False`)

These changes ensure the SP rejects unsigned or tampered SAML responses, which is required for production deployments.

## How Has This Been Tested?

- Tested locally with Okta SAML 2.0 application (integrator-5969311)
- Verified SAML login flow works end-to-end with strict validation enabled
- Confirmed assertion signature verification passes with Okta's signed responses
- Confirmed destination validation passes when `deployment.frontend_url` matches the Okta ACS URL

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
