### PR TITLE
Harden client score ingestion integrity

### DIFF
--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -14,7 +14,7 @@ removed - session telemetry now flows through /api/v1/ingest/session
 import asyncio
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, Header, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from loguru import logger as optic
 
 from api.deps import get_project_id, require_role
@@ -31,6 +31,8 @@ from services.clickhouse import (
     insert_spans,
     insert_traces,
     query_recent_events,
+    query_span_by_id,
+    query_trace_by_id,
 )
 from services.redis import publish
 from services.secrets_redactor import redact_secrets
@@ -56,6 +58,76 @@ _SHIM_EVENT_NAMES: dict[str, str] = {
     "other": "shim_other",
 }
 
+CLIENT_SCORE_SOURCE_PREFIX = "client:"
+UNTRUSTED_CLIENT_SCORE_METADATA = {
+    "score_trust": "untrusted_client",
+    "score_writer": "telemetry_api",
+}
+RESERVED_SCORE_SOURCES = frozenset(
+    {
+        "adversarial_scorer",
+        "eval_engine",
+        "internal",
+        "judge",
+        "kernel",
+        "ragas_eval",
+        "server",
+        "slm_scorer",
+        "system",
+        "trusted",
+    }
+)
+
+
+def _client_score_source(source: str | None) -> tuple[str, str]:
+    """Return a client-scoped source, rejecting names reserved for server writers."""
+    original = (source or "api").strip() or "api"
+    source_key = original.lower()
+    if source_key in RESERVED_SCORE_SOURCES:
+        raise HTTPException(status_code=422, detail=f"Score source '{original}' is reserved")
+    if source_key.startswith(CLIENT_SCORE_SOURCE_PREFIX):
+        return source_key, original
+    return f"{CLIENT_SCORE_SOURCE_PREFIX}{source_key}", original
+
+
+def _client_score_metadata(metadata: dict[str, str] | None, original_source: str) -> dict[str, str]:
+    clean_metadata = dict(metadata or {})
+    clean_metadata["score_original_source"] = original_source
+    clean_metadata.update(UNTRUSTED_CLIENT_SCORE_METADATA)
+    return clean_metadata
+
+
+async def _validate_score_references(
+    *,
+    score_id: str,
+    trace_id: str | None,
+    span_id: str | None,
+    project_id: str,
+    batch_trace_ids: set[str],
+    batch_span_trace_ids: dict[str, str],
+) -> None:
+    if trace_id and trace_id not in batch_trace_ids:
+        trace = await query_trace_by_id(project_id, trace_id)
+        if trace is None:
+            raise HTTPException(status_code=404, detail=f"Referenced trace not found for score {score_id}")
+
+    if not span_id:
+        return
+
+    if span_id in batch_span_trace_ids:
+        if trace_id and batch_span_trace_ids[span_id] != trace_id:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Referenced span does not belong to trace for score {score_id}",
+            )
+        return
+
+    span = await query_span_by_id(project_id, span_id)
+    if span is None:
+        raise HTTPException(status_code=404, detail=f"Referenced span not found for score {score_id}")
+    if trace_id and span.get("trace_id") != trace_id:
+        raise HTTPException(status_code=422, detail=f"Referenced span does not belong to trace for score {score_id}")
+
 
 @router.post("/ingest", response_model=IngestResponse)
 @limiter.limit("60/minute")
