### PR TITLE
fix(auth): use platform-aware browser open for device flow

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -553,8 +553,31 @@ def _do_device_flow_login(server_url: str):
 
     # Try to open browser automatically
     try:
-        webbrowser.open(verification_uri_complete)
-        rprint("[dim]Browser opened automatically.[/dim]")
+        import platform
+        import subprocess as _sp
+
+        _opened = False
+        _sys = platform.system()
+        if _sys == "Darwin":
+            _sp.Popen(["open", verification_uri_complete], stderr=_sp.DEVNULL, stdout=_sp.DEVNULL)
+            _opened = True
+        elif _sys == "Linux":
+            # WSL: use powershell.exe to open in Windows browser
+            _wsl = _sp.run(["wslpath", "-w", "/"], capture_output=True)
+            if _wsl.returncode == 0:
+                _sp.Popen(
+                    ["powershell.exe", "-NoProfile", "-c", f"Start-Process '{verification_uri_complete}'"],
+                    stderr=_sp.DEVNULL,
+                    stdout=_sp.DEVNULL,
+                )
+            else:
+                _sp.Popen(["xdg-open", verification_uri_complete], stderr=_sp.DEVNULL, stdout=_sp.DEVNULL)
+            _opened = True
+        else:
+            webbrowser.open(verification_uri_complete)
+            _opened = True
+        if _opened:
+            rprint("[dim]Browser opened automatically.[/dim]")
     except Exception:
         rprint("[dim]Could not open browser automatically. Please open the URL manually.[/dim]")
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose

Fix `observal auth login` printing `gio: Operation not supported` error on WSL when opening the browser for device authorization.

## Approach

**Problem:** `webbrowser.open()` on WSL calls `gio` (a Linux desktop tool) which fails with "Operation not supported" since WSL has no native browser. The error message is printed to the terminal, confusing users.

**Fix:** Replace `webbrowser.open()` with platform-aware subprocess calls:
- **macOS:** `open <url>`
- **Linux (WSL):** `powershell.exe Start-Process <url>` — opens in the Windows default browser
- **Linux (native):** `xdg-open <url>`
- **Windows:** falls back to `webbrowser.open()`

WSL detection uses `wslpath -w /` (returns 0 only on WSL). All subprocess calls suppress stderr/stdout to avoid terminal pollution.

## How has this been tested

- Manual testing on WSL: option [2] opens browser via `powershell.exe` without `gio` errors
- `observal_cli/tests/test_cmd_auth.py` — 10/10 passing
