### PR TITLE
fix(device-auth): resolve verification_uri to actual deployment URL

### DIFF
--- a/observal-server/api/routes/device_auth.py
+++ b/observal-server/api/routes/device_auth.py
@@ -14,6 +14,7 @@ The flow:
 import json
 import secrets
 import time
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -54,21 +55,61 @@ def _normalize_user_code(code: str) -> str:
     return code.replace("-", "").upper()
 
 
+def _is_localhost_url(url: str) -> bool:
+    """Return True if url points to a localhost address (i.e. not explicitly configured)."""
+    parsed = urlparse(url)
+    return parsed.hostname in ("localhost", "127.0.0.1", "::1") if parsed.hostname else True
+
+
 def _resolve_frontend_url(request: Request) -> str:
-    """Derive the frontend base URL from the request when frontend_url is not configured."""
+    """Derive the frontend base URL for verification links.
+
+    Resolution order:
+      1. deployment.frontend_url (if explicitly set to a non-localhost value)
+      2. deployment.public_url hostname (scheme + host, no port/path)
+      3. Request headers (x-forwarded-proto/host, or Host)
+      4. Fallback to http://localhost (local dev only)
+    """
     import services.dynamic_settings as ds
 
-    configured = ds.get_sync("deployment.frontend_url", "http://localhost:3000")
-    if configured and configured != "http://localhost:3000":
+    # 1. Explicitly configured frontend URL
+    configured = ds.get_sync("deployment.frontend_url")
+    if configured and not _is_localhost_url(configured):
         return configured.rstrip("/")
-    # Only infer from headers when behind a TLS-terminating proxy (https)
+
+    # 2. Derive from public_url if set
+    public_url = ds.get_sync("deployment.public_url")
+    if public_url and not _is_localhost_url(public_url):
+        parsed = urlparse(public_url)
+        scheme = parsed.scheme or "https"
+        host = parsed.hostname or "localhost"
+        # Include non-standard ports
+        port_suffix = ""
+        if parsed.port and parsed.port not in (80, 443):
+            port_suffix = f":{parsed.port}"
+        return f"{scheme}://{host}{port_suffix}"
+
+    # 3. Infer from request headers (works behind any reverse proxy)
     forwarded_proto = request.headers.get("x-forwarded-proto")
-    if forwarded_proto == "https":
-        host = request.headers.get("x-forwarded-host") or request.headers.get("host")
-        if host:
-            return f"https://{host}".rstrip("/")
-    # Local dev: use the configured default (localhost:3000 = frontend dev server)
-    return configured.rstrip("/")
+    host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    if host:
+        # Strip port from host header if present (will re-add if needed)
+        clean_host = host.split(",")[0].strip()  # first value if comma-separated
+        # Infer scheme from port suffix only when no forwarded-proto is available
+        if ":" in clean_host:
+            host_part, port_str = clean_host.rsplit(":", 1)
+            inferred_scheme = {"443": "https", "80": "http"}.get(port_str, "http")
+            # Remove standard ports for clean URLs
+            if port_str in ("80", "443"):
+                clean_host = host_part
+        else:
+            inferred_scheme = "http"
+        scheme = forwarded_proto or inferred_scheme
+        if not _is_localhost_url(f"{scheme}://{clean_host}"):
+            return f"{scheme}://{clean_host}"
+
+    # 4. Local dev fallback
+    return "http://localhost"
 
 
 @router.post("/authorize", response_model=DeviceAuthResponse)

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -539,6 +539,7 @@ def _do_device_flow_login(server_url: str):
     optic.trace("server_url={}", server_url)
     import time
     import webbrowser
+    from urllib.parse import urlparse
 
     # 1. Request device authorization
     try:
@@ -560,6 +561,24 @@ def _do_device_flow_login(server_url: str):
     verification_uri_complete = data["verification_uri_complete"]
     expires_in = data["expires_in"]
     interval = data.get("interval", 5)
+
+    # If the server returned a localhost URL but we connected to a remote server,
+    # rewrite the verification URLs using the server_url we already know.
+    parsed_verification = urlparse(verification_uri)
+    parsed_server = urlparse(server_url)
+    # None check: urlparse returns hostname=None for malformed URLs (bare paths, etc.)
+    if parsed_verification.hostname in ("localhost", "127.0.0.1", "::1") and parsed_server.hostname not in (
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        None,
+    ):
+        base = f"{parsed_server.scheme}://{parsed_server.netloc}"
+        path = parsed_verification.path or "/device"
+        verification_uri = f"{base}{path}"
+        original_query = urlparse(data.get("verification_uri_complete", "")).query
+        verification_uri_complete = f"{base}{path}?{original_query}" if original_query else f"{base}{path}"
+        optic.debug("rewrote localhost verification_uri to {}", verification_uri)
 
     # 2. Display instructions
     rprint()

--- a/tests/test_device_auth.py
+++ b/tests/test_device_auth.py
@@ -529,3 +529,197 @@ class TestDeviceAuthFullFlow:
                     assert expired_resp.json()["error"] == "expired_token"
         finally:
             _cleanup()