@@ -78,6 +150,8 @@ async def ingest(
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     ingested = 0
     errors = 0
+    batch_trace_ids = {t.trace_id for t in batch.traces or []}
+    batch_span_trace_ids = {s.span_id: s.trace_id for s in batch.spans or []}
 
     # --- Traces ---
     if batch.traces:
@@ -271,6 +345,15 @@ async def ingest(
         try:
             rows = []
             for sc in batch.scores:
+                await _validate_score_references(
+                    score_id=sc.score_id,
+                    trace_id=sc.trace_id,
+                    span_id=sc.span_id,
+                    project_id=project_id,
+                    batch_trace_ids=batch_trace_ids,
+                    batch_span_trace_ids=batch_span_trace_ids,
+                )
+                source, original_source = _client_score_source(sc.source)
                 rows.append(
                     {
                         "score_id": sc.score_id,
@@ -281,17 +364,19 @@ async def ingest(
                         "agent_id": sc.agent_id,
                         "user_id": user_id,
                         "name": sc.name,
-                        "source": sc.source,
+                        "source": source,
                         "data_type": sc.data_type,
                         "value": sc.value,
                         "string_value": sc.string_value,
                         "comment": sc.comment,
-                        "metadata": sc.metadata,
+                        "metadata": _client_score_metadata(sc.metadata, original_source),
                         "timestamp": now,
                     }
                 )
             await insert_scores(rows)
             ingested += len(rows)
+        except HTTPException:
+            raise
         except Exception:
             optic.error("Failed to insert scores")
             errors += len(batch.scores)

--- a/observal-server/api/routes/telemetry.py
+++ b/observal-server/api/routes/telemetry.py
@@ -65,14 +65,8 @@ UNTRUSTED_CLIENT_SCORE_METADATA = {
 }
 RESERVED_SCORE_SOURCES = frozenset(
     {
-        "adversarial_scorer",
-        "eval_engine",
         "internal",
-        "judge",
-        "kernel",
-        "ragas_eval",
         "server",
-        "slm_scorer",
         "system",
         "trusted",
     }

--- a/tests/test_audit2_pr2_score_integrity.py
+++ b/tests/test_audit2_pr2_score_integrity.py
@@ -1,0 +1,423 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import get_current_user
+from api.routes.telemetry import router
+from models.user import User, UserRole
+
+
+def _make_user(org_id: uuid.UUID | None = None):
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.org_id = org_id
+    user.role = UserRole.user
+    return user
+
+
+def _app_with_user(user):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    return app
+
+
+@pytest.mark.asyncio
+async def test_client_score_sources_are_namespaced_and_marked_untrusted():
+    app = _app_with_user(_make_user())
+
+    with patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "scores": [
+                        {
+                            "score_id": "score-1",
+                            "name": "accuracy",
+                            "source": "Eval",
+                            "value": 0.97,
+                            "metadata": {"team": "quality"},
+                        }
+                    ]
+                },
+            )
+
+    assert response.status_code == 200
+    rows = insert_scores.call_args.args[0]
+    assert rows[0]["source"] == "client:eval"
+    assert rows[0]["metadata"] == {
+        "team": "quality",
+        "score_original_source": "Eval",
+        "score_trust": "untrusted_client",
+        "score_writer": "telemetry_api",
+    }
+
+
+@pytest.mark.asyncio
+async def test_client_prefixed_score_source_is_preserved():
+    app = _app_with_user(_make_user())
+
+    with patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={"scores": [{"score_id": "score-1", "name": "accuracy", "source": "client:manual", "value": 1}]},
+            )
+
+    assert response.status_code == 200
+    rows = insert_scores.call_args.args[0]
+    assert rows[0]["source"] == "client:manual"
+
+
+@pytest.mark.asyncio
+async def test_reserved_internal_score_source_is_rejected():
+    app = _app_with_user(_make_user())
+
+    with patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={"scores": [{"score_id": "score-1", "name": "accuracy", "source": "eval_engine", "value": 0.5}]},
+            )
+
+    assert response.status_code == 422
+    assert "reserved" in response.text
+    insert_scores.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_score_references_in_same_batch_do_not_require_clickhouse_lookup():
+    app = _app_with_user(_make_user())
+
+    with (
+        patch("api.routes.telemetry.insert_traces", new_callable=AsyncMock),
+        patch("api.routes.telemetry.insert_spans", new_callable=AsyncMock),
+        patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores,
+        patch("api.routes.telemetry.query_trace_by_id", new_callable=AsyncMock) as query_trace_by_id,
+        patch("api.routes.telemetry.query_span_by_id", new_callable=AsyncMock) as query_span_by_id,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "traces": [{"trace_id": "trace-1", "start_time": "2026-01-01 00:00:00.000"}],
+                    "spans": [
+                        {
+                            "span_id": "span-1",
+                            "trace_id": "trace-1",
+                            "type": "tool_call",
+                            "name": "tool",
+                            "start_time": "2026-01-01 00:00:00.000",
+                        }
+                    ],
+                    "scores": [
+                        {
+                            "score_id": "score-1",
+                            "trace_id": "trace-1",
+                            "span_id": "span-1",
+                            "name": "accuracy",
+                            "value": 1,
+                        }
+                    ],
+                },
+            )
+
+    assert response.status_code == 200
+    assert response.json() == {"ingested": 3, "errors": 0}
+    insert_scores.assert_called_once()
+    query_trace_by_id.assert_not_called()
+    query_span_by_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_score_references_are_checked_with_org_project_id():
+    org_id = uuid.uuid4()
+    app = _app_with_user(_make_user(org_id=org_id))
+
+    with (
+        patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock),
+        patch("api.routes.telemetry.query_trace_by_id", new_callable=AsyncMock) as query_trace_by_id,
+        patch("api.routes.telemetry.query_span_by_id", new_callable=AsyncMock) as query_span_by_id,
+    ):
+        query_trace_by_id.return_value = {"trace_id": "trace-1"}
+        query_span_by_id.return_value = {"span_id": "span-1", "trace_id": "trace-1"}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "scores": [
+                        {
+                            "score_id": "score-1",
+                            "trace_id": "trace-1",
+                            "span_id": "span-1",
+                            "name": "accuracy",
+                            "value": 1,
+                        }
+                    ]
+                },
+            )
+
+    assert response.status_code == 200
+    query_trace_by_id.assert_awaited_once_with(str(org_id), "trace-1")
+    query_span_by_id.assert_awaited_once_with(str(org_id), "span-1")
+
+
+@pytest.mark.asyncio
+async def test_missing_referenced_span_is_rejected():
+    app = _app_with_user(_make_user())
+
+    with (
+        patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores,
+        patch("api.routes.telemetry.query_span_by_id", new_callable=AsyncMock, return_value=None),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={"scores": [{"score_id": "score-1", "span_id": "span-1", "name": "accuracy", "value": 1}]},
+            )
+
+    assert response.status_code == 404
+    assert "Referenced span not found" in response.text
+    insert_scores.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_referenced_span_must_match_referenced_trace():
+    app = _app_with_user(_make_user())
+
+    with (
+        patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores,
+        patch("api.routes.telemetry.query_trace_by_id", new_callable=AsyncMock, return_value={"trace_id": "trace-1"}),
+        patch(
+            "api.routes.telemetry.query_span_by_id",
+            new_callable=AsyncMock,
+            return_value={"span_id": "span-1", "trace_id": "trace-2"},
+        ),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "scores": [
+                        {
+                            "score_id": "score-1",
+                            "trace_id": "trace-1",
+                            "span_id": "span-1",
+                            "name": "accuracy",
+                            "value": 1,
+                        }
+                    ]
+                },
+            )
+
+    assert response.status_code == 422
+    assert "does not belong" in response.text
+    insert_scores.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_referenced_trace_is_rejected():
+    """Score referencing a trace not owned by the submitter's org (or not present) must 404."""
+    app = _app_with_user(_make_user())
+
+    with (
+        patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores,
+        patch("api.routes.telemetry.query_trace_by_id", new_callable=AsyncMock, return_value=None),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "scores": [
+                        {
+                            "score_id": "score-1",
+                            "trace_id": "trace-from-other-org",
+                            "name": "accuracy",
+                            "value": 1,
+                        }
+                    ]
+                },
+            )
+
+    assert response.status_code == 404
+    assert "Referenced trace not found" in response.text
+    insert_scores.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reserved", ["RAGAS_EVAL", "Eval_Engine", "SLM_Scorer", "JUDGE"])
+async def test_reserved_score_source_check_is_case_insensitive(reserved):
+    """Reserved-name check must lowercase to prevent trivial bypass via casing."""
+    app = _app_with_user(_make_user())
+
+    with patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={"scores": [{"score_id": "score-1", "name": "accuracy", "source": reserved, "value": 0.5}]},
+            )
+
+    assert response.status_code == 422
+    assert "reserved" in response.text
+    insert_scores.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_client_cannot_override_score_trust_metadata():
+    """Trust markers injected by the server must overwrite any client-supplied values."""
+    app = _app_with_user(_make_user())
+
+    with patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "scores": [
+                        {
+                            "score_id": "score-1",
+                            "name": "accuracy",
+                            "source": "manual",
+                            "value": 1,
+                            "metadata": {
+                                "score_trust": "trusted_server",
+                                "score_writer": "eval_engine",
+                                "score_original_source": "ragas_eval",
+                                "user_tag": "keepme",
+                            },
+                        }
+                    ]
+                },
+            )
+
+    assert response.status_code == 200
+    rows = insert_scores.call_args.args[0]
+    assert rows[0]["metadata"]["score_trust"] == "untrusted_client"
+    assert rows[0]["metadata"]["score_writer"] == "telemetry_api"
+    # Original-source field tracks what the client *said* it was, not their forged claim
+    assert rows[0]["metadata"]["score_original_source"] == "manual"
+    # Untouched user metadata is preserved
+    assert rows[0]["metadata"]["user_tag"] == "keepme"
+
+
+@pytest.mark.asyncio
+async def test_in_batch_span_with_mismatched_trace_id_is_rejected():
+    """Fast-path check: span in same batch but with a different trace_id must 422 without a DB hit."""
+    app = _app_with_user(_make_user())
+
+    with (
+        patch("api.routes.telemetry.insert_traces", new_callable=AsyncMock),
+        patch("api.routes.telemetry.insert_spans", new_callable=AsyncMock),
+        patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores,
+        patch("api.routes.telemetry.query_trace_by_id", new_callable=AsyncMock) as query_trace_by_id,
+        patch("api.routes.telemetry.query_span_by_id", new_callable=AsyncMock) as query_span_by_id,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "traces": [{"trace_id": "trace-1", "start_time": "2026-01-01 00:00:00.000"}],
+                    "spans": [
+                        {
+                            "span_id": "span-1",
+                            "trace_id": "trace-1",
+                            "type": "tool_call",
+                            "name": "tool",
+                            "start_time": "2026-01-01 00:00:00.000",
+                        }
+                    ],
+                    "scores": [
+                        {
+                            "score_id": "score-1",
+                            "trace_id": "trace-1",
+                            "span_id": "span-1",
+                            "name": "accuracy",
+                            "value": 1,
+                        },
+                        {
+                            "score_id": "score-2",
+                            "trace_id": "trace-1",
+                            "span_id": "span-1",
+                            "name": "latency",
+                            "value": 1,
+                        },
+                    ],
+                },
+            )
+
+    # Score-2 keeps the same trace_id, so this batch is fine — switch one to force a mismatch.
+    assert response.status_code == 200  # sanity-check the helper batch
+    insert_scores.assert_called_once()
+    query_trace_by_id.assert_not_called()
+    query_span_by_id.assert_not_called()
+
+    insert_scores.reset_mock()
+    with (
+        patch("api.routes.telemetry.insert_traces", new_callable=AsyncMock),
+        patch("api.routes.telemetry.insert_spans", new_callable=AsyncMock),
+        patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores,
+        patch("api.routes.telemetry.query_trace_by_id", new_callable=AsyncMock) as query_trace_by_id,
+        patch("api.routes.telemetry.query_span_by_id", new_callable=AsyncMock) as query_span_by_id,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/telemetry/ingest",
+                json={
+                    "traces": [
+                        {"trace_id": "trace-1", "start_time": "2026-01-01 00:00:00.000"},
+                        {"trace_id": "trace-2", "start_time": "2026-01-01 00:00:00.000"},
+                    ],
+                    "spans": [
+                        {
+                            "span_id": "span-1",
+                            "trace_id": "trace-1",
+                            "type": "tool_call",
+                            "name": "tool",
+                            "start_time": "2026-01-01 00:00:00.000",
+                        }
+                    ],
+                    "scores": [
+                        {
+                            "score_id": "score-1",
+                            "trace_id": "trace-2",  # mismatch: span-1 is on trace-1
+                            "span_id": "span-1",
+                            "name": "accuracy",
+                            "value": 1,
+                        }
+                    ],
+                },
+            )
+
+    assert response.status_code == 422
+    assert "does not belong" in response.text
+    insert_scores.assert_not_called()
+    query_trace_by_id.assert_not_called()
+    query_span_by_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_default_score_source_is_namespaced_to_client_api():
+    """source=None and source='' both fall back to 'api' and namespace to 'client:api'."""
+    app = _app_with_user(_make_user())
+
+    for payload_source in (None, ""):
+        with patch("api.routes.telemetry.insert_scores", new_callable=AsyncMock) as insert_scores:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                score = {"score_id": "score-1", "name": "accuracy", "value": 0.5}
+                if payload_source is not None:
+                    score["source"] = payload_source
+                response = await ac.post(
+                    "/api/v1/telemetry/ingest",
+                    json={"scores": [score]},
+                )
+
+        assert response.status_code == 200, payload_source
+        rows = insert_scores.call_args.args[0]
+        assert rows[0]["source"] == "client:api"
+        assert rows[0]["metadata"]["score_original_source"] == "api"

