### PR TITLE
fix(ide): standardize skill paths to Agent Skills spec for all IDEs

### DIFF
--- a/observal-server/schemas/ide_registry.py
+++ b/observal-server/schemas/ide_registry.py
@@ -36,10 +36,10 @@ IDE_REGISTRY: dict[str, dict] = {
         },
         "mcp_servers_key": "mcpServers",
         "skill_file": {
-            "project": ".cursor/rules/{name}.mdc",
-            "user": "~/.cursor/rules/{name}.mdc",
+            "project": ".cursor/skills/{name}/SKILL.md",
+            "user": "~/.cursor/skills/{name}/SKILL.md",
         },
-        "skill_format": "markdown_frontmatter",
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.cursor/mcp.json",
         "hook_type": "command",
         "hook_config_path": {
@@ -78,6 +78,7 @@ IDE_REGISTRY: dict[str, dict] = {
         "mcp_servers_key": "mcpServers",
         "skill_file": {
             "project": ".kiro/skills/{name}/SKILL.md",
+            "user": "~/.kiro/skills/{name}/SKILL.md",
         },
         "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.kiro/settings/mcp.json",
@@ -154,8 +155,10 @@ IDE_REGISTRY: dict[str, dict] = {
             "user": "~/.codex/config.toml",
         },
         "mcp_servers_key": "mcp.servers",
-        "skill_file": None,
-        "skill_format": None,
+        "skill_file": {
+            "user": "~/.codex/skills/{name}/SKILL.md",
+        },
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.codex/config.toml",
         "hook_type": "command",
         "hook_config_path": {
@@ -189,8 +192,9 @@ IDE_REGISTRY: dict[str, dict] = {
         "mcp_servers_key": "servers",
         "skill_file": {
             "project": ".github/skills/{name}/SKILL.md",
+            "user": "~/.copilot/skills/{name}/SKILL.md",
         },
-        "skill_format": "markdown",
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.vscode/mcp.json",
         "hook_type": "command",
         "hook_config_path": {
@@ -228,7 +232,7 @@ IDE_REGISTRY: dict[str, dict] = {
             "project": ".agents/skills/{name}/SKILL.md",
             "user": "~/.copilot/skills/{name}/SKILL.md",
         },
-        "skill_format": "markdown",
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.copilot/mcp-config.json",
         "hook_type": "command",
         "hook_config_path": {
@@ -306,9 +310,9 @@ IDE_REGISTRY: dict[str, dict] = {
         "mcp_servers_key": "mcpServers",
         "skill_file": {
             "project": ".agents/skills/{name}/SKILL.md",
-            "user": "~/.gemini/antigravity-cli/skills/{name}/SKILL.md",
+            "user": "~/.gemini/config/skills/{name}/SKILL.md",
         },
-        "skill_format": "markdown",
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.gemini/antigravity-cli/mcp_config.json",
         "hook_type": "command",
         "hook_config_path": {

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -499,6 +499,9 @@ def _generate_codex(manifest: AgentManifest) -> IdeAgentConfig:
         ),
     ]
 
+    skill_files = _build_skill_files(manifest, "codex")
+    files.extend(skill_files)
+
     saved_model = _saved_model_for(manifest, "codex")
     if saved_model:
         toml_lines: list[str] = [f'model = "{saved_model}"', ""]
@@ -529,6 +532,9 @@ def _generate_copilot(manifest: AgentManifest) -> IdeAgentConfig:
             format="markdown",
         ),
     ]
+
+    skill_files = _build_skill_files(manifest, "copilot")
+    files.extend(skill_files)
 
     if mcp_entries:
         copilot_mcp_entries = {}

--- a/observal_cli/ide_registry.py
+++ b/observal_cli/ide_registry.py
@@ -31,10 +31,10 @@ IDE_REGISTRY: dict[str, dict] = {
         },
         "mcp_servers_key": "mcpServers",
         "skill_file": {
-            "project": ".cursor/rules/{name}.mdc",
-            "user": "~/.cursor/rules/{name}.mdc",
+            "project": ".cursor/skills/{name}/SKILL.md",
+            "user": "~/.cursor/skills/{name}/SKILL.md",
         },
-        "skill_format": "markdown_frontmatter",
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.cursor/mcp.json",
         "hook_type": "command",
         "hook_config_path": {
@@ -73,6 +73,7 @@ IDE_REGISTRY: dict[str, dict] = {
         "mcp_servers_key": "mcpServers",
         "skill_file": {
             "project": ".kiro/skills/{name}/SKILL.md",
+            "user": "~/.kiro/skills/{name}/SKILL.md",
         },
         "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.kiro/settings/mcp.json",
@@ -149,8 +150,10 @@ IDE_REGISTRY: dict[str, dict] = {
             "user": "~/.codex/config.toml",
         },
         "mcp_servers_key": "mcp.servers",
-        "skill_file": None,
-        "skill_format": None,
+        "skill_file": {
+            "user": "~/.codex/skills/{name}/SKILL.md",
+        },
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.codex/config.toml",
         "hook_type": "command",
         "hook_config_path": {
@@ -184,8 +187,9 @@ IDE_REGISTRY: dict[str, dict] = {
         "mcp_servers_key": "servers",
         "skill_file": {
             "project": ".github/skills/{name}/SKILL.md",
+            "user": "~/.copilot/skills/{name}/SKILL.md",
         },
-        "skill_format": "markdown",
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.vscode/mcp.json",
         "hook_type": "command",
         "hook_config_path": {
@@ -223,7 +227,7 @@ IDE_REGISTRY: dict[str, dict] = {
             "project": ".agents/skills/{name}/SKILL.md",
             "user": "~/.copilot/skills/{name}/SKILL.md",
         },
-        "skill_format": "markdown",
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.copilot/mcp-config.json",
         "hook_type": "command",
         "hook_config_path": {
@@ -301,9 +305,9 @@ IDE_REGISTRY: dict[str, dict] = {
         "mcp_servers_key": "mcpServers",
         "skill_file": {
             "project": ".agents/skills/{name}/SKILL.md",
-            "user": "~/.gemini/antigravity-cli/skills/{name}/SKILL.md",
+            "user": "~/.gemini/config/skills/{name}/SKILL.md",
         },
-        "skill_format": "markdown",
+        "skill_format": "yaml_frontmatter",
         "home_mcp_config": "~/.gemini/antigravity-cli/mcp_config.json",
         "hook_type": "command",
         "hook_config_path": {

--- a/observal_cli/skill_installer.py
+++ b/observal_cli/skill_installer.py
@@ -41,18 +41,11 @@ def install_observal_skill():
 
     installed: list[str] = []
 
-    # Additional user-scope skill paths not formally in the registry but known to work.
-    # Kiro supports ~/.kiro/skills/<name>/SKILL.md at user scope even though the
-    # registry only documents the project-scope path.
-    _extra_user_paths: dict[str, str] = {
-        "kiro": "~/.kiro/skills/{name}/SKILL.md",
-    }
-
-    for ide, spec in IDE_REGISTRY.items():
+    for _ide, spec in IDE_REGISTRY.items():
         skill_file_spec = spec.get("skill_file") or {}
 
         # Install to user scope (global)
-        user_path = skill_file_spec.get("user") or _extra_user_paths.get(ide)
+        user_path = skill_file_spec.get("user")
         if not user_path:
             continue
 

--- a/tests/test_agent_builder_skills.py
+++ b/tests/test_agent_builder_skills.py
@@ -84,17 +84,17 @@ class TestBuildSkillFilesFallbackPath:
         assert "name: code-review" in content
         assert "command: /review" in content
 
-    def test_cursor_fallback_has_mdc_format(self):
+    def test_cursor_fallback_has_yaml_frontmatter(self):
         manifest = _skill_manifest()
         files = _build_skill_files(manifest, "cursor")
         assert len(files) == 1
-        assert "alwaysApply: false" in files[0].content
+        assert "name: code-review" in files[0].content
 
-    def test_monolithic_ides_return_empty(self):
-        """Only IDEs with no skill_file entry in IDE_REGISTRY return empty."""
+    def test_all_ides_produce_skill_files(self):
+        """All IDEs have skill_file entries and produce output."""
         manifest = _skill_manifest(skill_md_content=VERBATIM_MD)
-        # codex has no skill_file in IDE_REGISTRY.
-        assert _build_skill_files(manifest, "codex") == []
+        for ide in ("codex", "copilot", "cursor", "claude-code", "kiro"):
+            assert _build_skill_files(manifest, ide) != [], f"{ide} should produce skill files"
 
 
 class TestSkillFilePaths:
@@ -103,7 +103,7 @@ class TestSkillFilePaths:
         [
             ("claude-code", ".claude/skills/"),
             ("kiro", ".kiro/skills/"),
-            ("cursor", ".cursor/rules/"),
+            ("cursor", ".cursor/skills/"),
         ],
     )
     def test_skill_file_path(self, ide: str, expected_prefix: str):
@@ -118,7 +118,7 @@ class TestSkillFilePaths:
 class TestGenerateIdeAgentFilesWithSkills:
     @pytest.mark.parametrize(
         "ide",
-        ["claude-code", "cursor", "kiro", "opencode"],
+        ["claude-code", "cursor", "kiro", "opencode", "codex", "copilot"],
     )
     def test_skill_file_in_ide_output(self, ide: str):
         manifest = _skill_manifest(skill_md_content=VERBATIM_MD)
@@ -126,15 +126,3 @@ class TestGenerateIdeAgentFilesWithSkills:
         # The verbatim content uniquely identifies the skill file regardless of path.
         skill_files = [f for f in config.files if f.content == VERBATIM_MD]
         assert len(skill_files) == 1
-
-    @pytest.mark.parametrize(
-        "ide",
-        ["codex", "copilot"],
-    )
-    def test_no_skill_file_in_monolithic_ides(self, ide: str):
-        manifest = _skill_manifest(skill_md_content=VERBATIM_MD)
-        config = generate_ide_agent_files(manifest, ide)
-        skill_files = [
-            f for f in config.files if "SKILL.md" in f.path or "rules/" in f.path or "instructions/" in f.path
-        ]
-        assert len(skill_files) == 0

--- a/tests/test_skill_config_generator.py
+++ b/tests/test_skill_config_generator.py
@@ -86,18 +86,20 @@ class TestGenerateSkillFile:
     def test_cursor_project_scope(self):
         listing = _make_skill_listing()
         result = _generate_skill_file(listing, "cursor", scope="project")
-        assert result["path"] == ".cursor/rules/code-review.mdc"
-        assert _frontmatter(result["content"])["alwaysApply"] is False
-        assert "# code-review" in result["content"]
+        assert result["path"] == ".cursor/skills/code-review/SKILL.md"
+        fm = _frontmatter(result["content"])
+        assert fm["name"] == "code-review"
 
     def test_cursor_user_scope(self):
         listing = _make_skill_listing()
         result = _generate_skill_file(listing, "cursor", scope="user")
-        assert result["path"] == "~/.cursor/rules/code-review.mdc"
+        assert result["path"] == "~/.cursor/skills/code-review/SKILL.md"
 
-    def test_monolithic_ide_returns_none(self):
+    def test_codex_generates_skill_file(self):
         listing = _make_skill_listing()
-        assert _generate_skill_file(listing, "codex") is None
+        result = _generate_skill_file(listing, "codex")
+        assert result is not None
+        assert result["path"] == "~/.codex/skills/code-review/SKILL.md"
 
     def test_no_slash_command(self):
         listing = _make_skill_listing(slash_command=None)
@@ -161,10 +163,11 @@ class TestGenerateSkillConfig:
         assert "skill_file" in config
         assert config["skill_file"]["path"] == ".kiro/skills/code-review/SKILL.md"
 
-    def test_no_skill_file_for_codex(self):
+    def test_skill_file_for_codex(self):
         listing = _make_skill_listing()
         config = generate_skill_config(listing, "codex")
-        assert "skill_file" not in config
+        assert "skill_file" in config
+        assert config["skill_file"]["path"] == "~/.codex/skills/code-review/SKILL.md"
 
     def test_scope_user(self):
         listing = _make_skill_listing()


### PR DESCRIPTION
## Purpose / Description
The bundled Observal skills were not being injected to all 9 IDEs on login. Codex and Copilot (VS Code) were completely missing user-scope skill paths, Cursor was using the legacy .mdc rules format instead of the universal Agent Skills spec, Antigravity pointed to the runtime directory instead of the config directory, and several IDEs had incorrect skill_format values.

## Fixes
* Fixes skill injection for Codex, Copilot, Cursor, Kiro, and Antigravity

## Approach
The Agent Skills specification (https://agentskills.io/specification) defines a universal format: YAML frontmatter in a SKILL.md file inside a named directory. All IDEs that support skills use this same format.

This PR:
- Adds user-scope skill paths for Codex (`~/.codex/skills/{name}/SKILL.md`) and Copilot (`~/.copilot/skills/{name}/SKILL.md`)
- Fixes Cursor from `.cursor/rules/{name}.mdc` to `.cursor/skills/{name}/SKILL.md`
- Adds user-scope path for Kiro (`~/.kiro/skills/{name}/SKILL.md`)
- Fixes Antigravity from `~/.gemini/antigravity-cli/skills/` to `~/.gemini/config/skills/` (user config dir per official docs)
- Normalizes all `skill_format` values to `yaml_frontmatter`
- Removes the `_extra_user_paths` hack from `skill_installer.py` (Kiro now has a proper registry entry)
- Applies the same fixes to both CLI and server-side registries

## How Has This Been Tested?

- `pytest tests/test_observal_skill.py tests/test_ide_registry.py`: 70 tests pass
- Verified all 9 IDEs resolve correct user-scope paths via the registry
- Confirmed skill_installer.py iterates all IDEs without special-casing

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes (Pi coding agent)
- [x] Was the generated code manually reviewed and tested?