### PR TITLE
docs: add two-tier deployment guides (single-node and production)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -44,8 +44,11 @@
 
 * [Overview](self-hosting/README.md)
 * [Requirements](self-hosting/requirements.md)
+* [Single-node deployment](self-hosting/single-node-deploy.md)
+* [Production deployment](self-hosting/production-deploy.md)
 * [Docker Compose setup](self-hosting/docker-compose.md)
 * [AWS deployment with Terraform](self-hosting/aws-terraform.md)
+* [GCP deployment with Terraform](self-hosting/gcp-terraform.md)
 * [Configuration](self-hosting/configuration.md)
 * [Ports and volumes](self-hosting/ports-and-volumes.md)
 * [Databases](self-hosting/databases.md)

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -41,13 +41,33 @@ Run Observal entirely on your own infrastructure. No SaaS, no egress, every byte
 
 All services run on a private `observal-net` bridge network. Named volumes (`pgdata`, `chdata`, `redisdata`, `grafanadata`, `apidata`) hold persistent data.
 
-## Where to start
+## Deployment tiers
+
+Choose the deployment model that fits your team:
+
+| | [Single-node](single-node-deploy.md) | [Production](production-deploy.md) |
+|---|---|---|
+| **How** | Docker Compose on one VM | Terraform on AWS or GCP |
+| **Best for** | ≤50 users, internal tools, POCs | Enterprise, SLA-bound, 50+ users |
+| **Cost** | $20–150/mo | ~$180–255/mo |
+| **HA** | No | Yes (Multi-AZ databases, autoscaling) |
+| **Time to deploy** | 10 minutes | 20–30 minutes |
+
+**Start here:**
+
+| If you want to... | Read |
+| --- | --- |
+| Deploy on a single VM (simplest) | [Single-node deployment](single-node-deploy.md) |
+| Deploy a production HA stack | [Production deployment](production-deploy.md) |
+| Deploy on AWS specifically | [AWS deployment with Terraform](aws-terraform.md) |
+| Deploy on GCP specifically | [GCP deployment with Terraform](gcp-terraform.md) |
+
+**Then configure and operate:**
 
 | If you want to... | Read |
 | --- | --- |
 | Confirm your machine can run Observal | [Requirements](requirements.md) |
-| Get the stack running locally | [Docker Compose setup](docker-compose.md) |
-| Deploy to AWS in one command | [AWS deployment with Terraform](aws-terraform.md) |
+| Get the stack running locally for dev | [Docker Compose setup](docker-compose.md) |
 | Know every env var that matters | [Configuration](configuration.md) |
 | See every port and volume at a glance | [Ports and volumes](ports-and-volumes.md) |
 | Understand the DBs and retention | [Databases](databases.md) |