--- a/tests/test_audit2_pr2_score_integrity.py
+++ b/tests/test_audit2_pr2_score_integrity.py
@@ -13,6 +13,18 @@ from api.routes.telemetry import router
 from models.user import User, UserRole
 
 
+@pytest.fixture(autouse=True)
+def _disable_rate_limiter():
+    from api.ratelimit import limiter
+
+    old_enabled = limiter.enabled
+    limiter.enabled = False
+    try:
+        yield
+    finally:
+        limiter.enabled = old_enabled
+
+
 def _make_user(org_id: uuid.UUID | None = None):
     user = MagicMock(spec=User)
     user.id = uuid.uuid4()
@@ -41,7 +53,7 @@ async def test_client_score_sources_are_namespaced_and_marked_untrusted():
                         {
                             "score_id": "score-1",
                             "name": "accuracy",
-                            "source": "Eval",
+                            "source": "manual",
                             "value": 0.97,
                             "metadata": {"team": "quality"},
                         }
@@ -51,10 +63,10 @@ async def test_client_score_sources_are_namespaced_and_marked_untrusted():
 
     assert response.status_code == 200
     rows = insert_scores.call_args.args[0]
-    assert rows[0]["source"] == "client:eval"
+    assert rows[0]["source"] == "client:manual"
     assert rows[0]["metadata"] == {
         "team": "quality",
-        "score_original_source": "Eval",
+        "score_original_source": "manual",
         "score_trust": "untrusted_client",
         "score_writer": "telemetry_api",
     }
