### PR TITLE
fix/audit2 019 skill frontmatter injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 SrihariLegend <sriharilegend23@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 DoomsCoder <vedantkakade05@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
 # Changelog
@@ -1848,4 +1849,3 @@ All notable changes to this project will be documented in this file.
 ### Ui
 
 - brighter borders, responsive text scaling, observal favicon ([909a9b6](https://github.com/BlazeUp-AI/Observal/commit/909a9b6dd7cedc9ddaff31b208f09ace9d35be7e))
-

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 from datetime import UTC, datetime
@@ -36,10 +37,18 @@ from schemas.skill import (
     SkillSubmitRequest,
     SkillUpdateRequest,
 )
+from schemas.skill_commands import normalize_slash_command
 from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
-from services.skill_validator import SkillValidationError, validate_skill_md
+from services.skill_validator import SkillValidationError, validate_skill_md, validate_skill_md_content_frontmatter
 
 router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
+
+
+def _validate_stored_skill_md(skill_md_content: str | None, slash_command: str | None = None):
+    try:
+        return validate_skill_md_content_frontmatter(skill_md_content, slash_command=slash_command)
+    except SkillValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.post("/submit", response_model=SkillListingResponse)
@@ -70,22 +79,17 @@ async def submit_skill(
         # Registry direct: skill_md_content is required, no git validation
         if not skill_md_content:
             raise HTTPException(status_code=422, detail="skill_md_content is required for registry_direct delivery")
-        # Parse frontmatter for auto-fill using simple string ops (no regex on user data)
-        import re as _re
-
-        fm_match = _re.match(r"^---\r?\n([\s\S]*?)\r?\n---", skill_md_content)
-        if fm_match:
-            for line in fm_match.group(1).split("\n"):
-                if line.startswith("name:") and not name:
-                    name = line[5:].strip()
-                elif line.startswith("description:") and not description:
-                    val = line[12:].strip()
-                    # Strip surrounding quotes
-                    if len(val) >= 2 and val[0] in ("'", '"') and val[-1] == val[0]:
-                        val = val[1:-1]
-                    description = val
-                elif line.startswith("command:") and slash_command is None:
-                    slash_command = line[8:].strip().lstrip("/")
+        content_analysis = _validate_stored_skill_md(skill_md_content, slash_command)
+        fm = content_analysis.frontmatter
+        if fm:
+            fm_name = fm.get("name")
+            fm_description = fm.get("description")
+            if isinstance(fm_name, str) and not name:
+                name = fm_name
+            if isinstance(fm_description, str) and not description:
+                description = fm_description
+            if content_analysis.slash_command is not None:
+                slash_command = content_analysis.slash_command
         validated = True  # Content is inline, no need to fetch from git
     elif req.git_url:
         try:
@@ -105,13 +109,24 @@ async def submit_skill(
                 description = analysis.description
             if slash_command is None:
                 slash_command = analysis.slash_command
+            elif analysis.slash_command is not None and slash_command != analysis.slash_command:
+                raise HTTPException(status_code=422, detail="slash_command does not match SKILL.md frontmatter command")
         except SkillValidationError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    if skill_md_content:
+        content_analysis = _validate_stored_skill_md(skill_md_content, slash_command)
+        if content_analysis.slash_command is not None:
+            slash_command = content_analysis.slash_command
 
     if not name:
         raise HTTPException(status_code=422, detail="name is required")
     if not description:
         raise HTTPException(status_code=422, detail="description is required")
+    try:
+        slash_command = normalize_slash_command(slash_command)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"Invalid slash_command: {exc}") from exc
 
     # Re-check uniqueness with resolved name (may differ from req.name when auto-filled).
     if name != req.name:
@@ -260,6 +275,9 @@ async def save_skill_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("req={}", req)
+    content_analysis = _validate_stored_skill_md(req.skill_md_content, req.slash_command)
+    slash_command = content_analysis.slash_command
+
     listing = SkillListing(
         name=req.name,
         owner=req.owner or current_user.username or current_user.email,
@@ -282,7 +300,7 @@ async def save_skill_draft(
         script_filename=req.script_filename,
         target_agents=req.target_agents,
         task_type=req.task_type,
-        slash_command=req.slash_command,
+        slash_command=slash_command,
         supported_ides=req.supported_ides,
         status=ListingStatus.draft,
         released_by=current_user.id,
@@ -317,6 +335,19 @@ async def update_skill_draft(
     if not ver:
         raise HTTPException(status_code=400, detail="Listing has no version to update")
 
+    slash_command_should_update = "slash_command" in req.model_fields_set
+    slash_command_explicit_clear = slash_command_should_update and req.slash_command is None
+    slash_command = req.slash_command if slash_command_should_update else None
+    if req.skill_md_content is not None:
+        content_analysis = _validate_stored_skill_md(req.skill_md_content, slash_command)
+        if content_analysis.slash_command is not None and not slash_command_explicit_clear:
+            slash_command = content_analysis.slash_command
+            slash_command_should_update = True
+    elif slash_command_should_update:
+        content_analysis = _validate_stored_skill_md(ver.skill_md_content, slash_command)
+        if not slash_command_explicit_clear:
+            slash_command = content_analysis.slash_command
+
     for field in (
         "version",
         "description",
@@ -329,12 +360,14 @@ async def update_skill_draft(
         "script_filename",
         "target_agents",
         "task_type",
-        "slash_command",
         "supported_ides",
     ):
         val = getattr(req, field)
         if val is not None:
             setattr(ver, field, val)
+
+    if slash_command_should_update:
+        ver.slash_command = slash_command
 
     # Don't allow saving over another user's active lock
     if ver.is_editing and ver.editing_by != current_user.id and not _is_lock_expired(ver.editing_since):
@@ -417,6 +450,13 @@ async def submit_skill_draft(
         raise HTTPException(status_code=403, detail="Not the listing owner")
     if listing.status not in (ListingStatus.draft, ListingStatus.rejected):
         raise HTTPException(status_code=400, detail="Listing is not a draft")
+
+    ver = listing.latest_version
+    if not ver:
+        raise HTTPException(status_code=400, detail="Listing has no version")
+    content_analysis = _validate_stored_skill_md(ver.skill_md_content, ver.slash_command)
+    if content_analysis.slash_command is not None:
+        ver.slash_command = content_analysis.slash_command
 
     if not listing.description:
         raise HTTPException(status_code=400, detail="Description is required before submitting")

--- a/observal-server/schemas/skill.py
+++ b/observal-server/schemas/skill.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import uuid
@@ -10,6 +11,7 @@ from pydantic import BaseModel, field_validator
 
 from models.mcp import ListingStatus
 from schemas.constants import VALID_SKILL_TASK_TYPES, make_ide_list_validator, make_option_validator
+from schemas.skill_commands import normalize_slash_command
 
 
 class SkillSubmitRequest(BaseModel):
@@ -32,6 +34,11 @@ class SkillSubmitRequest(BaseModel):
     _validate_task_type = field_validator("task_type")(make_option_validator("task_type", VALID_SKILL_TASK_TYPES))
     _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
 
+    @field_validator("slash_command")
+    @classmethod
+    def _validate_slash_command(cls, v: str | None) -> str | None:
+        return normalize_slash_command(v)
+
 
 class SkillDraftRequest(BaseModel):
     name: str
@@ -52,6 +59,11 @@ class SkillDraftRequest(BaseModel):
 
     _validate_ides = field_validator("supported_ides")(make_ide_list_validator())
 
+    @field_validator("slash_command")
+    @classmethod
+    def _validate_slash_command(cls, v: str | None) -> str | None:
+        return normalize_slash_command(v)
+
 
 class SkillUpdateRequest(BaseModel):
     name: str | None = None
@@ -69,6 +81,11 @@ class SkillUpdateRequest(BaseModel):
     task_type: str | None = None
     slash_command: str | None = None
     supported_ides: list[str] | None = None
+
+    @field_validator("slash_command")
+    @classmethod
+    def _validate_slash_command(cls, v: str | None) -> str | None:
+        return normalize_slash_command(v)
 
 
 class SkillListingResponse(BaseModel):

--- a/observal-server/schemas/skill_commands.py
+++ b/observal-server/schemas/skill_commands.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+import re
+
+SLASH_COMMAND_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def normalize_slash_command(value: str | None) -> str | None:
+    """Return a canonical slash command name, or raise for unsafe values."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("slash_command must be a string")
+
+    if value == "":
+        return None
+    command = value
+    if command.startswith("/"):
+        command = command[1:]
+    if not SLASH_COMMAND_RE.fullmatch(command):
+        raise ValueError("slash_command must match ^[a-z0-9][a-z0-9_-]{0,63}$")
+    return command

--- a/observal-server/services/component_version_extras.py
+++ b/observal-server/services/component_version_extras.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Per-type field validation for component version publishing."""
@@ -8,6 +9,9 @@ from __future__ import annotations
 
 from fastapi import HTTPException
 from loguru import logger as optic
+
+from schemas.skill_commands import normalize_slash_command
+from services.skill_validator import SkillValidationError, validate_skill_md_content_frontmatter
 
 # Fields allowed in extra dict per component type
 HOOK_FIELDS = {
@@ -204,4 +208,19 @@ def validate_and_extract(component_type: str, extra: dict | None) -> dict:
                 detail=f"Field {field!r} must be a {expected_name}, got {type(value).__name__}",
             )
 
-    return {k: v for k, v in extra.items() if k in allowed}
+    clean = {k: v for k, v in extra.items() if k in allowed}
+    if component_type == "skill":
+        try:
+            if "slash_command" in clean:
+                clean["slash_command"] = normalize_slash_command(clean["slash_command"])
+            if "skill_md_content" in clean:
+                analysis = validate_skill_md_content_frontmatter(
+                    clean.get("skill_md_content"),
+                    slash_command=clean.get("slash_command") if "slash_command" in clean else None,
+                )
+                if analysis.slash_command is not None:
+                    clean["slash_command"] = analysis.slash_command
+        except (SkillValidationError, ValueError) as exc:
+            raise HTTPException(status_code=422, detail=f"Invalid skill metadata: {exc}") from exc
+
+    return clean

--- a/observal-server/services/config/skill_builder.py
+++ b/observal-server/services/config/skill_builder.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Consolidated skill file builder.
@@ -12,11 +13,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import yaml
+
 from schemas.ide_registry import IDE_REGISTRY
+from schemas.skill_commands import normalize_slash_command
 from services.shared.utils import sanitize_name as _sanitize_name
+from services.skill_validator import validate_skill_md_content_frontmatter
 
 if TYPE_CHECKING:
     from services.agent_builder_types import AgentFile, AgentManifest
+
+
+def _yaml_frontmatter(data: dict[str, str | bool]) -> str:
+    body = yaml.safe_dump(data, sort_keys=False, default_flow_style=False, allow_unicode=True).strip()
+    return f"---\n{body}\n---\n\n"
 
 
 def generate_skill_file(skill: dict, ide: str, scope: str = "project") -> dict | None:
@@ -40,14 +50,15 @@ def generate_skill_file(skill: dict, ide: str, scope: str = "project") -> dict |
 
     skill_format = spec.get("skill_format")
     if skill_format == "yaml_frontmatter":
-        content = f"---\nname: {name}\n"
+        frontmatter = {"name": name}
         if desc:
-            content += f'description: "{desc}"\n'
+            frontmatter["description"] = desc
         if slash_cmd and ide_key == "claude-code":
-            content += f"command: /{slash_cmd}\n"
-        content += f"---\n\n{desc}\n"
+            frontmatter["command"] = f"/{normalize_slash_command(slash_cmd)}"
+        content = _yaml_frontmatter(frontmatter) + f"{desc}\n"
     else:
-        content = f"---\ndescription: {desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+        frontmatter = {"description": desc, "alwaysApply": False}
+        content = _yaml_frontmatter(frontmatter) + f"# {name}\n\n{desc}\n"
 
     return {"path": path, "content": content}
 
@@ -79,19 +90,21 @@ def build_skill_files(manifest: AgentManifest, ide: str) -> list[AgentFile]:
         # Fast path: verbatim SKILL.md from git repo
         skill_md_content: str | None = (skill.config_override or {}).get("skill_md_content")
         if skill_md_content:
+            validate_skill_md_content_frontmatter(skill_md_content, slash_command=skill.slash_command)
             files.append(AgentFile(path=path, content=skill_md_content, format="markdown"))
             continue
 
         # Fallback: synthetic stub
         if skill_format == "yaml_frontmatter":
-            content = f"---\nname: {name}\n"
+            frontmatter = {"name": name}
             if desc:
-                content += f'description: "{desc}"\n'
+                frontmatter["description"] = desc
             if skill.slash_command and ide_key == "claude-code":
-                content += f"command: /{skill.slash_command}\n"
-            content += f"---\n\n{desc}\n"
+                frontmatter["command"] = f"/{normalize_slash_command(skill.slash_command)}"
+            content = _yaml_frontmatter(frontmatter) + f"{desc}\n"
         else:
-            content = f"---\ndescription: {desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+            frontmatter = {"description": desc, "alwaysApply": False}
+            content = _yaml_frontmatter(frontmatter) + f"# {name}\n\n{desc}\n"
 
         files.append(AgentFile(path=path, content=content, format="markdown"))
 

--- a/observal-server/services/insights/self_learn.py
+++ b/observal-server/services/insights/self_learn.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Self-learning pipeline: applies insight suggestions as pending registry items.
@@ -23,6 +24,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+import yaml
 from loguru import logger as optic
 from sqlalchemy import select
 
@@ -583,12 +585,14 @@ async def _create_skill_listing(
 ) -> dict | None:
     """Create a pending SkillListing from a features_to_try suggestion.
 
-    Validates through SkillSubmitRequest to ensure proper field values.
+    Validates through SkillSubmitRequest and SKILL.md frontmatter validation to
+    ensure proper field values.
     Wraps the example in proper SKILL.md frontmatter if not already formatted.
     """
     from pydantic import ValidationError
 
     from schemas.skill import SkillSubmitRequest
+    from services.skill_validator import SkillValidationError, validate_skill_md_content_frontmatter
 
     one_liner = feature.get("one_liner", "")
     example = feature.get("example", "")
@@ -606,8 +610,9 @@ async def _create_skill_listing(
     # Build proper SKILL.md content if the example is raw text
     skill_md = _ensure_skill_md_format(name, one_liner, example)
 
-    # Validate through Pydantic schema
+    # Validate through Pydantic schema and stored SKILL.md frontmatter rules.
     try:
+        validate_skill_md_content_frontmatter(skill_md)
         validated = SkillSubmitRequest(
             name=name,
             version="1.0.0",
@@ -619,7 +624,7 @@ async def _create_skill_listing(
             task_type="general",
             supported_ides=["claude-code", "kiro", "pi"],
         )
-    except ValidationError as e:
+    except (SkillValidationError, ValidationError) as e:
         optic.warning("self_learn_skill_validation_failed", name=name, errors=str(e))
         return None
 
@@ -673,11 +678,15 @@ def _ensure_skill_md_format(name: str, description: str, raw_example: str) -> st
     if raw_example.strip().startswith("---"):
         return raw_example  # Already has frontmatter
 
+    frontmatter = {
+        "name": name,
+        "description": description,
+        "version": "1.0.0",
+        "task_type": "general",
+    }
+    body = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False, allow_unicode=True).strip()
     return f"""---
-name: {name}
-description: "{description}"
-version: 1.0.0
-task_type: general
+{body}
 ---
 
 # {name}

--- a/observal-server/services/skill_config_generator.py
+++ b/observal-server/services/skill_config_generator.py
@@ -2,16 +2,25 @@
 # SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 from __future__ import annotations
 
 import re
 
+import yaml
 from loguru import logger as optic
 
 from schemas.ide_registry import IDE_REGISTRY
+from schemas.skill_commands import normalize_slash_command
 from services.shared.utils import sanitize_name as _sanitize_name
+from services.skill_validator import validate_skill_md_content_frontmatter
+
+
+def _yaml_frontmatter(data: dict[str, str]) -> str:
+    body = yaml.safe_dump(data, sort_keys=False, default_flow_style=False, allow_unicode=True).strip()
+    return f"---\n{body}\n---\n\n"
 
 
 def _short_description(desc: str, max_len: int = 200) -> str:
@@ -55,20 +64,22 @@ def _generate_skill_file(skill_listing, ide: str, scope: str = "project") -> dic
     # Fast path: verbatim SKILL.md cached from the git repo.
     skill_md_content = getattr(skill_listing, "skill_md_content", None)
     if skill_md_content:
+        validate_skill_md_content_frontmatter(skill_md_content, slash_command=slash_cmd)
         return {"path": path, "content": skill_md_content}
 
     # Fallback: synthesise a minimal stub from stored fields.
     short_desc = _short_description(desc)
     skill_format = spec.get("skill_format")
     if skill_format == "yaml_frontmatter":
-        content = f"---\nname: {name}\n"
+        frontmatter = {"name": name}
         if short_desc:
-            content += f'description: "{short_desc}"\n'
+            frontmatter["description"] = short_desc
         if slash_cmd and ide_key == "claude-code":
-            content += f"command: /{slash_cmd}\n"
-        content += f"---\n\n{desc}\n"
+            frontmatter["command"] = f"/{normalize_slash_command(slash_cmd)}"
+        content = _yaml_frontmatter(frontmatter) + f"{desc}\n"
     else:
-        content = f"---\ndescription: {short_desc}\nalwaysApply: false\n---\n\n# {name}\n\n{desc}\n"
+        frontmatter = {"description": short_desc, "alwaysApply": False}
+        content = _yaml_frontmatter(frontmatter) + f"# {name}\n\n{desc}\n"
 
     return {"path": path, "content": content}
 
@@ -119,6 +130,9 @@ def generate_skill_config(
     # Cache skill_md_content as a fast-path fallback (no git needed at install time).
     skill_md_content = getattr(skill_listing, "skill_md_content", None)
     if skill_md_content:
+        validate_skill_md_content_frontmatter(
+            skill_md_content, slash_command=getattr(skill_listing, "slash_command", None)
+        )
         config["skill"]["skill_md_content"] = skill_md_content
 
     # Delivery mode and registry-direct script

--- a/observal-server/services/skill_validator.py
+++ b/observal-server/services/skill_validator.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Lightweight SKILL.md validator.
@@ -17,9 +18,11 @@ import re
 import httpx
 import yaml
 from loguru import logger as optic
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-_FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---", re.DOTALL)
+from schemas.skill_commands import normalize_slash_command
+
+_FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", re.DOTALL)
 
 # GitHub raw URL pattern.
 # Input git_url examples:
@@ -39,6 +42,14 @@ class SkillAnalysis(BaseModel):
     slash_command: str | None = None
     raw_content: str = ""
     discovered_path: str | None = None  # Set when server auto-discovered the skill_path
+
+
+class SkillFrontmatterAnalysis(BaseModel):
+    """Strict validation result for stored SKILL.md content."""
+
+    has_frontmatter: bool = False
+    frontmatter: dict = Field(default_factory=dict)
+    slash_command: str | None = None
 
 
 class SkillValidationError(Exception):
@@ -110,7 +121,7 @@ def _build_raw_url(git_url: str, skill_path: str, git_ref: str) -> str:
     return f"{base}/raw/{git_ref}/{skill_md}"
 
 
-def _parse_frontmatter(content: str) -> dict:
+def parse_skill_frontmatter(content: str) -> dict:
     """Extract and parse YAML frontmatter block from markdown content.
 
     Mirrors vercel-labs parseFrontmatter: regex extraction + yaml.safe_load.
@@ -126,6 +137,68 @@ def _parse_frontmatter(content: str) -> dict:
         return result if isinstance(result, dict) else {}
     except yaml.YAMLError:
         return {}
+
+
+def _parse_frontmatter(content: str) -> dict:
+    return parse_skill_frontmatter(content)
+
+
+def validate_skill_md_content_frontmatter(
+    content: str | None,
+    *,
+    slash_command: str | None = None,
+) -> SkillFrontmatterAnalysis:
+    """Validate stored/verbatim SKILL.md frontmatter without rewriting content.
+
+    No frontmatter is accepted. If a frontmatter block is present, it must be
+    valid YAML mapping data. A present ``command`` key must normalize to the
+    same slash command supplied by the request, when one is supplied.
+    """
+    normalized_request_command: str | None = None
+    if slash_command is not None:
+        try:
+            normalized_request_command = normalize_slash_command(slash_command)
+        except ValueError as exc:
+            raise SkillValidationError(f"Invalid slash command: {exc}") from exc
+
+    if not content:
+        return SkillFrontmatterAnalysis(slash_command=normalized_request_command)
+
+    if not re.match(r"^---\r?\n", content):
+        return SkillFrontmatterAnalysis(slash_command=normalized_request_command)
+
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        raise SkillValidationError("Malformed SKILL.md frontmatter")
+
+    try:
+        parsed = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as exc:
+        raise SkillValidationError("Malformed SKILL.md frontmatter") from exc
+
+    if parsed is None:
+        parsed = {}
+    if not isinstance(parsed, dict):
+        raise SkillValidationError("SKILL.md frontmatter must be a YAML mapping")
+
+    frontmatter_command: str | None = None
+    if "command" in parsed:
+        raw_command = parsed["command"]
+        if not isinstance(raw_command, str) or raw_command == "":
+            raise SkillValidationError("Invalid slash command: command must match ^[a-z0-9][a-z0-9_-]{0,63}$")
+        try:
+            frontmatter_command = normalize_slash_command(raw_command)
+        except ValueError as exc:
+            raise SkillValidationError(f"Invalid slash command: {exc}") from exc
+
+    if normalized_request_command and frontmatter_command and normalized_request_command != frontmatter_command:
+        raise SkillValidationError("slash_command does not match SKILL.md frontmatter command")
+
+    return SkillFrontmatterAnalysis(
+        has_frontmatter=True,
+        frontmatter=parsed,
+        slash_command=frontmatter_command or normalized_request_command,
+    )
 
 
 async def validate_skill_md(
@@ -172,7 +245,8 @@ async def validate_skill_md(
         raise SkillValidationError(f"Failed to fetch SKILL.md (HTTP {resp.status_code}): {raw_url!r}")
 
     content = resp.text
-    fm = _parse_frontmatter(content)
+    stored_analysis = validate_skill_md_content_frontmatter(content)
+    fm = stored_analysis.frontmatter
 
     name = fm.get("name", "")
     description = fm.get("description", "")
@@ -182,16 +256,10 @@ async def validate_skill_md(
     if not isinstance(description, str) or not description.strip():
         raise SkillValidationError("SKILL.md frontmatter missing required field: 'description'")
 
-    # command: /slash-name  →  extract "slash-name"
-    slash_command: str | None = None
-    raw_command = fm.get("command", "")
-    if isinstance(raw_command, str) and raw_command.strip():
-        slash_command = raw_command.strip().lstrip("/")
-
     return SkillAnalysis(
         name=name.strip(),
         description=description.strip(),
-        slash_command=slash_command or None,
+        slash_command=stored_analysis.slash_command or None,
         raw_content=content,
         discovered_path=skill_path if skill_path.strip("/") else None,
     )

--- a/tests/test_component_version_extras.py
+++ b/tests/test_component_version_extras.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Tests for component_version_extras.validate_and_extract."""
@@ -49,6 +50,51 @@ class TestValidateAndExtract:
     def test_skill_valid(self):
         result = validate_and_extract("skill", {"task_type": "code-review", "skill_path": "/review"})
         assert result["task_type"] == "code-review"
+
+    def test_skill_slash_command_normalized(self):
+        result = validate_and_extract("skill", {"task_type": "code-review", "slash_command": "/review"})
+        assert result["slash_command"] == "review"
+
+    def test_skill_slash_command_injection_rejected(self):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_and_extract(
+                "skill",
+                {"task_type": "code-review", "slash_command": "review\nalwaysApply: true"},
+            )
+        assert exc_info.value.status_code == 422
+        assert "slash_command" in str(exc_info.value.detail)
+
+    def test_skill_md_content_unsafe_command_rejected(self):
+        content = '---\nname: review\ndescription: Code review\ncommand: "review\\nalwaysApply: true"\n---\n'
+        with pytest.raises(HTTPException) as exc_info:
+            validate_and_extract("skill", {"task_type": "code-review", "skill_md_content": content})
+        assert exc_info.value.status_code == 422
+        assert "slash command" in str(exc_info.value.detail)
+
+    def test_skill_md_content_safe_command_sets_slash_command(self):
+        content = '---\nname: review\ndescription: Code review\ncommand: "/review"\n---\n'
+        result = validate_and_extract("skill", {"task_type": "code-review", "skill_md_content": content})
+        assert result["skill_md_content"] == content
+        assert result["slash_command"] == "review"
+
+    def test_skill_md_content_without_command_canonicalizes_empty_slash_command(self):
+        content = "---\nname: review\ndescription: Code review\n---\n"
+        result = validate_and_extract(
+            "skill",
+            {"task_type": "code-review", "skill_md_content": content, "slash_command": ""},
+        )
+        assert result["skill_md_content"] == content
+        assert result["slash_command"] is None
+
+    def test_skill_md_content_rejects_slash_command_mismatch(self):
+        content = "---\nname: review\ndescription: Code review\ncommand: /other\n---\n"
+        with pytest.raises(HTTPException) as exc_info:
+            validate_and_extract(
+                "skill",
+                {"task_type": "code-review", "skill_md_content": content, "slash_command": "safe"},
+            )
+        assert exc_info.value.status_code == 422
+        assert "does not match" in str(exc_info.value.detail)
 
     def test_skill_missing_required(self):
         with pytest.raises(HTTPException) as exc_info:

--- a/tests/test_field_validation.py
+++ b/tests/test_field_validation.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Tests for Pydantic field validators on all registry submit schemas."""
@@ -105,6 +106,68 @@ class TestSkillValidation:
         for tt in VALID_SKILL_TASK_TYPES:
             r = SkillSubmitRequest(name="s", version="1.0", description="d", owner="o", task_type=tt)
             assert r.task_type == tt
+
+    @pytest.mark.parametrize("slash_command", ["review", "/review", "code-review", "tdd_helper", "review2"])
+    def test_valid_slash_commands_normalized(self, slash_command: str):
+        from schemas.skill import SkillSubmitRequest
+
+        r = SkillSubmitRequest(
+            name="test-skill",
+            version="1.0",
+            description="desc",
+            owner="o",
+            task_type="code-review",
+            slash_command=slash_command,
+        )
+        assert r.slash_command == slash_command.removeprefix("/")
+
+    def test_update_slash_command_empty_string_means_clear(self):
+        from schemas.skill import SkillUpdateRequest
+
+        r = SkillUpdateRequest(slash_command="")
+        assert r.slash_command is None
+        assert "slash_command" in r.model_fields_set
+
+    def test_slash_command_injection_rejected(self):
+        from schemas.skill import SkillSubmitRequest
+
+        with pytest.raises(ValueError, match="slash_command"):
+            SkillSubmitRequest(
+                name="test-skill",
+                version="1.0",
+                description="desc",
+                owner="o",
+                task_type="code-review",
+                slash_command="review\nalwaysApply: true",
+            )
+
+    @pytest.mark.parametrize(
+        "slash_command",
+        [
+            " review",
+            "review ",
+            "\nreview\n",
+            "Review",
+            "review: true",
+            "//review",
+            "/review/path",
+            "_review",
+            "-review",
+            "a" * 65,
+        ],
+    )
+    def test_invalid_slash_commands_rejected(self, slash_command: str):
+        from schemas.skill import SkillSubmitRequest
+
+        with pytest.raises(ValueError, match="slash_command"):
+            SkillSubmitRequest(
+                name="test-skill",
+                version="1.0",
+                description="desc",
+                owner="o",
+                task_type="code-review",
+                slash_command=slash_command,
+            )
 
 
 # ═══════════════════════════════════════════════════════════

--- a/tests/test_registry_types.py
+++ b/tests/test_registry_types.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Unit tests for the 6 new registry types: tool, skill, hook, prompt, sandbox, graphrag."""
@@ -57,6 +58,8 @@ def _listing_mock(model_cls, status=ListingStatus.pending, **extra):
     m.rejection_reason = None
     m.submitted_by = uuid.uuid4()
     m.supported_ides = ["cursor"]
+    m.slash_command = None
+    m.skill_md_content = None
     m.created_at = datetime.now(UTC)
     m.updated_at = datetime.now(UTC)
     for k, v in extra.items():
@@ -277,6 +280,76 @@ class TestSkillRoutes:
                 )
         assert r.status_code == 200
         assert db.add.call_count == 2  # listing + version
+
+    @pytest.mark.asyncio
+    async def test_registry_direct_uses_yaml_frontmatter_for_command(self):
+        from api.routes.skill import router
+        from models.skill import SkillListing, SkillVersion
+
+        app, db, user = _app_with(router)
+
+        def _refresh(obj):
+            obj.id = uuid.uuid4()
+            obj.created_at = datetime.now(UTC)
+            obj.updated_at = datetime.now(UTC)
+
+        db.refresh = AsyncMock(side_effect=_refresh)
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+
+        _orig_init = SkillListing.__init__
+
+        def _patched_init(self, **kwargs):
+            kwargs.pop("archive_url", None)
+            _orig_init(self, **kwargs)
+
+        skill_md = '---\nname: s\ndescription: d\ncommand: "/review"\n---\n\nBody\n'
+        with patch.object(SkillListing, "__init__", _patched_init):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.post(
+                    "/api/v1/skills/submit",
+                    json={
+                        "name": "s",
+                        "version": "1.0",
+                        "description": "d",
+                        "owner": "o",
+                        "task_type": "code-review",
+                        "delivery_mode": "registry_direct",
+                        "skill_md_content": skill_md,
+                    },
+                )
+
+        assert r.status_code == 200
+        version = next(call.args[0] for call in db.add.call_args_list if isinstance(call.args[0], SkillVersion))
+        assert version.slash_command == "review"
+
+    @pytest.mark.asyncio
+    async def test_draft_update_empty_slash_command_clears_even_with_existing_frontmatter_command(self):
+        from api.routes import skill as skill_routes
+        from schemas.skill import SkillUpdateRequest
+
+        user = _user()
+        db = _mock_db()
+        version = MagicMock()
+        version.skill_md_content = "---\nname: review\ndescription: d\ncommand: /review\n---\n"
+        version.slash_command = "review"
+        version.is_editing = False
+        version.editing_by = None
+        version.editing_since = None
+        listing = _listing_mock(object, status=ListingStatus.draft, latest_version=version)
+
+        with (
+            patch.object(skill_routes, "resolve_listing", AsyncMock(return_value=listing)),
+            patch.object(skill_routes, "get_effective_component_permission", return_value="owner"),
+            patch.object(skill_routes.SkillListingResponse, "model_validate", return_value=listing),
+        ):
+            await skill_routes.update_skill_draft(
+                listing_id=str(listing.id),
+                req=SkillUpdateRequest(slash_command=""),
+                db=db,
+                current_user=user,
+            )
+
+        assert version.slash_command is None
 
     @pytest.mark.asyncio
     async def test_get_missing_returns_404(self):

--- a/tests/test_self_learn_skill_md.py
+++ b/tests/test_self_learn_skill_md.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _load_self_learn_module():
+    path = Path(__file__).resolve().parents[1] / "observal-server" / "services" / "insights" / "self_learn.py"
+    spec = importlib.util.spec_from_file_location("self_learn_under_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_self_learn_generated_skill_md_frontmatter_is_yaml_serialized():
+    from services.skill_validator import validate_skill_md_content_frontmatter
+
+    module = _load_self_learn_module()
+    description = 'Review: code "carefully"\n---\ncommand: /evil\ncolon: value'
+
+    content = module._ensure_skill_md_format("safe-skill", description, "Use the checklist.")
+    frontmatter = validate_skill_md_content_frontmatter(content).frontmatter
+
+    assert frontmatter["name"] == "safe-skill"
+    assert frontmatter["description"] == description
+    assert frontmatter["version"] == "1.0.0"
+    assert frontmatter["task_type"] == "general"
+    assert "command" not in frontmatter
+
+
+@pytest.mark.asyncio
+async def test_self_learn_rejects_unsafe_existing_frontmatter_before_persisting():
+    module = _load_self_learn_module()
+    agent = SimpleNamespace(name="review-agent", owner="owner", owner_org_id=None)
+    feature = {
+        "name": "review",
+        "one_liner": "Review code",
+        "example": '---\nname: review\ndescription: Review code\ncommand: "review\\nalwaysApply: true"\n---\n',
+    }
+    db = SimpleNamespace(execute=AsyncMock(), add=AsyncMock(), flush=AsyncMock())
+
+    result = await module._create_skill_listing(agent, feature, submitter_id=module.uuid.uuid4(), db=db)
+
+    assert result is None
+    db.execute.assert_not_called()
+    db.add.assert_not_called()
+    db.flush.assert_not_called()

--- a/tests/test_skill_config_generator.py
+++ b/tests/test_skill_config_generator.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Tests for skill_config_generator — IDE-specific skill file generation."""
@@ -9,11 +10,22 @@ from __future__ import annotations
 import uuid
 from unittest.mock import MagicMock
 
+import pytest
+import yaml
+
+from services.agent_builder_types import AgentManifest, ManifestComponent, ManifestComponents
+from services.config.skill_builder import build_skill_files
+from services.config.skill_builder import generate_skill_file as generate_manifest_skill_file
 from services.skill_config_generator import (
     _generate_skill_file,
     _sanitize_name,
     generate_skill_config,
 )
+from services.skill_validator import SkillValidationError, validate_skill_md_content_frontmatter
+
+
+def _frontmatter(content: str) -> dict:
+    return yaml.safe_load(content.split("---", 2)[1])
 
 
 def _make_skill_listing(
@@ -54,9 +66,10 @@ class TestGenerateSkillFile:
         result = _generate_skill_file(listing, "claude-code", scope="project")
         assert result is not None
         assert result["path"] == ".claude/skills/code-review/SKILL.md"
-        assert "name: code-review" in result["content"]
-        assert 'description: "Automated code review skill"' in result["content"]
-        assert "command: /review" in result["content"]
+        fm = _frontmatter(result["content"])
+        assert fm["name"] == "code-review"
+        assert fm["description"] == "Automated code review skill"
+        assert fm["command"] == "/review"
 
     def test_claude_code_user_scope(self):
         listing = _make_skill_listing()
@@ -74,7 +87,7 @@ class TestGenerateSkillFile:
         listing = _make_skill_listing()
         result = _generate_skill_file(listing, "cursor", scope="project")
         assert result["path"] == ".cursor/rules/code-review.mdc"
-        assert "alwaysApply: false" in result["content"]
+        assert _frontmatter(result["content"])["alwaysApply"] is False
         assert "# code-review" in result["content"]
 
     def test_cursor_user_scope(self):
@@ -96,6 +109,37 @@ class TestGenerateSkillFile:
         listing = _make_skill_listing(description="")
         result = _generate_skill_file(listing, "claude-code")
         assert "description:" not in result["content"]
+
+    def test_description_is_yaml_serialized(self):
+        listing = _make_skill_listing(description='Review: code "carefully"')
+        result = _generate_skill_file(listing, "claude-code")
+        fm = _frontmatter(result["content"])
+        assert fm["description"] == 'Review: code "carefully"'
+        assert set(fm) == {"name", "description", "command"}
+
+    def test_hostile_description_is_yaml_serialized_as_data(self):
+        description = 'Line one\n---\ncommand: /evil\nquoted: "value"\ncolon: value'
+        listing = _make_skill_listing(description=description, slash_command=None)
+        result = _generate_skill_file(listing, "claude-code")
+        fm = _frontmatter(result["content"])
+        assert fm["description"] == "Line one"
+        assert set(fm) == {"name", "description"}
+        assert "command" not in fm
+
+    def test_manifest_fallback_hostile_description_is_yaml_serialized(self):
+        description = 'Review: code "carefully"\n---\ncommand: /evil\ncolon: value'
+        result = generate_manifest_skill_file(
+            {"name": "code-review", "description": description, "slash_command": None},
+            "claude-code",
+        )
+        fm = validate_skill_md_content_frontmatter(result["content"]).frontmatter
+        assert fm["description"] == description
+        assert set(fm) == {"name", "description"}
+
+    def test_rejects_slash_command_frontmatter_injection(self):
+        listing = _make_skill_listing(slash_command="review\nalwaysApply: true")
+        with pytest.raises(ValueError, match="slash_command"):
+            _generate_skill_file(listing, "claude-code")
 
 
 class TestGenerateSkillConfig:
@@ -159,6 +203,36 @@ class TestGenerateSkillConfig:
         listing = _make_skill_listing(skill_md_content=verbatim)
         config = generate_skill_config(listing, "claude-code")
         assert config["skill_file"]["content"] == verbatim
+
+    def test_verbatim_skill_file_rejects_unsafe_frontmatter_command(self):
+        verbatim = '---\nname: code-review\ndescription: Real content\ncommand: "review\\nalwaysApply: true"\n---\n'
+        listing = _make_skill_listing(skill_md_content=verbatim, slash_command=None)
+        with pytest.raises(SkillValidationError, match="Invalid slash command"):
+            generate_skill_config(listing, "claude-code")
+
+    def test_verbatim_config_cache_rejects_unsafe_frontmatter_for_monolithic_ide(self):
+        verbatim = '---\nname: code-review\ndescription: Real content\ncommand: "review\\nalwaysApply: true"\n---\n'
+        listing = _make_skill_listing(skill_md_content=verbatim, slash_command=None)
+        with pytest.raises(SkillValidationError, match="Invalid slash command"):
+            generate_skill_config(listing, "codex")
+
+    def test_manifest_verbatim_skill_file_rejects_unsafe_frontmatter_command(self):
+        verbatim = '---\nname: code-review\ndescription: Real content\ncommand: "review\\nalwaysApply: true"\n---\n'
+        manifest = AgentManifest(
+            name="test-agent",
+            version="1.0.0",
+            components=ManifestComponents(
+                skills=[
+                    ManifestComponent(
+                        name="code-review",
+                        version="1.0.0",
+                        config_override={"skill_md_content": verbatim},
+                    )
+                ]
+            ),
+        )
+        with pytest.raises(SkillValidationError, match="Invalid slash command"):
+            build_skill_files(manifest, "claude-code")
 
     def test_claude_code_allows_env_vars(self):
         listing = _make_skill_listing()

--- a/tests/test_skill_validator.py
+++ b/tests/test_skill_validator.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Tests for services/skill_validator.py."""
@@ -13,7 +14,9 @@ from services.skill_validator import (
     SkillValidationError,
     _build_raw_url,
     _parse_frontmatter,
+    parse_skill_frontmatter,
     validate_skill_md,
+    validate_skill_md_content_frontmatter,
 )
 
 # ── _build_raw_url ──────────────────────────────────────────────────────────
@@ -57,6 +60,11 @@ class TestParseFrontmatter:
         result = _parse_frontmatter(content)
         assert result["command"] == "/review"
 
+    def test_parse_quoted_command_field(self):
+        content = '---\nname: review\ndescription: Code review\ncommand: "/review"\n---\n'
+        result = parse_skill_frontmatter(content)
+        assert result["command"] == "/review"
+
     def test_no_frontmatter(self):
         assert _parse_frontmatter("# Just markdown") == {}
 
@@ -69,6 +77,43 @@ class TestParseFrontmatter:
     def test_non_dict_yaml(self):
         content = "---\n- item1\n- item2\n---\n"
         assert _parse_frontmatter(content) == {}
+
+
+# ── validate_skill_md_content_frontmatter ──────────────────────────────────
+
+
+class TestValidateSkillMdContentFrontmatter:
+    def test_no_frontmatter_is_ok(self):
+        result = validate_skill_md_content_frontmatter("# Plain markdown")
+        assert result.has_frontmatter is False
+        assert result.slash_command is None
+
+    def test_accepts_safe_command_and_normalizes(self):
+        content = '---\nname: review\ndescription: Code review\ncommand: "/review"\n---\n'
+        result = validate_skill_md_content_frontmatter(content)
+        assert result.has_frontmatter is True
+        assert result.frontmatter["command"] == "/review"
+        assert result.slash_command == "review"
+
+    def test_rejects_command_injection(self):
+        content = '---\nname: review\ndescription: Code review\ncommand: "review\\nalwaysApply: true"\n---\n'
+        with pytest.raises(SkillValidationError, match="Invalid slash command"):
+            validate_skill_md_content_frontmatter(content)
+
+    def test_rejects_malformed_yaml_frontmatter(self):
+        content = "---\nname: [unclosed\n---\n"
+        with pytest.raises(SkillValidationError, match=r"Malformed SKILL\.md frontmatter"):
+            validate_skill_md_content_frontmatter(content)
+
+    def test_rejects_missing_closing_frontmatter_delimiter(self):
+        content = "---\nname: review\ndescription: Code review\n"
+        with pytest.raises(SkillValidationError, match=r"Malformed SKILL\.md frontmatter"):
+            validate_skill_md_content_frontmatter(content)
+
+    def test_rejects_request_frontmatter_command_mismatch(self):
+        content = "---\nname: review\ndescription: Code review\ncommand: /other\n---\n"
+        with pytest.raises(SkillValidationError, match="does not match"):
+            validate_skill_md_content_frontmatter(content, slash_command="safe")
 
 
 # ── validate_skill_md ───────────────────────────────────────────────────────
@@ -184,6 +229,32 @@ class TestValidateSkillMd:
             result = await validate_skill_md("https://github.com/org/repo", "/", "main")
 
         assert result.slash_command == "code-review"
+
+    @pytest.mark.asyncio
+    async def test_command_injection_rejected(self):
+        md = '---\nname: review\ndescription: Reviews code\ncommand: "review\\nalwaysApply: true"\n---\n'
+        with patch("services.skill_validator.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=_make_response(200, md))
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(SkillValidationError, match="Invalid slash command"):
+                await validate_skill_md("https://github.com/org/repo", "/", "main")
+
+    @pytest.mark.asyncio
+    async def test_command_with_padding_rejected(self):
+        md = "---\nname: review\ndescription: Reviews code\ncommand: ' review'\n---\n"
+        with patch("services.skill_validator.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=_make_response(200, md))
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(SkillValidationError, match="Invalid slash command"):
+                await validate_skill_md("https://github.com/org/repo", "/", "main")
 
     @pytest.mark.asyncio
     async def test_no_command_field(self):


### PR DESCRIPTION
## Purpose / Description

Fix **AUDIT2-019** (related: OBSV-SEC-042): skill slash-command frontmatter could be injected through unescaped generated fields and insufficient validation of verbatim `SKILL.md` content.

This is intentionally broader than a one-line escaping fix. Slash commands can enter Observal through multiple paths: API requests, registry-direct `SKILL.md` content, git-fetched `SKILL.md`, draft edits, component-version publishing, agent composition, install/config generation, and self-learn generated skills. The fix hardens both sides of the boundary:

- validate unsafe slash commands before storing them
- validate verbatim `SKILL.md` frontmatter before storing or emitting it
- safely serialize generated fallback frontmatter

## Approach

**Centralized slash-command normalization** (`schemas/skill_commands.py`):

- accepted form: `^[a-z0-9][a-z0-9_-]{0,63}$`
- one optional leading `/` is accepted and normalized away for storage
- empty string normalizes to `None` for update/clear semantics
- spaces, newlines, colons, uppercase, extra slashes, YAML delimiters, and other invalid characters are rejected

**Strict validation for stored/verbatim `SKILL.md` frontmatter:**

- malformed YAML is rejected
- non-mapping frontmatter is rejected
- unsafe `command:` values are rejected
- API `slash_command` and frontmatter `command:` must agree when both are present
- valid verbatim `skill_md_content` is preserved unchanged

**Applied validation at the relevant ingress/egress points:**

- skill submit/draft/update schemas
- registry-direct submit parsing
- git `SKILL.md` validation
- draft create/update/submit
- component-version publishing
- install/config generation
- agent-builder skill-file generation
- self-learn generated skill ingestion

**Replaced generated fallback frontmatter string interpolation with `yaml.safe_dump()`** in:

- `services/skill_config_generator.py`
- `services/config/skill_builder.py`
- `services/insights/self_learn.py`

Also fixed empty `slash_command` update behavior so an explicit empty string clears the stored command.

Note: pre-commit hooks added SPDX headers to touched files and normalized `CHANGELOG.md` EOF in a separate `chore:` commit.

## How Has This Been Tested?

Focused tests:

```bash
uv run pytest tests/test_self_learn_skill_md.py tests/test_component_version_extras.py \
  tests/test_field_validation.py tests/test_skill_config_generator.py \
  tests/test_skill_validator.py -q
```

Result:

```text
130 passed
```

Lint:

```bash
uv run ruff check observal-server/schemas/skill_commands.py observal-server/schemas/skill.py \
  observal-server/services/skill_validator.py observal-server/api/routes/skill.py \
  observal-server/services/skill_config_generator.py observal-server/services/config/skill_builder.py \
  observal-server/services/component_version_extras.py observal-server/services/insights/self_learn.py \
  tests/test_component_version_extras.py tests/test_field_validation.py tests/test_registry_types.py \
  tests/test_self_learn_skill_md.py tests/test_skill_config_generator.py tests/test_skill_validator.py
```

Result:

```text
All checks passed!
```

Whitespace:

```bash
git diff --check
```

Result: passed.

Route-level regression coverage was also added in `tests/test_registry_types.py`. In this local environment, that file does not collect because `jwt` is missing:

```text
ModuleNotFoundError: No module named 'jwt'
```

## Learning (optional)

The risky pattern was not only string interpolation in generated YAML. The larger issue was that verbatim `SKILL.md` content can cross several boundaries before install. For that reason, this patch validates both generated and verbatim frontmatter paths.

For generated fallback files, `yaml.safe_dump()` emits user-controlled fields as YAML data rather than YAML syntax.

## Checklist

- [x] Descriptive commit message with a short title (`fix(security): validate skill slash commands`, 41 chars)
- [x] Commented code in hard-to-understand areas
- [x] Performed a self-review
- [x] No UI changes (no screenshots needed)