### PR TITLE
fix(migrate): schema compat and session_events support

### DIFF
--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -1,12 +1,12 @@
 <!-- SPDX-FileCopyrightText: 2026 Naraen Rammoorthi <naraen13@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 
-# observal migrate
+# observal server migrate
 
 Portable migration tools for moving an Observal instance between environments. The workflow has two phases:
 
 * **Phase 1 (shallow copy)**: exports PostgreSQL registry data (users, agents, components, feedback, etc.) to a `.tar.gz` archive of JSONL files.
-* **Phase 2 (deep copy)**: exports ClickHouse telemetry data (traces, spans, scores, audit logs, security events) to monthly Parquet files.
+* **Phase 2 (deep copy)**: exports ClickHouse telemetry data (traces, spans, scores, session events, audit logs, security events) to monthly Parquet files.
 
 Phase 2 depends on Phase 1. You must complete the shallow copy export and import before running the deep copy.
 
@@ -26,14 +26,14 @@ This installs `asyncpg` (PostgreSQL driver) and `pyarrow` (Parquet I/O). Without
 
 ## Phase 1: Shallow Copy (PostgreSQL)
 
-### observal migrate export
+### observal server migrate export
 
 Export all PostgreSQL registry data to a portable `.tar.gz` archive.
 
 #### Synopsis
 
 ```bash
-observal migrate export --db-url <postgres-url> [--output <path>]
+observal server migrate export --db-url <postgres-url> [--output <path>]
 ```
 
 #### Options
@@ -69,7 +69,7 @@ A sidecar `<archive-name>.manifest.json` is written alongside the archive for Ph
 #### Example
 
 ```bash
-observal migrate export \
+observal server migrate export \
   --db-url "postgresql://postgres:postgres@localhost:5432/observal" \
   --output ./migration/observal-export.tar.gz
 ```
@@ -91,14 +91,14 @@ Exporting to: ./migration/observal-export.tar.gz
 
 ---
 
-### observal migrate import
+### observal server migrate import
 
 Import a migration archive into the target PostgreSQL database.
 
 #### Synopsis
 
 ```bash
-observal migrate import --db-url <postgres-url> --archive <path>
+observal server migrate import --db-url <postgres-url> --archive <path> [--org-id <uuid>]
 ```
 
 #### Options
@@ -107,6 +107,7 @@ observal migrate import --db-url <postgres-url> --archive <path>
 | --- | --- |
 | `--db-url` | Target PostgreSQL connection string (required) |
 | `--archive`, `-a` | Path to the `.tar.gz` archive from `export` (required) |
+| `--org-id` | Normalize all org references to this UUID. Use when migrating between different orgs. |
 
 #### Behavior
 
@@ -114,13 +115,16 @@ observal migrate import --db-url <postgres-url> --archive <path>
 * Skips rows that already exist (matched by primary key)
 * Reports inserted vs skipped counts per table
 * Tables that don't exist on the target (older schema) are skipped gracefully
+* NOT NULL columns added in newer schemas are automatically filled with their server defaults (boolean, varchar, JSON, etc.)
+* Schema version mismatches between source and target are handled non-fatally
 
 #### Example
 
 ```bash
-observal migrate import \
+observal server migrate import \
   --db-url "postgresql://postgres:postgres@localhost:5432/observal" \
-  --archive ./migration/observal-export.tar.gz
+  --archive ./migration/observal-export.tar.gz \
+  --org-id "24387a71-352e-437f-ac64-5a41dc1dc44f"
 ```
 
 ```
@@ -136,14 +140,14 @@ Importing from: ./migration/observal-export.tar.gz
 
 ---
 
-### observal migrate validate
+### observal server migrate validate
 
 Validate archive integrity and optionally compare against a live database.
 
 #### Synopsis
 
 ```bash
-observal migrate validate --archive <path> [--db-url <postgres-url>]
+observal server migrate validate --archive <path> [--db-url <postgres-url>]
 ```
 
 #### Options
@@ -161,7 +165,7 @@ observal migrate validate --archive <path> [--db-url <postgres-url>]
 #### Example
 
 ```bash