@@ -84,7 +96,7 @@ async def test_reserved_internal_score_source_is_rejected():
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             response = await ac.post(
                 "/api/v1/telemetry/ingest",
-                json={"scores": [{"score_id": "score-1", "name": "accuracy", "source": "eval_engine", "value": 0.5}]},
+                json={"scores": [{"score_id": "score-1", "name": "accuracy", "source": "server", "value": 0.5}]},
             )
 
     assert response.status_code == 422
@@ -252,7 +264,7 @@ async def test_missing_referenced_trace_is_rejected():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("reserved", ["RAGAS_EVAL", "Eval_Engine", "SLM_Scorer", "JUDGE"])
+@pytest.mark.parametrize("reserved", ["SERVER", "Internal", "System", "TRUSTED"])
 async def test_reserved_score_source_check_is_case_insensitive(reserved):
     """Reserved-name check must lowercase to prevent trivial bypass via casing."""
     app = _app_with_user(_make_user())
@@ -287,8 +299,8 @@ async def test_client_cannot_override_score_trust_metadata():
                             "value": 1,
                             "metadata": {
                                 "score_trust": "trusted_server",
-                                "score_writer": "eval_engine",
-                                "score_original_source": "ragas_eval",
+                                "score_writer": "server",
+                                "score_original_source": "trusted",
                                 "user_tag": "keepme",
                             },
                         }
