### PR TITLE
fix: auto-fill owner from logged-in username

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -1,3 +1,4 @@
+<!-- SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
@@ -47,7 +48,6 @@ observal agent create --name my-agent --prompt-file ./PROMPT.md --ide kiro --ide
 | `--name`, `-n` | Agent name (lowercase, hyphens, underscores) |
 | `--version`, `-v` | Version (semver, e.g. 1.0.0) |
 | `--description`, `-d` | Short description |
-| `--owner` | Owner or team name |
 | `--prompt`, `-p` | System prompt text |
 | `--prompt-file` | Read system prompt from a file |
 | `--model`, `-m` | Model name (e.g. claude-sonnet-4) |

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
@@ -148,8 +149,8 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
     user_ids.update(v.released_by for v in seen_agents.values())
     user_map: dict[uuid.UUID, str] = {}
     if user_ids:
-        rows = await db.execute(select(User.id, User.email).where(User.id.in_(user_ids)))
-        user_map = {r[0]: r[1] for r in rows.all()}
+        rows = await db.execute(select(User.id, User.username).where(User.id.in_(user_ids)))
+        user_map = {r[0]: (r[1] or "") for r in rows.all()}
 
     items = []
     for agent_id, pending_ver in seen_agents.items():
@@ -263,7 +264,7 @@ async def _query_pending_components(db: AsyncSession, type_filter: str | None = 
     if user_ids:
         result = await db.execute(select(User).where(User.id.in_(user_ids)))
         for u in result.scalars().all():
-            user_map[u.id] = u.name or u.email
+            user_map[u.id] = u.username or u.email
 
     for item in items:
         uid = item["submitted_by"]
@@ -528,7 +529,7 @@ async def get_review(
         uid = uuid.UUID(uid_str)
         user = (await db.execute(select(User).where(User.id == uid))).scalar_one_or_none()
         if user:
-            result["submitted_by"] = user.name or user.email
+            result["submitted_by"] = user.username or user.email
     except (ValueError, AttributeError):
         pass
     return result
@@ -866,7 +867,7 @@ async def get_related_skills(
     if user_ids:
         rows = await db.execute(select(User).where(User.id.in_(user_ids)))
         for u in rows.scalars().all():
-            user_map[u.id] = u.name or u.email
+            user_map[u.id] = u.username or u.email
 
     result = {
         "skills": [

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
@@ -105,7 +106,6 @@ def agent_create(
     name: str | None = typer.Option(None, "--name", "-n", help="Agent name (lowercase, hyphens, underscores)"),
     version: str | None = typer.Option(None, "--version", "-v", help="Version (semver, e.g. 1.0.0)"),
     description: str | None = typer.Option(None, "--description", "-d", help="Short description"),
-    owner: str | None = typer.Option(None, "--owner", help="Owner / team name"),
     prompt: str | None = typer.Option(None, "--prompt", "-p", help="System prompt text"),
     prompt_file: str | None = typer.Option(None, "--prompt-file", help="Read system prompt from a file"),
     model_name: str | None = typer.Option(None, "--model", "-m", help="Model name (e.g. claude-sonnet-4)"),
@@ -166,14 +166,12 @@ def agent_create(
         # Default model
         _model = model_name or "claude-sonnet-4"
 
-        # Resolve owner from whoami if not provided
-        _owner = owner or ""
-        if not _owner:
-            try:
-                whoami = client.get("/api/v1/auth/whoami")
-                _owner = whoami.get("name") or whoami.get("email", "unknown")
-            except (Exception, SystemExit):
-                _owner = "unknown"
+        # Resolve owner from whoami
+        try:
+            whoami = client.get("/api/v1/auth/whoami")
+            _owner = whoami.get("username") or whoami.get("email", "unknown")
+        except (Exception, SystemExit):
+            _owner = config.load().get("username", "") or "unknown"
 
         payload = {
             "name": _name,
@@ -264,10 +262,10 @@ def agent_create(
     default_owner = ""
     try:
         whoami = client.get("/api/v1/auth/whoami")
-        default_owner = whoami.get("name") or whoami.get("email", "")
+        default_owner = whoami.get("username") or whoami.get("email", "")
     except (Exception, SystemExit):
         pass
-    owner = text_input("  Owner / Team", default=default_owner or "")
+    owner = default_owner or config.load().get("username", "") or "unknown"
     prompt_text = text_input("  System prompt (optional)", default="")
     max_tokens = text_input("  Max tokens", default="4096")
     temperature = text_input("  Temperature", default="0.2")
@@ -797,7 +795,7 @@ def agent_init(
     default_version = "0.1.0" if beta else "1.0.0"
     version = text_input("Version", default=default_version)
     description = text_input("Description")
-    owner = text_input("Owner / Team")
+    owner = config.load().get("username", "") or "unknown"
     model_name = text_input("Model name", default="claude-sonnet-4")
     prompt_text = text_input("System prompt")
 

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
 # SPDX-FileCopyrightText: 2026 Harishankar <harishankar0301@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
@@ -151,6 +152,7 @@ def login(
                 "refresh_token": data["refresh_token"],
                 "user_id": user.get("id", ""),
                 "user_name": user.get("name", ""),
+                "username": user.get("username", ""),
             }
             if endpoints:
                 cfg_data["web_url"] = endpoints.get("web", "")
@@ -495,6 +497,7 @@ def _do_password_login(server_url: str, email: str, password: str):
             "refresh_token": data["refresh_token"],
             "user_id": user.get("id", ""),
             "user_name": user.get("name", ""),
+            "username": user.get("username", ""),
         }
         if endpoints:
             cfg_data["web_url"] = endpoints.get("web", "")
@@ -608,6 +611,7 @@ def _do_device_flow_login(server_url: str):
                     "refresh_token": token_data["refresh_token"],
                     "user_id": user.get("id", ""),
                     "user_name": user.get("name", ""),
+                    "username": user.get("username", ""),
                 }
                 if endpoints:
                     cfg_data["web_url"] = endpoints.get("web", "")

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -93,6 +94,8 @@ def hook_submit(
         except FileNotFoundError:
             rprint(f"[red]File not found:[/red] {from_file}")
             raise typer.Exit(code=1)
+        if not payload.get("owner"):
+            payload["owner"] = config.load().get("username", "")
     else:
         # Read script content if --script provided
         script_content: str | None = None
@@ -109,7 +112,7 @@ def hook_submit(
         name = text_input("Hook name")
         version = text_input("Version", default="1.0.0")
         description = text_input("Description")
-        owner = text_input("Owner", default=config.load().get("user_name", ""))
+        owner = config.load().get("username", "")
         event = select_one("Event", VALID_HOOK_EVENTS)
         handler_type = select_one("Handler type", VALID_HOOK_HANDLER_TYPES)
 

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
@@ -536,15 +537,13 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
                 rprint("[yellow]Description is required.[/yellow]")
                 _desc = text_input("Description (what does this server do?)")
             _desc = _desc.strip()
-            _owner = text_input(
-                "Owner / Team (e.g. your GitHub username)", default=config.load().get("user_name", "default")
-            )
+            _owner = config.load().get("username", "")
             _category = category or select_one("Category", VALID_MCP_CATEGORIES, default="general")
         else:
             if dollar_vars:
                 rprint(f"\n[dim]Auto-detected {len(dollar_vars)} input variable(s) from $VAR patterns.[/dim]")
             _desc = _parsed_desc or _name
-            _owner = config.load().get("user_name", "") or "default"
+            _owner = config.load().get("username", "")
             _category = category or "general"
 
         supported_ides = list(VALID_IDES)
@@ -720,7 +719,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         _name = name or detected_name
         _version = detected_ver
         _desc = detected_desc
-        _owner = config.load().get("user_name", "") or "default"
+        _owner = config.load().get("username", "")
         _category = category or "general"
         if not _framework:
             _framework = "python"
@@ -815,7 +814,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         else:
             _desc = text_input("Description (what does this server do?)")
 
-        _owner = text_input("\nOwner / Team (e.g. your GitHub username)", default=config.load().get("user_name", ""))
+        _owner = config.load().get("username", "")
         rprint()
 
         _category = category or select_one("Category", VALID_MCP_CATEGORIES, default="general")

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
@@ -66,12 +67,14 @@ def prompt_submit(
             content = f.read()
         try:
             payload = _json.loads(content)
+            if not payload.get("owner"):
+                payload["owner"] = config.load().get("username", "")
         except _json.JSONDecodeError:
             payload = {
                 "name": text_input("Prompt name"),
                 "version": text_input("Version", default="1.0.0"),
                 "description": text_input("Description"),
-                "owner": text_input("Owner", default=config.load().get("user_name", "")),
+                "owner": config.load().get("username", ""),
                 "category": select_one("Category", VALID_PROMPT_CATEGORIES),
                 "template": content,
             }
@@ -80,7 +83,7 @@ def prompt_submit(
             "name": text_input("Prompt name"),
             "version": text_input("Version", default="1.0.0"),
             "description": text_input("Description"),
-            "owner": text_input("Owner", default=config.load().get("user_name", "")),
+            "owner": config.load().get("username", ""),
             "category": select_one("Category", VALID_PROMPT_CATEGORIES),
             "template": text_input("Template"),
         }

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
@@ -68,12 +69,14 @@ def sandbox_submit(
         except FileNotFoundError:
             rprint(f"[red]File not found:[/red] {from_file}")
             raise typer.Exit(code=1)
+        if not payload.get("owner"):
+            payload["owner"] = config.load().get("username", "")
     else:
         payload = {
             "name": text_input("Sandbox name"),
             "version": text_input("Version", default="1.0.0"),
             "description": text_input("Description"),
-            "owner": text_input("Owner", default=config.load().get("user_name", "")),
+            "owner": config.load().get("username", ""),
             "runtime_type": select_one("Runtime type", VALID_SANDBOX_RUNTIME_TYPES),
             "image": text_input("Image"),
             "resource_limits": _json.loads(text_input("Resource limits (JSON)")),

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
@@ -172,7 +173,7 @@ def skill_submit(
             "name": text_input("Skill name", default=prefill.get("name", "")),
             "version": text_input("Version", default="1.0.0"),
             "description": text_input("Description", default=prefill.get("description", "")),
-            "owner": text_input("Owner", default=config.load().get("user_name", "")),
+            "owner": config.load().get("username", ""),
             "task_type": select_one("Task type", VALID_SKILL_TASK_TYPES),
             "target_agents": [a.strip() for a in agents_input.split(",") if a.strip()],
             "delivery_mode": effective_delivery_mode,

--- a/observal_cli/skills/observal-agents/SKILL.md
+++ b/observal_cli/skills/observal-agents/SKILL.md
@@ -23,7 +23,7 @@ owner: observal
 
 ## Procedure: Create Agent
 
-Required: `--name`, `--description`, `--prompt`. Optional: `--model` (default: `claude-sonnet-4`), `--ide` (repeatable), `--owner`, `--prompt-file`, `--from-file`.
+Required: `--name`, `--description`, `--prompt`. Optional: `--model` (default: `claude-sonnet-4`), `--ide` (repeatable), `--prompt-file`, `--from-file`.
 
 > **WARNING:** Without `--name` and `--prompt`, the command launches an interactive wizard. Always pass at least `--name`, `--description`, and `--prompt`.
 
@@ -53,7 +53,6 @@ Skips review queue. Overwrites in place.
    name: existing-agent-name
    version: "1.0.0"
    description: "Updated description"
-   owner: "team-name"
    model_name: claude-sonnet-4
    model_config_json: {}
    models_by_ide: {}

--- a/tests/test_cmd_prompt.py
+++ b/tests/test_cmd_prompt.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Nithin <nithin30302@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -22,7 +23,7 @@ runner = CliRunner()
 
 
 def _patch_config_load():
-    return patch("observal_cli.config.load", return_value={"user_name": "testuser"})
+    return patch("observal_cli.config.load", return_value={"user_name": "testuser", "username": "testuser"})
 
 
 def _patch_resolve_alias():
@@ -48,8 +49,8 @@ def _patch_delete(return_value=None):
 class TestPromptSubmit:
     def test_submit_interactive(self):
         """Test prompt submit with interactive inputs, ensuring payload validation (name, category, etc)."""
-        # Inputs: name, version, description, owner, category, template
-        inputs = "my-prompt\n1.0.0\nMy description\ntestowner\ngeneral\nHello {{name}}!\n"
+        # Inputs: name, version, description, category, template
+        inputs = "my-prompt\n1.0.0\nMy description\ngeneral\nHello {{name}}!\n"
         with _patch_config_load(), _patch_post({"id": "prompt-123"}) as mock_post:
             result = runner.invoke(cli_app, ["registry", "prompt", "submit"], input=inputs)
 
@@ -64,13 +65,13 @@ class TestPromptSubmit:
             assert payload["name"] == "my-prompt"
             assert payload["version"] == "1.0.0"
             assert payload["description"] == "My description"
-            assert payload["owner"] == "testowner"
+            assert payload["owner"] == "testuser"
             assert payload["category"] == "general"
             assert payload["template"] == "Hello {{name}}!"
 
     def test_submit_draft(self):
         """Test prompt submit --draft saves a draft."""
-        inputs = "draft-prompt\n1.0.0\nDraft desc\ntestowner\ngeneral\nDraft template\n"
+        inputs = "draft-prompt\n1.0.0\nDraft desc\ngeneral\nDraft template\n"
         with _patch_config_load(), _patch_post({"id": "draft-123"}) as mock_post:
             result = runner.invoke(cli_app, ["registry", "prompt", "submit", "--draft"], input=inputs)
 

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
@@ -729,12 +730,13 @@ def _patch_put(return_value):
 class TestAgentInit:
     def test_creates_yaml_with_correct_fields(self, tmp_path: Path):
         """Interactive prompts produce a valid YAML file."""
-        inputs = "my-agent\n1.0.0\nA cool agent\nmy-team\nclaude-sonnet-4\nDo helpful things\n"
-        result = runner.invoke(
-            cli_app,
-            ["agent", "init", "--dir", str(tmp_path)],
-            input=inputs,
-        )
+        inputs = "my-agent\n1.0.0\nA cool agent\nclaude-sonnet-4\nDo helpful things\n"
+        with patch("observal_cli.config.load", return_value={"username": "my-team"}):
+            result = runner.invoke(
+                cli_app,
+                ["agent", "init", "--dir", str(tmp_path)],
+                input=inputs,
+            )
         assert result.exit_code == 0, result.output
         assert "Created" in result.output
 

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 // SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
@@ -125,7 +126,6 @@ export function SubmitComponentDialog({
 	const { data: ideList } = useIdes();
 	const defaultOwner =
 		(d?.owner as string) ||
-		whoami?.name ||
 		whoami?.username ||
 		whoami?.email ||
 		"";
@@ -136,8 +136,7 @@ export function SubmitComponentDialog({
 	const [description, setDescription] = useState(
 		(d?.description as string) ?? "",
 	);
-	const [ownerInput, setOwnerInput] = useState((d?.owner as string) ?? "");
-	const owner = ownerInput || defaultOwner;
+	const owner = defaultOwner;
 	const [supportedIdes, setSupportedIdes] = useState<string[]>(
 		Array.isArray(d?.supported_ides) ? (d.supported_ides as string[]) : [],
 	);
@@ -352,7 +351,6 @@ export function SubmitComponentDialog({
 		setName("");
 		setVersion("0.1.0");
 		setDescription("");
-		setOwnerInput("");
 		setSupportedIdes([]);
 		setMcpMode("json");
 		setJsonInput("");
@@ -599,16 +597,6 @@ export function SubmitComponentDialog({
 								placeholder="0.1.0"
 							/>
 						</div>
-					</div>
-
-					<div className="space-y-1.5">
-						<Label htmlFor="comp-owner">Owner</Label>
-						<Input
-							id="comp-owner"
-							value={owner}
-							onChange={(e) => setOwnerInput(e.target.value)}
-							placeholder="your-username"
-						/>
 					</div>
 
 					<div className="space-y-1.5">

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2026 Hemalatha Madeswaran <hemalathamadeswaran@gmail.com>
 // SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
 // SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
 // SPDX-FileCopyrightText: 2026 Harishankar <harishankar0301@gmail.com>
@@ -698,7 +699,7 @@ function AgentBuilderInner() {
       version: (versionOverride ?? version).trim() || "1.0.0",
       description: description.trim(),
       category: category || undefined,
-      owner: whoami?.name || whoami?.email || "unknown",
+      owner: whoami?.username || whoami?.email || "unknown",
       prompt: systemPrompt.trim(),
       model_name: modelName,
       models_by_ide: modelsByIde,


### PR DESCRIPTION
## Purpose / Description
Remove the ability for users to manually enter a custom owner name when submitting components or agents. Owner is now always auto-filled from the logged-in user's username.

## Fixes
* Fixes the issue where users could type any arbitrary name in the Owner field

## Approach
- **CLI**: Removed `--owner` flag from `agent create`. Replaced all `text_input("Owner"...)` prompts with `config.load().get("username")`. For `--from-file` paths, auto-injects owner if missing from the JSON.
- **Frontend**: Removed the Owner input field from `submit-component-dialog.tsx`. Uses `whoami.username` silently. Same fix in `builder.tsx`.
- **Server**: Updated `review.py` to display `user.username` instead of `user.name`/`user.email` in the review queue and detail endpoints.
- **Auth**: Store `username` in CLI config during login so it's available for auto-fill.
- **Docs/Skills**: Removed `--owner` from `docs/cli/agent.md` and `observal-agents/SKILL.md`.

No DB or schema changes. The `owner` column value is still written — just sourced from the authenticated username instead of user input.

## How Has This Been Tested?

1. Submitted a hook, prompt, sandbox, and agent via CLI — all show `Owner: super`
2. Verified `--from-file` without owner field auto-fills correctly
3. Verified `observal admin review show` displays `Submitted By: super`
4. Ran `ruff check` on all modified Python files — all passed
5. Frontend builds without TypeScript errors
6. Sub-agent regression check confirmed no broken imports, unused vars, or stale references

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)