### PR TITLE
fix(hooks): persist script_content in API response and write scripts …

### DIFF
--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "python3-saml>=1.16.0",
     "cffi",
     "slowapi",
-    "PyJWT>=2.8.0",
+    "PyJWT>=2.13.0",
     "aiosqlite>=0.22.1",
     "tenacity>=8.0.0",
     "python-multipart>=0.0.26",

--- a/observal-server/schemas/hook.py
+++ b/observal-server/schemas/hook.py
@@ -110,6 +110,8 @@ class HookListingResponse(BaseModel):
     handler_config: dict
     scope: str
     supported_ides: list[str]
+    script_content: str | None = None
+    script_filename: str | None = None
     status: ListingStatus
     rejection_reason: str | None = None
     submitted_by: uuid.UUID

--- a/observal-server/services/ide/helpers.py
+++ b/observal-server/services/ide/helpers.py
@@ -525,12 +525,12 @@ def _merge_hook_components_into_config(hooks_content: dict, hook_configs: list[d
         ide_event = events_map.get(event, event)
         handler_config = hc.get("handler_config", {})
         command = handler_config.get("command", "")
-        if not command:
-            continue
-
-        # If hook has a script_filename, rewrite command to the IDE scripts dir
         script_filename = hc.get("script_filename")
-        if script_filename and scripts_dir:
+        if not command and script_filename and scripts_dir:
+            command = f"{scripts_dir}/{script_filename}"
+        elif not command:
+            continue
+        elif script_filename and scripts_dir:
             command = f"{scripts_dir}/{script_filename}"
 
         if ide == "cursor":

--- a/observal-server/services/ide/kiro.py
+++ b/observal-server/services/ide/kiro.py
@@ -42,6 +42,12 @@ class KiroAdapter:
             "stop": [{"command": push_cmd}],
         }
 
+        kiro_spec = IDE_REGISTRY["kiro"]
+        kiro_scope = options.get("scope", kiro_spec["default_scope"])
+
+        # Determine scope-aware hooks dir
+        hooks_dir = "~/.kiro/hooks" if kiro_scope == "user" else ".kiro/hooks"
+
         # Merge custom hook components
         for hc in hook_configs:
             event = hc.get("event")
@@ -52,11 +58,13 @@ class KiroAdapter:
             handler_config = hc.get("handler_config", {})
             if handler_type == "command":
                 cmd = handler_config.get("command", "")
-                if not cmd:
-                    continue
                 script_filename = hc.get("script_filename")
-                if script_filename and cmd == script_filename:
-                    cmd = f".kiro/hooks/{script_filename}"
+                if not cmd and script_filename:
+                    cmd = f"{hooks_dir}/{script_filename}"
+                elif not cmd:
+                    continue
+                elif script_filename:
+                    cmd = f"{hooks_dir}/{script_filename}"
                 entry: dict = {"command": cmd}
                 if kiro_event in ("preToolUse", "postToolUse"):
                     entry["matcher"] = handler_config.get("matcher", "*")
@@ -70,8 +78,6 @@ class KiroAdapter:
                     entry["matcher"] = handler_config.get("matcher", "*")
                 hooks.setdefault(kiro_event, []).append(entry)
 
-        kiro_spec = IDE_REGISTRY["kiro"]
-        kiro_scope = options.get("scope", kiro_spec["default_scope"])
         agent_path = kiro_spec["rules_file"][kiro_scope].format(name=safe_name)
         kiro_model = options.get("_resolved_model", None)
 
@@ -105,6 +111,10 @@ class KiroAdapter:
 
         kiro_hook_files = _collect_hook_script_files(hook_configs, ctx.hook_listings, "kiro")
         if kiro_hook_files:
+            # Fix paths for user scope
+            if kiro_scope == "user":
+                for hf in kiro_hook_files:
+                    hf["path"] = hf["path"].replace(".kiro/hooks", "~/.kiro/hooks", 1)
             result["hook_files"] = kiro_hook_files
 
         warnings_combined = list(ctx.compatibility_warnings)

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1744,7 +1744,7 @@ requires-dist = [
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "pyjwt", specifier = ">=2.8.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv" },
     { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "python3-saml", specifier = ">=1.16.0" },
@@ -2144,11 +2144,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

  ## Purpose / Description
  
  Hook scripts submitted via the UI with `script_content` and `script_filename` were not being written to disk when an agent was
  pulled. The API response schema was missing these fields, and the Kiro adapter's command path rewrite had bugs that prevented the
  script file from being placed correctly.
  
  ## Approach
  
  1. Added `script_content` and `script_filename` to `HookListingResponse` schema so the API returns stored script data
  2. Fixed Kiro adapter to always rewrite command path when `script_filename` is present (previously only matched exact string
  equality, missing `./` prefix variants)
  3. Made hook file paths scope-aware: `~/.kiro/hooks/` for user scope, `.kiro/hooks/` for project scope
  4. Fixed `kiro_scope` referenced before assignment by moving the variable declaration earlier
  
  ## How Has This Been Tested?
  
  - 104 agent config generator tests pass
  - 59 CLI IDE adapter tests pass
  - Manual e2e: submitted hook with script content via UI, pulled agent into Kiro, verified script written to `~/.kiro/hooks/`,
  confirmed hook fires on session start
  
  ## Checklist
  
  - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
  - [x] You have commented your code, particularly in hard-to-understand areas
  - [x] You have performed a self-review of your own code
  - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)