### PR TITLE
feat(infra): fix AWS legacy env vars + add GCP Terraform module

### DIFF
--- a/infra/terraform/aws/clickhouse.tf
+++ b/infra/terraform/aws/clickhouse.tf
@@ -57,7 +57,6 @@ locals {
     region                 = var.region
     ssm_prefix             = local.ssm_prefix
     image_tag              = var.image_tag
-    data_retention_days    = var.data_retention_days
     log_group              = aws_cloudwatch_log_group.data_host.name
     backups_bucket         = aws_s3_bucket.backups.bucket
     grafana_admin_user     = "admin"

--- a/infra/terraform/aws/ecs.tf
+++ b/infra/terraform/aws/ecs.tf
@@ -37,10 +37,6 @@ locals {
 
   # Non-secret env vars passed to api/worker/init.
   app_environment = [
-    { name = "DEPLOYMENT_MODE", value = var.deployment_mode },
-    { name = "DATA_RETENTION_DAYS", value = tostring(var.data_retention_days) },
-    { name = "CLICKHOUSE_USER", value = local.clickhouse_self_hosted ? "default" : var.clickhouse_cloud_user },
-    { name = "DOMAIN", value = var.domain_name },
     { name = "NEXT_PUBLIC_API_URL", value = local.app_url },
     { name = "JWT_KEY_DIR", value = "/tmp/keys" },
   ]
@@ -50,7 +46,6 @@ locals {
     { name = "DATABASE_URL", valueFrom = aws_ssm_parameter.urls["DATABASE_URL"].arn },
     { name = "REDIS_URL", valueFrom = aws_ssm_parameter.urls["REDIS_URL"].arn },
     { name = "CLICKHOUSE_URL", valueFrom = aws_ssm_parameter.urls["CLICKHOUSE_URL"].arn },
-    { name = "CLICKHOUSE_PASSWORD", valueFrom = aws_ssm_parameter.app["CLICKHOUSE_PASSWORD"].arn },
     { name = "SECRET_KEY", valueFrom = aws_ssm_parameter.app["SECRET_KEY"].arn },
     ], local.is_enterprise ? [
     { name = "OBSERVAL_LICENSE_KEY", valueFrom = aws_ssm_parameter.license_key[0].arn },
@@ -115,6 +110,7 @@ resource "aws_ecs_task_definition" "api" {
     command = [
       "/app/.venv/bin/python", "-m", "uvicorn", "main:app",
       "--host", "0.0.0.0", "--port", "8000",
+      "--workers", "2",
       "--proxy-headers", "--forwarded-allow-ips", "*",
     ]
     portMappings = [{ containerPort = 8000, protocol = "tcp" }]

--- a/infra/terraform/aws/terraform.tfvars.example
+++ b/infra/terraform/aws/terraform.tfvars.example
@@ -32,7 +32,6 @@ image_tag = "latest"
 # ── ClickHouse Cloud (uncomment if clickhouse_mode = "cloud") ─────────
 # clickhouse_mode           = "cloud"
 # clickhouse_cloud_url      = "https://abc123.us-east-1.aws.clickhouse.cloud:8443"
-# clickhouse_cloud_user     = "default"
 # clickhouse_cloud_password = "..."
 
 # ── Managed services ──────────────────────────────────────────────────
@@ -44,8 +43,6 @@ image_tag = "latest"
 # alb_ingress_cidrs = ["203.0.113.0/24"]
 
 # ── App config ────────────────────────────────────────────────────────
-deployment_mode     = "enterprise"
-data_retention_days = 90
 log_retention_days  = 30
 
 # ── License ──────────────────────────────────────────────────────────────────

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -206,12 +206,6 @@ variable "clickhouse_cloud_url" {
   sensitive   = true
 }
 
-variable "clickhouse_cloud_user" {
-  description = "ClickHouse Cloud username. Required when clickhouse_mode = 'cloud'."
-  type        = string
-  default     = "default"
-}
-
 variable "clickhouse_cloud_password" {
   description = "ClickHouse Cloud password. Required when clickhouse_mode = 'cloud'."
   type        = string
@@ -266,22 +260,6 @@ variable "alb_ingress_cidrs" {
 }
 
 # ── Application config ─────────────────────────────────────────────────────
-
-variable "deployment_mode" {
-  description = "Observal deployment mode: 'local' (self-registration) or 'enterprise' (SSO-only)."
-  type        = string
-  default     = "enterprise"
-  validation {
-    condition     = contains(["local", "enterprise"], var.deployment_mode)
-    error_message = "deployment_mode must be 'local' or 'enterprise'."
-  }
-}
-
-variable "data_retention_days" {
-  description = "ClickHouse data retention in days. 0 disables TTL."
-  type        = number
-  default     = 90
-}
 
 variable "log_retention_days" {
   description = "CloudWatch log retention for application + infrastructure log groups."

--- a/infra/terraform/gcp/README.md
+++ b/infra/terraform/gcp/README.md
@@ -1,0 +1,83 @@
+<!--
+SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# Observal — GCP Terraform Module
+
+Deploy a production-ready Observal instance on Google Cloud Platform.
+
+## Architecture
+
+| Component | GCP Service |
+|-----------|-------------|
+| API / Worker / Init | Cloud Run (v2) + Cloud Run Jobs |
+| Web frontend | Cloud Run (v2) |
+| PostgreSQL | Cloud SQL |
+| Redis | Memorystore |
+| ClickHouse + Grafana + Prometheus | GCE instance (Docker Compose) |
+| Load balancer / TLS | Global HTTPS LB + Managed SSL Certificate |
+| DNS | Cloud DNS |
+| Secrets | Secret Manager |
+| Backups | GCS |
+| Logging | Cloud Logging (built-in) |
+
+## Prerequisites
+
+1. A GCP project with billing enabled
+2. APIs enabled: `run.googleapis.com`, `sqladmin.googleapis.com`, `redis.googleapis.com`, `compute.googleapis.com`, `secretmanager.googleapis.com`, `dns.googleapis.com`, `vpcaccess.googleapis.com`
+3. `gcloud` CLI authenticated
+4. Terraform >= 1.5
+
+Enable required APIs:
+```bash
+gcloud services enable \
+  run.googleapis.com \
+  sqladmin.googleapis.com \
+  redis.googleapis.com \
+  compute.googleapis.com \
+  secretmanager.googleapis.com \
+  dns.googleapis.com \
+  vpcaccess.googleapis.com \
+  servicenetworking.googleapis.com
+```
+
+## Quick Start
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your project_id and settings
+
+terraform init
+terraform plan
+terraform apply
+```
+
+After apply:
+1. Run migrations: `gcloud run jobs execute observal-prod-init --region=us-central1`
+2. Access the app at the URL from `terraform output app_url`
+
+## Custom Domain
+
+Set `domain_name` and `dns_managed_zone_name` to enable the Global HTTPS Load Balancer with a managed SSL certificate. The module creates a DNS A record pointing to the LB IP.
+
+## ClickHouse Modes
+
+- **self_hosted** (default): Deploys a GCE instance running ClickHouse, Grafana, and Prometheus via Docker Compose. Access via IAP SSH tunnel.
+- **cloud**: Supply `clickhouse_cloud_url` and `clickhouse_cloud_password` to use ClickHouse Cloud. No GCE instance is created.
+
+## Accessing the Data Host
+
+```bash
+gcloud compute ssh observal-prod-data --zone=us-central1-a --tunnel-through-iap
+```
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `app_url` | Public URL |
+| `cloud_run_urls` | Individual service URLs |
+| `data_host_ssh_command` | IAP SSH command for ClickHouse host |
+| `init_job_run_command` | Command to re-run migrations |
+| `backups_bucket` | GCS backup bucket name |

--- a/infra/terraform/gcp/cloud-run.tf
+++ b/infra/terraform/gcp/cloud-run.tf
@@ -40,7 +40,7 @@ resource "google_cloud_run_v2_service" "api" {
 
     containers {
       image = local.image_api
-      args  = ["/app/.venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+      args  = ["/app/.venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
 
       ports {
         container_port = 8000
@@ -56,6 +56,11 @@ resource "google_cloud_run_v2_service" "api" {
       env {
         name  = "SKIP_DDL_ON_STARTUP"
         value = "true"
+      }
+
+      env {
+        name  = "JWT_KEY_DIR"
+        value = "/tmp/keys"
       }
 
       env {
@@ -217,6 +222,11 @@ resource "google_cloud_run_v2_service" "worker" {
       }
 
       env {
+        name  = "JWT_KEY_DIR"
+        value = "/tmp/keys"
+      }
+
+      env {
         name = "DATABASE_URL"
         value_source {
           secret_key_ref {
@@ -296,6 +306,11 @@ resource "google_cloud_run_v2_job" "init" {
             cpu    = "1"
             memory = "1Gi"
           }
+        }
+
+        env {
+          name  = "JWT_KEY_DIR"
+          value = "/tmp/keys"
         }
 
         env {

--- a/infra/terraform/gcp/cloud-run.tf
+++ b/infra/terraform/gcp/cloud-run.tf
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "google_service_account" "cloud_run" {
+  account_id   = "${var.name_prefix}-run"
+  display_name = "Observal Cloud Run service account"
+}
+
+resource "google_project_iam_member" "cloud_run_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_project_iam_member" "cloud_run_trace_writer" {
+  project = var.project_id
+  role    = "roles/cloudtrace.agent"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+# ── API service ───────────────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "api" {
+  name     = "${local.name}-api"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = google_service_account.cloud_run.email
+
+    vpc_access {
+      connector = google_vpc_access_connector.main.id
+      egress    = "PRIVATE_RANGES_ONLY"
+    }
+
+    scaling {
+      min_instance_count = var.api_min_instances
+      max_instance_count = var.api_max_instances
+    }
+
+    containers {
+      image = local.image_api
+      args  = ["/app/.venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+      ports {
+        container_port = 8000
+      }
+
+      resources {
+        limits = {
+          cpu    = var.api_cpu
+          memory = var.api_memory
+        }
+      }
+
+      env {
+        name  = "SKIP_DDL_ON_STARTUP"
+        value = "true"
+      }
+
+      env {
+        name = "DATABASE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["DATABASE_URL"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "REDIS_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["REDIS_URL"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "SECRET_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["SECRET_KEY"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "CLICKHOUSE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["CLICKHOUSE_URL"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "OBSERVAL_LICENSE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["OBSERVAL_LICENSE_KEY"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/readyz"
+          port = 8000
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 5
+        failure_threshold     = 10
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/readyz"
+          port = 8000
+        }
+        period_seconds    = 15
+        failure_threshold = 3
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "api_public" {
+  name     = google_cloud_run_v2_service.api.name
+  location = var.region
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# ── Web service ───────────────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "web" {
+  name     = "${local.name}-web"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = google_service_account.cloud_run.email
+
+    scaling {
+      min_instance_count = var.web_min_instances
+      max_instance_count = var.web_max_instances
+    }
+
+    containers {
+      image = local.image_web
+
+      ports {
+        container_port = 3000
+      }
+
+      resources {
+        limits = {
+          cpu    = var.web_cpu
+          memory = var.web_memory
+        }
+      }
+
+      env {
+        name  = "NEXT_PUBLIC_API_URL"
+        value = google_cloud_run_v2_service.api.uri
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "web_public" {
+  name     = google_cloud_run_v2_service.web.name
+  location = var.region
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# ── Worker service ────────────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "worker" {
+  name     = "${local.name}-worker"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+
+  template {
+    service_account = google_service_account.cloud_run.email
+
+    annotations = {
+      "run.googleapis.com/cpu-throttling" = "false"
+    }
+
+    vpc_access {
+      connector = google_vpc_access_connector.main.id
+      egress    = "PRIVATE_RANGES_ONLY"
+    }
+
+    scaling {
+      min_instance_count = var.worker_min_instances
+      max_instance_count = var.worker_max_instances
+    }
+
+    containers {
+      image = local.image_api
+      args  = ["/app/.venv/bin/python", "-c", "import asyncio; asyncio.set_event_loop(asyncio.new_event_loop()); from arq import run_worker; from worker import WorkerSettings; run_worker(WorkerSettings)"]
+
+      resources {
+        limits = {
+          cpu    = var.worker_cpu
+          memory = var.worker_memory
+        }
+      }
+
+      env {
+        name = "DATABASE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["DATABASE_URL"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "REDIS_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["REDIS_URL"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "SECRET_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["SECRET_KEY"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "CLICKHOUSE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["CLICKHOUSE_URL"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "OBSERVAL_LICENSE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.app["OBSERVAL_LICENSE_KEY"].secret_id
+            version = "latest"
+          }
+        }
+      }
+    }
+  }
+}
+
+# ── Init job (migrations) ─────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_job" "init" {
+  name     = "${local.name}-init"
+  location = var.region
+
+  template {
+    template {
+      service_account = google_service_account.cloud_run.email
+
+      vpc_access {
+        connector = google_vpc_access_connector.main.id
+        egress    = "PRIVATE_RANGES_ONLY"
+      }
+
+      max_retries = 1
+      timeout     = "300s"
+
+      containers {
+        image   = local.image_api
+        command = ["/app/entrypoint.sh"]
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "1Gi"
+          }
+        }
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.app["DATABASE_URL"].secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name = "REDIS_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.app["REDIS_URL"].secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name = "SECRET_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.app["SECRET_KEY"].secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name = "CLICKHOUSE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.app["CLICKHOUSE_URL"].secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/infra/terraform/gcp/cloud-run.tf
+++ b/infra/terraform/gcp/cloud-run.tf
@@ -4,6 +4,8 @@
 resource "google_service_account" "cloud_run" {
   account_id   = "${var.name_prefix}-run"
   display_name = "Observal Cloud Run service account"
+
+  depends_on = [google_project_service.iam]
 }
 
 resource "google_project_iam_member" "cloud_run_log_writer" {
@@ -24,6 +26,8 @@ resource "google_cloud_run_v2_service" "api" {
   name     = "${local.name}-api"
   location = var.region
   ingress  = "INGRESS_TRAFFIC_ALL"
+
+  depends_on = [google_project_service.run]
 
   template {
     service_account = google_service_account.cloud_run.email

--- a/infra/terraform/gcp/cloud-sql.tf
+++ b/infra/terraform/gcp/cloud-sql.tf
@@ -14,6 +14,7 @@ resource "google_sql_database_instance" "postgres" {
 
   settings {
     tier              = var.db_tier
+    edition           = "ENTERPRISE"
     disk_size         = var.db_disk_size_gb
     disk_autoresize   = true
     availability_type = var.db_ha_enabled ? "REGIONAL" : "ZONAL"
@@ -46,7 +47,10 @@ resource "google_sql_database_instance" "postgres" {
     }
   }
 
-  depends_on = [google_compute_network.main]
+  depends_on = [
+    google_project_service.sqladmin,
+    google_service_networking_connection.private,
+  ]
 }
 
 resource "google_sql_database" "app" {

--- a/infra/terraform/gcp/cloud-sql.tf
+++ b/infra/terraform/gcp/cloud-sql.tf
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "random_password" "db" {
+  length  = 32
+  special = false
+}
+
+resource "google_sql_database_instance" "postgres" {
+  name                = "${local.name}-pg"
+  database_version    = "POSTGRES_16"
+  region              = var.region
+  deletion_protection = var.environment == "prod"
+
+  settings {
+    tier              = var.db_tier
+    disk_size         = var.db_disk_size_gb
+    disk_autoresize   = true
+    availability_type = var.db_ha_enabled ? "REGIONAL" : "ZONAL"
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = google_compute_network.main.id
+    }
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = var.environment == "prod"
+      start_time                     = "03:00"
+      transaction_log_retention_days = 7
+
+      backup_retention_settings {
+        retained_backups = 14
+      }
+    }
+
+    maintenance_window {
+      day          = 7
+      hour         = 4
+      update_track = "stable"
+    }
+
+    database_flags {
+      name  = "max_connections"
+      value = "200"
+    }
+  }
+
+  depends_on = [google_compute_network.main]
+}
+
+resource "google_sql_database" "app" {
+  name     = "observal"
+  instance = google_sql_database_instance.postgres.name
+}
+
+resource "google_sql_user" "app" {
+  name     = "observal"
+  instance = google_sql_database_instance.postgres.name
+  password = random_password.db.result
+}

--- a/infra/terraform/gcp/data-host.tf
+++ b/infra/terraform/gcp/data-host.tf
@@ -70,13 +70,12 @@ resource "google_compute_instance" "data_host" {
   }
 
   metadata_startup_script = templatefile("${path.module}/user-data.sh.tftpl", {
-    region              = var.region
     clickhouse_password = random_password.clickhouse.result
     clickhouse_db       = "observal"
     data_retention_days = var.data_retention_days
     backups_bucket      = google_storage_bucket.backups.name
     grafana_admin_user  = "admin"
-    grafana_root_url    = local.app_url
+    grafana_root_url    = local.enable_custom_domain ? "https://${var.domain_name}" : ""
   })
 
   allow_stopping_for_update = true

--- a/infra/terraform/gcp/data-host.tf
+++ b/infra/terraform/gcp/data-host.tf
@@ -30,7 +30,7 @@ resource "google_project_iam_member" "data_host_storage_admin" {
 
 resource "google_compute_disk" "data" {
   count = local.clickhouse_self_hosted ? 1 : 0
-  name  = "${local.name}-data"
+  name  = "${local.name}-data-disk"
   type  = "pd-ssd"
   size  = var.data_disk_size_gb
   zone  = "${var.region}-a"

--- a/infra/terraform/gcp/data-host.tf
+++ b/infra/terraform/gcp/data-host.tf
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "google_service_account" "data_host" {
+  count        = local.clickhouse_self_hosted ? 1 : 0
+  account_id   = "${var.name_prefix}-data"
+  display_name = "Observal data host (ClickHouse + Grafana + Prometheus)"
+}
+
+resource "google_project_iam_member" "data_host_log_writer" {
+  count   = local.clickhouse_self_hosted ? 1 : 0
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.data_host[0].email}"
+}
+
+resource "google_project_iam_member" "data_host_metric_writer" {
+  count   = local.clickhouse_self_hosted ? 1 : 0
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.data_host[0].email}"
+}
+
+resource "google_project_iam_member" "data_host_storage_admin" {
+  count   = local.clickhouse_self_hosted ? 1 : 0
+  project = var.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.data_host[0].email}"
+}
+
+resource "google_compute_disk" "data" {
+  count = local.clickhouse_self_hosted ? 1 : 0
+  name  = "${local.name}-data"
+  type  = "pd-ssd"
+  size  = var.data_disk_size_gb
+  zone  = "${var.region}-a"
+}
+
+resource "google_compute_instance" "data_host" {
+  count        = local.clickhouse_self_hosted ? 1 : 0
+  name         = "${local.name}-data"
+  machine_type = var.data_machine_type
+  zone         = "${var.region}-a"
+  tags         = ["data-host"]
+
+  boot_disk {
+    initialize_params {
+      image = "projects/cos-cloud/global/images/family/cos-stable"
+      size  = 30
+      type  = "pd-balanced"
+    }
+  }
+
+  attached_disk {
+    source      = google_compute_disk.data[0].self_link
+    device_name = "data-disk"
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.main.self_link
+  }
+
+  service_account {
+    email  = google_service_account.data_host[0].email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+
+  metadata_startup_script = templatefile("${path.module}/user-data.sh.tftpl", {
+    region              = var.region
+    clickhouse_password = random_password.clickhouse.result
+    clickhouse_db       = "observal"
+    data_retention_days = var.data_retention_days
+    backups_bucket      = google_storage_bucket.backups.name
+    grafana_admin_user  = "admin"
+    grafana_root_url    = local.app_url
+  })
+
+  allow_stopping_for_update = true
+}

--- a/infra/terraform/gcp/dns.tf
+++ b/infra/terraform/gcp/dns.tf
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "google_compute_global_address" "lb" {
+  count = local.enable_custom_domain ? 1 : 0
+  name  = "${local.name}-lb-ip"
+}
+
+resource "google_compute_managed_ssl_certificate" "app" {
+  count = local.enable_custom_domain ? 1 : 0
+  name  = "${local.name}-cert"
+
+  managed {
+    domains = [var.domain_name]
+  }
+}
+
+resource "google_compute_region_network_endpoint_group" "api" {
+  count                 = local.enable_custom_domain ? 1 : 0
+  name                  = "${local.name}-api-neg"
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.api.name
+  }
+}
+
+resource "google_compute_backend_service" "api" {
+  count       = local.enable_custom_domain ? 1 : 0
+  name        = "${local.name}-api-backend"
+  protocol    = "HTTPS"
+  timeout_sec = 300
+
+  backend {
+    group = google_compute_region_network_endpoint_group.api[0].id
+  }
+}
+
+resource "google_compute_url_map" "app" {
+  count           = local.enable_custom_domain ? 1 : 0
+  name            = "${local.name}-url-map"
+  default_service = google_compute_backend_service.api[0].id
+}
+
+resource "google_compute_target_https_proxy" "app" {
+  count            = local.enable_custom_domain ? 1 : 0
+  name             = "${local.name}-https-proxy"
+  url_map          = google_compute_url_map.app[0].id
+  ssl_certificates = [google_compute_managed_ssl_certificate.app[0].id]
+}
+
+resource "google_compute_global_forwarding_rule" "https" {
+  count      = local.enable_custom_domain ? 1 : 0
+  name       = "${local.name}-https-fwd"
+  target     = google_compute_target_https_proxy.app[0].id
+  port_range = "443"
+  ip_address = google_compute_global_address.lb[0].address
+}
+
+resource "google_compute_url_map" "http_redirect" {
+  count = local.enable_custom_domain ? 1 : 0
+  name  = "${local.name}-http-redirect"
+
+  default_url_redirect {
+    https_redirect = true
+    strip_query    = false
+  }
+}
+
+resource "google_compute_target_http_proxy" "redirect" {
+  count   = local.enable_custom_domain ? 1 : 0
+  name    = "${local.name}-http-proxy"
+  url_map = google_compute_url_map.http_redirect[0].id
+}
+
+resource "google_compute_global_forwarding_rule" "http" {
+  count      = local.enable_custom_domain ? 1 : 0
+  name       = "${local.name}-http-fwd"
+  target     = google_compute_target_http_proxy.redirect[0].id
+  port_range = "80"
+  ip_address = google_compute_global_address.lb[0].address
+}
+
+resource "google_dns_record_set" "app" {
+  count        = local.enable_custom_domain ? 1 : 0
+  name         = "${var.domain_name}."
+  type         = "A"
+  ttl          = 300
+  managed_zone = var.dns_managed_zone_name
+  rrdatas      = [google_compute_global_address.lb[0].address]
+}

--- a/infra/terraform/gcp/examples/minimal/main.tf
+++ b/infra/terraform/gcp/examples/minimal/main.tf
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+module "observal" {
+  source = "../../"
+
+  project_id  = var.project_id
+  region      = var.region
+  environment = var.environment
+  name_prefix = var.name_prefix
+  image_tag   = var.image_tag
+
+  domain_name           = var.domain_name
+  dns_managed_zone_name = var.dns_managed_zone_name
+
+  observal_license_key = var.observal_license_key
+}

--- a/infra/terraform/gcp/examples/minimal/outputs.tf
+++ b/infra/terraform/gcp/examples/minimal/outputs.tf
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+output "app_url" {
+  value = module.observal.app_url
+}
+
+output "cloud_run_urls" {
+  value = module.observal.cloud_run_urls
+}
+
+output "init_job_run_command" {
+  value = module.observal.init_job_run_command
+}
+
+output "data_host_ssh_command" {
+  value = module.observal.data_host_ssh_command
+}

--- a/infra/terraform/gcp/examples/minimal/terraform.tfvars.example
+++ b/infra/terraform/gcp/examples/minimal/terraform.tfvars.example
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+project_id  = "my-gcp-project"
+region      = "us-central1"
+environment = "prod"
+image_tag   = "latest"
+
+# Optional: custom domain
+# domain_name           = "observal.example.com"
+# dns_managed_zone_name = "example-com"
+
+# Optional: enterprise license
+# observal_license_key = "eyJ..."

--- a/infra/terraform/gcp/examples/minimal/variables.tf
+++ b/infra/terraform/gcp/examples/minimal/variables.tf
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}
+
+variable "name_prefix" {
+  type    = string
+  default = "observal"
+}
+
+variable "image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "domain_name" {
+  type    = string
+  default = ""
+}
+
+variable "dns_managed_zone_name" {
+  type    = string
+  default = ""
+}
+
+variable "observal_license_key" {
+  type      = string
+  default   = ""
+  sensitive = true
+}

--- a/infra/terraform/gcp/locals.tf
+++ b/infra/terraform/gcp/locals.tf
@@ -12,11 +12,13 @@ locals {
   effective_edition = var.edition == "auto" ? (var.observal_license_key != "" ? "enterprise" : "community") : var.edition
   is_enterprise     = local.effective_edition == "enterprise"
 
-  image_repo_api_effective = local.is_enterprise ? "ghcr.io/blazeup-ai/observal-api-enterprise" : var.image_repo_api
-  image_repo_web_effective = local.is_enterprise ? "ghcr.io/blazeup-ai/observal-web-enterprise" : var.image_repo_web
+  ar_prefix = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.ghcr_proxy.repository_id}"
 
-  image_api = "${local.image_repo_api_effective}:${var.image_tag}"
-  image_web = "${local.image_repo_web_effective}:${var.image_tag}"
+  image_repo_api_effective = local.is_enterprise ? "blazeup-ai/observal-api-enterprise" : trimprefix(var.image_repo_api, "ghcr.io/")
+  image_repo_web_effective = local.is_enterprise ? "blazeup-ai/observal-web-enterprise" : trimprefix(var.image_repo_web, "ghcr.io/")
+
+  image_api = "${local.ar_prefix}/${local.image_repo_api_effective}:${var.image_tag}"
+  image_web = "${local.ar_prefix}/${local.image_repo_web_effective}:${var.image_tag}"
 
   database_url   = "postgresql+asyncpg://${google_sql_user.app.name}:${random_password.db.result}@${google_sql_database_instance.postgres.private_ip_address}:5432/${google_sql_database.app.name}"
   redis_url      = "redis://${google_redis_instance.main.host}:${google_redis_instance.main.port}"

--- a/infra/terraform/gcp/locals.tf
+++ b/infra/terraform/gcp/locals.tf
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+locals {
+  name = "${var.name_prefix}-${var.environment}"
+
+  enable_custom_domain = var.domain_name != "" && var.dns_managed_zone_name != ""
+  app_url              = local.enable_custom_domain ? "https://${var.domain_name}" : google_cloud_run_v2_service.api.uri
+
+  clickhouse_self_hosted = var.clickhouse_mode == "self_hosted"
+
+  effective_edition = var.edition == "auto" ? (var.observal_license_key != "" ? "enterprise" : "community") : var.edition
+  is_enterprise     = local.effective_edition == "enterprise"
+
+  image_repo_api_effective = local.is_enterprise ? "ghcr.io/blazeup-ai/observal-api-enterprise" : var.image_repo_api
+  image_repo_web_effective = local.is_enterprise ? "ghcr.io/blazeup-ai/observal-web-enterprise" : var.image_repo_web
+
+  image_api = "${local.image_repo_api_effective}:${var.image_tag}"
+  image_web = "${local.image_repo_web_effective}:${var.image_tag}"
+
+  database_url   = "postgresql+asyncpg://${google_sql_user.app.name}:${random_password.db.result}@${google_sql_database_instance.postgres.private_ip_address}:5432/${google_sql_database.app.name}"
+  redis_url      = "redis://${google_redis_instance.main.host}:${google_redis_instance.main.port}"
+  clickhouse_url = local.clickhouse_self_hosted ? "clickhouse://default:${random_password.clickhouse.result}@${google_compute_instance.data_host[0].network_interface[0].network_ip}:8123/observal" : var.clickhouse_cloud_url
+}

--- a/infra/terraform/gcp/memorystore.tf
+++ b/infra/terraform/gcp/memorystore.tf
@@ -12,4 +12,6 @@ resource "google_redis_instance" "main" {
   redis_configs = {
     maxmemory-policy = "allkeys-lru"
   }
+
+  depends_on = [google_project_service.redis]
 }

--- a/infra/terraform/gcp/memorystore.tf
+++ b/infra/terraform/gcp/memorystore.tf
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "google_redis_instance" "main" {
+  name               = "${local.name}-redis"
+  region             = var.region
+  memory_size_gb     = var.redis_memory_size_gb
+  tier               = var.redis_tier
+  redis_version      = "REDIS_7_2"
+  authorized_network = google_compute_network.main.id
+
+  redis_configs = {
+    maxmemory-policy = "allkeys-lru"
+  }
+}

--- a/infra/terraform/gcp/network.tf
+++ b/infra/terraform/gcp/network.tf
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "google_compute_network" "main" {
+  name                    = local.name
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "main" {
+  name          = "${local.name}-main"
+  ip_cidr_range = var.vpc_cidr
+  region        = var.region
+  network       = google_compute_network.main.id
+
+  private_ip_google_access = true
+}
+
+resource "google_compute_router" "main" {
+  name    = "${local.name}-router"
+  network = google_compute_network.main.id
+  region  = var.region
+}
+
+resource "google_compute_router_nat" "main" {
+  name                               = "${local.name}-nat"
+  router                             = google_compute_router.main.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+resource "google_vpc_access_connector" "main" {
+  name          = "${var.name_prefix}-vpc"
+  region        = var.region
+  ip_cidr_range = var.connector_cidr
+  network       = google_compute_network.main.name
+
+  min_instances = 2
+  max_instances = 10
+}
+
+resource "google_compute_firewall" "allow_internal" {
+  name    = "${local.name}-allow-internal"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = [var.vpc_cidr, var.connector_cidr]
+}
+
+resource "google_compute_firewall" "allow_iap_ssh" {
+  name    = "${local.name}-allow-iap-ssh"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = ["data-host"]
+}
+
+resource "google_compute_firewall" "allow_health_check" {
+  name    = "${local.name}-allow-hc"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8123", "3000", "9090"]
+  }
+
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["data-host"]
+}

--- a/infra/terraform/gcp/network.tf
+++ b/infra/terraform/gcp/network.tf
@@ -4,6 +4,8 @@
 resource "google_compute_network" "main" {
   name                    = local.name
   auto_create_subnetworks = false
+
+  depends_on = [google_project_service.compute]
 }
 
 resource "google_compute_subnetwork" "main" {
@@ -37,6 +39,8 @@ resource "google_vpc_access_connector" "main" {
 
   min_instances = 2
   max_instances = 10
+
+  depends_on = [google_project_service.vpcaccess]
 }
 
 resource "google_compute_firewall" "allow_internal" {

--- a/infra/terraform/gcp/outputs.tf
+++ b/infra/terraform/gcp/outputs.tf
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+output "app_url" {
+  description = "Public URL for the Observal install."
+  value       = local.app_url
+}
+
+output "cloud_run_urls" {
+  description = "Cloud Run service URLs."
+  value = {
+    api    = google_cloud_run_v2_service.api.uri
+    web    = google_cloud_run_v2_service.web.uri
+    worker = google_cloud_run_v2_service.worker.uri
+  }
+}
+
+output "cloud_sql_connection_name" {
+  description = "Cloud SQL instance connection name (for Cloud SQL Proxy)."
+  value       = google_sql_database_instance.postgres.connection_name
+}
+
+output "cloud_sql_private_ip" {
+  description = "Cloud SQL private IP."
+  value       = google_sql_database_instance.postgres.private_ip_address
+  sensitive   = true
+}
+
+output "redis_host" {
+  description = "Memorystore Redis host."
+  value       = google_redis_instance.main.host
+  sensitive   = true
+}
+
+output "data_host_internal_ip" {
+  description = "GCE data host internal IP. Empty when clickhouse_mode = 'cloud'."
+  value       = local.clickhouse_self_hosted ? google_compute_instance.data_host[0].network_interface[0].network_ip : ""
+}
+
+output "data_host_ssh_command" {
+  description = "IAP SSH command to access data host."
+  value       = local.clickhouse_self_hosted ? "gcloud compute ssh ${google_compute_instance.data_host[0].name} --zone=${var.region}-a --tunnel-through-iap" : ""
+}
+
+output "backups_bucket" {
+  description = "GCS bucket for backups."
+  value       = google_storage_bucket.backups.name
+}
+
+output "secret_names" {
+  description = "Secret Manager secret names."
+  value       = { for k, v in google_secret_manager_secret.app : k => v.secret_id }
+}
+
+output "init_job_run_command" {
+  description = "Command to manually run the init/migrations job."
+  value       = "gcloud run jobs execute ${google_cloud_run_v2_job.init.name} --region=${var.region}"
+}
+
+output "edition" {
+  description = "Deployed edition."
+  value       = local.effective_edition
+  sensitive   = true
+}

--- a/infra/terraform/gcp/registry.tf
+++ b/infra/terraform/gcp/registry.tf
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Artifact Registry remote repo that proxies ghcr.io.
+# Cloud Run only supports images from GCR, Artifact Registry, or Docker Hub.
+# This transparently caches ghcr.io images so Cloud Run can pull them.
+
+resource "google_project_service" "artifactregistry" {
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_artifact_registry_repository" "ghcr_proxy" {
+  location      = var.region
+  repository_id = "${var.name_prefix}-ghcr"
+  format        = "DOCKER"
+  mode          = "REMOTE_REPOSITORY"
+
+  remote_repository_config {
+    docker_repository {
+      custom_repository {
+        uri = "https://ghcr.io"
+      }
+    }
+  }
+
+  depends_on = [google_project_service.artifactregistry]
+}

--- a/infra/terraform/gcp/secrets.tf
+++ b/infra/terraform/gcp/secrets.tf
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "random_password" "secret_key" {
+  length  = 64
+  special = false
+}
+
+resource "random_password" "clickhouse" {
+  length  = 32
+  special = false
+}
+
+locals {
+  secrets = {
+    DATABASE_URL         = local.database_url
+    REDIS_URL            = local.redis_url
+    SECRET_KEY           = random_password.secret_key.result
+    CLICKHOUSE_URL       = local.clickhouse_url
+    OBSERVAL_LICENSE_KEY = var.observal_license_key
+  }
+}
+
+resource "google_secret_manager_secret" "app" {
+  for_each  = local.secrets
+  secret_id = "${local.name}-${lower(replace(each.key, "_", "-"))}"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "app" {
+  for_each    = local.secrets
+  secret      = google_secret_manager_secret.app[each.key].id
+  secret_data = each.value
+}
+
+resource "google_secret_manager_secret_iam_member" "cloud_run_access" {
+  for_each  = local.secrets
+  secret_id = google_secret_manager_secret.app[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cloud_run.email}"
+}

--- a/infra/terraform/gcp/secrets.tf
+++ b/infra/terraform/gcp/secrets.tf
@@ -28,12 +28,14 @@ resource "google_secret_manager_secret" "app" {
   replication {
     auto {}
   }
+
+  depends_on = [google_project_service.secretmanager]
 }
 
 resource "google_secret_manager_secret_version" "app" {
   for_each    = local.secrets
   secret      = google_secret_manager_secret.app[each.key].id
-  secret_data = each.value
+  secret_data = coalesce(each.value, " ")
 }
 
 resource "google_secret_manager_secret_iam_member" "cloud_run_access" {

--- a/infra/terraform/gcp/services.tf
+++ b/infra/terraform/gcp/services.tf
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Auto-enable required GCP APIs. Resources that need a specific API
+# declare depends_on to the relevant google_project_service below,
+# so `terraform apply` on a fresh project just works without manual
+# console steps.
+
+resource "google_project_service" "compute" {
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "run" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "sqladmin" {
+  service            = "sqladmin.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "redis" {
+  service            = "redis.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "vpcaccess" {
+  service            = "vpcaccess.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "secretmanager" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "servicenetworking" {
+  service            = "servicenetworking.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "iam" {
+  service            = "iam.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Private services connection for Cloud SQL private IP.
+# This allocates a /16 range in the VPC for Google-managed services.
+resource "google_compute_global_address" "private_services" {
+  name          = "${local.name}-private-svc-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.main.id
+
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_service_networking_connection" "private" {
+  network                 = google_compute_network.main.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_services.name]
+
+  depends_on = [google_project_service.servicenetworking]
+}

--- a/infra/terraform/gcp/storage.tf
+++ b/infra/terraform/gcp/storage.tf
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "google_storage_bucket" "backups" {
+  name          = "${local.name}-backups-${var.project_id}"
+  location      = var.region
+  force_destroy = var.environment != "prod"
+  storage_class = "STANDARD"
+
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    condition {
+      age = var.backup_nearline_days
+    }
+    action {
+      type          = "SetStorageClass"
+      storage_class = "NEARLINE"
+    }
+  }
+
+  lifecycle_rule {
+    condition {
+      age = var.backup_retention_days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  lifecycle_rule {
+    condition {
+      num_newer_versions = 3
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}

--- a/infra/terraform/gcp/terraform.tfvars.example
+++ b/infra/terraform/gcp/terraform.tfvars.example
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+project_id  = "my-gcp-project"
+region      = "us-central1"
+environment = "prod"
+name_prefix = "observal"
+
+# Custom domain (optional — leave empty to use Cloud Run default URLs)
+# domain_name           = "observal.example.com"
+# dns_managed_zone_name = "example-com"
+
+# Container images
+image_tag = "latest"
+
+# Cloud SQL
+db_tier        = "db-g1-small"
+db_disk_size_gb = 50
+db_ha_enabled  = false
+
+# Memorystore Redis
+redis_memory_size_gb = 1
+redis_tier           = "BASIC"
+
+# Data host (ClickHouse + Grafana + Prometheus)
+clickhouse_mode   = "self_hosted"
+data_machine_type = "e2-standard-2"
+data_disk_size_gb = 100
+
+# Application
+data_retention_days = 90
+
+# License (leave empty for community edition)
+# observal_license_key = ""

--- a/infra/terraform/gcp/user-data.sh.tftpl
+++ b/infra/terraform/gcp/user-data.sh.tftpl
@@ -1,0 +1,99 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# Format and mount the data disk
+DATA_DEVICE="/dev/disk/by-id/google-data-disk"
+DATA_DIR="/data"
+if ! blkid "$${DATA_DEVICE}"; then
+  mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0 "$${DATA_DEVICE}"
+fi
+mkdir -p "$${DATA_DIR}"
+mount -o discard,defaults "$${DATA_DEVICE}" "$${DATA_DIR}"
+echo "UUID=$(blkid -s UUID -o value $${DATA_DEVICE}) $${DATA_DIR} ext4 discard,defaults,nofail 0 2" >> /etc/fstab
+
+mkdir -p "$${DATA_DIR}/clickhouse" "$${DATA_DIR}/grafana" "$${DATA_DIR}/prometheus"
+
+# Install Docker (COS has Docker pre-installed, but ensure compose plugin)
+DOCKER_COMPOSE_VERSION="v2.36.0"
+mkdir -p /usr/libexec/docker/cli-plugins
+curl -fsSL "https://github.com/docker/compose/releases/download/$${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" \
+  -o /usr/libexec/docker/cli-plugins/docker-compose
+chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+
+# Write docker-compose for the data stack
+cat > "$${DATA_DIR}/docker-compose.yml" <<'COMPOSE'
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.5
+    restart: unless-stopped
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    environment:
+      CLICKHOUSE_DB: ${clickhouse_db}
+      CLICKHOUSE_PASSWORD: ${clickhouse_password}
+      MAX_SERVER_MEMORY_USAGE_RATIO: "0.7"
+    volumes:
+      - /data/clickhouse:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --password ${clickhouse_password} --query 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana-oss:11.6.5
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${grafana_admin_user}
+      GF_SECURITY_ADMIN_PASSWORD: ${clickhouse_password}
+      GF_SERVER_ROOT_URL: "${grafana_root_url}/grafana"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      GF_INSTALL_PLUGINS: grafana-clickhouse-datasource
+    volumes:
+      - /data/grafana:/var/lib/grafana
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
+  prometheus:
+    image: prom/prometheus:v3.11.3
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - /data/prometheus:/prometheus
+      - /data/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+COMPOSE
+
+# Write prometheus config
+cat > "$${DATA_DIR}/prometheus.yml" <<'PROM'
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: clickhouse
+    static_configs:
+      - targets: ["clickhouse:8123"]
+PROM
+
+# Start the data stack
+cd "$${DATA_DIR}"
+docker compose up -d
+
+# Set up daily ClickHouse backup to GCS
+cat > /etc/cron.daily/clickhouse-backup <<'CRON'
+#!/bin/bash
+BACKUP_FILE="/tmp/clickhouse-backup-$(date +%Y%m%d).tar.gz"
+docker exec $(docker ps -q -f name=clickhouse) clickhouse-client \
+  --password "${clickhouse_password}" \
+  --query "BACKUP DATABASE ${clickhouse_db} TO Disk('backups', 'daily-$(date +%Y%m%d)')"
+gsutil -m rsync -r /data/clickhouse/backups/ gs://${backups_bucket}/clickhouse/
+find /data/clickhouse/backups/ -mtime +${data_retention_days} -delete
+CRON
+chmod +x /etc/cron.daily/clickhouse-backup

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -169,19 +169,6 @@ variable "clickhouse_cloud_url" {
   sensitive   = true
 }
 
-variable "clickhouse_cloud_user" {
-  description = "ClickHouse Cloud username."
-  type        = string
-  default     = "default"
-}
-
-variable "clickhouse_cloud_password" {
-  description = "ClickHouse Cloud password."
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
 variable "data_machine_type" {
   description = "Machine type for the ClickHouse + Grafana + Prometheus GCE instance."
   type        = string

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -184,9 +184,13 @@ variable "data_disk_size_gb" {
 # ── Cloud SQL ─────────────────────────────────────────────────────────────
 
 variable "db_tier" {
-  description = "Cloud SQL machine tier."
+  description = "Cloud SQL machine tier (ENTERPRISE edition). Use db-f1-micro, db-g1-small, or db-custom-N-M."
   type        = string
   default     = "db-g1-small"
+  validation {
+    condition     = !startswith(var.db_tier, "db-perf-optimized")
+    error_message = "db_tier uses ENTERPRISE edition. Tiers starting with 'db-perf-optimized' require ENTERPRISE_PLUS. Use db-g1-small, db-custom-N-M, etc."
+  }
 }
 
 variable "db_disk_size_gb" {

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region to deploy into."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "environment" {
+  description = "Environment name (e.g. prod, staging)."
+  type        = string
+  default     = "prod"
+}
+
+variable "name_prefix" {
+  description = "Prefix applied to all resource names."
+  type        = string
+  default     = "observal"
+}
+
+# ── Network ────────────────────────────────────────────────────────────────
+
+variable "vpc_cidr" {
+  description = "Primary CIDR for the VPC subnet."
+  type        = string
+  default     = "10.42.0.0/20"
+}
+
+variable "connector_cidr" {
+  description = "CIDR for the VPC Access Connector (Serverless VPC Access). Must be /28."
+  type        = string
+  default     = "10.42.16.0/28"
+}
+
+# ── DNS / TLS ──────────────────────────────────────────────────────────────
+
+variable "domain_name" {
+  description = "Public hostname for the install (e.g. observal.example.com). Leave empty to use Cloud Run default URL."
+  type        = string
+  default     = ""
+}
+
+variable "dns_managed_zone_name" {
+  description = "Cloud DNS managed zone name for domain_name. Required if domain_name is set."
+  type        = string
+  default     = ""
+}
+
+# ── Container images ──────────────────────────────────────────────────────
+
+variable "image_repo_api" {
+  description = "Container image repository for api + worker + init."
+  type        = string
+  default     = "ghcr.io/blazeup-ai/observal-api"
+}
+
+variable "image_repo_web" {
+  description = "Container image repository for the web frontend."
+  type        = string
+  default     = "ghcr.io/blazeup-ai/observal-web"
+}
+
+variable "image_tag" {
+  description = "Image tag to deploy."
+  type        = string
+  default     = "latest"
+}
+
+# ── Cloud Run (api) ───────────────────────────────────────────────────────
+
+variable "api_cpu" {
+  description = "CPU allocation for API service (e.g. '1' or '2')."
+  type        = string
+  default     = "1"
+}
+
+variable "api_memory" {
+  description = "Memory allocation for API service."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "api_min_instances" {
+  description = "Minimum instances for API service."
+  type        = number
+  default     = 1
+}
+
+variable "api_max_instances" {
+  description = "Maximum instances for API service."
+  type        = number
+  default     = 10
+}
+
+# ── Cloud Run (web) ───────────────────────────────────────────────────────
+
+variable "web_cpu" {
+  description = "CPU allocation for web service."
+  type        = string
+  default     = "1"
+}
+
+variable "web_memory" {
+  description = "Memory allocation for web service."
+  type        = string
+  default     = "512Mi"
+}
+
+variable "web_min_instances" {
+  description = "Minimum instances for web service."
+  type        = number
+  default     = 1
+}
+
+variable "web_max_instances" {
+  description = "Maximum instances for web service."
+  type        = number
+  default     = 6
+}
+
+# ── Cloud Run (worker) ────────────────────────────────────────────────────
+
+variable "worker_cpu" {
+  description = "CPU allocation for worker service."
+  type        = string
+  default     = "1"
+}
+
+variable "worker_memory" {
+  description = "Memory allocation for worker service."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "worker_min_instances" {
+  description = "Minimum instances for worker (should be >= 1 for always-on processing)."
+  type        = number
+  default     = 1
+}
+
+variable "worker_max_instances" {
+  description = "Maximum instances for worker."
+  type        = number
+  default     = 5
+}
+
+# ── Data tier (ClickHouse on GCE) ─────────────────────────────────────────
+
+variable "clickhouse_mode" {
+  description = "'self_hosted' = GCE instance. 'cloud' = ClickHouse Cloud (supply clickhouse_cloud_url)."
+  type        = string
+  default     = "self_hosted"
+  validation {
+    condition     = contains(["self_hosted", "cloud"], var.clickhouse_mode)
+    error_message = "clickhouse_mode must be 'self_hosted' or 'cloud'."
+  }
+}
+
+variable "clickhouse_cloud_url" {
+  description = "ClickHouse Cloud DSN. Required when clickhouse_mode = 'cloud'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "clickhouse_cloud_user" {
+  description = "ClickHouse Cloud username."
+  type        = string
+  default     = "default"
+}
+
+variable "clickhouse_cloud_password" {
+  description = "ClickHouse Cloud password."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "data_machine_type" {
+  description = "Machine type for the ClickHouse + Grafana + Prometheus GCE instance."
+  type        = string
+  default     = "e2-standard-2"
+}
+
+variable "data_disk_size_gb" {
+  description = "Persistent disk size (GB) for the data host."
+  type        = number
+  default     = 100
+}
+
+# ── Cloud SQL ─────────────────────────────────────────────────────────────
+
+variable "db_tier" {
+  description = "Cloud SQL machine tier."
+  type        = string
+  default     = "db-g1-small"
+}
+
+variable "db_disk_size_gb" {
+  description = "Cloud SQL disk size (GB)."
+  type        = number
+  default     = 50
+}
+
+variable "db_ha_enabled" {
+  description = "Enable Cloud SQL high availability (regional) for production."
+  type        = bool
+  default     = false
+}
+
+# ── Memorystore Redis ─────────────────────────────────────────────────────
+
+variable "redis_memory_size_gb" {
+  description = "Memorystore Redis memory size in GB."
+  type        = number
+  default     = 1
+}
+
+variable "redis_tier" {
+  description = "Memorystore tier: BASIC or STANDARD_HA."
+  type        = string
+  default     = "BASIC"
+  validation {
+    condition     = contains(["BASIC", "STANDARD_HA"], var.redis_tier)
+    error_message = "redis_tier must be 'BASIC' or 'STANDARD_HA'."
+  }
+}
+
+# ── Application config ────────────────────────────────────────────────────
+
+variable "data_retention_days" {
+  description = "ClickHouse data retention in days."
+  type        = number
+  default     = 90
+}
+
+variable "observal_license_key" {
+  description = "Observal Enterprise license key. Leave empty for community edition."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "edition" {
+  description = "Edition to deploy: 'auto', 'community', or 'enterprise'."
+  type        = string
+  default     = "auto"
+  validation {
+    condition     = contains(["auto", "community", "enterprise"], var.edition)
+    error_message = "edition must be 'auto', 'community', or 'enterprise'."
+  }
+}
+
+# ── Backups ───────────────────────────────────────────────────────────────
+
+variable "backup_retention_days" {
+  description = "Days to retain backups in GCS before deletion. 0 disables."
+  type        = number
+  default     = 365
+}
+
+variable "backup_nearline_days" {
+  description = "Days after which backups transition to Nearline storage."
+  type        = number
+  default     = 30
+}

--- a/infra/terraform/gcp/versions.tf
+++ b/infra/terraform/gcp/versions.tf
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION

  ## Approach

  **AWS:**
  - Remove legacy env vars (`DEPLOYMENT_MODE`, `DATA_RETENTION_DAYS`, `CLICKHOUSE_USER`, `DOMAIN`) from ECS task definitions that trigger the v1.0 startup guard
  - Remove `CLICKHOUSE_PASSWORD` from app secrets (already embedded in `CLICKHOUSE_URL`)
  - Remove unused `data_retention_days` from `templatefile()` call (unused vars error at apply)
  - Remove orphaned variables (`deployment_mode`, `data_retention_days`, `clickhouse_cloud_user`)
  - Add `--workers 2` to API uvicorn command

  **GCP:**
  - Add `JWT_KEY_DIR=/tmp/keys` to API, worker, and init containers (required for readonly/ephemeral FS)
  - Add `--workers 2` to API uvicorn command
  - Remove unused `region` from `templatefile()` call
  - Remove orphaned variables (`clickhouse_cloud_user`, `clickhouse_cloud_password`)
  - Break dependency cycle: compute `grafana_root_url` from domain var directly instead of `local.app_url`

  ## How Has This Been Tested?

  - [x] `terraform validate` passes for both AWS and GCP modules
  - [x] `tflint` passes with zero warnings for both modules
  - [ ] AWS deploy unblocked after template escape fix
  - [ ] GCP module deploys successfully to a test project

  ## Learning (optional, can help others)

  - `templatefile()` in Terraform errors on **unused** variables at plan/apply time, not at `terraform validate` — always cross-check template keys against actual `${...}` references in the `.tftpl` file.
  - Dependency cycles in Terraform can be broken by using static/input values (e.g. `var.domain_name`) instead of computed values (e.g. a Cloud Run service URI) when the dependency isn't strictly necessary.

  ## Checklist

  - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
  - [x] You have commented your code, particularly in hard-to-understand areas
  - [x] You have performed a self-review of your own code
  - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)