### PR TITLE
fix(infra): resolve all prod deployment failures in Terraform module

### DIFF
--- a/infra/terraform/aws/alb.tf
+++ b/infra/terraform/aws/alb.tf
@@ -7,7 +7,7 @@ resource "aws_lb" "app" {
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb.id]
-  subnets            = aws_subnet.public[*].id
+  subnets            = local.public_subnet_ids
 
   drop_invalid_header_fields = true
   tags                       = { Name = "${local.name}-alb" }
@@ -19,7 +19,7 @@ resource "aws_lb_target_group" "web" {
   name        = "${local.name}-web-tg"
   port        = 3000
   protocol    = "HTTP"
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = local.vpc_id
   target_type = "ip"
 
   deregistration_delay = 30
@@ -40,7 +40,7 @@ resource "aws_lb_target_group" "api" {
   name        = "${local.name}-api-tg"
   port        = 8000
   protocol    = "HTTP"
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = local.vpc_id
   target_type = "ip"
 
   deregistration_delay = 30
@@ -62,7 +62,7 @@ resource "aws_lb_target_group" "grafana" {
   name        = "${local.name}-grafana-tg"
   port        = 3001
   protocol    = "HTTP"
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = local.vpc_id
   target_type = "ip"
 
   deregistration_delay = 30

--- a/infra/terraform/aws/clickhouse.tf
+++ b/infra/terraform/aws/clickhouse.tf
@@ -46,7 +46,7 @@ resource "aws_ebs_volume" "data" {
 # survives instance replacement.
 resource "aws_network_interface" "data_host" {
   count           = local.clickhouse_self_hosted ? 1 : 0
-  subnet_id       = aws_subnet.private[0].id
+  subnet_id       = local.private_subnet_ids[0]
   security_groups = [aws_security_group.data_host[0].id]
 
   tags = { Name = "${local.name}-data-host-eni" }
@@ -78,7 +78,7 @@ resource "aws_instance" "data_host" {
   }
 
   user_data                   = local.data_host_user_data
-  user_data_replace_on_change = false
+  user_data_replace_on_change = true
 
   metadata_options {
     http_tokens   = "required"

--- a/infra/terraform/aws/deploy.sh
+++ b/infra/terraform/aws/deploy.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# deploy.sh
+# =========
+# Pre-flight validation for Observal AWS deployment.
+# Checks everything that can go wrong BEFORE you run terraform.
+# Does NOT run init/plan/apply. Tells you exactly what to do.
+#
+# Usage:
+#   ./deploy.sh                    # Run all checks
+#   ./deploy.sh --generate-tfvars  # Interactive tfvars generation
+#   ./deploy.sh --check-only       # Validate existing setup
+#
+# This script is idempotent. Run it as many times as you want.
+
+set -uo pipefail
+
+# ── Output formatting ────────────────────────────────────────────────────────
+PASS='\033[0;32m✓\033[0m'
+FAIL='\033[0;31m✗\033[0m'
+WARN='\033[1;33m!\033[0m'
+INFO='\033[0;36m→\033[0m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+ERRORS=0
+WARNINGS=0
+
+pass() { echo -e "  ${PASS} $*"; }
+fail() { echo -e "  ${FAIL} $*"; ERRORS=$((ERRORS + 1)); }
+warn() { echo -e "  ${WARN} $*"; WARNINGS=$((WARNINGS + 1)); }
+info() { echo -e "  ${INFO} $*"; }
+
+section() {
+  echo ""
+  echo -e "${BOLD}$*${NC}"
+  echo -e "${BOLD}$(printf '%.0s─' $(seq 1 ${#1}))${NC}"
+}
+
+# ── Parse flags ──────────────────────────────────────────────────────────────
+MODE="full"
+for arg in "$@"; do
+  case "$arg" in
+    --generate-tfvars) MODE="generate" ;;
+    --check-only)      MODE="check" ;;
+    --help|-h)
+      echo "Usage: $0 [--generate-tfvars|--check-only|--help]"
+      echo ""
+      echo "  (no flags)         Run all checks, offer to generate tfvars if missing"
+      echo "  --generate-tfvars  Interactive terraform.tfvars generation"
+      echo "  --check-only       Validate existing terraform.tfvars and environment"
+      exit 0
+      ;;
+    *) echo "Unknown flag: $arg. Use --help."; exit 1 ;;
+  esac
+done
+
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║        Observal Deployment Doctor                   ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════════════════════╝${NC}"
+
+# ── Check 1: Terraform binary ────────────────────────────────────────────────
+section "1. Terraform"
+
+TF=""
+if command -v terraform >/dev/null 2>&1; then
+  TF="terraform"
+elif command -v tofu >/dev/null 2>&1; then
+  TF="tofu"
+fi
+
+if [ -z "$TF" ]; then
+  fail "terraform/tofu not found"
+  info "Install: https://developer.hashicorp.com/terraform/install"
+  info "Or: brew install terraform"
+else
+  TF_VERSION=$($TF version -json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("terraform_version","0.0.0"))' 2>/dev/null || echo "0.0.0")
+  TF_MAJOR=$(echo "$TF_VERSION" | cut -d. -f1)
+  TF_MINOR=$(echo "$TF_VERSION" | cut -d. -f2)
+  if [ "$TF_MAJOR" -lt 1 ] || ([ "$TF_MAJOR" -eq 1 ] && [ "$TF_MINOR" -lt 6 ]); then
+    fail "$TF version $TF_VERSION < 1.6.0 (required)"
+    info "Upgrade: brew upgrade terraform"
+  else
+    pass "$TF $TF_VERSION"
+  fi
+fi
+
+# ── Check 2: AWS CLI + credentials ──────────────────────────────────────────
+section "2. AWS Credentials"
+
+if ! command -v aws >/dev/null 2>&1; then
+  fail "aws CLI not found"
+  info "Install: https://aws.amazon.com/cli/"
+else
+  pass "aws CLI installed"
+
+  if CALLER=$(aws sts get-caller-identity --output json 2>/dev/null); then
+    ACCOUNT_ID=$(echo "$CALLER" | python3 -c 'import sys,json;print(json.load(sys.stdin)["Account"])')
+    ARN=$(echo "$CALLER" | python3 -c 'import sys,json;print(json.load(sys.stdin)["Arn"])')
+    pass "Authenticated: $ARN"
+    pass "Account: $ACCOUNT_ID"
+  else
+    fail "AWS credentials not configured or expired"
+    info "Run: aws configure"
+    info "Or: export AWS_PROFILE=your-profile"
+  fi
+fi
+
+# ── Check 3: terraform.tfvars ────────────────────────────────────────────────
+section "3. Configuration (terraform.tfvars)"
+
+TFVARS_EXISTS=false
+if [ -f "terraform.tfvars" ]; then
+  TFVARS_EXISTS=true
+  pass "terraform.tfvars exists"
+
+  # Validate key fields
+  get_tfvar() { grep "^$1" terraform.tfvars 2>/dev/null | sed 's/.*=\s*"\(.*\)"/\1/' | sed "s/.*=\s*'/\1/" | head -1; }
+
+  REGION=$(get_tfvar "region")
+  IMAGE_TAG=$(get_tfvar "image_tag")
+  VPC_ID=$(get_tfvar "vpc_id")
+  LICENSE=$(get_tfvar "observal_license_key")
+  DEMO_EMAIL=$(get_tfvar "demo_super_admin_email")
+
+  [ -n "$REGION" ] && pass "region = $REGION" || fail "region not set"
+  [ -n "$IMAGE_TAG" ] && pass "image_tag = $IMAGE_TAG" || warn "image_tag not set (will use 'latest')"
+
+  if [ -n "$VPC_ID" ]; then
+    pass "BYO-VPC mode: $VPC_ID"
+    PRIV_SUBS=$(grep "private_subnet_ids" terraform.tfvars 2>/dev/null || echo "")
+    PUB_SUBS=$(grep "public_subnet_ids" terraform.tfvars 2>/dev/null || echo "")
+    [ -n "$PRIV_SUBS" ] && pass "private_subnet_ids set" || fail "private_subnet_ids required with vpc_id"
+    [ -n "$PUB_SUBS" ] && pass "public_subnet_ids set" || fail "public_subnet_ids required with vpc_id"
+  else
+    pass "VPC mode: create new"
+  fi
+
+  [ -n "$LICENSE" ] && pass "License key provided (enterprise)" || info "No license key (community edition)"
+  [ -n "$DEMO_EMAIL" ] && pass "Demo accounts configured" || warn "No demo accounts (you'll need to bootstrap manually via observal auth login)"
+else
+  if [ "$MODE" = "check" ]; then
+    fail "terraform.tfvars not found"
+    info "Run: $0 --generate-tfvars"
+  else
+    warn "terraform.tfvars not found (will generate below)"
+  fi
+fi
+
+# ── Check 4: Docker images exist ─────────────────────────────────────────────
+section "4. Container Images"
+
+check_ghcr_image() {
+  local image="$1"
+  local tag="$2"
+  # Use the GitHub container registry API (anonymous, no auth needed for public images)
+  local url="https://ghcr.io/v2/blazeup-ai/$image/manifests/$tag"
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+    "$url" 2>/dev/null)
+  [ "$status" = "200" ] || [ "$status" = "302" ]
+}
+
+TAG="${IMAGE_TAG:-latest}"
+for img in observal-api observal-web; do
+  if check_ghcr_image "$img" "$TAG"; then
+    pass "ghcr.io/blazeup-ai/$img:$TAG exists"
+  else
+    # Try with token auth
+    TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:blazeup-ai/$img:pull" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
+    if [ -n "$TOKEN" ]; then
+      status=$(curl -s -o /dev/null -w "%{http_code}" \
+        -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+        -H "Authorization: Bearer $TOKEN" \
+        "https://ghcr.io/v2/blazeup-ai/$img/manifests/$TAG" 2>/dev/null)
+      if [ "$status" = "200" ]; then
+        pass "ghcr.io/blazeup-ai/$img:$TAG exists"
+      else
+        fail "ghcr.io/blazeup-ai/$img:$TAG not found (HTTP $status)"
+        info "Check that a release with this tag exists, or use 'latest'"
+      fi
+    else
+      warn "Cannot verify ghcr.io/blazeup-ai/$img:$TAG (auth required or network issue)"
+    fi
+  fi
+done
+
+# ── Check 5: Release tarball (only for non-latest tags) ──────────────────────
+section "5. Release Tarball"
+
+if [ "$TAG" = "latest" ]; then
+  pass "image_tag=latest: embedded configs used (no tarball needed)"
+else
+  TARBALL_URL="https://github.com/BlazeUp-AI/Observal/releases/download/v${TAG}/observal-server-v${TAG}.tar.gz"
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L "$TARBALL_URL" 2>/dev/null)
+  if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "302" ]; then
+    pass "Release tarball v$TAG exists"
+  else
+    warn "Release tarball not found at v$TAG (HTTP $HTTP_STATUS)"
+    info "Grafana dashboards won't auto-provision. Core deployment still works."
+    info "Embedded ClickHouse configs will be used as fallback."
+  fi
+fi
+
+# ── Check 6: BYO-VPC validation ──────────────────────────────────────────────
+section "6. VPC Validation"
+
+if [ -n "${VPC_ID:-}" ] && [ "$VPC_ID" != "" ]; then
+  REGION_FLAG="--region ${REGION:-us-east-1}"
+
+  # Check VPC exists
+  VPC_STATE=$(aws ec2 describe-vpcs --vpc-ids "$VPC_ID" $REGION_FLAG --query 'Vpcs[0].State' --output text 2>/dev/null || echo "NOT_FOUND")
+  if [ "$VPC_STATE" = "available" ]; then
+    pass "VPC $VPC_ID exists and is available"
+
+    # Check DNS settings
+    DNS_SUPPORT=$(aws ec2 describe-vpc-attribute --vpc-id "$VPC_ID" --attribute enableDnsSupport $REGION_FLAG --query 'EnableDnsSupport.Value' --output text 2>/dev/null)
+    DNS_HOSTNAMES=$(aws ec2 describe-vpc-attribute --vpc-id "$VPC_ID" --attribute enableDnsHostnames $REGION_FLAG --query 'EnableDnsHostnames.Value' --output text 2>/dev/null)
+    [ "$DNS_SUPPORT" = "True" ] && pass "DNS support enabled" || fail "DNS support must be enabled on VPC"
+    [ "$DNS_HOSTNAMES" = "True" ] && pass "DNS hostnames enabled" || fail "DNS hostnames must be enabled on VPC"
+  else
+    fail "VPC $VPC_ID not found or not available (state: $VPC_STATE)"
+  fi
+
+  # Check private subnets have route to NAT (needed for image pulls)
+  if [ -n "${PRIV_SUBS:-}" ]; then
+    FIRST_PRIV=$(echo "$PRIV_SUBS" | grep -o 'subnet-[a-z0-9]*' | head -1)
+    if [ -n "$FIRST_PRIV" ]; then
+      RT=$(aws ec2 describe-route-tables $REGION_FLAG \
+        --filters "Name=association.subnet-id,Values=$FIRST_PRIV" \
+        --query 'RouteTables[0].Routes[?DestinationCidrBlock==`0.0.0.0/0`].NatGatewayId' \
+        --output text 2>/dev/null)
+      if [ -n "$RT" ] && [ "$RT" != "None" ]; then
+        pass "Private subnet $FIRST_PRIV has NAT gateway route"
+      else
+        fail "Private subnet $FIRST_PRIV has no NAT route (ECS tasks need outbound internet)"
+        info "Add a NAT gateway route to 0.0.0.0/0 in the subnet's route table"
+      fi
+    fi
+  fi
+else
+  pass "New VPC will be created (no validation needed)"
+fi
+
+# ── Check 7: IAM permissions ────────────────────────────────────────────────
+section "7. IAM Permissions (spot check)"
+
+# Quick smoke test: can we access key AWS services?
+if aws ecs list-clusters --region "${REGION:-us-east-1}" --max-results 1 >/dev/null 2>&1; then
+  pass "ECS access confirmed"
+else
+  fail "Cannot access ECS (check IAM permissions)"
+  info "Required: AdministratorAccess or equivalent for initial deployment"
+fi
+
+if aws ec2 describe-vpcs --region "${REGION:-us-east-1}" --max-results 1 >/dev/null 2>&1; then
+  pass "EC2/VPC access confirmed"
+else
+  fail "Cannot access EC2/VPC (check IAM permissions)"
+fi
+
+if aws ssm describe-parameters --region "${REGION:-us-east-1}" --max-results 1 >/dev/null 2>&1; then
+  pass "SSM access confirmed"
+else
+  fail "Cannot access SSM Parameter Store (check IAM permissions)"
+fi
+
+# ── Check 8: Name conflicts ─────────────────────────────────────────────────
+section "8. Resource Conflicts"
+
+ENV_NAME=$(get_tfvar "environment" 2>/dev/null || echo "")
+ENV_NAME="${ENV_NAME:-prod}"
+PREFIX="observal-${ENV_NAME}"
+
+# Check if ECS cluster already exists
+EXISTING_CLUSTER=$(aws ecs describe-clusters --region "${REGION:-us-east-1}" --clusters "${PREFIX}-cluster" --query 'clusters[?status==`ACTIVE`].clusterName' --output text 2>/dev/null || echo "")
+if [ -n "$EXISTING_CLUSTER" ]; then
+  warn "ECS cluster '${PREFIX}-cluster' already exists (terraform will import or conflict)"
+  info "If this is a re-deploy, this is expected. Use: terraform import"
+else
+  pass "No existing '${PREFIX}-cluster' found"
+fi
+
+# Check SSM namespace
+SSM_COUNT=$(aws ssm describe-parameters --region "${REGION:-us-east-1}" --parameter-filters "Key=Name,Option=BeginsWith,Values=/${PREFIX}/" --query 'length(Parameters)' --output text 2>/dev/null || echo "0")
+if [ "$SSM_COUNT" != "0" ] && [ "$SSM_COUNT" != "None" ]; then
+  warn "$SSM_COUNT existing SSM parameters under /${PREFIX}/ (previous deployment?)"
+  info "If re-deploying, terraform state should track these. Otherwise clean up first."
+else
+  pass "No existing SSM parameters under /${PREFIX}/"
+fi
+
+# ── Check 9: Terraform state ────────────────────────────────────────────────
+section "9. Terraform State"
+
+if [ -f "terraform.tfstate" ] || [ -d ".terraform" ]; then
+  pass "Existing terraform state found"
+  if [ -n "$TF" ] && [ -d ".terraform" ]; then
+    if $TF validate >/dev/null 2>&1; then
+      pass "terraform validate passes"
+    else
+      fail "terraform validate failed"
+      info "Run: $TF validate (to see errors)"
+    fi
+  fi
+else
+  pass "Fresh deployment (no existing state)"
+  info "Run: $TF init (after fixing any errors above)"
+fi
+
+# ── Generate tfvars (interactive) ────────────────────────────────────────────
+if [ "$TFVARS_EXISTS" = "false" ] && [ "$MODE" != "check" ]; then
+  section "Generate terraform.tfvars"
+  echo ""
+  read -rp "  Generate terraform.tfvars now? [Y/n]: " GEN
+  GEN="${GEN:-Y}"
+
+  if [[ "$GEN" =~ ^[Yy] ]]; then
+    echo ""
+
+    read -rp "  AWS Region [us-east-1]: " V_REGION
+    V_REGION="${V_REGION:-us-east-1}"
+
+    read -rp "  Environment [prod]: " V_ENV
+    V_ENV="${V_ENV:-prod}"
+
+    read -rp "  Image tag [latest]: " V_TAG
+    V_TAG="${V_TAG:-latest}"
+
+    echo ""
+    echo "  License key enables: insights, SAML, SCIM, exec dashboard, audit."
+    read -rp "  License key (empty = community): " V_LICENSE
+
+    echo ""
+    read -rp "  Use existing VPC? [y/N]: " V_BYO
+    V_BYO="${V_BYO:-N}"
+    V_VPC="" V_PRIV="" V_PUB=""
+    if [[ "$V_BYO" =~ ^[Yy] ]]; then
+      read -rp "  VPC ID: " V_VPC
+      read -rp "  Private subnet IDs (comma-separated): " V_PRIV
+      read -rp "  Public subnet IDs (comma-separated): " V_PUB
+    fi
+
+    echo ""
+    read -rp "  Create demo accounts? [Y/n]: " V_DEMO
+    V_DEMO="${V_DEMO:-Y}"
+    V_DEMO_EMAIL="" V_DEMO_PASS=""
+    if [[ "$V_DEMO" =~ ^[Yy] ]]; then
+      read -rp "  Admin email [admin@observal.local]: " V_DEMO_EMAIL
+      V_DEMO_EMAIL="${V_DEMO_EMAIL:-admin@observal.local}"
+      read -rsp "  Admin password [observal-demo-2026]: " V_DEMO_PASS
+      V_DEMO_PASS="${V_DEMO_PASS:-observal-demo-2026}"
+      echo ""
+    fi
+
+    echo ""
+    read -rp "  Custom domain (empty = ALB URL): " V_DOMAIN
+    V_ZONE=""
+    if [ -n "$V_DOMAIN" ]; then
+      read -rp "  Route53 zone ID for $V_DOMAIN: " V_ZONE
+    fi
+
+    # Write tfvars
+    cat > terraform.tfvars <<EOF
+# Generated by observal-deploy-doctor.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+region      = "$V_REGION"
+environment = "$V_ENV"
+name_prefix = "observal"
+image_tag   = "$V_TAG"
+EOF
+
+    [ -n "$V_DOMAIN" ] && echo "domain_name     = \"$V_DOMAIN\"" >> terraform.tfvars
+    [ -n "$V_ZONE" ] && echo "route53_zone_id = \"$V_ZONE\"" >> terraform.tfvars
+    [ -n "$V_LICENSE" ] && echo "observal_license_key = \"$V_LICENSE\"" >> terraform.tfvars
+
+    if [ -n "$V_VPC" ]; then
+      PRIV_LIST=$(echo "$V_PRIV" | sed 's/ //g' | sed 's/,/", "/g')
+      PUB_LIST=$(echo "$V_PUB" | sed 's/ //g' | sed 's/,/", "/g')
+      cat >> terraform.tfvars <<EOF
+vpc_id             = "$V_VPC"
+private_subnet_ids = ["$PRIV_LIST"]
+public_subnet_ids  = ["$PUB_LIST"]
+EOF
+    fi
+
+    if [[ "${V_DEMO:-N}" =~ ^[Yy] ]]; then
+      cat >> terraform.tfvars <<EOF
+demo_super_admin_email    = "$V_DEMO_EMAIL"
+demo_super_admin_password = "$V_DEMO_PASS"
+demo_admin_email          = "demo-admin@observal.local"
+demo_admin_password       = "$V_DEMO_PASS"
+demo_reviewer_email       = "demo-reviewer@observal.local"
+demo_reviewer_password    = "$V_DEMO_PASS"
+demo_user_email           = "demo-user@observal.local"
+demo_user_password        = "$V_DEMO_PASS"
+EOF
+    fi
+
+    echo ""
+    pass "Written: terraform.tfvars"
+  fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+section "Summary"
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo -e "  ${FAIL} ${BOLD}$ERRORS error(s)${NC} found. Fix them before deploying."
+  [ "$WARNINGS" -gt 0 ] && echo -e "  ${WARN} $WARNINGS warning(s) (non-blocking)"
+  echo ""
+  echo -e "  Re-run this script after fixing to verify: ${BOLD}$0${NC}"
+  echo ""
+  exit 1
+fi
+
+echo ""
+if [ "$WARNINGS" -gt 0 ]; then
+  echo -e "  ${WARN} $WARNINGS warning(s) (non-blocking, deployment will still work)"
+fi
+echo -e "  ${PASS} ${BOLD}All checks passed.${NC}"
+echo ""
+
+section "Next Steps"
+echo ""
+echo "  Run these commands in order:"
+echo ""
+echo -e "  ${BOLD}1.${NC} $TF init"
+echo -e "  ${BOLD}2.${NC} $TF plan -out=tfplan"
+echo -e "  ${BOLD}3.${NC} Review the plan output carefully"
+echo -e "  ${BOLD}4.${NC} $TF apply tfplan"
+echo ""
+echo "  Estimated time: 8-15 minutes for first deploy."
+echo ""
+echo "  After deployment:"
+echo -e "  ${BOLD}5.${NC} $TF output          # Get ALB URL and connection info"
+echo -e "  ${BOLD}6.${NC} observal config set server_url <URL>"
+echo -e "  ${BOLD}7.${NC} observal auth login  # Use demo credentials"
+echo ""
+echo "  To tear down:"
+echo -e "     $TF destroy"
+echo ""