-observal migrate validate \
+observal server migrate validate \
   --archive ./migration/observal-export.tar.gz \
   --db-url "postgresql://postgres:postgres@localhost:5432/observal"
 ```
@@ -188,14 +192,14 @@ Row count comparison:
 
 ## Phase 2: Deep Copy (ClickHouse Telemetry)
 
-### observal migrate export-telemetry
+### observal server migrate export-telemetry
 
 Export ClickHouse telemetry tables to monthly Parquet files.
 
 #### Synopsis
 
 ```bash
-observal migrate export-telemetry \
+observal server migrate export-telemetry \
   --clickhouse-url <url> \
   --manifest <path> \
   --output-dir <dir>
@@ -216,10 +220,13 @@ observal migrate export-telemetry \
 | `traces` | ReplacingMergeTree | `start_time` | Top-level trace records |
 | `spans` | ReplacingMergeTree | `start_time` | Individual span records |
 | `scores` | ReplacingMergeTree | `timestamp` | Feedback and rating scores |
+| `session_events` | MergeTree | `timestamp` | IDE session transcript events (powers the sessions UI) |
 | `audit_log` | MergeTree | `timestamp` | Audit trail entries |
 | `otel_logs` | MergeTree | `Timestamp` | OpenTelemetry log records |
 | `security_events` | MergeTree | `timestamp` | Security event records |
 | `webhook_deliveries` | MergeTree | `timestamp` | Webhook delivery records |
+
+Tables that don't exist on the source are skipped gracefully (useful when exporting from older instances).
 
 Data is partitioned by month. Each non-empty month produces one Parquet file (e.g. `traces_2025-01.parquet`).
 
@@ -235,7 +242,7 @@ The output directory contains:
 #### Example
 
 ```bash
-observal migrate export-telemetry \
+observal server migrate export-telemetry \
   --clickhouse-url "clickhouse://default:clickhouse@localhost:8123/observal" \
   --manifest ./migration/observal-export.manifest.json \
   --output-dir ./migration/telemetry/
@@ -251,6 +258,8 @@ Exporting telemetry to: ./migration/telemetry/
   Exporting spans_2025-02.parquet (41,220 rows)...
   ✓ spans: 69,324 rows in 2 file(s)
   ✓ scores: 1,205 rows in 1 file(s)
+  Exporting session_events_2025-01.parquet (12,450 rows)...
+  ✓ session_events: 12,450 rows in 1 file(s)
   audit_log: empty
   otel_logs: empty
   security_events: empty
@@ -259,9 +268,9 @@ Exporting telemetry to: ./migration/telemetry/
 ✓ Telemetry export complete
   Directory:  ./migration/telemetry/
   Migration:  a1b2c3d4-...
-  Rows:       79,832
-  Size:       12.4 MB
-  Duration:   18.7s
+  Rows:       92,282
+  Size:       14.2 MB
+  Duration:   21.3s
 
 ⚠  Parquet files may contain PII in trace input/output fields.
    Store securely and delete after import.
@@ -269,14 +278,14 @@ Exporting telemetry to: ./migration/telemetry/
 
 ---
 
-### observal migrate import-telemetry
+### observal server migrate import-telemetry
 
 Import Parquet telemetry files into the target ClickHouse instance.
 
 #### Synopsis
 
 ```bash
-observal migrate import-telemetry \
+observal server migrate import-telemetry \
   --clickhouse-url <url> \
   --input-dir <dir> \
   [--project-id <id>]
@@ -300,7 +309,7 @@ observal migrate import-telemetry \
 #### Example
 
 ```bash
-observal migrate import-telemetry \
+observal server migrate import-telemetry \
   --clickhouse-url "clickhouse://default:clickhouse@localhost:8123/observal" \
   --input-dir ./migration/telemetry/
 ```
@@ -316,18 +325,20 @@ Importing telemetry from: ./migration/telemetry/
   ✓ spans: 69,324 rows
   Importing scores_2025-02.parquet...
   ✓ scores: 1,205 rows
