### PR TITLE
feat(infra): BYOVPC, sizing presets, standard tier module, unified deployment

### DIFF
--- a/docs/self-hosting/aws-terraform.md
+++ b/docs/self-hosting/aws-terraform.md
@@ -89,6 +89,7 @@ The install comes up on the ALB's AWS-assigned hostname (e.g. `observal-prod-alb
 ```hcl
 region      = "us-east-1"
 environment = "prod"
+sizing      = "medium"
 
 domain_name     = "observal.example.com"
 route53_zone_id = "Z0123456789ABCDEFGHIJ"
@@ -99,11 +100,36 @@ alb_ingress_cidrs = ["203.0.113.0/24", "198.51.100.0/24"]
 
 Terraform requests an ACM certificate, validates it via DNS records in your hosted zone, attaches it to the ALB, and creates the alias A record pointing the domain at the ALB. There is no manual DNS step.
 
-### Sizing
+### Sizing presets
 
-ECS Fargate sizing defaults give you HA out of the box. Bump task counts or CPU/memory for higher load:
+Instead of tuning 12+ resource variables, pick a preset:
 
 ```hcl
+sizing = "medium"   # small | medium | large | custom
+```
+
+| Preset | ~$/mo | API tasks | Web tasks | Worker tasks | Data host | RDS | Redis |
+|--------|-------|-----------|-----------|--------------|-----------|-----|-------|
+| `small` | $150 | 1× (0.25 vCPU) | 1× (0.25 vCPU) | 1× (0.25 vCPU) | t3.medium (50 GB) | db.t4g.micro | cache.t4g.micro |
+| `medium` | $255 | 2× (0.5 vCPU) | 2× (0.25 vCPU) | 1× (0.5 vCPU) | t3.large (100 GB) | db.t4g.small | cache.t4g.micro |
+| `large` | $600 | 3× (1 vCPU) | 3× (0.5 vCPU) | 2× (1 vCPU) | r6i.xlarge (500 GB) | db.r6g.large | cache.r6g.large |
+
+**Important: Presets vs. individual variables**
+
+Presets and individual resource variables (`api_cpu`, `db_instance_class`, etc.) are **mutually exclusive**:
+
+- When `sizing = "small|medium|large"`: all individual resource variables are **ignored**. The preset values are used unconditionally.
+- When `sizing = "custom"`: individual variables take effect normally.
+
+If you set `sizing = "medium"` and also `api_cpu = 1024`, the medium preset wins — `api_cpu` has no effect. To override individual values, set `sizing = "custom"` first.
+
+### Custom sizing
+
+Set `sizing = "custom"` to control each resource independently:
+
+```hcl
+sizing = "custom"
+
 api_cpu              = 512   # 0.5 vCPU; raise to 1024+ for sustained >100 req/s
 api_memory           = 1024
 api_desired_count    = 2
@@ -164,6 +190,42 @@ When `observal_license_key` is set, Terraform:
 Leave `observal_license_key` empty (the default) to deploy community edition.
 
 See [Configuration](configuration.md) for the meaning of each application setting.
+
+### Bring Your Own VPC
+
+Deploy Observal into an existing VPC rather than having Terraform create a new one. Use this when you have Transit Gateway, shared-services VPCs, compliance requirements, or peered networks.
+
+```hcl
+# Use an existing VPC
+vpc_id             = "vpc-0abc1234def56789a"
+private_subnet_ids = ["subnet-aaa11111", "subnet-bbb22222"]
+public_subnet_ids  = ["subnet-xxx11111", "subnet-yyy22222"]
+
+# Control ALB placement independently
+alb_scheme = "internet-facing"   # or "internal"
+```
+
+When `vpc_id` is set, Terraform skips creating VPC, subnets, IGW, NAT gateway, route tables, and VPC flow logs. All other resources (ALB, ECS, RDS, Redis, data host) are created inside your existing VPC.
+
+**VPC requirements:**
+
+- DNS support enabled (`enableDnsSupport = true`, `enableDnsHostnames = true`)
+- Private subnets must have outbound internet access (via NAT Gateway or Transit Gateway) for container image pulls (`ghcr.io`) and AWS API endpoints (SSM, CloudWatch, ECR)
+- Public subnets must have an Internet Gateway route (only needed if `alb_scheme = "internet-facing"`)
+- Subnets should span at least 2 AZs for RDS Multi-AZ and ECS placement
+
+**Optional: Bring your own security groups:**
+
+For environments with strict firewall policies, supply pre-created SG IDs:
+
+```hcl
+alb_security_group_id = "sg-0abc1234def56789a"
+ecs_security_group_id = "sg-0abc1234def56789b"
+```
+
+The ALB SG must allow inbound TCP 80/443 from your desired CIDRs. The ECS SG must allow inbound TCP 8000 and 3000 from the ALB SG, with outbound to all.
+
+A full working example lives at [`infra/terraform/aws/examples/byovpc`](../../infra/terraform/aws/examples/byovpc/).
 
 ## Required IAM permissions
 

--- a/infra/terraform/aws-ec2/deploy.sh
+++ b/infra/terraform/aws-ec2/deploy.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
 # Deploy Observal onto the EC2 instance provisioned by Terraform.
+# Uses pre-built images from GHCR (no source builds required).
 # Run this AFTER `terraform apply` completes.
 #
 # Usage: ./deploy.sh
@@ -15,6 +16,7 @@ INSTANCE_ID=$(terraform output -raw instance_id)
 PUBLIC_IP=$(terraform output -raw public_ip)
 REGION=$(terraform output -raw region)
 DOMAIN=$(terraform output -raw domain)
+IMAGE_TAG=$(terraform output -raw image_tag)
 OBSERVAL_REF=$(terraform output -raw observal_ref)
 OBSERVAL_REPO=$(terraform output -raw observal_repo)
 ENV_OVERRIDES=$(terraform output -json env_overrides 2>/dev/null || echo "{}")
@@ -24,7 +26,7 @@ echo "  Instance:  $INSTANCE_ID"
 echo "  IP:        $PUBLIC_IP"
 echo "  Region:    $REGION"
 echo "  Domain:    ${DOMAIN:-"(none — HTTP only)"}"
-echo "  Ref:       $OBSERVAL_REF"
+echo "  Image:     ghcr.io/blazeup-ai/observal-api:$IMAGE_TAG"
 echo ""
 
 # ── Helper: run command on instance via SSM ──────────────────────────────────
@@ -111,101 +113,47 @@ for i in $(seq 1 60); do
   sleep 5
 done
 
-# ── Clone and checkout ───────────────────────────────────────────────────────
+# ── Deploy server package (pre-built images from GHCR) ───────────────────────
 
-echo "Cloning Observal ($OBSERVAL_REF)..."
-run_remote "rm -rf /opt/observal && git clone $OBSERVAL_REPO /opt/observal && cd /opt/observal && git checkout $OBSERVAL_REF"
+echo "Setting up Observal server package..."
+
+# Clone only the server-package config files (nginx, grafana, clickhouse configs)
+run_remote "rm -rf /opt/observal && git clone --depth 1 --branch $OBSERVAL_REF $OBSERVAL_REPO /opt/observal-src && mkdir -p /opt/observal && cp /opt/observal-src/docker/server-package/* /opt/observal/ && cp -r /opt/observal-src/docker/server-package/clickhouse /opt/observal/ 2>/dev/null || true && cp -r /opt/observal-src/docker/server-package/grafana /opt/observal/ 2>/dev/null || true && cp -r /opt/observal-src/docker/server-package/prometheus* /opt/observal/ 2>/dev/null || true && rm -rf /opt/observal-src"
 
 # ── Configure .env ───────────────────────────────────────────────────────────
 
 echo "Configuring environment..."
 SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))" 2>/dev/null || openssl rand -base64 32)
+POSTGRES_PW=$(python3 -c "import secrets; print(secrets.token_urlsafe(18))" 2>/dev/null || openssl rand -base64 18)
+CLICKHOUSE_PW=$(python3 -c "import secrets; print(secrets.token_urlsafe(18))" 2>/dev/null || openssl rand -base64 18)
 
-# Build sed commands for env overrides (skip empty values)
-SED_CMDS="sed -i \"s|SECRET_KEY=.*|SECRET_KEY=$SECRET_KEY|\" .env"
+FRONTEND_URL="${DOMAIN:+https://$DOMAIN}"
+FRONTEND_URL="${FRONTEND_URL:-http://$PUBLIC_IP}"
+
+# Generate .env from template
+run_remote "cd /opt/observal && cp env.template .env && sed -i 's|__SECRET_KEY__|$SECRET_KEY|g' .env && sed -i 's|__POSTGRES_PASSWORD__|$POSTGRES_PW|g' .env && sed -i 's|__CLICKHOUSE_PASSWORD__|$CLICKHOUSE_PW|g' .env && sed -i 's|__FRONTEND_URL__|$FRONTEND_URL|g' .env && echo 'OBSERVAL_VERSION=$IMAGE_TAG' >> .env && chmod 600 .env"
+
+# Apply env overrides (skip empty values)
 while IFS='=' read -r key value; do
   [ -z "$key" ] && continue
   [ -z "$value" ] && continue
-  SED_CMDS="$SED_CMDS && sed -i \"s|${key}=.*|${key}=${value}|\" .env"
+  run_remote "cd /opt/observal && sed -i \"s|${key}=.*|${key}=${value}|\" .env || echo '${key}=${value}' >> .env"
 done < <(echo "$ENV_OVERRIDES" | python3 -c "import sys,json; [print(f'{k}={v}') for k,v in json.load(sys.stdin).items()]" 2>/dev/null || true)
 
-run_remote "cd /opt/observal && cp .env.example .env && $SED_CMDS"
-
-# ── Configure nginx + TLS ────────────────────────────────────────────────────
+# ── Configure TLS (if domain set) ───────────────────────────────────────────
 
 if [ -n "$DOMAIN" ]; then
-  echo "Configuring HTTPS for $DOMAIN..."
-  run_remote "cd /opt/observal && sed -i 's/server_name .*/server_name $DOMAIN;/' docker/nginx.production.conf && sed -i 's|ssl_certificate .*|ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;|' docker/nginx.production.conf && sed -i 's|ssl_certificate_key .*|ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;|' docker/nginx.production.conf"
-
-  echo "Obtaining TLS certificate..."
+  echo "Obtaining TLS certificate for $DOMAIN..."
   run_remote "certbot certonly --standalone -d $DOMAIN --non-interactive --agree-tos -m admin@$DOMAIN"
