### PR TITLE
bump(release): v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2026-05-31
+
+### Added
+
+- add GCP Terraform module for self-hosting (**infra**) ([3f4312b](https://github.com/BlazeUp-AI/Observal/commit/3f4312b1c9456d0074a3f5819fe673fb44cc62ea))
+
+### Fixed
+
+- close API key redaction gaps across ingest, GraphQL, and settings (**security**) ([100c272](https://github.com/BlazeUp-AI/Observal/commit/100c27281bd7aa83d7e0418c1d51dd3148a2db9d))
+- auto-enable APIs, fix Cloud SQL edition, AR proxy for ghcr.io (**infra/gcp**) ([31652c0](https://github.com/BlazeUp-AI/Observal/commit/31652c0a9fb2520f8b0a1257b4f2b938aa773388))
+- align Terraform env vars with v1.0 and fix template bugs (**infra**) ([685cca3](https://github.com/BlazeUp-AI/Observal/commit/685cca3e4cd294c7b25178283620af00de44c4bb))
 ## [1.4.0] - 2026-05-31
 
 ### Added

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.4.0"
+version = "1.4.1"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "AGPL-3.0-only"

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -944,7 +944,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.4.0"
+version = "1.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [
     "pi-package",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.4.0"
+version = "1.4.1"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Release v1.4.1 (patch)

Bumps version `1.4.0` → `1.4.1` and regenerates changelog.

**Merging this PR will automatically trigger the release pipeline.**

### What happens after merge
- CLI binaries built for 6 platforms (Linux/macOS/Windows, x64/arm64)
- Docker images pushed to GHCR
- Server deployment tarball packaged
- PyPI package published
- **Approval required** in the `production` environment before GitHub Release publishes