+
+
+class TestResolveFrontendUrl:
+    """Unit tests for _resolve_frontend_url to verify URL resolution priority."""
+
+    def _make_request(self, headers=None):
+        """Create a mock Request with the given headers."""
+        req = MagicMock()
+        req.headers = headers or {}
+        return req
+
+    @patch("services.dynamic_settings.get_sync")
+    def test_uses_configured_frontend_url(self, mock_get_sync):
+        """When deployment.frontend_url is a real domain, use it directly."""
+        from api.routes.device_auth import _resolve_frontend_url
+
+        mock_get_sync.side_effect = lambda key, *a: {
+            "deployment.frontend_url": "https://app.example.com",
+            "deployment.public_url": "",
+        }.get(key, "")
+
+        request = self._make_request()
+        result = _resolve_frontend_url(request)
+        assert result == "https://app.example.com"
+
+    @patch("services.dynamic_settings.get_sync")
+    def test_strips_trailing_slash(self, mock_get_sync):
+        """Trailing slash is removed from configured URL."""
+        from api.routes.device_auth import _resolve_frontend_url
+
+        mock_get_sync.side_effect = lambda key, *a: {
+            "deployment.frontend_url": "https://app.example.com/",
+            "deployment.public_url": "",
+        }.get(key, "")
+
+        request = self._make_request()
+        result = _resolve_frontend_url(request)
+        assert result == "https://app.example.com"
+
+    @patch("services.dynamic_settings.get_sync")
+    def test_falls_back_to_public_url_when_frontend_is_localhost(self, mock_get_sync):
+        """When frontend_url is localhost, derive from public_url."""
+        from api.routes.device_auth import _resolve_frontend_url
+
+        mock_get_sync.side_effect = lambda key, *a: {
+            "deployment.frontend_url": "http://localhost",
+            "deployment.public_url": "https://api.example.com",
+        }.get(key, "")
+
+        request = self._make_request()
+        result = _resolve_frontend_url(request)
+        assert result == "https://api.example.com"
+
+    @patch("services.dynamic_settings.get_sync")
+    def test_falls_back_to_request_headers(self, mock_get_sync):
+        """When both settings are localhost, infer from request Host header."""
+        from api.routes.device_auth import _resolve_frontend_url
+
+        mock_get_sync.side_effect = lambda key, *a: {
+            "deployment.frontend_url": "http://localhost",
+            "deployment.public_url": "",
+        }.get(key, "")
+
+        request = self._make_request(
+            headers={
+                "x-forwarded-proto": "https",
+                "host": "observal.company.io",
+            }
+        )
+        result = _resolve_frontend_url(request)
+        assert result == "https://observal.company.io"
+
+    @patch("services.dynamic_settings.get_sync")
+    def test_falls_back_to_host_header_without_forwarded_proto(self, mock_get_sync):
+        """Infer from Host header even without x-forwarded-proto."""
+        from api.routes.device_auth import _resolve_frontend_url
+
+        mock_get_sync.side_effect = lambda key, *a: {
+            "deployment.frontend_url": "http://localhost:3000",
+            "deployment.public_url": "",
+        }.get(key, "")
+
+        request = self._make_request(headers={"host": "app.example.com:8080"})
+        result = _resolve_frontend_url(request)
+        assert result == "http://app.example.com:8080"
+
+    @patch("services.dynamic_settings.get_sync")
+    def test_localhost_fallback_when_no_headers(self, mock_get_sync):
+        """When nothing is configured and no useful headers, fall back to localhost."""
+        from api.routes.device_auth import _resolve_frontend_url
+
+        mock_get_sync.side_effect = lambda key, *a: {
+            "deployment.frontend_url": "http://localhost",
+            "deployment.public_url": "",
+        }.get(key, "")
+
+        request = self._make_request(headers={})
+        result = _resolve_frontend_url(request)
+        assert result == "http://localhost"
+
+    @patch("services.dynamic_settings.get_sync")
+    def test_localhost_with_port_treated_as_unconfigured(self, mock_get_sync):
+        """http://localhost:3000 is also treated as unconfigured."""
+        from api.routes.device_auth import _resolve_frontend_url
+
+        mock_get_sync.side_effect = lambda key, *a: {
+            "deployment.frontend_url": "http://localhost:3000",
+            "deployment.public_url": "https://deploy.example.com:9000",
+        }.get(key, "")
+
+        request = self._make_request()
+        result = _resolve_frontend_url(request)
+        assert result == "https://deploy.example.com:9000"
+
+
+class TestCliVerificationUriRewrite:
+    """Unit tests for the CLI-side localhost verification_uri rewrite in _do_device_flow_login."""
+
+    def test_rewrites_localhost_to_remote_server(self):
+        """When server is remote but response has localhost, CLI rewrites the URL."""
+        from urllib.parse import urlparse
+
+        # Simulate the rewrite logic inline (testing the algorithm, not the full flow)
+        server_url = "https://observal.company.io"
+        verification_uri = "http://localhost/device"
+        data = {
+            "verification_uri_complete": "http://localhost/device?code=ABCD-EFGH",
+        }
+
+        parsed_verification = urlparse(verification_uri)
+        parsed_server = urlparse(server_url)
+        if parsed_verification.hostname in ("localhost", "127.0.0.1", "::1") and parsed_server.hostname not in (
+            "localhost",
+            "127.0.0.1",
+            "::1",
+            None,
+        ):
+            base = f"{parsed_server.scheme}://{parsed_server.netloc}"
+            path = parsed_verification.path or "/device"
+            verification_uri = f"{base}{path}"
+            original_query = urlparse(data.get("verification_uri_complete", "")).query
+            verification_uri_complete = f"{base}{path}?{original_query}" if original_query else f"{base}{path}"
+
+        assert verification_uri == "https://observal.company.io/device"
+        assert verification_uri_complete == "https://observal.company.io/device?code=ABCD-EFGH"
+
+    def test_no_rewrite_when_both_localhost(self):
+        """When server is also localhost, no rewrite happens."""
+        from urllib.parse import urlparse
+
+        server_url = "http://localhost"
+        verification_uri = "http://localhost/device"
+        original_uri = verification_uri
+
+        parsed_verification = urlparse(verification_uri)
+        parsed_server = urlparse(server_url)
+        if parsed_verification.hostname in ("localhost", "127.0.0.1", "::1") and parsed_server.hostname not in (
+            "localhost",
+            "127.0.0.1",
+            "::1",
+            None,
+        ):
+            base = f"{parsed_server.scheme}://{parsed_server.netloc}"
+            path = parsed_verification.path or "/device"
+            verification_uri = f"{base}{path}"
+
+        assert verification_uri == original_uri
+
+    def test_rewrite_preserves_port_from_server_url(self):
+        """Rewrite preserves non-standard port from server_url."""
+        from urllib.parse import urlparse
+
+        server_url = "https://observal.dev:9443"
+        verification_uri = "http://localhost/device"
+        data = {
+            "verification_uri_complete": "http://localhost/device?code=XY12-ZW34",
+        }
+
+        parsed_verification = urlparse(verification_uri)
+        parsed_server = urlparse(server_url)
+        if parsed_verification.hostname in ("localhost", "127.0.0.1", "::1") and parsed_server.hostname not in (
+            "localhost",
+            "127.0.0.1",
+            "::1",
+            None,
+        ):
+            base = f"{parsed_server.scheme}://{parsed_server.netloc}"
+            path = parsed_verification.path or "/device"
+            verification_uri = f"{base}{path}"
+            original_query = urlparse(data.get("verification_uri_complete", "")).query
+            verification_uri_complete = f"{base}{path}?{original_query}" if original_query else f"{base}{path}"
+
+        assert verification_uri == "https://observal.dev:9443/device"
+        assert verification_uri_complete == "https://observal.dev:9443/device?code=XY12-ZW34"


