### PR TITLE
feat(feedback): enforce one review per user with full CRUD and anonymous support

### DIFF
--- a/observal-server/alembic/versions/006_feedback_one_per_user.py
+++ b/observal-server/alembic/versions/006_feedback_one_per_user.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Add unique constraint, anonymous flag, and updated_at to feedback.
+
+Revision ID: 006
+Revises: 005_insight_self_learn
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "006_feedback_one_per_user"
+down_revision = "005_insight_self_learn"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("feedback", sa.Column("anonymous", sa.Boolean(), server_default="false", nullable=False))
+    op.add_column("feedback", sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True))
+    op.create_unique_constraint("uq_feedback_user_listing", "feedback", ["user_id", "listing_id", "listing_type"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_feedback_user_listing", "feedback", type_="unique")
+    op.drop_column("feedback", "updated_at")
+    op.drop_column("feedback", "anonymous")

--- a/observal-server/api/routes/feedback.py
+++ b/observal-server/api/routes/feedback.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import uuid
-from datetime import UTC
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger as optic
@@ -20,34 +20,66 @@ from models.prompt import PromptListing
 from models.sandbox import SandboxListing
 from models.skill import SkillListing
 from models.user import User, UserRole
-from schemas.feedback import FeedbackCreateRequest, FeedbackResponse, FeedbackSummary
+from schemas.feedback import FeedbackCreateRequest, FeedbackResponse, FeedbackSummary, FeedbackUpdateRequest
 from services.clickhouse import insert_scores
 
 router = APIRouter(prefix="/api/v1/feedback", tags=["feedback"])
 
+LISTING_MODELS = {
+    "mcp": McpListing,
+    "agent": Agent,
+    "skill": SkillListing,
+    "hook": HookListing,
+    "prompt": PromptListing,
+    "sandbox": SandboxListing,
+}
 
-@router.post("", response_model=FeedbackResponse)
+
+def _serialize_feedback(fb: Feedback) -> FeedbackResponse:
+    """Serialize feedback, redacting user_id when anonymous."""
+    return FeedbackResponse(
+        id=fb.id,
+        listing_id=fb.listing_id,
+        listing_type=fb.listing_type,
+        user_id=None if fb.anonymous else fb.user_id,
+        rating=fb.rating,
+        comment=fb.comment,
+        anonymous=fb.anonymous,
+        created_at=fb.created_at,
+        updated_at=fb.updated_at,
+    )
+
+
+@router.post("", response_model=FeedbackResponse, status_code=201)
 async def create_feedback(
     req: FeedbackCreateRequest,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
+    """Submit a review. One review per user per listing (returns 409 if already reviewed)."""
+    optic.debug("feedback create: user={}, listing={}", current_user.id, req.listing_id)
+
     # Validate listing exists
-    optic.debug("feedback create")
-    listing_models = {
-        "mcp": McpListing,
-        "agent": Agent,
-        "skill": SkillListing,
-        "hook": HookListing,
-        "prompt": PromptListing,
-        "sandbox": SandboxListing,
-    }
-    model = listing_models.get(req.listing_type)
+    model = LISTING_MODELS.get(req.listing_type)
     if not model:
         raise HTTPException(status_code=400, detail=f"Unknown listing type: {req.listing_type}")
     exists = await db.scalar(select(model.id).where(model.id == req.listing_id))
     if not exists:
         raise HTTPException(status_code=404, detail="Listing not found")
+
+    # Enforce one review per user per listing
+    existing = await db.scalar(
+        select(Feedback.id).where(
+            Feedback.user_id == current_user.id,
+            Feedback.listing_id == req.listing_id,
+            Feedback.listing_type == req.listing_type,
+        )
+    )
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail="You have already reviewed this item. Use PUT to update your review.",
+        )
 
     fb = Feedback(
         listing_id=req.listing_id,
@@ -55,14 +87,13 @@ async def create_feedback(
         user_id=current_user.id,
         rating=req.rating,
         comment=req.comment,
+        anonymous=req.anonymous,
     )
     db.add(fb)
     await db.commit()
     await db.refresh(fb)
 
-    # Dual-write: also insert into ClickHouse scores table
-    from datetime import datetime
-
+    # Dual-write to ClickHouse scores table
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     try:
         await insert_scores(
@@ -78,14 +109,86 @@ async def create_feedback(
                     "data_type": "numeric",
                     "value": float(req.rating),
                     "comment": req.comment,
-                    "metadata": {"listing_type": req.listing_type},
+                    "metadata": {"listing_type": req.listing_type, "anonymous": req.anonymous},
                     "timestamp": now,
                 }
             ]
         )
     except Exception:
-        pass  # Don't fail the request if ClickHouse write fails
-    return FeedbackResponse.model_validate(fb)
+        optic.warning("ClickHouse dual-write failed for feedback id={}", fb.id)
+
+    return _serialize_feedback(fb)
+
+
+@router.get("/mine/{listing_type}/{listing_id}", response_model=FeedbackResponse)
+async def get_my_review(
+    listing_type: str,
+    listing_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Get the current user's review for a specific listing (if it exists)."""
+    if listing_type not in LISTING_MODELS:
+        raise HTTPException(status_code=400, detail=f"Unknown listing type: {listing_type}")
+    result = await db.execute(
+        select(Feedback).where(
+            Feedback.user_id == current_user.id,
+            Feedback.listing_id == listing_id,
+            Feedback.listing_type == listing_type,
+        )
+    )
+    fb = result.scalar_one_or_none()
+    if not fb:
+        raise HTTPException(status_code=404, detail="You have not reviewed this item")
+    return _serialize_feedback(fb)
+
+
+@router.put("/{feedback_id}", response_model=FeedbackResponse)
+async def update_feedback(
+    feedback_id: uuid.UUID,
+    req: FeedbackUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Update the current user's review. Only the review owner can update."""
+    result = await db.execute(select(Feedback).where(Feedback.id == feedback_id))
+    fb = result.scalar_one_or_none()
+    if not fb:
+        raise HTTPException(status_code=404, detail="Review not found")
+    if fb.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="You can only update your own review")
+
+    if req.rating is not None:
+        fb.rating = req.rating
+    if req.comment is not None:
+        fb.comment = req.comment
+    if req.anonymous is not None:
+        fb.anonymous = req.anonymous
+    fb.updated_at = datetime.now(UTC)
+
+    await db.commit()
+    await db.refresh(fb)
+    optic.debug("feedback updated: id={}", feedback_id)
+    return _serialize_feedback(fb)
+
+
+@router.delete("/{feedback_id}", status_code=204)
+async def delete_feedback(
+    feedback_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Delete the current user's review. Only the review owner can delete."""
+    result = await db.execute(select(Feedback).where(Feedback.id == feedback_id))
+    fb = result.scalar_one_or_none()
+    if not fb:
+        raise HTTPException(status_code=404, detail="Review not found")
+    if fb.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="You can only delete your own review")
+
+    await db.delete(fb)
+    await db.commit()
+    optic.debug("feedback deleted: id={}", feedback_id)
 
 
 @router.get("/me", response_model=list[FeedbackResponse])
@@ -124,7 +227,7 @@ async def my_feedback_received(
         select(Feedback).where(Feedback.listing_id.in_(all_ids)).order_by(Feedback.created_at.desc())
     )
     feedbacks = result.scalars().all()
-    return [FeedbackResponse.model_validate(f) for f in feedbacks]
+    return [_serialize_feedback(f) for f in feedbacks]
 
 
 @router.get("/summary/{listing_id}", response_model=FeedbackSummary)
@@ -146,13 +249,13 @@ async def feedback_summary(listing_id: uuid.UUID, db: AsyncSession = Depends(get
 
 @router.get("/{listing_type}/{listing_id}", response_model=list[FeedbackResponse])
 async def get_feedback(listing_type: str, listing_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    """Get all reviews for a listing. Anonymous reviews have user_id redacted."""
     optic.trace("listing_type={}, listing_id={}", listing_type, listing_id)
-    valid_types = {"mcp", "agent", "skill", "hook", "prompt", "sandbox"}
-    if listing_type not in valid_types:
+    if listing_type not in LISTING_MODELS:
         raise HTTPException(status_code=400, detail=f"Unknown listing type: {listing_type}")
     result = await db.execute(
         select(Feedback)
         .where(Feedback.listing_id == listing_id, Feedback.listing_type == listing_type)
         .order_by(Feedback.created_at.desc())
     )
-    return [FeedbackResponse.model_validate(f) for f in result.scalars().all()]
+    return [_serialize_feedback(f) for f in result.scalars().all()]

--- a/observal-server/models/feedback.py
+++ b/observal-server/models/feedback.py
@@ -5,7 +5,7 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Boolean, CheckConstraint, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -16,6 +16,7 @@ class Feedback(Base):
     __tablename__ = "feedback"
     __table_args__ = (
         CheckConstraint("rating >= 1 AND rating <= 5", name="ck_feedback_rating"),
+        UniqueConstraint("user_id", "listing_id", "listing_type", name="uq_feedback_user_listing"),
         Index("ix_feedback_listing", "listing_id", "listing_type"),
         Index("ix_feedback_user", "user_id"),
     )
@@ -26,4 +27,6 @@ class Feedback(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     rating: Mapped[int] = mapped_column(Integer, nullable=False)
     comment: Mapped[str | None] = mapped_column(Text, nullable=True)
+    anonymous: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false", nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/observal-server/schemas/feedback.py
+++ b/observal-server/schemas/feedback.py
@@ -5,7 +5,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class FeedbackCreateRequest(BaseModel):
@@ -13,16 +13,31 @@ class FeedbackCreateRequest(BaseModel):
     listing_type: str = Field(pattern="^(mcp|agent|skill|hook|prompt|sandbox)$")
     rating: int = Field(ge=1, le=5)
     comment: str | None = Field(None, max_length=5000)
+    anonymous: bool = False
+
+
+class FeedbackUpdateRequest(BaseModel):
+    rating: int | None = Field(None, ge=1, le=5)
+    comment: str | None = Field(None, max_length=5000)
+    anonymous: bool | None = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self) -> "FeedbackUpdateRequest":
+        if self.rating is None and self.comment is None and self.anonymous is None:
+            raise ValueError("At least one of rating, comment, or anonymous must be provided")
+        return self
 
 
 class FeedbackResponse(BaseModel):
     id: uuid.UUID
     listing_id: uuid.UUID
     listing_type: str
-    user_id: uuid.UUID
+    user_id: uuid.UUID | None  # None when anonymous
     rating: int
     comment: str | None
+    anonymous: bool
     created_at: datetime
+    updated_at: datetime | None = None
     model_config = {"from_attributes": True}
 
 

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -483,39 +483,28 @@ def _top_impl(item_type, output):
 def _rate(
     listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
     stars: int = typer.Option(..., "--stars", "-s", min=1, max=5, help="Rating 1-5"),
-    listing_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
+    listing_type: str = typer.Option("mcp", "--type", "-t", help="mcp, agent, skill, hook, prompt, or sandbox"),
     comment: str | None = typer.Option(None, "--comment", "-c"),
+    anonymous: bool = typer.Option(False, "--anonymous", "-a", help="Submit anonymously"),
 ):
-    """Rate an MCP server or agent.
+    """Rate an MCP server, agent, or component.
 
-    Submits a 1-5 star rating (with optional comment) for the specified
-    item. Ratings are dual-written to PostgreSQL and ClickHouse.
+    Submits a 1-5 star review. Each user can only submit one review per
+    item. Use `observal ops rate-update` to change it later.
 
     Examples:
 
         observal ops rate my-mcp --stars 5
 
         observal ops rate my-agent --type agent -s 4 -c "Great tool usage"
+
+        observal ops rate my-mcp --stars 5 --anonymous
     """
-    _rate_impl(listing_id, stars, listing_type, comment)
+    _rate_impl(listing_id, stars, listing_type, comment, anonymous)
 
 
-def _rate_impl(listing_id, stars, listing_type, comment):
-    resolved = config.resolve_alias(listing_id)
-    # Resolve name to UUID if not already a UUID
-    try:
-        import uuid as _uuid
-
-        _uuid.UUID(resolved)
-    except ValueError:
-        # Not a UUID, resolve via server show endpoint (handles name lookup)
-        endpoint = "/api/v1/agents" if listing_type == "agent" else f"/api/v1/{listing_type}s"
-        try:
-            item = client.get(f"{endpoint}/{resolved}")
-            resolved = item["id"]
-        except Exception:
-            rprint(f"[red]Could not find {listing_type} named '{resolved}'[/red]")
-            raise typer.Exit(1)
+def _rate_impl(listing_id, stars, listing_type, comment, anonymous=False):
+    resolved = _resolve_listing_id(listing_id, listing_type)
     with spinner("Submitting rating..."):
         client.post(
             "/api/v1/feedback",
@@ -524,9 +513,88 @@ def _rate_impl(listing_id, stars, listing_type, comment):
                 "listing_type": listing_type,
                 "rating": stars,
                 "comment": comment,
+                "anonymous": anonymous,
             },
         )
-    rprint(f"[green]u2713 Rated {star_rating(stars)}[/green]")
+    rprint(f"[green]\u2713 Rated {star_rating(stars)}[/green]")
+
+
+@ops_app.command(name="rate-update")
+def _rate_update(
+    listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    listing_type: str = typer.Option("mcp", "--type", "-t", help="mcp, agent, skill, hook, prompt, or sandbox"),
+    stars: int | None = typer.Option(None, "--stars", "-s", min=1, max=5, help="New rating 1-5"),
+    comment: str | None = typer.Option(None, "--comment", "-c", help="New comment"),
+    anonymous: bool | None = typer.Option(None, "--anonymous/--no-anonymous", help="Set or unset anonymous flag"),
+):
+    """Update your existing review for an item.
+
+    Only the fields you provide will be changed.
+
+    Examples:
+
+        observal ops rate-update my-mcp --stars 4
+
+        observal ops rate-update my-mcp --comment "Updated opinion" --anonymous
+    """
+    resolved = _resolve_listing_id(listing_id, listing_type)
+    # First, get the user's existing review
+    with spinner("Fetching your review..."):
+        review = client.get(f"/api/v1/feedback/mine/{listing_type}/{resolved}")
+    body = {}
+    if stars is not None:
+        body["rating"] = stars
+    if comment is not None:
+        body["comment"] = comment
+    if anonymous is not None:
+        body["anonymous"] = anonymous
+    if not body:
+        rprint("[yellow]Nothing to update. Provide --stars, --comment, or --anonymous.[/yellow]")
+        raise typer.Exit(1)
+    with spinner("Updating review..."):
+        client.put(f"/api/v1/feedback/{review['id']}", body)
+    rprint("[green]\u2713 Review updated[/green]")
+
+
+@ops_app.command(name="rate-delete")
+def _rate_delete(
+    listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    listing_type: str = typer.Option("mcp", "--type", "-t", help="mcp, agent, skill, hook, prompt, or sandbox"),
+):
+    """Delete your review for an item.
+
+    Permanently removes your review. You can submit a new one afterwards.
+
+    Examples:
+
+        observal ops rate-delete my-mcp
+
+        observal ops rate-delete my-agent --type agent
+    """
+    resolved = _resolve_listing_id(listing_id, listing_type)
+    with spinner("Fetching your review..."):
+        review = client.get(f"/api/v1/feedback/mine/{listing_type}/{resolved}")
+    with spinner("Deleting review..."):
+        client.delete(f"/api/v1/feedback/{review['id']}")
+    rprint("[green]\u2713 Review deleted[/green]")
+
+
+def _resolve_listing_id(listing_id: str, listing_type: str) -> str:
+    """Resolve a name/alias to UUID for feedback operations."""
+    resolved = config.resolve_alias(listing_id)
+    try:
+        import uuid as _uuid
+
+        _uuid.UUID(resolved)
+    except ValueError:
+        endpoint = "/api/v1/agents" if listing_type == "agent" else f"/api/v1/{listing_type}s"
+        try:
+            item = client.get(f"{endpoint}/{resolved}")
+            resolved = item["id"]
+        except Exception:
+            rprint(f"[red]Could not find {listing_type} named '{resolved}'[/red]")
+            raise typer.Exit(1)
+    return resolved
 
 
 @ops_app.command(name="feedback")

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -99,7 +99,9 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal ops feedback`: Show feedback for an MCP server or agent.
   - `observal ops metrics`: Show metrics for an MCP server or agent.
   - `observal ops overview`: Show enterprise overview stats.
-  - `observal ops rate`: Rate an MCP server or agent.
+  - `observal ops rate`: Rate an MCP server, agent, or component.
+  - `observal ops rate-delete`: Delete your review for an item.
+  - `observal ops rate-update`: Update your existing review for an item.
   - `observal ops spans`: List spans for a trace.
   - `observal ops top`: Show top MCP servers or agents by usage.
   - `observal ops traces`: List recent traces (sessions).

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -373,7 +373,7 @@ class TestFeedback:
                 "comment": "Great MCP!",
             },
         )
-        assert r2.status_code == 200, f"Feedback failed: {r2.text}"
+        assert r2.status_code in (200, 201), f"Feedback failed: {r2.text}"
 
         # Verify feedback appears
         r3 = await client.get(f"/api/v1/feedback/mcp/{mcp_id}", headers=admin_headers)

--- a/tests/test_phase9_10.py
+++ b/tests/test_phase9_10.py
@@ -31,11 +31,16 @@ def _make_app(user):
     app.dependency_overrides[get_current_user] = lambda: user
     # Mock DB session
     mock_db = AsyncMock()
-    mock_db.scalar = AsyncMock(return_value=uuid.uuid4())  # listing exists
+    # First scalar call checks listing exists (return UUID), second checks existing review (return None)
+    mock_db.scalar = AsyncMock(side_effect=[uuid.uuid4(), None])
     mock_db.add = MagicMock()
     mock_db.commit = AsyncMock()
     mock_db.refresh = AsyncMock(
-        side_effect=lambda fb: setattr(fb, "id", uuid.uuid4()) or setattr(fb, "created_at", "2026-01-01")
+        side_effect=lambda fb: (
+            setattr(fb, "id", uuid.uuid4())
+            or setattr(fb, "created_at", "2026-01-01")
+            or setattr(fb, "updated_at", None)
+        )
     )
     app.dependency_overrides[get_db] = lambda: mock_db
     return app
@@ -59,7 +64,7 @@ class TestFeedbackDualWrite:
                         "comment": "Great tool!",
                     },
                 )
-            assert r.status_code == 200
+            assert r.status_code == 201
             mock_insert.assert_called_once()
             scores = mock_insert.call_args[0][0]
             assert len(scores) == 1
@@ -104,7 +109,7 @@ class TestFeedbackDualWrite:
                         "rating": 3,
                     },
                 )
-            assert r.status_code == 200  # request still succeeds
+            assert r.status_code == 201  # request still succeeds
 
 
 # --- Phase 10: CLI Updates ---

--- a/web/src/components/registry/review-form.tsx
+++ b/web/src/components/registry/review-form.tsx
@@ -1,12 +1,29 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-
-import { useState } from "react";
-import { Star, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Star, Loader2, Pencil, Trash2, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { useSubmitFeedback } from "@/hooks/use-api";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  useSubmitFeedback,
+  useMyFeedback,
+  useUpdateFeedback,
+  useDeleteFeedback,
+} from "@/hooks/use-insights-api";
 
 interface ReviewFormProps {
   listingId: string;
@@ -22,34 +39,180 @@ export function ReviewForm({
   const [rating, setRating] = useState(0);
   const [hoveredStar, setHoveredStar] = useState(0);
   const [comment, setComment] = useState("");
+  const [anonymous, setAnonymous] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
-  const mutation = useSubmitFeedback();
+  const { data: myReview, isError: noExistingReview } = useMyFeedback(
+    listingType,
+    listingId,
+  );
+  const submitMutation = useSubmitFeedback();
+  const updateMutation = useUpdateFeedback();
+  const deleteMutation = useDeleteFeedback();
+
+  const hasExistingReview = !!myReview && !noExistingReview;
+
+  // Populate form when editing existing review
+  useEffect(() => {
+    if (isEditing && myReview) {
+      setRating(myReview.rating);
+      setComment(myReview.comment ?? "");
+      setAnonymous(myReview.anonymous ?? false);
+    }
+  }, [isEditing, myReview]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (rating === 0) return;
 
-    mutation.mutate(
-      {
-        listing_type: listingType,
-        listing_id: listingId,
-        rating: rating,
-        comment: comment.trim() || undefined,
-      },
-      {
-        onSuccess: () => {
-          setRating(0);
-          setComment("");
-          onSuccess?.();
+    if (isEditing && myReview) {
+      updateMutation.mutate(
+        {
+          feedbackId: myReview.id,
+          rating,
+          comment: comment.trim() || undefined,
+          anonymous,
         },
+        {
+          onSuccess: () => {
+            setIsEditing(false);
+            onSuccess?.();
+          },
+        },
+      );
+    } else {
+      submitMutation.mutate(
+        {
+          listing_type: listingType,
+          listing_id: listingId,
+          rating,
+          comment: comment.trim() || undefined,
+          anonymous,
+        },
+        {
+          onSuccess: () => {
+            setRating(0);
+            setComment("");
+            setAnonymous(false);
+            onSuccess?.();
+          },
+        },
+      );
+    }
+  }
+
+  function handleDelete() {
+    if (!myReview) return;
+    deleteMutation.mutate(myReview.id, {
+      onSuccess: () => {
+        setRating(0);
+        setComment("");
+        setAnonymous(false);
+        setIsEditing(false);
+        onSuccess?.();
       },
+    });
+  }
+
+  function handleCancelEdit() {
+    setIsEditing(false);
+    setRating(0);
+    setComment("");
+    setAnonymous(false);
+  }
+
+  // If user already has a review and is not editing, show their review with edit/delete
+  if (hasExistingReview && !isEditing) {
+    return (
+      <div className="space-y-3">
+        <h4 className="text-sm font-semibold font-[family-name:var(--font-display)]">
+          Your Review
+        </h4>
+        <div className="rounded-md border border-primary/30 bg-primary/5 p-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1">
+              {[1, 2, 3, 4, 5].map((star) => (
+                <Star
+                  key={star}
+                  className={`h-4 w-4 ${
+                    star <= myReview.rating
+                      ? "fill-current text-amber-500"
+                      : "text-muted-foreground/30"
+                  }`}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-2">
+              {myReview.anonymous && (
+                <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <EyeOff className="h-3 w-3" />
+                  Anonymous
+                </span>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={() => setIsEditing(true)}
+                title="Edit review"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-destructive hover:text-destructive"
+                    disabled={deleteMutation.isPending}
+                    title="Delete review"
+                  >
+                    {deleteMutation.isPending ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete review?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This will permanently remove your review. You can submit a new one afterwards.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleDelete}>
+                      Delete
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          </div>
+          {myReview.comment && (
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {myReview.comment}
+            </p>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {myReview.created_at &&
+              new Date(myReview.created_at).toLocaleDateString()}
+            {myReview.updated_at && " (edited)"}
+          </span>
+        </div>
+      </div>
     );
   }
+
+  // Show the form (create or edit mode)
+  const isPending = submitMutation.isPending || updateMutation.isPending;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <h4 className="text-sm font-semibold font-[family-name:var(--font-display)]">
-        Leave a Review
+        {isEditing ? "Edit Your Review" : "Leave a Review"}
       </h4>
 
       <div className="flex items-center gap-1">
@@ -84,20 +247,48 @@ export function ReviewForm({
         className="resize-none"
       />
 
-      <Button
-        type="submit"
-        size="sm"
-        disabled={rating === 0 || mutation.isPending}
-      >
-        {mutation.isPending ? (
-          <>
-            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-            Submitting
-          </>
-        ) : (
-          "Submit Review"
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="anonymous-review"
+          checked={anonymous}
+          onCheckedChange={(checked) => setAnonymous(checked === true)}
+        />
+        <Label
+          htmlFor="anonymous-review"
+          className="text-sm text-muted-foreground cursor-pointer"
+        >
+          Submit anonymously
+        </Label>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          type="submit"
+          size="sm"
+          disabled={rating === 0 || isPending}
+        >
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+              {isEditing ? "Updating" : "Submitting"}
+            </>
+          ) : isEditing ? (
+            "Update Review"
+          ) : (
+            "Submit Review"
+          )}
+        </Button>
+        {isEditing && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleCancelEdit}
+          >
+            Cancel
+          </Button>
         )}
-      </Button>
+      </div>
     </form>
   );
 }

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("flex flex-col space-y-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+      {...props}
+    />
+  );
+}
+
+const AlertDialogTitle = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants({ variant: "default" }), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(buttonVariants({ variant: "ghost" }), "mt-2 sm:mt-0", className)}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/web/src/hooks/use-insights-api.ts
+++ b/web/src/hooks/use-insights-api.ts
@@ -39,10 +39,51 @@ export function useSubmitFeedback() {
     mutationFn: feedback.submit,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["feedback"] });
-      toast.success("Feedback submitted");
+      toast.success("Review submitted");
     },
     onError: (err: Error) => {
-      toast.error(err.message || "Failed to submit feedback");
+      toast.error(err.message || "Failed to submit review");
+    },
+  });
+}
+
+export function useMyFeedback(type: string | undefined, id: string | undefined) {
+  return useQuery({
+    queryKey: ["feedback", "mine", type, id],
+    enabled: !!type && !!id,
+    queryFn: () => feedback.mine(type!, id!),
+    retry: (_count, err: unknown) => {
+      const status = (err as { status?: number })?.status;
+      return status !== 404;
+    },
+  });
+}
+
+export function useUpdateFeedback() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ feedbackId, ...body }: { feedbackId: string; rating?: number; comment?: string; anonymous?: boolean }) =>
+      feedback.update(feedbackId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["feedback"] });
+      toast.success("Review updated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to update review");
+    },
+  });
+}
+
+export function useDeleteFeedback() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (feedbackId: string) => feedback.remove(feedbackId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["feedback"] });
+      toast.success("Review deleted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to delete review");
     },
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -566,10 +566,19 @@ export const feedback = {
 		listing_id: string;
 		rating: number;
 		comment?: string;
+		anonymous?: boolean;
 	}) => post<FeedbackItem>("/feedback", body),
 	get: (type: string, id: string) =>
 		get<FeedbackItem[]>(`/feedback/${type}/${id}`),
 	summary: (id: string) => get<FeedbackSummary>(`/feedback/summary/${id}`),
+	mine: (type: string, id: string) =>
+		get<FeedbackItem>(`/feedback/mine/${type}/${id}`),
+	update: (feedbackId: string, body: {
+		rating?: number;
+		comment?: string;
+		anonymous?: boolean;
+	}) => put<FeedbackItem>(`/feedback/${feedbackId}`, body),
+	remove: (feedbackId: string) => del<void>(`/feedback/${feedbackId}`),
 };
 
 // ── Admin ───────────────────────────────────────────────────────────

--- a/web/src/lib/types/registry.ts
+++ b/web/src/lib/types/registry.ts
@@ -317,9 +317,12 @@ export interface FeedbackItem {
 	listing_id?: string;
 	listing_name?: string;
 	listing_type?: string;
+	user_id?: string | null;
 	rating: number;
 	comment?: string;
+	anonymous?: boolean;
 	user?: string;
 	username?: string;
 	created_at?: string;
+	updated_at?: string | null;
 }

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -32,6 +32,7 @@ import {
   useAgentDownloads,
   useFeedback,
   useFeedbackSummary,
+  useMyFeedback,
   useWhoami,
   useAgentVersions,
   useAgentVersionDetail,
@@ -316,6 +317,7 @@ export default function AgentDetailPage() {
   );
   const { data: feedbackSummary, refetch: refetchSummary } =
     useFeedbackSummary(id);
+  const { data: myReview } = useMyFeedback("agent", id);
 
   const { data: whoami } = useWhoami();
   const { data: versionsData } = useAgentVersions(id);
@@ -477,7 +479,6 @@ export default function AgentDetailPage() {
                       </span>
                     )}
                   </TabsTrigger>
-                  <TabsTrigger value="install">Install</TabsTrigger>
                   {canEdit && <TabsTrigger value="edit">Edit</TabsTrigger>}
                   {canEdit && <TabsTrigger value="insights">Insights</TabsTrigger>}
 
@@ -616,7 +617,9 @@ export default function AgentDetailPage() {
                     />
                   ) : (
                     <div className="space-y-4">
-                      {feedbackItems.map((fb: FeedbackItem) => (
+                      {feedbackItems
+                        .filter((fb: FeedbackItem) => !myReview || fb.id !== myReview.id)
+                        .map((fb: FeedbackItem) => (
                         <div
                           key={fb.id}
                           className="rounded-md border border-border p-4 space-y-2"
@@ -649,31 +652,6 @@ export default function AgentDetailPage() {
                       ))}
                     </div>
                   )}
-                </TabsContent>
-
-                <TabsContent value="install" className="mt-6 space-y-6">
-                  <div className="space-y-2">
-                    <h3 className="text-sm font-semibold font-display">
-                      Quick Install
-                    </h3>
-                    <p className="text-xs text-muted-foreground">
-                      Use the Observal CLI to pull this agent into your project.
-                    </p>
-                  </div>
-                  <PullCommand agentName={a.name} versions={versions} />
-
-                  <Separator />
-
-                  <div className="space-y-3">
-                    <h3 className="text-sm font-semibold font-display">
-                      Manual Configuration
-                    </h3>
-                    <p className="text-xs text-muted-foreground">
-                      Add the following to your IDE configuration to use this
-                      agent directly.
-                    </p>
-                    <ConfigSnippet agentName={a.name} />
-                  </div>
                 </TabsContent>
 
                 {canEdit && (
@@ -827,49 +805,4 @@ export default function AgentDetailPage() {
   );
 }
 
-function ConfigSnippet({
-  agentName,
-}: {
-  agentName: string;
-}) {
-  const [copied, setCopied] = useState(false);
 
-  const snippet = JSON.stringify(
-    {
-      observal: {
-        agent: agentName,
-        registry: "https://registry.observal.dev",
-      },
-    },
-    null,
-    2,
-  );
-
-  const handleCopy = useCallback(() => {
-    copyToClipboard(snippet);
-    setCopied(true);
-    toast.success("Copied to clipboard");
-    setTimeout(() => setCopied(false), 2000);
-  }, [snippet]);
-
-  return (
-    <div className="relative rounded-md border border-border bg-surface-sunken">
-      <Button
-        variant="ghost"
-        size="icon"
-        className="absolute top-2 right-2 h-7 w-7"
-        onClick={handleCopy}
-        aria-label="Copy config"
-      >
-        {copied ? (
-          <Check className="h-3.5 w-3.5 text-success" />
-        ) : (
-          <Copy className="h-3.5 w-3.5" />
-        )}
-      </Button>
-      <pre className="p-4 text-xs font-mono leading-relaxed overflow-x-auto text-foreground/80">
-        {snippet}
-      </pre>
-    </div>
-  );
-}

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -14,6 +14,7 @@ import {
   useRegistryItem,
   useFeedback,
   useFeedbackSummary,
+  useMyFeedback,
   useRegistryMetrics,
   useComponentVersions,
   useComponentVersionDetail,
@@ -52,6 +53,7 @@ export default function ComponentDetailPage() {
   const { data: item, isLoading, isError, error, refetch } = useRegistryItem(type, id);
   const { data: feedbackItems, refetch: refetchFeedback } = useFeedback(singularType, id);
   const { data: feedbackSummary, refetch: refetchSummary } = useFeedbackSummary(id);
+  const { data: myReview } = useMyFeedback(singularType, id);
   const { data: rawMetrics } = useRegistryMetrics(type, id);
   const { data: versionsData, isLoading: versionsLoading } = useComponentVersions(type, id);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
@@ -220,7 +222,9 @@ export default function ComponentDetailPage() {
                   />
                 ) : (
                   <div className="space-y-4">
-                    {feedbackItems.map((fb: FeedbackItem) => (
+                    {feedbackItems
+                      .filter((fb: FeedbackItem) => !myReview || fb.id !== myReview.id)
+                      .map((fb: FeedbackItem) => (
                       <div key={fb.id} className="rounded-md border border-border p-4 space-y-2">
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-1">


### PR DESCRIPTION
## Purpose / Description
Users could previously submit unlimited reviews per listing with no way to edit or delete them, and no option to post anonymously. This PR enforces one review per user per listing, adds full CRUD operations, and introduces anonymous review support.

## Fixes
* Fixes the review system to be production-ready with proper constraints

## Approach
**Server (model + routes):**
- Added `UniqueConstraint(user_id, listing_id, listing_type)` on the feedback table
- Added `anonymous` (bool) and `updated_at` columns
- POST returns 409 if user already reviewed the item
- New endpoints: `GET /feedback/mine/{type}/{id}`, `PUT /feedback/{id}`, `DELETE /feedback/{id}`
- Owner-only enforcement on update/delete (403 for others)
- Anonymous reviews have `user_id` redacted to `null` in responses

**CLI:**
- `observal ops rate` now accepts `--anonymous / -a`
- New `observal ops rate-update` command (partial update)
- New `observal ops rate-delete` command

**Frontend:**
- Rewrote `ReviewForm` component: shows existing review with edit/delete buttons when user already reviewed
- Added "Submit anonymously" checkbox
- User's own review appears at the top, filtered from the general list to avoid duplication
- Removed redundant "Install" tab (already shown in sidebar card)

**Migration:**
- Alembic migration `006_feedback_one_per_user` adds the new columns and unique constraint


## How Has This Been Tested?
- Verified model/schema imports pass with assertions on new fields and constraints
- CLI commands render help correctly with new flags (`--anonymous`, `rate-update`, `rate-delete`)
- TypeScript compiles with zero errors (`tsc --noEmit`)
- Ruff lint passes on all modified Python files
- Existing tests (`test_schema_redesign.py::TestFeedbackSubmissionUpdates`) still pass

<img width="1026" height="360" alt="image" src="https://github.com/user-attachments/assets/76671751-4573-4673-b1f4-b2449b4a326d" />

<img width="1021" height="278" alt="image" src="https://github.com/user-attachments/assets/3ae88a20-5947-4a25-b97a-82c0ce414d83" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes (Claude via Pi): code generation, review form rewrite, route logic
- [x] Was the generated code manually reviewed and tested?