### PR TITLE
fix: admin users page layout is misaligned  #1407

### DIFF
--- a/web/src/pages/admin/users.tsx
+++ b/web/src/pages/admin/users.tsx
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 // SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 // SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+// SPDX-FileCopyrightText: 2026 Anupam Kumar <anupam9594.kumar@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
@@ -247,7 +248,8 @@ export default function UsersPage() {
                       <TableCell className="py-1.5 text-xs text-muted-foreground text-right tabular-nums">
                         {u.created_at ? new Date(u.created_at).toLocaleDateString() : "-"}
                       </TableCell>
-                      <TableCell className="py-1.5 text-right space-x-1">
+                      <TableCell className="py-1.5">
+                        <div className="flex items-center justify-end gap-1">
                         {!ssoOnly && (
                           <Button
                             variant="ghost"
@@ -267,6 +269,7 @@ export default function UsersPage() {
                         >
                           <Trash2 className="h-3.5 w-3.5" />
                         </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
                   ))}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Anupam Kumar <anupam9594.kumar@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
The Admin → Users page had layout and alignment issues.
 Elements were visually misaligned and rows had inconsistent spacing and structure.

## Fixes
* Fixes #1407

<img width="1426" height="708" alt="image" src="https://github.com/user-attachments/assets/52d2d156-d10f-448e-8588-a9f5b971df6f" />


## Approach
Removed `text-right space-x-1` from the actions `TableCell` and replaced with a `<div className="flex items-center justify-end gap-1">` wrapper around the buttons for proper alignment and spacing.

## How Has This Been Tested?
1. Log in as admin
2. Navigate to Admin → Users
3. Verified all table rows have consistent height and alignment
4. Verified reset and delete buttons are properly aligned to the right
5. Compared before/after screenshots confirming visual consistency with the rest of the admin UI

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens

## AI Assistance
- [x] No