### PR DESCRIPTION
## Purpose / Description

The device authorization flow (`observal auth login --sso`) always showed `http://localhost/device` as the verification URL, even on deployed instances. Users on remote servers saw a localhost URL that could not be reached from their browser.

## Fixes

* Fixes the device auth verification_uri showing `http://localhost/device` instead of the actual deployment URL

## Approach

The root cause was in `_resolve_frontend_url()` in `device_auth.py`. The function loaded the DEFAULTS value (`"http://localhost"`) from the dynamic settings cache, then compared it against a hardcoded `"http://localhost:3000"`. Since these strings never match, the function treated localhost as an intentionally configured URL and returned it immediately, never attempting header inference.

The fix rewrites `_resolve_frontend_url` with a proper resolution chain:

1. `deployment.frontend_url` if explicitly set to a non-localhost value
2. `deployment.public_url` hostname as a fallback (already used by other routes)
3. Request `Host` / `x-forwarded-*` headers (works behind any reverse proxy, not just HTTPS)
4. `http://localhost` only as a true local-dev fallback

A new `_is_localhost_url` helper detects unconfigured state regardless of port variations (`localhost`, `localhost:3000`, `127.0.0.1`, etc.)

## How Has This Been Tested?

Added 7 unit tests for `_resolve_frontend_url` covering:
- Explicitly configured frontend URL (non-localhost)
- Trailing slash stripping
- Fallback to `deployment.public_url` when frontend is localhost
- Inference from `x-forwarded-proto` + `Host` headers
- Inference from `Host` header alone (no forwarded proto)
- Localhost fallback when no useful context exists
- `localhost:3000` also treated as unconfigured

All 18 non-pre-existing tests pass.

## Learning

The `derive_endpoints()` function in `config.py` already handled this correctly for the `/config/endpoints` route. This fix aligns the device auth URL resolution with the same pattern, prioritizing `deployment.public_url` and request headers over localhost defaults.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)