### PR TITLE
fix(security): redact MCP clone tokens

### DIFF
--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import ast
@@ -20,6 +21,7 @@ from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.mcp import McpListing, McpValidationResult
+from services.secrets_redactor import REDACTED, redact_secrets
 from services.ssrf_guard import is_private_url as _ssrf_is_private
 
 ALLOW_HTTP_GIT = os.environ.get("MCP_ALLOW_HTTP_GIT", "").lower() in ("1", "true", "yes")
@@ -82,6 +84,14 @@ def _build_clone_url(git_url: str) -> str:
     #   GitLab:  "oauth2" for OAuth tokens, or "private-token" for PATs
     token_user = os.environ.get("GIT_CLONE_TOKEN_USER", "x-access-token")
     return f"{parsed.scheme}://{token_user}:{git_token}@{parsed.hostname}{parsed.path}"
+
+
+def _redact_clone_error(error: Exception) -> str:
+    message = str(error)
+    git_token = os.environ.get("GIT_CLONE_TOKEN", "")
+    if git_token:
+        message = message.replace(git_token, REDACTED)
+    return redact_secrets(message)
 
 
 async def _async_clone(clone_url: str, dest: str, depth: int = 1) -> None:
@@ -502,7 +512,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
                 listing_id=listing.id,
                 stage="clone_and_inspect",
                 passed=False,
-                details=f"Failed to clone repo: {e}",
+                details=f"Failed to clone repo: {_redact_clone_error(e)}",
             )
         )
         await db.commit()

--- a/tests/test_audit2_pr1_ingest_bounds.py
+++ b/tests/test_audit2_pr1_ingest_bounds.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Regression coverage for Audit 2 PR1 ingest abuse guardrails."""
@@ -181,6 +182,35 @@ def test_mcp_validator_warning_is_empty_for_https_urls():
     with patch.object(mcp_validator, "ALLOW_HTTP_GIT", True):
         assert mcp_validator._git_url_warning("https://github.com/example/repo") == ""
         assert mcp_validator._git_url_warning("https://gitlab.example.com/x.git") == ""
+
+
+@pytest.mark.asyncio
+async def test_mcp_validator_redacts_clone_token_from_validation_details(monkeypatch):
+    import uuid
+
+    import services.mcp_validator as mcp_validator
+
+    token = "super-secret-git-token-1234567890"
+    listing = SimpleNamespace(id=uuid.uuid4(), git_url="https://github.com/example/private-repo.git")
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    clone_error = RuntimeError(
+        f"fatal: Authentication failed for 'https://x-access-token:{token}@github.com/example/private-repo.git/'"
+    )
+    monkeypatch.setenv("GIT_CLONE_TOKEN", token)
+
+    with (
+        patch.object(mcp_validator, "_validate_git_url", return_value=None),
+        patch.object(mcp_validator, "_async_clone", new=AsyncMock(side_effect=clone_error)),
+    ):
+        result = await mcp_validator._clone_and_inspect(listing, db, "/tmp/unused")
+
+    assert result is None
+    validation_result = db.add.call_args.args[0]
+    assert token not in validation_result.details
+    assert "Failed to clone repo:" in validation_result.details
+    assert "**REDACTED**" in validation_result.details
 
 
 def test_mcp_validator_env_var_controls_allowed_schemes_at_import():


### PR DESCRIPTION
## Purpose / Description

MCP validation supports private repositories by injecting `GIT_CLONE_TOKEN` into the Git clone URL before calling Git.

If the clone fails, the validation path currently stores the raw exception text in `McpValidationResult.details`. Git clone errors can include the URL that was attempted, which means an authenticated clone URL may be persisted with the token included.

That creates a secret exposure risk in validation results.

## Fixes

Fixes #1317 

## Approach

This change sanitizes clone failure messages before they are saved.

It adds a small helper that:

1. Replaces the configured `GIT_CLONE_TOKEN` with the project’s redaction marker.
2. Passes the resulting message through the existing `redact_secrets()` helper for defense in depth.
3. Uses the sanitized message when writing `McpValidationResult.details`.

This keeps the validation error useful while preventing the clone token from being stored.

A regression test was added for the specific failure mode: a clone exception containing an authenticated Git URL.

## How Has This Been Tested?

Ran the targeted backend regression test file:

```bash
uv run --project observal-server pytest tests/test_audit2_pr1_ingest_bounds.py -q
```

Result:

```text
22 passed in 0.59s
```
Commit hooks also passed when creating the commit.

## Learning (optional, can help others)

I followed the existing secret-redaction pattern already used elsewhere in the backend, especially the recent hardening around ingest and GraphQL read paths.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [x] UI changes: not applicable; backend-only change.