--- a/docs/self-hosting/gcp-terraform.md
+++ b/docs/self-hosting/gcp-terraform.md
@@ -1,0 +1,277 @@
+<!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# GCP deployment with Terraform
+
+End state: Observal running in your GCP project on Cloud Run, backed by Cloud SQL Postgres, Memorystore Redis, and a GCE instance for ClickHouse — with a Global HTTPS Load Balancer, managed SSL certificate, Secret Manager for credentials, and GCS for backups.
+
+For the overall deployment strategy and comparison with AWS, see [Production deployment](production-deploy.md). If you want a simpler single-VM setup, see [Single-node deployment](single-node-deploy.md).
+
+## What gets provisioned
+
+A single `terraform apply` creates:
+
+- **VPC** with a private subnet, Cloud NAT, and a Serverless VPC Access Connector
+- **Cloud Run v2 services**: `api`, `web`, `worker` with autoscaling (min/max instance counts)
+- **Cloud Run v2 job**: `init` (one-shot migrations + seeds)
+- **Cloud SQL Postgres** (Enterprise edition): optional HA, encrypted, automated backups
+- **Memorystore Redis**: BASIC or STANDARD_HA tier
+- **GCE instance** (data host): ClickHouse + Grafana + Prometheus on a persistent disk, accessible via IAP SSH tunnel
+- **Global HTTPS Load Balancer** with managed SSL certificate (when domain is supplied)
+- **Cloud DNS** A record pointing to the load balancer
+- **Secret Manager**: generated DB / ClickHouse / SECRET_KEY passwords, plus connection URLs injected into Cloud Run services
+- **GCS backups bucket**: versioned, lifecycle to Nearline → delete
+- **Artifact Registry**: for storing container images (optional)
+
+## Prerequisites
+
+| Requirement | Why |
+|---|---|
+| GCP project with billing enabled | Resources cost money |
+| `gcloud` CLI authenticated | `gcloud auth application-default login` |
+| Terraform ≥ 1.5 | `brew install terraform` |
+| (Optional) Cloud DNS managed zone | Required for HTTPS on a custom domain |
+
+Enable required APIs:
+
+```bash
+gcloud services enable \
+  run.googleapis.com \
+  sqladmin.googleapis.com \
+  redis.googleapis.com \
+  compute.googleapis.com \
+  secretmanager.googleapis.com \
+  dns.googleapis.com \
+  vpcaccess.googleapis.com \
+  servicenetworking.googleapis.com \
+  iam.googleapis.com
+```
+
+## Quickstart
+
+```bash
+git clone https://github.com/BlazeUp-AI/Observal.git
+cd Observal/infra/terraform/gcp
+
+# 1. Authenticate
+gcloud auth application-default login
+
+# 2. Configure
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+# At minimum, set project_id
+
+# 3. Apply
+terraform init
+terraform plan -out tf.plan
+terraform apply tf.plan
+
+# 4. Run migrations
+$(terraform output -raw init_job_run_command)
+
+# 5. Verify
+terraform output app_url
+```
+
+## Configuration
+
+All inputs live in `terraform.tfvars`.
+
+### Minimal (no custom domain)
+
+```hcl
+project_id  = "my-gcp-project"
+region      = "us-central1"
+environment = "prod"
+```
+
+The install comes up on the Cloud Run default URL (e.g. `https://observal-prod-api-xxxxx-uc.a.run.app`).
+
+### Recommended (HTTPS on your domain)
+
+```hcl
+project_id  = "my-gcp-project"
+region      = "us-central1"
+environment = "prod"
+
+domain_name           = "observal.example.com"
+dns_managed_zone_name = "example-com"
+```
+
+Terraform provisions a Global HTTPS Load Balancer with a Google-managed SSL certificate and creates the DNS A record.
+
+### Sizing
+
+```hcl
+# Cloud Run
+api_cpu            = "1"
+api_memory         = "1Gi"
+api_min_instances   = 1
+api_max_instances   = 10
+
+web_min_instances   = 1
+worker_min_instances = 1
+
+# Data tier
+data_machine_type  = "e2-standard-2"   # 2 vCPU / 8 GB
+data_disk_size_gb  = 100
+
+# Cloud SQL
+db_tier            = "db-g1-small"
+db_disk_size_gb    = 50
+db_ha_enabled      = false             # set true for production HA
+
+# Redis
+redis_memory_size_gb = 1
+redis_tier           = "BASIC"         # or STANDARD_HA
+```
+
+For high-throughput installs, bump `data_machine_type` to `e2-standard-4`, `db_tier` to `db-custom-4-16384`, and `redis_tier` to `STANDARD_HA`.
+
+### ClickHouse Cloud
+
+```hcl
+clickhouse_mode      = "cloud"
+clickhouse_cloud_url = "https://abc123.us-central1.gcp.clickhouse.cloud:8443"
+```
+
+The GCE data host is skipped entirely.
+
+### Enterprise edition
+
+```hcl
+observal_license_key = "eyJ...your-key..."
+```
+
+Stored in Secret Manager, injected into all Cloud Run services. Enterprise features activate automatically.
+
+## Operating the install
+
+### Shell into the data host
+
+```bash
+$(terraform output -raw data_host_ssh_command)
+# Inside:
+sudo docker compose -f /opt/observal/docker-compose.data.yml ps
+sudo docker compose -f /opt/observal/docker-compose.data.yml logs -f clickhouse
+```
+
+No public SSH. Access is through IAP (Identity-Aware Proxy) — authenticated, audited, no SSH keys to manage.
+
+### View logs
+
+Cloud Run logs go to Cloud Logging automatically:
+
+```bash
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=observal-prod-api" \
+  --limit 50 --format json
+```
+
+Or use the Cloud Console: **Logging → Logs Explorer**, filter by `resource.type="cloud_run_revision"`.
+
+### Re-run migrations
+
+```bash
+$(terraform output -raw init_job_run_command)
+```
+
+### Read a generated secret
+
+```bash
+gcloud secrets versions access latest \
+  --secret="observal-prod-SECRET_KEY"
+```
+
+### Upgrade to a new release
+
+```hcl
+# terraform.tfvars
+image_tag = "v1.5.0"
+```
+
+```bash
+terraform apply
+$(terraform output -raw init_job_run_command)
+```
+
+Cloud Run handles the rolling deploy. Zero downtime.
+
+### Resize the data disk
+
+```hcl
+data_disk_size_gb = 250
+```
+
+```bash
+terraform apply
+# SSH into the data host and resize the filesystem:
+$(terraform output -raw data_host_ssh_command)
+sudo growpart /dev/sdb 1 || true
+sudo resize2fs /dev/sdb1
+```
+
+### Destroy
+
+```bash
+terraform destroy
+```
+
+Cloud SQL deletion protection is enabled on prod. Disable manually before destroy if you mean it.
+
+## Cost estimate (us-central1, on-demand)
+
+| Component | Spec | ~$/month |
+|---|---|---|
+| Cloud Run api | 1 vCPU / 1 GB, min 1 instance | $25 |
+| Cloud Run web | 1 vCPU / 512 MB, min 1 instance | $15 |
+| Cloud Run worker | 1 vCPU / 1 GB, min 1 instance | $25 |
+| Cloud SQL Postgres | db-g1-small (shared) | $25 |
+| Memorystore Redis | 1 GB BASIC | $35 |
+| GCE data host | e2-standard-2 | $50 |
+| Global HTTPS LB | — | $18 |
+| Persistent Disk 100 GB | — | $4 |
+| GCS backups | ~1 GB | $0.02 |
+| **Total** | | **~$200** |
+
+Cloud Run scales to zero when idle (if `min_instances = 0`), which can significantly reduce costs for low-traffic deployments.
+
+## Production hardening checklist
+
+- [ ] Set `db_ha_enabled = true` for Cloud SQL high availability
+- [ ] Set `redis_tier = "STANDARD_HA"` for Redis failover
+- [ ] Restrict Cloud Run ingress (use `ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"` if behind GCLB)
+- [ ] Enable Cloud Armor (WAF) on the Global HTTPS Load Balancer
+- [ ] Enable Security Command Center in the project
+- [ ] Set up alerting on Cloud SQL CPU, memory, and Cloud Run error rates
+- [ ] Move ClickHouse to ClickHouse Cloud for HA
+- [ ] Configure [SSO](authentication.md)
+- [ ] Test [backup and restore](backup-and-restore.md) end-to-end
+- [ ] Set up Terraform remote state in GCS
+
+## Troubleshooting
+
+**Cloud Run service stuck in `Revision is not ready`.**
+Check revision logs in Cloud Logging. Common causes: Secret Manager permissions missing, VPC connector not ready, or image pull failure.
+
+**Init job fails.**
+```bash
+gcloud run jobs executions list --job=observal-prod-init --region=us-central1
+gcloud logging read "resource.type=cloud_run_job AND resource.labels.job_name=observal-prod-init" --limit 20
+```
+
+Usually: Cloud SQL not yet reachable (transient on first apply), or missing secret access.
+
+**502 from the load balancer.**
+The managed SSL certificate takes 10–30 minutes to provision. Check: **Network Services → Load Balancing → (your LB) → Backend services → Health**.
+
+**Cloud SQL connection refused from Cloud Run.**
+The VPC Access Connector must be in the same region as Cloud Run. Verify `connector_cidr` doesn't overlap with your VPC subnet.
+
+For application-level issues, see [Troubleshooting](troubleshooting.md).
+
+## Next
+
+- [Production deployment](production-deploy.md) — overview of both clouds
+- [Configuration](configuration.md) — environment variables
+- [Upgrades](upgrades.md) — upgrade and rollback procedures
+- [Backup and restore](backup-and-restore.md) — restore procedures

