### PR TITLE
fix(auth): extend refresh token to 30 days and handle session expiry UX

### DIFF
--- a/ee/observal_server/routes/sso_saml.py
+++ b/ee/observal_server/routes/sso_saml.py
@@ -157,7 +157,7 @@ def _build_auth(config, sp_private_key: str, request_data: dict) -> OneLogin_Sam
 async def _issue_tokens(user: User) -> tuple[str, str, int]:
     access_token, expires_in = create_access_token(user.id, user.role)
     refresh_token, jti = create_refresh_token(user.id, user.role)
-    refresh_ttl = ds.get_sync_int("jwt.refresh_token_expire_days", 7) * 86400
+    refresh_ttl = ds.get_sync_int("jwt.refresh_token_expire_days", 30) * 86400
     redis = get_redis()
     await redis.setex(f"refresh_jti:{jti}", refresh_ttl, str(user.id))
     await redis.delete(f"revoked_user:{user.id}")

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -122,7 +122,7 @@ async def _issue_tokens(user: User, groups: list[str] | None = None) -> tuple[st
 
     try:
         redis = get_redis()
-        refresh_ttl = ds.get_sync_int("jwt.refresh_token_expire_days", 7) * 86400
+        refresh_ttl = ds.get_sync_int("jwt.refresh_token_expire_days", 30) * 86400
         await redis.setex(f"refresh_jti:{jti}", refresh_ttl, str(user.id))
         # Clear any logout revocation so hooks resume after re-login
         await redis.delete(f"revoked_user:{user.id}")
@@ -620,7 +620,7 @@ async def refresh_token(request: Request, req: RefreshRequest, db: AsyncSession 
     new_refresh_token, new_jti = create_refresh_token(user.id, user.role, groups=groups)
 
     try:
-        refresh_ttl = ds.get_sync_int("jwt.refresh_token_expire_days", 7) * 86400
+        refresh_ttl = ds.get_sync_int("jwt.refresh_token_expire_days", 30) * 86400
         await redis.setex(f"refresh_jti:{new_jti}", refresh_ttl, str(user.id))
     except RedisError as e:
         optic.warning("Redis unavailable when storing new refresh JTI: {}", e)

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -138,6 +138,20 @@ async def lifespan(app: FastAPI):
 
     from database import async_session as _session_factory
 
+    # Migrate refresh token expiry: 7 → 30 days
+    async with _session_factory() as db:
+        from models.enterprise_config import EnterpriseConfig
+
+        result = await db.execute(
+            select(EnterpriseConfig).where(EnterpriseConfig.key == "jwt.refresh_token_expire_days")
+        )
+        cfg = result.scalar_one_or_none()
+        if cfg and cfg.value == "7":
+            cfg.value = "30"
+            await db.commit()
+            await ds.invalidate("jwt.refresh_token_expire_days")
+            await ds.refresh_sync_cache()
+
     # Ensure default org exists and backfill any users missing one
     async with _session_factory() as db:
         default_org = await get_or_create_default_org(db)

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -196,7 +196,7 @@ DEFAULTS: dict[str, str] = {
     "saml.sp_key_encryption_password": "",
     # JWT (runtime-tunable expiry settings)
     "jwt.access_token_expire_minutes": "60",
-    "jwt.refresh_token_expire_days": "7",
+    "jwt.refresh_token_expire_days": "30",
     "jwt.hooks_token_expire_minutes": "43200",
     # Resources
     "resource.db_pool_size": "10",

--- a/observal-server/services/jwt_service.py
+++ b/observal-server/services/jwt_service.py
@@ -64,7 +64,7 @@ def create_refresh_token(user_id: uuid.UUID, role: UserRole, groups: list[str] |
         "groups": groups or [],
         "jti": jti,
         "iat": now,
-        "exp": now + timedelta(days=ds.get_sync_int("jwt.refresh_token_expire_days", 7)),
+        "exp": now + timedelta(days=ds.get_sync_int("jwt.refresh_token_expire_days", 30)),
     }
     token = sign_token(payload)
     return token, jti

--- a/web/src/components/shared/error-state.tsx
+++ b/web/src/components/shared/error-state.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { AlertCircle, RefreshCw } from "lucide-react";
+import { AlertCircle, LogIn, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface ErrorStateProps {
@@ -10,6 +10,28 @@ interface ErrorStateProps {
 }
 
 export function ErrorState({ message, onRetry }: ErrorStateProps) {
+  const isSessionExpired =
+    message === "Session expired" ||
+    message?.toLowerCase() === "unauthorized" ||
+    message?.toLowerCase() === "not authenticated";
+
+  if (isSessionExpired) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-muted-foreground/30 py-16">
+        <LogIn className="h-10 w-10 text-muted-foreground/60" />
+        <p className="mt-4 text-sm font-medium">Your login has expired</p>
+        <p className="mt-1 max-w-sm text-center text-xs text-muted-foreground">
+          Please sign in again to continue.
+        </p>
+        <Button variant="outline" size="sm" className="mt-4" asChild>
+          <a href="/login?reason=session_expired">
+            <LogIn className="mr-1.5 h-3.5 w-3.5" /> Sign in
+          </a>
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-destructive/30 py-16">
       <AlertCircle className="h-10 w-10 text-destructive/60" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -251,6 +251,7 @@ async function request<T = unknown>(
 			clearSession();
 			if (typeof window !== "undefined") {
 				window.location.href = "/login?reason=session_expired";
+				return new Promise<T>(() => {});
 			}
 			throw new Error("Session expired");
 		}

--- a/web/src/lib/graphql-ws.ts
+++ b/web/src/lib/graphql-ws.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { createClient, type Client } from "graphql-ws";
+import { clearSession } from "@/lib/api";
 
 function getWsUrl(): string {
   const api =
@@ -19,6 +20,21 @@ function getToken(): string | null {
 }
 
 let client: Client | null = null;
+
+function handleSubscriptionAuthError(err: unknown) {
+  const msg = String(err ?? "").toLowerCase();
+  if (
+    msg.includes("not authenticated") ||
+    msg.includes("unauthorized") ||
+    msg.includes("invalid token") ||
+    msg.includes("token expired")
+  ) {
+    clearSession();
+    if (typeof window !== "undefined") {
+      window.location.href = "/login?reason=session_expired";
+    }
+  }
+}
 
 function getClient(): Client {
   if (!client) {
@@ -55,7 +71,7 @@ export function subscribeToSessionUpdates(
           onEvent(data.sessionId, data.eventName);
         }
       },
-      error: () => {},
+      error: (err) => handleSubscriptionAuthError(err),
       complete: () => {},
     },
   );
@@ -81,7 +97,7 @@ export function subscribeToReviewUpdates(
           onEvent(data.listingId, data.action);
         }
       },
-      error: () => {},
+      error: (err) => handleSubscriptionAuthError(err),
       complete: () => {},
     },
   );

--- a/web/src/pages/admin/settings.tsx
+++ b/web/src/pages/admin/settings.tsx
@@ -105,7 +105,7 @@ function getPlaceholder(key: string): string {
 		"saml.sp_key_encryption_password": "strong-random-password",
 		// JWT
 		"jwt.access_token_expire_minutes": "60",
-		"jwt.refresh_token_expire_days": "7",
+		"jwt.refresh_token_expire_days": "30",
 		"jwt.hooks_token_expire_minutes": "43200",
 		// Resources
 		"resource.db_pool_size": "10",
@@ -432,7 +432,7 @@ const SETTING_SECTIONS: SettingSection[] = [
 				label: "Refresh Token Lifetime",
 				subtitle: "Days before refresh tokens expire",
 				tooltip:
-					"How long a refresh token is valid. After expiry, users must re-authenticate fully (login again). Shorter = more secure but users log in more often. Default: 7 days.",
+					"How long a refresh token is valid. After expiry, users must re-authenticate fully (login again). Shorter = more secure but users log in more often. Default: 30 days.",
 			},
 			{
 				key: "jwt.hooks_token_expire_minutes",


### PR DESCRIPTION
 ---
  ## Summary
  - Refresh token lifetime: 7 → 30 days (users no longer get logged out after a week of inactivity)
  - Session expiry now auto-redirects to login with a clear message instead of showing generic errors

  ## Changes
  - Backend: updated refresh token default from 7 to 30 days in all fallback paths
  - Frontend: prevent error flash on expired session, show "Your login has expired" with sign-in button as
  safety net
  - Frontend: handle auth errors in GraphQL WebSocket subscriptions (previously swallowed silently)
  - Frontend: updated admin settings tooltip/placeholder to reflect new default
  
 **Note:** On first restart after deploy, the server automatically updates the refresh
  token setting from 7 → 30 days if it was never manually changed from the original default.


  ## Test plan
  - [ ] Clear access token manually → verify silent refresh works
  - [ ] Clear both tokens → verify redirect to `/login?reason=session_expired` with toast
  - [ ] Check admin settings page shows "Default: 30 days" in JWT tooltip