### PR TITLE
docs: rebrand README — remove observability framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
  ╚═════╝ ╚═════╝ ╚══════╝╚══════╝╚═╝  ╚═╝  ╚═══╝  ╚═╝  ╚═╝╚══════╝
 </pre>
 
-**A unified platform for agent distribution, observability and insights. Every session, prompt, and tool call is captured. Enterprise edition adds SSO, SCIM provisioning, and executive dashboards.**
+**A unified platform for agent registry and analytics. Enterprise edition adds SSO, SCIM provisioning, and organizational AI insights.**
 
 <p>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License"></a>
@@ -120,22 +120,6 @@ Once connected, Observal captures your entire coding session: every user prompt,
 ### The registry is a package manager for agents
 
 Browse published agents, see which IDEs they support, check download counts and ratings, and install with one command. Admins review submissions before they go live. Version diffs show exactly what changed between releases.
-
----
-
-## Session Observability
-
-**Full session overview with token counts, models, tools, and turn-by-turn timeline:**
-
-![Session detail showing tokens, tools, models, and turns](docs/img/ses1.png)
-
-**Every turn captured: user prompt, tool calls, thinking block, assistant response:**
-
-![Turn expanded showing user prompt, thinking, and response](docs/img/complete_capture_thinking_response.png)
-
-**Drill into any span to see exact tool inputs and outputs:**
-
-![Span detail showing bash command input and full output](docs/img/span.png)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates the README to align with the project's evolved positioning as an **agent registry and analytics** platform rather than an observability tool.

## Changes

### Tagline updated
- **Before:** "A unified platform for agent distribution, observability and insights. Every session, prompt, and tool call is captured. Enterprise edition adds SSO, SCIM provisioning, and executive dashboards."
- **After:** "A unified platform for agent registry and analytics. Enterprise edition adds SSO, SCIM provisioning, and organizational AI insights."

### Removed content
- Removed the entire **Session Observability** section, including:
  - Full session overview screenshot (`ses1.png`)
  - Turn capture screenshot (`complete_capture_thinking_response.png`)
  - Span detail screenshot (`span.png`)
  - All associated descriptions

### Rationale
- The word "observability" no longer reflects the product direction
- "Agent distribution" is redundant given the registry section already covers this
- "Executive dashboards" replaced with "organizational AI insights" to better describe the enterprise analytics capability
- The Session Observability section highlighted telemetry capture which is being de-emphasized in external messaging

## Testing
- Verified markdown renders correctly
- No broken links introduced (removed section was self-contained with its own images)