### PR TITLE
fix(insights): pass aws_region_name to LiteLLM for Bedrock calls

### DIFF
--- a/observal-server/services/insights/__init__.py
+++ b/observal-server/services/insights/__init__.py
@@ -114,6 +114,8 @@ async def _call_litellm(prompt: str, model: str, max_tokens: int = 16384) -> dic
     api_key = await ds.get("insights.api_key")
     api_base = await ds.get("insights.api_base")
 
+    aws_region = await ds.get("insights.aws_region")
+
     kwargs: dict = {
         "model": model,
         "messages": [{"role": "user", "content": prompt}],
@@ -129,6 +131,8 @@ async def _call_litellm(prompt: str, model: str, max_tokens: int = 16384) -> dic
         kwargs["api_key"] = api_key
     if api_base:
         kwargs["api_base"] = api_base
+    if aws_region and "bedrock" in model:
+        kwargs["aws_region_name"] = aws_region
 
     try:
         response = await litellm.acompletion(**kwargs)


### PR DESCRIPTION
 ## Purpose / Description
  LiteLLM defaults to us-west-2 for Bedrock when no region is specified, causing model invocation failures when the instance role and model access are configured in a different region (e.g. us-east-1).

  ## Fixes
  * Fixes dashboard "AI Insights not available" when using Bedrock with non-default AWS region

  ## Approach
 Read `insights.aws_region` from dynamic settings and pass it as `aws_region_name` to `litellm.acompletion()` for Bedrock models.

  ## How Has This Been Tested?
  - Tested on production EC2 (internal.observal.io) — confirmed LiteLLM Bedrock calls succeed with explicit region
  - Verified `call_model` returns valid JSON response from Claude Sonnet via Bedrock us-east-1

  ## Checklist
  - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
  - [x] You have commented your code, particularly in hard-to-understand areas
  - [x] You have performed a self-review of your own code
  - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)