+  Importing session_events_2025-01.parquet...
+  ✓ session_events: 12,450 rows
 
 ✓ Telemetry import complete
   Migration:  a1b2c3d4-...
-  Tables:     3
-  Rows:       79,832
-  Duration:   22.1s
+  Tables:     4
+  Rows:       92,282
+  Duration:   25.4s
 ```
 
 With project ID normalization:
 
 ```bash
-observal migrate import-telemetry \
+observal server migrate import-telemetry \
   --clickhouse-url "clickhouse://default:clickhouse@localhost:8123/observal" \
   --input-dir ./migration/telemetry/ \
   --project-id "my-local-org-id"
@@ -335,14 +346,14 @@ observal migrate import-telemetry \
 
 ---
 
-### observal migrate validate-telemetry
+### observal server migrate validate-telemetry
 
 Validate telemetry Parquet files and optionally cross-check against live databases.
 
 #### Synopsis
 
 ```bash
-observal migrate validate-telemetry \
+observal server migrate validate-telemetry \
   --input-dir <dir> \
   [--clickhouse-url <url>] \
   [--target-db-url <postgres-url>]
@@ -365,7 +376,7 @@ observal migrate validate-telemetry \
 #### Example
 
 ```bash
-observal migrate validate-telemetry \
+observal server migrate validate-telemetry \
   --input-dir ./migration/telemetry/ \
   --clickhouse-url "clickhouse://default:clickhouse@localhost:8123/observal" \
   --target-db-url "postgresql://postgres:postgres@localhost:5432/observal"
@@ -378,6 +389,7 @@ Checksum verification:
   ✓ spans_2025-01.parquet
   ✓ spans_2025-02.parquet
   ✓ scores_2025-02.parquet
+  ✓ session_events_2025-01.parquet
 
 ✓ All checksums valid
 
@@ -385,6 +397,7 @@ Row count comparison:
   ✓ traces: 9,303
   ✓ spans: 69,324
   ✓ scores: 1,205
+  ✓ session_events: 12,450
   - audit_log: table not on target
   - otel_logs: table not on target
 
@@ -419,18 +432,18 @@ Save the org ID; you'll use it in steps 2 and 5.
 
 ```bash
 # Step 1: Export from source
-observal migrate export \
+observal server migrate export \
   --db-url <source-postgres-url> \
   --output ./migration/export.tar.gz
 
 # Step 2: Import into target (with org remapping)
-observal migrate import \
+observal server migrate import \
   --db-url <target-postgres-url> \
   --archive ./migration/export.tar.gz \
   --org-id <target-org-id>
 
 # Step 3: Validate
-observal migrate validate \
+observal server migrate validate \
   --archive ./migration/export.tar.gz \
   --db-url <target-postgres-url>
 ```
@@ -439,19 +452,19 @@ observal migrate validate \
 
 ```bash
 # Step 4: Export telemetry from source
-observal migrate export-telemetry \
+observal server migrate export-telemetry \
   --clickhouse-url <source-clickhouse-url> \
   --manifest ./migration/export.manifest.json \
   --output-dir ./migration/telemetry/
 
 # Step 5: Import telemetry into target (with project_id remapping)
-observal migrate import-telemetry \
+observal server migrate import-telemetry \
   --clickhouse-url <target-clickhouse-url> \
   --input-dir ./migration/telemetry/ \
   --project-id <target-org-id>
 
 # Step 6: Validate telemetry
-observal migrate validate-telemetry \
+observal server migrate validate-telemetry \
   --input-dir ./migration/telemetry/ \
   --clickhouse-url <target-clickhouse-url>
 ```
@@ -479,6 +492,16 @@ observal ops traces --limit 5
 The `--db-url` for PostgreSQL accepts both `postgresql://` and `postgresql+asyncpg://` (the SQLAlchemy dialect prefix is stripped automatically). You can copy the `DATABASE_URL` from your `.env` directly.
 
 The `clickhouses://` scheme maps to HTTPS with a default port of 8443. Use it when connecting to ClickHouse over TLS (e.g. managed ClickHouse Cloud or production instances behind TLS termination).