@@ -351,7 +363,7 @@ async def test_in_batch_span_with_mismatched_trace_id_is_rejected():
                 },
             )
 
-    # Score-2 keeps the same trace_id, so this batch is fine — switch one to force a mismatch.
+    # Score-2 keeps the same trace_id, so this batch is fine, switch one to force a mismatch.
     assert response.status_code == 200  # sanity-check the helper batch
     insert_scores.assert_called_once()
     query_trace_by_id.assert_not_called()

--- a/tests/test_ingest_phase2.py
+++ b/tests/test_ingest_phase2.py
@@ -192,7 +192,7 @@ class TestIngestEndpoint:
             assert r.status_code == 200
             assert r.json()["ingested"] == 1
             rows = mock_ins.call_args[0][0]
-            assert rows[0]["source"] == "eval"
+            assert rows[0]["source"] == "client:eval"
             assert rows[0]["value"] == 0.95
             # timestamp injected server-side
             assert rows[0]["timestamp"] != ""

--- a/tests/test_ingest_phase2.py
+++ b/tests/test_ingest_phase2.py
@@ -184,7 +184,7 @@ class TestIngestEndpoint:
                                 "score_id": "sc1",
                                 "name": "accuracy",
                                 "value": 0.95,
-                                "source": "eval",
+                                "source": "manual",
                             }
                         ]
                     },
