### PR TITLE
feat(ci): expand Terraform CI to all modules with env consistency checks

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,11 +1,20 @@
 # SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Terraform — fmt + validate for the AWS self-hosting module.
+# Terraform — fmt + validate + tflint + env consistency for all modules.
 #
-# Runs on PRs that touch infra/terraform/aws/** and on pushes to main.
-# No AWS credentials needed — `terraform init -backend=false` is used.
+# Runs on PRs and pushes to main that touch infra/terraform/**, .env.example,
+# or observal-server/config.py. No cloud credentials needed.
+#
+# Modules covered:
+#   • infra/terraform/aws  (ECS Fargate — full matrix)
+#   • infra/terraform/gcp  (Cloud Run — full matrix)
+#   • infra/terraform/aws-ec2 (single-instance — fmt+validate only)
+#
+# aws-ec2 is excluded from the matrix and consistency checks because it uses
+# different variable conventions (name vs name_prefix, no clickhouse_mode).
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: Terraform
@@ -14,25 +23,40 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'infra/terraform/aws/**'
+      - 'infra/terraform/**'
       - '.github/workflows/terraform.yml'
+      - '.env.example'
+      - 'observal-server/config.py'
   push:
     branches: [main]
     paths:
-      - 'infra/terraform/aws/**'
+      - 'infra/terraform/**'
       - '.github/workflows/terraform.yml'
+      - '.env.example'
+      - 'observal-server/config.py'
 
 concurrency:
   group: terraform-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # ── fmt + validate (aws, gcp) ──────────────────────────────────────────────
   fmt-validate:
-    name: fmt + validate
+    name: "${{ matrix.module }} fmt+validate"
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [aws, gcp]
+        include:
+          - module: aws
+            working_dir: infra/terraform/aws
+            has_bootstrap: true
+          - module: gcp
+            working_dir: infra/terraform/gcp
+            has_bootstrap: false
 
     steps:
       - name: Checkout
@@ -45,38 +69,64 @@ jobs:
           terraform_wrapper: false
 
       - name: terraform fmt (recursive)
-        working-directory: infra/terraform/aws
+        working-directory: ${{ matrix.working_dir }}
         run: terraform fmt -check -recursive -diff
 
       - name: terraform init (root module, no backend)
-        working-directory: infra/terraform/aws
+        working-directory: ${{ matrix.working_dir }}
         run: terraform init -backend=false -input=false
 
       - name: terraform validate (root module)
-        working-directory: infra/terraform/aws
+        working-directory: ${{ matrix.working_dir }}
         run: terraform validate -no-color
 
       - name: terraform init (examples/minimal)
-        working-directory: infra/terraform/aws/examples/minimal
+        working-directory: ${{ matrix.working_dir }}/examples/minimal
         run: terraform init -backend=false -input=false
 
       - name: terraform validate (examples/minimal)
-        working-directory: infra/terraform/aws/examples/minimal
+        working-directory: ${{ matrix.working_dir }}/examples/minimal
+        run: terraform validate -no-color
+
+      - name: Check examples/byovpc exists
+        id: byovpc
+        run: test -f "${{ matrix.working_dir }}/examples/byovpc/main.tf" && echo "exists=true" >> "$GITHUB_OUTPUT" || echo "exists=false" >> "$GITHUB_OUTPUT"
+
+      - name: terraform init (examples/byovpc)
+        if: steps.byovpc.outputs.exists == 'true'
+        working-directory: ${{ matrix.working_dir }}/examples/byovpc
+        run: terraform init -backend=false -input=false
+
+      - name: terraform validate (examples/byovpc)
+        if: steps.byovpc.outputs.exists == 'true'
+        working-directory: ${{ matrix.working_dir }}/examples/byovpc
         run: terraform validate -no-color
 
       - name: terraform init (bootstrap)
-        working-directory: infra/terraform/aws/bootstrap
+        if: matrix.has_bootstrap
+        working-directory: ${{ matrix.working_dir }}/bootstrap
         run: terraform init -backend=false -input=false
 
       - name: terraform validate (bootstrap)