--- a/infra/terraform/aws/ecs.tf
+++ b/infra/terraform/aws/ecs.tf
@@ -36,10 +36,19 @@ locals {
   web_image = "${var.image_repo_web}:${var.image_tag}"
 
   # Non-secret env vars passed to api/worker/init.
-  app_environment = [
+  app_environment = concat([
     { name = "NEXT_PUBLIC_API_URL", value = local.app_url },
     { name = "JWT_KEY_DIR", value = "/tmp/keys" },
-  ]
+    ], var.demo_super_admin_email != "" ? [
+    { name = "DEMO_SUPER_ADMIN_EMAIL", value = var.demo_super_admin_email },
+    { name = "DEMO_SUPER_ADMIN_PASSWORD", value = var.demo_super_admin_password },
+    { name = "DEMO_ADMIN_EMAIL", value = var.demo_admin_email },
+    { name = "DEMO_ADMIN_PASSWORD", value = var.demo_admin_password },
+    { name = "DEMO_REVIEWER_EMAIL", value = var.demo_reviewer_email },
+    { name = "DEMO_REVIEWER_PASSWORD", value = var.demo_reviewer_password },
+    { name = "DEMO_USER_EMAIL", value = var.demo_user_email },
+    { name = "DEMO_USER_PASSWORD", value = var.demo_user_password },
+  ] : [])
 
   # Secrets injected by ECS at task start. Reference SSM Parameter Store ARNs.
   app_secrets = concat([
@@ -243,7 +252,7 @@ resource "aws_ecs_service" "api" {
   health_check_grace_period_seconds  = 60
 
   network_configuration {
-    subnets          = aws_subnet.private[*].id
+    subnets          = local.private_subnet_ids
     security_groups  = [aws_security_group.ecs_tasks.id]
     assign_public_ip = false
   }
@@ -278,7 +287,7 @@ resource "aws_ecs_service" "web" {
   health_check_grace_period_seconds  = 30
 
   network_configuration {
-    subnets          = aws_subnet.private[*].id
+    subnets          = local.private_subnet_ids
     security_groups  = [aws_security_group.ecs_tasks.id]
     assign_public_ip = false
   }
@@ -309,7 +318,7 @@ resource "aws_ecs_service" "worker" {
   deployment_maximum_percent         = 200
 
   network_configuration {
-    subnets          = aws_subnet.private[*].id
+    subnets          = local.private_subnet_ids
     security_groups  = [aws_security_group.ecs_tasks.id]
     assign_public_ip = false
   }
@@ -342,12 +351,20 @@ resource "null_resource" "run_init" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
       set -euo pipefail
+
+      # Give the data-host EC2 instance time to bootstrap ClickHouse.
+      # user-data takes 2-4 minutes (package install + docker pull + start).
+      # The init task's entrypoint.sh also retries 15 times with backoff,
+      # so this is a best-effort head start, not a hard gate.
+      echo "Waiting 120s for data-tier bootstrap to complete..."
+      sleep 120
+
       task_arn=$(aws ecs run-task \
         --region ${var.region} \
         --cluster ${aws_ecs_cluster.main.name} \
         --launch-type FARGATE \
         --task-definition ${aws_ecs_task_definition.init.arn} \
-        --network-configuration "awsvpcConfiguration={subnets=[${join(",", aws_subnet.private[*].id)}],securityGroups=[${aws_security_group.ecs_tasks.id}],assignPublicIp=DISABLED}" \
+        --network-configuration "awsvpcConfiguration={subnets=[${join(",", local.private_subnet_ids)}],securityGroups=[${aws_security_group.ecs_tasks.id}],assignPublicIp=DISABLED}" \
         --query 'tasks[0].taskArn' --output text)
       echo "Init task started: $task_arn"
       aws ecs wait tasks-stopped --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --tasks "$task_arn"
@@ -366,6 +383,7 @@ resource "null_resource" "run_init" {
     aws_ecs_cluster.main,
     aws_iam_role_policy_attachment.ecs_execution_managed,
     aws_iam_role_policy_attachment.ecs_execution_secrets,
+    aws_instance.data_host,
   ]
 }
 

--- a/infra/terraform/aws/locals.tf
+++ b/infra/terraform/aws/locals.tf
@@ -13,17 +13,29 @@ locals {
   name = "${var.name_prefix}-${var.environment}"
   azs  = slice(data.aws_availability_zones.available.names, 0, var.az_count)
 
+  # BYO-VPC: when vpc_id is provided, use existing resources; otherwise create new ones.
+  create_vpc = var.vpc_id == ""
+  vpc_id     = local.create_vpc ? aws_vpc.main[0].id : var.vpc_id
+  vpc_cidr   = local.create_vpc ? aws_vpc.main[0].cidr_block : data.aws_vpc.existing[0].cidr_block
+
+  private_subnet_ids = local.create_vpc ? aws_subnet.private[*].id : var.private_subnet_ids
+  public_subnet_ids  = local.create_vpc ? aws_subnet.public[*].id : var.public_subnet_ids
+
   enable_tls = var.domain_name != "" && var.route53_zone_id != ""
   app_url    = local.enable_tls ? "https://${var.domain_name}" : "http://${aws_lb.app.dns_name}"
 
   clickhouse_self_hosted = var.clickhouse_mode == "self_hosted"
 
-  # Internal DNS name for ClickHouse — ECS tasks resolve it via the private Route53 zone.
+  # Internal DNS name for ClickHouse
   clickhouse_host_internal = local.clickhouse_self_hosted ? "clickhouse.${var.internal_dns_zone}" : ""
 
   ssm_prefix = "/${local.name}"
 
-  # Enterprise features activate at runtime via the license key, not via
-  # a separate image. The community image already contains ee/ and all code.
   is_enterprise = var.observal_license_key != ""
+}
+
+# Lookup existing VPC when using BYO-VPC
+data "aws_vpc" "existing" {
+  count = local.create_vpc ? 0 : 1
+  id    = var.vpc_id
 }

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -27,7 +27,7 @@ output "ecs_service_names" {
 
 output "init_run_task_command" {
   description = "Manual command to re-run the migrations/seed task."
-  value       = "aws ecs run-task --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --launch-type FARGATE --task-definition ${aws_ecs_task_definition.init.family} --network-configuration 'awsvpcConfiguration={subnets=[${join(",", aws_subnet.private[*].id)}],securityGroups=[${aws_security_group.ecs_tasks.id}],assignPublicIp=DISABLED}'"
+  value       = "aws ecs run-task --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --launch-type FARGATE --task-definition ${aws_ecs_task_definition.init.family} --network-configuration 'awsvpcConfiguration={subnets=[${join(",", local.private_subnet_ids)}],securityGroups=[${aws_security_group.ecs_tasks.id}],assignPublicIp=DISABLED}'"
 }
 
 output "rds_endpoint" {

--- a/infra/terraform/aws/postgresql.tf
+++ b/infra/terraform/aws/postgresql.tf
@@ -3,7 +3,7 @@
 
 resource "aws_db_subnet_group" "main" {
   name       = "${local.name}-db"
-  subnet_ids = aws_subnet.private[*].id
+  subnet_ids = local.private_subnet_ids
   tags       = { Name = "${local.name}-db-subnet-group" }
 }
 

--- a/infra/terraform/aws/redis.tf
+++ b/infra/terraform/aws/redis.tf
@@ -3,7 +3,7 @@
 
 resource "aws_elasticache_subnet_group" "redis" {
   name       = "${local.name}-redis"
-  subnet_ids = aws_subnet.private[*].id
+  subnet_ids = local.private_subnet_ids
 }
 
 resource "aws_elasticache_replication_group" "redis" {

--- a/infra/terraform/aws/security.tf
+++ b/infra/terraform/aws/security.tf
@@ -5,7 +5,7 @@
 resource "aws_security_group" "alb" {
   name        = "${local.name}-alb"
   description = "Public ingress to the load balancer."
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = local.vpc_id
 
   # tfsec:ignore:aws-ec2-no-public-ingress-sgr ALB is internet-facing by design; restrict via var.alb_ingress_cidrs.
   ingress {
@@ -41,7 +41,7 @@ resource "aws_security_group" "alb" {
 resource "aws_security_group" "ecs_tasks" {
   name        = "${local.name}-ecs-tasks"
   description = "Fargate task ENIs for api/web/worker. Inbound only from ALB."
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = local.vpc_id
 
   ingress {
     description     = "API HTTP from ALB"
@@ -76,7 +76,7 @@ resource "aws_security_group" "data_host" {
   count       = local.clickhouse_self_hosted ? 1 : 0
   name        = "${local.name}-data-host"
   description = "ClickHouse + Grafana + Prometheus EC2. Inbound from ALB (Grafana) and ECS tasks (ClickHouse)."
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = local.vpc_id
 
   ingress {
     description     = "Grafana UI from ALB"
@@ -118,7 +118,7 @@ resource "aws_security_group" "data_host" {
 resource "aws_security_group" "db" {
   name        = "${local.name}-db"
   description = "Postgres reachable only from ECS tasks."
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = local.vpc_id
 
   ingress {
     description     = "Postgres from ECS tasks"
@@ -133,7 +133,7 @@ resource "aws_security_group" "db" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [aws_vpc.main.cidr_block]
+    cidr_blocks = [local.vpc_cidr]
   }
 
   tags = { Name = "${local.name}-db-sg" }
@@ -143,7 +143,7 @@ resource "aws_security_group" "db" {
 resource "aws_security_group" "redis" {
   name        = "${local.name}-redis"
   description = "Redis reachable from ECS tasks (api + worker)."
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = local.vpc_id
 
   ingress {
     description     = "Redis from ECS tasks"
@@ -158,7 +158,7 @@ resource "aws_security_group" "redis" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [aws_vpc.main.cidr_block]
+    cidr_blocks = [local.vpc_cidr]
   }
 
   tags = { Name = "${local.name}-redis-sg" }

--- a/infra/terraform/aws/terraform.tfvars.example
+++ b/infra/terraform/aws/terraform.tfvars.example
@@ -49,3 +49,15 @@ log_retention_days  = 30
 # Provide your enterprise license key to enable enterprise features.
 # Without a key, community edition is deployed (same image, features gated at runtime).
 # observal_license_key = "eyJ...<your-key>..."
+
+# ── Demo account (optional, first-deploy convenience) ────────────────────────
+# Creates demo accounts on first startup for immediate access.
+# All tiers auto-delete when real users are created at that role.
+# demo_super_admin_email    = "admin@yourcompany.com"
+# demo_super_admin_password = "change-me-immediately"
+# demo_admin_email          = "demo-admin@yourcompany.com"
+# demo_admin_password       = "change-me-immediately"
+# demo_reviewer_email       = "demo-reviewer@yourcompany.com"
+# demo_reviewer_password    = "change-me-immediately"
+# demo_user_email           = "demo-user@yourcompany.com"
+# demo_user_password        = "change-me-immediately"

--- a/infra/terraform/aws/user-data.sh.tftpl
+++ b/infra/terraform/aws/user-data.sh.tftpl
@@ -72,16 +72,126 @@ EOF
 INSTALL_DIR=/opt/observal
 mkdir -p "$INSTALL_DIR"
 cd "$INSTALL_DIR"
-curl -fsSL "https://github.com/BlazeUp-AI/Observal/releases/download/${image_tag}/observal-server-${image_tag}.tar.gz" \
-  -o /tmp/observal.tgz
-tar -xzf /tmp/observal.tgz --strip-components=1
-rm /tmp/observal.tgz
+
+TARBALL_URL="https://github.com/BlazeUp-AI/Observal/releases/download/v${image_tag}/observal-server-v${image_tag}.tar.gz"
+TARBALL_OK=false
+if [ "${image_tag}" != "latest" ]; then
+  for attempt in 1 2 3 4 5; do
+    if curl -fsSL "$TARBALL_URL" -o /tmp/observal.tgz; then
+      tar -xzf /tmp/observal.tgz --strip-components=1
+      rm /tmp/observal.tgz
+      TARBALL_OK=true
+      break
+    fi
+    echo "Tarball download attempt $attempt failed, retrying in 10s..."
+    sleep 10
+  done
+fi
+if [ "$TARBALL_OK" = "false" ]; then
+  echo "Using embedded configs (tarball skipped or unavailable)."
+fi
+
+# ── Ensure critical ClickHouse configs exist (embedded fallback) ───────
+# These are written unconditionally so bootstrapping succeeds even if the
+# tarball download fails (e.g. private repo, missing release, network issue).
+mkdir -p "$INSTALL_DIR/docker/clickhouse/config.d"
+mkdir -p "$INSTALL_DIR/docker/clickhouse/users.d"
+
+cat > "$INSTALL_DIR/docker/clickhouse/config.d/memory.xml" <<'CHCFG'
+<clickhouse>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+    <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
+    <merge_tree>
+        <parts_to_delay_insert>200</parts_to_delay_insert>
+        <parts_to_throw_insert>500</parts_to_throw_insert>
+        <max_bytes_to_merge_at_max_space_in_pool>5368709120</max_bytes_to_merge_at_max_space_in_pool>
+    </merge_tree>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 3 DAY</ttl>
+    </query_log>
+    <trace_log>
+        <database>system</database>
+        <table>trace_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </trace_log>
+    <text_log>
+        <database>system</database>
+        <table>text_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </text_log>
+    <metric_log>
+        <database>system</database>
+        <table>metric_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </metric_log>
+    <asynchronous_metric_log>
+        <database>system</database>
+        <table>asynchronous_metric_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </asynchronous_metric_log>
+    <part_log>
+        <database>system</database>
+        <table>part_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 1 DAY</ttl>
+    </part_log>
+</clickhouse>
+CHCFG
+
+cat > "$INSTALL_DIR/docker/clickhouse/users.d/default-user.xml" <<CHUSER
+<clickhouse>
+  <users>
+    <default remove="remove"></default>
+    <default>
+      <profile>default</profile>
+      <networks><ip>::/0</ip></networks>
+      <password><![CDATA[$${CLICKHOUSE_PASSWORD}]]></password>
+      <quota>default</quota>
+      <access_management>0</access_management>
+    </default>
+  </users>
+</clickhouse>
+CHUSER
+
+cat > "$INSTALL_DIR/docker/clickhouse/users.d/memory.xml" <<'CHPROF'
+<clickhouse>
+    <profiles>
+        <default>
+            <max_memory_usage>400000000</max_memory_usage>
+            <max_bytes_before_external_group_by>200000000</max_bytes_before_external_group_by>
+            <max_bytes_before_external_sort>200000000</max_bytes_before_external_sort>
+            <max_bytes_in_join>100000000</max_bytes_in_join>
+            <join_algorithm>auto</join_algorithm>
+            <async_insert>1</async_insert>
+            <wait_for_async_insert>0</wait_for_async_insert>
+            <async_insert_max_data_size>1048576</async_insert_max_data_size>
+            <async_insert_busy_timeout_ms>200</async_insert_busy_timeout_ms>
+            <deduplicate_merge_projection_mode>drop</deduplicate_merge_projection_mode>
+        </default>
+    </profiles>
+</clickhouse>
+CHPROF
 
 # ── Render the data-tier compose file (CH + Grafana + Prometheus only) ──
 cat > "$INSTALL_DIR/docker-compose.data.yml" <<'COMPOSE'
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:26.3
+    image: clickhouse/clickhouse-server:26.5
     container_name: observal-clickhouse
     restart: unless-stopped
     ports:
@@ -154,14 +264,41 @@ cd "$INSTALL_DIR"
 docker compose --env-file "$INSTALL_DIR/.env" -f docker-compose.data.yml pull
 docker compose --env-file "$INSTALL_DIR/.env" -f docker-compose.data.yml up -d
 
+# Wait for ClickHouse to become healthy before declaring bootstrap done
+echo "Waiting for ClickHouse HTTP interface..."
+for i in $(seq 1 30); do
+  if wget -q --spider http://localhost:8123/ping 2>/dev/null; then
+    echo "ClickHouse healthy after $i attempts"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "ERROR: ClickHouse did not become healthy within 5 minutes"
+    docker compose -f docker-compose.data.yml logs clickhouse | tail -50
+    exit 1
+  fi
+  sleep 10
+done
+
 # ── Daily ClickHouse snapshot to S3 ──────────────────────────────
-cat > /usr/local/bin/observal-ch-backup.sh <<EOF
+cat > /usr/local/bin/observal-ch-backup.sh <<'BACKUP'
 #!/bin/bash
 set -euo pipefail
-TS=\$(date -u +%Y%m%dT%H%M%SZ)
-docker exec observal-clickhouse clickhouse-client --password "$CLICKHOUSE_PASSWORD" --query "BACKUP DATABASE observal TO S3('s3://${backups_bucket}/clickhouse/\$TS/', '$(aws configure get aws_access_key_id || echo '')', '$(aws configure get aws_secret_access_key || echo '')')" || \\
-docker exec observal-clickhouse clickhouse-backup create_remote "obs-\$TS" || true
-EOF
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+CH_PASS=$(grep CLICKHOUSE_PASSWORD /opt/observal/.env | cut -d= -f2-)
+
+# Attempt native BACKUP command first (ClickHouse 26+)
+docker exec observal-clickhouse clickhouse-client \
+  --password "$CH_PASS" \
+  --query "BACKUP DATABASE observal TO Disk('backups', '$TS')" 2>/dev/null && {
+  # Upload the backup via AWS CLI using the instance IAM role
+  BACKUP_PATH=$(docker exec observal-clickhouse find /var/lib/clickhouse/backups -maxdepth 1 -name "$TS" -type d)
+  if [ -n "$BACKUP_PATH" ]; then
+    docker cp "observal-clickhouse:$BACKUP_PATH" "/tmp/ch-backup-$TS"
+    aws s3 sync "/tmp/ch-backup-$TS" "s3://${backups_bucket}/clickhouse/$TS/" --quiet
+    rm -rf "/tmp/ch-backup-$TS"
+  fi
+} || echo "ClickHouse backup failed (non-fatal), check instance IAM role and disk config"
+BACKUP
 chmod +x /usr/local/bin/observal-ch-backup.sh
 
 cat > /etc/systemd/system/observal-ch-backup.service <<'EOF'

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -308,3 +308,80 @@ variable "observal_license_key" {
   sensitive   = true
 }
 
+# ── Demo account seeding (optional, first-deploy only) ────────────────────────
+
+variable "demo_super_admin_email" {
+  description = "Email for the demo super-admin account. Leave empty to skip all demo seeding."
+  type        = string
+  default     = ""
+}
+
+variable "demo_super_admin_password" {
+  description = "Password for the demo super-admin account."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "demo_admin_email" {
+  description = "Email for the demo admin account."
+  type        = string
+  default     = ""
+}
+
+variable "demo_admin_password" {
+  description = "Password for the demo admin account."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "demo_reviewer_email" {
+  description = "Email for the demo reviewer account."
+  type        = string
+  default     = ""
+}
+
+variable "demo_reviewer_password" {
+  description = "Password for the demo reviewer account."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "demo_user_email" {
+  description = "Email for the demo user account."
+  type        = string
+  default     = ""
+}
+
+variable "demo_user_password" {
+  description = "Password for the demo user account."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# ── Bring-your-own VPC (optional) ─────────────────────────────────────────────
+# Set these to deploy into an existing VPC instead of creating a new one.
+# When vpc_id is set, Terraform skips creating VPC, subnets, IGW, NAT, and
+# route tables. You must provide at least 2 public and 2 private subnet IDs.
+
+variable "vpc_id" {
+  description = "Existing VPC ID. Leave empty to create a new VPC."
+  type        = string
+  default     = ""
+}
+
+variable "private_subnet_ids" {
+  description = "List of existing private subnet IDs (at least 2, in different AZs). Required when vpc_id is set."
+  type        = list(string)
+  default     = []
+}
+
+variable "public_subnet_ids" {
+  description = "List of existing public subnet IDs (at least 2, in different AZs). Required when vpc_id is set."
+  type        = list(string)
+  default     = []
+}
+

--- a/infra/terraform/aws/vpc.tf
+++ b/infra/terraform/aws/vpc.tf
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
+# All VPC networking resources are conditional on local.create_vpc.
+# When vpc_id is provided (BYO-VPC), none of these are created.
+
 resource "aws_vpc" "main" {
+  count                = local.create_vpc ? 1 : 0
   cidr_block           = var.vpc_cidr
   enable_dns_hostnames = true
   enable_dns_support   = true
@@ -10,14 +14,15 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_internet_gateway" "main" {
-  vpc_id = aws_vpc.main.id
+  count  = local.create_vpc ? 1 : 0
+  vpc_id = aws_vpc.main[0].id
   tags   = { Name = "${local.name}-igw" }
 }
 
 # tfsec:ignore:aws-ec2-no-public-ip-subnet Public subnets host the ALB and NAT gateway only; application workloads live in private subnets.
 resource "aws_subnet" "public" {
-  count                   = var.az_count
-  vpc_id                  = aws_vpc.main.id
+  count                   = local.create_vpc ? var.az_count : 0
+  vpc_id                  = aws_vpc.main[0].id
   cidr_block              = var.public_subnet_cidrs[count.index]
   availability_zone       = local.azs[count.index]
   map_public_ip_on_launch = true
@@ -29,8 +34,8 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_subnet" "private" {
-  count             = var.az_count
-  vpc_id            = aws_vpc.main.id
+  count             = local.create_vpc ? var.az_count : 0
+  vpc_id            = aws_vpc.main[0].id
   cidr_block        = var.private_subnet_cidrs[count.index]
   availability_zone = local.azs[count.index]
 
@@ -41,12 +46,14 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_eip" "nat" {
+  count  = local.create_vpc ? 1 : 0
   domain = "vpc"
   tags   = { Name = "${local.name}-nat-eip" }
 }
 
 resource "aws_nat_gateway" "main" {
-  allocation_id = aws_eip.nat.id
+  count         = local.create_vpc ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
   subnet_id     = aws_subnet.public[0].id
   tags          = { Name = "${local.name}-nat" }
 
@@ -54,38 +61,41 @@ resource "aws_nat_gateway" "main" {
 }
 
 resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.main.id
+  count  = local.create_vpc ? 1 : 0
+  vpc_id = aws_vpc.main[0].id
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.main.id
+    gateway_id = aws_internet_gateway.main[0].id
   }
   tags = { Name = "${local.name}-public-rt" }
 }
 
 resource "aws_route_table" "private" {
-  vpc_id = aws_vpc.main.id
+  count  = local.create_vpc ? 1 : 0
+  vpc_id = aws_vpc.main[0].id
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.main.id
+    nat_gateway_id = aws_nat_gateway.main[0].id
   }
   tags = { Name = "${local.name}-private-rt" }
 }
 
 resource "aws_route_table_association" "public" {
-  count          = var.az_count
+  count          = local.create_vpc ? var.az_count : 0
   subnet_id      = aws_subnet.public[count.index].id
-  route_table_id = aws_route_table.public.id
+  route_table_id = aws_route_table.public[0].id
 }
 
 resource "aws_route_table_association" "private" {
-  count          = var.az_count
+  count          = local.create_vpc ? var.az_count : 0
   subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = aws_route_table.private.id
+  route_table_id = aws_route_table.private[0].id
 }
 
-# ── Flow Logs ──────────────────────────────────────────────────────────────
+# ── Flow Logs (only for managed VPC) ──────────────────────────────────────
 
 data "aws_iam_policy_document" "flow_logs_assume" {
+  count = local.create_vpc ? 1 : 0
   statement {
     actions = ["sts:AssumeRole"]
     principals {
@@ -96,6 +106,7 @@ data "aws_iam_policy_document" "flow_logs_assume" {
 }
 
 data "aws_iam_policy_document" "flow_logs_publish" {
+  count = local.create_vpc ? 1 : 0
   # tfsec:ignore:aws-iam-no-policy-wildcards Resource wildcard is bounded to log streams within the flow-log group only.
   statement {
     actions = [
@@ -109,31 +120,34 @@ data "aws_iam_policy_document" "flow_logs_publish" {
 }
 
 resource "aws_iam_role" "flow_logs" {
+  count              = local.create_vpc ? 1 : 0
   name               = "${local.name}-flow-logs"
-  assume_role_policy = data.aws_iam_policy_document.flow_logs_assume.json
+  assume_role_policy = data.aws_iam_policy_document.flow_logs_assume[0].json
 }
 
 resource "aws_iam_role_policy" "flow_logs" {
-  role   = aws_iam_role.flow_logs.id
-  policy = data.aws_iam_policy_document.flow_logs_publish.json
+  count  = local.create_vpc ? 1 : 0
+  role   = aws_iam_role.flow_logs[0].id
+  policy = data.aws_iam_policy_document.flow_logs_publish[0].json
 }
 
 resource "aws_flow_log" "main" {
-  vpc_id          = aws_vpc.main.id
+  count           = local.create_vpc ? 1 : 0
+  vpc_id          = local.vpc_id
   log_destination = aws_cloudwatch_log_group.flow_logs.arn
-  iam_role_arn    = aws_iam_role.flow_logs.arn
+  iam_role_arn    = aws_iam_role.flow_logs[0].arn
   traffic_type    = "ALL"
 
   tags = { Name = "${local.name}-flow-logs" }
 }
 
-# ── Private DNS zone for VPC-internal resolution (ECS → ClickHouse/Grafana) ──
+# ── Private DNS zone for VPC-internal resolution (ECS -> ClickHouse/Grafana) ──
 
 resource "aws_route53_zone" "internal" {
   name = var.internal_dns_zone
 
   vpc {
-    vpc_id = aws_vpc.main.id
+    vpc_id = local.vpc_id
   }
 
   tags = { Name = "${local.name}-internal-zone" }


### PR DESCRIPTION
## Purpose / Description

Fixes all cascading failures from the first prod deployment on Fargate. The Terraform module now works end-to-end with minimal user input (license key + region).

Root causes addressed:
- Tarball URL missing `v` prefix caused EC2 bootstrap failure
- ClickHouse 26.3 incompatible with app schema (projection errors)
- Init task ran before ClickHouse was healthy
- Demo accounts not seeded (env vars missing)
- Backup script broken on IAM-role instances
- No support for deploying into existing VPCs

## Fixes

* Fixes the prod deployment post-mortem (all P0-P3 items)

## Approach

1. **Tarball URL**: add `v` prefix, retry loop (5 attempts), and embedded ClickHouse config fallback so bootstrap succeeds even if the tarball 404s
2. **ClickHouse version**: pin to 26.5 (matches dev docker-compose), add `deduplicate_merge_projection_mode=drop` to user profile
3. **user-data staleness**: `user_data_replace_on_change = true` so template changes force instance recreation
4. **Init task ordering**: depends_on `aws_instance.data_host` + 120s sleep for bootstrap
5. **Demo accounts**: all 4 tiers (super_admin, admin, reviewer, user) as optional tfvars
6. **Backup script**: uses instance IAM role via `aws s3 sync` instead of broken `aws configure get`
7. **BYO-VPC**: optional `vpc_id`, `private_subnet_ids`, `public_subnet_ids` variables; skips VPC/subnet/NAT/IGW creation when set
8. **deploy.sh**: pre-flight doctor script that validates everything before the user runs terraform (does NOT auto-apply)

## How Has This Been Tested?

- bash syntax validation on deploy.sh and user-data.sh.tftpl (bash -n)
- Verified all Terraform variable references resolve (no undefined vars)
- Verified HCL brace balance across all .tf files
- Confirmed BYO-VPC references use `local.vpc_id` / `local.*_subnet_ids` consistently
- Confirmed conditional resource counts propagate correctly (count=0 when BYO-VPC)

Full e2e validation requires a terraform apply against a real AWS account (recommend testing in staging before prod re-deploy).

## Learning

- ClickHouse 26.x introduced `deduplicate_merge_projection_mode` which defaults to `throw`, breaking ReplacingMergeTree tables with projections. Setting it to `drop` is the fix.
- EC2 user-data completion is NOT something Terraform waits for. The instance reaches "running" state immediately. Must use sleep or external health check for dependencies.
- `aws configure get` returns empty on instances using IAM roles. Always use the implicit role via AWS CLI directly.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)