### PR TITLE
fix(infra): fix deploy doctor sed portability and ec2 describe-vpcs check

### DIFF
--- a/infra/terraform/aws/deploy.sh
+++ b/infra/terraform/aws/deploy.sh
@@ -118,7 +118,7 @@ if [ -f "terraform.tfvars" ]; then
   pass "terraform.tfvars exists"
 
   # Validate key fields
-  get_tfvar() { grep "^$1" terraform.tfvars 2>/dev/null | sed 's/.*=\s*"\(.*\)"/\1/' | sed "s/.*=\s*'/\1/" | head -1; }
+  get_tfvar() { grep "^$1" terraform.tfvars 2>/dev/null | sed 's/.*=[ ]*"\(.*\)"/\1/' | sed "s/.*=[ ]*'\(.*\)'/\1/" | head -1; }
 
   REGION=$(get_tfvar "region")
   IMAGE_TAG=$(get_tfvar "image_tag")
@@ -257,7 +257,7 @@ else
   info "Required: AdministratorAccess or equivalent for initial deployment"
 fi
 
-if aws ec2 describe-vpcs --region "${REGION:-us-east-1}" --max-results 1 >/dev/null 2>&1; then
+if aws ec2 describe-vpcs --region "${REGION:-us-east-1}" --query 'Vpcs[0].VpcId' --output text >/dev/null 2>&1; then
   pass "EC2/VPC access confirmed"
 else
   fail "Cannot access EC2/VPC (check IAM permissions)"


### PR DESCRIPTION
## Purpose / Description

Fixes two bugs in `deploy.sh` that caused false-positive failures during the prod deployment validation:

1. `get_tfvar()` regex used `\s*` which is not supported by BSD sed (macOS) or some minimal Linux environments. Values like `region = "us-east-1"` were not extracted, causing "region not set" errors even when set correctly.

2. The EC2/VPC permission check used `aws ec2 describe-vpcs --max-results 1` but `describe-vpcs` does not support `--max-results`. The invalid parameter caused the AWS CLI to error, which the script misreported as "Cannot access EC2/VPC (check IAM permissions)" even with AdministratorAccess.

## Fixes

* Fixes deploy doctor false failures reported during Appian prod deployment

## Approach

- Replace `\s*` with `[ ]*` in sed for POSIX portability
- Replace `--max-results 1` with `--query` to validate EC2 access without unsupported flags

## How Has This Been Tested?

- Verified sed extraction works on macOS BSD sed: `echo 'region = "us-east-1"' | sed 's/.*=[ ]*"\(.*\)"/\1/'` outputs `us-east-1`
- bash -n syntax check passes
- The failing tfvars from the Appian deployment (region, image_tag, license_key all set) would now parse correctly

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)