### PR TITLE
feat(settings): revamp Agent Insights with provider-aware model selection

### DIFF
--- a/observal-server/api/routes/admin/enterprise_settings.py
+++ b/observal-server/api/routes/admin/enterprise_settings.py
@@ -4,8 +4,12 @@
 
 """Admin settings, diagnostics, and resource tuning routes."""
 
+import time
+
+import litellm
 from fastapi import Depends, HTTPException
 from loguru import logger as optic
+from pydantic import BaseModel
 from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,6 +19,7 @@ from config import HAS_LICENSE, settings
 from models.enterprise_config import EnterpriseConfig
 from models.user import User, UserRole
 from schemas.admin import EnterpriseConfigResponse, EnterpriseConfigUpdate, SettingRevokedResponse
+from services.insights import _normalize_model_id
 from services.secrets_redactor import REDACTED
 from services.security_events import EventType, SecurityEvent, Severity, emit_security_event
 
@@ -321,3 +326,95 @@ async def apply_resources(
         "applied": {k: current[k] for k in applied_keys},
         "message": "ClickHouse resource settings applied",
     }
+
+
+# ── Insights Test Connection ───────────────────────────────
+
+
+class _TestConnectionRequest(BaseModel):
+    model: str | None = None
+
+
+class _TestConnectionResponse(BaseModel):
+    success: bool
+    model: str | None = None
+    latency_ms: int | None = None
+    error: str | None = None
+    hint: str | None = None
+
+
+def _get_connection_error_hint(error_str: str, model: str) -> str:
+    model_lower = model.lower()
+    if "model identifier is invalid" in error_str or "model_not_found" in error_str:
+        if "bedrock" in model_lower:
+            return (
+                "Model ID is not available in your region. "
+                "Ensure the Base URL region matches where the model is enabled. "
+                "Cross-region models use prefixes like us./eu./apac. (e.g., bedrock/us.anthropic.claude-sonnet-4-6-v1)."
+            )
+        return "Model ID not recognized. Verify the format: provider/model-name"
+    if "auth" in error_str or "401" in error_str or "invalid api key" in error_str or "forbidden" in error_str:
+        if "anthropic" in model_lower:
+            return "Invalid API key. Get one at console.anthropic.com"
+        if "bedrock" in model_lower:
+            return "Bearer token may be expired. Regenerate in AWS Console."
+        if "openai" in model_lower:
+            return "Invalid API key. Get one at platform.openai.com/api-keys"
+        if "gemini" in model_lower:
+            return "Invalid API key. Get one at aistudio.google.com/apikey"
+        return "Authentication failed. Verify your API key."
+    if "timeout" in error_str or "timed out" in error_str or "connect" in error_str:
+        return "Could not reach endpoint. Check your Base URL and network connectivity."
+    if "not found" in error_str or "does not exist" in error_str or "unknown provider" in error_str:
+        return "Model ID not recognized. Verify the format: provider/model-name"
+    if "rate" in error_str or "429" in error_str:
+        return "Rate limited by provider. The key is valid, try again in a moment."
+    if "access" in error_str and "bedrock" in model_lower:
+        return "Model access not enabled. Enable the model in your AWS Bedrock console for this region."
+    return "Connection test failed. Check your settings and try again."
+
+
+@router.post("/insights/test-connection", response_model=_TestConnectionResponse)
+async def test_insights_connection(
+    req: _TestConnectionRequest,
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Test LLM connectivity with a minimal prompt."""
+    api_key = await ds.get("insights.api_key")
+    api_base = await ds.get("insights.api_base")
+    aws_region = await ds.get("insights.aws_region")
+    model = req.model or await ds.get("insights.model_sections")
+
+    if not model:
+        return _TestConnectionResponse(
+            success=False,
+            error="No model configured",
+            hint="Set the Sections Model first, or provide a model in the request.",
+        )
+
+    model = _normalize_model_id(model)
+
+    kwargs: dict = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Say hello in exactly one word."}],
+        "max_tokens": 10,
+        "timeout": 15,
+        "drop_params": True,
+    }
+    if api_key:
+        kwargs["api_key"] = api_key
+    if api_base:
+        kwargs["api_base"] = api_base
+    if aws_region and "bedrock" in model:
+        kwargs["aws_region_name"] = aws_region
+
+    start = time.time()
+    try:
+        await litellm.acompletion(**kwargs)
+        latency_ms = int((time.time() - start) * 1000)
+        return _TestConnectionResponse(success=True, model=model, latency_ms=latency_ms)
+    except Exception as e:
+        optic.warning("insights connection test failed, model={}, error={}", model, str(e))
+        error_str = str(e).lower()
+        hint = _get_connection_error_hint(error_str, model)
+        return _TestConnectionResponse(success=False, model=model, error=str(e)[:200], hint=hint)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -583,6 +583,14 @@ export const admin = {
 			`/admin/settings/${key}/revoke`,
 			{},
 		),
+	testInsightsConnection: (body?: { model?: string }) =>
+		post<{
+			success: boolean;
+			model?: string;
+			latency_ms?: number;
+			error?: string;
+			hint?: string;
+		}>("/admin/insights/test-connection", body ?? {}),
 	users: () => get<AdminUser[]>("/admin/users"),
 	createUser: (body: {
 		email: string;

--- a/web/src/pages/admin/settings.tsx
+++ b/web/src/pages/admin/settings.tsx
@@ -25,6 +25,7 @@ import {
 	AlertTriangle,
 	ShieldAlert,
 } from "lucide-react";
+import { InsightsSection } from "./settings/insights-section";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAdminSettings, useSystemWarnings } from "@/hooks/use-api";
@@ -1559,6 +1560,22 @@ export default function SettingsPage() {
 							{SETTING_SECTIONS.filter((s) => !s.danger && (!s.requiresFeature || licensedFeatures.includes(s.requiresFeature) || licensedFeatures.includes("all"))).map((section) => {
 								const visibleSettings = section.settings.filter((d) => !d.requiresFeature || licensedFeatures.includes(d.requiresFeature) || licensedFeatures.includes("all"));
 								if (visibleSettings.length === 0) return null;
+
+								if (section.title === "Agent Insights") {
+									return (
+										<InsightsSection
+											key={section.title}
+											entries={entries as { key: string; value: string; is_sensitive?: boolean; is_set?: boolean }[]}
+											onSave={async (key, value) => {
+												await admin.updateSetting(key, { value });
+												refetch();
+											}}
+											onRevoke={(key) => setRevokeConfirmKey(key)}
+											refetch={refetch}
+										/>
+									);
+								}
+
 								// Check for deprecated AWS settings that are still configured
 								const deprecatedAwsKeys = ["insights.aws_region", "insights.aws_access_key_id", "insights.aws_secret_access_key", "insights.aws_session_token", "insights.model_url", "insights.model_api_key"];
 								const hasNewApiKey = entries.some((e) => e.key === "insights.api_key" && e.value && e.value !== "");

--- a/web/src/pages/admin/settings/insights-constants.ts
+++ b/web/src/pages/admin/settings/insights-constants.ts
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+export type ProviderId =
+	| "anthropic"
+	| "openai"
+	| "bedrock"
+	| "gemini"
+	| "azure"
+	| "ollama"
+	| "groq"
+	| "mistral"
+	| "together"
+	| "deepseek"
+	| "other";
+
+export interface ProviderOption {
+	id: ProviderId;
+	label: string;
+	requiresBaseUrl: boolean;
+	baseUrlHint?: string;
+	hasRecommendations: boolean;
+}
+
+export interface ModelSuggestion {
+	id: string;
+	label: string;
+	tier: "primary" | "fast";
+}
+
+export type InsightsStatus = "not_configured" | "partial" | "ready";
+
+export const PROVIDERS: ProviderOption[] = [
+	{
+		id: "anthropic",
+		label: "Anthropic",
+		requiresBaseUrl: false,
+		hasRecommendations: true,
+	},
+	{
+		id: "openai",
+		label: "OpenAI",
+		requiresBaseUrl: false,
+		hasRecommendations: true,
+	},
+	{
+		id: "bedrock",
+		label: "AWS Bedrock",
+		requiresBaseUrl: false,
+		baseUrlHint: "https://bedrock-runtime.<region>.amazonaws.com",
+		hasRecommendations: true,
+	},
+	{
+		id: "gemini",
+		label: "Google Gemini",
+		requiresBaseUrl: false,
+		hasRecommendations: true,
+	},
+	{
+		id: "azure",
+		label: "Azure OpenAI",
+		requiresBaseUrl: true,
+		baseUrlHint: "https://<instance>.openai.azure.com",
+		hasRecommendations: false,
+	},
+	{
+		id: "ollama",
+		label: "Ollama",
+		requiresBaseUrl: true,
+		baseUrlHint: "http://localhost:11434",
+		hasRecommendations: false,
+	},
+	{
+		id: "groq",
+		label: "Groq",
+		requiresBaseUrl: false,
+		hasRecommendations: false,
+	},
+	{
+		id: "mistral",
+		label: "Mistral",
+		requiresBaseUrl: false,
+		hasRecommendations: false,
+	},
+	{
+		id: "together",
+		label: "Together AI",
+		requiresBaseUrl: false,
+		hasRecommendations: false,
+	},
+	{
+		id: "deepseek",
+		label: "Deepseek",
+		requiresBaseUrl: false,
+		hasRecommendations: false,
+	},
+	{
+		id: "other",
+		label: "Other",
+		requiresBaseUrl: true,
+		baseUrlHint: "https://your-provider.example.com/v1",
+		hasRecommendations: false,
+	},
+];
+
+export const PROVIDER_MODELS: Record<string, ModelSuggestion[]> = {
+	anthropic: [
+		{ id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6", tier: "primary" },
+		{ id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7", tier: "primary" },
+		{ id: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5", tier: "primary" },
+		{ id: "anthropic/claude-haiku-4-5-20251001", label: "Claude Haiku 4.5", tier: "fast" },
+	],
+	openai: [
+		{ id: "openai/gpt-4o", label: "GPT-4o", tier: "primary" },
+		{ id: "openai/o3", label: "O3", tier: "primary" },
+		{ id: "openai/gpt-4o-mini", label: "GPT-4o Mini", tier: "fast" },
+		{ id: "openai/o4-mini", label: "O4 Mini", tier: "fast" },
+	],
+	bedrock: [
+		{ id: "bedrock/global.anthropic.claude-opus-4-6-v1", label: "Claude Opus 4.6 (Global)", tier: "primary" },
+		{ id: "bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0", label: "Claude Opus 4.5 (Global)", tier: "primary" },
+		{ id: "bedrock/us.anthropic.claude-sonnet-4-6-v1", label: "Claude Sonnet 4.6 (US only)", tier: "primary" },
+		{ id: "bedrock/us.anthropic.claude-opus-4-6-v1", label: "Claude Opus 4.6 (US only)", tier: "primary" },
+		{ id: "bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Claude Haiku 4.5 (Global)", tier: "fast" },
+		{ id: "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Claude Haiku 4.5 (US only)", tier: "fast" },
+		{ id: "bedrock/us.amazon.nova-pro-v1:0", label: "Amazon Nova Pro (US only)", tier: "primary" },
+		{ id: "bedrock/us.amazon.nova-lite-v1:0", label: "Amazon Nova Lite (US only)", tier: "fast" },
+	],
+	gemini: [
+		{ id: "gemini/gemini-2.5-pro", label: "Gemini 2.5 Pro", tier: "primary" },
+		{ id: "gemini/gemini-2.5-flash", label: "Gemini 2.5 Flash", tier: "fast" },
+		{ id: "gemini/gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite", tier: "fast" },
+	],
+	azure: [
+		{ id: "azure/my-gpt4o-deployment", label: "GPT-4o (example)", tier: "primary" },
+		{ id: "azure/my-gpt4o-mini-deployment", label: "GPT-4o Mini (example)", tier: "fast" },
+	],
+	ollama: [
+		{ id: "ollama/llama3", label: "Llama 3", tier: "primary" },
+		{ id: "ollama/mistral", label: "Mistral", tier: "primary" },
+		{ id: "ollama/qwen2.5", label: "Qwen 2.5", tier: "fast" },
+	],
+	groq: [
+		{ id: "groq/llama-3.3-70b-versatile", label: "Llama 3.3 70B", tier: "primary" },
+		{ id: "groq/llama-3.1-8b-instant", label: "Llama 3.1 8B", tier: "fast" },
+	],
+	mistral: [
+		{ id: "mistral/mistral-large-latest", label: "Mistral Large", tier: "primary" },
+		{ id: "mistral/mistral-small-latest", label: "Mistral Small", tier: "fast" },
+	],
+	together: [
+		{ id: "together_ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo", label: "Llama 3.1 70B Turbo", tier: "primary" },
+	],
+	deepseek: [
+		{ id: "deepseek/deepseek-chat", label: "Deepseek Chat", tier: "primary" },
+	],
+};
+
+export const RECOMMENDED_MODELS: Record<string, { sections: string; synthesis: string; facets: string }> = {
+	anthropic: {
+		sections: "anthropic/claude-sonnet-4-6",
+		synthesis: "anthropic/claude-sonnet-4-6",
+		facets: "anthropic/claude-haiku-4-5-20251001",
+	},
+	openai: {
+		sections: "openai/gpt-4o",
+		synthesis: "openai/gpt-4o",
+		facets: "openai/gpt-4o-mini",
+	},
+	bedrock: {
+		sections: "bedrock/global.anthropic.claude-opus-4-6-v1",
+		synthesis: "bedrock/global.anthropic.claude-opus-4-6-v1",
+		facets: "bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0",
+	},
+	gemini: {
+		sections: "gemini/gemini-2.5-pro",
+		synthesis: "gemini/gemini-2.5-pro",
+		facets: "gemini/gemini-2.5-flash",
+	},
+};
+
+export function detectProviderFromKey(apiKey: string): ProviderId | "" {
+	if (!apiKey) return "";
+	if (apiKey.startsWith("sk-ant-")) return "anthropic";
+	if (apiKey.startsWith("sk-proj-") || apiKey.startsWith("sk-")) return "openai";
+	if (apiKey.startsWith("AIza")) return "gemini";
+	if (apiKey.startsWith("ABSK") || apiKey.startsWith("aws-")) return "bedrock";
+	if (apiKey.startsWith("gsk_")) return "groq";
+	return "";
+}
+
+export function detectProvider(modelValue: string): ProviderId | "" {
+	if (!modelValue) return "";
+	const prefix = modelValue.split("/")[0];
+	const match = PROVIDERS.find((p) => p.id === prefix);
+	if (match) return match.id;
+	if (prefix === "together_ai") return "together";
+	return "other";
+}
+
+export function getInsightsStatus(
+	entries: { key: string; value: string; is_set?: boolean }[],
+): InsightsStatus {
+	const apiKeyEntry = entries.find((e) => e.key === "insights.api_key");
+	const apiBaseEntry = entries.find((e) => e.key === "insights.api_base");
+	const modelEntry = entries.find((e) => e.key === "insights.model_sections");
+
+	const hasKey = apiKeyEntry?.is_set || (apiKeyEntry?.value && apiKeyEntry.value !== "");
+	const hasBase = apiBaseEntry?.value && apiBaseEntry.value !== "";
+	const hasModel = modelEntry?.value && modelEntry.value !== "";
+
+	if (!hasKey && !hasBase && !hasModel) return "not_configured";
+	if (!hasModel) return "partial";
+	return "ready";
+}

--- a/web/src/pages/admin/settings/insights-section.tsx
+++ b/web/src/pages/admin/settings/insights-section.tsx
@@ -1,0 +1,614 @@
+// SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+	Activity,
+	Check,
+	ChevronsUpDown,
+	Eye,
+	EyeOff,
+	Loader2,
+	Sparkles,
+} from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { admin } from "@/lib/api";
+import { ModelCombobox } from "./model-combobox";
+import {
+	type ProviderId,
+	type InsightsStatus,
+	PROVIDERS,
+	PROVIDER_MODELS,
+	RECOMMENDED_MODELS,
+	detectProvider,
+	detectProviderFromKey,
+	getInsightsStatus,
+} from "./insights-constants";
+
+interface InsightsSectionProps {
+	entries: { key: string; value: string; is_sensitive?: boolean; is_set?: boolean }[];
+	onSave: (key: string, value: string) => Promise<void>;
+	onRevoke: (key: string) => void;
+	refetch: () => void;
+}
+
+interface TestResult {
+	success: boolean;
+	model?: string;
+	latency_ms?: number;
+	error?: string;
+	hint?: string;
+}
+
+export function InsightsSection({ entries, onSave, onRevoke, refetch }: InsightsSectionProps) {
+	const getEntryValue = useCallback(
+		(key: string) => {
+			const entry = entries.find((e) => e.key === key);
+			if (!entry) return "";
+			if (entry.is_sensitive) return "";
+			return entry.value || "";
+		},
+		[entries],
+	);
+
+	const isKeySet = useCallback(
+		(key: string) => {
+			const entry = entries.find((e) => e.key === key);
+			return entry?.is_set || (entry?.value ? entry.value !== "" : false);
+		},
+		[entries],
+	);
+
+	// State
+	const [provider, setProvider] = useState<ProviderId | "">("");
+	const [providerOpen, setProviderOpen] = useState(false);
+	const [apiKeyValue, setApiKeyValue] = useState("");
+	const [showApiKey, setShowApiKey] = useState(false);
+	const [apiBase, setApiBase] = useState("");
+	const [modelSections, setModelSections] = useState("");
+	const [modelSynthesis, setModelSynthesis] = useState("");
+	const [modelFacets, setModelFacets] = useState("");
+	const [batchEnabled, setBatchEnabled] = useState(true);
+	const [batchPeriod, setBatchPeriod] = useState("14");
+	const [minSessions, setMinSessions] = useState("5");
+	const [maxFacetCalls, setMaxFacetCalls] = useState("100");
+	const [facetConcurrency, setFacetConcurrency] = useState("25");
+	const [saving, setSaving] = useState<Record<string, boolean>>({});
+	const [testingConnection, setTestingConnection] = useState(false);
+	const [testResult, setTestResult] = useState<TestResult | null>(null);
+
+	// Initialize from entries
+	useEffect(() => {
+		const sections = getEntryValue("insights.model_sections");
+		const synthesis = getEntryValue("insights.model_synthesis");
+		const facets = getEntryValue("insights.model_facets");
+		const base = getEntryValue("insights.api_base");
+		const batch = getEntryValue("insights.batch_enabled");
+		const period = getEntryValue("insights.batch_period_days");
+		const sessions = getEntryValue("insights.min_sessions");
+		const maxCalls = getEntryValue("insights.facet_max_calls");
+		const concurrency = getEntryValue("insights.facet_concurrency");
+
+		setModelSections(sections);
+		setModelSynthesis(synthesis);
+		setModelFacets(facets);
+		setApiBase(base);
+		setBatchEnabled(batch !== "false");
+		setBatchPeriod(period || "14");
+		setMinSessions(sessions || "5");
+		setMaxFacetCalls(maxCalls || "100");
+		setFacetConcurrency(concurrency || "25");
+
+		const detected = detectProvider(sections);
+		if (detected) setProvider(detected);
+	}, [entries, getEntryValue]);
+
+	// Auto-detect provider from API key
+	useEffect(() => {
+		if (apiKeyValue && !provider) {
+			const detected = detectProviderFromKey(apiKeyValue);
+			if (detected) setProvider(detected);
+		}
+	}, [apiKeyValue, provider]);
+
+	// Derived values
+	const status: InsightsStatus = useMemo(() => getInsightsStatus(entries), [entries]);
+	const selectedProvider = useMemo(
+		() => PROVIDERS.find((p) => p.id === provider),
+		[provider],
+	);
+	const showBaseUrl = provider !== "";
+	const suggestions = useMemo(
+		() => (provider ? PROVIDER_MODELS[provider] || [] : []),
+		[provider],
+	);
+	const showRecommended = useMemo(
+		() =>
+			provider !== "" &&
+			RECOMMENDED_MODELS[provider] &&
+			(!modelSections || !modelSynthesis || !modelFacets),
+		[provider, modelSections, modelSynthesis, modelFacets],
+	);
+
+	// Handlers
+	const handleSave = useCallback(
+		async (key: string, value: string) => {
+			setSaving((s) => ({ ...s, [key]: true }));
+			try {
+				await onSave(key, value);
+			} catch {
+				toast.error(`Failed to save ${key.split(".")[1]}`);
+			} finally {
+				setSaving((s) => ({ ...s, [key]: false }));
+			}
+		},
+		[onSave],
+	);
+
+	const handleApiKeySave = useCallback(async () => {
+		if (!apiKeyValue) return;
+		await handleSave("insights.api_key", apiKeyValue);
+		setApiKeyValue("");
+	}, [apiKeyValue, handleSave]);
+
+	const handleTestConnection = useCallback(async () => {
+		setTestingConnection(true);
+		setTestResult(null);
+		try {
+			const modelsToTest: { model: string; label: string }[] = [];
+			if (modelSections) modelsToTest.push({ model: modelSections, label: "Sections" });
+			if (modelSynthesis && modelSynthesis !== modelSections) modelsToTest.push({ model: modelSynthesis, label: "Synthesis" });
+			if (modelFacets && modelFacets !== modelSections && modelFacets !== modelSynthesis) modelsToTest.push({ model: modelFacets, label: "Facets" });
+
+			if (modelsToTest.length === 0) {
+				setTestResult({
+					success: false,
+					error: "No models configured",
+					hint: "Set at least the Sections Model before testing.",
+				});
+				return;
+			}
+
+			for (const { model, label } of modelsToTest) {
+				const result = (await admin.testInsightsConnection({ model })) as TestResult;
+				if (!result.success) {
+					setTestResult({
+						...result,
+						error: `${label} Model failed: ${result.error}`,
+					});
+					return;
+				}
+			}
+
+			setTestResult({
+				success: true,
+				model: modelsToTest.length === 1
+					? modelsToTest[0].model
+					: `All ${modelsToTest.length} models connected`,
+				latency_ms: undefined,
+			});
+		} catch (e) {
+			setTestResult({
+				success: false,
+				error: e instanceof Error ? e.message : "Request failed",
+				hint: "Could not reach the server. Is it running?",
+			});
+		} finally {
+			setTestingConnection(false);
+		}
+	}, [modelSections, modelSynthesis, modelFacets]);
+
+	const handleUseRecommended = useCallback(async () => {
+		if (!provider || !RECOMMENDED_MODELS[provider]) return;
+		const rec = RECOMMENDED_MODELS[provider];
+		setModelSections(rec.sections);
+		setModelSynthesis(rec.synthesis);
+		setModelFacets(rec.facets);
+		await Promise.all([
+			handleSave("insights.model_sections", rec.sections),
+			handleSave("insights.model_synthesis", rec.synthesis),
+			handleSave("insights.model_facets", rec.facets),
+		]);
+	}, [provider, handleSave]);
+
+	const handleModelChange = useCallback(
+		(key: string, setter: (v: string) => void) => (value: string) => {
+			setter(value);
+			handleSave(key, value);
+		},
+		[handleSave],
+	);
+
+	const handleProviderChange = useCallback(
+		(id: ProviderId | "") => {
+			const previousProvider = provider;
+			setProvider(id);
+
+			if (id !== previousProvider && previousProvider !== "") {
+				setModelSections("");
+				setModelSynthesis("");
+				setModelFacets("");
+				void (async () => {
+					try {
+						await Promise.all([
+							onSave("insights.model_sections", ""),
+							onSave("insights.model_synthesis", ""),
+							onSave("insights.model_facets", ""),
+						]);
+					} catch {
+						toast.error("Failed to clear model settings for the previous provider");
+						refetch();
+					}
+				})();
+			}
+
+			setProviderOpen(false);
+		},
+		[onSave, provider, refetch],
+	);
+
+	// Status config
+	const statusConfig = {
+		not_configured: { color: "bg-zinc-400", label: "Not configured" },
+		partial: { color: "bg-amber-400", label: "Partially configured" },
+		ready: { color: "bg-emerald-400", label: "Ready" },
+	};
+
+	return (
+		<section className="mb-6 mt-2">
+			{/* Header */}
+			<div className="flex items-center justify-between mb-1">
+				<h3 className="text-sm font-semibold uppercase tracking-wider text-foreground/80 flex items-center gap-1.5">
+					<Activity className="h-3.5 w-3.5" />
+					Agent Insights
+				</h3>
+				<div className="flex items-center gap-1.5">
+					<div className={cn("h-2 w-2 rounded-full", statusConfig[status].color)} />
+					<span className="text-xs text-muted-foreground">
+						{statusConfig[status].label}
+					</span>
+				</div>
+			</div>
+			<p className="text-xs text-foreground/60 mb-3">
+				Configure LLM provider for the insights engine. Supports any LiteLLM-compatible provider.
+			</p>
+
+			{/* Main card */}
+			<div className="rounded-lg border border-border bg-card p-5 space-y-5">
+				{/* Provider selector */}
+				<div>
+					<label className="text-sm font-medium text-foreground block mb-2">Provider</label>
+					<Popover open={providerOpen} onOpenChange={setProviderOpen}>
+						<PopoverTrigger asChild>
+							<Button
+								variant="outline"
+								role="combobox"
+								aria-expanded={providerOpen}
+								className={cn(
+									"w-full max-w-xs justify-between h-9 text-sm",
+									!provider && "text-muted-foreground",
+								)}
+							>
+								{selectedProvider?.label || "Select provider..."}
+								<ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-50" />
+							</Button>
+						</PopoverTrigger>
+						<PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+							<Command>
+								<CommandInput placeholder="Search providers..." />
+								<CommandList>
+									<CommandEmpty>No provider found.</CommandEmpty>
+									<CommandGroup>
+										{PROVIDERS.map((p) => (
+											<CommandItem
+												key={p.id}
+												value={p.label}
+												onSelect={() => handleProviderChange(p.id)}
+											>
+												<Check
+													className={cn(
+														"mr-2 h-3.5 w-3.5",
+														provider === p.id ? "opacity-100" : "opacity-0",
+													)}
+												/>
+												{p.label}
+											</CommandItem>
+										))}
+									</CommandGroup>
+								</CommandList>
+							</Command>
+						</PopoverContent>
+					</Popover>
+				</div>
+
+				{/* API Key */}
+				<div className="space-y-1.5">
+					<label className="text-sm font-medium text-foreground">API Key</label>
+					<div className="flex items-center gap-2">
+						<div className="relative flex-1 max-w-md">
+							<Input
+								type={showApiKey ? "text" : "password"}
+								value={apiKeyValue}
+								onChange={(e) => setApiKeyValue(e.target.value)}
+								placeholder={
+									isKeySet("insights.api_key")
+										? "Key is set, enter new value to replace"
+										: "sk-ant-... or sk-... or Bedrock API key"
+								}
+								className="h-9 text-sm font-mono pr-9"
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleApiKeySave();
+								}}
+							/>
+							<button
+								type="button"
+								className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+								onClick={() => setShowApiKey(!showApiKey)}
+								tabIndex={-1}
+							>
+								{showApiKey ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+							</button>
+						</div>
+						<Button
+							size="sm"
+							variant="outline"
+							className="h-9 px-3 text-xs"
+							onClick={handleApiKeySave}
+							disabled={!apiKeyValue || saving["insights.api_key"]}
+						>
+							{saving["insights.api_key"] ? (
+								<Loader2 className="h-3.5 w-3.5 animate-spin" />
+							) : (
+								"Save"
+							)}
+						</Button>
+						<Button
+							size="sm"
+							variant="outline"
+							className="h-9 px-3 text-xs"
+							onClick={handleTestConnection}
+							disabled={testingConnection}
+						>
+							{testingConnection && (
+								<Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+							)}
+							Test Connection
+						</Button>
+						{isKeySet("insights.api_key") && (
+							<Button
+								size="sm"
+								variant="ghost"
+								className="h-9 px-2 text-xs text-destructive hover:text-destructive"
+								onClick={() => onRevoke("insights.api_key")}
+							>
+								Revoke
+							</Button>
+						)}
+					</div>
+					{/* Test result banner */}
+					{testResult && (
+						<div
+							className={cn(
+								"rounded-md px-3 py-2 text-xs flex items-start gap-2",
+								testResult.success
+									? "bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-300"
+									: "bg-destructive/10 border border-destructive/20 text-destructive",
+							)}
+						>
+							{testResult.success ? (
+								<>
+									<Check className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+									<span>
+										Connected to <span className="font-mono font-medium">{testResult.model}</span>
+										{testResult.latency_ms != null && ` (${testResult.latency_ms}ms)`}
+									</span>
+								</>
+							) : (
+								<div className="space-y-0.5">
+									<p className="font-medium">{testResult.error}</p>
+									{testResult.hint && (
+										<p className="text-muted-foreground">{testResult.hint}</p>
+									)}
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+
+	
+				{/* Divider */}
+				<div className="border-t border-border/50" />
+
+				{/* Models heading */}
+				<div className="space-y-1">
+					<p className="text-sm font-medium text-foreground">Models</p>
+					<p className="text-xs text-muted-foreground">
+						Only Sections Model is required. Others fall back to it if left empty.
+					</p>
+				</div>
+
+				{/* Model selectors - aligned grid */}
+				<div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+					<ModelCombobox
+						label="Sections Model"
+						subtitle="Writes the detailed report. Use your best model."
+						value={modelSections}
+						onChange={handleModelChange("insights.model_sections", setModelSections)}
+						suggestions={suggestions}
+						placeholder="Required"
+					/>
+					<ModelCombobox
+						label="Synthesis Model"
+						subtitle="Aggregates patterns. Falls back to Sections if empty."
+						value={modelSynthesis}
+						onChange={handleModelChange("insights.model_synthesis", setModelSynthesis)}
+						suggestions={suggestions}
+						placeholder="Optional"
+					/>
+					<ModelCombobox
+						label="Facets Model"
+						subtitle="Scans each session. Runs many times, use cheapest."
+						value={modelFacets}
+						onChange={handleModelChange("insights.model_facets", setModelFacets)}
+						suggestions={suggestions}
+						placeholder="Optional"
+					/>
+				</div>
+
+				{/* Use Recommended */}
+				{showRecommended && (
+					<Button
+						variant="outline"
+						size="sm"
+						className="h-8 text-xs"
+						onClick={handleUseRecommended}
+						disabled={saving["insights.model_sections"]}
+					>
+						<Sparkles className="h-3.5 w-3.5 mr-1.5" />
+						Use recommended models
+					</Button>
+				)}
+
+				{/* Base URL - above advanced */}
+				{showBaseUrl && (
+					<div className="space-y-1.5">
+						<label className="text-xs font-medium text-muted-foreground">
+							Base URL
+							{selectedProvider?.requiresBaseUrl ? (
+								<span className="font-normal text-foreground ml-1">(required for {selectedProvider.label})</span>
+							) : (
+								<span className="font-normal ml-1">(optional)</span>
+							)}
+						</label>
+						<Input
+							value={apiBase}
+							onChange={(e) => setApiBase(e.target.value)}
+							placeholder={selectedProvider?.baseUrlHint || "https://..."}
+							className="h-8 text-xs font-mono max-w-md"
+							onBlur={() => {
+								if (apiBase !== getEntryValue("insights.api_base")) {
+									handleSave("insights.api_base", apiBase);
+								}
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") handleSave("insights.api_base", apiBase);
+							}}
+						/>
+					</div>
+				)}
+
+				{/* Advanced settings */}
+				<details className="group rounded-md border border-border/70">
+					<summary className="flex items-center gap-2 px-4 py-2.5 cursor-pointer select-none hover:bg-muted/30 transition-colors text-sm font-medium text-foreground/70">
+						Advanced
+					</summary>
+					<div className="px-4 pb-4 pt-2 space-y-4 border-t border-border/50">
+						<div className="flex items-center justify-between">
+							<div>
+								<p className="text-sm font-medium">Batch Processing</p>
+								<p className="text-xs text-muted-foreground">
+									Automatically generate reports on schedule
+								</p>
+							</div>
+							<Switch
+								checked={batchEnabled}
+								onCheckedChange={(checked) => {
+									setBatchEnabled(checked);
+									handleSave("insights.batch_enabled", String(checked));
+								}}
+							/>
+						</div>
+
+						<div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+							<div className="space-y-1">
+								<label className="text-xs text-muted-foreground">
+									Batch Period (days)
+								</label>
+								<Input
+									type="number"
+									min={1}
+									value={batchPeriod}
+									onChange={(e) => setBatchPeriod(e.target.value)}
+									className="h-8 text-sm"
+									onBlur={() => {
+										if (batchPeriod !== getEntryValue("insights.batch_period_days")) {
+											handleSave("insights.batch_period_days", batchPeriod);
+										}
+									}}
+								/>
+							</div>
+							<div className="space-y-1">
+								<label className="text-xs text-muted-foreground">
+									Min Sessions
+								</label>
+								<Input
+									type="number"
+									min={1}
+									value={minSessions}
+									onChange={(e) => setMinSessions(e.target.value)}
+									className="h-8 text-sm"
+									onBlur={() => {
+										if (minSessions !== getEntryValue("insights.min_sessions")) {
+											handleSave("insights.min_sessions", minSessions);
+										}
+									}}
+								/>
+							</div>
+							<div className="space-y-1">
+								<label className="text-xs text-muted-foreground">
+									Max Facet Calls
+								</label>
+								<Input
+									type="number"
+									min={1}
+									value={maxFacetCalls}
+									onChange={(e) => setMaxFacetCalls(e.target.value)}
+									className="h-8 text-sm"
+									onBlur={() => {
+										if (maxFacetCalls !== getEntryValue("insights.facet_max_calls")) {
+											handleSave("insights.facet_max_calls", maxFacetCalls);
+										}
+									}}
+								/>
+							</div>
+							<div className="space-y-1">
+								<label className="text-xs text-muted-foreground">
+									Facet Concurrency
+								</label>
+								<Input
+									type="number"
+									min={1}
+									value={facetConcurrency}
+									onChange={(e) => setFacetConcurrency(e.target.value)}
+									className="h-8 text-sm"
+									onBlur={() => {
+										if (facetConcurrency !== getEntryValue("insights.facet_concurrency")) {
+											handleSave("insights.facet_concurrency", facetConcurrency);
+										}
+									}}
+								/>
+							</div>
+						</div>
+					</div>
+				</details>
+			</div>
+		</section>
+	);
+}

--- a/web/src/pages/admin/settings/model-combobox.tsx
+++ b/web/src/pages/admin/settings/model-combobox.tsx
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { useState, useRef, useEffect } from "react";
+import { Check, ChevronDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import type { ModelSuggestion } from "./insights-constants";
+
+interface ModelComboboxProps {
+	value: string;
+	onChange: (value: string) => void;
+	suggestions: ModelSuggestion[];
+	label: string;
+	subtitle: string;
+	placeholder?: string;
+	disabled?: boolean;
+}
+
+export function ModelCombobox({
+	value,
+	onChange,
+	suggestions,
+	label,
+	subtitle,
+	placeholder = "Select or type model...",
+	disabled,
+}: ModelComboboxProps) {
+	const [open, setOpen] = useState(false);
+	const [inputValue, setInputValue] = useState(value);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		setInputValue(value);
+	}, [value]);
+
+	const primaryModels = suggestions.filter((s) => s.tier === "primary");
+	const fastModels = suggestions.filter((s) => s.tier === "fast");
+
+	const filteredPrimary = primaryModels.filter(
+		(s) =>
+			!inputValue ||
+			s.id.toLowerCase().includes(inputValue.toLowerCase()) ||
+			s.label.toLowerCase().includes(inputValue.toLowerCase()),
+	);
+	const filteredFast = fastModels.filter(
+		(s) =>
+			!inputValue ||
+			s.id.toLowerCase().includes(inputValue.toLowerCase()) ||
+			s.label.toLowerCase().includes(inputValue.toLowerCase()),
+	);
+
+	const handleSelect = (modelId: string) => {
+		setInputValue(modelId);
+		onChange(modelId);
+		setOpen(false);
+	};
+
+	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setInputValue(e.target.value);
+		if (!open) setOpen(true);
+	};
+
+	const handleInputKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			onChange(inputValue);
+			setOpen(false);
+		}
+		if (e.key === "Escape") {
+			setOpen(false);
+		}
+	};
+
+	const handleInputBlur = () => {
+		setTimeout(() => {
+			if (inputValue !== value) {
+				onChange(inputValue);
+			}
+			setOpen(false);
+		}, 150);
+	};
+
+	const handleClear = () => {
+		setInputValue("");
+		onChange("");
+		inputRef.current?.focus();
+	};
+
+	return (
+		<div className="flex flex-col space-y-1.5">
+			<div className="min-h-[2.5rem]">
+				<p className="text-sm font-medium text-foreground leading-tight">{label}</p>
+				<p className="text-xs text-muted-foreground leading-relaxed mt-0.5">{subtitle}</p>
+			</div>
+			<Popover open={open} onOpenChange={setOpen}>
+				<PopoverTrigger asChild>
+					<div className="relative">
+						<input
+							ref={inputRef}
+							type="text"
+							value={inputValue}
+							onChange={handleInputChange}
+							onFocus={() => setOpen(true)}
+							onBlur={handleInputBlur}
+							onKeyDown={handleInputKeyDown}
+							placeholder={placeholder}
+							disabled={disabled}
+							className={cn(
+								"flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-xs font-mono shadow-sm transition-colors",
+								"placeholder:text-muted-foreground placeholder:font-sans",
+								"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+								"disabled:cursor-not-allowed disabled:opacity-50",
+								"pr-14",
+							)}
+						/>
+						<div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+							{inputValue && (
+								<button
+									type="button"
+									className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+									onClick={handleClear}
+									tabIndex={-1}
+								>
+									<X className="h-3 w-3" />
+								</button>
+							)}
+							<button
+								type="button"
+								className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+								onClick={() => setOpen(!open)}
+								tabIndex={-1}
+							>
+								<ChevronDown className="h-3.5 w-3.5" />
+							</button>
+						</div>
+					</div>
+				</PopoverTrigger>
+				<PopoverContent
+					className="w-[var(--radix-popover-trigger-width)] p-0"
+					align="start"
+					onOpenAutoFocus={(e) => e.preventDefault()}
+				>
+					<Command shouldFilter={false}>
+						<CommandList>
+							{filteredPrimary.length === 0 && filteredFast.length === 0 && (
+								<CommandEmpty>
+									{inputValue ? (
+										<span className="text-xs text-muted-foreground">
+											Press Enter to use <span className="font-mono font-medium">{inputValue}</span>
+										</span>
+									) : (
+										<span className="text-xs text-muted-foreground">Type a model ID (provider/model-name)</span>
+									)}
+								</CommandEmpty>
+							)}
+							{filteredPrimary.length > 0 && (
+								<CommandGroup heading="Recommended">
+									{filteredPrimary.map((model) => (
+										<CommandItem
+											key={model.id}
+											value={model.id}
+											onSelect={() => handleSelect(model.id)}
+											onMouseDown={(e) => e.preventDefault()}
+										>
+											<Check
+												className={cn(
+													"mr-2 h-3.5 w-3.5 shrink-0",
+													value === model.id ? "opacity-100" : "opacity-0",
+												)}
+											/>
+											<div className="flex flex-col min-w-0">
+												<span className="text-sm truncate">{model.label}</span>
+												<span className="text-xs text-muted-foreground font-mono truncate">
+													{model.id}
+												</span>
+											</div>
+										</CommandItem>
+									))}
+								</CommandGroup>
+							)}
+							{filteredFast.length > 0 && (
+								<CommandGroup heading="Fast / Budget">
+									{filteredFast.map((model) => (
+										<CommandItem
+											key={model.id}
+											value={model.id}
+											onSelect={() => handleSelect(model.id)}
+											onMouseDown={(e) => e.preventDefault()}
+										>
+											<Check
+												className={cn(
+													"mr-2 h-3.5 w-3.5 shrink-0",
+													value === model.id ? "opacity-100" : "opacity-0",
+												)}
+											/>
+											<div className="flex flex-col min-w-0">
+												<span className="text-sm truncate">{model.label}</span>
+												<span className="text-xs text-muted-foreground font-mono truncate">
+													{model.id}
+												</span>
+											</div>
+										</CommandItem>
+									))}
+								</CommandGroup>
+							)}
+						</CommandList>
+					</Command>
+				</PopoverContent>
+			</Popover>
+		</div>
+	);
+}


### PR DESCRIPTION
## Purpose / Description

  Before: admins had to manually type model IDs like `bedrock/global.anthropic.claude-opus-4-6-v1` into
  plain text fields with no help.

  After: a guided setup with provider dropdown, searchable model picker, and a "Test Connection" button to
  - **Model comboboxes** — searchable dropdown with suggestions, or type any custom ID
  - **Test Connection** — one click to verify your key + models actually work
  - **Status indicator** — shows if setup is complete at a glance
  - **Auto-detect** — paste an API key and provider is detected from prefix
  - **Recommended models** — one button fills all 3 model slots with sensible defaults
  - **Advanced section** — batch settings tucked away for clean UI

  ## Backend

  New endpoint: `POST /admin/insights/test-connection` — tests each model, returns specific error hints if
  something fails.

  ## How Has This Been Tested?

  - Playwright E2E tests (provider switch, model editing, dropdown, other sections intact)
  - Backend endpoint tested with valid/invalid/missing models
  - Docker build passes for both API and web
  - ruff lint + TypeScript build clean
  - Manual end-to-end: configured Bedrock, ran insights generation successfully
  
  
<img width="2827" height="1526" alt="image" src="https://github.com/user-attachments/assets/040160a7-eb8f-4c05-a330-0e73ed6401e9" />


  ## Checklist

  - [x] Descriptive commit message with short title
  - [x] Self-review completed
  - [x] UI changes tested in browser
  - [x] SPDX headers on all new files
  - [x] Lint clean, Docker build passes