-        working-directory: infra/terraform/aws/bootstrap
+        if: matrix.has_bootstrap
+        working-directory: ${{ matrix.working_dir }}/bootstrap
         run: terraform validate -no-color
 
+  # ── tflint (aws, gcp) ─────────────────────────────────────────────────────
   tflint:
-    name: tflint
+    name: "${{ matrix.module }} tflint"
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [aws, gcp]
+        include:
+          - module: aws
+            working_dir: infra/terraform/aws
+          - module: gcp
+            working_dir: infra/terraform/gcp
 
     steps:
       - name: Checkout
@@ -88,11 +138,57 @@ jobs:
           tflint_version: v0.55.0
 
       - name: tflint init
-        working-directory: infra/terraform/aws
+        working-directory: ${{ matrix.working_dir }}
         run: tflint --init
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: tflint
-        working-directory: infra/terraform/aws
+        working-directory: ${{ matrix.working_dir }}
         run: tflint --recursive --format=compact
+
+  # ── aws-ec2 (lightweight, different conventions) ───────────────────────────
+  fmt-validate-ec2:
+    name: "aws-ec2 fmt+validate"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.9.8
+          terraform_wrapper: false
+
+      - name: terraform fmt
+        working-directory: infra/terraform/aws-ec2
+        run: terraform fmt -check -diff
+
+      - name: terraform init + validate
+        working-directory: infra/terraform/aws-ec2
+        run: |
+          terraform init -backend=false -input=false
+          terraform validate -no-color
+
+  # ── Terraform <-> App env consistency ──────────────────────────────────────
+  consistency:
+    name: "terraform-env consistency"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run consistency checks
+        run: python scripts/check_terraform_consistency.py

--- a/infra/terraform/gcp/.tflint.hcl
+++ b/infra/terraform/gcp/.tflint.hcl
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "google" {
+  enabled = true
+  version = "0.30.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
+}