--- a/docs/self-hosting/production-deploy.md
+++ b/docs/self-hosting/production-deploy.md
@@ -1,0 +1,286 @@
+<!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Production deployment
+
+Deploy Observal as a distributed, highly-available stack on AWS or GCP using Terraform. Best for enterprise customers, SLA-bound deployments, teams over 50 users, and any environment where uptime and horizontal scaling matter.
+
+**End state:** a fully managed Observal install with autoscaling compute, managed databases with automated failover, encrypted secrets, centralized logging, automated backups, and HTTPS on your domain — provisioned with a single `terraform apply`.
+
+## When to use this vs. single-node
+
+| | [Single-node](single-node-deploy.md) | Production (this guide) |
+|---|---|---|
+| **Best for** | Small/mid teams, internal use, POCs | Enterprise, SLA-bound, high-traffic |
+| **Infra** | 1 VM, any cloud or on-prem | ~100 managed cloud resources |
+| **Cost** | $20–150/mo | ~$255/mo (AWS) |
+| **HA** | No — single point of failure | Yes — Multi-AZ databases, autoscaling compute |
+| **Failover** | Manual (reboot / redeploy) | Automatic (managed services handle it) |
+| **Scaling** | Vertical (bigger VM) | Horizontal (add more containers) |
+| **Backups** | Cron + S3 | Automated (RDS snapshots, systemd timers, S3 lifecycle) |
+| **Secrets** | `.env` file on disk | SSM Parameter Store / Secret Manager (encrypted, auditable) |
+| **Logging** | `docker compose logs` | CloudWatch / Cloud Logging (centralized, retained, searchable) |
+| **Time to deploy** | 10 minutes | 20–30 minutes |
+
+## Choose your cloud
+
+Observal ships Terraform modules for both AWS and GCP. They provision equivalent architectures using each cloud's native managed services.
+
+### AWS
+
+```
+  Internet ──► ALB (HTTPS) ──┬── /api/*  ──► ECS Fargate: api (2–10×)
+                              ├── default ──► ECS Fargate: web (2–6×)
+                              └── /grafana/* ► EC2 data host
+                                                │
+                              ECS Fargate: worker (1–5×)
+                                    │
+                    ┌───────────────┼───────────────┐
+                    ▼               ▼               ▼
+              RDS Postgres    ElastiCache      EC2 + EBS
+              (Multi-AZ)     Redis (2-node)   ClickHouse
+                                              Grafana
+                                              Prometheus
+```
+
+| Component | AWS Service | Notes |
+|---|---|---|
+| Compute (stateless) | ECS Fargate | api, web, worker as separate services |
+| Postgres | RDS Postgres 16 | Multi-AZ on prod, encrypted, automated backups |
+| Redis | ElastiCache Redis 7 | 2-node replication, automatic failover on prod |
+| ClickHouse | EC2 + EBS gp3 | Self-hosted; option to use ClickHouse Cloud |
+| Load balancer | ALB | HTTPS via ACM, path-based routing |
+| Secrets | SSM Parameter Store | Encrypted with KMS, injected into ECS tasks |
+| Logging | CloudWatch | Per-service log groups |
+| Backups | S3 + RDS snapshots | Lifecycle: Standard → IA → Glacier → expire |
+| DNS | Route 53 | Optional; works without a custom domain |
+
+**Full walkthrough:** [AWS deployment with Terraform](aws-terraform.md)
+
+**Quick start:**
+
+```bash
+git clone https://github.com/BlazeUp-AI/Observal.git
+cd Observal/infra/terraform/aws
+
+# Configure
+cp terraform.tfvars.example terraform.tfvars
+# Edit: region, environment, domain_name (optional), alb_ingress_cidrs
+
+# Deploy
+terraform init
+terraform plan -out tf.plan
+terraform apply tf.plan
+
+# Verify
+terraform output app_url
+curl -fsS "$(terraform output -raw app_url)/readyz"
+```
+
+Apply takes ~20–30 minutes (RDS Multi-AZ provisioning dominates). Baseline cost: **~$255/mo** in us-east-1.
+
+### GCP
+
+```
+  Internet ──► Global HTTPS LB ──┬── /api/*  ──► Cloud Run: api
+               (managed SSL)     ├── default ──► Cloud Run: web
+                                 └── /grafana/* ► GCE data host (IAP)
+                                
+                              Cloud Run Job: init (migrations)
+                              Cloud Run: worker
+                                    │
+                    ┌───────────────┼───────────────┐
+                    ▼               ▼               ▼
+              Cloud SQL         Memorystore      GCE + PD
+              (Postgres)        (Redis)          ClickHouse
+                                                 Grafana
+                                                 Prometheus
+```
+
+| Component | GCP Service | Notes |
+|---|---|---|
+| Compute (stateless) | Cloud Run v2 | api, web, worker as separate services |
+| Migrations | Cloud Run Jobs | One-shot init task |
+| Postgres | Cloud SQL | HA configuration available |
+| Redis | Memorystore | Managed Redis |
+| ClickHouse | GCE instance | Docker Compose on a single VM; option for ClickHouse Cloud |
+| Load balancer | Global HTTPS LB | Managed SSL certificate |
+| Secrets | Secret Manager | Injected into Cloud Run at start |
+| Logging | Cloud Logging | Built-in, no config needed |
+| Backups | GCS | Versioned bucket with lifecycle |
+| DNS | Cloud DNS | Optional |
+| Shell access | IAP SSH tunnel | No public SSH, no SSH keys |
+
+**Full walkthrough:** [GCP deployment with Terraform](gcp-terraform.md)
+
+**Quick start:**
+
+```bash
+cd Observal/infra/terraform/gcp
+
+# Enable required APIs
+gcloud services enable \
+  run.googleapis.com sqladmin.googleapis.com redis.googleapis.com \
+  compute.googleapis.com secretmanager.googleapis.com \
+  dns.googleapis.com vpcaccess.googleapis.com \
+  servicenetworking.googleapis.com
+
+# Configure
+cp terraform.tfvars.example terraform.tfvars
+# Edit: project_id, region, domain_name (optional)
+
+# Deploy
+terraform init
+terraform plan -out tf.plan
+terraform apply tf.plan
+
+# Run migrations
+gcloud run jobs execute observal-prod-init --region=us-central1
+
+# Verify
+terraform output app_url
+```
+
+## Enterprise edition
+
+Both Terraform modules support deploying the enterprise edition. Set the license key variable:
+
+**AWS** (`terraform.tfvars`):
+```hcl
+observal_license_key = "eyJ...your-key..."
+```
+
+**GCP** (`terraform.tfvars`):
+```hcl
+observal_license_key = "eyJ...your-key..."
+```
+
+When a license key is provided, Terraform:
+1. Stores the key in SSM Parameter Store (AWS) or Secret Manager (GCP) as an encrypted secret
+2. Injects `OBSERVAL_LICENSE_KEY` into every compute task at startup
+3. Enterprise features (SAML SSO, SCIM, audit logs, executive dashboards) activate automatically
+
+Leave the key empty to deploy community edition.
+
+## Day-2 operations
+
+These apply to both AWS and GCP. Cloud-specific commands are in the respective guides.
+
+### Upgrade to a new release
+
+```hcl
+# terraform.tfvars
+image_tag = "v1.5.0"
+```
+
+```bash
+terraform apply
+```
+
+The init task re-runs migrations. Compute services roll over with zero downtime.
+
+### Roll back
+
+Set `image_tag` to the previous version and `terraform apply`. Database data is not affected. If the failed version ran a destructive migration (rare, always called out in the CHANGELOG), restore from the pre-upgrade database backup.
+
+### Scale up
+
+Adjust variables in `terraform.tfvars`:
+
+```hcl
+# More API containers
+api_desired_count  = 4
+api_autoscale_max  = 20
+
+# Bigger database
+db_instance_class  = "db.m6g.large"      # AWS
+# postgres_tier    = "db-custom-4-16384"  # GCP
+
+# Bigger ClickHouse host
+data_instance_type = "m6i.xlarge"        # AWS
+# data_machine_type = "e2-standard-4"    # GCP
+```
+
+```bash
+terraform apply
+```
+
+### ClickHouse Cloud (for HA)
+
+The self-hosted ClickHouse is a single instance. For real high availability:
+
+```hcl
+clickhouse_mode           = "cloud"
+clickhouse_cloud_url      = "https://abc123.us-east-1.aws.clickhouse.cloud:8443"
+clickhouse_cloud_password = "..."
+```
+
+The EC2/GCE data host is skipped entirely. You become responsible for Grafana hosting (AWS Managed Grafana or a separate Cloud Run service).
+
+### Tear down
+
+```bash
+terraform destroy
+```
+
+On prod, databases have deletion protection enabled. Disable manually before destroy if you really mean it.
+
+## Cost comparison
+
+### AWS (us-east-1, on-demand)
+
+| Component | Spec | ~$/month |
+|---|---|---|
+| Fargate api 2× | 0.5 vCPU / 1 GB | $30 |
+| Fargate web 2× | 0.25 vCPU / 0.5 GB | $15 |
+| Fargate worker 1× | 0.5 vCPU / 1 GB | $15 |
+| EC2 data host | t3.large | $60 |
+| RDS Postgres Multi-AZ | db.t4g.small | $50 |
+| ElastiCache Redis 2× | cache.t4g.micro | $25 |
+| ALB | — | $20 |
+| NAT Gateway | — | $33 + egress |
+| EBS gp3 100 GB | — | $8 |
+| S3 backups | ~1 GB cold | $0.10 |
+| **Total** | | **~$255** |
+
+Set `environment = "staging"` to halve the bill (single-AZ RDS, one Redis node, no deletion protection).
+
+### GCP (us-central1, on-demand)
+
+| Component | Spec | ~$/month |
+|---|---|---|
+| Cloud Run api | 1 vCPU / 512 MB, min 1 instance | $25 |
+| Cloud Run web | 1 vCPU / 256 MB, min 1 instance | $15 |
+| Cloud Run worker | 1 vCPU / 512 MB, min 1 instance | $25 |
+| Cloud SQL Postgres | db-f1-micro (shared) | $10 |
+| Memorystore Redis | 1 GB basic | $35 |
+| GCE data host | e2-standard-2 | $50 |
+| Global HTTPS LB | — | $18 |
+| Persistent Disk 100 GB | — | $4 |
+| GCS backups | ~1 GB cold | $0.02 |
+| **Total** | | **~$180** |
+
+GCP is typically cheaper due to Cloud Run's per-request billing and no NAT Gateway equivalent charge.
+
+## Production hardening checklist
+
+Applies to both clouds. See the cloud-specific guides for implementation details.
+
+- [ ] Enable remote Terraform state (S3 + DynamoDB on AWS, GCS on GCP)
+- [ ] Restrict load balancer ingress to known CIDRs
+- [ ] Enable cloud security services (GuardDuty + Config on AWS, Security Command Center on GCP)
+- [ ] Set up alerting on database CPU, memory, and 5xx error rates
+- [ ] Attach a WAF to the load balancer
+- [ ] Enable Redis transit encryption
+- [ ] Configure [SSO](authentication.md) (SAML or OIDC)
+- [ ] Move ClickHouse to ClickHouse Cloud for HA
+- [ ] Test the [backup and restore](backup-and-restore.md) procedure end-to-end
+- [ ] Replace the GitHub tarball pull in the data host bootstrap with an artifact you control
+
+## Next
+
+- [AWS deployment with Terraform](aws-terraform.md) — full AWS walkthrough
+- [GCP deployment with Terraform](gcp-terraform.md) — full GCP walkthrough
+- [Configuration](configuration.md) — environment variables reference
+- [Upgrades](upgrades.md) — upgrade and rollback procedures
+- [Backup and restore](backup-and-restore.md) — detailed restore procedures

