### PR TITLE
feat(security): make sensitive settings write-once and retractable

### DIFF
--- a/observal-server/api/routes/admin/enterprise_settings.py
+++ b/observal-server/api/routes/admin/enterprise_settings.py
@@ -14,7 +14,8 @@ from api.deps import get_db, require_role
 from config import HAS_LICENSE, settings
 from models.enterprise_config import EnterpriseConfig
 from models.user import User, UserRole
-from schemas.admin import EnterpriseConfigResponse, EnterpriseConfigUpdate
+from schemas.admin import EnterpriseConfigResponse, EnterpriseConfigUpdate, SettingRevokedResponse
+from services.secrets_redactor import REDACTED
 from services.security_events import EventType, SecurityEvent, Severity, emit_security_event
 
 from ._router import router
@@ -126,7 +127,20 @@ async def list_settings(
 ):
     optic.debug("admin settings list")
     result = await db.execute(select(EnterpriseConfig).order_by(EnterpriseConfig.key))
-    configs = [EnterpriseConfigResponse.model_validate(c) for c in result.scalars().all()]
+    configs = []
+    for c in result.scalars().all():
+        sensitive = c.key in ds.SENSITIVE_KEYS
+        has_value = bool(c.value)
+        # Never return plaintext or ciphertext for sensitive keys.
+        display_value = (REDACTED if has_value else "") if sensitive else c.value
+        configs.append(
+            EnterpriseConfigResponse(
+                key=c.key,
+                value=display_value,
+                is_sensitive=sensitive,
+                is_set=has_value,
+            )
+        )
     return configs
 
 
@@ -141,7 +155,15 @@ async def get_setting(
     cfg = result.scalar_one_or_none()
     if not cfg:
         raise HTTPException(status_code=404, detail="Setting not found")
-    return EnterpriseConfigResponse.model_validate(cfg)
+    sensitive = key in ds.SENSITIVE_KEYS
+    has_value = bool(cfg.value)
+    display_value = (REDACTED if has_value else "") if sensitive else cfg.value
+    return EnterpriseConfigResponse(
+        key=cfg.key,
+        value=display_value,
+        is_sensitive=sensitive,
+        is_set=has_value,
+    )
 
 
 @router.put("/settings/{key}", response_model=EnterpriseConfigResponse)
@@ -157,12 +179,15 @@ async def upsert_setting(
     elif key == "branding.app_name":
         _validate_branding_app_name(req.value)
 
+    sensitive = key in ds.SENSITIVE_KEYS
+    store_value = ds.encrypt_value(req.value) if sensitive else req.value
+
     result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key == key))
     cfg = result.scalar_one_or_none()
     if cfg:
-        cfg.value = req.value
+        cfg.value = store_value
     else:
-        cfg = EnterpriseConfig(key=key, value=req.value)
+        cfg = EnterpriseConfig(key=key, value=store_value)
         db.add(cfg)
     await db.commit()
     await db.refresh(cfg)
@@ -180,7 +205,14 @@ async def upsert_setting(
             target_type="setting",
         )
     )
-    return EnterpriseConfigResponse.model_validate(cfg)
+    # Sensitive values are only visible in this single response (the moment of entry).
+    # All subsequent GET requests will return the redacted constant.
+    return EnterpriseConfigResponse(
+        key=cfg.key,
+        value=REDACTED if sensitive else cfg.value,
+        is_sensitive=sensitive,
+        is_set=True,
+    )
 
 
 @router.delete("/settings/{key}")
