### PR TITLE
fix(docker): increase API health check start_period to 60s

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,8 +84,8 @@ services:
         ]
       interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 15s
+      retries: 5
+      start_period: 60s
     read_only: true
     tmpfs:
       - /tmp


### PR DESCRIPTION
## Purpose

  Increase Docker health check `start_period` from 15s to 60s for the API container.

  ## Fixes

  Multi-worker uvicorn with Redis pubsub subscriber takes ~30-45s to stabilize on cold start. The previous 15s window caused the container to be marked unhealthy,
  failing CI deploys even though the app was functional.

  ## Approach

  - `start_period`: 15s → 60s
  - `retries`: 3 → 5

  ## How Has This Been Tested?

  - Observed on `internal.observal.io` — API responded correctly to `/readyz` but docker marked it unhealthy during the startup crash-loop. After stabilization (~30s),
  container became healthy and stayed healthy.

  ## Checklist

  - [x] Descriptive commit message with short title
  - [x] Self-review performed