### PR TITLE
feat(web): add three-state empty illustrations to traces page

### DIFF
--- a/web/src/components/shared/empty-state.tsx
+++ b/web/src/components/shared/empty-state.tsx
@@ -33,7 +33,12 @@ export function EmptyState({
       )}
       {actionLabel && (actionHref || onAction) && (
         actionHref ? (
-          <a href={actionHref}>
+          <a
+            href={actionHref}
+            {...(actionHref.startsWith("http")
+              ? { target: "_blank", rel: "noopener noreferrer" }
+              : {})}
+          >
             <Button variant="outline" size="sm" className="mt-4">
               {actionLabel}
             </Button>

--- a/web/src/pages/user/traces/index.tsx
+++ b/web/src/pages/user/traces/index.tsx
@@ -16,6 +16,7 @@ import {
 	ArrowUp,
 	ArrowDown,
 	BarChart3,
+	SlidersHorizontal,
 } from "lucide-react";
 import {
 	useSessions2,
@@ -44,6 +45,14 @@ import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import type { Session } from "@/lib/types";
+
+/** Quickstart docs URL shown in the first-time empty state CTA. */
+const DOCS_QUICKSTART_URL =
+	"https://github.com/BlazeUp-AI/Observal/blob/main/docs/getting-started/quickstart.md";
+
+function truncateQuery(q: string, max = 50): string {
+	return q.length > max ? `${q.slice(0, max)}…` : q;
+}
 
 // ── Search query parser (Discord-style: platform:kiro user:"John Doe") ───────
 
@@ -74,6 +83,103 @@ function parseSearchQuery(query: string): { text: string; filters: Record<string
 	// Remaining text after removing filter tokens
 	const text = query.replace(/(\w+):(?:"[^"]*"|[^\s]*)/g, "").trim();
 	return { text, filters };
+}
+
+function filterTokensOnly(query: string): string {
+	const tokens = query.match(/(\w+):(?:"[^"]*"|[^\s]*)/g);
+	return tokens ? tokens.join(" ").trim() : "";
+}
+
+type TracesEmptyStateKind = "first-time" | "filter" | "search" | "fallback";
+
+function applyParameterFilters(
+	sessions: Session[],
+	filters: Record<string, string>,
+): Session[] {
+	let result = sessions;
+
+	if (filters.platform) {
+		const p = filters.platform.toLowerCase();
+		result = result.filter(
+			(s) =>
+				(s.service_name ?? "").toLowerCase().includes(p) ||
+				(s.platform ?? "").toLowerCase().includes(p),
+		);
+	}
+	if (filters.user) {
+		const u = filters.user.toLowerCase();
+		result = result.filter((s) =>
+			(s.user_name ?? "").toLowerCase().includes(u),
+		);
+	}
+	if (filters.agent) {
+		const a = filters.agent.toLowerCase();
+		result = result.filter((s) =>
+			(s.agent_name ?? "").toLowerCase().includes(a),
+		);
+	}
+	if (filters.model) {
+		const m = filters.model.toLowerCase();
+		result = result.filter((s) =>
+			(s.model ?? "").toLowerCase().includes(m),
+		);
+	}
+	if (filters.days) {
+		const d = parseInt(filters.days, 10);
+		if (!isNaN(d) && d > 0) {
+			const cutoff = Date.now() - d * 86_400_000;
+			result = result.filter((s) =>
+				s.first_event_time && toDate(s.first_event_time).getTime() >= cutoff,
+			);
+		}
+	}
+	if (filters.status) {
+		const st = filters.status.toLowerCase();
+		if (st === "active") result = result.filter((s) => s.is_active);
+		else if (st === "inactive") result = result.filter((s) => !s.is_active);
+	}
+
+	return result;
+}
+
+function applyTextFilter(sessions: Session[], text: string): Session[] {
+	if (!text) return sessions;
+	const lower = text.toLowerCase();
+	return sessions.filter(
+		(s) =>
+			(s.session_id ?? "").toLowerCase().includes(lower) ||
+			(s.user_name ?? "").toLowerCase().includes(lower) ||
+			(s.agent_name ?? "").toLowerCase().includes(lower) ||
+			(s.model ?? "").toLowerCase().includes(lower) ||
+			(s.platform ?? "").toLowerCase().includes(lower),
+	);
+}
+
+function getTracesEmptyStateKind(
+	sessions: Session[],
+	query: string,
+): TracesEmptyStateKind {
+	const { text, filters } = parseSearchQuery(query);
+	const hasFilters = Object.keys(filters).length > 0;
+	const hasText = text.length > 0;
+
+	if (sessions.length === 0) {
+		if (hasText) return "search";
+		if (hasFilters) return "filter";
+		return "first-time";
+	}
+
+	if (hasFilters) {
+		const afterFilters = applyParameterFilters(sessions, filters);
+		if (afterFilters.length === 0) return "filter";
+		if (hasText && applyTextFilter(afterFilters, text).length === 0) {
+			return "search";
+		}
+		return "fallback";
+	}
+
+	if (hasText && applyTextFilter(sessions, text).length === 0) return "search";
+	return "fallback";
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -363,68 +469,33 @@ export default function TracesPage() {
 		[updateURL],
 	);
 
+	const clearSearch = useCallback(() => {
+		const remaining = filterTokensOnly(globalFilter);
+		clearTimeout(debounceRef.current);
+		setSearchValue(remaining);
+		setGlobalFilter(remaining);
+		updateURL(remaining);
+	}, [globalFilter, updateURL]);
+
+	const clearFilters = useCallback(() => {
+		const { text } = parseSearchQuery(globalFilter);
+		clearTimeout(debounceRef.current);
+		setSearchValue(text);
+		setGlobalFilter(text);
+		updateURL(text);
+	}, [globalFilter, updateURL]);
+
 	const allSessions = useMemo(() => (sessions ?? []) as Session[], [sessions]);
 
-	// Apply parameterized filters from search query
+	const parsedQuery = useMemo(() => parseSearchQuery(globalFilter), [globalFilter]);
+	const emptyStateKind = useMemo(
+		() => getTracesEmptyStateKind(allSessions, globalFilter),
+		[allSessions, globalFilter],
+	);
+
 	const filteredSessions = useMemo(() => {
 		const { text, filters } = parseSearchQuery(globalFilter);
-		let result = allSessions;
-
-		if (filters.platform) {
-			const p = filters.platform.toLowerCase();
-			result = result.filter(
-				(s) =>
-					(s.service_name ?? "").toLowerCase().includes(p) ||
-					(s.platform ?? "").toLowerCase().includes(p),
-			);
-		}
-		if (filters.user) {
-			const u = filters.user.toLowerCase();
-			result = result.filter((s) =>
-				(s.user_name ?? "").toLowerCase().includes(u),
-			);
-		}
-		if (filters.agent) {
-			const a = filters.agent.toLowerCase();
-			result = result.filter((s) =>
-				(s.agent_name ?? "").toLowerCase().includes(a),
-			);
-		}
-		if (filters.model) {
-			const m = filters.model.toLowerCase();
-			result = result.filter((s) =>
-				(s.model ?? "").toLowerCase().includes(m),
-			);
-		}
-		if (filters.days) {
-			const d = parseInt(filters.days, 10);
-			if (!isNaN(d) && d > 0) {
-				const cutoff = Date.now() - d * 86_400_000;
-				result = result.filter((s) =>
-					s.first_event_time && toDate(s.first_event_time).getTime() >= cutoff,
-				);
-			}
-		}
-		if (filters.status) {
-			const st = filters.status.toLowerCase();
-			if (st === "active") result = result.filter((s) => s.is_active);
-			else if (st === "inactive") result = result.filter((s) => !s.is_active);
-		}
-
-		// Free text search on session label / user / model
-		if (text) {
-			const lower = text.toLowerCase();
-			result = result.filter(
-				(s) =>
-					(s.session_id ?? "").toLowerCase().includes(lower) ||
-					(s.user_name ?? "").toLowerCase().includes(lower) ||
-					(s.agent_name ?? "").toLowerCase().includes(lower) ||
-					(s.model ?? "").toLowerCase().includes(lower) ||
-					(s.platform ?? "").toLowerCase().includes(lower),
-			);
-		}
-
-		return result;
+		return applyTextFilter(applyParameterFilters(allSessions, filters), text);
 	}, [allSessions, globalFilter]);
 
 	const data = useMemo(
@@ -443,6 +514,49 @@ export default function TracesPage() {
 
 	const todaySessions = summary?.today_sessions ?? allSessions.length;
 
+	const tracesEmptyState = (() => {
+		switch (emptyStateKind) {
+			case "search":
+				return (
+					<EmptyState
+						icon={Search}
+						title="No traces match your search"
+						description={`No traces found for "${truncateQuery(parsedQuery.text)}". Try a different search term.`}
+						actionLabel="Clear search"
+						onAction={clearSearch}
+					/>
+				);
+			case "filter":
+				return (
+					<EmptyState
+						icon={SlidersHorizontal}
+						title="No results for this filter"
+						description="No traces match the selected filters. Try adjusting your filter criteria or clear all filters."
+						actionLabel="Clear filters"
+						onAction={clearFilters}
+					/>
+				);
+			case "first-time":
+				return (
+					<EmptyState
+						icon={Activity}
+						title="No traces yet"
+						description="Traces are created automatically when tools are invoked through Observal. Connect an IDE to start collecting traces."
+						actionLabel="Connect your first IDE"
+						actionHref={DOCS_QUICKSTART_URL}
+					/>
+				);
+			default:
+				return (
+					<EmptyState
+						icon={Activity}
+						title="No matching sessions"
+						description="No sessions match the current view."
+					/>
+				);
+		}
+	})();
+
 	return (
 		<>
 			<PageHeader
@@ -458,11 +572,7 @@ export default function TracesPage() {
 				) : isError ? (
 					<ErrorState message={error?.message} onRetry={() => refetch()} />
 				) : allSessions.length === 0 ? (
-					<EmptyState
-						icon={Activity}
-						title="No sessions yet"
-						description="Sessions will appear here once telemetry data is collected from your IDE."
-					/>
+					tracesEmptyState
 				) : (
 					<div className="animate-in space-y-5">
 						{/* ── Summary ── */}
@@ -533,12 +643,9 @@ export default function TracesPage() {
 								</TableHeader>
 								<TableBody>
 									{table.getRowModel().rows.length === 0 ? (
-										<TableRow>
-											<TableCell
-												colSpan={columns.length}
-												className="h-32 text-center text-sm text-muted-foreground"
-											>
-												No matching sessions.
+										<TableRow className="hover:bg-transparent">
+											<TableCell colSpan={columns.length} className="p-0">
+												{tracesEmptyState}
 											</TableCell>
 										</TableRow>
 									) : (


### PR DESCRIPTION
## Purpose / Description
The traces page showed a blank or minimal empty state when no sessions existed or when filters/search returned zero results. This adds contextual empty-state UI so users understand why the list is empty and what to do next.

## Fixes
* Fixes #871

## Approach
- Extended the traces page (`web/src/pages/user/traces/index.tsx`) to render `EmptyState` in three cases:
  - **No traces yet** — first-time user with no sessions; includes "Connect your first IDE" CTA linking to the quickstart docs
  - **No results for this filter** — parameterized filters (`platform:`, `user:`, etc.) match nothing; includes "Clear filters"
  - **No traces match your search** — free-text search matches nothing; includes "Clear search"
- Added `getTracesEmptyStateKind()` to distinguish filter vs search when both are present (e.g. `platform:kiro John` shows filter state when the platform filter caused zero results, not search)
- Replaced inline "No matching sessions." table text with the shared `EmptyState` component
- Updated `EmptyState` to open external `http` links in a new tab with `rel="noopener noreferrer"`

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Self-reviewed code for the three empty-state branches
- [x] Verified IDE linter reports no errors on changed files
- [x] Manual verification (recommended):
  1. Fresh/empty traces list → "No traces yet" + quickstart CTA opens in new tab
  2. With sessions present, search `platform:nonexistent` → "No results for this filter" + Clear filters works
  3. With sessions present, type `zzzznonexistent` → "No traces match your search" + Clear search works
  4. Toggle light/dark mode on all three states

```bash
cd web
pnpm install
pnpm run typecheck
pnpm run lint
```

<img width="1600" height="653" alt="image" src="https://github.com/user-attachments/assets/10695d0d-fc1b-4429-94b1-f68260298ee7" />
<img width="1600" height="917" alt="image" src="https://github.com/user-attachments/assets/15e45f94-54eb-4252-adf9-b3ca44bfe37c" />
<img width="1600" height="962" alt="image" src="https://github.com/user-attachments/assets/db223f4b-c302-4e38-af32-e8d11e808b67" />

## Learning (optional, can help others)
The traces page uses a Discord-style search bar with embedded filter tokens (`platform:kiro user:name`). Empty-state detection applies filters and free text in stages so mixed queries show the correct state and CTA.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Cursor
- [x] Was the generated code manually reviewed and tested?