@@ -199,6 +231,44 @@ async def delete_setting(
     await ds.invalidate(key)
     await ds.refresh_sync_cache()
     return {"deleted": key}
+
+
+@router.post("/settings/{key}/revoke", response_model=SettingRevokedResponse)
+async def revoke_setting(
+    key: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Revoke a sensitive setting (API key, secret). Permanently deletes the value.
+
+    Unlike DELETE which removes any setting, this endpoint is restricted to
+    sensitive keys only and emits a dedicated security audit event.
+    """
+    optic.trace("key={}", key)
+    if key not in ds.SENSITIVE_KEYS:
+        raise HTTPException(status_code=400, detail="Only sensitive keys can be revoked")
+    result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key == key))
+    cfg = result.scalar_one_or_none()
+    if not cfg:
+        raise HTTPException(status_code=404, detail="Setting not found or already revoked")
+    await db.delete(cfg)
+    await db.commit()
+    await ds.invalidate(key)
+    await ds.refresh_sync_cache()
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.SETTING_CHANGED,
+            severity=Severity.CRITICAL,
+            outcome="success",
+            actor_id=str(current_user.id),
+            actor_email=current_user.email,
+            actor_role=current_user.role.value,
+            target_id=key,
+            target_type="sensitive_setting",
+            detail=f"Sensitive setting revoked: {key}",
+        )
+    )
+    return {"revoked": key, "message": "Secret has been permanently deleted"}
 
 
 @router.post("/resources/apply")

--- a/observal-server/schemas/admin.py
+++ b/observal-server/schemas/admin.py
@@ -13,11 +13,18 @@ from pydantic import BaseModel, field_validator
 class EnterpriseConfigResponse(BaseModel):
     key: str
     value: str
+    is_sensitive: bool = False
+    is_set: bool = False
     model_config = {"from_attributes": True}
 
 
 class EnterpriseConfigUpdate(BaseModel):
     value: str
+
+
+class SettingRevokedResponse(BaseModel):
+    revoked: str
+    message: str
 
 
 class UserAdminResponse(BaseModel):

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -572,6 +572,11 @@ export const admin = {
 	updateSetting: (key: string, body: unknown) =>
 		put<unknown>(`/admin/settings/${key}`, body),
 	deleteSetting: (key: string) => del(`/admin/settings/${key}`),
+	revokeSetting: (key: string) =>
+		post<{ revoked: string; message: string }>(
+			`/admin/settings/${key}/revoke`,
+			{},
+		),
 	users: () => get<AdminUser[]>("/admin/users"),
 	createUser: (body: {
 		email: string;

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -22,6 +22,8 @@ export interface AdminUser {
 export interface AdminSetting {
 	key: string;
 	value: string;
+	is_sensitive?: boolean;
+	is_set?: boolean;
 }
 
 export interface AuditLogEntry {

--- a/web/src/pages/admin/settings.tsx
+++ b/web/src/pages/admin/settings.tsx
@@ -54,18 +54,18 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-// Sensitive keys that should be masked in display
+// Sensitive keys that should never be displayed in plaintext.
+// The server enforces this too (returns **REDACTED** for these keys),
+// but we keep the set here for UI affordances (revoke button, write-only input).
 const SENSITIVE_KEYS = new Set([
+	"insights.aws_access_key_id",
+	"insights.aws_secret_access_key",
+	"insights.aws_session_token",
 	"saml.idp_x509_cert",
 	"saml.sp_key_encryption_password",
 ]);
 
-function maskValue(key: string, value: string): string {
-	if (!SENSITIVE_KEYS.has(key)) return value;
-	if (!value || value.length <= 4)
-		return "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022";
-	return "\u2022\u2022\u2022\u2022\u2022\u2022" + value.slice(-4);
-}
+const REDACTED_VALUE = "**REDACTED**";
 
 /** Generate a helpful placeholder for the value input based on the key */
 function getPlaceholder(key: string): string {
@@ -653,6 +653,7 @@ export default function SettingsPage() {
 	} = useDeploymentConfig();
 	const [editingKey, setEditingKey] = useState<string | null>(null);
 	const [editingValue, setEditingValue] = useState("");
+	const [revokeConfirmKey, setRevokeConfirmKey] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
 	const [applyingResources, setApplyingResources] = useState(false);
 	const [tracePrivacy, setTracePrivacy] = useState(false);
@@ -1592,14 +1593,24 @@ export default function SettingsPage() {
 											);
 										}
 										if (existing && existing.value) {
+											const isSensitive = (existing as AdminSetting).is_sensitive || SENSITIVE_KEYS.has(d.key);
+											const isSet = (existing as AdminSetting).is_set ?? !!existing.value;
 											return (
 												<div key={d.key} className="rounded-md border-2 border-border bg-card p-3 relative">
 													<div className="absolute right-2 top-2"><Tooltip><TooltipTrigger asChild><HelpCircle className="h-5 w-5 text-muted-foreground/40 hover:text-foreground transition-colors cursor-help" /></TooltipTrigger><TooltipContent side="left" className="max-w-[340px] text-sm leading-relaxed p-3">{d.tooltip}</TooltipContent></Tooltip></div>
 													<span className="text-sm font-semibold text-foreground">{d.label}</span>
 													<div className="flex items-center gap-2 mt-1.5">
-														<span className="text-xs text-foreground/70 font-[family-name:var(--font-mono)] truncate flex-1">{SENSITIVE_KEYS.has(d.key) ? maskValue(d.key, existing.value) : existing.value}</span>
-														<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => { setEditingKey(d.key); setEditingValue(SENSITIVE_KEYS.has(d.key) ? "" : existing.value); }}><Pencil className="h-3 w-3 text-muted-foreground" /></Button>
-														<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={async () => { await admin.updateSetting(d.key, { value: "" }); refetch(); toast.success(`Cleared ${d.label}`); }}><Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" /></Button>
+														{isSensitive ? (
+															<span className="text-xs text-foreground/70 font-[family-name:var(--font-mono)] truncate flex-1">{isSet ? REDACTED_VALUE : "Not set"}</span>
+														) : (
+															<span className="text-xs text-foreground/70 font-[family-name:var(--font-mono)] truncate flex-1">{existing.value}</span>
+														)}
+														<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => { setEditingKey(d.key); setEditingValue(isSensitive ? "" : (existing?.value ?? "")); }}><Pencil className="h-3 w-3 text-muted-foreground" /></Button>
+														{isSensitive && isSet ? (
+															<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => setRevokeConfirmKey(d.key)}><Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" /></Button>
+														) : (
+															<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={async () => { await admin.updateSetting(d.key, { value: "" }); refetch(); toast.success(`Cleared ${d.label}`); }}><Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" /></Button>
+														)}
 													</div>
 												</div>
 											);
@@ -1657,14 +1668,24 @@ export default function SettingsPage() {
 															);
 														}
 														if (existing && existing.value) {
+															const isSensitive = (existing as AdminSetting).is_sensitive || SENSITIVE_KEYS.has(d.key);
+															const isSet = (existing as AdminSetting).is_set ?? !!existing.value;
 															return (
 																<div key={d.key} className="rounded-md border-2 border-border bg-card p-3 relative">
 																	<div className="absolute right-2 top-2"><Tooltip><TooltipTrigger asChild><HelpCircle className="h-5 w-5 text-muted-foreground/40 hover:text-foreground transition-colors cursor-help" /></TooltipTrigger><TooltipContent side="left" className="max-w-[340px] text-sm leading-relaxed p-3">{d.tooltip}</TooltipContent></Tooltip></div>
 																	<span className="text-sm font-semibold text-foreground">{d.label}</span>
 																	<div className="flex items-center gap-2 mt-1.5">
-																		<span className="text-xs text-foreground/70 font-[family-name:var(--font-mono)] truncate flex-1">{SENSITIVE_KEYS.has(d.key) ? maskValue(d.key, existing.value) : existing.value}</span>
-																		<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => { setEditingKey(d.key); setEditingValue(SENSITIVE_KEYS.has(d.key) ? "" : existing.value); }}><Pencil className="h-3 w-3 text-muted-foreground" /></Button>
-																		<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={async () => { await admin.updateSetting(d.key, { value: "" }); refetch(); toast.success(`Cleared ${d.label}`); }}><Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" /></Button>
+																		{isSensitive ? (
+																			<span className="text-xs text-foreground/70 font-[family-name:var(--font-mono)] truncate flex-1">{isSet ? REDACTED_VALUE : "Not set"}</span>
+																		) : (
+																			<span className="text-xs text-foreground/70 font-[family-name:var(--font-mono)] truncate flex-1">{existing.value}</span>
+																		)}
+																		<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => { setEditingKey(d.key); setEditingValue(isSensitive ? "" : existing.value); }}><Pencil className="h-3 w-3 text-muted-foreground" /></Button>
+																		{isSensitive && isSet ? (
+																			<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => setRevokeConfirmKey(d.key)}><Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" /></Button>
+																		) : (
+																			<Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={async () => { await admin.updateSetting(d.key, { value: "" }); refetch(); toast.success(`Cleared ${d.label}`); }}><Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" /></Button>
+																		)}
 																	</div>
 																</div>
 															);
@@ -1688,6 +1709,20 @@ export default function SettingsPage() {
 					</div>
 				)}
 			</div>
+			<Dialog open={revokeConfirmKey !== null} onOpenChange={(open) => { if (!open) setRevokeConfirmKey(null); }}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Revoke secret</DialogTitle>
+						<DialogDescription>
+							This will permanently delete the stored value for <strong>{revokeConfirmKey}</strong>. Any features depending on this credential will stop working immediately. This cannot be undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setRevokeConfirmKey(null)}>Cancel</Button>
+						<Button variant="destructive" onClick={async () => { try { await admin.revokeSetting(revokeConfirmKey!); refetch(); toast.success(`Revoked ${revokeConfirmKey}`); } catch (e: unknown) { toast.error(e instanceof Error ? e.message : "Failed to revoke setting"); } finally { setRevokeConfirmKey(null); } }}>Revoke</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</>
 	);
 }


### PR DESCRIPTION
## Purpose / Description

Sensitive API keys and secrets stored in super admin settings (AWS credentials, SAML certificates, encryption passwords) were previously returned as plaintext in API responses. The frontend masked them visually, but the raw values were exposed in network traffic. This change enforces server-side write-once semantics and adds a revocation mechanism.

## Fixes

* Fixes the security gap where sensitive settings could be read back via the API after initial entry

## Approach

**Server-side (enterprise_settings.py):**
- GET /admin/settings and GET /admin/settings/{key} now return `**REDACTED**` (from `services.secrets_redactor.REDACTED`) for any key in `SENSITIVE_KEYS`. The plaintext is never sent over the wire after the initial save.
- PUT /admin/settings/{key} encrypts sensitive values with Fernet before DB storage. The response confirms save with the redacted constant.
- New POST /admin/settings/{key}/revoke endpoint permanently deletes a sensitive key, restricted to `SENSITIVE_KEYS` only, with a CRITICAL-severity audit event.

**Schema (schemas/admin.py):**
- `EnterpriseConfigResponse` extended with `is_sensitive: bool` and `is_set: bool` fields so the frontend can render appropriate UI without needing client-side secret knowledge.

**Frontend (settings.tsx, api.ts, types/admin.ts):**
- `SENSITIVE_KEYS` expanded to match the server set (added `insights.aws_*`).
- Removed client-side `maskValue()` function; relies on server-provided `is_sensitive`/`is_set`.
- Sensitive keys show `**REDACTED**` when set, with a revoke (trash) button instead of the generic clear.
- Edit always starts with empty input for sensitive keys (cannot pre-fill, value is not available).
- Added `admin.revokeSetting()` API client method.

## How Has This Been Tested?

- `uv run pytest tests/test_enterprise.py` passes (6/6)
- `ruff check` passes on all modified Python files
- TypeScript compiles clean (`tsc --noEmit --skipLibCheck`)
- Manual review of the API response contract: sensitive keys return `**REDACTED**` in list/get, and the PUT response also returns redacted

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)