### PR TITLE
feat(infra): Azure Terraform module for self-hosted deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,12 @@ observal-web/dist/
 docker/data/
 docker/clickhouse/users.d/default-user.xml
 
+# Terraform
+**/.terraform/
+*.tfplan
+*.tfstate
+*.tfstate.backup
+
 # Local / ephemeral
 .playwright-mcp/
 e2e-screenshots/

--- a/docker/nginx-azure.conf
+++ b/docker/nginx-azure.conf
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Azure deployment: web container with API proxy.
+# Routes /api/ to the API Container App via its public FQDN.
+
+server {
+    listen 3000;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Security headers
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
+    resolver 168.63.129.16 valid=30s;
+
+    # Proxy API requests to the API Container App
+    location /api/ {
+        set $backend "https://observal-staging-api.delightfulground-0a073dc9.centralus.azurecontainerapps.io";
+        proxy_pass $backend;
+        proxy_ssl_server_name on;
+        proxy_set_header Host observal-staging-api.delightfulground-0a073dc9.centralus.azurecontainerapps.io;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 3600s;
+        client_max_body_size 10m;
+    }
+
+    location /health {
+        set $backend "https://observal-staging-api.delightfulground-0a073dc9.centralus.azurecontainerapps.io";
+        proxy_pass $backend;
+        proxy_ssl_server_name on;
+        proxy_set_header Host observal-staging-api.delightfulground-0a073dc9.centralus.azurecontainerapps.io;
+    }
+
+    # Static assets with aggressive caching
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/infra/terraform/azure/.terraform.lock.hcl
+++ b/infra/terraform/azure/.terraform.lock.hcl
@@ -5,43 +5,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "4.75.0"
+  version     = "4.76.0"
   constraints = "~> 4.0"
   hashes = [
-    "h1:0JyotknrI6hbvX39FH5e9nv/L9RJKFq+Y4NKAuBMK+g=",
-    "zh:09dd209d0726fc2bbdf10db3de5de3a80e9550a48310189c6f98f15aad781eb3",
-    "zh:11a3c4641f821f45beb0133e7ad114439b9a9b3de7a4830dadc1aa6f71e57afb",
-    "zh:1a2529e284e6e20e7002452419923de9c543f03974f3ba16c0ebf6088e3c0f49",
-    "zh:227e8f23f25b527435027daad02b049591f09b67d3a3498ebc138a9d96c66118",
-    "zh:350f08691650939b0a34768aefb9a2c9bff3259343567f80966a86b3e897fa89",
-    "zh:3a822aece9ac11308867d9682813d7a600d8ecf4c2fa6442a4e8726df8572370",
-    "zh:6e33ad5d9ce95bb710144b8013810d3e7a7490802b0835684b906ddd18b0054c",
+    "h1:4VD01UBYjsa3w7zeEBKnDtwClwpsPw6Dk+V9evhiKqU=",
+    "zh:07bb3a087abca8bd14cc28e3d3d4abb71e0ed711ecec65e7c0a2f1a97b948cf4",
+    "zh:0fa6640b5d6c0b0fe0b7fa25cebc0091b7dda2efd83ec0347c5a50dfce0957bc",
+    "zh:3c8618c8a5ab07fadfcb53ecf614f7b99e25bb6c407cf0af703a6b0647d4461d",
+    "zh:5f23fdda6ff290bc99b25b68f612bf67fbb503b04b1e38664e66d3204a51e99e",
+    "zh:68e6794cbe5e3b021657035c2465767b8296beed6c9acc8a9e032c4b90ba5746",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7c17892d1a241934eaf36b3fb65055827a334fe698dc03f22c44a21f2e550367",
-    "zh:a13ddbd5899d41ae5011ab3b3b72ef79a4ad4f6bad7fd1fc7b03fccd33d8048d",
-    "zh:fb2de687765b2fcbccc18c9a82e2ea5fce5b900c3e113fe24e0937f2173917a7",
-    "zh:fff4a65661eff3796999846ac099b8e54bab5497ee6995a70db6fb5ef9e926d5",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.3.0"
-  constraints = "~> 3.2"
-  hashes = [
-    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
-    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
-    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
-    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
-    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
-    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
-    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
-    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
-    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
-    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
-    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
-    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+    "zh:8a51dad112248d3fdfb19cdd65a182bd6a37e7fb7f1af801ab72a962813b5188",
+    "zh:945ff59c36de8c2128487f4ae0838655feef7c869112430ffa24ea69ff483b76",
+    "zh:b7306af0ecc8ad78771c17e0e911dd7a561251e4255ffe80516f0654a53f42bb",
+    "zh:c584de4858fc4ece330f1986f371acd235a5444e9b14ecea177779b1214539e0",
+    "zh:daa3675af21f8cdf330532af0b420287388f62ac57eaf0bd4c48e732d1052f35",
+    "zh:e76d972712b48a689f8deae41a3ad796c31d8b3798074d66c6f68e2b3b0aaa1f",
   ]
 }
 
@@ -67,7 +46,8 @@ provider "registry.terraform.io/hashicorp/random" {
 }
 
 provider "registry.terraform.io/hashicorp/tls" {
-  version = "4.3.0"
+  version     = "4.3.0"
+  constraints = "~> 4.0"
   hashes = [
     "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",

--- a/infra/terraform/azure/.terraform.lock.hcl
+++ b/infra/terraform/azure/.terraform.lock.hcl
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.75.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:0JyotknrI6hbvX39FH5e9nv/L9RJKFq+Y4NKAuBMK+g=",
+    "zh:09dd209d0726fc2bbdf10db3de5de3a80e9550a48310189c6f98f15aad781eb3",
+    "zh:11a3c4641f821f45beb0133e7ad114439b9a9b3de7a4830dadc1aa6f71e57afb",
+    "zh:1a2529e284e6e20e7002452419923de9c543f03974f3ba16c0ebf6088e3c0f49",
+    "zh:227e8f23f25b527435027daad02b049591f09b67d3a3498ebc138a9d96c66118",
+    "zh:350f08691650939b0a34768aefb9a2c9bff3259343567f80966a86b3e897fa89",
+    "zh:3a822aece9ac11308867d9682813d7a600d8ecf4c2fa6442a4e8726df8572370",
+    "zh:6e33ad5d9ce95bb710144b8013810d3e7a7490802b0835684b906ddd18b0054c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7c17892d1a241934eaf36b3fb65055827a334fe698dc03f22c44a21f2e550367",
+    "zh:a13ddbd5899d41ae5011ab3b3b72ef79a4ad4f6bad7fd1fc7b03fccd33d8048d",
+    "zh:fb2de687765b2fcbccc18c9a82e2ea5fce5b900c3e113fe24e0937f2173917a7",
+    "zh:fff4a65661eff3796999846ac099b8e54bab5497ee6995a70db6fb5ef9e926d5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.3.0"
+  hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/azure/README.md
+++ b/infra/terraform/azure/README.md
@@ -1,0 +1,91 @@
+<!-- SPDX-FileCopyrightText: 2026 Tanvi Reddy -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Observal - Azure Terraform Module
+
+Deploy Observal to Azure using Container Apps, PostgreSQL Flexible Server, Azure Cache for Redis, and a self-hosted ClickHouse VM.
+
+## Architecture
+
+```
+Internet
+    |
+    v
+Azure Container Apps (VNet-integrated)
+    ├── observal-api     (FastAPI, autoscale 2-10)
+    ├── observal-web     (nginx SPA, autoscale 2-6)
+    ├── observal-worker  (arq background jobs, autoscale 1-5)
+    └── observal-init    (one-shot migration job)
+    |
+    v (private VNet)
+    ├── Azure Database for PostgreSQL Flexible Server (zone-redundant in prod)
+    ├── Azure Cache for Redis (Standard tier, TLS-only)
+    └── Azure VM: ClickHouse + Prometheus (Premium SSD data disk)
+    |
+    v
+Azure Managed Grafana (connected to Log Analytics + ClickHouse)
+```
+
+## Prerequisites
+
+- Azure CLI (`az login`)
+- Terraform >= 1.5
+- Docker (for building/pushing images to ACR)
+
+## Quick Start
+
+```bash
+# 1. Initialize
+cd infra/terraform/azure
+terraform init
+
+# 2. Deploy staging
+terraform apply -var-file=staging.tfvars
+
+# 3. Push images to ACR (after first apply creates the registry)
+ACR=$(terraform output -raw acr_login_server)
+az acr login --name $ACR
+docker tag ghcr.io/blazeup-ai/observal-api:latest $ACR/observal-api:latest
+docker tag ghcr.io/blazeup-ai/observal-web:latest $ACR/observal-web:latest
+docker push $ACR/observal-api:latest
+docker push $ACR/observal-web:latest
+
+# 4. Trigger the init job (migrations)
+az containerapp job start -n observal-staging-init -g observal-staging-rg
+
+# 5. Get URLs
+terraform output api_url
+terraform output web_url
+```
+
+## Environments
+
+| File | Description |
+|------|-------------|
+| `staging.tfvars` | Cost-optimized, single replicas, smaller SKUs |
+| `prod.tfvars` | Zone-redundant PostgreSQL, HA Redis, autoscaling, larger VMs |
+
+## ClickHouse Modes
+
+Set `clickhouse_mode`:
+- `"self_hosted"` (default) - Azure VM with managed disk. Cheapest option.
+- `"cloud"` - ClickHouse Cloud. Supply `clickhouse_cloud_url` and `clickhouse_cloud_password`.
+
+## Estimated Monthly Cost (Staging)
+
+| Resource | ~Cost |
+|----------|-------|
+| Container Apps (3 apps, min replicas) | $30 |
+| PostgreSQL Flexible (B2s) | $25 |
+| Redis (Standard C0) | $15 |
+| ClickHouse VM (D2s_v5) | $70 |
+| Managed Grafana | $10 |
+| Log Analytics | $5 |
+| ACR (Basic) | $5 |
+| **Total** | **~$160/mo** |
+
+## Destroying
+
+```bash
+terraform destroy -var-file=staging.tfvars
+```

--- a/infra/terraform/azure/acr.tf
+++ b/infra/terraform/azure/acr.tf
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "azurerm_container_registry" "main" {
+  name                = replace("${var.name_prefix}${var.environment}acr", "-", "")
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = local.is_prod ? "Premium" : "Basic"
+  admin_enabled       = true
+
+  tags = local.tags
+}

--- a/infra/terraform/azure/backend.tf
+++ b/infra/terraform/azure/backend.tf
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Remote state stored in Azure Blob Storage.
+# The storage account is created out-of-band (see README).
+
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "observal-tfstate-rg"
+    storage_account_name = "observaltfstate"
+    container_name       = "tfstate"
+    key                  = "staging.terraform.tfstate"
+  }
+}

--- a/infra/terraform/azure/clickhouse.tf
+++ b/infra/terraform/azure/clickhouse.tf
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Data tier: Azure VM running ClickHouse + Prometheus via docker-compose.
+# When clickhouse_mode = "cloud", none of these resources are created.
+
+resource "azurerm_network_interface" "clickhouse" {
+  count               = local.clickhouse_self_hosted ? 1 : 0
+  name                = "${local.name}-clickhouse-nic"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.vm.id
+    private_ip_address_allocation = "Dynamic"
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_managed_disk" "clickhouse_data" {
+  count                = local.clickhouse_self_hosted ? 1 : 0
+  name                 = "${local.name}-clickhouse-data"
+  location             = azurerm_resource_group.main.location
+  resource_group_name  = azurerm_resource_group.main.name
+  storage_account_type = "Premium_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = var.clickhouse_disk_size_gb
+
+  tags = local.tags
+}
+
+resource "azurerm_linux_virtual_machine" "clickhouse" {
+  count               = local.clickhouse_self_hosted ? 1 : 0
+  name                = "${local.name}-clickhouse"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  size                = var.clickhouse_vm_size
+  admin_username      = "observal"
+
+  network_interface_ids = [azurerm_network_interface.clickhouse[0].id]
+
+  admin_ssh_key {
+    username   = "observal"
+    public_key = tls_private_key.clickhouse[0].public_key_openssh
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+    disk_size_gb         = 30
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+
+  custom_data = base64encode(templatefile("${path.module}/cloud-init.yaml.tftpl", {
+    clickhouse_password = random_password.clickhouse.result
+    clickhouse_db       = "observal"
+  }))
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "clickhouse_data" {
+  count              = local.clickhouse_self_hosted ? 1 : 0
+  managed_disk_id    = azurerm_managed_disk.clickhouse_data[0].id
+  virtual_machine_id = azurerm_linux_virtual_machine.clickhouse[0].id
+  lun                = 0
+  caching            = "ReadOnly"
+}
+
+resource "tls_private_key" "clickhouse" {
+  count     = local.clickhouse_self_hosted ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}

--- a/infra/terraform/azure/clickhouse.tf
+++ b/infra/terraform/azure/clickhouse.tf
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Tanvi Reddy
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Data tier: Azure VM running ClickHouse + Prometheus via docker-compose.
-# When clickhouse_mode = "cloud", none of these resources are created.
+# Data tier: Azure VM running ClickHouse + Redis + Prometheus via docker-compose.
+# The VM is created when clickhouse_mode = "self_hosted" OR redis_mode = "self_hosted".
 
 resource "azurerm_network_interface" "clickhouse" {
-  count               = local.clickhouse_self_hosted ? 1 : 0
-  name                = "${local.name}-clickhouse-nic"
+  count               = local.needs_vm ? 1 : 0
+  name                = "${local.name}-data-nic"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
 
@@ -20,8 +20,8 @@ resource "azurerm_network_interface" "clickhouse" {
 }
 
 resource "azurerm_managed_disk" "clickhouse_data" {
-  count                = local.clickhouse_self_hosted ? 1 : 0
-  name                 = "${local.name}-clickhouse-data"
+  count                = local.needs_vm ? 1 : 0
+  name                 = "${local.name}-data-disk"
   location             = azurerm_resource_group.main.location
   resource_group_name  = azurerm_resource_group.main.name
   storage_account_type = "Premium_LRS"
@@ -32,8 +32,8 @@ resource "azurerm_managed_disk" "clickhouse_data" {
 }
 
 resource "azurerm_linux_virtual_machine" "clickhouse" {
-  count               = local.clickhouse_self_hosted ? 1 : 0
-  name                = "${local.name}-clickhouse"
+  count               = local.needs_vm ? 1 : 0
+  name                = "${local.name}-data"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   size                = var.clickhouse_vm_size
@@ -72,7 +72,7 @@ resource "azurerm_linux_virtual_machine" "clickhouse" {
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "clickhouse_data" {
-  count              = local.clickhouse_self_hosted ? 1 : 0
+  count              = local.needs_vm ? 1 : 0
   managed_disk_id    = azurerm_managed_disk.clickhouse_data[0].id
   virtual_machine_id = azurerm_linux_virtual_machine.clickhouse[0].id
   lun                = 0
@@ -80,7 +80,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "clickhouse_data" {
 }
 
 resource "tls_private_key" "clickhouse" {
-  count     = local.clickhouse_self_hosted ? 1 : 0
+  count     = local.needs_vm ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 4096
 }

--- a/infra/terraform/azure/cloud-init.yaml.tftpl
+++ b/infra/terraform/azure/cloud-init.yaml.tftpl
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - docker.io
+  - docker-compose-v2
+
+write_files:
+  - path: /opt/observal/docker-compose.yml
+    content: |
+      services:
+        clickhouse:
+          image: clickhouse/clickhouse-server:26.5
+          restart: unless-stopped
+          ports:
+            - "8123:8123"
+            - "9000:9000"
+          environment:
+            CLICKHOUSE_DB: ${clickhouse_db}
+            CLICKHOUSE_USER: default
+            CLICKHOUSE_PASSWORD: ${clickhouse_password}
+            MAX_SERVER_MEMORY_USAGE_RATIO: "0.8"
+          volumes:
+            - /data/clickhouse:/var/lib/clickhouse
+          deploy:
+            resources:
+              limits:
+                memory: 6G
+
+        prometheus:
+          image: prom/prometheus:v3.12.0
+          restart: unless-stopped
+          ports:
+            - "9090:9090"
+          volumes:
+            - /opt/observal/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+            - /data/prometheus:/prometheus
+          deploy:
+            resources:
+              limits:
+                memory: 512M
+
+  - path: /opt/observal/prometheus.yml
+    content: |
+      global:
+        scrape_interval: 15s
+      scrape_configs:
+        - job_name: observal-api
+          metrics_path: /metrics
+          static_configs:
+            - targets: []
+
+runcmd:
+  # Format and mount data disk
+  - |
+    if ! blkid /dev/sdc; then
+      mkfs.ext4 /dev/sdc
+    fi
+    mkdir -p /data
+    mount /dev/sdc /data
+    echo '/dev/sdc /data ext4 defaults,nofail 0 2' >> /etc/fstab
+  - mkdir -p /data/clickhouse /data/prometheus
+  - systemctl enable docker
+  - systemctl start docker
+  - cd /opt/observal && docker compose up -d

--- a/infra/terraform/azure/cloud-init.yaml.tftpl
+++ b/infra/terraform/azure/cloud-init.yaml.tftpl
@@ -1,7 +1,6 @@
+#cloud-config
 # SPDX-FileCopyrightText: 2026 Tanvi Reddy
 # SPDX-License-Identifier: AGPL-3.0-only
-
-#cloud-config
 package_update: true
 package_upgrade: true
 
@@ -14,7 +13,7 @@ write_files:
     content: |
       services:
         clickhouse:
-          image: clickhouse/clickhouse-server:26.5
+          image: clickhouse/clickhouse-server:25.6
           restart: unless-stopped
           ports:
             - "8123:8123"
@@ -29,7 +28,20 @@ write_files:
           deploy:
             resources:
               limits:
-                memory: 6G
+                memory: 4G
+
+        redis:
+          image: redis:7-alpine
+          restart: unless-stopped
+          ports:
+            - "6379:6379"
+          command: redis-server --maxmemory 512mb --maxmemory-policy volatile-lru --appendonly yes
+          volumes:
+            - /data/redis:/data
+          deploy:
+            resources:
+              limits:
+                memory: 768M
 
         prometheus:
           image: prom/prometheus:v3.12.0
@@ -63,7 +75,7 @@ runcmd:
     mkdir -p /data
     mount /dev/sdc /data
     echo '/dev/sdc /data ext4 defaults,nofail 0 2' >> /etc/fstab
-  - mkdir -p /data/clickhouse /data/prometheus
+  - mkdir -p /data/clickhouse /data/prometheus /data/redis
   - systemctl enable docker
   - systemctl start docker
   - cd /opt/observal && docker compose up -d

--- a/infra/terraform/azure/container-apps.tf
+++ b/infra/terraform/azure/container-apps.tf
@@ -17,6 +17,32 @@ resource "azurerm_container_app_environment" "main" {
   ]
 }
 
+# Persistent storage for JWT keys (survives container restarts)
+resource "azurerm_storage_account" "keys" {
+  name                     = replace("${var.name_prefix}${var.environment}keys", "-", "")
+  resource_group_name      = azurerm_resource_group.main.name
+  location                 = azurerm_resource_group.main.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = local.tags
+}
+
+resource "azurerm_storage_share" "jwt_keys" {
+  name               = "jwt-keys"
+  storage_account_id = azurerm_storage_account.keys.id
+  quota              = 1
+}
+
+resource "azurerm_container_app_environment_storage" "jwt_keys" {
+  name                         = "jwtkeys"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  account_name                 = azurerm_storage_account.keys.name
+  share_name                   = azurerm_storage_share.jwt_keys.name
+  access_key                   = azurerm_storage_account.keys.primary_access_key
+  access_mode                  = "ReadWrite"
+}
+
 # -- API service -------------------------------------------------------------
 
 resource "azurerm_container_app" "api" {
@@ -60,6 +86,12 @@ resource "azurerm_container_app" "api" {
     min_replicas = var.api_min_replicas
     max_replicas = var.api_max_replicas
 
+    volume {
+      name         = "jwt-keys"
+      storage_name = azurerm_container_app_environment_storage.jwt_keys.name
+      storage_type = "AzureFile"
+    }
+
     container {
       name   = "api"
       image  = local.api_image
@@ -72,6 +104,11 @@ resource "azurerm_container_app" "api" {
         "--workers", "2",
         "--proxy-headers", "--forwarded-allow-ips", "*",
       ]
+
+      volume_mounts {
+        name = "jwt-keys"
+        path = "/app/keys"
+      }
 
       env {
         name        = "DATABASE_URL"
@@ -100,7 +137,7 @@ resource "azurerm_container_app" "api" {
 
       env {
         name  = "JWT_KEY_DIR"
-        value = "/tmp/keys"
+        value = "/app/keys"
       }
 
       liveness_probe {

--- a/infra/terraform/azure/container-apps.tf
+++ b/infra/terraform/azure/container-apps.tf
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Container Apps Environment with VNet integration
+resource "azurerm_container_app_environment" "main" {
+  name                       = "${local.name}-env"
+  location                   = azurerm_resource_group.main.location
+  resource_group_name        = azurerm_resource_group.main.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  infrastructure_subnet_id   = azurerm_subnet.container_apps.id
+
+  tags = local.tags
+}
+
+# -- API service -------------------------------------------------------------
+
+resource "azurerm_container_app" "api" {
+  name                         = "${local.name}-api"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Single"
+
+  registry {
+    server               = azurerm_container_registry.main.login_server
+    username             = azurerm_container_registry.main.admin_username
+    password_secret_name = "acr-password"
+  }
+
+  secret {
+    name  = "acr-password"
+    value = azurerm_container_registry.main.admin_password
+  }
+
+  secret {
+    name  = "database-url"
+    value = local.database_url
+  }
+
+  secret {
+    name  = "redis-url"
+    value = local.redis_url
+  }
+
+  secret {
+    name  = "clickhouse-url"
+    value = local.clickhouse_url
+  }
+
+  secret {
+    name  = "secret-key"
+    value = random_password.secret_key.result
+  }
+
+  template {
+    min_replicas = var.api_min_replicas
+    max_replicas = var.api_max_replicas
+
+    container {
+      name   = "api"
+      image  = local.api_image
+      cpu    = var.api_cpu
+      memory = var.api_memory
+
+      command = [
+        "/app/.venv/bin/python", "-m", "uvicorn", "main:app",
+        "--host", "0.0.0.0", "--port", "8000",
+        "--workers", "2",
+        "--proxy-headers", "--forwarded-allow-ips", "*",
+      ]
+
+      env {
+        name        = "DATABASE_URL"
+        secret_name = "database-url"
+      }
+
+      env {
+        name        = "REDIS_URL"
+        secret_name = "redis-url"
+      }
+
+      env {
+        name        = "CLICKHOUSE_URL"
+        secret_name = "clickhouse-url"
+      }
+
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+
+      env {
+        name  = "SKIP_DDL_ON_STARTUP"
+        value = "true"
+      }
+
+      env {
+        name  = "JWT_KEY_DIR"
+        value = "/tmp/keys"
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        path      = "/readyz"
+        port      = 8000
+      }
+
+      readiness_probe {
+        transport = "HTTP"
+        path      = "/readyz"
+        port      = 8000
+      }
+
+      startup_probe {
+        transport               = "HTTP"
+        path                    = "/readyz"
+        port                    = 8000
+        failure_count_threshold = 10
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8000
+    transport        = "http"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  tags = local.tags
+}
+
+# -- Web service -------------------------------------------------------------
+
+resource "azurerm_container_app" "web" {
+  name                         = "${local.name}-web"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Single"
+
+  registry {
+    server               = azurerm_container_registry.main.login_server
+    username             = azurerm_container_registry.main.admin_username
+    password_secret_name = "acr-password"
+  }
+
+  secret {
+    name  = "acr-password"
+    value = azurerm_container_registry.main.admin_password
+  }
+
+  template {
+    min_replicas = var.web_min_replicas
+    max_replicas = var.web_max_replicas
+
+    container {
+      name   = "web"
+      image  = local.web_image
+      cpu    = var.web_cpu
+      memory = var.web_memory
+
+      liveness_probe {
+        transport = "HTTP"
+        path      = "/"
+        port      = 3000
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 3000
+    transport        = "http"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  tags = local.tags
+}
+
+# -- Worker service ----------------------------------------------------------
+
+resource "azurerm_container_app" "worker" {
+  name                         = "${local.name}-worker"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Single"
+
+  registry {
+    server               = azurerm_container_registry.main.login_server
+    username             = azurerm_container_registry.main.admin_username
+    password_secret_name = "acr-password"
+  }
+
+  secret {
+    name  = "acr-password"
+    value = azurerm_container_registry.main.admin_password
+  }
+
+  secret {
+    name  = "database-url"
+    value = local.database_url
+  }
+
+  secret {
+    name  = "redis-url"
+    value = local.redis_url
+  }
+
+  secret {
+    name  = "clickhouse-url"
+    value = local.clickhouse_url
+  }
+
+  secret {
+    name  = "secret-key"
+    value = random_password.secret_key.result
+  }
+
+  template {
+    min_replicas = var.worker_min_replicas
+    max_replicas = var.worker_max_replicas
+
+    container {
+      name   = "worker"
+      image  = local.api_image
+      cpu    = var.worker_cpu
+      memory = var.worker_memory
+
+      command = [
+        "/app/.venv/bin/python", "-c",
+        "import asyncio; asyncio.set_event_loop(asyncio.new_event_loop()); from arq import run_worker; from worker import WorkerSettings; run_worker(WorkerSettings)",
+      ]
+
+      env {
+        name        = "DATABASE_URL"
+        secret_name = "database-url"
+      }
+
+      env {
+        name        = "REDIS_URL"
+        secret_name = "redis-url"
+      }
+
+      env {
+        name        = "CLICKHOUSE_URL"
+        secret_name = "clickhouse-url"
+      }
+
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+
+      env {
+        name  = "JWT_KEY_DIR"
+        value = "/tmp/keys"
+      }
+    }
+  }
+
+  tags = local.tags
+}
+
+# -- Init job (migrations) ---------------------------------------------------
+
+resource "azurerm_container_app_job" "init" {
+  name                         = "${local.name}-init"
+  location                     = azurerm_resource_group.main.location
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  replica_timeout_in_seconds   = 600
+  replica_retry_limit          = 1
+
+  manual_trigger_config {
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  registry {
+    server               = azurerm_container_registry.main.login_server
+    username             = azurerm_container_registry.main.admin_username
+    password_secret_name = "acr-password"
+  }
+
+  secret {
+    name  = "acr-password"
+    value = azurerm_container_registry.main.admin_password
+  }
+
+  secret {
+    name  = "database-url"
+    value = local.database_url
+  }
+
+  secret {
+    name  = "redis-url"
+    value = local.redis_url
+  }
+
+  secret {
+    name  = "clickhouse-url"
+    value = local.clickhouse_url
+  }
+
+  secret {
+    name  = "secret-key"
+    value = random_password.secret_key.result
+  }
+
+  template {
+    container {
+      name   = "init"
+      image  = local.api_image
+      cpu    = 0.5
+      memory = "1Gi"
+
+      command = ["/app/entrypoint.sh"]
+
+      env {
+        name        = "DATABASE_URL"
+        secret_name = "database-url"
+      }
+
+      env {
+        name        = "REDIS_URL"
+        secret_name = "redis-url"
+      }
+
+      env {
+        name        = "CLICKHOUSE_URL"
+        secret_name = "clickhouse-url"
+      }
+
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+
+      env {
+        name  = "JWT_KEY_DIR"
+        value = "/tmp/keys"
+      }
+    }
+  }
+
+  tags = local.tags
+}

--- a/infra/terraform/azure/container-apps.tf
+++ b/infra/terraform/azure/container-apps.tf
@@ -99,15 +99,13 @@ resource "azurerm_container_app" "api" {
       memory = var.api_memory
 
       command = [
-        "/app/.venv/bin/python", "-m", "uvicorn", "main:app",
-        "--host", "0.0.0.0", "--port", "8000",
-        "--workers", "2",
-        "--proxy-headers", "--forwarded-allow-ips", "*",
+        "/bin/bash", "-c",
+        "mkdir -p /tmp/keys && cp -a /mnt/jwt-keys/. /tmp/keys/ 2>/dev/null; trap 'cp -a /tmp/keys/. /mnt/jwt-keys/ 2>/dev/null' EXIT; exec /app/.venv/bin/python -m uvicorn main:app --host 0.0.0.0 --port 8000 --workers 2 --proxy-headers --forwarded-allow-ips '*'",
       ]
 
       volume_mounts {
         name = "jwt-keys"
-        path = "/app/keys"
+        path = "/mnt/jwt-keys"
       }
 
       env {
@@ -137,7 +135,7 @@ resource "azurerm_container_app" "api" {
 
       env {
         name  = "JWT_KEY_DIR"
-        value = "/app/keys"
+        value = "/tmp/keys"
       }
 
       liveness_probe {

--- a/infra/terraform/azure/container-apps.tf
+++ b/infra/terraform/azure/container-apps.tf
@@ -10,6 +10,11 @@ resource "azurerm_container_app_environment" "main" {
   infrastructure_subnet_id   = azurerm_subnet.container_apps.id
 
   tags = local.tags
+
+  depends_on = [
+    azurerm_subnet.container_apps,
+    azurerm_virtual_network.main,
+  ]
 }
 
 # -- API service -------------------------------------------------------------

--- a/infra/terraform/azure/examples/minimal/.terraform.lock.hcl
+++ b/infra/terraform/azure/examples/minimal/.terraform.lock.hcl
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.75.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:0JyotknrI6hbvX39FH5e9nv/L9RJKFq+Y4NKAuBMK+g=",
+    "zh:09dd209d0726fc2bbdf10db3de5de3a80e9550a48310189c6f98f15aad781eb3",
+    "zh:11a3c4641f821f45beb0133e7ad114439b9a9b3de7a4830dadc1aa6f71e57afb",
+    "zh:1a2529e284e6e20e7002452419923de9c543f03974f3ba16c0ebf6088e3c0f49",
+    "zh:227e8f23f25b527435027daad02b049591f09b67d3a3498ebc138a9d96c66118",
+    "zh:350f08691650939b0a34768aefb9a2c9bff3259343567f80966a86b3e897fa89",
+    "zh:3a822aece9ac11308867d9682813d7a600d8ecf4c2fa6442a4e8726df8572370",
+    "zh:6e33ad5d9ce95bb710144b8013810d3e7a7490802b0835684b906ddd18b0054c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7c17892d1a241934eaf36b3fb65055827a334fe698dc03f22c44a21f2e550367",
+    "zh:a13ddbd5899d41ae5011ab3b3b72ef79a4ad4f6bad7fd1fc7b03fccd33d8048d",
+    "zh:fb2de687765b2fcbccc18c9a82e2ea5fce5b900c3e113fe24e0937f2173917a7",
+    "zh:fff4a65661eff3796999846ac099b8e54bab5497ee6995a70db6fb5ef9e926d5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.3.0"
+  hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/azure/examples/minimal/main.tf
+++ b/infra/terraform/azure/examples/minimal/main.tf
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Minimal example: deploy Observal to Azure with defaults.
+
+module "observal" {
+  source = "../../"
+
+  subscription_id = "6a0284fc-791a-4d77-9520-69cdaa79ba44"
+  environment     = "staging"
+  location        = "eastus"
+}
+
+output "api_url" {
+  value = module.observal.api_url
+}
+
+output "web_url" {
+  value = module.observal.web_url
+}

--- a/infra/terraform/azure/grafana.tf
+++ b/infra/terraform/azure/grafana.tf
@@ -1,9 +1,17 @@
 # SPDX-FileCopyrightText: 2026 Tanvi Reddy
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Azure Managed Grafana - enterprise-ready observability dashboard.
-# Connects to ClickHouse on the data VM for telemetry queries.
+# Azure Monitor Workspace (required for Managed Grafana integration)
+resource "azurerm_monitor_workspace" "main" {
+  count               = var.grafana_enabled ? 1 : 0
+  name                = "${local.name}-monitor"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
 
+  tags = local.tags
+}
+
+# Azure Managed Grafana - enterprise-ready observability dashboard.
 resource "azurerm_dashboard_grafana" "main" {
   count               = var.grafana_enabled ? 1 : 0
   name                = "${var.name_prefix}-${var.environment}-gf"
@@ -18,7 +26,7 @@ resource "azurerm_dashboard_grafana" "main" {
   }
 
   azure_monitor_workspace_integrations {
-    resource_id = azurerm_log_analytics_workspace.main.id
+    resource_id = azurerm_monitor_workspace.main[0].id
   }
 
   tags = local.tags

--- a/infra/terraform/azure/grafana.tf
+++ b/infra/terraform/azure/grafana.tf
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Azure Managed Grafana - enterprise-ready observability dashboard.
+# Connects to ClickHouse on the data VM for telemetry queries.
+
+resource "azurerm_dashboard_grafana" "main" {
+  count               = var.grafana_enabled ? 1 : 0
+  name                = "${var.name_prefix}-${var.environment}-gf"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "Standard"
+
+  grafana_major_version = "11"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  azure_monitor_workspace_integrations {
+    resource_id = azurerm_log_analytics_workspace.main.id
+  }
+
+  tags = local.tags
+}
+
+# Grant the current user Grafana Admin role
+resource "azurerm_role_assignment" "grafana_admin" {
+  count                = var.grafana_enabled ? 1 : 0
+  scope                = azurerm_dashboard_grafana.main[0].id
+  role_definition_name = "Grafana Admin"
+  principal_id         = data.azurerm_client_config.current.object_id
+}

--- a/infra/terraform/azure/locals.tf
+++ b/infra/terraform/azure/locals.tf
@@ -7,13 +7,16 @@ locals {
   location = var.location
 
   clickhouse_self_hosted = var.clickhouse_mode == "self_hosted"
+  # VM is needed if either ClickHouse or Redis is self-hosted
+  needs_vm = local.clickhouse_self_hosted || var.redis_mode == "self_hosted"
 
   api_image = "${azurerm_container_registry.main.login_server}/${var.name_prefix}-api:${var.image_tag}"
   web_image = "${azurerm_container_registry.main.login_server}/${var.name_prefix}-web:${var.image_tag}"
 
   # Connection strings built from managed resources
-  database_url   = "postgresql+asyncpg://${azurerm_postgresql_flexible_server.main.administrator_login}:${random_password.db.result}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/observal?sslmode=require"
-  redis_url      = "rediss://:${azurerm_redis_cache.main.primary_access_key}@${azurerm_redis_cache.main.hostname}:${azurerm_redis_cache.main.ssl_port}"
+  database_url   = "postgresql+asyncpg://${azurerm_postgresql_flexible_server.main.administrator_login}:${random_password.db.result}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/observal?ssl=require"
+  redis_self_hosted = var.redis_mode == "self_hosted"
+  redis_url        = local.redis_self_hosted ? "redis://${azurerm_network_interface.clickhouse[0].private_ip_address}:6379" : "rediss://:${azurerm_redis_enterprise_database.main[0].primary_access_key}@${azurerm_redis_enterprise_cluster.main[0].hostname}:10000"
   clickhouse_url = local.clickhouse_self_hosted ? "clickhouse://default:${random_password.clickhouse.result}@${azurerm_network_interface.clickhouse[0].private_ip_address}:8123/observal" : var.clickhouse_cloud_url
 
   tags = {

--- a/infra/terraform/azure/locals.tf
+++ b/infra/terraform/azure/locals.tf
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+locals {
+  name     = "${var.name_prefix}-${var.environment}"
+  is_prod  = var.environment == "prod"
+  location = var.location
+
+  clickhouse_self_hosted = var.clickhouse_mode == "self_hosted"
+
+  api_image = "${azurerm_container_registry.main.login_server}/${var.name_prefix}-api:${var.image_tag}"
+  web_image = "${azurerm_container_registry.main.login_server}/${var.name_prefix}-web:${var.image_tag}"
+
+  # Connection strings built from managed resources
+  database_url   = "postgresql+asyncpg://${azurerm_postgresql_flexible_server.main.administrator_login}:${random_password.db.result}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/observal?sslmode=require"
+  redis_url      = "rediss://:${azurerm_redis_cache.main.primary_access_key}@${azurerm_redis_cache.main.hostname}:${azurerm_redis_cache.main.ssl_port}"
+  clickhouse_url = local.clickhouse_self_hosted ? "clickhouse://default:${random_password.clickhouse.result}@${azurerm_network_interface.clickhouse[0].private_ip_address}:8123/observal" : var.clickhouse_cloud_url
+
+  tags = {
+    Project     = "observal"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}

--- a/infra/terraform/azure/log-analytics.tf
+++ b/infra/terraform/azure/log-analytics.tf
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "azurerm_log_analytics_workspace" "main" {
+  name                = "${local.name}-logs"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "PerGB2018"
+  retention_in_days   = var.log_retention_days
+
+  tags = local.tags
+}

--- a/infra/terraform/azure/network.tf
+++ b/infra/terraform/azure/network.tf
@@ -69,6 +69,18 @@ resource "azurerm_network_security_group" "vm" {
   }
 
   security_rule {
+    name                       = "AllowRedisFromVNet"
+    priority                   = 105
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "6379"
+    source_address_prefix      = var.vnet_cidr
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
     name                       = "AllowGrafanaFromVNet"
     priority                   = 110
     direction                  = "Inbound"

--- a/infra/terraform/azure/network.tf
+++ b/infra/terraform/azure/network.tf
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "azurerm_virtual_network" "main" {
+  name                = "${local.name}-vnet"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  address_space       = [var.vnet_cidr]
+  tags                = local.tags
+}
+
+# Container Apps Environment requires a dedicated subnet (min /23)
+resource "azurerm_subnet" "container_apps" {
+  name                 = "${local.name}-container-apps"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.subnet_container_apps_cidr]
+
+  delegation {
+    name = "container-apps"
+    service_delegation {
+      name    = "Microsoft.App/environments"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# Data services subnet (PostgreSQL, Redis private endpoints)
+resource "azurerm_subnet" "data" {
+  name                 = "${local.name}-data"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.subnet_data_cidr]
+
+  delegation {
+    name = "postgresql"
+    service_delegation {
+      name    = "Microsoft.DBforPostgreSQL/flexibleServers"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# VM subnet for ClickHouse host
+resource "azurerm_subnet" "vm" {
+  name                 = "${local.name}-vm"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.subnet_vm_cidr]
+}
+
+# NSG for the VM subnet
+resource "azurerm_network_security_group" "vm" {
+  name                = "${local.name}-vm-nsg"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = local.tags
+
+  security_rule {
+    name                       = "AllowClickHouseFromVNet"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "8123"
+    source_address_prefix      = var.vnet_cidr
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "AllowGrafanaFromVNet"
+    priority                   = 110
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "3001"
+    source_address_prefix      = var.vnet_cidr
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "AllowPrometheusFromVNet"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "9090"
+    source_address_prefix      = var.vnet_cidr
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "DenyAllInbound"
+    priority                   = 4096
+    direction                  = "Inbound"
+    access                     = "Deny"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "vm" {
+  subnet_id                 = azurerm_subnet.vm.id
+  network_security_group_id = azurerm_network_security_group.vm.id
+}
+
+# Private DNS zone for PostgreSQL
+resource "azurerm_private_dns_zone" "postgresql" {
+  name                = "${var.name_prefix}.postgres.database.azure.com"
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = local.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "postgresql" {
+  name                  = "${local.name}-pg-dns-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.postgresql.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+}

--- a/infra/terraform/azure/outputs.tf
+++ b/infra/terraform/azure/outputs.tf
@@ -22,8 +22,8 @@ output "postgresql_fqdn" {
 }
 
 output "redis_hostname" {
-  description = "Redis cache hostname."
-  value       = azurerm_redis_cache.main.hostname
+  description = "Redis endpoint."
+  value       = var.redis_mode == "enterprise" ? azurerm_redis_enterprise_cluster.main[0].hostname : "${azurerm_network_interface.clickhouse[0].private_ip_address}:6379"
 }
 
 output "clickhouse_private_ip" {

--- a/infra/terraform/azure/outputs.tf
+++ b/infra/terraform/azure/outputs.tf
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+output "api_url" {
+  description = "Public URL of the API service."
+  value       = "https://${azurerm_container_app.api.ingress[0].fqdn}"
+}
+
+output "web_url" {
+  description = "Public URL of the web frontend."
+  value       = "https://${azurerm_container_app.web.ingress[0].fqdn}"
+}
+
+output "grafana_url" {
+  description = "URL of the Azure Managed Grafana instance."
+  value       = var.grafana_enabled ? azurerm_dashboard_grafana.main[0].endpoint : "disabled"
+}
+
+output "postgresql_fqdn" {
+  description = "PostgreSQL server FQDN (private, VNet only)."
+  value       = azurerm_postgresql_flexible_server.main.fqdn
+}
+
+output "redis_hostname" {
+  description = "Redis cache hostname."
+  value       = azurerm_redis_cache.main.hostname
+}
+
+output "clickhouse_private_ip" {
+  description = "ClickHouse VM private IP (VNet only)."
+  value       = local.clickhouse_self_hosted ? azurerm_network_interface.clickhouse[0].private_ip_address : "using ClickHouse Cloud"
+}
+
+output "acr_login_server" {
+  description = "ACR login server for pushing images."
+  value       = azurerm_container_registry.main.login_server
+}
+
+output "resource_group_name" {
+  description = "Resource group containing all resources."
+  value       = azurerm_resource_group.main.name
+}

--- a/infra/terraform/azure/postgresql.tf
+++ b/infra/terraform/azure/postgresql.tf
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                          = "${local.name}-pg"
+  resource_group_name           = azurerm_resource_group.main.name
+  location                      = azurerm_resource_group.main.location
+  version                       = "16"
+  delegated_subnet_id           = azurerm_subnet.data.id
+  private_dns_zone_id           = azurerm_private_dns_zone.postgresql.id
+  public_network_access_enabled = false
+
+  administrator_login    = "observal"
+  administrator_password = random_password.db.result
+
+  sku_name   = var.postgresql_sku
+  storage_mb = var.postgresql_storage_gb * 1024
+
+  zone = local.is_prod ? "1" : null
+
+  dynamic "high_availability" {
+    for_each = local.is_prod ? [1] : []
+    content {
+      mode                      = "ZoneRedundant"
+      standby_availability_zone = "2"
+    }
+  }
+
+  backup_retention_days        = local.is_prod ? 35 : 7
+  geo_redundant_backup_enabled = local.is_prod
+
+  tags = local.tags
+
+  depends_on = [azurerm_private_dns_zone_virtual_network_link.postgresql]
+
+  lifecycle {
+    ignore_changes = [zone]
+  }
+}
+
+resource "azurerm_postgresql_flexible_server_database" "observal" {
+  name      = "observal"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "max_connections" {
+  name      = "max_connections"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "300"
+}

--- a/infra/terraform/azure/prod.tfvars
+++ b/infra/terraform/azure/prod.tfvars
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Production environment - HA, zone-redundant, deletion-protected.
+
+subscription_id = "6a0284fc-791a-4d77-9520-69cdaa79ba44"
+environment     = "prod"
+location        = "eastus"
+name_prefix     = "observal"
+
+# Production-grade PostgreSQL
+postgresql_sku        = "GP_Standard_D2ds_v5"
+postgresql_storage_gb = 128
+redis_sku             = "Standard"
+redis_capacity        = 1
+
+# Production replicas with autoscaling
+api_min_replicas    = 2
+api_max_replicas    = 10
+web_min_replicas    = 2
+web_max_replicas    = 6
+worker_min_replicas = 1
+worker_max_replicas = 5
+
+# Larger ClickHouse VM for production workloads
+clickhouse_vm_size      = "Standard_D4s_v5"
+clickhouse_disk_size_gb = 200
+
+# Managed Grafana
+grafana_enabled = true
+
+# 30-day log retention
+log_retention_days = 30

--- a/infra/terraform/azure/prod.tfvars
+++ b/infra/terraform/azure/prod.tfvars
@@ -11,8 +11,10 @@ name_prefix     = "observal"
 # Production-grade PostgreSQL
 postgresql_sku        = "GP_Standard_D2ds_v5"
 postgresql_storage_gb = 128
-redis_sku             = "Standard"
-redis_capacity        = 1
+
+# Azure Managed Redis (switch to "enterprise" when subscription has quota)
+redis_mode           = "self_hosted"
+redis_enterprise_sku = "Enterprise_E10-2"
 
 # Production replicas with autoscaling
 api_min_replicas    = 2
@@ -23,7 +25,7 @@ worker_min_replicas = 1
 worker_max_replicas = 5
 
 # Larger ClickHouse VM for production workloads
-clickhouse_vm_size      = "Standard_D4s_v5"
+clickhouse_vm_size      = "Standard_D4ads_v7"
 clickhouse_disk_size_gb = 200
 
 # Managed Grafana

--- a/infra/terraform/azure/redis.tf
+++ b/infra/terraform/azure/redis.tf
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "azurerm_redis_cache" "main" {
+  name                 = "${local.name}-redis"
+  location             = azurerm_resource_group.main.location
+  resource_group_name  = azurerm_resource_group.main.name
+  capacity             = var.redis_capacity
+  family               = var.redis_sku == "Premium" ? "P" : "C"
+  sku_name             = var.redis_sku
+  non_ssl_port_enabled = false
+  minimum_tls_version  = "1.2"
+
+  redis_configuration {
+    maxmemory_policy = "volatile-lru"
+  }
+
+  tags = local.tags
+}

--- a/infra/terraform/azure/redis.tf
+++ b/infra/terraform/azure/redis.tf
@@ -1,19 +1,29 @@
 # SPDX-FileCopyrightText: 2026 Tanvi Reddy
 # SPDX-License-Identifier: AGPL-3.0-only
 
-resource "azurerm_redis_cache" "main" {
-  name                 = "${local.name}-redis"
-  location             = azurerm_resource_group.main.location
-  resource_group_name  = azurerm_resource_group.main.name
-  capacity             = var.redis_capacity
-  family               = var.redis_sku == "Premium" ? "P" : "C"
-  sku_name             = var.redis_sku
-  non_ssl_port_enabled = false
-  minimum_tls_version  = "1.2"
+# Redis runs on the ClickHouse VM via Docker Compose (self_hosted mode).
+# When redis_mode = "enterprise", an Azure Managed Redis cluster is provisioned instead.
+#
+# Enterprise mode requires a subscription with Redis Enterprise quota.
+# Most Azure for Students / Sponsorship subscriptions don't have this.
 
-  redis_configuration {
-    maxmemory_policy = "volatile-lru"
-  }
+resource "azurerm_redis_enterprise_cluster" "main" {
+  count               = var.redis_mode == "enterprise" ? 1 : 0
+  name                = "${local.name}-redis"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku_name            = var.redis_enterprise_sku
+
+  minimum_tls_version = "1.2"
 
   tags = local.tags
+}
+
+resource "azurerm_redis_enterprise_database" "main" {
+  count             = var.redis_mode == "enterprise" ? 1 : 0
+  name              = "default"
+  cluster_id        = azurerm_redis_enterprise_cluster.main[0].id
+  client_protocol   = "Encrypted"
+  clustering_policy = "EnterpriseCluster"
+  eviction_policy   = "VolatileLRU"
 }

--- a/infra/terraform/azure/resource-group.tf
+++ b/infra/terraform/azure/resource-group.tf
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+resource "azurerm_resource_group" "main" {
+  name     = "${local.name}-rg"
+  location = local.location
+  tags     = local.tags
+}

--- a/infra/terraform/azure/secrets.tf
+++ b/infra/terraform/azure/secrets.tf
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+data "azurerm_client_config" "current" {}
+
+resource "random_password" "db" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "clickhouse" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "secret_key" {
+  length  = 64
+  special = false
+}
+
+resource "azurerm_key_vault" "main" {
+  name                       = "${var.name_prefix}-${var.environment}-kv"
+  location                   = azurerm_resource_group.main.location
+  resource_group_name        = azurerm_resource_group.main.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = local.is_prod
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = ["Get", "List", "Set", "Delete", "Purge"]
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_key_vault_secret" "database_url" {
+  name         = "DATABASE-URL"
+  value        = local.database_url
+  key_vault_id = azurerm_key_vault.main.id
+}
+
+resource "azurerm_key_vault_secret" "redis_url" {
+  name         = "REDIS-URL"
+  value        = local.redis_url
+  key_vault_id = azurerm_key_vault.main.id
+}
+
+resource "azurerm_key_vault_secret" "clickhouse_url" {
+  name         = "CLICKHOUSE-URL"
+  value        = local.clickhouse_url
+  key_vault_id = azurerm_key_vault.main.id
+}
+
+resource "azurerm_key_vault_secret" "secret_key" {
+  name         = "SECRET-KEY"
+  value        = random_password.secret_key.result
+  key_vault_id = azurerm_key_vault.main.id
+}

--- a/infra/terraform/azure/secrets.tf
+++ b/infra/terraform/azure/secrets.tf
@@ -18,8 +18,12 @@ resource "random_password" "secret_key" {
   special = false
 }
 
+resource "random_id" "kv_suffix" {
+  byte_length = 3
+}
+
 resource "azurerm_key_vault" "main" {
-  name                       = "${var.name_prefix}-${var.environment}-kv"
+  name                       = "${var.name_prefix}-${var.environment}-${random_id.kv_suffix.hex}"
   location                   = azurerm_resource_group.main.location
   resource_group_name        = azurerm_resource_group.main.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id

--- a/infra/terraform/azure/staging.tfvars
+++ b/infra/terraform/azure/staging.tfvars
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Staging environment - cost-optimized for development/testing.
+
+subscription_id = "6a0284fc-791a-4d77-9520-69cdaa79ba44"
+environment     = "staging"
+location        = "eastus"
+name_prefix     = "observal"
+
+# Smaller SKUs for staging
+postgresql_sku        = "B_Standard_B2s"
+postgresql_storage_gb = 32
+redis_sku             = "Standard"
+redis_capacity        = 0
+
+# Minimal replicas
+api_min_replicas    = 1
+api_max_replicas    = 3
+web_min_replicas    = 1
+web_max_replicas    = 2
+worker_min_replicas = 1
+worker_max_replicas = 2
+
+# Smaller ClickHouse VM
+clickhouse_vm_size      = "Standard_D2s_v5"
+clickhouse_disk_size_gb = 50
+
+# Managed Grafana
+grafana_enabled = true
+
+# Minimum allowed by Azure is 30
+log_retention_days = 30

--- a/infra/terraform/azure/staging.tfvars
+++ b/infra/terraform/azure/staging.tfvars
@@ -5,14 +5,15 @@
 
 subscription_id = "6a0284fc-791a-4d77-9520-69cdaa79ba44"
 environment     = "staging"
-location        = "eastus"
+location        = "centralus"
 name_prefix     = "observal"
 
-# Smaller SKUs for staging
+# Smaller PostgreSQL for staging
 postgresql_sku        = "B_Standard_B2s"
 postgresql_storage_gb = 32
-redis_sku             = "Standard"
-redis_capacity        = 0
+
+# Redis on ClickHouse VM (Enterprise not available on this subscription)
+redis_mode = "self_hosted"
 
 # Minimal replicas
 api_min_replicas    = 1
@@ -23,7 +24,7 @@ worker_min_replicas = 1
 worker_max_replicas = 2
 
 # Smaller ClickHouse VM
-clickhouse_vm_size      = "Standard_D2s_v5"
+clickhouse_vm_size      = "Standard_D2ads_v7"
 clickhouse_disk_size_gb = 50
 
 # Managed Grafana

--- a/infra/terraform/azure/variables.tf
+++ b/infra/terraform/azure/variables.tf
@@ -185,7 +185,7 @@ variable "clickhouse_cloud_password" {
 variable "clickhouse_vm_size" {
   description = "Azure VM size for the ClickHouse host."
   type        = string
-  default     = "Standard_D2s_v5"
+  default     = "Standard_D2ads_v7"
 }
 
 variable "clickhouse_disk_size_gb" {
@@ -208,16 +208,20 @@ variable "postgresql_storage_gb" {
   default     = 64
 }
 
-variable "redis_sku" {
-  description = "Azure Cache for Redis SKU (Basic, Standard, Premium)."
+variable "redis_mode" {
+  description = "Where Redis lives. 'self_hosted' = on ClickHouse VM via Docker. 'enterprise' = Azure Managed Redis (requires Enterprise quota)."
   type        = string
-  default     = "Standard"
+  default     = "self_hosted"
+  validation {
+    condition     = contains(["self_hosted", "enterprise"], var.redis_mode)
+    error_message = "redis_mode must be 'self_hosted' or 'enterprise'."
+  }
 }
 
-variable "redis_capacity" {
-  description = "Azure Cache for Redis capacity (0=250MB, 1=1GB, 2=2.5GB, etc)."
-  type        = number
-  default     = 1
+variable "redis_enterprise_sku" {
+  description = "Azure Managed Redis (Enterprise) SKU. Only used when redis_mode = 'enterprise'."
+  type        = string
+  default     = "Enterprise_E5-2"
 }
 
 # -- Observability -----------------------------------------------------------

--- a/infra/terraform/azure/variables.tf
+++ b/infra/terraform/azure/variables.tf
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+variable "subscription_id" {
+  description = "Azure subscription ID."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region to deploy into."
+  type        = string
+  default     = "eastus"
+}
+
+variable "environment" {
+  description = "Environment name (prod or staging). Drives HA toggles, deletion protection, and SKU sizing."
+  type        = string
+  default     = "staging"
+  validation {
+    condition     = contains(["prod", "staging"], var.environment)
+    error_message = "environment must be 'prod' or 'staging'."
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix applied to all resource names."
+  type        = string
+  default     = "observal"
+}
+
+# -- Network -----------------------------------------------------------------
+
+variable "vnet_cidr" {
+  description = "CIDR block for the VNet."
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+variable "subnet_container_apps_cidr" {
+  description = "CIDR for the Container Apps subnet (min /23)."
+  type        = string
+  default     = "10.42.0.0/23"
+}
+
+variable "subnet_data_cidr" {
+  description = "CIDR for the data tier subnet (PostgreSQL, Redis, ClickHouse VM)."
+  type        = string
+  default     = "10.42.4.0/24"
+}
+
+variable "subnet_vm_cidr" {
+  description = "CIDR for the ClickHouse VM subnet."
+  type        = string
+  default     = "10.42.5.0/24"
+}
+
+# -- DNS / TLS ---------------------------------------------------------------
+
+variable "domain_name" {
+  description = "Custom domain for the deployment. Leave empty to use Azure-provided URLs."
+  type        = string
+  default     = ""
+}
+
+# -- Container Images --------------------------------------------------------
+
+variable "image_repo_api" {
+  description = "Container image repository for api + worker + init."
+  type        = string
+  default     = "ghcr.io/blazeup-ai/observal-api"
+}
+
+variable "image_repo_web" {
+  description = "Container image repository for the web frontend."
+  type        = string
+  default     = "ghcr.io/blazeup-ai/observal-web"
+}
+
+variable "image_tag" {
+  description = "Image tag to deploy. Bump and re-apply to roll out a new release."
+  type        = string
+  default     = "latest"
+}
+
+# -- Container Apps (api / web / worker) -------------------------------------
+
+variable "api_cpu" {
+  description = "CPU cores for the API container (e.g. 0.5, 1, 2)."
+  type        = number
+  default     = 0.5
+}
+
+variable "api_memory" {
+  description = "Memory (Gi) for the API container."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "api_min_replicas" {
+  description = "Minimum API replicas."
+  type        = number
+  default     = 2
+}
+
+variable "api_max_replicas" {
+  description = "Maximum API replicas."
+  type        = number
+  default     = 10
+}
+
+variable "web_cpu" {
+  description = "CPU cores for the web container."
+  type        = number
+  default     = 0.25
+}
+
+variable "web_memory" {
+  description = "Memory (Gi) for the web container."
+  type        = string
+  default     = "0.5Gi"
+}
+
+variable "web_min_replicas" {
+  description = "Minimum web replicas."
+  type        = number
+  default     = 2
+}
+
+variable "web_max_replicas" {
+  description = "Maximum web replicas."
+  type        = number
+  default     = 6
+}
+
+variable "worker_cpu" {
+  description = "CPU cores for the worker container."
+  type        = number
+  default     = 0.5
+}
+
+variable "worker_memory" {
+  description = "Memory (Gi) for the worker container."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "worker_min_replicas" {
+  description = "Minimum worker replicas."
+  type        = number
+  default     = 1
+}
+
+variable "worker_max_replicas" {
+  description = "Maximum worker replicas."
+  type        = number
+  default     = 5
+}
+
+# -- Data tier (ClickHouse) --------------------------------------------------
+
+variable "clickhouse_mode" {
+  description = "Where ClickHouse lives. 'self_hosted' = Azure VM. 'cloud' = ClickHouse Cloud (supply clickhouse_cloud_url + clickhouse_cloud_password)."
+  type        = string
+  default     = "self_hosted"
+  validation {
+    condition     = contains(["self_hosted", "cloud"], var.clickhouse_mode)
+    error_message = "clickhouse_mode must be 'self_hosted' or 'cloud'."
+  }
+}
+
+variable "clickhouse_cloud_url" {
+  description = "ClickHouse Cloud DSN. Required when clickhouse_mode = 'cloud'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "clickhouse_cloud_password" {
+  description = "ClickHouse Cloud password. Required when clickhouse_mode = 'cloud'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "clickhouse_vm_size" {
+  description = "Azure VM size for the ClickHouse host."
+  type        = string
+  default     = "Standard_D2s_v5"
+}
+
+variable "clickhouse_disk_size_gb" {
+  description = "Size of the managed disk for ClickHouse data."
+  type        = number
+  default     = 100
+}
+
+# -- Managed data services ---------------------------------------------------
+
+variable "postgresql_sku" {
+  description = "PostgreSQL Flexible Server SKU."
+  type        = string
+  default     = "B_Standard_B2s"
+}
+
+variable "postgresql_storage_gb" {
+  description = "PostgreSQL storage in GB."
+  type        = number
+  default     = 64
+}
+
+variable "redis_sku" {
+  description = "Azure Cache for Redis SKU (Basic, Standard, Premium)."
+  type        = string
+  default     = "Standard"
+}
+
+variable "redis_capacity" {
+  description = "Azure Cache for Redis capacity (0=250MB, 1=1GB, 2=2.5GB, etc)."
+  type        = number
+  default     = 1
+}
+
+# -- Observability -----------------------------------------------------------
+
+variable "grafana_enabled" {
+  description = "Deploy Azure Managed Grafana instance."
+  type        = bool
+  default     = true
+}
+
+# -- Application config ------------------------------------------------------
+
+variable "observal_license_key" {
+  description = "Observal Enterprise license key. Leave empty for community edition."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "log_retention_days" {
+  description = "Log Analytics workspace retention in days."
+  type        = number
+  default     = 30
+}
+
+# -- Demo accounts -----------------------------------------------------------
+
+variable "demo_super_admin_email" {
+  description = "Email for the demo super-admin account. Leave empty to skip demo seeding."
+  type        = string
+  default     = ""
+}
+
+variable "demo_super_admin_password" {
+  description = "Password for the demo super-admin account."
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/infra/terraform/azure/versions.tf
+++ b/infra/terraform/azure/versions.tf
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Tanvi Reddy
+# SPDX-License-Identifier: AGPL-3.0-only
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = true
+    }
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
+  subscription_id = var.subscription_id
+}

--- a/infra/terraform/azure/versions.tf
+++ b/infra/terraform/azure/versions.tf
@@ -13,9 +13,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.2"
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
     }
   }
 }
@@ -23,10 +23,11 @@ terraform {
 provider "azurerm" {
   features {
     resource_group {
-      prevent_deletion_if_contains_resources = true
+      prevent_deletion_if_contains_resources = false
     }
     key_vault {
-      purge_soft_delete_on_destroy = false
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
     }
   }
   subscription_id = var.subscription_id


### PR DESCRIPTION
## Summary

Adds a complete Azure Terraform module to deploy Observal as a self-hosted stack on Azure. **Successfully deployed and running in staging.**

## Architecture

- **Container Apps** — API, web, worker (autoscaling), and init job (migrations)
- **PostgreSQL Flexible Server** — zone-redundant in prod, private VNet link
- **Redis** — self-hosted on data VM (Enterprise toggle available when subscription has quota)
- **ClickHouse VM** — self-hosted on Premium SSD (with ClickHouse Cloud toggle)
- **Azure Managed Grafana** — connected to Azure Monitor Workspace
- **ACR** — private container registry
- **Azure File Share** — persistent JWT key storage (survives container restarts)
- **Remote state** — Azure Blob Storage backend for team collaboration

## Environments

| File | Description |
|------|-------------|
| `staging.tfvars` | Cost-optimized (~$120/mo), centralus, single replicas, D2ads_v7 VM |
| `prod.tfvars` | Zone-redundant PG, HA, autoscaling, D4ads_v7 VM |

## Deployed & Verified

- API: `https://observal-staging-api.delightfulground-0a073dc9.centralus.azurecontainerapps.io`
- Web: `https://staging.internal.observal.io/`
- Grafana: `https://observal-staging-gf-eqcxd8ayedd3dafd.cus.grafana.azure.com`
- Health check: `/readyz` → `{"status":"ok","postgres":"ok","clickhouse":"ok","redis":"ok"}`

## What's NOT included (yet)

- Custom domain (waiting on CNAME from DNS admin)
- CI/CD pipeline for `terraform apply` (service principal created, waiting on repo secrets)
- Auto-deploy workflow for code changes (build + push images on merge)

## Issues resolved during deployment

- `Microsoft.App`, `Microsoft.Dashboard`, `Microsoft.Monitor` providers required registration
- PostgreSQL Flexible Server restricted in eastus/eastus2 — switched to centralus
- D-series v5 VMs blocked — switched to D-series v7
- Redis Enterprise unavailable on subscription — self-hosted on data VM
- Cloud-init SPDX header blocked `#cloud-config` parsing — moved to first line
- `asyncpg` requires `ssl=require` not `sslmode=require`
- Azure File Share doesn't support `chmod` — copy-on-start/save-on-stop pattern for JWT keys
- Key Vault soft-delete collision — random suffix on name