### PR TITLE
test(version-check): use UTC clock for short-TTL cache timestamp

### DIFF
--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -367,7 +367,7 @@ class TestCheckVersionCompatibility:
         fresh_cache = {
             "server_version": "1.0.5",
             "source": "server",
-            "last_checked": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+            "last_checked": time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime()),
         }
         monkeypatch.setattr(version_check, "_read_cache", lambda: fresh_cache)
         network_called = {"hit": False}


### PR DESCRIPTION
## Summary
  Fixes the flaky `test_uses_short_ttl_cache` failure on machines in timezones
  ahead of UTC (e.g. IST).

  The test stamped `last_checked` with `time.strftime("...+00:00")`, which uses
  the **local** clock but labels it UTC. In `_should_check`
  (`observal_cli/version_check.py:199`) the clock-skew guard then sees a
  "future" timestamp, treats the cache as stale, and forces a network call —
  breaking `assert network_called["hit"] is False`.

  Using `time.gmtime()` makes the `+00:00` label match the actual instant, so
  the test is correct in every timezone (matches production, which writes
  `datetime.now(UTC).isoformat()`).

  ## Test
  49/49 pass in `tests/test_version_check.py` under `TZ=Asia/Kolkata`.

  Closes #1370 