### PR TITLE
fix(infra): remove references to nonexistent enterprise artifacts

### DIFF
--- a/infra/terraform/aws/locals.tf
+++ b/infra/terraform/aws/locals.tf
@@ -27,7 +27,8 @@ locals {
   effective_edition = var.edition == "auto" ? (var.observal_license_key != "" ? "enterprise" : "community") : var.edition
   is_enterprise     = local.effective_edition == "enterprise"
 
-  # Enterprise uses separate image repos
+  # Enterprise uses a separate API image (includes compiled insights);
+  # the web image is identical for both editions (gating is server-side).
   image_repo_api_effective = local.is_enterprise ? "ghcr.io/blazeup-ai/observal-api-enterprise" : var.image_repo_api
-  image_repo_web_effective = local.is_enterprise ? "ghcr.io/blazeup-ai/observal-web-enterprise" : var.image_repo_web
+  image_repo_web_effective = var.image_repo_web
 }

--- a/install-server.sh
+++ b/install-server.sh
@@ -208,11 +208,9 @@ info "Installing Observal Server $VERSION [$EDITION edition]"
 
 # ── Download ─────────────────────────────────────────────────
 
-if [ "$EDITION" = "enterprise" ]; then
-    ARTIFACT="observal-server-enterprise-${VERSION}.tar.gz"
-else
-    ARTIFACT="observal-server-${VERSION}.tar.gz"
-fi
+# Same server package for both editions; enterprise features activate via the
+# license key passed to setup.sh at the end of this script.
+ARTIFACT="observal-server-${VERSION}.tar.gz"
 
 if [ -n "$BASE_URL" ]; then
     URL="${BASE_URL}/${ARTIFACT}"
@@ -225,11 +223,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 info "Downloading server package ($EDITION)..."
 if ! curl -fsSL -o "$TMPDIR/$ARTIFACT" "$URL"; then
-    if [ "$EDITION" = "enterprise" ]; then
-        die "Enterprise package '$ARTIFACT' was not found for $VERSION. Check https://github.com/$GITHUB_REPO/releases or re-run without --license-key to install community edition."
-    else
-        die "Download failed. Check that $VERSION exists at https://github.com/$GITHUB_REPO/releases"
-    fi
+    die "Download failed. Check that $VERSION exists at https://github.com/$GITHUB_REPO/releases"
 fi
 
 # ── Unpack ───────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -218,11 +218,9 @@ info "Installing Observal CLI $VERSION ($OS/$ARCH) [$EDITION edition]"
 EXT=""
 [ "$OS" = "windows" ] && EXT=".exe"
 
-if [ "$EDITION" = "enterprise" ]; then
-    ARTIFACT="observal-enterprise-${OS}-${ARCH}${EXT}"
-else
-    ARTIFACT="observal-${OS}-${ARCH}${EXT}"
-fi
+# Same binary for both editions; enterprise activates via the license key
+# written to ~/.observal/config.json below.
+ARTIFACT="observal-${OS}-${ARCH}${EXT}"
 
 if [ -n "$BASE_URL" ]; then
     URL="${BASE_URL}/${ARTIFACT}"
@@ -237,11 +235,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 info "Downloading $ARTIFACT..."
 if ! curl -fsSL -o "$TMPDIR/$ARTIFACT" "$URL"; then
-    if [ "$EDITION" = "enterprise" ]; then
-        die "Enterprise artifact '$ARTIFACT' was not found for $VERSION. Check https://github.com/$GITHUB_REPO/releases or re-run without --license-key to install community edition."
-    else
-        die "Download failed. Check that $VERSION exists at https://github.com/$GITHUB_REPO/releases"
-    fi
+    die "Download failed. Check that $VERSION exists at https://github.com/$GITHUB_REPO/releases"
 fi
 
 info "Verifying checksum..."


### PR DESCRIPTION
## Purpose / Description
The Terraform config and install scripts referenced enterprise-specific Docker images and tarballs (`observal-web-enterprise`, `observal-server-enterprise-*`, `observal-enterprise-*`) that CI never produces. This caused `docker pull` and `curl` failures during enterprise deployments.

Enterprise features activate via the license key at runtime, not via separate artifacts. The only distinct enterprise image is the API (`observal-api-enterprise`), which bundles compiled insights.

## Fixes
* Fixes Terraform `docker pull` failure for `ghcr.io/blazeup-ai/observal-web-enterprise`
* Fixes `install-server.sh` curl 404 when using `--license-key`
* Fixes `install.sh` curl 404 when using `--license-key`

## Approach
- `infra/terraform/aws/locals.tf`: removed the enterprise override for web image. Only the API image differs between editions.
- `install-server.sh`: always downloads `observal-server-${VERSION}.tar.gz` (license key is passed to `setup.sh` at runtime).
- `install.sh`: always downloads `observal-${OS}-${ARCH}` (license key is written to `~/.observal/config.json`).

## How Has This Been Tested?
- Verified `bash -n` syntax check passes on both install scripts
- Confirmed `release.yml` only produces `observal-server-v*.tar.gz` and `observal-{os}-{arch}` artifacts
- Confirmed `release-enterprise.yml` only builds `observal-api-enterprise` Docker image (no web image, no tarball)
- Validated Terraform locals structure is syntactically correct

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)