+
+## Schema Compatibility
+
+The migration handles schema version mismatches between source and target:
+
+* **Extra columns in archive** (source is newer): columns not present on target are silently dropped.
+* **Missing columns in archive** (target is newer): NOT NULL columns with server defaults are filled automatically. This includes boolean (`false`), varchar (e.g. `'git_fetch'`), and JSON/JSONB (`{}`) columns.
+* **Missing tables on source** (ClickHouse): tables that don't exist on the source are skipped during telemetry export.
+
+This makes it safe to migrate between instances at different schema versions without manual intervention.
 
 ## Security Notes
 
@@ -511,5 +534,6 @@ If you encounter a permission error during import, ask your DBA to grant the app
 
 ## Related
 
+* [`observal server`](server.md): server management commands
 * [`observal admin`](admin.md): admin commands
 * [`observal auth`](auth.md): authentication (must be logged in as super_admin)

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -139,6 +139,7 @@ CLICKHOUSE_TABLES: list[TableCfg] = [
     {"name": "traces", "engine": "replacing", "time_col": "start_time", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
     {"name": "spans", "engine": "replacing", "time_col": "start_time", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
     {"name": "scores", "engine": "replacing", "time_col": "timestamp", "fk_cols": ["agent_id", "mcp_id", "user_id"]},
+    {"name": "session_events", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["agent_id", "user_id"]},
     {"name": "audit_log", "engine": "mergetree", "time_col": "timestamp", "fk_cols": ["actor_id"]},
     # otel_logs DDL uses capital-T "Timestamp" (OpenTelemetry convention)
     {"name": "otel_logs", "engine": "mergetree", "time_col": "Timestamp", "fk_cols": []},
@@ -410,34 +411,41 @@ async def _get_org_fk_columns(conn: asyncpg.Connection) -> set[str]:
 
 
 async def _get_notnull_json_defaults(conn: asyncpg.Connection, table: str) -> dict[str, str]:
-    """Discover NOT NULL JSON/JSONB columns for a table and provide safe defaults.
+    """Discover NOT NULL columns with defaults for a table.
 
-    SQLAlchemy models define defaults in Python (default=dict, default=list) which
-    don't appear in information_schema.column_default. We detect NOT NULL JSON columns
-    and provide empty-object defaults so older archives with NULL values don't crash.
+    Handles both JSON/JSONB columns (which may lack DB defaults but need empty objects)
+    and all other NOT NULL columns with explicit column_default values (boolean, varchar, etc).
+    For boolean columns without defaults, uses false as fallback.
+    This ensures migration from older schemas doesn't crash on missing columns.
     """
     rows = await conn.fetch(
         """
-        SELECT column_name, column_default
+        SELECT column_name, column_default, udt_name
         FROM information_schema.columns
         WHERE table_name = $1
             AND table_schema = 'public'
             AND is_nullable = 'NO'
-            AND udt_name IN ('json', 'jsonb')
+            AND (udt_name IN ('json', 'jsonb', 'bool') OR column_default IS NOT NULL)
         """,
         table,
     )
     defaults: dict[str, str] = {}
     for row in rows:
+        col_name = row["column_name"]
         col_default = row["column_default"]
+        udt_name = row["udt_name"]
+
         if col_default:
-            # Has an explicit DB default - extract the JSON value
+            # Has an explicit DB default - extract the value
             clean = col_default.split("::")[0].strip().strip("'")
-            defaults[row["column_name"]] = clean
-        else:
-            # No DB default but column is NOT NULL - use empty object as safe fallback.
+            defaults[col_name] = clean
+        elif udt_name in ("json", "jsonb"):
+            # No DB default but column is NOT NULL JSON/JSONB - use empty object as safe fallback.
             # This covers SQLAlchemy models with default=dict or default=list.
-            defaults[row["column_name"]] = "{}"
+            defaults[col_name] = "{}"
+        elif udt_name == "bool":
+            # No DB default but column is NOT NULL boolean - use false as safe fallback.
+            defaults[col_name] = "false"
     return defaults
 
 
@@ -451,8 +459,12 @@ def _coerce_value(value: object, pg_type: str) -> object:
         return datetime.fromisoformat(value)
     if pg_type == "interval" and isinstance(value, (int, float)):
         return timedelta(seconds=value)
-    if pg_type in ("bool",) and isinstance(value, bool):
-        return value
+    if pg_type in ("bool",):
+        if isinstance(value, bool):
+            return value
+        elif isinstance(value, str):
+            # Handle string defaults from column_default ('true', 'false')
+            return value.lower() in ("true", "t", "1", "yes")
     if pg_type in ("int4", "int8", "int2") and isinstance(value, (int, float)):
         return int(value)
     if pg_type in ("float4", "float8", "numeric") and isinstance(value, (int, float)):
@@ -463,7 +475,7 @@ def _coerce_value(value: object, pg_type: str) -> object:
     return value
 
 
-# NOT NULL JSON defaults are now derived from information_schema at runtime
+# NOT NULL defaults are now derived from information_schema at runtime
 # (see _get_notnull_json_defaults). No hardcoded map needed.
 
 
@@ -509,7 +521,7 @@ async def _flush_batch(
     defaulted_cols: set[str] = set()
 
     for row in batch:
-        # Apply NOT NULL JSON defaults for columns that are NULL in the archive
+        # Apply NOT NULL defaults for columns that are NULL in the archive
         if notnull_defaults:
             for col, default_val in notnull_defaults.items():
                 if col in columns and row.get(col) is None:
@@ -693,7 +705,11 @@ async def _ch_import(
     import httpx as _httpx
 
     sql_prefix = f"INSERT INTO {table} FORMAT Parquet"
-    params = {"database": db, "query": sql_prefix}
+    params = {
+        "database": db,
+        "query": sql_prefix,
+        "max_memory_usage": "2000000000",  # 2 GB - handles large Parquet files (e.g. session_events with raw_line)
+    }
 
     async def _file_stream():
         with open(parquet_path, "rb") as f:
@@ -959,7 +975,7 @@ async def _import_archive(db_url: str, archive_path: Path, normalize_org_id: str
                     # Get column types for proper coercion
                     col_types = await _get_column_types(conn, table)
 
-                    # Get NOT NULL JSON defaults from schema (avoids hardcoded map)
+                    # Get NOT NULL defaults from schema (handles all types with defaults)
                     notnull_defaults = await _get_notnull_json_defaults(conn, table)
 
                     ins, sk, tw = await _insert_table(
@@ -1280,8 +1296,21 @@ async def _export_telemetry(
         total_size = 0
 
         async with _httpx.AsyncClient(timeout=_httpx.Timeout(300.0, connect=10.0)) as http_client:
+            # Pre-check which tables exist on the source to skip gracefully
+            existing_sql = "SELECT name FROM system.tables WHERE database = {db:String} FORMAT JSON"
+            existing_resp = await _ch_query(
+                http_url, db, user, password, existing_sql, http_client=http_client, extra_params={"param_db": db}
+            )
+            source_tables = {r["name"] for r in existing_resp.json().get("data", [])}
+
             for table_cfg in CLICKHOUSE_TABLES:
                 table_name = table_cfg["name"]
+
+                # Skip tables that don't exist on source
+                if table_name not in source_tables:
+                    table_meta[table_name] = {"files": [], "row_count": 0, "checksum": {}, "time_range": None}
+                    rprint(f"  [dim]{table_name}: table not found on source (skipped)[/dim]")
+                    continue
 
                 # Query time range
                 tr_sql = _build_ch_time_range_query(table_cfg)

--- a/tests/test_migrate_telemetry.py
+++ b/tests/test_migrate_telemetry.py
@@ -387,8 +387,8 @@ class TestReadCount:
 class TestConstants:
     """Verify CLICKHOUSE_TABLES, FK_PG_TABLE_MAP, and EPOCH_SENTINELS."""
 
-    def test_clickhouse_tables_has_7_entries(self):
-        assert len(CLICKHOUSE_TABLES) == 7
+    def test_clickhouse_tables_has_8_entries(self):
+        assert len(CLICKHOUSE_TABLES) == 8
 
     def test_each_table_has_required_keys(self):
         for table_cfg in CLICKHOUSE_TABLES:
@@ -403,6 +403,7 @@ class TestConstants:
             "traces",
             "spans",
             "scores",
+            "session_events",
             "audit_log",
             "otel_logs",
             "security_events",
@@ -421,6 +422,7 @@ class TestConstants:
     def test_mergetree_tables(self):
         mergetree = [t["name"] for t in CLICKHOUSE_TABLES if t["engine"] == "mergetree"]
         assert set(mergetree) == {
+            "session_events",
             "audit_log",
             "otel_logs",
             "security_events",


### PR DESCRIPTION
## Purpose / Description

The migration workflow (`observal server migrate`) was crashing and producing incomplete results when migrating from an older instance to a newer local one. Three categories of failure were found and fixed:

1. **Schema mismatch on PG import** — newer columns added via Alembic (e.g. `retention_enabled`, `delivery_mode`, `validated`) are NOT NULL on the target but don't exist in the source archive. The import was crashing with `NotNullViolationError` instead of filling in the column's server default.

2. **Missing `session_events` export** — the frontend sessions page reads from `session_stats_agg`, a materialized view over `session_events`. This table was not included in the Phase 2 telemetry export, so sessions never appeared in the UI after migration.

3. **ClickHouse memory limit exceeded on import** — `session_events` Parquet files containing large `raw_line` columns exceeded ClickHouse's default ~400MB query memory limit, crashing the import mid-run.

A secondary improvement: older source instances may not have newer ClickHouse tables. The export now pre-checks `system.tables` and skips gracefully instead of crashing with `UNKNOWN_TABLE`.

## Approach

- **`_get_notnull_json_defaults`**: Extended the SQL query from `udt_name IN ('json', 'jsonb')` to also match `'bool'` and any column with an explicit `column_default`. The import now auto-fills server defaults for new NOT NULL columns missing from the archive.
- **`_coerce_value`**: Added string→bool coercion so `'false'`/`'true'` string values (from `column_default`) are converted to Python `bool` before asyncpg receives them.
- **`CLICKHOUSE_TABLES`**: Added `session_events` (MergeTree, `timestamp`) so Phase 2 exports the table that powers the frontend sessions UI.
- **`_ch_import`**: Added `max_memory_usage=2000000000` (2GB) to the ClickHouse HTTP query params for Parquet imports, allowing large `session_events` files to import without OOM errors.
- **`_export_telemetry`**: Queries `system.tables` upfront and skips any table in `CLICKHOUSE_TABLES` that doesn't exist on the source, instead of failing mid-export.
- **`docs/cli/migrate.md`**: Updated all commands from `observal migrate` to `observal server migrate`, added `session_events` to the exported tables, added a Schema Compatibility section, and documented the `--org-id` flag on import.

## How Has This Been Tested?

**Round 1 — `dev.observal.io` (older schema, no `session_events`):**

- Phase 1 export + import completed. New schema columns (`retention_enabled`, `delivery_mode`, `validated`, etc.) were filled automatically with server defaults — no `NotNullViolationError`.
- Phase 2 export gracefully skipped `session_events` (not present on source) and completed without crashing.
- `observal agent list` and `observal ops traces --limit 5` both returned results.
- Frontend sessions page required a manual backfill of `session_events` from the `traces` table to display sessions — this confirmed `session_events` needed to be added to the export table list.

**Round 2 — `internal.observal.io` (newer schema, has `session_events`):**

- Full two-phase migration completed without errors.
- `session_events` (~49K rows) exported and imported successfully — confirmed the ClickHouse memory fix works (previously OOM'd without `max_memory_usage=2GB`).
- Frontend sessions page displayed traces immediately after import with no manual backfill needed.
- Tested with enterprise license activated — per-agent AI insights reports from the source were visible in the frontend after migration.


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