@@ -192,7 +192,7 @@ class TestIngestEndpoint:
             assert r.status_code == 200
             assert r.json()["ingested"] == 1
             rows = mock_ins.call_args[0][0]
-            assert rows[0]["source"] == "client:eval"
+            assert rows[0]["source"] == "client:manual"
             assert rows[0]["value"] == 0.95
             # timestamp injected server-side
             assert rows[0]["timestamp"] != ""


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description

Treat client-submitted scores as untrusted so clients cannot spoof server-owned score provenance or attach scores to traces/spans outside their authenticated project scope.

This addresses score-ingest integrity for #1117. Since evals are deprecated, this PR no longer treats old eval-specific source names as active server writers; if clients submit those strings, they are handled as untrusted `client:*` sources.

## Fixes

* Fixes #1117
* Part of SOC 2 technical remediation for telemetry score-source integrity.

## Approach

This change hardens the telemetry score-ingest path only.

- Rejects current generic reserved server/internal score sources: `server`, `system`, `internal`, and `trusted`.
- Rewrites accepted client-provided score sources under a `client:` namespace.
- Stamps accepted client scores with untrusted-writer provenance metadata.
- Validates referenced trace/span IDs against the authenticated user's project scope.
- Allows references to traces/spans submitted in the same ingest batch.
- Rejects forged or cross-project trace/span references.

## How Has This Been Tested?

Targeted tests:

```bash
PYTHONPATH="$PWD/observal-server:$PWD" \
uv run --active --project ./observal-server --no-sync pytest \
  tests/test_audit2_pr2_score_integrity.py \
  tests/test_ingest_phase2.py \
  tests/test_clickhouse_phase1.py \
  -q
```

These cover:

- reserved-source rejection
- client-source rewriting
- untrusted-writer provenance metadata
- in-batch trace/span reference validation
- existing trace/span lookup within the authenticated user's project
- cross-project/forged reference rejection
- accepted client score submissions

Lint/format:

```bash
uv tool run ruff check \
  observal-server/api/routes/telemetry.py \
  tests/test_audit2_pr2_score_integrity.py \
  tests/test_ingest_phase2.py

uv tool run ruff format --check \
  observal-server/api/routes/telemetry.py \
  tests/test_audit2_pr2_score_integrity.py \
  tests/test_ingest_phase2.py
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: not applicable; no UI changes in this PR