### PR TITLE
ec2 terraform vars - env

### DIFF
--- a/infra/terraform/aws-ec2/deploy.sh
+++ b/infra/terraform/aws-ec2/deploy.sh
@@ -17,6 +17,7 @@ REGION=$(terraform output -raw region)
 DOMAIN=$(terraform output -raw domain)
 OBSERVAL_REF=$(terraform output -raw observal_ref)
 OBSERVAL_REPO=$(terraform output -raw observal_repo)
+ENV_OVERRIDES=$(terraform output -json env_overrides 2>/dev/null || echo "{}")
 
 echo "=== Observal EC2 Deploy ==="
 echo "  Instance:  $INSTANCE_ID"
@@ -119,7 +120,16 @@ run_remote "rm -rf /opt/observal && git clone $OBSERVAL_REPO /opt/observal && cd
 
 echo "Configuring environment..."
 SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))" 2>/dev/null || openssl rand -base64 32)
-run_remote "cd /opt/observal && cp .env.example .env && sed -i \"s|SECRET_KEY=.*|SECRET_KEY=$SECRET_KEY|\" .env"
+
+# Build sed commands for env overrides (skip empty values)
+SED_CMDS="sed -i \"s|SECRET_KEY=.*|SECRET_KEY=$SECRET_KEY|\" .env"
+while IFS='=' read -r key value; do
+  [ -z "$key" ] && continue
+  [ -z "$value" ] && continue
+  SED_CMDS="$SED_CMDS && sed -i \"s|${key}=.*|${key}=${value}|\" .env"
+done < <(echo "$ENV_OVERRIDES" | python3 -c "import sys,json; [print(f'{k}={v}') for k,v in json.load(sys.stdin).items()]" 2>/dev/null || true)
+
+run_remote "cd /opt/observal && cp .env.example .env && $SED_CMDS"
 
 # ── Configure nginx + TLS ────────────────────────────────────────────────────
 

--- a/infra/terraform/aws-ec2/outputs.tf
+++ b/infra/terraform/aws-ec2/outputs.tf
@@ -36,6 +36,12 @@ output "observal_ref" {
   value       = var.observal_ref
 }
 
+output "env_overrides" {
+  description = "Environment overrides (for deploy.sh)"
+  value       = var.env_overrides
+  sensitive   = true
+}
+
 output "observal_repo" {
   description = "Git repository URL"
   value       = var.observal_repo

--- a/infra/terraform/aws-ec2/terraform.tfvars.example
+++ b/infra/terraform/aws-ec2/terraform.tfvars.example
@@ -19,6 +19,34 @@ route53_zone_id = ""
 # Git ref to deploy (branch, tag, or commit SHA)
 observal_ref = "main"
 
+# Environment variable overrides
+# Empty values ("") use the default from .env.example. Only fill in what you need to change.
+env_overrides = {
+  OBSERVAL_LICENSE_KEY      = ""
+  OAUTH_CLIENT_ID           = ""
+  OAUTH_CLIENT_SECRET       = ""
+  JWT_KEY_DIR               = ""
+  JWT_SIGNING_ALGORITHM     = ""
+  LOG_LEVEL                 = ""
+  LOG_FORMAT                = ""
+  SEED_DEMO_ACCOUNTS        = ""
+  DEMO_SUPER_ADMIN_EMAIL    = ""
+  DEMO_SUPER_ADMIN_PASSWORD = ""
+  DEMO_ADMIN_EMAIL          = ""
+  DEMO_ADMIN_PASSWORD       = ""
+  DEMO_REVIEWER_EMAIL       = ""
+  DEMO_REVIEWER_PASSWORD    = ""
+  DEMO_USER_EMAIL           = ""
+  DEMO_USER_PASSWORD        = ""
+  DATABASE_URL              = ""
+  CLICKHOUSE_URL            = ""
+  REDIS_URL                 = ""
+  POSTGRES_USER             = ""
+  POSTGRES_PASSWORD         = ""
+  CLICKHOUSE_USER           = ""
+  CLICKHOUSE_PASSWORD       = ""
+}
+
 # VPC (optional — leave empty for default VPC)
 # vpc_id    = "vpc-0123456789abcdef0"
 # subnet_id = "subnet-0123456789abcdef0"

--- a/infra/terraform/aws-ec2/variables.tf
+++ b/infra/terraform/aws-ec2/variables.tf
@@ -42,6 +42,12 @@ variable "subnet_id" {
   default     = ""
 }
 
+variable "env_overrides" {
+  description = "Map of environment variables to override in .env (empty values are ignored, defaults from .env.example are kept)"
+  type        = map(string)
+  default     = {}
+}
+
 variable "observal_ref" {
   description = "Git branch, tag, or commit SHA to deploy"
   type        = string


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Add `env_overrides` terraform variable to allow customization of any Observal .env value (license key, OAuth, demo accounts, etc.) without hardcoding individual variables for each setting.


## Approach
- Added `env_overrides` as a `map(string)` variable — users pass key/value pairs in their tfvars
- `deploy.sh` reads the map as JSON from terraform output and applies non-empty values via `sed` to the .env file
- Empty values are skipped, preserving .env.example defaults
- Marked as `sensitive` to avoid printing secrets in plan output

## How Has This Been Tested?
- Terraform validates cleanly (`terraform validate` passes)
- Shell script passes syntax check (`bash -n deploy.sh`)
- Based on the same env override pattern used in production earlier

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->
