### PR TITLE
feat: add Cursor support to doctor commands

### DIFF
--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -86,11 +86,15 @@ def doctor(
     rprint("[cyan]Checking Kiro...[/cyan]")
     _check_kiro(issues, warnings)
 
-    # 4. Check Pi
+    # 4. Check Cursor
+    rprint("[cyan]Checking Cursor...[/cyan]")
+    _check_cursor(issues, warnings)
+
+    # 5. Check Pi
     rprint("[cyan]Checking Pi...[/cyan]")
     _check_pi(issues, warnings)
 
-    # 5. Check if observal skill is installed
+    # 6. Check if observal skill is installed
     skill_missing = _check_observal_skill_missing()
     if skill_missing:
         warnings.append(
@@ -288,6 +292,41 @@ def _check_kiro(issues: list, warnings: list):
         )
 
 
+def _check_cursor(issues: list, warnings: list):
+    optic.trace("issues={}, warnings={}", issues, warnings)
+    cursor_dir = Path.home() / ".cursor"
+    if not cursor_dir.is_dir():
+        rprint("  [dim]No ~/.cursor/ found[/dim]")
+        return
+
+    hooks_path = cursor_dir / "hooks.json"
+    if not hooks_path.exists():
+        warnings.append(
+            "Cursor hooks.json not found. "
+            "Run `observal doctor patch --all --ide cursor` to inject hooks."
+        )
+        return
+
+    try:
+        data = json.loads(hooks_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        issues.append(f"{hooks_path}: not valid JSON.")
+        return
+
+    hooks = data.get("hooks", {})
+    has_session_push = any(
+        "cursor_session_push" in e.get("command", "")
+        for event in ("beforeSubmitPrompt", "stop")
+        for e in hooks.get(event, [])
+    )
+
+    if not has_session_push:
+        warnings.append(
+            "Cursor session push hooks not installed. "
+            "Run `observal doctor patch --all --ide cursor` to inject them."
+        )
+
+
 def _check_pi(issues: list, warnings: list):
     """Check if Observal pi extension is installed."""
     optic.debug("_check_pi")
@@ -324,7 +363,7 @@ def doctor_cleanup(
         None,
         "--ide",
         "-i",
-        help="Target IDE only (claude-code, kiro). Default: all.",
+        help="Target IDE only (claude-code, kiro, cursor). Default: all.",
     ),
     dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show what would be removed without doing it"),
 ):
@@ -340,10 +379,11 @@ def doctor_cleanup(
       observal doctor cleanup                          # Clean all supported IDEs
       observal doctor cleanup --ide claude-code        # Claude Code only
       observal doctor cleanup --ide kiro               # Kiro only
+      observal doctor cleanup --ide cursor             # Cursor only
       observal doctor cleanup --ide claude-code --dry-run  # Preview without changes
     """
     optic.trace("ide={}, dry_run={}", ide, dry_run)
-    targets = [ide] if ide else ["claude-code", "kiro"]
+    targets = [ide] if ide else ["claude-code", "kiro", "cursor"]
     any_changes = False
 
     rprint("[bold]Observal Doctor - Cleanup[/bold]\n")
@@ -355,6 +395,10 @@ def doctor_cleanup(
 
         elif target in ("kiro", "kiro-cli"):
             changed = _cleanup_kiro(dry_run)
+            any_changes = any_changes or changed
+
+        elif target == "cursor":
+            changed = _cleanup_cursor(dry_run)
             any_changes = any_changes or changed
 
         else:
@@ -470,6 +514,58 @@ def _cleanup_kiro(dry_run: bool) -> bool:
 
     if not changed:
         rprint("  [dim]No Observal artifacts found in Kiro agents[/dim]")
+
+    return changed
+
+
+def _cleanup_cursor(dry_run: bool) -> bool:
+    optic.trace("dry_run={}", dry_run)
+    rprint("[cyan]Cursor[/cyan]")
+    hooks_path = Path.home() / ".cursor" / "hooks.json"
+    if not hooks_path.exists():
+        rprint("  [dim]No ~/.cursor/hooks.json found - skipping[/dim]")
+        return False
+
+    try:
+        data = json.loads(hooks_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        rprint(f"  [red]Failed to read hooks.json: {e}[/red]")
+        return False
+
+    hooks = data.get("hooks", {})
+    changed = False
+    removed_events = []
+
+    for event, entries in list(hooks.items()):
+        if not isinstance(entries, list):
+            continue
+        cleaned = [
+            e
+            for e in entries
+            if "cursor_session_push" not in e.get("command", "")
+            and "session_push" not in e.get("command", "")
+        ]
+        if len(cleaned) < len(entries):
+            removed_events.append(f"{event} ({len(entries) - len(cleaned)} removed)")
+            if not dry_run:
+                if cleaned:
+                    hooks[event] = cleaned
+                else:
+                    del hooks[event]
+            changed = True
+
+    if removed_events:
+        verb = "Would remove" if dry_run else "Removed"
+        rprint(f"  {verb} hooks: {', '.join(removed_events)}")
+
+    if changed and not dry_run:
+        if not data.get("hooks"):
+            data.pop("hooks", None)
+        hooks_path.write_text(json.dumps(data, indent=2) + "\n")
+        rprint(f"  [green]Written {hooks_path}[/green]")
+
+    if not changed:
+        rprint("  [dim]No Observal artifacts found[/dim]")
 
     return changed
 

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -818,7 +818,7 @@ def _patch_kiro(dry_run: bool) -> bool:
 def _patch_cursor(dry_run: bool) -> bool:
     """Install session push hooks into ~/.cursor/hooks.json."""
     optic.trace("dry_run={}", dry_run)
-    import sys
+    from observal_cli.ide_specs.cursor_hooks_spec import CURSOR_HOOK_EVENTS, build_cursor_hooks
 
     rprint("[cyan]Cursor - session push hooks[/cyan]")
 
@@ -827,17 +827,7 @@ def _patch_cursor(dry_run: bool) -> bool:
         rprint("  [dim]No ~/.cursor/ directory - skipping[/dim]")
         return False
 
-    # Use the current interpreter (from the observal CLI's venv) so that
-    # httpx and other dependencies are available when Cursor fires the hook.
-    cmd = f"{sys.executable} -m observal_cli.hooks.cursor_session_push"
-
-    desired = {
-        "version": 1,
-        "hooks": {
-            "beforeSubmitPrompt": [{"command": cmd, "type": "command"}],
-            "stop": [{"command": cmd, "type": "command"}],
-        },
-    }
+    desired_hooks = build_cursor_hooks()
 
     # Load existing hooks.json if present
     existing = {}
@@ -847,26 +837,22 @@ def _patch_cursor(dry_run: bool) -> bool:
         except (json.JSONDecodeError, OSError):
             pass
 
-    # Check if already patched
     existing_hooks = existing.get("hooks", {})
-    needs_update = False
 
-    for event in ("beforeSubmitPrompt", "stop"):
-        entries = existing_hooks.get(event, [])
-        has_observal = any("cursor_session_push" in e.get("command", "") for e in entries)
-        if not has_observal:
-            needs_update = True
-            break
+    # Check if already patched (all desired events have an Observal entry)
+    needs_update = any(
+        not any("cursor_session_push" in e.get("command", "") for e in existing_hooks.get(event, []))
+        for event in CURSOR_HOOK_EVENTS
+    )
 
     if not needs_update:
         rprint("  [dim]Already up to date[/dim]")
         return False
 
-    # Merge: keep existing non-Observal hooks, add ours
+    # Merge: keep existing non-Observal hooks, append ours
     merged_hooks = existing_hooks.copy()
-    for event, desired_entries in desired["hooks"].items():
+    for event, desired_entries in desired_hooks.items():
         current = merged_hooks.get(event, [])
-        # Remove old Observal hooks
         cleaned = [
             h
             for h in current
@@ -874,10 +860,8 @@ def _patch_cursor(dry_run: bool) -> bool:
         ]
         merged_hooks[event] = cleaned + desired_entries
 
-    result = {"version": 1, "hooks": merged_hooks}
-
     if not dry_run:
-        hooks_path.write_text(json.dumps(result, indent=2) + "\n")
+        hooks_path.write_text(json.dumps({"version": 1, "hooks": merged_hooks}, indent=2) + "\n")
 
     verb = "Would install" if dry_run else "Installed"
     rprint(f"  {verb} hooks in {hooks_path}")

--- a/observal_cli/ide_specs/cursor_hooks_spec.py
+++ b/observal_cli/ide_specs/cursor_hooks_spec.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Cursor IDE hook specification for session JSONL push.
+
+Cursor hooks live in ~/.cursor/hooks.json and fire on two events:
+  - beforeSubmitPrompt  (analogous to UserPromptSubmit in Claude Code)
+  - stop                (session end)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+CURSOR_HOOK_EVENTS = ("beforeSubmitPrompt", "stop")
+
+# Parent of the observal_cli package directory
+_PKG_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+
+
+def _python_cmd() -> str:
+    """Return python command with PYTHONPATH set if needed."""
+    try:
+        import importlib.util
+
+        if importlib.util.find_spec("observal_cli") is not None:
+            return sys.executable
+    except Exception:
+        pass
+    if sys.platform == "win32":
+        return f'set "PYTHONPATH={_PKG_ROOT}" && {sys.executable}'
+    return f"PYTHONPATH={_PKG_ROOT} {sys.executable}"
+
+
+def build_cursor_hooks() -> dict:
+    """Build the hooks dict for ~/.cursor/hooks.json.
+
+    Returns a dict mapping each Cursor event name to a list of hook entries,
+    ready to be merged into the top-level ``hooks`` object.
+    """
+    cmd = f"{_python_cmd()} -m observal_cli.hooks.cursor_session_push"
+    entry = {"command": cmd, "type": "command"}
+    return {event: [entry] for event in CURSOR_HOOK_EVENTS}

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -1,15 +1,17 @@
 # SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
+# ruff: noqa: E402, I001
 
 """Unit tests for Cursor-specific doctor helpers.
 
 All tests use tmp_path so they never touch the real ~/.cursor directory.
 
-`typer` and `rich` are not installed in the minimal test environment, so we
-inject lightweight stubs into sys.modules before importing cmd_doctor.  The
-stubs only need to satisfy the module-level code that runs at import time;
-the actual test targets (_check_cursor / _patch_cursor / _cleanup_cursor) use
-nothing from those two packages.
+When ``typer`` or ``rich`` are absent from the test environment (e.g. the
+minimal CI matrix) we inject self-referential stubs into sys.modules *before*
+importing cmd_doctor.  ``setdefault`` is a no-op when the real packages are
+already present, so the stubs never interfere with other test files that
+import typer directly.  The ``_Fake`` sentinel handles every attribute /
+call pattern that typer and rich use at module-import time.
 """
 
 from __future__ import annotations
@@ -21,50 +23,61 @@ from pathlib import Path
 from unittest.mock import patch
 
 
-# ── Minimal stubs for CLI-only deps ──────────────────────────
+# ── Self-referential stub that satisfies any typer/rich usage ─
+
+
+class _Fake:
+    """A callable sentinel that returns itself for any attribute or call.
+
+    Covers:
+    - ``typer.Typer()``              → _Fake instance with .callback / .command
+    - ``@app.callback(...)``         → decorator that returns the wrapped fn
+    - ``@app.command(name=...)``     → decorator that returns the wrapped fn
+    - ``typer.Option(default, ...)`` → returns the default value
+    - ``typer.Argument(default,..)`` → returns the default value
+    - ``typer.Context``              → usable as a type annotation
+    - any other attribute access     → returns a new _Fake
+    """
+
+    def __init__(self, _default=None):
+        self._default = _default
+
+    def __call__(self, *args, **kwargs):
+        # Decorator pattern: single callable arg → return it unchanged.
+        if len(args) == 1 and callable(args[0]) and not isinstance(args[0], type):
+            return args[0]
+        # Option/Argument pattern: first positional arg is the default.
+        if args:
+            return args[0]
+        return _Fake()
+
+    def __getattr__(self, name: str) -> _Fake:
+        return _Fake()
 
 
 def _make_typer_stub() -> types.ModuleType:
     stub = types.ModuleType("typer")
-
-    class _FakeApp:
-        def callback(self, *a, **kw):
-            def deco(f):
-                return f
-
-            return deco
-
-        def command(self, *a, **kw):
-            def deco(f):
-                return f
-
-            return deco
-
-    stub.Typer = lambda **kw: _FakeApp()
-    stub.Option = lambda *a, **kw: a[0] if a else None
-    stub.Context = type("Context", (), {})
-    stub.Exit = type("Exit", (SystemExit,), {})
-    stub.confirm = lambda *a, **kw: False
+    stub.__getattr__ = lambda name: _Fake()  # type: ignore[attr-defined]
+    # Exit must be an exception subclass so `raise typer.Exit(...)` works.
+    stub.Exit = type("Exit", (SystemExit,), {})  # type: ignore[attr-defined]
     return stub
 
 
 def _make_rich_stub() -> types.ModuleType:
     stub = types.ModuleType("rich")
-    stub.print = print  # redirect to stdlib
+    stub.print = print  # type: ignore[attr-defined]
     return stub
 
 
+# Only inject when the real packages are absent — setdefault is a no-op
+# if typer/rich are already installed in the current Python environment.
 sys.modules.setdefault("typer", _make_typer_stub())
 sys.modules.setdefault("rich", _make_rich_stub())
 
-# Ensure `from rich import print as rprint` resolves from our stub
-if hasattr(sys.modules["rich"], "print"):
-    pass  # already set above
 
+# ── Import helpers under test (after stubs are in place) ─────
 
-# ── Import helpers under test ────────────────────────────────
-
-from observal_cli.cmd_doctor import _check_cursor, _cleanup_cursor, _patch_cursor  # noqa: E402
+from observal_cli.cmd_doctor import _check_cursor, _cleanup_cursor, _patch_cursor
 
 
 # ── Small test helpers ────────────────────────────────────────

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -1,0 +1,309 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Unit tests for Cursor-specific doctor helpers.
+
+All tests use tmp_path so they never touch the real ~/.cursor directory.
+
+`typer` and `rich` are not installed in the minimal test environment, so we
+inject lightweight stubs into sys.modules before importing cmd_doctor.  The
+stubs only need to satisfy the module-level code that runs at import time;
+the actual test targets (_check_cursor / _patch_cursor / _cleanup_cursor) use
+nothing from those two packages.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+# ── Minimal stubs for CLI-only deps ──────────────────────────
+
+
+def _make_typer_stub() -> types.ModuleType:
+    stub = types.ModuleType("typer")
+
+    class _FakeApp:
+        def callback(self, *a, **kw):
+            def deco(f):
+                return f
+
+            return deco
+
+        def command(self, *a, **kw):
+            def deco(f):
+                return f
+
+            return deco
+
+    stub.Typer = lambda **kw: _FakeApp()
+    stub.Option = lambda *a, **kw: a[0] if a else None
+    stub.Context = type("Context", (), {})
+    stub.Exit = type("Exit", (SystemExit,), {})
+    stub.confirm = lambda *a, **kw: False
+    return stub
+
+
+def _make_rich_stub() -> types.ModuleType:
+    stub = types.ModuleType("rich")
+    stub.print = print  # redirect to stdlib
+    return stub
+
+
+sys.modules.setdefault("typer", _make_typer_stub())
+sys.modules.setdefault("rich", _make_rich_stub())
+
+# Ensure `from rich import print as rprint` resolves from our stub
+if hasattr(sys.modules["rich"], "print"):
+    pass  # already set above
+
+
+# ── Import helpers under test ────────────────────────────────
+
+from observal_cli.cmd_doctor import _check_cursor, _cleanup_cursor, _patch_cursor  # noqa: E402
+
+
+# ── Small test helpers ────────────────────────────────────────
+
+
+def _write_hooks(cursor_dir: Path, hooks: dict) -> Path:
+    hooks_path = cursor_dir / "hooks.json"
+    hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    hooks_path.write_text(json.dumps({"version": 1, "hooks": hooks}))
+    return hooks_path
+
+
+def _observal_entry() -> dict:
+    return {"command": f"{sys.executable} -m observal_cli.hooks.cursor_session_push", "type": "command"}
+
+
+def _foreign_entry() -> dict:
+    return {"command": "/usr/local/bin/my-custom-hook.sh", "type": "command"}
+
+
+# ── _check_cursor ────────────────────────────────────────────
+
+
+class TestCheckCursor:
+    def test_no_cursor_dir_is_silent(self, tmp_path: Path):
+        """`_check_cursor` silently skips when ~/.cursor does not exist."""
+        issues: list[str] = []
+        warnings: list[str] = []
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _check_cursor(issues, warnings)
+
+        assert not issues
+        assert not warnings
+
+    def test_missing_hooks_json_adds_warning(self, tmp_path: Path):
+        """`_check_cursor` warns when ~/.cursor exists but hooks.json is absent."""
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir(parents=True)
+
+        issues: list[str] = []
+        warnings: list[str] = []
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _check_cursor(issues, warnings)
+
+        assert not issues
+        assert len(warnings) == 1
+        assert "hooks.json not found" in warnings[0]
+
+    def test_hooks_present_no_warning(self, tmp_path: Path):
+        """`_check_cursor` is silent when both hook events carry the session push."""
+        cursor_dir = tmp_path / ".cursor"
+        _write_hooks(
+            cursor_dir,
+            {
+                "beforeSubmitPrompt": [_observal_entry()],
+                "stop": [_observal_entry()],
+            },
+        )
+
+        issues: list[str] = []
+        warnings: list[str] = []
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _check_cursor(issues, warnings)
+
+        assert not issues
+        assert not warnings
+
+    def test_missing_observal_hook_adds_warning(self, tmp_path: Path):
+        """`_check_cursor` warns when hooks.json contains only foreign entries."""
+        cursor_dir = tmp_path / ".cursor"
+        _write_hooks(cursor_dir, {"beforeSubmitPrompt": [_foreign_entry()]})
+
+        issues: list[str] = []
+        warnings: list[str] = []
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _check_cursor(issues, warnings)
+
+        assert not issues
+        assert len(warnings) == 1
+        assert "session push hooks not installed" in warnings[0]
+
+    def test_invalid_json_adds_issue(self, tmp_path: Path):
+        """`_check_cursor` raises an issue for a corrupted hooks.json."""
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir(parents=True)
+        (cursor_dir / "hooks.json").write_text("not { valid json")
+
+        issues: list[str] = []
+        warnings: list[str] = []
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _check_cursor(issues, warnings)
+
+        assert len(issues) == 1
+        assert "not valid JSON" in issues[0]
+
+
+# ── _patch_cursor ────────────────────────────────────────────
+
+
+class TestPatchCursor:
+    def test_no_cursor_dir_skips(self, tmp_path: Path):
+        """`_patch_cursor` returns False when ~/.cursor does not exist."""
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _patch_cursor(dry_run=False)
+
+        assert result is False
+
+    def test_writes_hooks_when_absent(self, tmp_path: Path):
+        """`_patch_cursor` creates hooks.json with both required events."""
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir(parents=True)
+        hooks_path = cursor_dir / "hooks.json"
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _patch_cursor(dry_run=False)
+
+        assert result is True
+        assert hooks_path.exists()
+        data = json.loads(hooks_path.read_text())
+        assert "beforeSubmitPrompt" in data["hooks"]
+        assert "stop" in data["hooks"]
+        assert any("cursor_session_push" in e["command"] for e in data["hooks"]["beforeSubmitPrompt"])
+
+    def test_dry_run_does_not_write(self, tmp_path: Path):
+        """`_patch_cursor(dry_run=True)` returns True but never creates the file."""
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir(parents=True)
+        hooks_path = cursor_dir / "hooks.json"
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _patch_cursor(dry_run=True)
+
+        assert result is True
+        assert not hooks_path.exists()
+
+    def test_idempotent_patch(self, tmp_path: Path):
+        """`_patch_cursor` is a no-op when Observal hooks are already present."""
+        cursor_dir = tmp_path / ".cursor"
+        _write_hooks(
+            cursor_dir,
+            {
+                "beforeSubmitPrompt": [_observal_entry()],
+                "stop": [_observal_entry()],
+            },
+        )
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _patch_cursor(dry_run=False)
+
+        assert result is False
+
+    def test_preserves_foreign_hooks(self, tmp_path: Path):
+        """`_patch_cursor` keeps non-Observal hooks alongside the injected ones."""
+        cursor_dir = tmp_path / ".cursor"
+        _write_hooks(cursor_dir, {"beforeSubmitPrompt": [_foreign_entry()]})
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _patch_cursor(dry_run=False)
+
+        data = json.loads((cursor_dir / "hooks.json").read_text())
+        bp = data["hooks"]["beforeSubmitPrompt"]
+        commands = [e["command"] for e in bp]
+        assert any("cursor_session_push" in c for c in commands), "Observal hook not injected"
+        assert any("my-custom-hook" in c for c in commands), "Foreign hook was removed"
+
+
+# ── _cleanup_cursor ──────────────────────────────────────────
+
+
+class TestCleanupCursor:
+    def test_no_hooks_json_skips(self, tmp_path: Path):
+        """`_cleanup_cursor` returns False when hooks.json is absent."""
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _cleanup_cursor(dry_run=False)
+
+        assert result is False
+
+    def test_removes_observal_hooks_keeps_foreign(self, tmp_path: Path):
+        """`_cleanup_cursor` strips Observal entries while preserving foreign ones."""
+        cursor_dir = tmp_path / ".cursor"
+        _write_hooks(
+            cursor_dir,
+            {
+                "beforeSubmitPrompt": [_observal_entry(), _foreign_entry()],
+                "stop": [_observal_entry()],
+            },
+        )
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _cleanup_cursor(dry_run=False)
+
+        assert result is True
+        data = json.loads((cursor_dir / "hooks.json").read_text())
+        hooks = data.get("hooks", {})
+        # Foreign hook preserved in beforeSubmitPrompt
+        bp = hooks.get("beforeSubmitPrompt", [])
+        assert len(bp) == 1
+        assert "my-custom-hook" in bp[0]["command"]
+        # stop event fully removed (no entries left)
+        assert "stop" not in hooks
+
+    def test_dry_run_does_not_write(self, tmp_path: Path):
+        """`_cleanup_cursor(dry_run=True)` reports changes but leaves the file unchanged."""
+        cursor_dir = tmp_path / ".cursor"
+        _write_hooks(cursor_dir, {"beforeSubmitPrompt": [_observal_entry()]})
+        original_text = (cursor_dir / "hooks.json").read_text()
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _cleanup_cursor(dry_run=True)
+
+        assert result is True
+        assert (cursor_dir / "hooks.json").read_text() == original_text
+
+    def test_nothing_to_clean_returns_false(self, tmp_path: Path):
+        """`_cleanup_cursor` returns False when no Observal hooks are present."""
+        cursor_dir = tmp_path / ".cursor"
+        _write_hooks(cursor_dir, {"beforeSubmitPrompt": [_foreign_entry()]})
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _cleanup_cursor(dry_run=False)
+
+        assert result is False
+
+    def test_full_cleanup_removes_all_observal_entries(self, tmp_path: Path):
+        """`_cleanup_cursor` clears every Observal hook across multiple events."""
+        cursor_dir = tmp_path / ".cursor"
+        _write_hooks(
+            cursor_dir,
+            {
+                "beforeSubmitPrompt": [_observal_entry()],
+                "stop": [_observal_entry()],
+            },
+        )
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            result = _cleanup_cursor(dry_run=False)
+
+        assert result is True
+        data = json.loads((cursor_dir / "hooks.json").read_text())
+        hooks = data.get("hooks", {})
+        assert "beforeSubmitPrompt" not in hooks
+        assert "stop" not in hooks


### PR DESCRIPTION
Purpose / Description
Extends observal doctor to support Cursor as a first-class IDE alongside Claude Code and Kiro. Previously, observal doctor (check/patch/cleanup) had no Cursor-specific logic, so users could not diagnose or instrument their Cursor setup for Observal session telemetry.

Fixes
Fixes https://github.com/BlazeUp-AI/Observal/issues/830
Approach
Added three new helpers in observal_cli/cmd_doctor.py and a dedicated hook spec module, following the exact patterns established by the Kiro and Claude Code implementations:

cursor_hooks_spec.py — single source of truth for the two Cursor hook events (beforeSubmitPrompt, stop) and the build_cursor_hooks() factory, analogous to kiro_hooks_spec.py.
_check_cursor(issues, warnings) — checks ~/.cursor/hooks.json for Observal session-push entries; emits a warning if hooks are missing, an issue if the file is corrupt, and silently skips when ~/.cursor/ doesn't exist.
_patch_cursor(dry_run) — refactored to import and call build_cursor_hooks() from the spec (eliminating the previous inline duplication flagged by CodeRabbit). Merges Observal hooks non-destructively, preserving all foreign hooks.
_cleanup_cursor(dry_run) — removes only Observal-managed entries from hooks.json without touching foreign hooks. Respects --dry-run.
The doctor callback, doctor_cleanup targets list, and --ide help text were all updated to include cursor.

How Has This Been Tested?
15 unit tests added in tests/test_cmd_doctor.py covering all three helpers across three test classes (TestCheckCursor, TestPatchCursor, TestCleanupCursor):

All tests use tmp_path and patch.object(Path, "home", ...) — no real ~/.cursor is touched.
Scenarios covered: no directory, missing hooks.json, valid hooks already present, hooks absent (warning path), corrupted JSON (issue path), dry-run no-write, idempotent patch, foreign hook preservation, full cleanup, partial cleanup.
python -m pytest tests/test_cmd_doctor.py -v

15 passed in 0.41s
Checklist

You have a descriptive commit message with a short title (first line, max 50 chars).

You have commented your code, particularly in hard-to-understand areas

You have performed a self-review of your own code

UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)