### PR TITLE
fix(opencode): use dynamic agent-specific rules file paths

### DIFF
--- a/observal-server/schemas/ide_registry.py
+++ b/observal-server/schemas/ide_registry.py
@@ -284,10 +284,10 @@ IDE_REGISTRY: dict[str, dict] = {
         "features": {"hooks", "mcp_servers"},
         "scopes": ["project", "user"],
         "default_scope": "user",
-        "scope_labels": ("project (AGENTS.md)", "user (~/.config/opencode/opencode.json)"),
+        "scope_labels": ("project (.opencode/agents/<name>.md)", "user (~/.config/opencode/agents/<name>.md)"),
         "rules_file": {
-            "project": "AGENTS.md",
-            "user": "~/.config/opencode/AGENTS.md",
+            "project": ".opencode/agents/{name}.md",
+            "user": "~/.config/opencode/agents/{name}.md",
         },
         "rules_format": "markdown",
         "mcp_config_path": {

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -15,7 +15,7 @@ Generates IDE-specific agent files from a ResolvedAgent:
 - Kiro: ~/.kiro/agents/<name>.json (JSON)
 - Codex: AGENTS.md (markdown)
 - GitHub Copilot: .github/copilot-instructions.md (markdown)
-- OpenCode: AGENTS.md (markdown) + opencode.json (MCP config)
+- OpenCode: .opencode/agents/<name>.md (markdown) + opencode.json (MCP config)
 
 """
 
@@ -597,7 +597,8 @@ def _generate_copilot(manifest: AgentManifest) -> IdeAgentConfig:
 
 
 def _generate_opencode(manifest: AgentManifest) -> IdeAgentConfig:
-    """Generate OpenCode agent config (AGENTS.md + opencode.json with flat command arrays)."""
+    """Generate OpenCode agent config (.opencode/agents/<name>.md + opencode.json with flat command arrays)."""
+    safe_name = _sanitize_name(manifest.name)
     mcp_entries = _build_mcp_entries(manifest)
     rules_content = _build_rules_markdown(manifest)
 
@@ -611,7 +612,7 @@ def _generate_opencode(manifest: AgentManifest) -> IdeAgentConfig:
 
     files = [
         AgentFile(
-            path="AGENTS.md",
+            path=f".opencode/agents/{safe_name}.md",
             content=rules_content,
             format="markdown",
         ),

--- a/observal-server/services/ide/opencode.py
+++ b/observal-server/services/ide/opencode.py
@@ -21,6 +21,7 @@ class OpenCodeAdapter:
 
     def format_config(self, ctx: ConfigContext) -> dict:
         optic.trace("ctx={}", ctx)
+        safe_name = ctx.safe_name
         options = ctx.options
         mcp_configs = ctx.mcp_configs
         rules_content = ctx.rules_content
@@ -35,7 +36,7 @@ class OpenCodeAdapter:
             if "env" in v:
                 opencode_configs[k]["env"] = v["env"]
 
-        rules_path = opencode_spec["rules_file"].get(opencode_scope, "AGENTS.md")
+        rules_path = opencode_spec["rules_file"][opencode_scope].format(name=safe_name)
         mcp_path = opencode_spec["mcp_config_path"].get(
             opencode_scope, next(iter(opencode_spec["mcp_config_path"].values()))
         )

--- a/observal_cli/ide_registry.py
+++ b/observal_cli/ide_registry.py
@@ -284,10 +284,10 @@ IDE_REGISTRY: dict[str, dict] = {
         "features": {"hooks", "mcp_servers"},
         "scopes": ["project", "user"],
         "default_scope": "user",
-        "scope_labels": ("project (AGENTS.md)", "user (~/.config/opencode/opencode.json)"),
+        "scope_labels": ("project (.opencode/agents/<name>.md)", "user (~/.config/opencode/agents/<name>.md)"),
         "rules_file": {
-            "project": "AGENTS.md",
-            "user": "~/.config/opencode/AGENTS.md",
+            "project": ".opencode/agents/{name}.md",
+            "user": "~/.config/opencode/agents/{name}.md",
         },
         "rules_format": "markdown",
         "mcp_config_path": {

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -320,12 +320,12 @@ class TestGenerateOpenCodeConfig:
     def test_rules_path(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "opencode")
-        assert cfg["rules_file"]["path"] == "~/.config/opencode/AGENTS.md"
+        assert cfg["rules_file"]["path"] == "~/.config/opencode/agents/test-agent.md"
 
     def test_rules_path_project_scope(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "opencode", options={"scope": "project"})
-        assert cfg["rules_file"]["path"] == "AGENTS.md"
+        assert cfg["rules_file"]["path"] == ".opencode/agents/test-agent.md"
 
     def test_mcp_config_path(self):
         agent = _make_agent()
@@ -889,11 +889,11 @@ class TestPullCopilot:
 
 
 class TestPullOpenCode:
-    def test_writes_agents_md_and_opencode_json(self, tmp_path):
+    def test_writes_rules_file_and_opencode_json(self, tmp_path):
         snippet = {
             "config_snippet": {
                 "rules_file": {
-                    "path": "AGENTS.md",
+                    "path": ".opencode/agents/test-agent.md",
                     "content": "# OpenCode Rules\n\nBe concise.\n",
                 },
                 "mcp_config": {
@@ -907,7 +907,7 @@ class TestPullOpenCode:
                         }
                     },
                 },
-                "scope": "user",
+                "scope": "project",
             }
         }
         with _patch_config(), _patch_get_agent(), _patch_post(snippet):
@@ -927,7 +927,7 @@ class TestPullOpenCode:
                 ],
             )
         assert result.exit_code == 0, result.output
-        rules = tmp_path / "AGENTS.md"
+        rules = tmp_path / ".opencode" / "agents" / "test-agent.md"
         assert rules.exists()
         config = tmp_path / ".config" / "opencode" / "opencode.json"
         assert config.exists()
@@ -940,17 +940,29 @@ class TestPullOpenCode:
         snippet = {
             "config_snippet": {
                 "rules_file": {
-                    "path": "AGENTS.md",
+                    "path": ".opencode/agents/test-agent.md",
                     "content": "# Simple Agent\n",
                 },
             }
         }
         with _patch_config(), _patch_get_agent(), _patch_post(snippet):
             result = runner.invoke(
-                cli_app, ["agent", "pull", "abc123", "--ide", "opencode", "--dir", str(tmp_path), "--no-prompt"]
+                cli_app,
+                [
+                    "agent",
+                    "pull",
+                    "abc123",
+                    "--ide",
+                    "opencode",
+                    "--dir",
+                    str(tmp_path),
+                    "--no-prompt",
+                    "--scope",
+                    "project",
+                ],
             )
         assert result.exit_code == 0, result.output
-        assert (tmp_path / "AGENTS.md").exists()
+        assert (tmp_path / ".opencode" / "agents" / "test-agent.md").exists()
 
 
 class TestPullGemini:
@@ -990,10 +1002,16 @@ class TestPullGemini:
 class TestPullDryRunAllIdes:
     @pytest.mark.parametrize("ide", ["codex", "copilot", "opencode"])
     def test_dry_run_does_not_write_files(self, tmp_path, ide):
+        path_map = {
+            "codex": "AGENTS.md",
+            "copilot": ".github/copilot-instructions.md",
+            "opencode": ".opencode/agents/test-agent.md",
+        }
+        rules_path = path_map[ide]
         snippet = {
             "config_snippet": {
                 "rules_file": {
-                    "path": "AGENTS.md",
+                    "path": rules_path,
                     "content": "# Test\n",
                 },
             }
@@ -1005,7 +1023,7 @@ class TestPullDryRunAllIdes:
 
         assert result.exit_code == 0, result.output
         assert "Dry run" in result.output
-        assert not (tmp_path / "AGENTS.md").exists()
+        assert not (tmp_path / rules_path).exists()
 
     def test_dry_run_gemini(self, tmp_path):
         snippet = {

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -569,3 +569,11 @@ class TestBuilderModelEmission:
         assert isinstance(oc_file.content, dict)
         assert oc_file.content["model"].endswith("/claude-sonnet-4-5")
         assert oc_file.content["model"].split("/")[0] in {"anthropic", "openai", "google"}
+
+    def test_opencode_rules_file_path(self):
+        from services.agent_builder import _generate_opencode
+
+        manifest = _empty_manifest()
+        cfg = _generate_opencode(manifest)
+        rules_file = next(f for f in cfg.files if f.path.endswith(".md"))
+        assert rules_file.path == ".opencode/agents/test-agent.md"

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -161,6 +161,29 @@ def _copilot_snippet() -> dict:
     }
 
 
+def _opencode_snippet() -> dict:
+    return {
+        "config_snippet": {
+            "rules_file": {
+                "path": ".opencode/agents/my-agent.md",
+                "content": "# My Agent Rules\n",
+            },
+            "mcp_config": {
+                "path": ".opencode/opencode.json",
+                "content": {
+                    "mcp": {
+                        "my-server": {
+                            "type": "local",
+                            "command": ["observal-shim", "--mcp-id", "xyz", "--", "npx", "-y", "my-server"],
+                        }
+                    }
+                },
+            },
+            "hooks_config": {"path": ".opencode/plugins/observal-plugin.mjs", "content": "export default {};"},
+        }
+    }
+
+
 # ═══════════════════════════════════════════════════════════════
 # 1. Cursor / VSCode format
 # ═══════════════════════════════════════════════════════════════
@@ -393,6 +416,47 @@ class TestPullCopilot:
         rules = tmp_path / ".github" / "copilot-instructions.md"
         assert rules.exists()
         assert "Copilot Instructions" in rules.read_text()
+
+
+# ═══════════════════════════════════════════════════════════════
+# 6b. OpenCode format
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestPullOpenCode:
+    def test_writes_rules_mcp_and_hooks(self, tmp_path: Path):
+        with _patch_config(), _patch_get_agent(), _patch_post(_opencode_snippet()):
+            result = runner.invoke(
+                cli_app,
+                [
+                    "agent",
+                    "pull",
+                    "abc123",
+                    "--ide",
+                    "opencode",
+                    "--dir",
+                    str(tmp_path),
+                    "--no-prompt",
+                    "--scope",
+                    "project",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        rules = tmp_path / ".opencode" / "agents" / "my-agent.md"
+        assert rules.exists()
+        assert "My Agent Rules" in rules.read_text()
+
+        mcp = tmp_path / ".opencode" / "opencode.json"
+        assert mcp.exists()
+        data = json.loads(mcp.read_text())
+        assert "my-server" in data["mcp"]
+        assert data["mcp"]["my-server"]["type"] == "local"
+
+        hook = tmp_path / ".opencode" / "plugins" / "observal-plugin.mjs"
+        assert hook.exists()
+        assert "export default" in hook.read_text()
 
 
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes an issue where pulling or building OpenCode agents would write the rules markdown to the static path `AGENTS.md` instead of the dynamic, agent-specific `{name}.md` path (e.g. `.opencode/agents/{name}.md` or `~/.config/opencode/agents/{name}.md`).

## Fixes
* Fixes #1304

## Approach
* **OpenCode Adapter Path Resolution**: Updated `OpenCodeAdapter.format_config` to dynamically format the rules file path using the agent's safe name from the context (`safe_name = ctx.safe_name`), and updated the default lookup fallback to a direct dictionary access `opencode_spec["rules_file"][opencode_scope]`.
* **Registry Alignment**: Configured the registry schemas mirror files `observal-server/schemas/ide_registry.py` and `observal_cli/ide_registry.py` to specify rules paths in the `{name}.md` format for both project and user scopes.
* **Manifest Builder Generation**: Updated `_generate_opencode()` in `observal-server/services/agent_builder.py` to resolve and use the sanitized safe name of the manifest, resolving rules generation for `observal agent build/install` actions.
* **Registry scope labels**: Fixed a minor mismatch in the registry display scope labels to correctly show `.opencode/agents/<name>.md` and `~/.config/opencode/agents/<name>.md`.

## How Has This Been Tested?
* **E2E Rules Path Generation**: Updated `test_rules_path` and `test_rules_path_project_scope` in `tests/test_ide_config_e2e.py` to verify dynamic name interpolation.
* **Offline Manifest Builder Tests**: Added `test_opencode_rules_file_path` in `TestBuilderModelEmission` inside `tests/test_model_registry.py` to assert correct rules generation.
* **CLI Integration Pull Tests**:
  * Added `_opencode_snippet` mock helper and `TestPullOpenCode` test class in `tests/test_pull_and_agent_cli.py` to test rules, MCP configs, and plugins generation.
  * Updated `TestPullOpenCode` in `tests/test_ide_config_e2e.py` to mock and assert the new agent-specific paths.
  * Parametrized and dynamically matched mock paths for Codex, Copilot, and OpenCode in `TestPullDryRunAllIdes.test_dry_run_does_not_write_files` to ensure realistic testing.

All tests ran successfully:
```bash
# E2E Config Generation tests
pytest tests/test_ide_config_e2e.py -q
# Model catalog/manifest builder tests
pytest tests/test_model_registry.py -q
# CLI Agent pull/install tests
pytest tests/test_pull_and_agent_cli.py -q
