### PR TITLE
fix(server): resolve API OOM crash loop and pub/sub subscriber failures

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       replicas: ${API_REPLICAS:-1}
       resources:
         limits:
-          memory: 512M
+          memory: ${API_MEMORY_LIMIT:-1536M}
     networks:
       - observal-net
 
@@ -205,7 +205,7 @@ services:
       replicas: ${WORKER_REPLICAS:-1}
       resources:
         limits:
-          memory: 512M
+          memory: ${WORKER_MEMORY_LIMIT:-1536M}
     networks:
       - observal-net
 

--- a/observal-server/services/agent_registry_cache.py
+++ b/observal-server/services/agent_registry_cache.py
@@ -82,14 +82,26 @@ async def _periodic_refresh() -> None:
 
 
 async def _listen_for_invalidation() -> None:
-    """Subscribe to Redis pub/sub for immediate cache invalidation."""
-    try:
-        async for _msg in subscribe(INVALIDATION_CHANNEL):
-            await _refresh_all()
-    except asyncio.CancelledError:
-        pass
-    except Exception:
-        optic.error("registry cache subscriber crashed - cache will not auto-update")
+    """Subscribe to Redis pub/sub for immediate cache invalidation.
+
+    Retries indefinitely with backoff — the periodic refresh task ensures
+    the cache stays reasonably fresh even if pub/sub is temporarily down.
+    """
+    backoff = 5
+    while True:
+        try:
+            async for _msg in subscribe(INVALIDATION_CHANNEL):
+                backoff = 5
+                await _refresh_all()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            optic.warning(
+                "registry cache subscriber lost connection - retrying in {}s (periodic refresh still active)",
+                backoff,
+            )
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 60)
 
 
 async def start() -> None:

--- a/observal-server/services/redis.py
+++ b/observal-server/services/redis.py
@@ -78,7 +78,13 @@ async def subscribe(channel: str):
     max_reconnects = 5
     reconnect_count = 0
     while reconnect_count < max_reconnects:
-        r = get_redis()
+        pubsub_pool = aioredis.ConnectionPool.from_url(
+            settings.REDIS_URL,
+            decode_responses=True,
+            max_connections=2,
+            socket_connect_timeout=settings.REDIS_SOCKET_TIMEOUT,
+        )
+        r = aioredis.Redis(connection_pool=pubsub_pool)
         pubsub = r.pubsub()
         try:
             await pubsub.subscribe(channel)
@@ -91,7 +97,7 @@ async def subscribe(channel: str):
                     except (json.JSONDecodeError, TypeError):
                         optic.trace("malformed message on '{}', skipping", channel)
                         continue
-        except (ConnectionError, OSError) as e:
+        except (ConnectionError, OSError, TimeoutError) as e:
             reconnect_count += 1
             optic.warning(
                 "lost connection to '{}', reconnecting ({}/{}) - {}",
@@ -105,6 +111,10 @@ async def subscribe(channel: str):
             try:
                 await pubsub.unsubscribe(channel)
                 await pubsub.close()
+            except Exception:
+                pass
+            try:
+                await pubsub_pool.disconnect()
             except Exception:
                 pass
 


### PR DESCRIPTION
## Purpose / Description
API container OOM crash-loops every ~12s after LiteLLM was added, making the app extremely slow. The Redis pub/sub subscriber also dies permanently on timeout, flooding logs with errors.

## Fixes
* Fixes the production outage on internal.observal.io (API unresponsive)

## Approach
1. Increase API/worker memory limits from 512MB to 1536MB (configurable via env var)
2. Use a dedicated connection pool without `socket_timeout` for pub/sub subscribers
3. Catch `TimeoutError` in the subscribe reconnect handler
4. Make registry cache subscriber retry indefinitely with backoff instead of dying permanently

## How Has This Been Tested?
- Deployed to production EC2 (`internal.observal.io`) — API stable at 675MB/1.5GB, 0.5% CPU
- Confirmed crash loop stopped (was restarting every ~12s, now stable)
- Verified Redis pub/sub subscribe works without timeout errors

## Learning
- LiteLLM imports cost ~131MB — pushed the process past the 512MB container limit
- Redis `socket_timeout` applies to pub/sub `listen()` which needs to block indefinitely waiting for messages
- OOM-killed child processes leave zombies that accumulate (38 at peak)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)