### PR TITLE
fix(api): return 409 on duplicate name for MCP submit and agent draft

### DIFF
--- a/observal-server/api/routes/agent/draft.py
+++ b/observal-server/api/routes/agent/draft.py
@@ -35,6 +35,13 @@ async def save_draft(
 ):
     """Create an agent as a draft (relaxed validation, not submitted for review)."""
     optic.trace("req={}", req)
+    existing = await db.execute(select(Agent.id).where(Agent.name == req.name, Agent.created_by == current_user.id))
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"You already have an agent named '{req.name}'. Pick a different name or delete the existing one.",
+        )
+
     agent = Agent(
         name=req.name,
         owner=req.owner or current_user.username or current_user.email,

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -139,11 +139,10 @@ async def submit_mcp(
         .first()
     )
     if existing:
-        if existing.status == ListingStatus.approved:
-            raise HTTPException(status_code=409, detail=f"You already have an approved listing named '{req.name}'")
-        # Replace the old pending/rejected listing
-        await db.delete(existing)
-        await db.flush()
+        raise HTTPException(
+            status_code=409,
+            detail=("A listing with this name already exists"),
+        )
 
     listing = McpListing(
         name=req.name,
@@ -182,7 +181,6 @@ async def submit_mcp(
     listing.latest_version_id = version.id
     await db.commit()
     await db.refresh(listing)
-
     if req.client_analysis:
         # CLI already cloned and analyzed locally - store results directly
         await _store_client_analysis(listing, req.client_analysis, db)

--- a/observal-server/tests/test_agent_draft_conflict.py
+++ b/observal-server/tests/test_agent_draft_conflict.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Shreyansh Pandey <shreyanshpandey@users.noreply.github.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for agent draft duplicate-name conflict handling.
+
+Ensures that saving an agent draft with a name that already exists for
+the same user returns a proper 409 Conflict instead of an unhandled 500
+IntegrityError crash.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.agent.draft import save_draft
+from schemas.agent import AgentCreateRequest
+
+
+@pytest.mark.asyncio
+async def test_save_draft_returns_409_when_duplicate_name_exists():
+    """Saving an agent draft with a name the user already has returns 409."""
+
+    # Mock: existing agent found with same name for this user
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = uuid.uuid4()
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=mock_result)
+
+    req = AgentCreateRequest(
+        name="duplicate-agent",
+        version="1.0.0",
+        description="Test agent draft conflict",
+        owner="admin",
+        model_name="gpt-4",
+        prompt="You are a test agent",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await save_draft(req, db, MagicMock())
+
+    assert exc.value.status_code == 409

--- a/observal-server/tests/test_mcp_submit_conflict.py
+++ b/observal-server/tests/test_mcp_submit_conflict.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 Shreyansh Pandey <shreyanshpandey@users.noreply.github.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for MCP submit duplicate-name conflict handling.
+
+Ensures that submitting an MCP with a name that already exists for the
+same user returns a proper 409 Conflict instead of a 500 crash caused
+by the CircularDependencyError in the delete+recreate pattern.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from models.mcp import McpListing
+
+
+@pytest.mark.asyncio
+async def test_submit_mcp_returns_409_when_duplicate_name_exists():
+    """Submitting an MCP with a name the user already has returns 409."""
+    from api.routes.mcp import submit_mcp
+    from schemas.mcp import McpSubmitRequest
+
+    # Mock: existing listing found with same name for this user
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = MagicMock(spec=McpListing)
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=mock_result)
+
+    req = McpSubmitRequest(
+        name="duplicate-test",
+        version="1.0.0",
+        description="Test duplicate name conflict",
+        category="developer-tools",
+        owner="admin",
+        command="node",
+        args=["index.js"],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await submit_mcp(req, MagicMock(), db, MagicMock())
+
+    assert exc.value.status_code == 409


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Submitting an MCP with a name that already exists for the same user returns HTTP 500 (Internal Server Error) instead of a proper 409 Conflict. The same issue affects the agent draft endpoint saving a draft with a duplicate name crashes with an unhandled 500.

## Fixes
* Fixes #900 

## Approach
Root cause was a `CircularDependencyError` in the delete+recreate pattern for existing listings. The `latest_version_id` FK creates a cycle with the `versions` cascade.

Fix: replaced the delete+recreate with a simple pre-check SELECT → 409 for all duplicate names, matching the existing pattern used by skill, hook, prompt, sandbox, and agent create endpoints. Applied the same pre-check to agent draft, which had no duplicate-name handling at all.

## How Has This Been Tested?

- Unit tests in `test_mcp_submit_conflict.py` and `test_agent_draft_conflict.py` verify both endpoints return 409 on duplicate name
- Manual curl testing confirmed 200 on first submit, 409 on second

## Learning (optional, can help others)
The issue's suggested fix (`try/except IntegrityError`) would not have worked as there is no PostgreSQL unique constraint on `mcp_listings.name`, so the `IntegrityError` never fires. The actual 500 was from `CircularDependencyError` during SQLAlchemy's delete cascade, not a database constraint violation.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->
