### PR TITLE
Feat/saml sso login

### DIFF
--- a/ee/observal_server/routes/sso_saml.py
+++ b/ee/observal_server/routes/sso_saml.py
@@ -196,21 +196,7 @@ async def saml_acs(request: Request, db: AsyncSession = Depends(get_db)):
     auth.process_response()
     errors = auth.get_errors()
 
-    # If only signature validation failed but we have valid attributes, proceed anyway
-    # This handles cases where xmlsec1 has compatibility issues with certain IdP signatures
-    if errors == ["invalid_response"] and "Signature validation failed" in (auth.get_last_error_reason() or ""):
-        logger.warning("SAML signature validation failed but proceeding (debug mode)")
-        errors = []
-
-    # Debug: log the IDP cert being used and full error details
-    logger.warning(
-        "SAML DEBUG: idp_cert first 60 chars: %s", config.idp_x509_cert[:60] if config.idp_x509_cert else "NONE"
-    )
-    logger.warning("SAML DEBUG: sp_entity_id: %s", config.sp_entity_id)
-    logger.warning("SAML DEBUG: sp_acs_url: %s", config.sp_acs_url)
-    logger.warning("SAML DEBUG: errors: %s", errors)
-    logger.warning("SAML DEBUG: last_error_reason: %s", auth.get_last_error_reason())
-    logger.warning("SAML DEBUG: is_authenticated: %s", auth.is_authenticated())
+    logger.debug("SAML ACS: errors=%s, reason=%s", errors, auth.get_last_error_reason())
 
     source_ip = request.client.host if request.client else ""
     user_agent = request.headers.get("user-agent", "")
@@ -233,8 +219,8 @@ async def saml_acs(request: Request, db: AsyncSession = Depends(get_db)):
             detail=f"SAML validation failed: {error_reason}",
         )
 
-    # Bypass is_authenticated check when signature validation was skipped (debug mode)
-    if not auth.is_authenticated() and "Signature validation failed" not in (auth.get_last_error_reason() or ""):
+    # Reject unauthenticated assertions
+    if not auth.is_authenticated():
         await emit_security_event(
             SecurityEvent(
                 event_type=EventType.SSO_FAILURE,
@@ -287,22 +273,6 @@ async def saml_acs(request: Request, db: AsyncSession = Depends(get_db)):
         raise HTTPException(status_code=503, detail="Unable to verify SAML assertion -- try again")
 
     email, attributes = extract_name_id_and_attrs(auth)
-    if not email:
-        # Fallback: extract email from raw SAML response when signature bypass is active
-        import base64
-        import xml.etree.ElementTree as ET
-
-        raw_saml = request_data["post_data"].get("SAMLResponse", "")
-        if raw_saml:
-            try:
-                decoded = base64.b64decode(raw_saml)
-                root = ET.fromstring(decoded)
-                name_id_el = root.find(".//{urn:oasis:names:tc:SAML:2.0:assertion}NameID")
-                if name_id_el is not None and name_id_el.text:
-                    email = name_id_el.text.strip().lower()
-                    logger.warning("SAML DEBUG: extracted email from raw XML: %s", email)
-            except Exception as e:
-                logger.error("SAML DEBUG: failed to parse raw response: %s", e)
 
     if not email:
         raise HTTPException(status_code=400, detail="No email in SAML assertion NameID")
@@ -379,7 +349,6 @@ async def saml_acs(request: Request, db: AsyncSession = Depends(get_db)):
     await db.commit()
 
     code = secrets.token_urlsafe(32)
-    logger.warning("SAML DEBUG: issuing code=%s, access_token first 50=%s", code, access_token[:50])
     redis = get_redis()
     await redis.setex(
         f"oauth_code:{code}",

--- a/ee/observal_server/services/saml.py
+++ b/ee/observal_server/services/saml.py
@@ -110,7 +110,7 @@ def build_saml_settings(
     idp_cert_clean = _strip_pem_headers(idp_x509_cert)
 
     settings_dict: dict[str, Any] = {
-        "strict": False,
+        "strict": strict,
         "debug": True,
         "sp": {
             "entityId": sp_entity_id,
@@ -132,15 +132,15 @@ def build_saml_settings(
         },
         "security": {
             "authnRequestsSigned": False,
-            "wantAssertionsSigned": False,
+            "wantAssertionsSigned": True,
             "wantMessagesSigned": False,
-            "wantResponsesSigned": False,
+            "wantResponsesSigned": True,
             "wantNameIdEncrypted": False,
             "wantAssertionsEncrypted": False,
             "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
             "requestedAuthnContext": False,
-            "relaxDestinationValidation": True,
+            "relaxDestinationValidation": False,
             "wantNameId": True,
         },
     }

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -62,7 +62,11 @@ class TestSamlKeyGeneration:
         assert result["sp"]["entityId"] == "https://app.example.com/api/v1/sso/saml/metadata"
         assert "x509cert" in result["sp"]
         assert "privateKey" in result["sp"]
+        assert result["strict"] is True
         assert result["security"]["authnRequestsSigned"] is False
+        assert result["security"]["wantAssertionsSigned"] is True
+        assert result["security"]["wantResponsesSigned"] is True
+        assert result["security"]["relaxDestinationValidation"] is False
 
 
 class TestSamlHelpers:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description

Remove debug-mode security bypasses from the SAML ACS handler and enforce strict signature validation. The initial SAML implementation relaxed all security settings and included bypasses that allowed forged/unsigned SAML responses to authenticate successfully.

## Fixes

* Fixes security vulnerability in SAML SSO where signature validation was bypassed
* Fixes sensitive data leakage in production logs (access tokens, IdP certificates)

## Approach

**`ee/observal_server/services/saml.py`:**
- Use the `strict` parameter instead of hardcoding `False`
- Require signed assertions (`wantAssertionsSigned: True`)
- Require signed responses (`wantResponsesSigned: True`)
- Disable relaxed destination validation (`relaxDestinationValidation: False`)

**`ee/observal_server/routes/sso_saml.py`:**
- Remove signature validation bypass that cleared errors and proceeded anyway
- Remove `is_authenticated()` bypass that skipped the check on signature failures
- Remove raw XML email extraction fallback (only needed when signatures were bypassed)
- Remove debug logs leaking IdP cert, entity IDs, and access tokens

**`tests/test_saml.py`:**
- Add assertions for `strict`, `wantAssertionsSigned`, `wantResponsesSigned`, and `relaxDestinationValidation` to prevent regression

## How Has This Been Tested?

- Tested locally with Okta SAML 2.0 application (integrator-5969311)
- Verified SAML login flow works end-to-end with strict validation enabled
- Confirmed assertion signature verification passes with Okta's signed responses
- Confirmed destination validation passes when `deployment.frontend_url` matches the Okta ACS URL
- Confirmed unsigned/forged responses are now properly rejected with 400/401

## Learning

The python3-saml library uses `request_data["http_host"]` to determine where the response was "received at" for destination validation. This must match the ACS URL configured in the IdP. The `deployment.frontend_url` dynamic setting controls this — it must be set correctly for strict mode to work.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
