### PR TITLE
feat(ci): add dependency compliance and enterprise readiness artifacts

### DIFF
--- a/.github/vex/observal.vex.json
+++ b/.github/vex/observal.vex.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://github.com/BlazeUp-AI/Observal/.github/vex/observal.vex.json",
+  "@id": "https://github.com/BlazeUp-AI/Observal/blob/main/.github/vex/observal.vex.json",
   "author": "Observal Security <contact@observal.io>",
   "timestamp": "2026-05-31T00:00:00Z",
   "version": 1,
@@ -19,7 +19,7 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_reachable",
+      "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Observal does not use the affected Starlette multipart form parsing path that triggers this vulnerability. All file uploads are handled via dedicated streaming endpoints with size limits enforced at the nginx layer."
     },
     {
@@ -36,7 +36,7 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_reachable",
+      "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "The affected code path requires specific Host header manipulation that is blocked by Observal's nginx reverse proxy configuration (see docker/nginx.conf header validation rules)."
     }
   ]

--- a/.github/vex/observal.vex.json
+++ b/.github/vex/observal.vex.json
@@ -1,0 +1,43 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/BlazeUp-AI/Observal/.github/vex/observal.vex.json",
+  "author": "Observal Security <contact@observal.io>",
+  "timestamp": "2026-05-31T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "@id": "https://github.com/pypa/advisory-database/blob/main/vulns/PYSEC-2025-183.yaml",
+        "name": "PYSEC-2025-183"
+      },
+      "products": [
+        {
+          "@id": "pkg:pypi/observal-server",
+          "subcomponents": [
+            {"@id": "pkg:pypi/starlette"}
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_reachable",
+      "impact_statement": "Observal does not use the affected Starlette multipart form parsing path that triggers this vulnerability. All file uploads are handled via dedicated streaming endpoints with size limits enforced at the nginx layer."
+    },
+    {
+      "vulnerability": {
+        "@id": "https://github.com/pypa/advisory-database/blob/main/vulns/PYSEC-2026-161.yaml",
+        "name": "PYSEC-2026-161"
+      },
+      "products": [
+        {
+          "@id": "pkg:pypi/observal-server",
+          "subcomponents": [
+            {"@id": "pkg:pypi/starlette"}
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_reachable",
+      "impact_statement": "The affected code path requires specific Host header manipulation that is blocked by Observal's nginx reverse proxy configuration (see docker/nginx.conf header validation rules)."
+    }
+  ]
+}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: License & vulnerability gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          deny-licenses: SSPL-1.0, BUSL-1.1, Elastic-2.0
+          comment-summary-in-pr: always
+          license-check: true
+          vulnerability-check: true

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -88,6 +88,10 @@ jobs:
       - name: Generate VEX document
         run: uv run --no-project scripts/generate_vex.py observal.openvex.json
 
+      # ── Generate third-party notices ─────────────────────────
+      - name: Generate third-party notices
+        run: uv run --no-project scripts/generate_third_party_notices.py THIRD_PARTY_NOTICES.md
+
       # ── Upload SBOM artifacts ────────────────────────────────
       - uses: actions/upload-artifact@v7
         with:
@@ -96,6 +100,7 @@ jobs:
             sbom-python.cdx.json
             sbom-node.cdx.json
             observal.openvex.json
+            THIRD_PARTY_NOTICES.md
 
       # ── Attach to release ────────────────────────────────────
       - name: Attach SBOMs to release
@@ -107,6 +112,7 @@ jobs:
             sbom-python.cdx.json \
             sbom-node.cdx.json \
             observal.openvex.json \
+            THIRD_PARTY_NOTICES.md \
             --clobber
 
   license-check:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -84,6 +84,10 @@ jobs:
               --label "security,automated"
           fi
 
+      # ── Generate VEX document ────────────────────────────────
+      - name: Generate VEX document
+        run: uv run --no-project scripts/generate_vex.py observal.openvex.json
+
       # ── Upload SBOM artifacts ────────────────────────────────
       - uses: actions/upload-artifact@v7
         with:
@@ -91,6 +95,7 @@ jobs:
           path: |
             sbom-python.cdx.json
             sbom-node.cdx.json
+            observal.openvex.json
 
       # ── Attach to release ────────────────────────────────────
       - name: Attach SBOMs to release
@@ -101,6 +106,7 @@ jobs:
           gh release upload "${{ github.event.release.tag_name }}" \
             sbom-python.cdx.json \
             sbom-node.cdx.json \
+            observal.openvex.json \
             --clobber
 
   license-check:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -343,3 +343,13 @@ SPDX-License-Identifier = "AGPL-3.0-only"
 path = "web/src/routeTree.gen.ts"
 SPDX-FileCopyrightText = "2026 Hari Srinivasan <harisrini21@gmail.com>"
 SPDX-License-Identifier = "AGPL-3.0-only"
+
+[[annotations]]
+path = ".github/vex/observal.vex.json"
+SPDX-FileCopyrightText = "2026 Kaushik Kumar <kaushikrjpm10@gmail.com>"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+[[annotations]]
+path = "scripts/license-format.json"
+SPDX-FileCopyrightText = "2026 Kaushik Kumar <kaushikrjpm10@gmail.com>"
+SPDX-License-Identifier = "AGPL-3.0-only"

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,70 @@
+<!-- SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Observal Licensing
+
+## Overview
+
+Observal uses a dual-licensing model:
+
+| Component | License | Location |
+|-----------|---------|----------|
+| Core platform | GNU Affero General Public License v3.0 (AGPL-3.0-only) | Everything outside `ee/` |
+| Enterprise features | Observal Enterprise License v1.0 (proprietary) | `ee/` directory |
+
+## Open-Source Core (AGPL-3.0)
+
+The open-source core is fully functional on its own. You can self-host, modify, and distribute it under the terms of the AGPL-3.0. The AGPL requires that:
+
+1. **Source disclosure** — If you modify Observal and make it available over a network (e.g., as a hosted service), you must make your modified source code available to users under the same AGPL terms.
+2. **Copyleft** — Derivative works must also be licensed under AGPL-3.0.
+3. **No additional restrictions** — You cannot impose further restrictions beyond what the AGPL permits.
+
+This applies to all code outside the `ee/` directory.
+
+## Enterprise Edition (Commercial License)
+
+The `ee/` directory contains proprietary enterprise features (advanced insights, SAML SSO, etc.) that require a commercial license for production use.
+
+### What the commercial license grants
+
+When you purchase an Observal Enterprise license:
+
+1. **No AGPL copyleft obligation** — You may use the combined product (core + enterprise) without the requirement to disclose your modifications or derivative works.
+2. **No source disclosure requirement** — You are not required to provide source code to your users, even when offering Observal as a network service.
+3. **Production use of enterprise features** — You may deploy `ee/` code in production, staging, and user-facing environments.
+4. **Proprietary modifications** — You may make private modifications to the codebase without releasing them.
+
+In short: **purchasing an Enterprise license removes all AGPL obligations** for your organization's use of Observal.
+
+### What the commercial license does NOT grant
+
+- The right to redistribute Observal (core or enterprise) to third parties as a standalone product.
+- The right to sublicense.
+- The right to use enterprise code in a competing product.
+
+See [`ee/LICENSE`](../ee/LICENSE) for complete terms.
+
+## For contributors
+
+All contributions to the open-source core (outside `ee/`) require signing the [Contributor License Agreement](../CLA.md). The CLA grants BlazeUp AI the right to sublicense contributions — including under the commercial license — while you retain copyright.
+
+Community contributions to the `ee/` directory are not accepted.
+
+## For enterprise buyers
+
+If your legal or procurement team needs clarification:
+
+- **Contact:** contact@observal.io
+- **Website:** https://observal.io/
+
+### Common questions
+
+**Q: If I self-host the open-source core without enterprise features, do I need a commercial license?**
+A: No. The AGPL governs your use. You only need a commercial license if you want to avoid AGPL obligations or use enterprise features.
+
+**Q: If I modify the core and use it internally (not over a network), do I need to share source?**
+A: No. The AGPL's network-use clause (Section 13) only triggers when you make the software available to others over a network.
+
+**Q: Does the commercial license cover all future versions?**
+A: License terms (duration, version coverage) are specified in your commercial agreement. Contact sales for details.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -24,7 +24,7 @@ This applies to all code outside the `ee/` directory.
 
 ## Enterprise Edition (Commercial License)
 
-The `ee/` directory contains proprietary enterprise features (advanced insights, SAML SSO, etc.) that require a commercial license for production use.
+The `ee/` directory contains proprietary enterprise features (SAML SSO, SCIM provisioning, exec dashboard, HIPAA audit) that require a commercial license for production use.
 
 ### What the commercial license grants
 

--- a/scripts/generate_third_party_notices.py
+++ b/scripts/generate_third_party_notices.py
@@ -13,7 +13,10 @@ def get_python_licenses() -> list[dict]:
     """Get Python dependency licenses via pip-licenses."""
     result = subprocess.run(
         [
-            "uv", "run", "--with", "pip-licenses",
+            "uv",
+            "run",
+            "--with",
+            "pip-licenses",
             "pip-licenses",
             "--format=json",
             "--with-urls",
@@ -35,10 +38,13 @@ def get_node_licenses() -> list[dict]:
     format_path = str(Path(__file__).parent / "license-format.json")
     result = subprocess.run(
         [
-            "pnpm", "dlx", "license-checker-rspack",
+            "pnpm",
+            "dlx",
+            "license-checker-rspack",
             "--json",
             "--production",
-            "--customPath", format_path,
+            "--customPath",
+            format_path,
         ],
         capture_output=True,
         text=True,
@@ -50,24 +56,26 @@ def get_node_licenses() -> list[dict]:
     raw = json.loads(result.stdout)
     packages = []
     for name, info in raw.items():
-        packages.append({
-            "Name": name,
-            "License": info.get("licenses", "Unknown"),
-            "URL": info.get("repository", ""),
-            "LicenseText": info.get("licenseText", ""),
-        })
+        packages.append(
+            {
+                "Name": name,
+                "License": info.get("licenses", "Unknown"),
+                "URL": info.get("repository", ""),
+                "LicenseText": info.get("licenseText", ""),
+            }
+        )
     return packages
 
 
 def generate_notices(python_pkgs: list[dict], node_pkgs: list[dict], output: str):
     """Write the combined THIRD_PARTY_NOTICES.md file."""
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
     with open(output, "w") as f:
         f.write("# Third-Party Notices\n\n")
         f.write("This file lists all third-party dependencies used by Observal,\n")
         f.write("along with their respective licenses.\n\n")
-        f.write(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d')}\n\n")
+        f.write(f"Generated: {datetime.now(UTC).strftime('%Y-%m-%d')}\n\n")
         f.write("---\n\n")
 
         # Python dependencies
@@ -101,7 +109,8 @@ def generate_notices(python_pkgs: list[dict], node_pkgs: list[dict], output: str
         f.write("where available.\n\n")
 
         apache_pkgs = [
-            p for p in python_pkgs + node_pkgs
+            p
+            for p in python_pkgs + node_pkgs
             if "Apache" in p.get("License", "") or "apache" in p.get("License", "").lower()
         ]
         for pkg in sorted(apache_pkgs, key=lambda p: p.get("Name", "").lower()):

--- a/scripts/generate_third_party_notices.py
+++ b/scripts/generate_third_party_notices.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Generate THIRD_PARTY_NOTICES.md from Python and Node.js dependency licenses."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_python_licenses() -> list[dict]:
+    """Get Python dependency licenses via pip-licenses."""
+    result = subprocess.run(
+        [
+            "uv", "run", "--with", "pip-licenses",
+            "pip-licenses",
+            "--format=json",
+            "--with-urls",
+            "--with-license-file",
+            "--no-license-path",
+        ],
+        capture_output=True,
+        text=True,
+        cwd="observal-server",
+    )
+    if result.returncode != 0:
+        print(f"Warning: pip-licenses failed: {result.stderr}", file=sys.stderr)
+        return []
+    return json.loads(result.stdout)
+
+
+def get_node_licenses() -> list[dict]:
+    """Get Node.js dependency licenses via license-checker-rspack."""
+    format_path = str(Path(__file__).parent / "license-format.json")
+    result = subprocess.run(
+        [
+            "pnpm", "dlx", "license-checker-rspack",
+            "--json",
+            "--production",
+            "--customPath", format_path,
+        ],
+        capture_output=True,
+        text=True,
+        cwd="web",
+    )
+    if result.returncode != 0:
+        print(f"Warning: license-checker failed: {result.stderr}", file=sys.stderr)
+        return []
+    raw = json.loads(result.stdout)
+    packages = []
+    for name, info in raw.items():
+        packages.append({
+            "Name": name,
+            "License": info.get("licenses", "Unknown"),
+            "URL": info.get("repository", ""),
+            "LicenseText": info.get("licenseText", ""),
+        })
+    return packages
+
+
+def generate_notices(python_pkgs: list[dict], node_pkgs: list[dict], output: str):
+    """Write the combined THIRD_PARTY_NOTICES.md file."""
+    from datetime import datetime, timezone
+
+    with open(output, "w") as f:
+        f.write("# Third-Party Notices\n\n")
+        f.write("This file lists all third-party dependencies used by Observal,\n")
+        f.write("along with their respective licenses.\n\n")
+        f.write(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d')}\n\n")
+        f.write("---\n\n")
+
+        # Python dependencies
+        f.write("## Python Dependencies (observal-server)\n\n")
+        f.write("| Package | License | URL |\n")
+        f.write("|---------|---------|-----|\n")
+        for pkg in sorted(python_pkgs, key=lambda p: p.get("Name", "").lower()):
+            name = pkg.get("Name", "")
+            license_name = pkg.get("License", "Unknown")
+            url = pkg.get("URL", "")
+            f.write(f"| {name} | {license_name} | {url} |\n")
+
+        f.write("\n---\n\n")
+
+        # Node.js dependencies
+        f.write("## Node.js Dependencies (web)\n\n")
+        f.write("| Package | License | URL |\n")
+        f.write("|---------|---------|-----|\n")
+        for pkg in sorted(node_pkgs, key=lambda p: p.get("Name", "").lower()):
+            name = pkg.get("Name", "")
+            license_name = pkg.get("License", "Unknown")
+            url = pkg.get("URL", "")
+            f.write(f"| {name} | {license_name} | {url} |\n")
+
+        f.write("\n---\n\n")
+
+        # Apache NOTICE section
+        f.write("## NOTICE (Apache-2.0 Licensed Dependencies)\n\n")
+        f.write("The following dependencies are licensed under the Apache License 2.0.\n")
+        f.write("As required by Section 4(d), their NOTICE files are reproduced below\n")
+        f.write("where available.\n\n")
+
+        apache_pkgs = [
+            p for p in python_pkgs + node_pkgs
+            if "Apache" in p.get("License", "") or "apache" in p.get("License", "").lower()
+        ]
+        for pkg in sorted(apache_pkgs, key=lambda p: p.get("Name", "").lower()):
+            name = pkg.get("Name", "")
+            license_text = pkg.get("LicenseText", "")
+            f.write(f"### {name}\n\n")
+            if license_text and license_text != "UNKNOWN":
+                # Truncate very long license texts to just the NOTICE portion
+                text = license_text[:2000] if len(license_text) > 2000 else license_text
+                f.write(f"```\n{text}\n```\n\n")
+            else:
+                f.write("NOTICE file not available in package metadata.\n\n")
+
+    print(f"Generated {output}")
+    print(f"  Python packages: {len(python_pkgs)}")
+    print(f"  Node.js packages: {len(node_pkgs)}")
+    print(f"  Apache-2.0 packages with NOTICE: {len(apache_pkgs)}")
+
+
+def main():
+    output = sys.argv[1] if len(sys.argv) > 1 else "THIRD_PARTY_NOTICES.md"
+    python_pkgs = get_python_licenses()
+    node_pkgs = get_node_licenses()
+    generate_notices(python_pkgs, node_pkgs, output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_third_party_notices.py
+++ b/scripts/generate_third_party_notices.py
@@ -9,6 +9,11 @@ import sys
 from pathlib import Path
 
 
+def _escape_md(text: str) -> str:
+    """Escape pipe characters for markdown table cells."""
+    return text.replace("|", "\\|")
+
+
 def get_python_licenses() -> list[dict]:
     """Get Python dependency licenses via pip-licenses."""
     result = subprocess.run(
@@ -30,7 +35,11 @@ def get_python_licenses() -> list[dict]:
     if result.returncode != 0:
         print(f"Warning: pip-licenses failed: {result.stderr}", file=sys.stderr)
         return []
-    return json.loads(result.stdout)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print("Warning: pip-licenses output is not valid JSON", file=sys.stderr)
+        return []
 
 
 def get_node_licenses() -> list[dict]:
@@ -53,7 +62,11 @@ def get_node_licenses() -> list[dict]:
     if result.returncode != 0:
         print(f"Warning: license-checker failed: {result.stderr}", file=sys.stderr)
         return []
-    raw = json.loads(result.stdout)
+    try:
+        raw = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print("Warning: license-checker output is not valid JSON", file=sys.stderr)
+        return []
     packages = []
     for name, info in raw.items():
         packages.append(
@@ -83,9 +96,9 @@ def generate_notices(python_pkgs: list[dict], node_pkgs: list[dict], output: str
         f.write("| Package | License | URL |\n")
         f.write("|---------|---------|-----|\n")
         for pkg in sorted(python_pkgs, key=lambda p: p.get("Name", "").lower()):
-            name = pkg.get("Name", "")
-            license_name = pkg.get("License", "Unknown")
-            url = pkg.get("URL", "")
+            name = _escape_md(pkg.get("Name", ""))
+            license_name = _escape_md(pkg.get("License", "Unknown"))
+            url = _escape_md(pkg.get("URL", ""))
             f.write(f"| {name} | {license_name} | {url} |\n")
 
         f.write("\n---\n\n")
@@ -95,9 +108,9 @@ def generate_notices(python_pkgs: list[dict], node_pkgs: list[dict], output: str
         f.write("| Package | License | URL |\n")
         f.write("|---------|---------|-----|\n")
         for pkg in sorted(node_pkgs, key=lambda p: p.get("Name", "").lower()):
-            name = pkg.get("Name", "")
-            license_name = pkg.get("License", "Unknown")
-            url = pkg.get("URL", "")
+            name = _escape_md(pkg.get("Name", ""))
+            license_name = _escape_md(pkg.get("License", "Unknown"))
+            url = _escape_md(pkg.get("URL", ""))
             f.write(f"| {name} | {license_name} | {url} |\n")
 
         f.write("\n---\n\n")
@@ -108,11 +121,7 @@ def generate_notices(python_pkgs: list[dict], node_pkgs: list[dict], output: str
         f.write("As required by Section 4(d), their NOTICE files are reproduced below\n")
         f.write("where available.\n\n")
 
-        apache_pkgs = [
-            p
-            for p in python_pkgs + node_pkgs
-            if "Apache" in p.get("License", "") or "apache" in p.get("License", "").lower()
-        ]
+        apache_pkgs = [p for p in python_pkgs + node_pkgs if "apache" in p.get("License", "").lower()]
         for pkg in sorted(apache_pkgs, key=lambda p: p.get("Name", "").lower()):
             name = pkg.get("Name", "")
             license_text = pkg.get("LicenseText", "")

--- a/scripts/generate_vex.py
+++ b/scripts/generate_vex.py
@@ -5,7 +5,7 @@
 
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def main():
@@ -15,7 +15,7 @@ def main():
     with open(source) as f:
         vex = json.load(f)
 
-    vex["timestamp"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    vex["timestamp"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     with open(output, "w") as f:
         json.dump(vex, f, indent=2)

--- a/scripts/generate_vex.py
+++ b/scripts/generate_vex.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Generate a timestamped OpenVEX document from static VEX statements."""
+
+import json
+import sys
+from datetime import datetime, timezone
+
+
+def main():
+    source = ".github/vex/observal.vex.json"
+    output = sys.argv[1] if len(sys.argv) > 1 else "observal.openvex.json"
+
+    with open(source) as f:
+        vex = json.load(f)
+
+    vex["timestamp"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    with open(output, "w") as f:
+        json.dump(vex, f, indent=2)
+        f.write("\n")
+
+    print(f"Generated VEX document: {output} ({len(vex['statements'])} statements)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/license-format.json
+++ b/scripts/license-format.json
@@ -1,0 +1,7 @@
+{
+  "name": "",
+  "version": "",
+  "licenses": "",
+  "repository": "",
+  "licenseText": ""
+}


### PR DESCRIPTION
## Purpose / Description

Adds compliance artifacts and CI gates to make Observal enterprise-ready. Covers supply-chain transparency (VEX), licensing clarity for buyers, and dependency governance.

## Features

### VEX (Vulnerability Exploitability Exchange) generation

- Adds a formal OpenVEX document (`.github/vex/observal.vex.json`) that explains **why** the 2 currently suppressed CVEs (PYSEC-2025-183, PYSEC-2026-161) do not affect Observal
- A CI script timestamps it and attaches it to every GitHub release alongside the SBOMs
- Without this, we suppress CVEs silently with no justification. VEX makes the reasoning machine-readable and auditable

### Commercial licensing whitepaper

- Adds `docs/licensing.md`, a plain-English explainer of our dual-license model
- Tells enterprise buyers: "AGPL governs the open-source core; buying an Enterprise license removes all AGPL obligations"
- Answers common procurement questions (do I need a license for internal use? what about network use?)
- This is the #1 document enterprise legal teams ask for before signing

### Dependency Review Action (PR license gate)

- New workflow that runs on every PR and **blocks merge if a new dependency has a prohibited license** (SSPL, BUSL, Elastic-2.0)
- Currently, license policy is only enforced *after* merge via ScanCode. This catches violations *before* they land
- Also flags high-severity CVEs introduced by new deps
- Uses GitHub's native dependency graph: zero config, instant feedback in PR comments

### THIRD_PARTY_NOTICES generation

- CI script that collects all Python + Node.js dependency licenses into one markdown file
- Includes a dedicated section reproducing Apache-2.0 NOTICE texts (legally required by Apache 2.0 Section 4d)
- Attached to every GitHub release as `THIRD_PARTY_NOTICES.md`
- Enterprise procurement teams routinely ask "show me all licenses in your product". This answers that in one file

## Approach

- VEX and THIRD_PARTY_NOTICES generation are integrated as new steps in the existing `sbom.yml` workflow (no new workflow sprawl)
- Dependency Review is a standalone lightweight workflow (only runs on PRs, ~10 seconds)
- All new Python scripts use only stdlib, no new dependencies added to the project
- REUSE annotations added for new JSON files that cannot contain SPDX headers

## How Has This Been Tested?

- `scripts/generate_vex.py`: ran end-to-end locally, validated output is correct OpenVEX JSON with proper `@context`, timestamp, and `vulnerable_code_not_in_execute_path` justification enum
- `scripts/generate_third_party_notices.py`: tested with empty inputs (graceful handling), pipe character escaping, and JSON parse failure scenarios
- All YAML workflows validated with `yaml.safe_load()`
- All Python scripts pass `ruff check` and `ruff format --check`
- All JSON files validated with `json.load()`

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A, no UI changes)