--- a/infra/terraform/gcp/examples/minimal/main.tf
+++ b/infra/terraform/gcp/examples/minimal/main.tf
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
+terraform {
+  required_version = ">= 1.6.0"
+}
+
 module "observal" {
   source = "../../"
 

--- a/scripts/check_terraform_consistency.py
+++ b/scripts/check_terraform_consistency.py
@@ -44,9 +44,17 @@ PROVIDER_SPECIFIC: dict[str, set[str]] = {
 
 
 def parse_variables(tf_path: Path) -> set[str]:
-    """Extract variable names from a variables.tf file."""
+    """Extract variable names from a variables.tf file (ignoring commented lines)."""
     content = tf_path.read_text()
-    return set(re.findall(r'variable\s+"([^"]+)"', content))
+    results: set[str] = set()
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or stripped.startswith("//"):
+            continue
+        m = re.match(r'\s*variable\s+"([^"]+)"', line)
+        if m:
+            results.add(m.group(1))
+    return results
 
 
 def check_common_variables() -> list[str]:
@@ -68,6 +76,15 @@ def check_common_variables() -> list[str]:
 
 PLACEHOLDER_DEFAULTS = {"change-me-to-a-random-string"}
 
+# Env vars in .env.example that only apply to docker-compose (not Terraform deployments)
+DOCKER_COMPOSE_ONLY = {
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD",
+    "CLICKHOUSE_USER",
+    "CLICKHOUSE_PASSWORD",
+    "SEED_DEMO_ACCOUNTS",
+}
+
 
 def parse_settings_fields() -> dict[str, bool]:
     """Parse observal-server/config.py Settings class for field names + defaults.
@@ -75,6 +92,10 @@ def parse_settings_fields() -> dict[str, bool]:
     Returns dict of {FIELD_NAME: has_usable_default}.
     """
     config_path = ROOT / "observal-server" / "config.py"
+    if not config_path.exists():
+        print("  WARNING: observal-server/config.py not found")
+        return {}
+
     content = config_path.read_text()
 
     # Extract the Settings class body
@@ -108,7 +129,12 @@ def parse_settings_fields() -> dict[str, bool]:
 
 
 def parse_terraform_provisioned(module_path: Path) -> set[str]:
-    """Extract env var names provisioned by Terraform for a module."""
+    """Extract env var names provisioned by Terraform for a module.
+
+    Only matches name = "UPPER_CASE" patterns which in these .tf files
+    exclusively appear inside container env blocks (environment/secrets lists
+    in ecs.tf, env {} blocks in cloud-run.tf). Resource names use lowercase.
+    """
     provisioned: set[str] = set()
 
     # secrets.tf: keys in local maps like "DATABASE_URL" = ...
@@ -122,7 +148,6 @@ def parse_terraform_provisioned(module_path: Path) -> set[str]:
         path = module_path / tf_file
         if path.exists():
             content = path.read_text()
-            # Match: { name = "ENV_VAR_NAME", ... } or env { name = "..." }
             provisioned.update(re.findall(r'name\s*=\s*"([A-Z][A-Z_0-9]+)"', content))
 
     # variables.tf: demo_* terraform vars map to DEMO_* env vars
@@ -200,13 +225,6 @@ def check_injected_vars() -> list[str]:
 
 # ── Check 5: .env.example coverage ───────────────────────────────────────────
 
-DOCKER_COMPOSE_ONLY = {
-    "POSTGRES_USER",
-    "POSTGRES_PASSWORD",
-    "CLICKHOUSE_USER",
-    "CLICKHOUSE_PASSWORD",
-}
-
 
 def parse_env_example() -> set[str]:
     """Extract KEY names from .env.example."""
@@ -247,8 +265,6 @@ def check_env_example_coverage() -> list[str]:
             continue
         if key in KNOWN_NON_CONFIG_VARS:
             continue
-        if key == "SEED_DEMO_ACCOUNTS":
-            continue
         errors.append(f"  .env.example has {key} but no Terraform module provisions it")
 
     return errors
@@ -268,32 +284,32 @@ def main() -> None:
     all_errors: list[str] = []
     all_warnings: list[str] = []
 
-    print("\n[1/5] Common variables across modules...")
+    print("\n[1/4] Common variables across modules...")
     errs = check_common_variables()
     all_errors.extend(errs)
     print(f"  {PASS_ICON} PASS" if not errs else "\n".join(errs))
 
-    print("\n[2/5] Required env var coverage (no default, must be provisioned)...")
+    print("\n[2/4] App env var coverage...")
     errs, warns = check_env_coverage()
     all_errors.extend(errs)
     all_warnings.extend(warns)
-    print(f"  {PASS_ICON} PASS" if not errs else "\n".join(errs))
-
-    print("\n[3/5] Optional env vars not exposed via Terraform...")
+    if errs:
+        print("\n".join(errs))
+    else:
+        print(f"  {PASS_ICON} Required vars: PASS")
     if warns:
         for w in warns:
             print(f"  {WARN_ICON} {w.strip()}")
-            # GitHub Actions annotation — shows as yellow badge on the PR Checks tab
             print(f"::warning title=Terraform env gap::{w.strip()}")
     else:
-        print(f"  {PASS_ICON} All optional vars are exposed")
+        print(f"  {PASS_ICON} Optional vars: all exposed")
 
-    print("\n[4/5] Injected secrets cross-check...")
+    print("\n[3/4] Injected secrets cross-check...")
     errs = check_injected_vars()
     all_errors.extend(errs)
     print(f"  {PASS_ICON} PASS" if not errs else "\n".join(errs))
 
-    print("\n[5/5] .env.example coverage...")
+    print("\n[4/4] .env.example coverage...")
     errs = check_env_example_coverage()
     all_errors.extend(errs)
     print(f"  {PASS_ICON} PASS" if not errs else "\n".join(errs))

--- a/scripts/check_terraform_consistency.py
+++ b/scripts/check_terraform_consistency.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Terraform <-> App environment consistency checker.
+
+Ensures that:
+1. Common variables exist across all Terraform modules
+2. Every required app env var has a Terraform provisioning path (errors if missing)
+3. Optional env vars not exposed via Terraform are surfaced as warnings
+4. Injected secrets/env match what config.py expects
+5. .env.example stays in sync with Terraform
+
+Stdlib-only (no pip dependencies) so it runs in CI without install steps.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+MODULES: dict[str, Path] = {
+    "aws": ROOT / "infra" / "terraform" / "aws",
+    "gcp": ROOT / "infra" / "terraform" / "gcp",
+}
+
+# ── Check 1: Common variables across modules ─────────────────────────────────
+
+COMMON_VARS = {
+    "environment",
+    "name_prefix",
+    "image_tag",
+    "clickhouse_mode",
+    "observal_license_key",
+}
+
+PROVIDER_SPECIFIC: dict[str, set[str]] = {
+    "aws": {"region"},
+    "gcp": {"region", "project_id"},
+}
+
+
+def parse_variables(tf_path: Path) -> set[str]:
+    """Extract variable names from a variables.tf file."""
+    content = tf_path.read_text()
+    return set(re.findall(r'variable\s+"([^"]+)"', content))
+
+
+def check_common_variables() -> list[str]:
+    errors = []
+    for name, path in MODULES.items():
+        vars_file = path / "variables.tf"
+        if not vars_file.exists():
+            errors.append(f"  {name}/variables.tf does not exist")
+            continue
+        declared = parse_variables(vars_file)
+        required = COMMON_VARS | PROVIDER_SPECIFIC.get(name, set())
+        missing = required - declared
+        if missing:
+            errors.append(f"  {name}/variables.tf missing: {sorted(missing)}")
+    return errors
+
+
+# ── Check 2 & 3: App env var coverage ────────────────────────────────────────
+
+PLACEHOLDER_DEFAULTS = {"change-me-to-a-random-string"}
+
+
+def parse_settings_fields() -> dict[str, bool]:
+    """Parse observal-server/config.py Settings class for field names + defaults.
+
+    Returns dict of {FIELD_NAME: has_usable_default}.
+    """
+    config_path = ROOT / "observal-server" / "config.py"
+    content = config_path.read_text()
+
+    # Extract the Settings class body
+    match = re.search(r"class Settings\(BaseSettings\):(.*?)(?=\n\S|\nclass |\Z)", content, re.DOTALL)
+    if not match:
+        return {}
+
+    class_body = match.group(1)
+    fields: dict[str, bool] = {}
+
+    for line in class_body.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("model_config"):
+            continue
+
+        # Match: FIELD_NAME: type = default
+        m = re.match(r"([A-Z][A-Z_0-9]+)\s*:\s*.+?=\s*(.+)$", line)
+        if m:
+            name, default = m.group(1), m.group(2).strip()
+            # None is a usable default (means "optional, not configured")
+            has_usable_default = default.strip("\"'") not in PLACEHOLDER_DEFAULTS
+            fields[name] = has_usable_default
+            continue
+
+        # Match: FIELD_NAME: type (no default)
+        m = re.match(r"([A-Z][A-Z_0-9]+)\s*:\s*\S+", line)
+        if m:
+            fields[m.group(1)] = False
+
+    return fields
+
+
+def parse_terraform_provisioned(module_path: Path) -> set[str]:
+    """Extract env var names provisioned by Terraform for a module."""
+    provisioned: set[str] = set()
+
+    # secrets.tf: keys in local maps like "DATABASE_URL" = ...
+    secrets_tf = module_path / "secrets.tf"
+    if secrets_tf.exists():
+        content = secrets_tf.read_text()
+        provisioned.update(re.findall(r'"([A-Z][A-Z_0-9]+)"\s*=', content))
+
+    # ecs.tf (AWS) or cloud-run.tf (GCP): env var names injected into containers
+    for tf_file in ("ecs.tf", "cloud-run.tf"):
+        path = module_path / tf_file
+        if path.exists():
+            content = path.read_text()
+            # Match: { name = "ENV_VAR_NAME", ... } or env { name = "..." }
+            provisioned.update(re.findall(r'name\s*=\s*"([A-Z][A-Z_0-9]+)"', content))
+
+    # variables.tf: demo_* terraform vars map to DEMO_* env vars
+    vars_tf = module_path / "variables.tf"
+    if vars_tf.exists():
+        content = vars_tf.read_text()
+        for var_name in re.findall(r'variable\s+"(demo_[^"]+)"', content):
+            provisioned.add(var_name.upper())
+
+    return provisioned
+
+
+def check_env_coverage() -> tuple[list[str], list[str]]:
+    """Check env var coverage. Returns (errors, warnings).
+
+    Errors: vars with no usable default AND no Terraform provisioning (app would crash).
+    Warnings: vars with usable defaults but not exposed via Terraform (can't customize without rebuilding).
+    """
+    fields = parse_settings_fields()
+    errors = []
+    warnings = []
+
+    for module_name, module_path in MODULES.items():
+        provisioned = parse_terraform_provisioned(module_path)
+
+        # Errors: required vars (no usable default) missing from Terraform
+        required_missing = {name for name, has_default in fields.items() if not has_default} - provisioned
+        if required_missing:
+            errors.append(
+                f"  {module_name}: config.py requires these env vars but Terraform "
+                f"doesn't provision them: {sorted(required_missing)}"
+            )
+
+        # Warnings: optional vars (have defaults) not exposed via Terraform
+        optional_unexposed = {name for name, has_default in fields.items() if has_default} - provisioned
+        if optional_unexposed:
+            warnings.append(
+                f"  {module_name}: these config.py vars have defaults but aren't "
+                f"exposed in Terraform (can't customize via tfvars): {sorted(optional_unexposed)}"
+            )
+
+    return errors, warnings
+
+
+# ── Check 4: Cross-check injected secrets ─────────────────────────────────────
+
+# Env vars that Terraform injects but config.py doesn't read via Settings
+KNOWN_NON_CONFIG_VARS = {
+    "NEXT_PUBLIC_API_URL",  # consumed by web container, not config.py
+    "OBSERVAL_LICENSE_KEY",  # read via os.environ.get, not Settings class
+    "PORT",  # consumed by Next.js web container, not the API
+}
+
+# Raw secrets used to build connection URLs, not injected as env vars
+RAW_SECRETS = {
+    "GRAFANA_ADMIN_PASSWORD",
+    "DB_PASSWORD",
+    "CLICKHOUSE_PASSWORD",
+}
+
+
+def check_injected_vars() -> list[str]:
+    """Every injected env var should map to something the app reads."""
+    fields = parse_settings_fields()
+    field_names = set(fields.keys()) | KNOWN_NON_CONFIG_VARS
+    errors = []
+
+    for module_name, module_path in MODULES.items():
+        provisioned = parse_terraform_provisioned(module_path)
+        unknown = provisioned - field_names - RAW_SECRETS
+        if unknown:
+            errors.append(f"  {module_name}: Terraform injects vars not found in config.py: {sorted(unknown)}")
+    return errors
+
+
+# ── Check 5: .env.example coverage ───────────────────────────────────────────
+
+DOCKER_COMPOSE_ONLY = {
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD",
+    "CLICKHOUSE_USER",
+    "CLICKHOUSE_PASSWORD",
+}
+
+
+def parse_env_example() -> set[str]:
+    """Extract KEY names from .env.example."""
+    env_path = ROOT / ".env.example"
+    if not env_path.exists():
+        return set()
+    keys: set[str] = set()
+    for line in env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Z][A-Z_0-9]+)\s*=", line)
+        if m:
+            keys.add(m.group(1))
+    return keys
+
+
+def check_env_example_coverage() -> list[str]:
+    """Every .env.example var should have a Terraform path or be docker-only."""
+    env_keys = parse_env_example()
+    if not env_keys:
+        return ["  .env.example not found or empty"]
+
+    errors = []
+
+    all_provisioned: set[str] = set()
+    for module_path in MODULES.values():
+        all_provisioned.update(parse_terraform_provisioned(module_path))
+
+    fields = parse_settings_fields()
+
+    for key in sorted(env_keys):
+        if key in DOCKER_COMPOSE_ONLY:
+            continue
+        if key in all_provisioned:
+            continue
+        if fields.get(key, False):
+            continue
+        if key in KNOWN_NON_CONFIG_VARS:
+            continue
+        if key == "SEED_DEMO_ACCOUNTS":
+            continue
+        errors.append(f"  .env.example has {key} but no Terraform module provisions it")
+
+    return errors
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+WARN_ICON = "\033[1;33m!\033[0m"
+PASS_ICON = "\033[0;32m✓\033[0m"
+FAIL_ICON = "\033[0;31m✗\033[0m"
+
+
+def main() -> None:
+    print("Terraform <-> App consistency checks")
+    print("=" * 60)
+
+    all_errors: list[str] = []
+    all_warnings: list[str] = []
+
+    print("\n[1/5] Common variables across modules...")
+    errs = check_common_variables()
+    all_errors.extend(errs)
+    print(f"  {PASS_ICON} PASS" if not errs else "\n".join(errs))
+
+    print("\n[2/5] Required env var coverage (no default, must be provisioned)...")
+    errs, warns = check_env_coverage()
+    all_errors.extend(errs)
+    all_warnings.extend(warns)
+    print(f"  {PASS_ICON} PASS" if not errs else "\n".join(errs))
+
+    print("\n[3/5] Optional env vars not exposed via Terraform...")
+    if warns:
+        for w in warns:
+            print(f"  {WARN_ICON} {w.strip()}")
+            # GitHub Actions annotation — shows as yellow badge on the PR Checks tab
+            print(f"::warning title=Terraform env gap::{w.strip()}")
+    else:
+        print(f"  {PASS_ICON} All optional vars are exposed")
+
+    print("\n[4/5] Injected secrets cross-check...")
+    errs = check_injected_vars()
+    all_errors.extend(errs)
+    print(f"  {PASS_ICON} PASS" if not errs else "\n".join(errs))
+
+    print("\n[5/5] .env.example coverage...")
+    errs = check_env_example_coverage()
+    all_errors.extend(errs)
+    print(f"  {PASS_ICON} PASS" if not errs else "\n".join(errs))
+
+    print("\n" + "=" * 60)
+    if all_errors:
+        print(f"{FAIL_ICON} FAILED: {len(all_errors)} error(s)")
+        sys.exit(1)
+    elif all_warnings:
+        print(f"{WARN_ICON} PASSED with {len(all_warnings)} warning(s) (non-blocking)")
+        sys.exit(0)
+    else:
+        print(f"{PASS_ICON} ALL CHECKS PASSED")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
The Terraform CI workflow only validated the AWS ECS module. GCP and aws-ec2 had zero CI coverage, and there was no automated check that Terraform actually provisions every env var the app needs. Drift between config.py and infrastructure would only surface at deploy time.

## Fixes
* Fixes #1126

## Approach

Rewrote `.github/workflows/terraform.yml` with a matrix strategy covering aws + gcp (fmt, validate, tflint) and a lightweight aws-ec2 job (fmt + validate only)

Added `infra/terraform/gcp/.tflint.hcl` with the Google provider ruleset so tflint can lint GCP resources

Created `scripts/check_terraform_consistency.py` (stdlib-only) that runs 4 checks:
   - Common variables exist across all modules (environment, name_prefix, image_tag, etc.)
   - Every required app env var in config.py has a Terraform provisioning path
   - Every env var Terraform injects actually maps to something the app reads
   - .env.example stays in sync with Terraform provisioning


## How Has This Been Tested?

passes all 4 checks against the current codebase
checked for no lint/format violations
`terraform fmt -check -recursive` passes for both aws and gcp modules
workflow only triggers on relevant path changes (`infra/terraform/**`, `.env.example`, `config.py`, itself)


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->