--- a/docs/self-hosting/single-node-deploy.md
+++ b/docs/self-hosting/single-node-deploy.md
@@ -1,0 +1,356 @@
+<!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Single-node deployment
+
+Run the full Observal stack on a single VM with Docker Compose. Best for teams of up to ~50 users, internal tools, evaluations, and any deployment where simplicity matters more than multi-AZ redundancy.
+
+**End state:** Observal running behind TLS on one server, with automated backups to S3-compatible storage, surviving reboots, and upgradable in under a minute.
+
+## When to use this vs. the Terraform module
+
+| | Single-node (this guide) | [Production Terraform](aws-terraform.md) |
+|---|---|---|
+| **Best for** | Small/mid teams, internal use, POCs | Enterprise, SLA-bound, high-traffic |
+| **Infra** | 1 VM, any cloud or on-prem | ~100 managed AWS resources |
+| **Cost** | $20–150/mo | ~$255/mo |
+| **HA** | No — single point of failure | Yes — Multi-AZ Postgres, autoscaling ECS |
+| **Time to deploy** | 10 minutes | 20–30 minutes |
+| **Operational complexity** | Low — SSH, docker compose, cron | Medium — Terraform, AWS console, CloudWatch |
+| **Scaling** | Vertical (bigger VM) | Horizontal (more Fargate tasks) |
+
+## Architecture
+
+```
+  ┌──────────────────────────────────────────────────┐
+  │                   Single VM                      │
+  │                                                  │
+  │  ┌─────────┐    ┌───────────┐   ┌────────────┐  │
+  │  │  nginx   │───►│   API     │   │   Worker   │  │
+  │  │  (TLS)   │    │ (FastAPI) │   │   (arq)    │  │
+  │  └────┬─────┘    └─────┬─────┘   └──────┬─────┘  │
+  │       │                │                │        │
+  │  ┌────▼─────┐    ┌─────▼─────┐   ┌──────▼─────┐ │
+  │  │   Web    │    │ Postgres  │   │   Redis    │  │
+  │  │ (Next.js)│    └───────────┘   └────────────┘  │
+  │  └──────────┘    ┌───────────┐   ┌────────────┐  │
+  │                  │ClickHouse │   │  Grafana   │  │
+  │                  └───────────┘   └────────────┘  │
+  │                                                  │
+  │  [systemd] ──► docker compose (auto-restart)     │
+  │  [cron]    ──► daily backups to S3               │
+  └──────────────────────────────────────────────────┘
+```
+
+Everything runs as Docker containers on a single host. The nginx LB routes traffic and terminates TLS. Docker's restart policy and systemd keep the stack running across reboots.
+
+## Prerequisites
+
+| Requirement | Minimum | Recommended |
+|---|---|---|
+| **VM** | 2 vCPU, 4 GB RAM, 40 GB SSD | 4 vCPU, 8 GB RAM, 100 GB SSD |
+| **OS** | Ubuntu 22.04+ / Amazon Linux 2023 / Debian 12 | Ubuntu 24.04 LTS |
+| **Docker** | Engine ≥ 24.0 with Compose v2 | Latest stable |
+| **Domain** (for TLS) | A DNS record pointing to the VM's public IP | — |
+| **Firewall** | Ports 80, 443 open inbound | — |
+
+### Sizing guide
+
+| Team size | VM spec | Estimated cost (AWS) |
+|---|---|---|
+| 1–10 users | `t3.medium` (2 vCPU / 4 GB) | ~$30/mo |
+| 10–30 users | `t3.large` (2 vCPU / 8 GB) | ~$60/mo |
+| 30–50 users | `t3.xlarge` (4 vCPU / 16 GB) | ~$120/mo |
+| 50+ users | Consider the [Terraform module](aws-terraform.md) | ~$255/mo |
+
+ClickHouse is the memory consumer. If you run out, increase `CLICKHOUSE_MEMORY_LIMIT` before resizing the VM.
+
+## Step 1: Provision the VM
+
+Use any cloud provider or on-prem hypervisor. Example for AWS:
+
+```bash
+aws ec2 run-instances \
+  --image-id ami-0c7217cdde317cfec \
+  --instance-type t3.large \
+  --key-name your-key \
+  --security-group-ids sg-xxxxx \
+  --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":100,"VolumeType":"gp3"}}]' \
+  --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=observal}]'
+```
+
+For other clouds:
+- **GCP:** `e2-standard-2` with 100 GB balanced persistent disk
+- **Azure:** `Standard_B2ms` with 100 GB Premium SSD
+- **Hetzner:** `CPX31` (4 vCPU / 8 GB, ~€15/mo)
+- **On-prem:** any Linux box meeting the specs above
+
+## Step 2: Install Docker
+
+SSH into the VM and install Docker:
+
+```bash
+ssh ubuntu@your-server-ip
+
+# Ubuntu / Debian
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Verify
+docker version
+docker compose version
+```
+
+## Step 3: Clone and configure
+
+```bash
+git clone https://github.com/BlazeUp-AI/Observal.git
+cd Observal
+cp .env.example .env
+```
+
+Edit `.env` for production. At minimum, change these:
+
+```bash
+# Generate a secure secret key
+SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+
+# Set strong database passwords
+POSTGRES_PASSWORD=$(openssl rand -base64 24)
+CLICKHOUSE_PASSWORD=$(openssl rand -base64 24)
+
+# Set your domain (used for CORS and OAuth redirects)
+CORS_ALLOWED_ORIGINS=https://observal.yourcompany.com
+FRONTEND_URL=https://observal.yourcompany.com
+
+# Remove demo accounts for production
+# Comment out or delete all DEMO_* variables
+```
+
+Write them into `.env`:
+
+```bash
+sed -i "s|^SECRET_KEY=.*|SECRET_KEY=$SECRET_KEY|" .env
+sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$POSTGRES_PASSWORD|" .env
+sed -i "s|^CLICKHOUSE_PASSWORD=.*|CLICKHOUSE_PASSWORD=$CLICKHOUSE_PASSWORD|" .env
+```
+
+> **Enterprise edition:** Set `OBSERVAL_LICENSE_KEY=eyJ...` in `.env` to enable SAML SSO, SCIM, audit logs, and executive dashboards. See [Configuration](configuration.md).
+
+## Step 4: Set up TLS
+
+### Option A: Caddy (simplest — automatic HTTPS)
+
+```bash
+sudo apt install -y caddy
+```
+
+Create `/etc/caddy/Caddyfile`:
+
+```caddyfile
+observal.yourcompany.com {
+    reverse_proxy localhost:80
+}
+```
+
+```bash
+sudo systemctl enable --now caddy
+```
+
+Caddy handles Let's Encrypt certificates automatically. No renewal cron needed.
+
+### Option B: Certbot + nginx production config
+
+```bash
+sudo apt install -y certbot
+sudo certbot certonly --standalone -d observal.yourcompany.com
+```
+
+Then use the production compose overlay which configures nginx for TLS:
+
+```bash
+cd docker
+docker compose -f docker-compose.yml -f docker-compose.production.yml up -d
+```
+
+Set up auto-renewal:
+
+```bash
+echo "0 3 * * * certbot renew --quiet && docker compose -f /home/ubuntu/Observal/docker/docker-compose.yml -f /home/ubuntu/Observal/docker/docker-compose.production.yml restart observal-lb" | sudo tee -a /etc/crontab
+```
+
+### Option C: Behind a cloud load balancer
+
+If your VM sits behind an AWS ALB, GCP HTTPS LB, or Cloudflare, terminate TLS there and proxy to port 80 on the VM. No TLS config on the VM itself.
+
+## Step 5: Start the stack
+
+```bash
+cd ~/Observal
+docker compose -f docker/docker-compose.yml up -d --build
+```
+
+First build takes 3–5 minutes (pulling images, building the API and web containers). Watch the logs:
+
+```bash
+docker compose -f docker/docker-compose.yml logs -f observal-init observal-api
+```
+
+Wait for:
+```
+observal-init  | INFO - Database up to date.
+observal-api   | INFO - Application startup complete.
+```
+
+Verify:
+
+```bash
+curl -fsSL http://localhost/health
+# {"status":"ok","initialized":true}
+```
+
+## Step 6: Survive reboots
+
+Docker's `restart: unless-stopped` policy (already set in `docker-compose.yml`) handles container restarts. To ensure Docker itself starts on boot:
+
+```bash
+sudo systemctl enable docker
+```
+
+Test it:
+
+```bash
+sudo reboot
+# After reconnecting:
+docker compose -f ~/Observal/docker/docker-compose.yml ps
+# All services should be running
+```
+
+## Step 7: Set up automated backups
+
+Create a backup script:
+
+```bash
+sudo mkdir -p /opt/observal-backups
+cat << 'SCRIPT' | sudo tee /opt/observal-backups/backup.sh
+#!/bin/bash
+set -euo pipefail
+
+BACKUP_DIR="/opt/observal-backups"
+DATE=$(date +%Y%m%d-%H%M)
+COMPOSE="docker compose -f /home/ubuntu/Observal/docker/docker-compose.yml"
+
+# Postgres
+$COMPOSE exec -T observal-db pg_dump -U postgres observal | gzip > "$BACKUP_DIR/pg-$DATE.sql.gz"
+
+# JWT keys
+$COMPOSE exec -T observal-api tar czf - -C /data keys > "$BACKUP_DIR/keys-$DATE.tar.gz"
+
+# Prune backups older than 30 days
+find "$BACKUP_DIR" -name "pg-*.sql.gz" -mtime +30 -delete
+find "$BACKUP_DIR" -name "keys-*.tar.gz" -mtime +30 -delete
+
+# Upload to S3 (optional — install awscli first)
+# aws s3 sync "$BACKUP_DIR" s3://your-backup-bucket/observal/ --exclude "backup.sh"
+
+echo "Backup completed: $DATE"
+SCRIPT
+
+sudo chmod +x /opt/observal-backups/backup.sh
+```
+
+Schedule it:
+
+```bash
+echo "0 3 * * * root /opt/observal-backups/backup.sh >> /var/log/observal-backup.log 2>&1" | sudo tee /etc/cron.d/observal-backup
+```
+
+For ClickHouse (weekly, since it's larger):
+
+```bash
+echo "0 4 * * 0 root docker compose -f /home/ubuntu/Observal/docker/docker-compose.yml exec -T observal-clickhouse clickhouse-client --password \$CLICKHOUSE_PASSWORD --query \"BACKUP DATABASE observal TO Disk('backups', 'weekly-\$(date +\%Y\%m\%d).zip')\" >> /var/log/observal-backup.log 2>&1" | sudo tee /etc/cron.d/observal-ch-backup
+```
+
+See [Backup and restore](backup-and-restore.md) for detailed restore procedures.
+
+## Step 8: First login
+
+Install the CLI on your local machine:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+```
+
+Log in:
+
+```bash
+observal auth login
+# Server URL: https://observal.yourcompany.com
+# Email: (create your admin account or use demo creds if you kept them)
+```
+
+Verify:
+
+```bash
+observal auth whoami
+observal auth status
+```
+
+## Upgrades
+
+```bash
+cd ~/Observal
+git fetch --tags
+git checkout v1.5.0    # or whatever version
+
+docker compose -f docker/docker-compose.yml up -d --build
+```
+
+Migrations run automatically on API startup. See [Upgrades](upgrades.md) for rollback procedures.
+
+Or use the CLI:
+
+```bash
+observal server upgrade --version 1.5.0
+```
+
+## Monitoring
+
+The stack includes Prometheus and Grafana. Access Grafana at `http://your-server:3001` (default admin/admin).
+
+For basic alerting without Grafana, add a health check cron:
+
+```bash
+echo "*/5 * * * * root curl -fsS http://localhost/health > /dev/null || echo 'Observal health check failed' | mail -s 'ALERT: Observal down' ops@yourcompany.com" | sudo tee /etc/cron.d/observal-health
+```
+
+## Security hardening
+
+Before exposing to the internet:
+
+- [ ] Remove all `DEMO_*` env vars from `.env`
+- [ ] Set a strong `SECRET_KEY`
+- [ ] Restrict SSH access (key-only, no password auth)
+- [ ] Configure a firewall (`ufw allow 80,443/tcp && ufw enable`)
+- [ ] Set up [SSO](authentication.md) if available
+- [ ] Enable automatic security updates (`sudo apt install unattended-upgrades`)
+- [ ] Bind database ports to localhost only (already done in `docker-compose.yml` via `127.0.0.1:` prefix)
+
+## Scaling up
+
+When you outgrow a single node:
+
+| Symptom | Fix |
+|---|---|
+| API response times increasing | Increase `API_WORKERS` in `.env` (default 2), or bump to a bigger VM |
+| ClickHouse queries slow | Increase `CLICKHOUSE_MEMORY_LIMIT`, move to a bigger VM, or externalize to [ClickHouse Cloud](https://clickhouse.cloud) |
+| Disk filling up | Reduce `DATA_RETENTION_DAYS`, add a bigger disk, or move ClickHouse data to a separate volume |
+| Need HA / zero downtime deploys | Migrate to the [Terraform module](aws-terraform.md) |
+
+## Next
+
+- [Configuration](configuration.md) — all environment variables
+- [Backup and restore](backup-and-restore.md) — detailed restore procedures
+- [Upgrades](upgrades.md) — safe upgrade and rollback flow
+- [Troubleshooting](troubleshooting.md) — common issues


### PR DESCRIPTION
## Purpose / Description
  Adds two-tier deployment documentation so clients have a clear path depending on their scale and requirements: a single-node
  Docker Compose deploy for small teams, and a production Terraform deploy (AWS/GCP) for enterprise use. Also adds the missing
  GCP Terraform guide.
  ## Fixes
  * N/A (new documentation)
  ## Approach
  - Created `single-node-deploy.md` covering VM provisioning, TLS, backups, hardening, and scaling guidance
  - Created `production-deploy.md` as the overview page comparing AWS vs GCP with architecture diagrams and cost tables
  - Created `gcp-terraform.md` with a full GCP Cloud Run + Cloud SQL walkthrough (was missing)
  - Updated `README.md` with a deployment tier comparison table at the top
  - Updated `SUMMARY.md` navigation to include all new pages
  ## How Has This Been Tested?
  Documentation-only change. Verified all internal links reference existing pages and all Terraform variable names match the
  actual module code.
  ## Checklist
  - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
  - [x] You have commented your code, particularly in hard-to-understand areas
  - [x] You have performed a self-review of your own code
  - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)