### PR TITLE
fix: align action buttons and department cell in Admin Users table

### DIFF
--- a/web/src/pages/admin/users.tsx
+++ b/web/src/pages/admin/users.tsx
@@ -5,7 +5,6 @@
 // SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-
 import { useState, useCallback } from "react";
 import { Users, Plus, Copy, Check, Loader2, Key, Trash2, RotateCcw } from "lucide-react";
 import { toast } from "sonner";
@@ -74,7 +73,7 @@ function DepartmentInput({ userId, currentDept }: { userId: string; currentDept:
     return (
       <button
         onClick={() => setEditing(true)}
-        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        className="flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors min-h-[28px]"
         title="Click to set department"
       >
         {currentDept || "—"}
@@ -223,7 +222,7 @@ export default function UsersPage() {
                     <TableHead className="h-8 text-xs">Role</TableHead>
                     <TableHead className="h-8 text-xs">Department</TableHead>
                     <TableHead className="h-8 text-xs text-right">Joined</TableHead>
-                    <TableHead className="h-8 text-xs w-[60px]" />
+                    <TableHead className="h-8 text-xs w-[80px]" />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -247,26 +246,28 @@ export default function UsersPage() {
                       <TableCell className="py-1.5 text-xs text-muted-foreground text-right tabular-nums">
                         {u.created_at ? new Date(u.created_at).toLocaleDateString() : "-"}
                       </TableCell>
-                      <TableCell className="py-1.5 text-right space-x-1">
-                        {!ssoOnly && (
+                      <TableCell className="py-1.5">
+                        <div className="flex items-center justify-end gap-1">
+                          {!ssoOnly && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                              title="Reset password"
+                              onClick={() => setResetTarget(u)}
+                            >
+                              <RotateCcw className="h-3.5 w-3.5" />
+                            </Button>
+                          )}
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
-                            title="Reset password"
-                            onClick={() => setResetTarget(u)}
+                            className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                            onClick={() => setDeleteTarget(u)}
                           >
-                            <RotateCcw className="h-3.5 w-3.5" />
+                            <Trash2 className="h-3.5 w-3.5" />
                           </Button>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-                          onClick={() => setDeleteTarget(u)}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
                   ))}


### PR DESCRIPTION
## Purpose / Description

Fix alignment inconsistencies in the Admin Users table by improving action button layout and ensuring the Department cell aligns correctly with other row content.

## Fixes

* Fixes #<!-- issue number -->

## Approach

Implemented three targeted UI fixes:

1. Replaced `space-x-1` with `flex items-center justify-end gap-1` in the action buttons column for consistent flexbox-based alignment.
2. Increased the action column width from `w-[60px]` to `w-[80px]` to prevent overflow when both **Reset Password** and **Delete** actions are visible.
3. Added `flex items-center min-h-[28px]` to the `DepartmentInput` trigger button to improve vertical alignment with adjacent table cells.

## How Has This Been Tested?

- Verified action buttons remain properly aligned when:
  - Only the Delete button is shown
  - Both Reset Password and Delete buttons are shown
- Confirmed no button overflow occurs in the action column.
- Checked Department cell alignment across multiple user rows.
- Verified visual consistency with surrounding table content.

## Learning (optional)

- Flexbox alignment (`items-center`, `justify-end`, `gap-*`) provides more predictable spacing and alignment than `space-x-*` for conditional UI elements.
- Applying a minimum height to interactive elements helps maintain consistent row alignment in dense tables.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens.

## AI Assistance

- [x] Yes (ChatGPT)
- [x] Was the generated code manually reviewed and tested?
