### PR TITLE
docs: update code of conduct redirect file path in development guide

### DIFF
--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -71,7 +71,7 @@ We are a small, active community and we take the quality of interactions serious
 >
 > - Pinging contributors, maintainers, or reviewers unnecessarily (outside of a direct reply on your own open PR or issue)
 > - Submitting low-effort or unreviewed PRs (slop), including unreviewed AI output or autonomous agent submissions
-> - Violating the [Code of Conduct](../../CODE_OF_CONDUCT.md) in any channel
+> - Violating the [Code of Conduct](../CODE_OF_CONDUCT.md) in any channel
 > - Harassing reviewers over merge timelines
 
 Maintainers volunteer their time. Treat them accordingly.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Updated the broken `CODE_OF_CONDUCT.md` reference in `DEVELOPMENT_GUIDE.md`

## Fixes
* Fixes #1402

## Approach
Replaced the incorrect path reference with the correct reference to `CODE_OF_CONDUCT.md`

## How Has This Been Tested?

- Open `DEVELOPMENT_GUIDE.md`
- Navigate the code of conduct reference (around line 74) under the community guidelines section
- Verify the link that correctly redirects to `CODE_OF_CONDUCT.md`