### PR TITLE
fix(security): count all secret redactions

### DIFF
--- a/observal-server/services/secrets_redactor.py
+++ b/observal-server/services/secrets_redactor.py
@@ -206,17 +206,20 @@ def redact_secrets(text: str) -> str:
     if text == REDACTED:
         return text
 
+    global _redaction_count
+
     # 1. PEM private keys (replace entire block)
-    text = _RE_PRIVATE_KEY.sub(REDACTED, text)
+    text, n = _RE_PRIVATE_KEY.subn(REDACTED, text)
+    _redaction_count += n
 
     # 2. Known API key prefixes (single-pass alternation with short-circuit)
-    global _redaction_count
     if any(prefix in text for prefix in _QUICK_PREFIXES):
         text, n = _COMBINED_KEY_PATTERN.subn(REDACTED, text)
         _redaction_count += n
 
     # 3. JWT tokens
-    text = _RE_JWT.sub(REDACTED, text)
+    text, n = _RE_JWT.subn(REDACTED, text)
+    _redaction_count += n
 
     # 4. Key=value assignments with secret-sounding key names
     #    Replace only the VALUE, keep the key name
@@ -224,15 +227,21 @@ def redact_secrets(text: str) -> str:
         optic.trace("redacted a secret match")
         # Groups: 1=double-quoted, 2=single-quoted, 3=unquoted
         val = m.group(1) or m.group(2) or m.group(3)
-        return m.group(0).replace(val, REDACTED) if val else m.group(0)
+        if not val or val == REDACTED:
+            return m.group(0)
+        global _redaction_count
+        _redaction_count += 1
+        return m.group(0).replace(val, REDACTED)
 
     text = _RE_KEY_VALUE.sub(_replace_kv, text)
 
-    # 5. Connection strings - redact password only
-    text = _RE_CONN_STRING.sub(r"\1" + REDACTED + r"\3", text)
+    # 5. Connection strings, redact password only
+    text, n = _RE_CONN_STRING.subn(r"\1" + REDACTED + r"\3", text)
+    _redaction_count += n
 
-    # 6. Auth headers - redact token only
-    text = _RE_AUTH_HEADER.sub(r"\1" + REDACTED, text)
+    # 6. Auth headers, redact token only
+    text, n = _RE_AUTH_HEADER.subn(r"\1" + REDACTED, text)
+    _redaction_count += n
 
     return text
 

--- a/tests/test_secrets_redactor.py
+++ b/tests/test_secrets_redactor.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "observal-server"))
 
-from services.secrets_redactor import REDACTED, redact_dict, redact_secrets
+from services.secrets_redactor import REDACTED, get_and_reset_redaction_count, redact_dict, redact_secrets
 
 # ============================================================================
 # Known API key prefixes — MUST be redacted
@@ -408,3 +408,27 @@ class TestIdempotency:
         once = redact_secrets(text)
         twice = redact_secrets(once)
         assert once == twice
+
+
+class TestRedactionCount:
+    def test_counts_all_redaction_types(self):
+        get_and_reset_redaction_count()
+        text = "\n".join(
+            [
+                "OPENAI_KEY=sk-proj-abc123def456ghi789jkl012mno345",
+                "password=mySuperSecretPassword123!",
+                "postgresql://admin:s3cretP@ss@localhost:5432/mydb",
+                "X-API-Key: abcdef1234567890abcdef1234567890",
+            ]
+        )
+
+        redact_secrets(text)
+
+        assert get_and_reset_redaction_count() == 4
+
+    def test_non_secret_text_does_not_increment_count(self):
+        get_and_reset_redaction_count()
+
+        redact_secrets("normal text without sensitive values")
+
+        assert get_and_reset_redaction_count() == 0


### PR DESCRIPTION
## Purpose / Description
Secret redaction metrics undercounted redactions because several replacement paths did not increment the shared counter. This made redaction reporting inaccurate for private keys, JWTs, connection strings, and authorization headers.

## Fixes
No linked issue.

## Approach
The redactor now uses `subn` for every regex replacement path that can redact a secret, and increments the counter by the number of replacements. Key value redaction continues to count inside the replacement callback so only actual value replacements are counted. The existing combined known-key scan is preserved.

## How Has This Been Tested?

Ran:

```bash
uv run pytest -q tests/test_secrets_redactor.py
uv run ruff check observal-server/services/secrets_redactor.py tests/test_secrets_redactor.py
uv run ruff format --check observal-server/services/secrets_redactor.py tests/test_secrets_redactor.py
uv run --with reuse reuse lint
git diff --check
```

Result: all passed locally.

## Learning (optional, can help others)
Reviewed `observal-server/services/secrets_redactor.py` and its tests to confirm all redaction paths now report counts consistently without changing the redacted output.

No external libraries or new patterns were added.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

UI checkbox is unchecked because this PR has no UI changes.

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?