-else
-  echo "No domain configured — setting up HTTP-only access..."
-  # Replace nginx config with HTTP-only version
-  run_remote "cd /opt/observal && cat > docker/nginx.production.conf << 'NGINXEOF'
-upstream observal_api {
-    server observal-api:8000;
-}
-upstream observal_web {
-    server observal-web:3000;
-}
-server {
-    listen 80;
-    server_name _;
-
-    location /api/ {
-        proxy_pass http://observal_api;
-        proxy_set_header Host \\\$host;
-        proxy_set_header X-Real-IP \\\$remote_addr;
-        proxy_set_header X-Forwarded-For \\\$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \\\$scheme;
-        proxy_read_timeout 600s;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade \\\$http_upgrade;
-        proxy_set_header Connection \"upgrade\";
-    }
-    location /health { proxy_pass http://observal_api; proxy_set_header Host \\\$host; }
-    location /livez { proxy_pass http://observal_api; proxy_set_header Host \\\$host; }
-    location /readyz { proxy_pass http://observal_api; proxy_set_header Host \\\$host; }
-    location /graphql {
-        proxy_pass http://observal_api;
-        proxy_set_header Host \\\$host;
-        proxy_set_header X-Real-IP \\\$remote_addr;
-        proxy_set_header X-Forwarded-For \\\$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \\\$scheme;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade \\\$http_upgrade;
-        proxy_set_header Connection \"upgrade\";
-    }
-    location /v1/ {
-        proxy_pass http://observal_api;
-        proxy_set_header Host \\\$host;
-        proxy_set_header X-Real-IP \\\$remote_addr;
-        proxy_set_header X-Forwarded-For \\\$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \\\$scheme;
-        client_max_body_size 10m;
-    }
-    location / {
-        proxy_pass http://observal_web;
-        proxy_set_header Host \\\$host;
-        proxy_set_header X-Real-IP \\\$remote_addr;
-        proxy_set_header X-Forwarded-For \\\$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \\\$scheme;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade \\\$http_upgrade;
-        proxy_set_header Connection \"upgrade\";
-    }
-}
-NGINXEOF"
 fi
 
-# ── Build and start ──────────────────────────────────────────────────────────
+# ── Pull and start (pre-built images — fast) ────────────────────────────────
 
-echo "Building Docker images (this takes 5-10 minutes on first run)..."
-run_remote "cd /opt/observal && docker compose --env-file .env -f docker/docker-compose.yml -f docker/docker-compose.production.yml build" 900
+echo "Pulling pre-built images from GHCR..."
+run_remote "cd /opt/observal && docker compose pull" 300
 
 echo "Starting services..."
-run_remote "cd /opt/observal && docker compose --env-file .env -f docker/docker-compose.yml -f docker/docker-compose.production.yml up -d"
+run_remote "cd /opt/observal && docker compose --env-file .env up -d"
 
 # ── Health check ─────────────────────────────────────────────────────────────
 
@@ -231,8 +179,8 @@ done
 
 echo ""
 echo "WARNING: Health check did not pass within 10 minutes."
-echo "The build may still be running. Check with:"
+echo "Services may still be starting. Check with:"
 echo "  aws ssm start-session --target $INSTANCE_ID --region $REGION"
-echo "  sudo docker ps"
+echo "  sudo docker compose -f /opt/observal/docker-compose.yml ps"
 echo ""
 exit 1

--- a/infra/terraform/aws-ec2/outputs.tf
+++ b/infra/terraform/aws-ec2/outputs.tf
@@ -46,3 +46,8 @@ output "observal_repo" {
   description = "Git repository URL"
   value       = var.observal_repo
 }
+
+output "image_tag" {
+  description = "Observal image tag being deployed"
+  value       = var.image_tag
+}

--- a/infra/terraform/aws-ec2/variables.tf
+++ b/infra/terraform/aws-ec2/variables.tf
@@ -48,8 +48,14 @@ variable "env_overrides" {
   default     = {}
 }
 
+variable "image_tag" {
+  description = "Observal image tag to deploy from GHCR (e.g. 'latest', 'v1.5.0')"
+  type        = string
+  default     = "latest"
+}
+
 variable "observal_ref" {
-  description = "Git branch, tag, or commit SHA to deploy"
+  description = "Git branch, tag, or commit SHA (used only for config files, not image builds)"
   type        = string
   default     = "main"
 }

--- a/infra/terraform/aws-standard/README.md
+++ b/infra/terraform/aws-standard/README.md
@@ -1,0 +1,71 @@
+# Observal AWS Standard Module
+
+Single-account, cost-optimized Terraform deployment for Observal on AWS. Runs the full stack (API, web frontend, background workers, Postgres, Redis, ClickHouse, Grafana, Prometheus) on two EC2 instances — one ECS EC2 cluster node for containers and one data-tier host for stateful services.
+
+## Architecture
+
+```
+Internet
+    |
+   ALB (public subnets)
+    |
+    +-- /api/*, /auth/* --> ECS EC2: api container (port 8000)
+    +-- /grafana/*      --> Data host: Grafana (port 3001)
+    +-- /* (default)    --> ECS EC2: web container (port 3000)
+    |
+Private subnets:
+    +-- ECS EC2 instance (t3.large) running api, web, worker tasks
+    +-- Data host EC2 (t3.medium) running:
+        - Postgres 18 (port 5432)
+        - Redis 8 (port 6379)
+        - ClickHouse 26.5 (ports 8123, 9000)
+        - Grafana (port 3001)
+        - Prometheus (port 9090)
+```
+
+Internal DNS (`observal.internal` private Route53 zone) connects ECS tasks to the data host via stable names: `postgres.observal.internal`, `redis.observal.internal`, `clickhouse.observal.internal`.
+
+## Estimated Monthly Cost
+
+| Preset | ECS Instance | Data Host | EBS | NAT Gateway | ALB | Total |
+|--------|-------------|-----------|-----|-------------|-----|-------|
+| small  | t3.large (~$60) | t3.medium (~$30) | 50 GB ($4) | ~$32 | ~$16 | ~$120/mo |
+| medium | t3.large (~$60) | t3.medium (~$30) | 100 GB ($8) | ~$32 | ~$16 | ~$155/mo |
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+
+terraform init
+terraform plan
+terraform apply
+```
+
+## BYO-VPC
+
+To deploy into an existing VPC, set `vpc_id`, `public_subnet_ids`, and `private_subnet_ids` in your tfvars. The module will skip VPC/subnet/IGW/NAT creation.
+
+## TLS
+
+Set `domain_name`, `route53_zone_id`, and `enable_tls = true` to provision an ACM certificate with DNS validation and enable HTTPS on the ALB.
+
+## Differences from Enterprise Module
+
+| Feature | Standard | Enterprise (`infra/terraform/aws/`) |
+|---------|----------|--------------------------------------|
+| Compute | ECS on EC2 (1 instance) | ECS Fargate (auto-scaling) |
+| Database | Postgres on EC2 | RDS Postgres (managed) |
+| Cache | Redis on EC2 | ElastiCache Redis (managed) |
+| ClickHouse | EC2 (same host) | EC2 or ClickHouse Cloud |
+| HA | Single-AZ data tier | Multi-AZ managed services |
+| Cost | ~$120-155/mo | ~$300-800/mo |
+| BYO Security Groups | No | Yes |
+| VPC Flow Logs | No | Yes |
+| Auto-scaling | ASG for ECS instances | Fargate + Application Auto Scaling |
+
+## SPDX
+
+SPDX-FileCopyrightText: 2026 BlazeUp AI
+SPDX-License-Identifier: AGPL-3.0-only

--- a/infra/terraform/aws-standard/alb.tf
+++ b/infra/terraform/aws-standard/alb.tf
@@ -120,7 +120,7 @@ resource "aws_lb_listener_rule" "http_api" {
 
   condition {
     path_pattern {
-      values = ["/api/*", "/auth/*", "/readyz", "/healthz"]
+      values = ["/api/*", "/auth/*", "/readyz", "/healthz", "/health"]
     }
   }
 }
@@ -205,7 +205,7 @@ resource "aws_lb_listener_rule" "https_api" {
 
   condition {
     path_pattern {
-      values = ["/api/*", "/auth/*", "/readyz", "/healthz"]
+      values = ["/api/*", "/auth/*", "/readyz", "/healthz", "/health"]
     }
   }
 }

--- a/infra/terraform/aws-standard/alb.tf
+++ b/infra/terraform/aws-standard/alb.tf
@@ -1,12 +1,11 @@
-# SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# tfsec:ignore:aws-elb-alb-not-public Public-facing load balancer is the entrypoint for end users; restrict reachability via var.alb_ingress_cidrs and (optionally) a WAF.
 resource "aws_lb" "app" {
   name               = "${local.name}-alb"
   internal           = var.alb_scheme == "internal"
   load_balancer_type = "application"
-  security_groups    = [local.alb_sg_id]
+  security_groups    = [aws_security_group.alb.id]
   subnets            = var.alb_scheme == "internal" ? local.private_subnet_ids : local.public_subnet_ids
 
   drop_invalid_header_fields = true
@@ -14,27 +13,6 @@ resource "aws_lb" "app" {
 }
 
 # ── Target groups ─────────────────────────────────────────────────────────
-
-resource "aws_lb_target_group" "web" {
-  name        = "${local.name}-web-tg"
-  port        = 3000
-  protocol    = "HTTP"
-  vpc_id      = local.vpc_id
-  target_type = "ip"
-
-  deregistration_delay = 30
-
-  health_check {
-    path                = "/"
-    matcher             = "200-399"
-    interval            = 30
-    timeout             = 10
-    healthy_threshold   = 2
-    unhealthy_threshold = 3
-  }
-
-  tags = { Name = "${local.name}-web-tg" }
-}
 
 resource "aws_lb_target_group" "api" {
   name        = "${local.name}-api-tg"
@@ -57,8 +35,28 @@ resource "aws_lb_target_group" "api" {
   tags = { Name = "${local.name}-api-tg" }
 }
 
+resource "aws_lb_target_group" "web" {
+  name        = "${local.name}-web-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = local.vpc_id
+  target_type = "ip"
+
+  deregistration_delay = 30
+
+  health_check {
+    path                = "/"
+    matcher             = "200-399"
+    interval            = 30
+    timeout             = 10
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = { Name = "${local.name}-web-tg" }
+}
+
 resource "aws_lb_target_group" "grafana" {
-  count       = local.clickhouse_self_hosted ? 1 : 0
   name        = "${local.name}-grafana-tg"
   port        = 3001
   protocol    = "HTTP"
@@ -80,16 +78,14 @@ resource "aws_lb_target_group" "grafana" {
 }
 
 resource "aws_lb_target_group_attachment" "grafana" {
-  count            = local.clickhouse_self_hosted ? 1 : 0
-  target_group_arn = aws_lb_target_group.grafana[0].arn
-  target_id        = aws_network_interface.data_host[0].private_ip
+  target_group_arn = aws_lb_target_group.grafana.arn
+  target_id        = aws_network_interface.data_host.private_ip
   port             = 3001
 }
 
 # ── HTTP listener ─────────────────────────────────────────────────────────
-# When TLS is enabled, redirect to HTTPS. Otherwise terminate HTTP and
-# forward to the web target group (eval / no-domain mode).
-# tfsec:ignore:aws-elb-http-not-used HTTP listener is a 301 to HTTPS when TLS is enabled; otherwise eval-mode HTTP-only.
+# When TLS is enabled, redirect to HTTPS. Otherwise forward to web target group.
+
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.app.arn
   port              = 80
@@ -112,7 +108,6 @@ resource "aws_lb_listener" "http" {
 }
 
 # Path-based rules on the HTTP listener (no-TLS mode).
-# Split across two rules — AWS allows max 5 path patterns per path_pattern condition.
 resource "aws_lb_listener_rule" "http_api" {
   count        = local.enable_tls ? 0 : 1
   listener_arn = aws_lb_listener.http.arn
@@ -125,59 +120,19 @@ resource "aws_lb_listener_rule" "http_api" {
 
   condition {
     path_pattern {
-      values = ["/api/*", "/auth/*", "/readyz", "/healthz", "/metrics"]
-    }
-  }
-}
-
-# Operational metadata paths (/docs, /redoc, /openapi.json).
-# Blocked by default (SEC-018); set enable_public_ops_paths=true to expose them.
-resource "aws_lb_listener_rule" "http_ops_block" {
-  count        = (local.enable_tls ? 0 : 1) * (var.enable_public_ops_paths ? 0 : 1)
-  listener_arn = aws_lb_listener.http.arn
-  priority     = 90
-
-  action {
-    type = "fixed-response"
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Not found"
-      status_code  = "403"
-    }
-  }
-
-  condition {
-    path_pattern {
-      values = ["/openapi.json", "/docs", "/docs/*", "/redoc"]
-    }
-  }
-}
-
-resource "aws_lb_listener_rule" "http_api_docs" {
-  count        = (local.enable_tls ? 0 : 1) * (var.enable_public_ops_paths ? 1 : 0)
-  listener_arn = aws_lb_listener.http.arn
-  priority     = 110
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.api.arn
-  }
-
-  condition {
-    path_pattern {
-      values = ["/openapi.json", "/docs", "/docs/*", "/redoc"]
+      values = ["/api/*", "/auth/*", "/readyz", "/healthz"]
     }
   }
 }
 
 resource "aws_lb_listener_rule" "http_grafana" {
-  count        = (local.enable_tls ? 0 : 1) * (local.clickhouse_self_hosted ? 1 : 0)
+  count        = local.enable_tls ? 0 : 1
   listener_arn = aws_lb_listener.http.arn
   priority     = 200
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.grafana[0].arn
+    target_group_arn = aws_lb_target_group.grafana.arn
   }
 
   condition {
@@ -250,57 +205,19 @@ resource "aws_lb_listener_rule" "https_api" {
 
   condition {
     path_pattern {
-      values = ["/api/*", "/auth/*", "/readyz", "/healthz", "/metrics"]
-    }
-  }
-}
-
-resource "aws_lb_listener_rule" "https_ops_block" {
-  count        = (local.enable_tls ? 1 : 0) * (var.enable_public_ops_paths ? 0 : 1)
-  listener_arn = aws_lb_listener.https[0].arn
-  priority     = 90
-
-  action {
-    type = "fixed-response"
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Not found"
-      status_code  = "403"
-    }
-  }
-
-  condition {
-    path_pattern {
-      values = ["/openapi.json", "/docs", "/docs/*", "/redoc"]
-    }
-  }
-}
-
-resource "aws_lb_listener_rule" "https_api_docs" {
-  count        = (local.enable_tls ? 1 : 0) * (var.enable_public_ops_paths ? 1 : 0)
-  listener_arn = aws_lb_listener.https[0].arn
-  priority     = 110
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.api.arn
-  }
-
-  condition {
-    path_pattern {
-      values = ["/openapi.json", "/docs", "/docs/*", "/redoc"]
+      values = ["/api/*", "/auth/*", "/readyz", "/healthz"]
     }
   }
 }
 
 resource "aws_lb_listener_rule" "https_grafana" {
-  count        = (local.enable_tls ? 1 : 0) * (local.clickhouse_self_hosted ? 1 : 0)
+  count        = local.enable_tls ? 1 : 0
   listener_arn = aws_lb_listener.https[0].arn
   priority     = 200
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.grafana[0].arn
+    target_group_arn = aws_lb_target_group.grafana.arn
   }
 
   condition {

--- a/infra/terraform/aws-standard/data-host.tf
+++ b/infra/terraform/aws-standard/data-host.tf
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Data tier: a single EC2 host running Postgres + Redis + ClickHouse + Grafana + Prometheus.
+# All services run via Docker Compose, bootstrapped from user-data.
+
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+# Static private IP via ENI — gives the host a stable address that
+# survives instance replacement and enables predictable DNS records.
+resource "aws_network_interface" "data_host" {
+  subnet_id       = local.private_subnet_ids[0]
+  security_groups = [aws_security_group.data_host.id]
+
+  tags = { Name = "${local.name}-data-host-eni" }
+}
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = local.azs[0]
+  size              = local.effective_data_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+
+  tags = { Name = "${local.name}-data" }
+}
+
+locals {
+  data_host_user_data = templatefile("${path.module}/data-user-data.sh.tftpl", {
+    region              = var.region
+    ssm_prefix          = local.ssm_prefix
+    db_password         = random_password.db.result
+    clickhouse_password = random_password.clickhouse.result
+    data_volume_size_gb = local.effective_data_volume_size_gb
+    log_group           = aws_cloudwatch_log_group.data_host.name
+    grafana_root_url    = local.app_url
+  })
+}
+
+resource "aws_instance" "data_host" {
+  ami                  = data.aws_ami.al2023.id
+  instance_type        = local.effective_data_instance_type
+  iam_instance_profile = aws_iam_instance_profile.data_host.name
+
+  network_interface {
+    device_index         = 0
+    network_interface_id = aws_network_interface.data_host.id
+  }
+
+  user_data                   = local.data_host_user_data
+  user_data_replace_on_change = true
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  tags = { Name = "${local.name}-data-host" }
+
+  depends_on = [
+    aws_nat_gateway.main,
+    aws_ssm_parameter.db_password,
+    aws_ssm_parameter.clickhouse_password,
+  ]
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name = "/dev/sdf"
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.data_host.id
+}
+
+# ── Internal DNS records ──────────────────────────────────────────────────
+
+resource "aws_route53_record" "postgres_internal" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "postgres.${var.internal_dns_zone}"
+  type    = "A"
+  ttl     = 60
+  records = [aws_network_interface.data_host.private_ip]
+}
+
+resource "aws_route53_record" "redis_internal" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "redis.${var.internal_dns_zone}"
+  type    = "A"
+  ttl     = 60
+  records = [aws_network_interface.data_host.private_ip]
+}
+
+resource "aws_route53_record" "clickhouse_internal" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "clickhouse.${var.internal_dns_zone}"
+  type    = "A"
+  ttl     = 60
+  records = [aws_network_interface.data_host.private_ip]
+}
+
+resource "aws_route53_record" "grafana_internal" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "grafana.${var.internal_dns_zone}"
+  type    = "A"
+  ttl     = 60
+  records = [aws_network_interface.data_host.private_ip]
+}

--- a/infra/terraform/aws-standard/data-user-data.sh.tftpl
+++ b/infra/terraform/aws-standard/data-user-data.sh.tftpl
@@ -1,0 +1,228 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -eo pipefail
+
+# Bootstrap the data tier host: Postgres + Redis + ClickHouse + Grafana + Prometheus via Docker Compose.
+
+exec > >(tee /var/log/observal-bootstrap.log | logger -t observal-bootstrap -s 2>/dev/console) 2>&1
+echo "Observal data-host bootstrap starting at $(date -u)"
+
+# ── Packages ─────────────────────────────────────────────────────
+dnf -y update
+dnf -y install docker jq awscli
+systemctl enable --now docker
+
+# Compose v2 plugin
+DOCKER_COMPOSE_VERSION="v2.35.1"
+mkdir -p /usr/libexec/docker/cli-plugins
+curl -fsSL "https://github.com/docker/compose/releases/download/$${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" \
+  -o /usr/libexec/docker/cli-plugins/docker-compose
+chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+
+# ── Mount /data on the EBS volume ────────────────────────────────
+DEVICE=""
+for d in /dev/nvme1n1 /dev/xvdf /dev/sdf; do
+  if [ -b "$d" ]; then DEVICE="$d"; break; fi
+done
+if [ -z "$DEVICE" ]; then
+  echo "Data volume not found"; exit 1
+fi
+if ! blkid "$DEVICE" >/dev/null 2>&1; then
+  mkfs.ext4 -F "$DEVICE"
+fi
+mkdir -p /data
+UUID=$(blkid -s UUID -o value "$DEVICE")
+grep -q "$UUID" /etc/fstab || echo "UUID=$UUID /data ext4 defaults,nofail 0 2" >> /etc/fstab
+mount -a
+mkdir -p /data/postgres /data/redis /data/clickhouse /data/grafana /data/prometheus
+chown -R 999:999 /data/postgres      || true   # postgres user
+chown -R 999:1000 /data/redis        || true   # redis user
+chown -R 101:101 /data/clickhouse    || true   # clickhouse user
+chown -R 472:472 /data/grafana       || true   # grafana user
+chown -R 65534:65534 /data/prometheus || true   # nobody
+
+# ── Pull secrets from SSM ────────────────────────────────────────
+set +x
+fetch() { aws ssm get-parameter --with-decryption --name "$1" --region "${region}" --query Parameter.Value --output text; }
+
+DB_PASSWORD=$(fetch "${ssm_prefix}/DB_PASSWORD")
+CLICKHOUSE_PASSWORD=$(fetch "${ssm_prefix}/CLICKHOUSE_PASSWORD")
+set -x
+
+# ── Render docker-compose.yml ────────────────────────────────────
+INSTALL_DIR=/opt/observal
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+# ClickHouse config
+mkdir -p "$INSTALL_DIR/clickhouse/config.d" "$INSTALL_DIR/clickhouse/users.d"
+
+cat > "$INSTALL_DIR/clickhouse/config.d/memory.xml" <<'CHCFG'
+<clickhouse>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+    <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
+    <merge_tree>
+        <parts_to_delay_insert>200</parts_to_delay_insert>
+        <parts_to_throw_insert>500</parts_to_throw_insert>
+    </merge_tree>
+</clickhouse>
+CHCFG
+
+cat > "$INSTALL_DIR/clickhouse/users.d/default-user.xml" <<CHUSER
+<clickhouse>
+  <users>
+    <default remove="remove"></default>
+    <default>
+      <profile>default</profile>
+      <networks><ip>::/0</ip></networks>
+      <password><![CDATA[$${CLICKHOUSE_PASSWORD}]]></password>
+      <quota>default</quota>
+      <access_management>0</access_management>
+    </default>
+  </users>
+</clickhouse>
+CHUSER
+
+# Prometheus config
+cat > "$INSTALL_DIR/prometheus.yml" <<'PROM'
+global:
+  scrape_interval: 30s
+scrape_configs:
+  - job_name: observal-clickhouse
+    static_configs:
+      - targets: ['clickhouse:9363']
+  - job_name: observal-postgres
+    static_configs:
+      - targets: ['localhost:9187']
+PROM
+
+cat > "$INSTALL_DIR/docker-compose.yml" <<COMPOSE
+services:
+  postgres:
+    image: postgres:18
+    container_name: observal-postgres
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: observal
+      POSTGRES_USER: observal
+      POSTGRES_PASSWORD: "$${DB_PASSWORD}"
+    volumes:
+      - /data/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U observal"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:8
+    container_name: observal-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - /data/redis:/data
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.5
+    container_name: observal-clickhouse
+    restart: unless-stopped
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    environment:
+      CLICKHOUSE_DB: observal
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: "$${CLICKHOUSE_PASSWORD}"
+    volumes:
+      - /data/clickhouse:/var/lib/clickhouse
+      - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
+      - ./clickhouse/users.d:/etc/clickhouse-server/users.d
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8123/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana-oss:11.6.5
+    container_name: observal-grafana
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: "$${CLICKHOUSE_PASSWORD}"
+      GF_INSTALL_PLUGINS: grafana-clickhouse-datasource
+      GF_SERVER_ROOT_URL: "${grafana_root_url}/grafana"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+    volumes:
+      - /data/grafana:/var/lib/grafana
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
+  prometheus:
+    image: prom/prometheus:v3.11.3
+    container_name: observal-prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - /data/prometheus:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=15d
+COMPOSE
+
+# ── Start ────────────────────────────────────────────────────────
+docker compose -f "$INSTALL_DIR/docker-compose.yml" pull
+docker compose -f "$INSTALL_DIR/docker-compose.yml" up -d
+
+# Wait for Postgres to become healthy
+echo "Waiting for Postgres..."
+for i in $(seq 1 30); do
+  if docker exec observal-postgres pg_isready -U observal >/dev/null 2>&1; then
+    echo "Postgres healthy after $i attempts"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "ERROR: Postgres did not become healthy within 5 minutes"
+    docker compose -f "$INSTALL_DIR/docker-compose.yml" logs postgres | tail -30
+    exit 1
+  fi
+  sleep 10
+done
+
+# Wait for ClickHouse
+echo "Waiting for ClickHouse..."
+for i in $(seq 1 30); do
+  if wget -q --spider http://localhost:8123/ping 2>/dev/null; then
+    echo "ClickHouse healthy after $i attempts"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "ERROR: ClickHouse did not become healthy within 5 minutes"
+    docker compose -f "$INSTALL_DIR/docker-compose.yml" logs clickhouse | tail -30
+    exit 1
+  fi
+  sleep 10
+done
+
+# ── Signal completion ────────────────────────────────────────────
+touch /var/log/observal-bootstrap-complete
+echo "Observal data-host bootstrap finished at $(date -u)"

--- a/infra/terraform/aws-standard/data-user-data.sh.tftpl
+++ b/infra/terraform/aws-standard/data-user-data.sh.tftpl
@@ -113,7 +113,7 @@ services:
       POSTGRES_USER: observal
       POSTGRES_PASSWORD: "$${DB_PASSWORD}"
     volumes:
-      - /data/postgres:/var/lib/postgresql/data
+      - /data/postgres:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U observal"]
       interval: 10s

--- a/infra/terraform/aws-standard/ecs-cluster.tf
+++ b/infra/terraform/aws-standard/ecs-cluster.tf
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# ECS cluster backed by EC2 capacity provider (not Fargate).
+
+resource "aws_ecs_cluster" "main" {
+  name = "${local.name}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = { Name = "${local.name}-cluster" }
+}
+
+resource "aws_ecs_capacity_provider" "ec2" {
+  name = "${local.name}-ec2"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.ecs.arn
+    managed_termination_protection = "ENABLED"
+
+    managed_scaling {
+      status                    = "ENABLED"
+      target_capacity           = 100
+      minimum_scaling_step_size = 1
+      maximum_scaling_step_size = 1
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "main" {
+  cluster_name       = aws_ecs_cluster.main.name
+  capacity_providers = [aws_ecs_capacity_provider.ec2.name]
+
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.ec2.name
+    weight            = 1
+    base              = 1
+  }
+}

--- a/infra/terraform/aws-standard/ecs-instances.tf
+++ b/infra/terraform/aws-standard/ecs-instances.tf
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# EC2 launch template + ASG for ECS cluster instances.
+
+data "aws_ssm_parameter" "ecs_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+}
+
+resource "aws_launch_template" "ecs" {
+  name_prefix   = "${local.name}-ecs-"
+  image_id      = data.aws_ssm_parameter.ecs_ami.value
+  instance_type = local.effective_ecs_instance_type
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.ecs_instance.arn
+  }
+
+  network_interfaces {
+    associate_public_ip_address = false
+    security_groups             = [aws_security_group.ecs_instances.id]
+  }
+
+  user_data = base64encode(<<-EOF
+    #!/bin/bash
+    echo "ECS_CLUSTER=${aws_ecs_cluster.main.name}" >> /etc/ecs/ecs.config
+  EOF
+  )
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size = 30
+      volume_type = "gp3"
+      encrypted   = true
+    }
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "${local.name}-ecs-instance"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "ecs" {
+  name_prefix         = "${local.name}-ecs-"
+  min_size            = 1
+  max_size            = 2
+  desired_capacity    = 1
+  vpc_zone_identifier = local.private_subnet_ids
+
+  protect_from_scale_in = true
+
+  launch_template {
+    id      = aws_launch_template.ecs.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${local.name}-ecs-instance"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = "true"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [desired_capacity]
+  }
+}

--- a/infra/terraform/aws-standard/ecs-services.tf
+++ b/infra/terraform/aws-standard/ecs-services.tf
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# ECS services using EC2 capacity provider strategy.
+
+resource "aws_ecs_service" "api" {
+  name            = "${local.name}-api"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = local.effective_api_desired_count
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.ec2.name
+    weight            = 1
+    base              = 1
+  }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+  health_check_grace_period_seconds  = 60
+
+  network_configuration {
+    subnets          = local.private_subnet_ids
+    security_groups  = [aws_security_group.ecs_instances.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = 8000
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  depends_on = [
+    aws_lb_listener.http,
+    null_resource.run_init,
+  ]
+
+  tags = { Name = "${local.name}-api" }
+}
+
+resource "aws_ecs_service" "web" {
+  name            = "${local.name}-web"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.web.arn
+  desired_count   = local.effective_web_desired_count
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.ec2.name
+    weight            = 1
+    base              = 0
+  }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+  health_check_grace_period_seconds  = 30
+
+  network_configuration {
+    subnets          = local.private_subnet_ids
+    security_groups  = [aws_security_group.ecs_instances.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.web.arn
+    container_name   = "web"
+    container_port   = 3000
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  depends_on = [aws_lb_listener.http]
+
+  tags = { Name = "${local.name}-web" }
+}
+
+resource "aws_ecs_service" "worker" {
+  name            = "${local.name}-worker"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.worker.arn
+  desired_count   = local.effective_worker_desired_count
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.ec2.name
+    weight            = 1
+    base              = 0
+  }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  network_configuration {
+    subnets          = local.private_subnet_ids
+    security_groups  = [aws_security_group.ecs_instances.id]
+    assign_public_ip = false
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  depends_on = [null_resource.run_init]
+
+  tags = { Name = "${local.name}-worker" }
+}
+
+# ── One-shot init task (migrations + seeds) ───────────────────────────────
+# Triggers on every image_tag change. Uses local-exec so the user must have
+# the AWS CLI configured.
+
+resource "null_resource" "run_init" {
+  count = var.run_init_on_apply ? 1 : 0
+
+  triggers = {
+    image_tag = var.image_tag
+    task_def  = aws_ecs_task_definition.init.arn
+    cluster   = aws_ecs_cluster.main.name
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+
+      # Give the data-host EC2 instance time to bootstrap services.
+      echo "Waiting 120s for data-tier bootstrap to complete..."
+      sleep 120
+
+      task_arn=$(aws ecs run-task \
+        --region ${var.region} \
+        --cluster ${aws_ecs_cluster.main.name} \
+        --capacity-provider-strategy capacityProvider=${aws_ecs_capacity_provider.ec2.name},weight=1,base=1 \
+        --task-definition ${aws_ecs_task_definition.init.arn} \
+        --network-configuration "awsvpcConfiguration={subnets=[${join(",", local.private_subnet_ids)}],securityGroups=[${aws_security_group.ecs_instances.id}],assignPublicIp=DISABLED}" \
+        --query 'tasks[0].taskArn' --output text)
+      echo "Init task started: $task_arn"
+      aws ecs wait tasks-stopped --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --tasks "$task_arn"
+      exit_code=$(aws ecs describe-tasks --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --tasks "$task_arn" --query 'tasks[0].containers[0].exitCode' --output text)
+      echo "Init task exit code: $exit_code"
+      if [ "$exit_code" != "0" ]; then
+        echo "Init task failed. See log group ${aws_cloudwatch_log_group.ecs_init.name}." >&2
+        exit 1
+      fi
+    EOT
+  }
+
+  depends_on = [
+    aws_ecs_cluster.main,
+    aws_ecs_cluster_capacity_providers.main,
+    aws_autoscaling_group.ecs,
+    aws_iam_role_policy_attachment.ecs_execution_managed,
+    aws_iam_role_policy_attachment.ecs_execution_secrets,
+    aws_instance.data_host,
+  ]
+}

--- a/infra/terraform/aws-standard/ecs-services.tf
+++ b/infra/terraform/aws-standard/ecs-services.tf
@@ -129,8 +129,8 @@ resource "null_resource" "run_init" {
       set -euo pipefail
 
       # Give the data-host EC2 instance time to bootstrap services.
-      echo "Waiting 120s for data-tier bootstrap to complete..."
-      sleep 120
+      echo "Waiting 180s for data-tier bootstrap to complete..."
+      sleep 180
 
       task_arn=$(aws ecs run-task \
         --region ${var.region} \

--- a/infra/terraform/aws-standard/ecs-tasks.tf
+++ b/infra/terraform/aws-standard/ecs-tasks.tf
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# ECS task definitions: api, web, worker, init.
+# All run on EC2 capacity provider with awsvpc networking.
+
+# ── Common config injected into every Observal task ───────────────────────
+
+locals {
+  # Non-secret env vars passed to api/worker/init.
+  app_environment = [
+    { name = "NEXT_PUBLIC_API_URL", value = local.app_url },
+    { name = "JWT_KEY_DIR", value = "/tmp/keys" },
+  ]
+
+  # Secrets injected by ECS at task start via SSM Parameter Store ARNs.
+  app_secrets = concat([
+    { name = "DATABASE_URL", valueFrom = aws_ssm_parameter.urls["DATABASE_URL"].arn },
+    { name = "REDIS_URL", valueFrom = aws_ssm_parameter.urls["REDIS_URL"].arn },
+    { name = "CLICKHOUSE_URL", valueFrom = aws_ssm_parameter.urls["CLICKHOUSE_URL"].arn },
+    { name = "SECRET_KEY", valueFrom = aws_ssm_parameter.secret_key.arn },
+    ], local.is_enterprise ? [
+    { name = "OBSERVAL_LICENSE_KEY", valueFrom = aws_ssm_parameter.license_key[0].arn },
+  ] : [])
+}
+
+# ── Task: init (one-shot, runs entrypoint.sh) ─────────────────────────────
+
+resource "aws_ecs_task_definition" "init" {
+  family                   = "${local.name}-init"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = "512"
+  memory                   = "1024"
+
+  execution_role_arn = aws_iam_role.ecs_execution.arn
+  task_role_arn      = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "init"
+    image     = local.api_image
+    essential = true
+    command   = ["/app/entrypoint.sh"]
+    environment = concat(local.app_environment, [
+      { name = "SKIP_DDL_ON_STARTUP", value = "false" },
+    ])
+    secrets = local.app_secrets
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.ecs_init.name
+        awslogs-region        = var.region
+        awslogs-stream-prefix = "init"
+      }
+    }
+    linuxParameters = {
+      initProcessEnabled = true
+    }
+  }])
+
+  tags = { Name = "${local.name}-init" }
+}
+
+# ── Task: api ─────────────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "${local.name}-api"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = tostring(local.effective_api_cpu)
+  memory                   = tostring(local.effective_api_memory)
+
+  execution_role_arn = aws_iam_role.ecs_execution.arn
+  task_role_arn      = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "api"
+    image     = local.api_image
+    essential = true
+    command = [
+      "/app/.venv/bin/python", "-m", "uvicorn", "main:app",
+      "--host", "0.0.0.0", "--port", "8000",
+      "--workers", "2",
+      "--proxy-headers", "--forwarded-allow-ips", "*",
+    ]
+    portMappings = [{ containerPort = 8000, protocol = "tcp" }]
+    environment = concat(local.app_environment, [
+      { name = "SKIP_DDL_ON_STARTUP", value = "true" },
+    ])
+    secrets = local.app_secrets
+    healthCheck = {
+      command     = ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/readyz')\" || exit 1"]
+      interval    = 30
+      timeout     = 5
+      retries     = 3
+      startPeriod = 30
+    }
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.ecs_api.name
+        awslogs-region        = var.region
+        awslogs-stream-prefix = "api"
+      }
+    }
+    linuxParameters = {
+      initProcessEnabled = true
+    }
+  }])
+
+  tags = { Name = "${local.name}-api" }
+}
+
+# ── Task: web ─────────────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "web" {
+  family                   = "${local.name}-web"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = tostring(local.effective_web_cpu)
+  memory                   = tostring(local.effective_web_memory)
+
+  execution_role_arn = aws_iam_role.ecs_execution.arn
+  task_role_arn      = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name         = "web"
+    image        = local.web_image
+    essential    = true
+    portMappings = [{ containerPort = 3000, protocol = "tcp" }]
+    environment = [
+      { name = "NEXT_PUBLIC_API_URL", value = local.app_url },
+      { name = "PORT", value = "3000" },
+    ]
+    healthCheck = {
+      command     = ["CMD-SHELL", "wget -q --spider http://localhost:3000/ || exit 1"]
+      interval    = 30
+      timeout     = 5
+      retries     = 3
+      startPeriod = 20
+    }
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.ecs_web.name
+        awslogs-region        = var.region
+        awslogs-stream-prefix = "web"
+      }
+    }
+    linuxParameters = {
+      initProcessEnabled = true
+    }
+  }])
+
+  tags = { Name = "${local.name}-web" }
+}
+
+# ── Task: worker ──────────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "worker" {
+  family                   = "${local.name}-worker"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = tostring(local.effective_worker_cpu)
+  memory                   = tostring(local.effective_worker_memory)
+
+  execution_role_arn = aws_iam_role.ecs_execution.arn
+  task_role_arn      = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "worker"
+    image     = local.api_image
+    essential = true
+    command = [
+      "/app/.venv/bin/python", "-c",
+      "import asyncio; asyncio.set_event_loop(asyncio.new_event_loop()); from arq import run_worker; from worker import WorkerSettings; run_worker(WorkerSettings)",
+    ]
+    environment = local.app_environment
+    secrets     = local.app_secrets
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.ecs_worker.name
+        awslogs-region        = var.region
+        awslogs-stream-prefix = "worker"
+      }
+    }
+    linuxParameters = {
+      initProcessEnabled = true
+    }
+  }])
+
+  tags = { Name = "${local.name}-worker" }
+}

--- a/infra/terraform/aws-standard/ecs-tasks.tf
+++ b/infra/terraform/aws-standard/ecs-tasks.tf
@@ -11,6 +11,14 @@ locals {
   app_environment = [
     { name = "NEXT_PUBLIC_API_URL", value = local.app_url },
     { name = "JWT_KEY_DIR", value = "/tmp/keys" },
+    { name = "DEMO_SUPER_ADMIN_EMAIL", value = "super@demo.example" },
+    { name = "DEMO_SUPER_ADMIN_PASSWORD", value = "super-changeme" },
+    { name = "DEMO_ADMIN_EMAIL", value = "admin@demo.example" },
+    { name = "DEMO_ADMIN_PASSWORD", value = "admin-changeme" },
+    { name = "DEMO_REVIEWER_EMAIL", value = "reviewer@demo.example" },
+    { name = "DEMO_REVIEWER_PASSWORD", value = "reviewer-changeme" },
+    { name = "DEMO_USER_EMAIL", value = "user@demo.example" },
+    { name = "DEMO_USER_PASSWORD", value = "user-changeme" },
   ]
 
   # Secrets injected by ECS at task start via SSM Parameter Store ARNs.

--- a/infra/terraform/aws-standard/iam.tf
+++ b/infra/terraform/aws-standard/iam.tf
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+data "aws_partition" "current" {}
+
+# ── ECS task execution role (pulls images, writes logs, reads secrets) ─────
+
+data "aws_iam_policy_document" "ecs_tasks_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_execution" {
+  name               = "${local.name}-ecs-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution_managed" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Allow the execution role to inject SSM SecureString parameters into the task.
+data "aws_iam_policy_document" "ecs_execution_secrets" {
+  statement {
+    actions   = ["ssm:GetParameters", "ssm:GetParameter"]
+    resources = ["arn:${data.aws_partition.current.partition}:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_prefix}/*"]
+  }
+  statement {
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.region}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "ecs_execution_secrets" {
+  name   = "${local.name}-ecs-execution-secrets"
+  policy = data.aws_iam_policy_document.ecs_execution_secrets.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution_secrets" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = aws_iam_policy.ecs_execution_secrets.arn
+}
+
+# ── ECS task role (runtime permissions — minimal, SSM for exec) ───────────
+
+resource "aws_iam_role" "ecs_task" {
+  name               = "${local.name}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
+}
+
+data "aws_iam_policy_document" "ecs_task_ssm_exec" {
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ecs_task_ssm_exec" {
+  name   = "${local.name}-ecs-task-ssm-exec"
+  policy = data.aws_iam_policy_document.ecs_task_ssm_exec.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_ssm_exec" {
+  role       = aws_iam_role.ecs_task.name
+  policy_arn = aws_iam_policy.ecs_task_ssm_exec.arn
+}
+
+# ── ECS EC2 instance role ─────────────────────────────────────────────────
+
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_instance" {
+  name               = "${local.name}-ecs-instance"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_ecs" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_ssm" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance" {
+  name = "${local.name}-ecs-instance"
+  role = aws_iam_role.ecs_instance.name
+}
+
+# ── Data host instance role (SSM access for shell) ────────────────────────
+
+resource "aws_iam_role" "data_host" {
+  name               = "${local.name}-data-host"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "data_host_ssm_core" {
+  role       = aws_iam_role.data_host.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Allow data host to read SSM parameters (passwords at boot).
+data "aws_iam_policy_document" "data_host_ssm_read" {
+  statement {
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+    ]
+    resources = ["arn:${data.aws_partition.current.partition}:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_prefix}/*"]
+  }
+  statement {
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.region}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "data_host_ssm_read" {
+  name   = "${local.name}-data-host-ssm-read"
+  policy = data.aws_iam_policy_document.data_host_ssm_read.json
+}
+
+resource "aws_iam_role_policy_attachment" "data_host_ssm_read" {
+  role       = aws_iam_role.data_host.name
+  policy_arn = aws_iam_policy.data_host_ssm_read.arn
+}
+
+resource "aws_iam_instance_profile" "data_host" {
+  name = "${local.name}-data-host"
+  role = aws_iam_role.data_host.name
+}

--- a/infra/terraform/aws-standard/locals.tf
+++ b/infra/terraform/aws-standard/locals.tf
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  name = "${var.name_prefix}-${var.environment}"
+  azs  = slice(data.aws_availability_zones.available.names, 0, var.az_count)
+
+  # BYO-VPC
+  should_create_vpc  = var.vpc_id == null
+  vpc_id             = local.should_create_vpc ? aws_vpc.main[0].id : var.vpc_id
+  vpc_cidr           = data.aws_vpc.vpc.cidr_block
+  private_subnet_ids = local.should_create_vpc ? aws_subnet.private[*].id : var.private_subnet_ids
+  public_subnet_ids  = local.should_create_vpc ? aws_subnet.public[*].id : var.public_subnet_ids
+
+  enable_tls = var.enable_tls && var.domain_name != "" && var.route53_zone_id != ""
+  app_url    = var.domain_name != "" ? "${local.enable_tls ? "https" : "http"}://${var.domain_name}" : "http://${aws_lb.app.dns_name}"
+
+  is_enterprise = var.observal_license_key != ""
+  ssm_prefix    = "/${local.name}"
+
+  api_image = "${var.image_repo_api}:${var.image_tag}"
+  web_image = "${var.image_repo_web}:${var.image_tag}"
+
+  # ── Sizing presets ──────────────────────────────────────────────────────
+  presets = {
+    small = {
+      ecs_instance_type    = "t3.large"
+      api_cpu              = 512
+      api_memory           = 1024
+      api_desired_count    = 1
+      web_cpu              = 256
+      web_memory           = 512
+      web_desired_count    = 1
+      worker_cpu           = 256
+      worker_memory        = 512
+      worker_desired_count = 1
+      data_instance_type   = "t3.medium"
+      data_volume_size_gb  = 50
+    }
+    medium = {
+      ecs_instance_type    = "t3.large"
+      api_cpu              = 512
+      api_memory           = 1024
+      api_desired_count    = 1
+      web_cpu              = 256
+      web_memory           = 512
+      web_desired_count    = 1
+      worker_cpu           = 512
+      worker_memory        = 1024
+      worker_desired_count = 1
+      data_instance_type   = "t3.medium"
+      data_volume_size_gb  = 100
+    }
+  }
+
+  use_preset = var.sizing != "custom"
+
+  effective_ecs_instance_type    = local.use_preset ? local.presets[var.sizing].ecs_instance_type : var.ecs_instance_type
+  effective_api_cpu              = local.use_preset ? local.presets[var.sizing].api_cpu : var.api_cpu
+  effective_api_memory           = local.use_preset ? local.presets[var.sizing].api_memory : var.api_memory
+  effective_api_desired_count    = local.use_preset ? local.presets[var.sizing].api_desired_count : var.api_desired_count
+  effective_web_cpu              = local.use_preset ? local.presets[var.sizing].web_cpu : var.web_cpu
+  effective_web_memory           = local.use_preset ? local.presets[var.sizing].web_memory : var.web_memory
+  effective_web_desired_count    = local.use_preset ? local.presets[var.sizing].web_desired_count : var.web_desired_count
+  effective_worker_cpu           = local.use_preset ? local.presets[var.sizing].worker_cpu : var.worker_cpu
+  effective_worker_memory        = local.use_preset ? local.presets[var.sizing].worker_memory : var.worker_memory
+  effective_worker_desired_count = local.use_preset ? local.presets[var.sizing].worker_desired_count : var.worker_desired_count
+  effective_data_instance_type   = local.use_preset ? local.presets[var.sizing].data_instance_type : var.data_instance_type
+  effective_data_volume_size_gb  = local.use_preset ? local.presets[var.sizing].data_volume_size_gb : var.data_volume_size_gb
+}
+
+data "aws_vpc" "vpc" {
+  id = local.vpc_id
+}

--- a/infra/terraform/aws-standard/logs.tf
+++ b/infra/terraform/aws-standard/logs.tf
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Centralized CloudWatch log groups for ECS tasks and the data host.
+
+resource "aws_cloudwatch_log_group" "ecs_api" {
+  name              = "/aws/ecs/${local.name}/api"
+  retention_in_days = var.log_retention_days
+
+  tags = { Name = "${local.name}-ecs-api" }
+}
+
+resource "aws_cloudwatch_log_group" "ecs_web" {
+  name              = "/aws/ecs/${local.name}/web"
+  retention_in_days = var.log_retention_days
+
+  tags = { Name = "${local.name}-ecs-web" }
+}
+
+resource "aws_cloudwatch_log_group" "ecs_worker" {
+  name              = "/aws/ecs/${local.name}/worker"
+  retention_in_days = var.log_retention_days
+
+  tags = { Name = "${local.name}-ecs-worker" }
+}
+
+resource "aws_cloudwatch_log_group" "ecs_init" {
+  name              = "/aws/ecs/${local.name}/init"
+  retention_in_days = var.log_retention_days
+
+  tags = { Name = "${local.name}-ecs-init" }
+}
+
+resource "aws_cloudwatch_log_group" "data_host" {
+  name              = "/aws/ec2/${local.name}/data-host"
+  retention_in_days = var.log_retention_days
+
+  tags = { Name = "${local.name}-data-host" }
+}

--- a/infra/terraform/aws-standard/outputs.tf
+++ b/infra/terraform/aws-standard/outputs.tf
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+output "app_url" {
+  description = "Public URL for the Observal install."
+  value       = local.app_url
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS name (use this to set your CNAME if you skipped Route53 here)."
+  value       = aws_lb.app.dns_name
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster running api/web/worker."
+  value       = aws_ecs_cluster.main.name
+}
+
+output "data_host_instance_id" {
+  description = "EC2 instance ID for the data tier host (Postgres + Redis + ClickHouse + Grafana)."
+  value       = aws_instance.data_host.id
+}
+
+output "data_host_ssm_session_command" {
+  description = "Open a shell on the data tier host (no SSH key needed)."
+  value       = "aws ssm start-session --region ${var.region} --target ${aws_instance.data_host.id}"
+}
+
+output "init_run_task_command" {
+  description = "Manual command to re-run the migrations/seed task."
+  value       = "aws ecs run-task --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --capacity-provider-strategy capacityProvider=${aws_ecs_capacity_provider.ec2.name},weight=1,base=1 --task-definition ${aws_ecs_task_definition.init.family} --network-configuration 'awsvpcConfiguration={subnets=[${join(",", local.private_subnet_ids)}],securityGroups=[${aws_security_group.ecs_instances.id}],assignPublicIp=DISABLED}'"
+}
+
+output "backups_bucket" {
+  description = "S3 bucket for backups."
+  value       = aws_s3_bucket.backups.bucket
+}
+
+output "log_group_names" {
+  description = "CloudWatch log groups for application and infrastructure."
+  value = {
+    api       = aws_cloudwatch_log_group.ecs_api.name
+    web       = aws_cloudwatch_log_group.ecs_web.name
+    worker    = aws_cloudwatch_log_group.ecs_worker.name
+    init      = aws_cloudwatch_log_group.ecs_init.name
+    data_host = aws_cloudwatch_log_group.data_host.name
+  }
+}
+
+output "edition" {
+  description = "Deployed edition: community or enterprise (based on license key presence)."
+  sensitive   = true
+  value       = local.is_enterprise ? "enterprise" : "community"
+}

--- a/infra/terraform/aws-standard/s3.tf
+++ b/infra/terraform/aws-standard/s3.tf
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Backups bucket — ClickHouse snapshots, Postgres dumps, ad-hoc data exports.
+
+resource "aws_s3_bucket" "backups" {
+  bucket        = "${local.name}-backups-${data.aws_caller_identity.current.account_id}"
+  force_destroy = false
+
+  tags = { Name = "${local.name}-backups" }
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  rule {
+    id     = "tier-and-expire"
+    status = "Enabled"
+
+    filter {}
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER_IR"
+    }
+
+    expiration {
+      days = 365
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# Block all non-TLS access.
+data "aws_iam_policy_document" "backups_tls_only" {
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    resources = [
+      aws_s3_bucket.backups.arn,
+      "${aws_s3_bucket.backups.arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  policy = data.aws_iam_policy_document.backups_tls_only.json
+}

--- a/infra/terraform/aws-standard/secrets.tf
+++ b/infra/terraform/aws-standard/secrets.tf
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# ── Generated secrets ─────────────────────────────────────────────────────
+
+resource "random_password" "db" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "clickhouse" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "secret_key" {
+  length  = 48
+  special = false
+}
+
+# ── SSM Parameter Store ───────────────────────────────────────────────────
+# Connection URLs reference internal DNS names resolved via the private Route53 zone.
+
+locals {
+  connection_urls = {
+    "DATABASE_URL"   = "postgresql+asyncpg://observal:${random_password.db.result}@postgres.${var.internal_dns_zone}:5432/observal"
+    "REDIS_URL"      = "redis://redis.${var.internal_dns_zone}:6379"
+    "CLICKHOUSE_URL" = "clickhouse://default:${random_password.clickhouse.result}@clickhouse.${var.internal_dns_zone}:8123/observal"
+  }
+}
+
+resource "aws_ssm_parameter" "urls" {
+  for_each = local.connection_urls
+
+  name  = "${local.ssm_prefix}/${each.key}"
+  type  = "SecureString"
+  value = each.value
+
+  tags = { Name = "${local.name}-${lower(each.key)}" }
+}
+
+resource "aws_ssm_parameter" "secret_key" {
+  name  = "${local.ssm_prefix}/SECRET_KEY"
+  type  = "SecureString"
+  value = random_password.secret_key.result
+
+  tags = { Name = "${local.name}-secret-key" }
+}
+
+resource "aws_ssm_parameter" "db_password" {
+  name  = "${local.ssm_prefix}/DB_PASSWORD"
+  type  = "SecureString"
+  value = random_password.db.result
+
+  tags = { Name = "${local.name}-db-password" }
+}
+
+resource "aws_ssm_parameter" "clickhouse_password" {
+  name  = "${local.ssm_prefix}/CLICKHOUSE_PASSWORD"
+  type  = "SecureString"
+  value = random_password.clickhouse.result
+
+  tags = { Name = "${local.name}-clickhouse-password" }
+}
+
+# ── License key (enterprise only) ────────────────────────────────────────
+
+resource "aws_ssm_parameter" "license_key" {
+  count = local.is_enterprise ? 1 : 0
+
+  name  = "${local.ssm_prefix}/OBSERVAL_LICENSE_KEY"
+  type  = "SecureString"
+  value = var.observal_license_key
+
+  tags = { Name = "${local.name}-license-key" }
+}

--- a/infra/terraform/aws-standard/security.tf
+++ b/infra/terraform/aws-standard/security.tf
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# ── ALB ────────────────────────────────────────────────────────────────────
+resource "aws_security_group" "alb" {
+  name        = "${local.name}-alb"
+  description = "Public ingress to the load balancer."
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description = "HTTP from approved CIDRs"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.alb_ingress_cidrs
+  }
+
+  ingress {
+    description = "HTTPS from approved CIDRs"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.alb_ingress_cidrs
+  }
+
+  egress {
+    description = "All egress (load balancer to targets)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${local.name}-alb-sg" }
+}
+
+# ── ECS instances (api/web/worker) ────────────────────────────────────────
+resource "aws_security_group" "ecs_instances" {
+  name        = "${local.name}-ecs-instances"
+  description = "ECS EC2 instances running api/web/worker. Inbound from ALB only."
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description     = "API HTTP from ALB"
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    description     = "Web HTTP from ALB"
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    description = "All egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${local.name}-ecs-instances-sg" }
+}
+
+# ── Data host (Postgres + Redis + ClickHouse + Grafana + Prometheus) ──────
+resource "aws_security_group" "data_host" {
+  name        = "${local.name}-data-host"
+  description = "Data tier EC2: Postgres, Redis, ClickHouse, Grafana, Prometheus."
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description     = "Postgres from ECS instances"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_instances.id]
+  }
+
+  ingress {
+    description     = "Redis from ECS instances"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_instances.id]
+  }
+
+  ingress {
+    description     = "ClickHouse HTTP from ECS instances"
+    from_port       = 8123
+    to_port         = 8123
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_instances.id]
+  }
+
+  ingress {
+    description     = "ClickHouse native protocol from ECS instances"
+    from_port       = 9000
+    to_port         = 9000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_instances.id]
+  }
+
+  ingress {
+    description     = "Grafana UI from ALB"
+    from_port       = 3001
+    to_port         = 3001
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    description = "All egress (image pulls, OS updates, AWS APIs)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${local.name}-data-host-sg" }
+}

--- a/infra/terraform/aws-standard/terraform.tfvars.example
+++ b/infra/terraform/aws-standard/terraform.tfvars.example
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Copy to terraform.tfvars and fill in.
+# terraform.tfvars is gitignored — never commit secrets or per-customer values.
+
+region      = "us-east-1"
+environment = "prod"
+name_prefix = "observal"
+
+# ── Sizing preset ────────────────────────────────────────────────────────
+# "small" (~$120/mo): 1× t3.large ECS, t3.medium data host, 50 GB EBS
+# "medium" (~$155/mo): 1× t3.large ECS, t3.medium data host, 100 GB EBS
+# "custom": full manual control via the variables below
+sizing = "medium"
+
+# ── DNS / TLS (optional) ──────────────────────────────────────────────
+# Leave both empty to expose the install over plain HTTP on the ALB DNS name.
+# domain_name     = "observal.example.com"
+# route53_zone_id = "Z0123456789ABCDEFGHIJ"
+
+# ── Image tag (matches the Observal release you want to install) ──────
+image_tag = "latest"
+
+# ── ECS EC2 cluster ──────────────────────────────────────────────────
+# ecs_instance_type    = "t3.large"
+# api_cpu              = 512
+# api_memory           = 1024
+# api_desired_count    = 1
+# web_cpu              = 256
+# web_memory           = 512
+# web_desired_count    = 1
+# worker_cpu           = 512
+# worker_memory        = 1024
+# worker_desired_count = 1
+
+# ── Data tier EC2 (Postgres + Redis + ClickHouse + Grafana + Prometheus) ──
+# data_instance_type   = "t3.medium"
+# data_volume_size_gb  = 100
+
+# ── Access ────────────────────────────────────────────────────────────
+# Restrict ALB ingress for private installs (e.g. office VPN, corporate egress).
+# alb_ingress_cidrs = ["203.0.113.0/24"]
+# alb_scheme        = "internet-facing"
+
+# ── App config ────────────────────────────────────────────────────────
+log_retention_days = 30
+
+# ── License ──────────────────────────────────────────────────────────────────
+# Provide your enterprise license key to enable enterprise features.
+# Without a key, community edition is deployed (same image, features gated at runtime).
+# observal_license_key = "eyJ...<your-key>..."
+
+# ── Bring-your-own VPC (BYO-VPC) ─────────────────────────────────────────────
+# Deploy into an existing VPC instead of creating one.
+#
+# vpc_id             = "vpc-08ffcfb6fed514106"
+# public_subnet_ids  = ["subnet-05b9a5aa32f4e6460", "subnet-09c4c954239fc48c0"]
+# private_subnet_ids = ["subnet-05b9a5aa32f4e6460", "subnet-09c4c954239fc48c0"]
+
+# ── TLS ──────────────────────────────────────────────────────────────────────
+# Set enable_tls = false for private Route53 zones where ACM DNS validation
+# cannot complete.
+#
+# enable_tls = false

--- a/infra/terraform/aws-standard/variables.tf
+++ b/infra/terraform/aws-standard/variables.tf
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+variable "region" {
+  description = "AWS region to deploy into."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment name (e.g. prod, staging)."
+  type        = string
+  default     = "prod"
+}
+
+variable "name_prefix" {
+  description = "Prefix applied to all resource names."
+  type        = string
+  default     = "observal"
+}
+
+# ── Sizing ────────────────────────────────────────────────────────────────────
+
+variable "sizing" {
+  description = "Resource sizing preset: small (~$120/mo) or medium (~$155/mo). Set 'custom' for manual control."
+  type        = string
+  default     = "medium"
+
+  validation {
+    condition     = contains(["small", "medium", "custom"], var.sizing)
+    error_message = "sizing must be 'small', 'medium', or 'custom'."
+  }
+}
+
+# ── Container images ──────────────────────────────────────────────────────────
+
+variable "image_repo_api" {
+  description = "Container image repository for api + worker + init."
+  type        = string
+  default     = "ghcr.io/blazeup-ai/observal-api"
+}
+
+variable "image_repo_web" {
+  description = "Container image repository for the web frontend."
+  type        = string
+  default     = "ghcr.io/blazeup-ai/observal-web"
+}
+
+variable "image_tag" {
+  description = "Tag of the Observal images to deploy."
+  type        = string
+  default     = "latest"
+}
+
+# ── ECS EC2 cluster ───────────────────────────────────────────────────────────
+
+variable "ecs_instance_type" {
+  description = "EC2 instance type for the ECS cluster (runs API, web, worker containers)."
+  type        = string
+  default     = "t3.large"
+}
+
+variable "api_cpu" {
+  description = "CPU units for the API task (only when sizing = custom)."
+  type        = number
+  default     = 512
+}
+
+variable "api_memory" {
+  description = "Memory (MB) for the API task (only when sizing = custom)."
+  type        = number
+  default     = 1024
+}
+
+variable "api_desired_count" {
+  description = "Number of API tasks (only when sizing = custom)."
+  type        = number
+  default     = 1
+}
+
+variable "web_cpu" {
+  description = "CPU units for the web task (only when sizing = custom)."
+  type        = number
+  default     = 256
+}
+
+variable "web_memory" {
+  description = "Memory (MB) for the web task (only when sizing = custom)."
+  type        = number
+  default     = 512
+}
+
+variable "web_desired_count" {
+  description = "Number of web tasks (only when sizing = custom)."
+  type        = number
+  default     = 1
+}
+
+variable "worker_cpu" {
+  description = "CPU units for the worker task (only when sizing = custom)."
+  type        = number
+  default     = 512
+}
+
+variable "worker_memory" {
+  description = "Memory (MB) for the worker task (only when sizing = custom)."
+  type        = number
+  default     = 1024
+}
+
+variable "worker_desired_count" {
+  description = "Number of worker tasks (only when sizing = custom)."
+  type        = number
+  default     = 1
+}
+
+# ── Data tier EC2 ─────────────────────────────────────────────────────────────
+
+variable "data_instance_type" {
+  description = "EC2 instance type for the data host (Postgres + Redis + ClickHouse)."
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "data_volume_size_gb" {
+  description = "EBS volume size for the data host."
+  type        = number
+  default     = 100
+}
+
+# ── Network ───────────────────────────────────────────────────────────────────
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+variable "az_count" {
+  description = "Number of availability zones."
+  type        = number
+  default     = 2
+}
+
+variable "internal_dns_zone" {
+  description = "Private Route 53 zone for internal DNS."
+  type        = string
+  default     = "observal.internal"
+}
+
+# ── BYO-VPC ───────────────────────────────────────────────────────────────────
+
+variable "vpc_id" {
+  description = "Existing VPC ID. Leave null to create a new VPC."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.vpc_id == null || can(regex("^vpc-", var.vpc_id))
+    error_message = "VPC ID must start with 'vpc-' if provided."
+  }
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs (required when vpc_id is set)."
+  type        = list(string)
+  default     = null
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs (required when vpc_id is set)."
+  type        = list(string)
+  default     = null
+}
+
+# ── DNS / TLS ─────────────────────────────────────────────────────────────────
+
+variable "domain_name" {
+  description = "Public hostname for the install. Leave empty for ALB DNS over HTTP."
+  type        = string
+  default     = ""
+}
+
+variable "route53_zone_id" {
+  description = "Route 53 hosted zone ID. Required if domain_name is set."
+  type        = string
+  default     = ""
+}
+
+variable "enable_tls" {
+  description = "Enable TLS via ACM."
+  type        = bool
+  default     = true
+}
+
+# ── Access controls ───────────────────────────────────────────────────────────
+
+variable "alb_ingress_cidrs" {
+  description = "CIDR blocks allowed to reach the ALB."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "alb_scheme" {
+  description = "ALB scheme: 'internet-facing' or 'internal'."
+  type        = string
+  default     = "internet-facing"
+
+  validation {
+    condition     = contains(["internet-facing", "internal"], var.alb_scheme)
+    error_message = "alb_scheme must be 'internet-facing' or 'internal'."
+  }
+}
+
+# ── Application ───────────────────────────────────────────────────────────────
+
+variable "observal_license_key" {
+  description = "Observal Enterprise license key. Leave empty for community."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention."
+  type        = number
+  default     = 30
+}
+
+variable "run_init_on_apply" {
+  description = "Run migrations task when image_tag changes."
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/aws-standard/versions.tf
+++ b/infra/terraform/aws-standard/versions.tf
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws    = { source = "hashicorp/aws", version = "~> 5.70" }
+    random = { source = "hashicorp/random", version = "~> 3.6" }
+    null   = { source = "hashicorp/null", version = "~> 3.2" }
+  }
+
+  # Uncomment and configure for remote state.
+  # backend "s3" {
+  #   bucket         = "your-tf-state-bucket"
+  #   key            = "observal/standard/terraform.tfstate"
+  #   region         = "us-east-1"
+  #   dynamodb_table = "your-tf-lock-table"
+  #   encrypt        = true
+  # }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = "Observal"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+}

--- a/infra/terraform/aws-standard/vpc.tf
+++ b/infra/terraform/aws-standard/vpc.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # All VPC networking resources are conditional on local.should_create_vpc.
@@ -19,11 +19,11 @@ resource "aws_internet_gateway" "main" {
   tags   = { Name = "${local.name}-igw" }
 }
 
-# tfsec:ignore:aws-ec2-no-public-ip-subnet Public subnets host the ALB and NAT gateway only; application workloads live in private subnets.
+# Public subnets host the ALB and NAT gateway only.
 resource "aws_subnet" "public" {
   count                   = local.should_create_vpc ? var.az_count : 0
   vpc_id                  = aws_vpc.main[0].id
-  cidr_block              = var.public_subnet_cidrs[count.index]
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
   availability_zone       = local.azs[count.index]
   map_public_ip_on_launch = true
 
@@ -33,10 +33,11 @@ resource "aws_subnet" "public" {
   }
 }
 
+# Private subnets host ECS tasks and the data host.
 resource "aws_subnet" "private" {
   count             = local.should_create_vpc ? var.az_count : 0
   vpc_id            = aws_vpc.main[0].id
-  cidr_block        = var.private_subnet_cidrs[count.index]
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, 10 + count.index)
   availability_zone = local.azs[count.index]
 
   tags = {
@@ -92,56 +93,7 @@ resource "aws_route_table_association" "private" {
   route_table_id = aws_route_table.private[0].id
 }
 
-# ── Flow Logs (only for managed VPC) ──────────────────────────────────────
-
-data "aws_iam_policy_document" "flow_logs_assume" {
-  count = local.should_create_vpc ? 1 : 0
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["vpc-flow-logs.amazonaws.com"]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "flow_logs_publish" {
-  count = local.should_create_vpc ? 1 : 0
-  # tfsec:ignore:aws-iam-no-policy-wildcards Resource wildcard is bounded to log streams within the flow-log group only.
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:DescribeLogGroups",
-      "logs:DescribeLogStreams",
-    ]
-    resources = ["${aws_cloudwatch_log_group.flow_logs.arn}:*"]
-  }
-}
-
-resource "aws_iam_role" "flow_logs" {
-  count              = local.should_create_vpc ? 1 : 0
-  name               = "${local.name}-flow-logs"
-  assume_role_policy = data.aws_iam_policy_document.flow_logs_assume[0].json
-}
-
-resource "aws_iam_role_policy" "flow_logs" {
-  count  = local.should_create_vpc ? 1 : 0
-  role   = aws_iam_role.flow_logs[0].id
-  policy = data.aws_iam_policy_document.flow_logs_publish[0].json
-}
-
-resource "aws_flow_log" "main" {
-  count           = local.should_create_vpc ? 1 : 0
-  vpc_id          = local.vpc_id
-  log_destination = aws_cloudwatch_log_group.flow_logs.arn
-  iam_role_arn    = aws_iam_role.flow_logs[0].arn
-  traffic_type    = "ALL"
-
-  tags = { Name = "${local.name}-flow-logs" }
-}
-
-# ── Private DNS zone for VPC-internal resolution (ECS -> ClickHouse/Grafana) ──
+# ── Private DNS zone for VPC-internal resolution ─────────────────────────
 
 resource "aws_route53_zone" "internal" {
   name = var.internal_dns_zone

--- a/infra/terraform/aws/alb.tf
+++ b/infra/terraform/aws/alb.tf
@@ -125,7 +125,7 @@ resource "aws_lb_listener_rule" "http_api" {
 
   condition {
     path_pattern {
-      values = ["/api/*", "/auth/*", "/readyz", "/healthz", "/metrics"]
+      values = ["/api/*", "/auth/*", "/readyz", "/healthz", "/health", "/metrics"]
     }
   }
 }
@@ -250,7 +250,7 @@ resource "aws_lb_listener_rule" "https_api" {
 
   condition {
     path_pattern {
-      values = ["/api/*", "/auth/*", "/readyz", "/healthz", "/metrics"]
+      values = ["/api/*", "/auth/*", "/readyz", "/healthz", "/health", "/metrics"]
     }
   }
 }

--- a/infra/terraform/aws/clickhouse.tf
+++ b/infra/terraform/aws/clickhouse.tf
@@ -35,7 +35,7 @@ data "aws_ami" "al2023" {
 resource "aws_ebs_volume" "data" {
   count             = local.clickhouse_self_hosted ? 1 : 0
   availability_zone = local.azs[0]
-  size              = var.data_volume_size_gb
+  size              = local.effective_data_volume_size_gb
   type              = "gp3"
   encrypted         = true
 
@@ -69,7 +69,7 @@ locals {
 resource "aws_instance" "data_host" {
   count                = local.clickhouse_self_hosted ? 1 : 0
   ami                  = data.aws_ami.al2023[0].id
-  instance_type        = var.data_instance_type
+  instance_type        = local.effective_data_instance_type
   iam_instance_profile = aws_iam_instance_profile.data_host[0].name
 
   network_interface {

--- a/infra/terraform/aws/deploy.sh
+++ b/infra/terraform/aws/deploy.sh
@@ -332,6 +332,29 @@ if [ "$TFVARS_EXISTS" = "false" ] && [ "$MODE" != "check" ]; then
     V_TAG="${V_TAG:-latest}"
 
     echo ""
+    echo "  Sizing (determines CPU, memory, instance types, replica counts):"
+    echo "    small  — evaluation / dev  (~\$150/mo): 1× api, 1× web, t3.medium data"
+    echo "    medium — production team   (~\$255/mo): 2× api, 2× web, t3.large data"
+    echo "    large  — enterprise scale  (~\$600/mo): 3× api, 3× web, r6i.xlarge data"
+    echo "    custom — set individual sizes in terraform.tfvars manually"
+    read -rp "  Sizing [medium]: " V_SIZING
+    V_SIZING="${V_SIZING:-medium}"
+
+    echo ""
+    echo "  ClickHouse (analytics database):"
+    echo "    self_hosted — bundled on EC2, simpler, single point of failure"
+    echo "    cloud       — ClickHouse Cloud, HA, you supply the URL"
+    read -rp "  ClickHouse mode [self_hosted]: " V_CH_MODE
+    V_CH_MODE="${V_CH_MODE:-self_hosted}"
+
+    V_CH_URL="" V_CH_PASS=""
+    if [ "$V_CH_MODE" = "cloud" ]; then
+      read -rp "  ClickHouse Cloud URL: " V_CH_URL
+      read -rsp "  ClickHouse Cloud password: " V_CH_PASS
+      echo ""
+    fi
+
+    echo ""
     echo "  License key enables: insights, SAML, SCIM, exec dashboard, audit."
     read -rp "  License key (empty = community): " V_LICENSE
 
@@ -374,9 +397,18 @@ name_prefix = "observal"
 image_tag   = "$V_TAG"
 EOF
 
+    [ "$V_SIZING" != "custom" ] && echo "sizing = \"$V_SIZING\"" >> terraform.tfvars
     [ -n "$V_DOMAIN" ] && echo "domain_name     = \"$V_DOMAIN\"" >> terraform.tfvars
     [ -n "$V_ZONE" ] && echo "route53_zone_id = \"$V_ZONE\"" >> terraform.tfvars
     [ -n "$V_LICENSE" ] && echo "observal_license_key = \"$V_LICENSE\"" >> terraform.tfvars
+
+    if [ "$V_CH_MODE" = "cloud" ]; then
+      cat >> terraform.tfvars <<CHEOF
+clickhouse_mode           = "cloud"
+clickhouse_cloud_url      = "$V_CH_URL"
+clickhouse_cloud_password = "$V_CH_PASS"
+CHEOF
+    fi
 
     if [ -n "$V_VPC" ]; then
       PRIV_LIST=$(echo "$V_PRIV" | sed 's/ //g' | sed 's/,/", "/g')
@@ -426,22 +458,74 @@ fi
 echo -e "  ${PASS} ${BOLD}All checks passed.${NC}"
 echo ""
 
-section "Next Steps"
-echo ""
-echo "  Run these commands in order:"
-echo ""
-echo -e "  ${BOLD}1.${NC} $TF init"
-echo -e "  ${BOLD}2.${NC} $TF plan -out=tfplan"
-echo -e "  ${BOLD}3.${NC} Review the plan output carefully"
-echo -e "  ${BOLD}4.${NC} $TF apply tfplan"
-echo ""
-echo "  Estimated time: 8-15 minutes for first deploy."
-echo ""
-echo "  After deployment:"
-echo -e "  ${BOLD}5.${NC} $TF output          # Get ALB URL and connection info"
-echo -e "  ${BOLD}6.${NC} observal config set server_url <URL>"
-echo -e "  ${BOLD}7.${NC} observal auth login  # Use demo credentials"
-echo ""
-echo "  To tear down:"
-echo -e "     $TF destroy"
-echo ""
+# ── Optional: Auto-apply ────────────────────────────────────────────────────
+if [ -n "$TF" ] && [ -f "terraform.tfvars" ]; then
+  echo ""
+  read -rp "  Run terraform init + plan + apply now? [y/N]: " V_APPLY
+  V_APPLY="${V_APPLY:-N}"
+  if [[ "$V_APPLY" =~ ^[Yy] ]]; then
+    section "Deploying"
+    echo ""
+    info "Running: $TF init"
+    if ! $TF init; then
+      fail "terraform init failed"
+      exit 1
+    fi
+    echo ""
+    info "Running: $TF plan -out=tfplan"
+    if ! $TF plan -out=tfplan; then
+      fail "terraform plan failed"
+      exit 1
+    fi
+    echo ""
+    read -rp "  Plan looks good. Apply? [y/N]: " V_CONFIRM
+    V_CONFIRM="${V_CONFIRM:-N}"
+    if [[ "$V_CONFIRM" =~ ^[Yy] ]]; then
+      $TF apply tfplan
+      echo ""
+      pass "Deployment complete!"
+      echo ""
+      echo -e "  App URL: ${BOLD}$($TF output -raw app_url 2>/dev/null || echo '(check: terraform output app_url)')${NC}"
+      echo ""
+      echo "  After deployment:"
+      echo -e "  ${BOLD}1.${NC} $TF output          # Get ALB URL and connection info"
+      echo -e "  ${BOLD}2.${NC} observal config set server_url <URL>"
+      echo -e "  ${BOLD}3.${NC} observal auth login  # Use demo credentials"
+      echo ""
+    else
+      info "Skipped. Run manually: $TF apply tfplan"
+    fi
+  else
+    section "Next Steps"
+    echo ""
+    echo "  Run these commands in order:"
+    echo ""
+    echo -e "  ${BOLD}1.${NC} $TF init"
+    echo -e "  ${BOLD}2.${NC} $TF plan -out=tfplan"
+    echo -e "  ${BOLD}3.${NC} Review the plan output carefully"
+    echo -e "  ${BOLD}4.${NC} $TF apply tfplan"
+    echo ""
+    echo "  Estimated time: 8-15 minutes for first deploy."
+    echo ""
+    echo "  After deployment:"
+    echo -e "  ${BOLD}5.${NC} $TF output          # Get ALB URL and connection info"
+    echo -e "  ${BOLD}6.${NC} observal config set server_url <URL>"
+    echo -e "  ${BOLD}7.${NC} observal auth login  # Use demo credentials"
+    echo ""
+    echo "  To tear down:"
+    echo -e "     $TF destroy"
+    echo ""
+  fi
+else
+  section "Next Steps"
+  echo ""
+  echo "  Run these commands in order:"
+  echo ""
+  echo -e "  ${BOLD}1.${NC} $TF init"
+  echo -e "  ${BOLD}2.${NC} $TF plan -out=tfplan"
+  echo -e "  ${BOLD}3.${NC} Review the plan output carefully"
+  echo -e "  ${BOLD}4.${NC} $TF apply tfplan"
+  echo ""
+  echo "  Estimated time: 8-15 minutes for first deploy."
+  echo ""
+fi

--- a/infra/terraform/aws/ecs.tf
+++ b/infra/terraform/aws/ecs.tf
@@ -106,8 +106,8 @@ resource "aws_ecs_task_definition" "api" {
   family                   = "${local.name}-api"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = tostring(var.api_cpu)
-  memory                   = tostring(var.api_memory)
+  cpu                      = tostring(local.effective_api_cpu)
+  memory                   = tostring(local.effective_api_memory)
 
   execution_role_arn = aws_iam_role.ecs_execution.arn
   task_role_arn      = aws_iam_role.ecs_task.arn
@@ -158,8 +158,8 @@ resource "aws_ecs_task_definition" "worker" {
   family                   = "${local.name}-worker"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = tostring(var.worker_cpu)
-  memory                   = tostring(var.worker_memory)
+  cpu                      = tostring(local.effective_worker_cpu)
+  memory                   = tostring(local.effective_worker_memory)
 
   execution_role_arn = aws_iam_role.ecs_execution.arn
   task_role_arn      = aws_iam_role.ecs_task.arn
@@ -198,8 +198,8 @@ resource "aws_ecs_task_definition" "web" {
   family                   = "${local.name}-web"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = tostring(var.web_cpu)
-  memory                   = tostring(var.web_memory)
+  cpu                      = tostring(local.effective_web_cpu)
+  memory                   = tostring(local.effective_web_memory)
 
   execution_role_arn = aws_iam_role.ecs_execution.arn
   task_role_arn      = aws_iam_role.ecs_task.arn
@@ -249,7 +249,7 @@ resource "aws_ecs_service" "api" {
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.api.arn
   launch_type     = "FARGATE"
-  desired_count   = var.api_desired_count
+  desired_count   = local.effective_api_desired_count
 
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
@@ -257,7 +257,7 @@ resource "aws_ecs_service" "api" {
 
   network_configuration {
     subnets          = local.private_subnet_ids
-    security_groups  = [aws_security_group.ecs_tasks.id]
+    security_groups  = [local.ecs_sg_id]
     assign_public_ip = false
   }
 
@@ -284,7 +284,7 @@ resource "aws_ecs_service" "web" {
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.web.arn
   launch_type     = "FARGATE"
-  desired_count   = var.web_desired_count
+  desired_count   = local.effective_web_desired_count
 
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
@@ -292,7 +292,7 @@ resource "aws_ecs_service" "web" {
 
   network_configuration {
     subnets          = local.private_subnet_ids
-    security_groups  = [aws_security_group.ecs_tasks.id]
+    security_groups  = [local.ecs_sg_id]
     assign_public_ip = false
   }
 
@@ -316,14 +316,14 @@ resource "aws_ecs_service" "worker" {
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.worker.arn
   launch_type     = "FARGATE"
-  desired_count   = var.worker_desired_count
+  desired_count   = local.effective_worker_desired_count
 
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
   network_configuration {
     subnets          = local.private_subnet_ids
-    security_groups  = [aws_security_group.ecs_tasks.id]
+    security_groups  = [local.ecs_sg_id]
     assign_public_ip = false
   }
 
@@ -368,7 +368,7 @@ resource "null_resource" "run_init" {
         --cluster ${aws_ecs_cluster.main.name} \
         --launch-type FARGATE \
         --task-definition ${aws_ecs_task_definition.init.arn} \
-        --network-configuration "awsvpcConfiguration={subnets=[${join(",", local.private_subnet_ids)}],securityGroups=[${aws_security_group.ecs_tasks.id}],assignPublicIp=DISABLED}" \
+        --network-configuration "awsvpcConfiguration={subnets=[${join(",", local.private_subnet_ids)}],securityGroups=[${local.ecs_sg_id}],assignPublicIp=DISABLED}" \
         --query 'tasks[0].taskArn' --output text)
       echo "Init task started: $task_arn"
       aws ecs wait tasks-stopped --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --tasks "$task_arn"
@@ -397,8 +397,8 @@ resource "aws_appautoscaling_target" "api" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.api.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = var.api_autoscale_min
-  max_capacity       = var.api_autoscale_max
+  min_capacity       = local.effective_api_autoscale_min
+  max_capacity       = local.effective_api_autoscale_max
 }
 
 resource "aws_appautoscaling_policy" "api_cpu" {
@@ -422,8 +422,8 @@ resource "aws_appautoscaling_target" "web" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.web.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = var.web_autoscale_min
-  max_capacity       = var.web_autoscale_max
+  min_capacity       = local.effective_web_autoscale_min
+  max_capacity       = local.effective_web_autoscale_max
 }
 
 resource "aws_appautoscaling_policy" "web_cpu" {
@@ -447,8 +447,8 @@ resource "aws_appautoscaling_target" "worker" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.worker.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = var.worker_autoscale_min
-  max_capacity       = var.worker_autoscale_max
+  min_capacity       = local.effective_worker_autoscale_min
+  max_capacity       = local.effective_worker_autoscale_max
 }
 
 resource "aws_appautoscaling_policy" "worker_cpu" {

--- a/infra/terraform/aws/examples/byovpc/README.md
+++ b/infra/terraform/aws/examples/byovpc/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 BlazeUp AI -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 # Bring Your Own VPC Example
 
 Deploy Observal into an existing VPC instead of having Terraform create one.

--- a/infra/terraform/aws/examples/byovpc/README.md
+++ b/infra/terraform/aws/examples/byovpc/README.md
@@ -1,0 +1,30 @@
+# Bring Your Own VPC Example
+
+Deploy Observal into an existing VPC instead of having Terraform create one.
+
+## Prerequisites
+
+Your existing VPC must have:
+
+- **DNS support enabled** (`enableDnsSupport = true`, `enableDnsHostnames = true`)
+- **At least 2 private subnets** in different AZs with outbound internet access (via NAT Gateway or Transit Gateway) for container image pulls and AWS API calls
+- **At least 2 public subnets** in different AZs (only required if `alb_scheme = "internet-facing"`)
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your VPC and subnet IDs
+
+terraform init
+terraform apply
+```
+
+## Optional: Bring Your Own Security Groups
+
+For environments with strict firewall policies, you can supply pre-created security groups:
+
+- **ALB SG** must allow inbound TCP 80 and 443 from your desired client CIDRs
+- **ECS SG** must allow inbound TCP 8000 and 3000 from the ALB security group, and outbound to all (for image pulls and AWS APIs)
+
+If not provided, the module creates these security groups automatically.

--- a/infra/terraform/aws/examples/byovpc/main.tf
+++ b/infra/terraform/aws/examples/byovpc/main.tf
@@ -1,0 +1,29 @@
+# Deploy Observal into an existing VPC.
+#
+# Prerequisites:
+#   - VPC with DNS hostnames + DNS support enabled
+#   - At least 2 private subnets (with NAT/TGW route for outbound)
+#   - At least 2 public subnets (if ALB is internet-facing)
+
+module "observal" {
+  source = "../.."
+
+  region      = var.region
+  environment = var.environment
+  name_prefix = var.name_prefix
+
+  # BYO-VPC
+  vpc_id             = var.vpc_id
+  private_subnet_ids = var.private_subnet_ids
+  public_subnet_ids  = var.public_subnet_ids
+
+  # Optional: BYO security groups
+  alb_security_group_id = var.alb_security_group_id
+  ecs_security_group_id = var.ecs_security_group_id
+
+  # ALB scheme — use "internal" if your VPC has no public subnets
+  alb_scheme = var.alb_scheme
+
+  # Restrict ALB ingress to your corporate CIDR
+  alb_ingress_cidrs = var.alb_ingress_cidrs
+}

--- a/infra/terraform/aws/examples/byovpc/main.tf
+++ b/infra/terraform/aws/examples/byovpc/main.tf
@@ -1,9 +1,20 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
 # Deploy Observal into an existing VPC.
 #
 # Prerequisites:
 #   - VPC with DNS hostnames + DNS support enabled
 #   - At least 2 private subnets (with NAT/TGW route for outbound)
 #   - At least 2 public subnets (if ALB is internet-facing)
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.70" }
+  }
+}
 
 module "observal" {
   source = "../.."

--- a/infra/terraform/aws/examples/byovpc/outputs.tf
+++ b/infra/terraform/aws/examples/byovpc/outputs.tf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
 output "app_url" {
   description = "Observal application URL."
   value       = module.observal.app_url

--- a/infra/terraform/aws/examples/byovpc/outputs.tf
+++ b/infra/terraform/aws/examples/byovpc/outputs.tf
@@ -1,0 +1,14 @@
+output "app_url" {
+  description = "Observal application URL."
+  value       = module.observal.app_url
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS name."
+  value       = module.observal.alb_dns_name
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = module.observal.ecs_cluster_name
+}

--- a/infra/terraform/aws/examples/byovpc/terraform.tfvars.example
+++ b/infra/terraform/aws/examples/byovpc/terraform.tfvars.example
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
 region      = "us-east-1"
 environment = "prod"
 name_prefix = "observal"

--- a/infra/terraform/aws/examples/byovpc/terraform.tfvars.example
+++ b/infra/terraform/aws/examples/byovpc/terraform.tfvars.example
@@ -1,0 +1,17 @@
+region      = "us-east-1"
+environment = "prod"
+name_prefix = "observal"
+
+vpc_id             = "vpc-0abc1234def56789a"
+private_subnet_ids = ["subnet-aaa11111", "subnet-bbb22222"]
+public_subnet_ids  = ["subnet-xxx11111", "subnet-yyy22222"]
+
+# Optional: use pre-created security groups
+# alb_security_group_id = "sg-0abc1234def56789a"
+# ecs_security_group_id = "sg-0abc1234def56789b"
+
+# Use "internal" if deploying behind a Transit Gateway or private network
+alb_scheme = "internet-facing"
+
+# Restrict to your corporate network
+# alb_ingress_cidrs = ["10.0.0.0/8"]

--- a/infra/terraform/aws/examples/byovpc/variables.tf
+++ b/infra/terraform/aws/examples/byovpc/variables.tf
@@ -1,0 +1,53 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}
+
+variable "name_prefix" {
+  type    = string
+  default = "observal"
+}
+
+variable "vpc_id" {
+  description = "Existing VPC ID (e.g. vpc-0abc1234def56789a)"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "At least 2 private subnet IDs in different AZs"
+  type        = list(string)
+}
+
+variable "public_subnet_ids" {
+  description = "At least 2 public subnet IDs in different AZs"
+  type        = list(string)
+}
+
+variable "alb_security_group_id" {
+  description = "Optional: existing ALB security group ID"
+  type        = string
+  default     = null
+}
+
+variable "ecs_security_group_id" {
+  description = "Optional: existing ECS tasks security group ID"
+  type        = string
+  default     = null
+}
+
+variable "alb_scheme" {
+  description = "ALB scheme: 'internet-facing' or 'internal'"
+  type        = string
+  default     = "internet-facing"
+}
+
+variable "alb_ingress_cidrs" {
+  description = "CIDRs allowed to reach the ALB"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/infra/terraform/aws/examples/byovpc/variables.tf
+++ b/infra/terraform/aws/examples/byovpc/variables.tf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+
 variable "region" {
   type    = string
   default = "us-east-1"

--- a/infra/terraform/aws/locals.tf
+++ b/infra/terraform/aws/locals.tf
@@ -14,12 +14,107 @@ locals {
   azs  = slice(data.aws_availability_zones.available.names, 0, var.az_count)
 
   # BYO-VPC: when vpc_id is provided, use existing resources; otherwise create new ones.
-  create_vpc = var.vpc_id == ""
-  vpc_id     = local.create_vpc ? aws_vpc.main[0].id : var.vpc_id
-  vpc_cidr   = local.create_vpc ? aws_vpc.main[0].cidr_block : data.aws_vpc.existing[0].cidr_block
+  should_create_vpc = var.vpc_id == null
 
-  private_subnet_ids = local.create_vpc ? aws_subnet.private[*].id : var.private_subnet_ids
-  public_subnet_ids  = local.create_vpc ? aws_subnet.public[*].id : var.public_subnet_ids
+  vpc_id             = local.should_create_vpc ? aws_vpc.main[0].id : var.vpc_id
+  vpc_cidr           = data.aws_vpc.vpc.cidr_block
+  private_subnet_ids = local.should_create_vpc ? aws_subnet.private[*].id : var.private_subnet_ids
+  public_subnet_ids  = local.should_create_vpc ? aws_subnet.public[*].id : var.public_subnet_ids
+
+  # BYO Security Groups
+  create_alb_sg = var.alb_security_group_id == null
+  create_ecs_sg = var.ecs_security_group_id == null
+  alb_sg_id     = local.create_alb_sg ? aws_security_group.alb[0].id : var.alb_security_group_id
+  ecs_sg_id     = local.create_ecs_sg ? aws_security_group.ecs_tasks[0].id : var.ecs_security_group_id
+
+  # ── Sizing presets ──────────────────────────────────────────────────────
+  presets = {
+    small = {
+      api_cpu              = 256
+      api_memory           = 512
+      api_desired_count    = 1
+      api_autoscale_min    = 1
+      api_autoscale_max    = 3
+      web_cpu              = 256
+      web_memory           = 512
+      web_desired_count    = 1
+      web_autoscale_min    = 1
+      web_autoscale_max    = 2
+      worker_cpu           = 256
+      worker_memory        = 512
+      worker_desired_count = 1
+      worker_autoscale_min = 1
+      worker_autoscale_max = 2
+      db_instance_class    = "db.t4g.micro"
+      redis_node_type      = "cache.t4g.micro"
+      data_instance_type   = "t3.medium"
+      data_volume_size_gb  = 50
+    }
+    medium = {
+      api_cpu              = 512
+      api_memory           = 1024
+      api_desired_count    = 2
+      api_autoscale_min    = 2
+      api_autoscale_max    = 10
+      web_cpu              = 256
+      web_memory           = 512
+      web_desired_count    = 2
+      web_autoscale_min    = 2
+      web_autoscale_max    = 6
+      worker_cpu           = 512
+      worker_memory        = 1024
+      worker_desired_count = 1
+      worker_autoscale_min = 1
+      worker_autoscale_max = 5
+      db_instance_class    = "db.t4g.small"
+      redis_node_type      = "cache.t4g.micro"
+      data_instance_type   = "t3.large"
+      data_volume_size_gb  = 100
+    }
+    large = {
+      api_cpu              = 1024
+      api_memory           = 2048
+      api_desired_count    = 3
+      api_autoscale_min    = 3
+      api_autoscale_max    = 20
+      web_cpu              = 512
+      web_memory           = 1024
+      web_desired_count    = 3
+      web_autoscale_min    = 3
+      web_autoscale_max    = 10
+      worker_cpu           = 1024
+      worker_memory        = 2048
+      worker_desired_count = 2
+      worker_autoscale_min = 2
+      worker_autoscale_max = 10
+      db_instance_class    = "db.r6g.large"
+      redis_node_type      = "cache.r6g.large"
+      data_instance_type   = "r6i.xlarge"
+      data_volume_size_gb  = 500
+    }
+  }
+
+  use_preset = var.sizing != "custom"
+
+  effective_api_cpu              = local.use_preset ? local.presets[var.sizing].api_cpu : var.api_cpu
+  effective_api_memory           = local.use_preset ? local.presets[var.sizing].api_memory : var.api_memory
+  effective_api_desired_count    = local.use_preset ? local.presets[var.sizing].api_desired_count : var.api_desired_count
+  effective_api_autoscale_min    = local.use_preset ? local.presets[var.sizing].api_autoscale_min : var.api_autoscale_min
+  effective_api_autoscale_max    = local.use_preset ? local.presets[var.sizing].api_autoscale_max : var.api_autoscale_max
+  effective_web_cpu              = local.use_preset ? local.presets[var.sizing].web_cpu : var.web_cpu
+  effective_web_memory           = local.use_preset ? local.presets[var.sizing].web_memory : var.web_memory
+  effective_web_desired_count    = local.use_preset ? local.presets[var.sizing].web_desired_count : var.web_desired_count
+  effective_web_autoscale_min    = local.use_preset ? local.presets[var.sizing].web_autoscale_min : var.web_autoscale_min
+  effective_web_autoscale_max    = local.use_preset ? local.presets[var.sizing].web_autoscale_max : var.web_autoscale_max
+  effective_worker_cpu           = local.use_preset ? local.presets[var.sizing].worker_cpu : var.worker_cpu
+  effective_worker_memory        = local.use_preset ? local.presets[var.sizing].worker_memory : var.worker_memory
+  effective_worker_desired_count = local.use_preset ? local.presets[var.sizing].worker_desired_count : var.worker_desired_count
+  effective_worker_autoscale_min = local.use_preset ? local.presets[var.sizing].worker_autoscale_min : var.worker_autoscale_min
+  effective_worker_autoscale_max = local.use_preset ? local.presets[var.sizing].worker_autoscale_max : var.worker_autoscale_max
+  effective_db_instance_class    = local.use_preset ? local.presets[var.sizing].db_instance_class : var.db_instance_class
+  effective_redis_node_type      = local.use_preset ? local.presets[var.sizing].redis_node_type : var.redis_node_type
+  effective_data_instance_type   = local.use_preset ? local.presets[var.sizing].data_instance_type : var.data_instance_type
+  effective_data_volume_size_gb  = local.use_preset ? local.presets[var.sizing].data_volume_size_gb : var.data_volume_size_gb
 
   enable_tls = var.enable_tls && var.domain_name != "" && var.route53_zone_id != ""
   app_url    = var.domain_name != "" ? "${local.enable_tls ? "https" : "http"}://${var.domain_name}" : "http://${aws_lb.app.dns_name}"
@@ -34,8 +129,23 @@ locals {
   is_enterprise = var.observal_license_key != ""
 }
 
-# Lookup existing VPC when using BYO-VPC
-data "aws_vpc" "existing" {
-  count = local.create_vpc ? 0 : 1
-  id    = var.vpc_id
+# Always fetch VPC metadata (works in both create and BYO modes).
+data "aws_vpc" "vpc" {
+  id = local.vpc_id
+}
+
+# Cross-variable validation: subnets required when using BYO-VPC.
+resource "terraform_data" "byovpc_validation" {
+  count = local.should_create_vpc ? 0 : 1
+
+  lifecycle {
+    precondition {
+      condition     = var.private_subnet_ids != null && length(var.private_subnet_ids) >= 2
+      error_message = "private_subnet_ids must be provided (at least 2) when vpc_id is set."
+    }
+    precondition {
+      condition     = var.public_subnet_ids != null && length(var.public_subnet_ids) >= 2
+      error_message = "public_subnet_ids must be provided (at least 2) when vpc_id is set."
+    }
+  }
 }

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -27,7 +27,7 @@ output "ecs_service_names" {
 
 output "init_run_task_command" {
   description = "Manual command to re-run the migrations/seed task."
-  value       = "aws ecs run-task --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --launch-type FARGATE --task-definition ${aws_ecs_task_definition.init.family} --network-configuration 'awsvpcConfiguration={subnets=[${join(",", local.private_subnet_ids)}],securityGroups=[${aws_security_group.ecs_tasks.id}],assignPublicIp=DISABLED}'"
+  value       = "aws ecs run-task --region ${var.region} --cluster ${aws_ecs_cluster.main.name} --launch-type FARGATE --task-definition ${aws_ecs_task_definition.init.family} --network-configuration 'awsvpcConfiguration={subnets=[${join(",", local.private_subnet_ids)}],securityGroups=[${local.ecs_sg_id}],assignPublicIp=DISABLED}'"
 }
 
 output "rds_endpoint" {

--- a/infra/terraform/aws/postgresql.tf
+++ b/infra/terraform/aws/postgresql.tf
@@ -17,7 +17,7 @@ resource "aws_db_instance" "postgres" {
   identifier     = "${local.name}-pg"
   engine         = "postgres"
   engine_version = "16"
-  instance_class = var.db_instance_class
+  instance_class = local.effective_db_instance_class
 
   allocated_storage     = var.db_allocated_storage_gb
   max_allocated_storage = var.db_max_allocated_storage_gb

--- a/infra/terraform/aws/redis.tf
+++ b/infra/terraform/aws/redis.tf
@@ -12,7 +12,7 @@ resource "aws_elasticache_replication_group" "redis" {
 
   engine         = "redis"
   engine_version = "7.1"
-  node_type      = var.redis_node_type
+  node_type      = local.effective_redis_node_type
   port           = 6379
 
   num_cache_clusters         = var.environment == "prod" ? 2 : 1

--- a/infra/terraform/aws/security.tf
+++ b/infra/terraform/aws/security.tf
@@ -3,6 +3,7 @@
 
 # ── ALB ────────────────────────────────────────────────────────────────────
 resource "aws_security_group" "alb" {
+  count       = local.create_alb_sg ? 1 : 0
   name        = "${local.name}-alb"
   description = "Public ingress to the load balancer."
   vpc_id      = local.vpc_id
@@ -39,6 +40,7 @@ resource "aws_security_group" "alb" {
 
 # ── ECS task ENIs (api/web/worker) ─────────────────────────────────────────
 resource "aws_security_group" "ecs_tasks" {
+  count       = local.create_ecs_sg ? 1 : 0
   name        = "${local.name}-ecs-tasks"
   description = "Fargate task ENIs for api/web/worker. Inbound only from ALB."
   vpc_id      = local.vpc_id
@@ -48,7 +50,7 @@ resource "aws_security_group" "ecs_tasks" {
     from_port       = 8000
     to_port         = 8000
     protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id]
+    security_groups = [local.alb_sg_id]
   }
 
   ingress {
@@ -56,7 +58,7 @@ resource "aws_security_group" "ecs_tasks" {
     from_port       = 3000
     to_port         = 3000
     protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id]
+    security_groups = [local.alb_sg_id]
   }
 
   # tfsec:ignore:aws-ec2-no-public-egress-sgr Required: image pulls (ghcr.io), AWS API endpoints (SSM, CloudWatch, ECR), Postgres/Redis/ClickHouse in-VPC.
@@ -83,7 +85,7 @@ resource "aws_security_group" "data_host" {
     from_port       = 3001
     to_port         = 3001
     protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id]
+    security_groups = [local.alb_sg_id]
   }
 
   ingress {
@@ -91,7 +93,7 @@ resource "aws_security_group" "data_host" {
     from_port       = 8123
     to_port         = 8123
     protocol        = "tcp"
-    security_groups = [aws_security_group.ecs_tasks.id]
+    security_groups = [local.ecs_sg_id]
   }
 
   ingress {
@@ -99,7 +101,7 @@ resource "aws_security_group" "data_host" {
     from_port       = 9000
     to_port         = 9000
     protocol        = "tcp"
-    security_groups = [aws_security_group.ecs_tasks.id]
+    security_groups = [local.ecs_sg_id]
   }
 
   # tfsec:ignore:aws-ec2-no-public-egress-sgr Required: image pulls (ghcr.io), GitHub release tarball, SSM/EC2/CloudWatch endpoints, OS package mirrors.
@@ -125,7 +127,7 @@ resource "aws_security_group" "db" {
     from_port       = 5432
     to_port         = 5432
     protocol        = "tcp"
-    security_groups = [aws_security_group.ecs_tasks.id]
+    security_groups = [local.ecs_sg_id]
   }
 
   egress {
@@ -150,7 +152,7 @@ resource "aws_security_group" "redis" {
     from_port       = 6379
     to_port         = 6379
     protocol        = "tcp"
-    security_groups = [aws_security_group.ecs_tasks.id]
+    security_groups = [local.ecs_sg_id]
   }
 
   egress {

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -414,7 +414,7 @@ variable "private_subnet_ids" {
   default     = null
 
   validation {
-    condition     = var.private_subnet_ids == null || length(var.private_subnet_ids) >= 2
+    condition     = var.private_subnet_ids == null || length(coalesce(var.private_subnet_ids, [])) >= 2
     error_message = "At least 2 private_subnet_ids are required when using an existing VPC."
   }
 }
@@ -425,7 +425,7 @@ variable "public_subnet_ids" {
   default     = null
 
   validation {
-    condition     = var.public_subnet_ids == null || length(var.public_subnet_ids) >= 2
+    condition     = var.public_subnet_ids == null || length(coalesce(var.public_subnet_ids, [])) >= 2
     error_message = "At least 2 public_subnet_ids are required when using an existing VPC."
   }
 }

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -71,6 +71,30 @@ variable "enable_tls" {
   default     = true
 }
 
+# ── Sizing preset ─────────────────────────────────────────────────────────
+# Pick a preset to configure all resource sizes at once. Individual resource
+# variables (api_cpu, db_instance_class, etc.) are IGNORED when sizing != "custom".
+#
+# IMPORTANT: Presets and individual vars are mutually exclusive.
+# When sizing = "small|medium|large", individual resource variables have no effect.
+# Set sizing = "custom" to control each resource variable independently.
+#
+# Presets:
+#   small  (~$150/mo) — 1× api, 1× web, 1× worker, t3.medium data, db.t4g.micro
+#   medium (~$255/mo) — 2× api, 2× web, 1× worker, t3.large data, db.t4g.small
+#   large  (~$600/mo) — 3× api, 3× web, 2× worker, r6i.xlarge data, db.r6g.large
+
+variable "sizing" {
+  description = "Resource sizing preset. Set 'custom' to use individual resource variables instead."
+  type        = string
+  default     = "medium"
+
+  validation {
+    condition     = contains(["small", "medium", "large", "custom"], var.sizing)
+    error_message = "sizing must be 'small', 'medium', 'large', or 'custom'."
+  }
+}
+
 # ── ECS Fargate (api / web / worker / init) ────────────────────────────────
 
 variable "image_repo_api" {
@@ -374,20 +398,73 @@ variable "demo_user_password" {
 # route tables. You must provide at least 2 public and 2 private subnet IDs.
 
 variable "vpc_id" {
-  description = "Existing VPC ID. Leave empty to create a new VPC."
+  description = "ID of an existing VPC to reuse. Leave empty to create a new VPC."
   type        = string
-  default     = ""
+  default     = null
+
+  validation {
+    condition     = var.vpc_id == null || can(regex("^vpc-", var.vpc_id))
+    error_message = "VPC ID must start with 'vpc-' if provided."
+  }
 }
 
 variable "private_subnet_ids" {
-  description = "List of existing private subnet IDs (at least 2, in different AZs). Required when vpc_id is set."
+  description = "List of private subnet IDs (required when using existing VPC). At least 2, in different AZs."
   type        = list(string)
-  default     = []
+  default     = null
+
+  validation {
+    condition     = var.private_subnet_ids == null || length(var.private_subnet_ids) >= 2
+    error_message = "At least 2 private_subnet_ids are required when using an existing VPC."
+  }
 }
 
 variable "public_subnet_ids" {
-  description = "List of existing public subnet IDs (at least 2, in different AZs). Required when vpc_id is set."
+  description = "List of public subnet IDs (required when using existing VPC). At least 2, in different AZs."
   type        = list(string)
-  default     = []
+  default     = null
+
+  validation {
+    condition     = var.public_subnet_ids == null || length(var.public_subnet_ids) >= 2
+    error_message = "At least 2 public_subnet_ids are required when using an existing VPC."
+  }
+}
+
+# ── Bring-your-own Security Groups (optional) ────────────────────────────────
+# Advanced: supply pre-created SG IDs to skip security group creation.
+# The ALB SG must allow inbound 80/443 from your desired CIDRs.
+# The ECS SG must allow inbound 8000/3000 from the ALB SG.
+
+variable "alb_security_group_id" {
+  description = "Existing ALB security group ID. Leave empty to create one."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.alb_security_group_id == null || can(regex("^sg-", var.alb_security_group_id))
+    error_message = "alb_security_group_id must start with 'sg-' if provided."
+  }
+}
+
+variable "ecs_security_group_id" {
+  description = "Existing ECS tasks security group ID. Leave empty to create one."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.ecs_security_group_id == null || can(regex("^sg-", var.ecs_security_group_id))
+    error_message = "ecs_security_group_id must start with 'sg-' if provided."
+  }
+}
+
+variable "alb_scheme" {
+  description = "Scheme for the ALB: 'internet-facing' or 'internal'."
+  type        = string
+  default     = "internet-facing"
+
+  validation {
+    condition     = contains(["internet-facing", "internal"], var.alb_scheme)
+    error_message = "alb_scheme must be 'internet-facing' or 'internal'."
+  }
 }
 

--- a/infra/terraform/deploy.sh
+++ b/infra/terraform/deploy.sh
@@ -216,14 +216,19 @@ validate_standard() {
     [ -n "$pub" ] && pass "public_subnet_ids set" || fail "vpc_id set but public_subnet_ids missing"
   fi
 
-  # Check GHCR image accessibility
+  # Check GHCR image accessibility (requires token even for public images)
   local tag="${image_tag:-latest}"
-  local status
-  status=$(curl -s -o /dev/null -w "%{http_code}" "https://ghcr.io/v2/blazeup-ai/observal-api/manifests/$tag" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" 2>/dev/null || echo "000")
-  if [ "$status" = "200" ] || [ "$status" = "302" ]; then
+  local token status
+  token=$(curl -s "https://ghcr.io/token?scope=repository:blazeup-ai/observal-api:pull" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
+  if [ -n "$token" ]; then
+    status=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://ghcr.io/v2/blazeup-ai/observal-api/manifests/$tag" 2>/dev/null || echo "000")
+  else
+    status="000"
+  fi
+  if [ "$status" = "200" ]; then
     pass "GHCR image observal-api:$tag reachable"
   else
-    warn "Cannot verify GHCR image (HTTP $status) — may need auth token"
+    warn "Cannot verify GHCR image observal-api:$tag (HTTP $status)"
   fi
 }
 

--- a/infra/terraform/deploy.sh
+++ b/infra/terraform/deploy.sh
@@ -356,15 +356,15 @@ if [[ ! "$CONFIRM" =~ ^[Yy] ]]; then
 fi
 
 echo ""
-info "Applying..."
-APPLY_OUTPUT=$($TF -chdir="$MODULE_DIR" apply tfplan 2>&1)
-APPLY_EXIT=$?
+info "Applying (live output below)..."
+echo ""
+$TF -chdir="$MODULE_DIR" apply tfplan 2>&1 | tee /tmp/observal-apply-output.log
+APPLY_EXIT=${PIPESTATUS[0]}
 
 if [ "$APPLY_EXIT" -ne 0 ]; then
-  echo "$APPLY_OUTPUT"
   echo ""
 
-  if echo "$APPLY_OUTPUT" | grep -qi "already exists\|AlreadyExists\|BucketAlreadyExists\|EntityAlreadyExists\|ResourceAlreadyExistsException\|ParameterAlreadyExists"; then
+  if grep -qi "already exists\|AlreadyExists\|BucketAlreadyExists\|EntityAlreadyExists\|ResourceAlreadyExistsException\|ParameterAlreadyExists" /tmp/observal-apply-output.log 2>/dev/null; then
     echo -e "  ${FAIL} ${BOLD}Resource conflict: some AWS resources already exist.${NC}"
     echo ""
     echo "  This usually means a previous deployment with the same name_prefix + environment"
@@ -388,8 +388,10 @@ if [ "$APPLY_EXIT" -ne 0 ]; then
   else
     fail "terraform apply failed (see errors above)"
   fi
+  rm -f /tmp/observal-apply-output.log
   exit 1
 fi
+rm -f /tmp/observal-apply-output.log
 
 # ── Post-apply ───────────────────────────────────────────────────────────────
 section "Post-Deploy"

--- a/infra/terraform/deploy.sh
+++ b/infra/terraform/deploy.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Unified Observal AWS Deployment
+# ================================
+# Interactive guided setup for all deployment tiers.
+#
+# Usage:
+#   ./deploy.sh          # Full guided flow
+#   ./deploy.sh --help   # Show usage
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Output formatting ────────────────────────────────────────────────────────
+PASS='\033[0;32m✓\033[0m'
+FAIL='\033[0;31m✗\033[0m'
+WARN='\033[1;33m!\033[0m'
+INFO='\033[0;36m→\033[0m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+ERRORS=0
+
+pass() { echo -e "  ${PASS} $*"; }
+fail() { echo -e "  ${FAIL} $*"; ERRORS=$((ERRORS + 1)); }
+warn() { echo -e "  ${WARN} $*"; }
+info() { echo -e "  ${INFO} $*"; }
+
+section() {
+  echo ""
+  echo -e "${BOLD}$*${NC}"
+  echo -e "${BOLD}$(printf '%.0s─' $(seq 1 ${#1}))${NC}"
+}
+
+# ── Help ─────────────────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
+  echo "Usage: $0"
+  echo ""
+  echo "Interactive guided deployment for Observal on AWS."
+  echo "Walks you through tier selection, configuration, validation, and apply."
+  echo ""
+  echo "Tiers:"
+  echo "  1) Single     — All-in-one EC2 (~\$60/mo)"
+  echo "  2) Standard   — ECS EC2 + data host (~\$155/mo)"
+  echo "  3) Enterprise — ECS Fargate + managed services (~\$255/mo)"
+  exit 0
+fi
+
+# ── Banner ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║         Observal AWS Deployment                     ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════════════════════╝${NC}"
+
+# ── Tier Selection ───────────────────────────────────────────────────────────
+section "Choose Deployment Tier"
+echo ""
+echo -e "  ${BOLD}1) Single${NC}      — Everything on one EC2 instance"
+echo "                   Docker Compose, ~\$60/mo"
+echo "                   Best for: dev, demos, small teams (<20 users)"
+echo ""
+echo -e "  ${BOLD}2) Standard${NC}    — ECS on EC2 + separate data host"
+echo "                   Rolling deploys, scalable app tier, ~\$155/mo"
+echo "                   Best for: production teams, moderate load"
+echo ""
+echo -e "  ${BOLD}3) Enterprise${NC}  — ECS Fargate + RDS + ElastiCache"
+echo "                   Fully managed, autoscaling, HA, ~\$255/mo"
+echo "                   Best for: large orgs, compliance, SLA-required"
+echo ""
+read -rp "  Choose tier [1/2/3]: " TIER_CHOICE
+
+case "$TIER_CHOICE" in
+  1) MODULE_DIR="$SCRIPT_DIR/aws-ec2";     TIER_NAME="Single";     TIER_COST="~\$60/mo" ;;
+  2) MODULE_DIR="$SCRIPT_DIR/aws-standard"; TIER_NAME="Standard";   TIER_COST="~\$155/mo" ;;
+  3) MODULE_DIR="$SCRIPT_DIR/aws";          TIER_NAME="Enterprise"; TIER_COST="~\$255/mo" ;;
+  *)
+    echo "Invalid choice. Enter 1, 2, or 3."
+    exit 1
+    ;;
+esac
+
+echo ""
+info "Selected: ${BOLD}$TIER_NAME${NC} ($TIER_COST)"
+
+# ── Pre-flight: Terraform ────────────────────────────────────────────────────
+section "Pre-flight Checks"
+
+TF=""
+if command -v terraform >/dev/null 2>&1; then
+  TF="terraform"
+elif command -v tofu >/dev/null 2>&1; then
+  TF="tofu"
+fi
+
+if [ -z "$TF" ]; then
+  fail "terraform/tofu not found"
+  info "Install: https://developer.hashicorp.com/terraform/install"
+  echo ""
+  exit 1
+else
+  TF_VERSION=$($TF version -json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("terraform_version","0.0.0"))' 2>/dev/null || echo "0.0.0")
+  TF_MAJOR=$(echo "$TF_VERSION" | cut -d. -f1)
+  TF_MINOR=$(echo "$TF_VERSION" | cut -d. -f2)
+  if [ "$TF_MAJOR" -lt 1 ] || ([ "$TF_MAJOR" -eq 1 ] && [ "$TF_MINOR" -lt 6 ]); then
+    fail "$TF version $TF_VERSION < 1.6.0 (required)"
+    exit 1
+  else
+    pass "$TF $TF_VERSION"
+  fi
+fi
+
+# ── Pre-flight: AWS credentials ──────────────────────────────────────────────
+if ! command -v aws >/dev/null 2>&1; then
+  fail "aws CLI not found"
+  info "Install: https://aws.amazon.com/cli/"
+  exit 1
+else
+  pass "aws CLI installed"
+  if CALLER=$(aws sts get-caller-identity --output json 2>/dev/null); then
+    ARN=$(echo "$CALLER" | python3 -c 'import sys,json;print(json.load(sys.stdin)["Arn"])')
+    pass "Authenticated: $ARN"
+  else
+    fail "AWS credentials not configured or expired"
+    info "Run: aws configure"
+    exit 1
+  fi
+fi
+
+# ── terraform.tfvars setup ───────────────────────────────────────────────────
+section "Configuration"
+
+TFVARS="$MODULE_DIR/terraform.tfvars"
+TFVARS_EXAMPLE="$MODULE_DIR/terraform.tfvars.example"
+
+if [ ! -f "$TFVARS" ]; then
+  if [ -f "$TFVARS_EXAMPLE" ]; then
+    cp "$TFVARS_EXAMPLE" "$TFVARS"
+    pass "Created terraform.tfvars from example"
+  else
+    fail "No terraform.tfvars.example found in $MODULE_DIR"
+    exit 1
+  fi
+else
+  pass "terraform.tfvars exists"
+fi
+
+echo ""
+echo -e "  ${BOLD}Edit your configuration:${NC}"
+echo -e "    $TFVARS"
+echo ""
+echo "  At minimum, set: region"
+if [ "$TIER_CHOICE" != "1" ]; then
+  echo "  For HTTPS: set domain_name + route53_zone_id"
+fi
+echo ""
+
+# ── Validation loop ──────────────────────────────────────────────────────────
+
+validate_single() {
+  ERRORS=0
+  local get_var
+  get_var() { grep "^$1" "$TFVARS" 2>/dev/null | sed 's/.*=\s*"\(.*\)"/\1/' | head -1; }
+
+  local region name image_tag domain zone
+  region=$(get_var "region")
+  name=$(get_var "name")
+  image_tag=$(get_var "image_tag")
+  domain=$(get_var "domain")
+  zone=$(get_var "route53_zone_id")
+
+  [ -n "$region" ] && pass "region = $region" || fail "region not set"
+  [ -n "$name" ] && pass "name = $name" || fail "name not set (deployment identifier)"
+  [ -n "$image_tag" ] && pass "image_tag = $image_tag" || pass "image_tag not set (will use 'latest')"
+
+  if [ -n "$domain" ] && [ -z "$zone" ]; then
+    fail "domain is set but route53_zone_id is missing"
+  elif [ -n "$domain" ]; then
+    pass "domain = $domain"
+  fi
+}
+
+validate_standard() {
+  ERRORS=0
+  local get_var
+  get_var() { grep "^$1" "$TFVARS" 2>/dev/null | sed 's/.*=\s*"\(.*\)"/\1/' | head -1; }
+
+  local region environment image_tag domain zone vpc_id
+
+  region=$(get_var "region")
+  environment=$(get_var "environment")
+  image_tag=$(get_var "image_tag")
+  domain=$(get_var "domain_name")
+  zone=$(get_var "route53_zone_id")
+  vpc_id=$(get_var "vpc_id")
+
+  [ -n "$region" ] && pass "region = $region" || fail "region not set"
+  [ -n "$environment" ] && pass "environment = $environment" || pass "environment not set (defaults to 'prod')"
+  [ -n "$image_tag" ] && pass "image_tag = $image_tag" || pass "image_tag not set (will use 'latest')"
+
+  if [ -n "$domain" ] && [ -z "$zone" ]; then
+    fail "domain_name is set but route53_zone_id is missing"
+  elif [ -n "$domain" ]; then
+    pass "domain = $domain (HTTPS)"
+  else
+    pass "No domain (HTTP on ALB DNS)"
+  fi
+
+  if [ -n "$vpc_id" ]; then
+    local priv pub
+    priv=$(grep "private_subnet_ids" "$TFVARS" 2>/dev/null || echo "")
+    pub=$(grep "public_subnet_ids" "$TFVARS" 2>/dev/null || echo "")
+    [ -n "$priv" ] && pass "private_subnet_ids set" || fail "vpc_id set but private_subnet_ids missing"
+    [ -n "$pub" ] && pass "public_subnet_ids set" || fail "vpc_id set but public_subnet_ids missing"
+  fi
+
+  # Check GHCR image accessibility
+  local tag="${image_tag:-latest}"
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" "https://ghcr.io/v2/blazeup-ai/observal-api/manifests/$tag" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" 2>/dev/null || echo "000")
+  if [ "$status" = "200" ] || [ "$status" = "302" ]; then
+    pass "GHCR image observal-api:$tag reachable"
+  else
+    warn "Cannot verify GHCR image (HTTP $status) — may need auth token"
+  fi
+}
+
+validate_enterprise() {
+  ERRORS=0
+  local get_var
+  get_var() { grep "^$1" "$TFVARS" 2>/dev/null | sed 's/.*=\s*"\(.*\)"/\1/' | head -1; }
+
+  local region environment image_tag domain zone vpc_id
+
+  region=$(get_var "region")
+  environment=$(get_var "environment")
+  image_tag=$(get_var "image_tag")
+  domain=$(get_var "domain_name")
+  zone=$(get_var "route53_zone_id")
+  vpc_id=$(get_var "vpc_id")
+
+  [ -n "$region" ] && pass "region = $region" || fail "region not set"
+  [ -n "$environment" ] && pass "environment = $environment" || pass "environment defaults to 'prod'"
+  [ -n "$image_tag" ] && pass "image_tag = $image_tag" || pass "image_tag defaults to 'latest'"
+
+  if [ -n "$domain" ] && [ -z "$zone" ]; then
+    fail "domain_name is set but route53_zone_id is missing"
+  elif [ -n "$domain" ]; then
+    pass "domain = $domain (HTTPS)"
+  fi
+
+  if [ -n "$vpc_id" ]; then
+    local priv pub
+    priv=$(grep "private_subnet_ids" "$TFVARS" 2>/dev/null || echo "")
+    pub=$(grep "public_subnet_ids" "$TFVARS" 2>/dev/null || echo "")
+    [ -n "$priv" ] && pass "private_subnet_ids set" || fail "vpc_id set but private_subnet_ids missing"
+    [ -n "$pub" ] && pass "public_subnet_ids set" || fail "vpc_id set but public_subnet_ids missing"
+  fi
+
+  # IAM smoke test
+  if aws ecs list-clusters --region "${region:-us-east-1}" --max-results 1 >/dev/null 2>&1; then
+    pass "ECS access confirmed"
+  else
+    fail "Cannot access ECS (check IAM permissions)"
+  fi
+}
+
+# Run validation loop
+while true; do
+  section "Validating Configuration"
+
+  case "$TIER_CHOICE" in
+    1) validate_single ;;
+    2) validate_standard ;;
+    3) validate_enterprise ;;
+  esac
+
+  if [ "$ERRORS" -eq 0 ]; then
+    echo ""
+    pass "All checks passed."
+    break
+  else
+    echo ""
+    echo -e "  ${FAIL} ${BOLD}$ERRORS error(s) found.${NC}"
+    echo ""
+    echo "  Fix the issues in: $TFVARS"
+    echo ""
+    read -rp "  Press Enter to re-validate (or 'quit' to abort): " RESP
+    [ "$RESP" = "quit" ] && exit 0
+  fi
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+section "Deployment Summary"
+echo ""
+echo -e "  Tier:     ${BOLD}$TIER_NAME${NC}"
+echo -e "  Cost:     $TIER_COST"
+echo -e "  Module:   $MODULE_DIR"
+echo -e "  Config:   $TFVARS"
+echo ""
+
+# ── Apply ────────────────────────────────────────────────────────────────────
+read -rp "  Proceed with deployment? [y/N]: " PROCEED
+PROCEED="${PROCEED:-N}"
+
+if [[ ! "$PROCEED" =~ ^[Yy] ]]; then
+  echo ""
+  info "Aborted. To deploy manually:"
+  echo "    cd $MODULE_DIR"
+  echo "    $TF init && $TF plan -out=tfplan && $TF apply tfplan"
+  echo ""
+  exit 0
+fi
+
+section "Deploying ($TIER_NAME)"
+
+echo ""
+info "Running: $TF -chdir=$MODULE_DIR init"
+if ! $TF -chdir="$MODULE_DIR" init; then
+  fail "terraform init failed"
+  exit 1
+fi
+
+echo ""
+info "Running: $TF -chdir=$MODULE_DIR plan -out=tfplan"
+if ! $TF -chdir="$MODULE_DIR" plan -out=tfplan; then
+  fail "terraform plan failed"
+  exit 1
+fi
+
+echo ""
+read -rp "  Plan generated. Apply now? [y/N]: " CONFIRM
+CONFIRM="${CONFIRM:-N}"
+
+if [[ ! "$CONFIRM" =~ ^[Yy] ]]; then
+  info "Skipped. Apply manually: $TF -chdir=$MODULE_DIR apply tfplan"
+  exit 0
+fi
+
+echo ""
+info "Applying..."
+if ! $TF -chdir="$MODULE_DIR" apply tfplan; then
+  fail "terraform apply failed"
+  exit 1
+fi
+
+# ── Post-apply ───────────────────────────────────────────────────────────────
+section "Post-Deploy"
+
+case "$TIER_CHOICE" in
+  1)
+    echo ""
+    info "Running application deployment to EC2 via SSM..."
+    echo ""
+    (cd "$MODULE_DIR" && ./deploy.sh)
+    ;;
+  2|3)
+    echo ""
+    info "ECS services are pulling images from GHCR and starting..."
+    info "This typically takes 2-4 minutes."
+    echo ""
+
+    APP_URL=$($TF -chdir="$MODULE_DIR" output -raw app_url 2>/dev/null || echo "")
+    if [ -n "$APP_URL" ]; then
+      echo "  Waiting for $APP_URL/readyz ..."
+      for i in $(seq 1 30); do
+        status=$(curl -sf -o /dev/null -w "%{http_code}" "$APP_URL/readyz" 2>/dev/null || echo "000")
+        if [ "$status" = "200" ]; then
+          echo ""
+          pass "Observal is live!"
+          break
+        fi
+        printf "."
+        sleep 10
+      done
+      if [ "$status" != "200" ]; then
+        echo ""
+        warn "Health check did not pass yet. Services may still be starting."
+        info "Check: $TF -chdir=$MODULE_DIR output"
+      fi
+    fi
+    ;;
+esac
+
+# ── Final output ─────────────────────────────────────────────────────────────
+echo ""
+section "Deployment Complete"
+echo ""
+echo "  Useful commands:"
+echo ""
+echo -e "  ${BOLD}View outputs:${NC}    $TF -chdir=$MODULE_DIR output"
+echo -e "  ${BOLD}View logs:${NC}       $TF -chdir=$MODULE_DIR output log_group_names"
+echo -e "  ${BOLD}Destroy:${NC}         $TF -chdir=$MODULE_DIR destroy"
+echo ""
+echo "  Get started:"
+echo -e "  ${BOLD}1.${NC} observal config set server_url <app_url>"
+echo -e "  ${BOLD}2.${NC} observal auth login"
+echo ""

--- a/infra/terraform/deploy.sh
+++ b/infra/terraform/deploy.sh
@@ -216,6 +216,17 @@ validate_standard() {
     [ -n "$pub" ] && pass "public_subnet_ids set" || fail "vpc_id set but public_subnet_ids missing"
   fi
 
+  # Check for resource naming conflicts
+  local prefix="${environment:-prod}"
+  local full_name="observal-${prefix}"
+  local region_flag="--region ${region:-us-east-1}"
+  local existing_alb
+  existing_alb=$(aws elbv2 describe-load-balancers $region_flag --names "${full_name}-alb" --query 'LoadBalancers[0].LoadBalancerArn' --output text 2>/dev/null || echo "None")
+  if [ "$existing_alb" != "None" ] && [ -n "$existing_alb" ]; then
+    fail "ALB '${full_name}-alb' already exists in this account/region"
+    info "Change name_prefix in terraform.tfvars or delete the existing ALB first"
+  fi
+
   # Check GHCR image accessibility (requires token even for public images)
   local tag="${image_tag:-latest}"
   local token status
@@ -346,8 +357,37 @@ fi
 
 echo ""
 info "Applying..."
-if ! $TF -chdir="$MODULE_DIR" apply tfplan; then
-  fail "terraform apply failed"
+APPLY_OUTPUT=$($TF -chdir="$MODULE_DIR" apply tfplan 2>&1)
+APPLY_EXIT=$?
+
+if [ "$APPLY_EXIT" -ne 0 ]; then
+  echo "$APPLY_OUTPUT"
+  echo ""
+
+  if echo "$APPLY_OUTPUT" | grep -qi "already exists\|AlreadyExists\|BucketAlreadyExists\|EntityAlreadyExists\|ResourceAlreadyExistsException\|ParameterAlreadyExists"; then
+    echo -e "  ${FAIL} ${BOLD}Resource conflict: some AWS resources already exist.${NC}"
+    echo ""
+    echo "  This usually means a previous deployment with the same name_prefix + environment"
+    echo "  left resources behind (no terraform state to track them)."
+    echo ""
+    echo -e "  ${BOLD}Options to fix:${NC}"
+    echo ""
+    echo "  1. Use a different name (easiest):"
+    echo "     Edit $TFVARS and change:"
+    echo "       name_prefix = \"observal-v2\"   # or any unique name"
+    echo "     Then re-run this script."
+    echo ""
+    echo "  2. Delete the old resources first:"
+    echo "     The conflicting resources are listed in the errors above."
+    echo "     Delete them via AWS Console or CLI, then re-run."
+    echo ""
+    echo "  3. Import them into Terraform state:"
+    echo "     terraform -chdir=$MODULE_DIR import <resource_address> <resource_id>"
+    echo "     (advanced — run for each conflicting resource)"
+    echo ""
+  else
+    fail "terraform apply failed (see errors above)"
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Purpose / Description

  Add three-tier AWS deployment with unified entry point. Customers can now choose Single ($60/mo), Standard ($155/mo), or Enterprise ($255/mo) from a single deploy script that validates config and runs terraform.

## Fixes

  - Fixes incomplete BYOVPC support in the enterprise module
  - Fixes slow 15-min deploy on single-instance tier (was building from source)

## Approach

  - Rewrote BYOVPC to use null-based toggle pattern (adopted from langfuse-terraform-aws), added validation blocks, BYO security groups, and explicit ALB scheme control
  - Added sizing presets (small/medium/large/custom) so users pick a tier instead of tuning 12 variables
  - Created new aws-standard module: ECS with EC2 launch type for app containers, separate EC2 for Postgres/Redis/ClickHouse
  - Switched aws-ec2 module to pull pre-built GHCR images instead of cloning and building on-instance
  - Created unified infra/terraform/deploy.sh with tier selection, validation loop, and guided apply

## How Has This Been Tested?

  - terraform fmt -check -recursive passes for all modules
  - terraform validate passes for aws/, aws-standard/, aws-ec2/, and examples/byovpc/
  - bash -n deploy.sh syntax check passes on all scripts
  - Verified no stale references to old variable patterns (grep for old locals/var names)

## Checklist

  - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
  - [x] You have commented your code, particularly in hard-to-understand areas
  - [x] You have performed a self-review of your own code
  - [ ] UI changes: include screenshots of all affected screens