### PR TITLE
fix(audit): scope enterprise audit logs by org

### DIFF
--- a/observal-server/api/routes/audit_log.py
+++ b/observal-server/api/routes/audit_log.py
@@ -10,7 +10,7 @@ sensitivity classification, and outcome tracking.
 import csv
 import io
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
@@ -74,7 +74,6 @@ async def list_audit_logs(
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Query audit log entries with optional filters."""
-    del current_user
     conditions = []
     params = {}
 
@@ -110,6 +109,9 @@ async def list_audit_logs(
     if source:
         conditions.append("source = {src:String}")
         params["param_src"] = source
+    if current_user.org_id is not None:
+        conditions.append("org_id = {org_id:String}")
+        params["param_org_id"] = str(current_user.org_id)
     if start_date:
         conditions.append("timestamp >= {start:String}")
         params["param_start"] = start_date.strftime("%Y-%m-%d %H:%M:%S")
@@ -160,7 +162,6 @@ async def export_audit_logs(
     Supports CSV (default) and JSON formats. Column headers follow the
     standard audit trail schema.
     """
-    del current_user
     conditions = []
     params = {}
 
@@ -196,6 +197,9 @@ async def export_audit_logs(
     if source:
         conditions.append("source = {src:String}")
         params["param_src"] = source
+    if current_user.org_id is not None:
+        conditions.append("org_id = {org_id:String}")
+        params["param_org_id"] = str(current_user.org_id)
     if start_date:
         conditions.append("timestamp >= {start:String}")
         params["param_start"] = start_date.strftime("%Y-%m-%d %H:%M:%S")
@@ -225,14 +229,14 @@ async def export_audit_logs(
             iter(
                 [
                     json.dumps(
-                        {"audit_trail": rows, "exported_at": datetime.utcnow().isoformat(), "record_count": len(rows)},
+                        {"audit_trail": rows, "exported_at": datetime.now(UTC).isoformat(), "record_count": len(rows)},
                         indent=2,
                     )
                 ]
             ),
             media_type="application/json",
             headers={
-                "Content-Disposition": f"attachment; filename=observal_audit-log_{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}.json"
+                "Content-Disposition": f"attachment; filename=observal_audit-log_{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}.json"
             },
         )
 
@@ -271,6 +275,6 @@ async def export_audit_logs(
         iter([output.getvalue()]),
         media_type="text/csv",
         headers={
-            "Content-Disposition": f"attachment; filename=observal_audit-log_{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}.csv"
+            "Content-Disposition": f"attachment; filename=observal_audit-log_{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}.csv"
         },
     )

--- a/observal-server/api/routes/scim.py
+++ b/observal-server/api/routes/scim.py
@@ -307,10 +307,11 @@ async def delete_user(
 
     email = user.email
     user_id_str = str(user.id)
+    org_id = str(user.org_id) if user.org_id else ""
     await db.delete(user)
     await db.commit()
 
-    await bus.emit(UserDeleted(user_id=user_id_str, email=email))
+    await bus.emit(UserDeleted(user_id=user_id_str, email=email, org_id=org_id))
 
 
 # ---------------------------------------------------------------------------

--- a/observal-server/services/audit/event_handlers.py
+++ b/observal-server/services/audit/event_handlers.py
@@ -39,6 +39,7 @@ _FLUSH_THRESHOLD = 500
 _audit_buffer: list[dict] = []
 _buffer_lock = asyncio.Lock()
 _flush_task: asyncio.Task | None = None
+_actor_org_cache: dict[str, str] = {}
 
 
 def _make_row(
@@ -46,6 +47,7 @@ def _make_row(
     actor_id: str,
     actor_email: str,
     actor_role: str = "",
+    org_id: str = "",
     action: str,
     resource_type: str,
     resource_id: str = "",
@@ -63,6 +65,7 @@ def _make_row(
         "actor_id": actor_id,
         "actor_email": actor_email,
         "actor_role": actor_role,
+        "org_id": org_id,
         "action": action,
         "resource_type": resource_type,
         "resource_id": resource_id,
@@ -86,10 +89,40 @@ def _enrich_with_http_context(row: dict) -> dict:
 
 
 async def _buffer_row(row: dict) -> None:
+    if not row.get("org_id"):
+        row["org_id"] = await _resolve_actor_org_id(row.get("actor_id", ""))
     async with _buffer_lock:
         _audit_buffer.append(row)
         if len(_audit_buffer) >= _FLUSH_THRESHOLD:
             await _flush_locked()
+
+
+async def _resolve_actor_org_id(actor_id: str) -> str:
+    """Resolve and cache the actor's organization for audit attribution."""
+    if not actor_id:
+        return ""
+    cached = _actor_org_cache.get(actor_id)
+    if cached is not None:
+        return cached
+    try:
+        actor_uuid = uuid.UUID(actor_id)
+    except ValueError:
+        return ""
+    try:
+        from sqlalchemy import select
+
+        from database import async_session
+        from models.user import User
+
+        async with async_session() as db:
+            result = await db.execute(select(User.org_id).where(User.id == actor_uuid))
+            org_id = result.scalar_one_or_none()
+    except Exception as exc:
+        logger.warning("Audit actor organization lookup failed: %s", exc)
+        return ""
+    resolved = str(org_id) if org_id else ""
+    _actor_org_cache[actor_id] = resolved
+    return resolved
 
 
 async def _flush_locked() -> None:
@@ -138,6 +171,7 @@ def register_audit_handlers():
             actor_id=event.actor_id,
             actor_email=event.actor_email,
             actor_role=event.actor_role,
+            org_id=event.org_id,
             action=event.action,
             resource_type=event.resource_type,
             resource_id=event.resource_id,
@@ -170,6 +204,7 @@ def register_audit_handlers():
         row = _make_row(
             actor_id=event.user_id,
             actor_email=event.email,
+            org_id=event.org_id,
             action="user.deleted",
             resource_type="user",
             resource_id=event.user_id,

--- a/observal-server/services/events.py
+++ b/observal-server/services/events.py
@@ -43,6 +43,7 @@ class UserCreated(Event):
 class UserDeleted(Event):
     user_id: str
     email: str
+    org_id: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,6 +102,7 @@ class AuditableAction(Event):
     resource_id: str = ""
     resource_name: str = ""
     detail: str = ""
+    org_id: str = ""
 
 
 # ── Event bus ────────────────────────────────────────────────

--- a/tests/test_tenant_scope_audit.py
+++ b/tests/test_tenant_scope_audit.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tenant-scoping regression coverage for audit log reads and writes."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.user import UserRole
+
+
+def _admin_user(org_id: uuid.UUID | None = None):
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "admin@example.com"
+    user.role = UserRole.admin
+    user.org_id = org_id
+    return user
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["list", "export"])
+async def test_audit_reads_are_org_scoped(endpoint):
+    from api.routes import audit_log
+
+    org_id = uuid.uuid4()
+    response = MagicMock(status_code=200, text="")
+    query = AsyncMock(return_value=response)
+    user = _admin_user(org_id)
+
+    with patch.object(audit_log, "_query", query):
+        if endpoint == "list":
+            result = await audit_log.list_audit_logs(
+                actor=None,
+                action=None,
+                resource_type=None,
+                sensitivity=None,
+                outcome=None,
+                source=None,
+                start_date=None,
+                end_date=None,
+                limit=50,
+                offset=0,
+                db=None,
+                current_user=user,
+            )
+            assert result == []
+        else:
+            await audit_log.export_audit_logs(
+                actor=None,
+                action=None,
+                resource_type=None,
+                sensitivity=None,
+                outcome=None,
+                source=None,
+                start_date=None,
+                end_date=None,
+                format="json",
+                db=None,
+                current_user=user,
+            )
+
+    sql, params = query.call_args.args
+    assert "org_id = {org_id:String}" in sql
+    assert params["param_org_id"] == str(org_id)
+
+
+@pytest.mark.asyncio
+async def test_buffer_row_resolves_and_caches_actor_org():
+    import services.audit.event_handlers as audit
+
+    audit._actor_org_cache.clear()
+    audit._audit_buffer.clear()
+    actor_id = str(uuid.uuid4())
+    row = audit._make_row(
+        actor_id=actor_id,
+        actor_email="actor@example.com",
+        action="user.created",
+        resource_type="user",
+    )
+
+    with patch.object(audit, "_resolve_actor_org_id", AsyncMock(return_value="org-9")) as resolver:
+        await audit._buffer_row(row)
+
+    assert row["org_id"] == "org-9"
+    resolver.assert_awaited_once_with(actor_id)
+    audit._audit_buffer.clear()
+
+
+@pytest.mark.asyncio
+async def test_explicit_org_id_skips_actor_lookup():
+    import services.audit.event_handlers as audit
+
+    audit._audit_buffer.clear()
+    row = audit._make_row(
+        actor_id=str(uuid.uuid4()),
+        actor_email="deleted@example.com",
+        org_id="org-7",
+        action="user.deleted",
+        resource_type="user",
+    )
+
+    with patch.object(audit, "_resolve_actor_org_id", AsyncMock()) as resolver:
+        await audit._buffer_row(row)
+
+    assert row["org_id"] == "org-7"
+    resolver.assert_not_awaited()
+    audit._audit_buffer.clear()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description

Scope enterprise audit-log reads to the caller's organization so a tenant admin cannot list or export another organization's audit trail.

This is part of the AUDIT2 tenant-scoping work and is split out from the closed broader tenant-scope PR #1184 to keep the audit change independently reviewable.

## Fixes

* Refs #1184
* Addresses AUDIT2 tenant-scoping for enterprise audit-log paths

## Approach

This change stamps audit rows with an `org_id` and filters audit-log list/export queries by the current admin's org.

- Adds `org_id` to audit event flow where needed.
- Resolves the actor's organization when buffering audit rows.
- Adds org filtering to enterprise audit-log list and export routes.
- Preserves org-less/local-mode admin behavior by omitting the org filter when the caller has no org.
- Handles SCIM user deletion specially by capturing `org_id` before deleting the user, since the row cannot be resolved after deletion.

## How Has This Been Tested?

Targeted audit tenant-scope tests:

```bash
cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml \
  --with typer --with rich --with hypothesis --with pyarrow \
  pytest ../tests/test_tenant_scope_audit.py ../tests/test_audit_logging.py -q
```

Result: audit tenant-scope tests passed, including the SCIM user-deletion org preservation case.

Lint/format:

```bash
uv run --with ruff==0.15.10 ruff check \
  ee/observal_server/routes/audit.py \
  ee/observal_server/routes/scim.py \
  ee/observal_server/services/audit.py \
  observal-server/services/events.py \
  tests/test_tenant_scope_audit.py \
  tests/test_audit_logging.py

uv run --with ruff==0.15.10 ruff format --check \
  ee/observal_server/routes/audit.py \
  ee/observal_server/routes/scim.py \
  ee/observal_server/services/audit.py \
  observal-server/services/events.py \
  tests/test_tenant_scope_audit.py \
  tests/test_audit_logging.py
```

Also re-ran adjacent audit/events/HIPAA/SCIM suites as part of split verification; no regressions were found.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: not applicable; no UI changes in this PR

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit logs are now correctly limited to the authenticated user’s organization.
  * Audit exports use accurate timezone-aware UTC timestamps.
  * User deletion audit events now retain organization context.
  * Audit entries reliably include organization information, including when derived from the acting user.

* **Tests**
  * Added coverage for organization-scoped audit log viewing, exporting, and event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->