### PR TITLE
bump(release): v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.4] - 2026-06-01
+
+### Added
+
+- allow agent owners and co-authors to generate insights (**insights**) ([d285cd7](https://github.com/BlazeUp-AI/Observal/commit/d285cd7c3ba68cc42fb799461b0d0b4db9f8fede))
+- replace custom LLM calls with LiteLLM (**insights**) ([0b59845](https://github.com/BlazeUp-AI/Observal/commit/0b59845a45cf3ddfaf4aae86a6e803079e876791))
+
+### Changed
+
+- remove global admin Insights page from sidebar (**web**) ([68ef1e2](https://github.com/BlazeUp-AI/Observal/commit/68ef1e2677441dd4f843155400bc8e8f6e73e4d6))
+- consolidate command structure, remove duplicates (**cli**) ([a222745](https://github.com/BlazeUp-AI/Observal/commit/a22274599bc6d55b349eb200add889dbba1a0655))
+
+### Fixed
+
+- remove dots from approved/pending badges, remove placeholder Analytics tab (**web**) ([4851822](https://github.com/BlazeUp-AI/Observal/commit/485182235f3a7fa0a92029aedd224e22dc21bce0))
+- skip AWS credential check when direct API key is configured (**insights**) ([4b72c76](https://github.com/BlazeUp-AI/Observal/commit/4b72c76c1513ed04cea182e834af01a4d7beb3be))
+- increase API health check start_period to 60s (**docker**) ([de74ff4](https://github.com/BlazeUp-AI/Observal/commit/de74ff4ba56647fd59843eff9d895b7878eb9653))
+- chunk all session push paths to respect MAX_SESSION_LINES (**ingest**) ([1478885](https://github.com/BlazeUp-AI/Observal/commit/1478885b1657949486e39df448e877c2a3d25791))
 ## [1.4.3] - 2026-05-31
 
 ### Added

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.4.3"
+version = "1.4.4"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "AGPL-3.0-only"

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1671,7 +1671,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.4.3"
+version = "1.4.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [
     "pi-package",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.4.3"
+version = "1.4.4"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.4.3"
+version = "1.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Release v1.4.4 (patch)

Bumps version `1.4.3` → `1.4.4` and regenerates changelog.

**Merging this PR will automatically trigger the release pipeline.**

### What happens after merge
- CLI binaries built for 6 platforms (Linux/macOS/Windows, x64/arm64)
- Docker images pushed to GHCR
- Server deployment tarball packaged
- PyPI package published
- **Approval required** in the `production` environment before GitHub Release publishes