### PR TITLE
feat(invites): teammate invites with admin UI and PostHog analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ observal
 
 REST at `/api/v1/`. GraphQL at `/api/v1/graphql` (read-only telemetry layer with subscriptions).
 
-Key route files: `auth.py`, `mcp.py`, `skill.py`, `hook.py`, `prompt.py`, `sandbox.py`, `review.py`, `feedback.py`, `dashboard.py`, `insights.py`, `reconcile.py`, `ingest.py`, `telemetry.py`, `alert.py`, `config.py`, `sessions.py`, `device_auth.py`, `jwks.py`, `component_source.py`, `component_versions.py`, `agent_versions.py`, `bulk.py`, `support.py`, `preview.py`, `audit.py`, `registry_models.py`.
+Key route files: `auth.py`, `mcp.py`, `skill.py`, `hook.py`, `prompt.py`, `sandbox.py`, `review.py`, `feedback.py`, `dashboard.py`, `insights.py`, `reconcile.py`, `ingest.py`, `telemetry.py`, `alert.py`, `config.py`, `sessions.py`, `device_auth.py`, `jwks.py`, `component_source.py`, `component_versions.py`, `agent_versions.py`, `bulk.py`, `support.py`, `preview.py`, `audit.py`, `registry_models.py`, `invite.py`.
 
 Sub-packages: `agent/` (crud, install, draft), `admin/` (enterprise_settings, users, org, retention).
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,15 @@ Logs are written to `~/.observal/logs/dev.log` and include structured context fo
 
 Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://github.com/BlazeUp-AI/Observal/security/advisories) or email contact@blazeup.app. Do not open a public issue. See [SECURITY.md](SECURITY.md).
 
+## Privacy
+
+Self-hosted Observal sends **no usage telemetry** by default. The hosted
+observal.io instance enables a small set of product analytics events
+(PostHog); private deployments keep them off unless an operator explicitly
+opts in via `PRODUCT_ANALYTICS_ENABLED=true`. See
+[docs/self-hosting/telemetry.md](docs/self-hosting/telemetry.md) for exactly
+what is sent, when, and how to keep it off.
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=BlazeUp-AI%2FObserval&type=date&legend=top-left">

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -54,6 +54,7 @@
 * [Databases](self-hosting/databases.md)
 * [Authentication and SSO](self-hosting/authentication.md)
 * [Telemetry pipeline](self-hosting/telemetry-pipeline.md)
+* [Product analytics telemetry](self-hosting/telemetry.md)
 * [Upgrades](self-hosting/upgrades.md)
 * [Backup and restore](self-hosting/backup-and-restore.md)
 * [Troubleshooting](self-hosting/troubleshooting.md)

--- a/docs/self-hosting/telemetry.md
+++ b/docs/self-hosting/telemetry.md
@@ -1,0 +1,119 @@
+<!-- SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Product analytics telemetry (PostHog)
+
+Observal can send a small set of product-usage events to [PostHog](https://posthog.com)
+(PostHog Cloud US). This is **off by default** and intended **only for the public
+observal.io instance**.
+
+> **Enterprise / private deployments: leave this off.**
+> Enabling product analytics sends the events documented below to PostHog Cloud
+> US, which makes PostHog a data subprocessor for your deployment. If your
+> organization has data-residency, SOC 2, or customer-VPC requirements, do not
+> set `PRODUCT_ANALYTICS_ENABLED=true`.
+
+This is separate from the [telemetry pipeline](telemetry-pipeline.md), which is
+your own trace/observability data and never leaves your deployment.
+
+## How to keep it off
+
+Do nothing. The default is off:
+
+```bash
+PRODUCT_ANALYTICS_ENABLED=false   # default
+```
+
+With the flag unset or false (or with no `POSTHOG_API_KEY`), the server makes
+zero requests to PostHog and the web app never loads or initializes
+`posthog-js`.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `PRODUCT_ANALYTICS_ENABLED` | `false` | Master switch. Must be explicitly set to `true` to send anything. |
+| `POSTHOG_API_KEY` | empty | PostHog **project** API key (`phc_...`, write-only). Analytics stays off while empty. |
+| `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog ingestion host. |
+
+## The gate
+
+An event is sent only when **all** of the following are true:
+
+1. `PRODUCT_ANALYTICS_ENABLED=true`
+2. `POSTHOG_API_KEY` is non-empty
+3. The acting user's organization has **not** enabled trace privacy
+   (`organizations.trace_privacy`). Orgs that opted into trace privacy emit no
+   usage telemetry of any kind.
+
+The same gate controls the web app: the public config endpoint
+(`/api/v1/config/public`) only exposes the PostHog key and host when the gate
+passes, and `posthog-js` is only initialized when it does.
+
+## Exactly what is sent
+
+### Events
+
+| Event | Source | Fired when | Properties |
+|---|---|---|---|
+| `user_signed_up` | server | A real (non-demo) user account is created via `/auth/init`, `/auth/bootstrap`, OIDC signup, SAML JIT provisioning, or SCIM provisioning | `utm_source`, `utm_medium`, `utm_campaign` (all nullable), `auth_provider` (`local` / `oidc` / `saml` / `scim`), `org_id` (UUID, nullable) |
+| `agent_registered` | server | An agent is created in the registry | `workspace_id` (org UUID), `agent_id` (agent UUID), `agent_type` (agent category, nullable) |
+| `invite_sent` | server | An admin creates a teammate invite | `workspace_id` (org UUID), `invite_channel` (`email` / `link`) |
+| `invite_accepted` | server | An invited user completes signup via an invite link | `workspace_id` (org UUID) |
+| `insights_viewed` | web app | A user opens an insights report page | `workspace_id` (org UUID) |
+
+Notes:
+
+- **Demo accounts emit nothing.**
+- SSO/SCIM-provisioned users are counted as signups with null UTMs (bucketed
+  as organic by downstream consumers).
+- `utm_*` values come from first-touch attribution: the web app stores
+  `utm_source` / `utm_medium` / `utm_campaign` from the first URL that carried
+  them (in `localStorage`, 90-day expiry, first touch wins) and forwards them
+  with the signup request. They are used only for the `user_signed_up` event
+  and are never persisted to the database.
+- Invite acceptances also emit `user_signed_up` with `utm_source` forced to
+  `"invite"` (server-side), so invite-loop signups are attributed correctly
+  regardless of stored first-touch UTMs. The invitee's email address is never
+  sent — only org and invite UUIDs.
+
+### Identity
+
+- The PostHog distinct ID is always the **user UUID** (`users.id`).
+- The web app calls `posthog.identify(<user UUID>)` only — no email, name, or
+  any other person properties are set.
+
+### What is never sent
+
+- Email addresses, names, usernames, password hashes, avatars
+- Organization names or slugs (UUIDs only)
+- Prompts, agent YAML, trace content, session data
+- IP addresses — server-side captures explicitly null `$ip` so PostHog stores
+  no IP and performs no geolocation
+
+### Web app posture
+
+When enabled, `posthog-js` is initialized with:
+
+- `autocapture: false`
+- `capture_pageview: false`
+- `disable_session_recording: true`
+- `person_profiles: 'identified_only'`
+
+The only frontend event is `insights_viewed`. There is no autocapture, no
+pageview tracking, and no session replay. This is a deliberate privacy
+posture.
+
+## Reliability
+
+Captures are fire-and-forget: events are queued in memory and flushed by a
+background thread, and any PostHog failure (bad key, network down) is logged
+and swallowed. Analytics can never fail or slow down an API request. Queued
+events are flushed on graceful shutdown.
+
+## Support bundles
+
+`observal support bundle` includes `PRODUCT_ANALYTICS_ENABLED` and
+`POSTHOG_HOST` so support can confirm the analytics posture of a deployment.
+The `POSTHOG_API_KEY` value is always redacted by the CLI redaction layer
+(only its presence is visible).

--- a/ee/observal_server/routes/scim.py
+++ b/ee/observal_server/routes/scim.py
@@ -221,7 +221,15 @@ async def create_user(
         )
 
     await db.commit()
-    await bus.emit(UserCreated(user_id=str(user.id), email=user.email, role=user.role.value))
+    await bus.emit(
+        UserCreated(
+            user_id=str(user.id),
+            email=user.email,
+            role=user.role.value,
+            org_id=str(user.org_id) if user.org_id else None,
+            auth_provider="scim",
+        )
+    )
 
     base_url = str(request.base_url).rstrip("/") + "/api/v1/scim"
     return JSONResponse(

--- a/ee/observal_server/routes/sso_saml.py
+++ b/ee/observal_server/routes/sso_saml.py
@@ -35,6 +35,7 @@ from ee.observal_server.services.saml import (
 )
 from models.saml_config import SamlConfig
 from models.user import User, UserRole
+from services.events import UserCreated, bus
 from services.jwt_service import create_access_token, create_refresh_token
 from services.redis import get_redis
 from services.security_events import (
@@ -283,8 +284,10 @@ async def saml_acs(request: Request, db: AsyncSession = Depends(get_db)):
 
     result = await db.execute(select(User).where(User.email == email))
     user = result.scalar_one_or_none()
+    is_new_user = False
 
     if not user:
+        is_new_user = True
         jit_enabled = getattr(config, "jit_provisioning", True)
         if not jit_enabled:
             await emit_security_event(
@@ -348,6 +351,17 @@ async def saml_acs(request: Request, db: AsyncSession = Depends(get_db)):
 
     access_token, refresh_token, expires_in = await _issue_tokens(user)
     await db.commit()
+
+    if is_new_user:
+        await bus.emit(
+            UserCreated(
+                user_id=str(user.id),
+                email=user.email,
+                role=user.role.value,
+                org_id=str(user.org_id) if user.org_id else None,
+                auth_provider="saml",
+            )
+        )
 
     code = secrets.token_urlsafe(32)
     redis = get_redis()

--- a/observal-server/alembic/versions/007_invites.py
+++ b/observal-server/alembic/versions/007_invites.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Add invites table for teammate invitations.
+
+Revision ID: 007_invites
+Revises: 006_feedback_one_per_user
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision = "007_invites"
+down_revision = "006_feedback_one_per_user"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invites",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "org_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("email", sa.String(255), nullable=True),
+        sa.Column(
+            "role",
+            sa.Enum("super_admin", "admin", "reviewer", "user", name="userrole", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "channel",
+            sa.Enum("email", "link", name="invitechannel"),
+            nullable=False,
+        ),
+        sa.Column("token_hash", sa.String(64), nullable=False, unique=True),
+        sa.Column("invited_by", UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("accepted_by", UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("revoked", sa.Boolean(), server_default="false", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("invites")
+    op.execute("DROP TYPE IF EXISTS invitechannel")

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -34,6 +34,7 @@ from schemas.agent import (
     AgentUpdateRequest,
 )
 from services.config_generator import validate_mcp_command
+from services.events import AgentCreated, bus
 from services.ide_feature_inference import compute_supported_ides, infer_required_features
 from services.registry_telemetry import emit_registry_event
 
@@ -198,6 +199,15 @@ async def create_agent(
 
     agent = await _load_agent(db, str(agent.id))
     name_map = await _resolve_component_names(agent.components, db)
+
+    await bus.emit(
+        AgentCreated(
+            agent_id=str(agent.id),
+            org_id=str(current_user.org_id) if current_user.org_id else None,
+            category=agent.category,
+            created_by=str(current_user.id),
+        )
+    )
 
     emit_registry_event(
         action="agent.create",

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -43,6 +43,7 @@ from schemas.auth import (
     UsernameUpdateRequest,
     UserResponse,
 )
+from services.events import UserCreated, bus
 from services.jwt_service import create_access_token, create_refresh_token, decode_access_token, decode_refresh_token
 from services.redis import get_redis
 from services.security_events import (
@@ -160,6 +161,19 @@ async def init_admin(req: InitRequest, db: AsyncSession = Depends(get_db)):
         raise HTTPException(status_code=409, detail="System already initialized or email/username already exists")
     await db.refresh(user)
 
+    await bus.emit(
+        UserCreated(
+            user_id=str(user.id),
+            email=user.email,
+            role=user.role.value,
+            org_id=str(user.org_id) if user.org_id else None,
+            auth_provider="local",
+            utm_source=req.utm_source,
+            utm_medium=req.utm_medium,
+            utm_campaign=req.utm_campaign,
+        )
+    )
+
     access_token, refresh_token, expires_in = await _issue_tokens(user)
     return InitResponse(
         user=UserResponse.model_validate(user),
@@ -197,6 +211,16 @@ async def bootstrap(request: Request, db: AsyncSession = Depends(get_db)):
         await db.rollback()
         raise HTTPException(status_code=409, detail="System already initialized")
     await db.refresh(user)
+
+    await bus.emit(
+        UserCreated(
+            user_id=str(user.id),
+            email=user.email,
+            role=user.role.value,
+            org_id=str(user.org_id) if user.org_id else None,
+            auth_provider="local",
+        )
+    )
 
     access_token, refresh_token, expires_in = await _issue_tokens(user)
     return InitResponse(
@@ -326,6 +350,7 @@ async def oauth_callback(request: Request, db: AsyncSession = Depends(get_db)):
     # Check if user exists
     result = await db.execute(select(User).where(User.email == email))
     user = result.scalar_one_or_none()
+    is_new_user = False
 
     if not user:
         # Auto-create new user via SSO
@@ -336,8 +361,10 @@ async def oauth_callback(request: Request, db: AsyncSession = Depends(get_db)):
             name=name,
             role=UserRole.user,
             org_id=default_org.id,
+            auth_provider="oidc",
         )
         db.add(user)
+        is_new_user = True
 
         try:
             await db.flush()
@@ -346,6 +373,7 @@ async def oauth_callback(request: Request, db: AsyncSession = Depends(get_db)):
             # Race condition: user was created between our check and commit
             result = await db.execute(select(User).where(User.email == email))
             user = result.scalar_one_or_none()
+            is_new_user = False
             if not user:
                 raise HTTPException(status_code=500, detail="Failed to create or find user")
 
@@ -380,6 +408,11 @@ async def oauth_callback(request: Request, db: AsyncSession = Depends(get_db)):
                     "expires_in": expires_in,
                     "user_id": str(user.id),
                     "role": user.role.value,
+                    # Signal to /exchange that this login created the account,
+                    # so the UserCreated event can carry the frontend's
+                    # first-touch UTM attribution (the callback never sees it).
+                    "new_user": is_new_user,
+                    "org_id": str(user.org_id) if user.org_id else None,
                 }
             ),
         )
@@ -445,6 +478,24 @@ async def exchange_code(req: CodeExchangeRequest, db: AsyncSession = Depends(get
 
     if not user:
         raise HTTPException(status_code=400, detail="Invalid or expired code")
+
+    # OAuth signups are created in the redirect callback, which never sees the
+    # frontend's stored first-touch UTMs - so the signup event is emitted here,
+    # on the one-time code exchange that completes the signup.
+    if payload.get("new_user"):
+        await bus.emit(
+            UserCreated(
+                user_id=str(user.id),
+                email=user.email,
+                role=user.role.value,
+                org_id=payload.get("org_id"),
+                auth_provider="oidc",
+                utm_source=req.utm_source,
+                utm_medium=req.utm_medium,
+                utm_campaign=req.utm_campaign,
+            )
+        )
+
     return InitResponse(
         user=UserResponse.model_validate(user),
         access_token=access_token,
@@ -456,7 +507,9 @@ async def exchange_code(req: CodeExchangeRequest, db: AsyncSession = Depends(get
 @router.get("/whoami", response_model=UserResponse)
 async def whoami(current_user: User = Depends(get_current_user)):
     optic.debug("auth whoami")
-    return UserResponse.model_validate(current_user)
+    resp = UserResponse.model_validate(current_user)
+    resp.trace_privacy = bool(getattr(current_user, "_trace_privacy", False))
+    return resp
 
 
 @router.post("/logout")

--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -124,6 +124,17 @@ async def get_public_config(db=Depends(get_db)):
 
     sso_only = await ds.get_bool("deployment.sso_only")
 
+    # Product analytics: posthog-js is only initialized by the frontend when
+    # enabled=true (same gate as server-side capture). The phc_ project key is
+    # public-by-design but still only shipped when analytics is on.
+    from services.product_analytics import is_enabled as analytics_enabled
+
+    product_analytics = {
+        "enabled": analytics_enabled(),
+        "posthog_key": settings.POSTHOG_API_KEY if analytics_enabled() else None,
+        "posthog_host": settings.POSTHOG_HOST if analytics_enabled() else None,
+    }
+
     return {
         "licensed": licensed,
         "sso_enabled": bool(settings.OAUTH_CLIENT_ID),
@@ -134,6 +145,7 @@ async def get_public_config(db=Depends(get_db)):
         "branding_logo": branding_logo,
         "branding_app_name": branding_app_name,
         "branding_wordmark": branding_wordmark,
+        "product_analytics": product_analytics,
     }
 
 

--- a/observal-server/api/routes/invite.py
+++ b/observal-server/api/routes/invite.py
@@ -1,0 +1,309 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Teammate invite routes.
+
+Admins create single-use, time-limited invite tokens (optionally pinned to
+an email address). The raw token is returned exactly once; only its SHA-256
+hash is stored. Anyone holding the link can preview it (lookup) and accept
+it (public, password-auth deployments only), which creates an account in
+the inviting org with the preassigned role and logs the user in.
+
+There is no SMTP integration: for channel=email the admin copies the
+generated link and sends it through their own channel; the invite is simply
+pinned to that address at acceptance time.
+"""
+
+import hashlib
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from loguru import logger as optic
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import ROLE_HIERARCHY, get_db, require_password_auth, require_role
+from api.ratelimit import limiter
+from models.invite import Invite, InviteChannel
+from models.organization import Organization
+from models.user import User, UserRole
+from schemas.auth import UserResponse
+from schemas.invite import (
+    InviteAcceptRequest,
+    InviteAcceptResponse,
+    InviteCreateRequest,
+    InviteCreateResponse,
+    InviteLookupResponse,
+    InviteResponse,
+)
+from services.events import InviteAccepted, InviteSent, UserCreated, bus
+from services.security_events import EventType, SecurityEvent, Severity, emit_security_event
+from services.username_generator import generate_unique_username
+
+router = APIRouter(prefix="/api/v1/invites", tags=["invites"])
+
+INVITE_TTL_DAYS = 7
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+async def _get_invite_by_token(db: AsyncSession, token: str) -> Invite | None:
+    result = await db.execute(select(Invite).where(Invite.token_hash == _hash_token(token)))
+    return result.scalar_one_or_none()
+
+
+# ── Admin: create / list / revoke ────────────────────────────────────
+
+
+@router.post("", response_model=InviteCreateResponse, dependencies=[Depends(require_password_auth)])
+async def create_invite(
+    req: InviteCreateRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    optic.debug("invite create requested")
+    try:
+        role = UserRole(req.role)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid role. Must be one of: {[r.value for r in UserRole]}")
+
+    if ROLE_HIERARCHY.get(role, 999) < ROLE_HIERARCHY[current_user.role]:
+        raise HTTPException(status_code=403, detail="Cannot assign a role higher than your own")
+
+    if not current_user.org_id:
+        raise HTTPException(status_code=400, detail="Your account has no organization")
+
+    if req.email:
+        existing = await db.scalar(select(User.id).where(User.email == req.email))
+        if existing:
+            raise HTTPException(status_code=409, detail="A user with this email already exists")
+
+        now = datetime.now(UTC)
+        pending = await db.execute(
+            select(Invite).where(
+                Invite.org_id == current_user.org_id,
+                Invite.email == req.email,
+                Invite.revoked.is_(False),
+                Invite.accepted_at.is_(None),
+                Invite.expires_at > now,
+            )
+        )
+        if pending.scalars().first():
+            raise HTTPException(status_code=409, detail="A pending invite for this email already exists")
+
+    token = secrets.token_urlsafe(32)
+    invite = Invite(
+        org_id=current_user.org_id,
+        email=req.email,
+        role=role,
+        channel=InviteChannel.email if req.email else InviteChannel.link,
+        token_hash=_hash_token(token),
+        invited_by=current_user.id,
+        expires_at=datetime.now(UTC) + timedelta(days=INVITE_TTL_DAYS),
+    )
+    db.add(invite)
+    await db.commit()
+    await db.refresh(invite)
+
+    await bus.emit(
+        InviteSent(
+            invite_id=str(invite.id),
+            org_id=str(invite.org_id),
+            channel=invite.channel.value,
+            invited_by=str(current_user.id),
+        )
+    )
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.INVITE_CREATED,
+            severity=Severity.INFO,
+            outcome="success",
+            actor_id=str(current_user.id),
+            actor_email=current_user.email,
+            actor_role=current_user.role.value,
+            target_id=str(invite.id),
+            target_type="invite",
+            detail=f"Invite created ({invite.channel.value}) with role {role.value}",
+        )
+    )
+
+    from api.routes.device_auth import _resolve_frontend_url
+
+    invite_url = f"{_resolve_frontend_url(request)}/invite/{token}"
+    return InviteCreateResponse(
+        id=invite.id,
+        email=invite.email,
+        role=invite.role.value,
+        channel=invite.channel.value,
+        status=invite.status,
+        created_at=invite.created_at,
+        expires_at=invite.expires_at,
+        accepted_at=invite.accepted_at,
+        token=token,
+        invite_url=invite_url,
+    )
+
+
+@router.get("", response_model=list[InviteResponse])
+async def list_invites(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    optic.debug("invite list requested")
+    stmt = select(Invite).order_by(Invite.created_at.desc())
+    if current_user.org_id is not None:
+        stmt = stmt.where(Invite.org_id == current_user.org_id)
+    result = await db.execute(stmt)
+    return [InviteResponse.model_validate(i) for i in result.scalars().all()]
+
+
+@router.delete("/{invite_id}", status_code=204)
+async def revoke_invite(
+    invite_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    optic.debug("invite revoke requested")
+    stmt = select(Invite).where(Invite.id == invite_id)
+    if current_user.org_id is not None:
+        stmt = stmt.where(Invite.org_id == current_user.org_id)
+    result = await db.execute(stmt)
+    invite = result.scalar_one_or_none()
+    if not invite:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    if invite.accepted_at is not None:
+        raise HTTPException(status_code=400, detail="Invite has already been accepted")
+
+    invite.revoked = True
+    await db.commit()
+
+
+# ── Public: lookup / accept ──────────────────────────────────────────
+
+
+@router.get("/lookup/{token}", response_model=InviteLookupResponse)
+@limiter.limit("20/minute")
+async def lookup_invite(token: str, request: Request, db: AsyncSession = Depends(get_db)):
+    """Public preview of an invite for the acceptance page. Never 404s on a
+    bad token (to keep responses uniform); returns valid=false instead."""
+    optic.debug("invite lookup requested")
+    invite = await _get_invite_by_token(db, token)
+    if not invite:
+        return InviteLookupResponse(valid=False, reason="not_found")
+
+    status = invite.status
+    if status != "pending":
+        return InviteLookupResponse(valid=False, reason=status)
+
+    org_name = await db.scalar(select(Organization.name).where(Organization.id == invite.org_id))
+    return InviteLookupResponse(
+        valid=True,
+        org_name=org_name,
+        email=invite.email,
+        role=invite.role.value,
+        expires_at=invite.expires_at,
+    )
+
+
+@router.post("/accept", response_model=InviteAcceptResponse, dependencies=[Depends(require_password_auth)])
+@limiter.limit("5/minute")
+async def accept_invite(req: InviteAcceptRequest, request: Request, db: AsyncSession = Depends(get_db)):
+    """Accept an invite: create the account in the inviting org and log in."""
+    optic.debug("invite accept requested")
+    invite = await _get_invite_by_token(db, req.token)
+    if not invite:
+        raise HTTPException(status_code=404, detail="Invite not found")
+
+    status = invite.status
+    if status == "revoked":
+        raise HTTPException(status_code=410, detail="This invite has been revoked")
+    if status == "accepted":
+        raise HTTPException(status_code=410, detail="This invite has already been used")
+    if status == "expired":
+        raise HTTPException(status_code=410, detail="This invite has expired")
+
+    if invite.email:
+        if req.email and req.email != invite.email:
+            raise HTTPException(status_code=400, detail="This invite is for a different email address")
+        email = invite.email
+    else:
+        if not req.email:
+            raise HTTPException(status_code=422, detail="Email is required for this invite")
+        email = req.email
+
+    existing = await db.scalar(select(User.id).where(User.email == email))
+    if existing:
+        raise HTTPException(status_code=409, detail="A user with this email already exists")
+
+    from api.routes.auth import _issue_tokens, _validate_password_strength
+
+    _validate_password_strength(req.password)
+
+    username = req.username or await generate_unique_username(email, db)
+    user = User(
+        email=email,
+        username=username,
+        name=req.name,
+        role=invite.role,
+        org_id=invite.org_id,
+        auth_provider="local",
+    )
+    user.set_password(req.password)
+    db.add(user)
+    try:
+        await db.flush()
+        invite.accepted_at = datetime.now(UTC)
+        invite.accepted_by = user.id
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Email or username already exists")
+    await db.refresh(user)
+
+    org_id = str(user.org_id) if user.org_id else None
+    # utm_source is forced to "invite" so the GTM engine attributes this
+    # signup to the invite loop regardless of stored first-touch UTMs.
+    await bus.emit(
+        UserCreated(
+            user_id=str(user.id),
+            email=user.email,
+            role=user.role.value,
+            org_id=org_id,
+            auth_provider="local",
+            utm_source="invite",
+        )
+    )
+    await bus.emit(
+        InviteAccepted(
+            invite_id=str(invite.id),
+            org_id=org_id,
+            user_id=str(user.id),
+        )
+    )
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.REGISTRATION,
+            severity=Severity.INFO,
+            outcome="success",
+            actor_id=str(user.id),
+            actor_email=user.email,
+            actor_role=user.role.value,
+            target_id=str(invite.id),
+            target_type="invite",
+            detail=f"User {user.email} signed up via invite",
+        )
+    )
+
+    access_token, refresh_token, expires_in = await _issue_tokens(user)
+    return InviteAcceptResponse(
+        user=UserResponse.model_validate(user),
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_in=expires_in,
+    )

--- a/observal-server/api/routes/support.py
+++ b/observal-server/api/routes/support.py
@@ -194,6 +194,11 @@ CONFIG_ALLOWLIST = frozenset(
         "CLICKHOUSE_URL",
         "REDIS_URL",
         "JWT_SIGNING_ALGORITHM",
+        "PRODUCT_ANALYTICS_ENABLED",
+        # Key value is redacted CLI-side (matches the api_key sensitive-key
+        # pattern); only presence/absence is diagnostically useful.
+        "POSTHOG_API_KEY",
+        "POSTHOG_HOST",
     }
 )
 

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -58,6 +58,15 @@ class Settings(BaseSettings):
 
     SKIP_DDL_ON_STARTUP: bool = False
 
+    # Product analytics (PostHog) - OFF by default.
+    # Only the public observal.io instance should enable this. Private /
+    # enterprise deployments must leave it off: enabling it sends usage
+    # events to PostHog Cloud (US), making PostHog a subprocessor.
+    # See docs/self-hosting/telemetry.md for exactly what is sent.
+    PRODUCT_ANALYTICS_ENABLED: bool = False
+    POSTHOG_API_KEY: str = ""  # phc_... project API key (write-only key, not personal)
+    POSTHOG_HOST: str = "https://us.i.posthog.com"
+
     # Demo accounts (boot-time, needed to bootstrap first login)
     SEED_DEMO_ACCOUNTS: bool = True
     DEMO_SUPER_ADMIN_EMAIL: str | None = None

--- a/observal-server/main.py
+++ b/observal-server/main.py
@@ -52,6 +52,7 @@ from api.routes.feedback import router as feedback_router
 from api.routes.hook import router as hook_router
 from api.routes.ingest import router as ingest_router
 from api.routes.insights import router as insights_router
+from api.routes.invite import router as invite_router
 from api.routes.jwks import router as jwks_router
 from api.routes.layer_snapshot import router as layer_snapshot_router
 from api.routes.logs_stream import router as logs_stream_router
@@ -165,6 +166,10 @@ async def lifespan(app: FastAPI):
     async with _session_factory() as db:
         await seed_demo_accounts(db)
 
+    # Product analytics (PostHog) bus subscribers. Registering is always safe:
+    # every capture is a no-op unless PRODUCT_ANALYTICS_ENABLED + key are set.
+    import services.product_analytics_handlers  # noqa: F401
+
     # Initialize enterprise audit system (license-gated)
     if AUDIT_LICENSED:
         setup_audit()
@@ -183,6 +188,11 @@ async def lifespan(app: FastAPI):
 
     if AUDIT_LICENSED:
         await shutdown_audit()
+
+    # Flush any queued product analytics events (no-op when disabled)
+    import services.product_analytics as product_analytics
+
+    product_analytics.shutdown()
 
     from services.agent_registry_cache import stop as stop_registry_cache
 
@@ -449,6 +459,7 @@ app.include_router(telemetry_router)
 app.include_router(dashboard_router)
 app.include_router(feedback_router)
 app.include_router(insights_router)
+app.include_router(invite_router)
 app.include_router(reconcile_router)
 app.include_router(ingest_router)
 app.include_router(admin_router)

--- a/observal-server/models/__init__.py
+++ b/observal-server/models/__init__.py
@@ -22,6 +22,7 @@ from models.insight_meta_cache import InsightMetaCache
 from models.insight_report import InsightReport, InsightReportStatus
 from models.insight_session_facets import InsightSessionFacets
 from models.insight_session_meta import InsightSessionMeta
+from models.invite import Invite, InviteChannel
 from models.mcp import ListingStatus, McpDownload, McpListing, McpValidationResult
 from models.organization import Organization
 from models.prompt import PromptDownload, PromptListing
@@ -55,6 +56,8 @@ __all__ = [
     "InsightReportStatus",
     "InsightSessionFacets",
     "InsightSessionMeta",
+    "Invite",
+    "InviteChannel",
     "ListingStatus",
     "McpDownload",
     "McpListing",

--- a/observal-server/models/invite.py
+++ b/observal-server/models/invite.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Teammate invites.
+
+An invite is a single-use, time-limited token that lets someone join the
+inviting admin's organization with a preassigned role. The raw token is
+shown exactly once at creation time; only its SHA-256 hash is stored.
+
+Channels:
+- ``email``: the invite is pinned to a specific email address - only that
+  address can accept it.
+- ``link``:  a shareable link; the acceptor supplies their own email.
+"""
+
+import enum
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+from models.user import UserRole
+
+
+class InviteChannel(str, enum.Enum):
+    email = "email"
+    link = "link"
+
+
+class Invite(Base):
+    __tablename__ = "invites"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    # Pinned recipient for channel=email; None for shareable links
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.user, nullable=False)
+    channel: Mapped[InviteChannel] = mapped_column(Enum(InviteChannel), default=InviteChannel.link, nullable=False)
+    # SHA-256 hex of the raw token (raw token is never persisted)
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    invited_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    accepted_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    revoked: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false", nullable=False)
+
+    @property
+    def status(self) -> str:
+        if self.revoked:
+            return "revoked"
+        if self.accepted_at is not None:
+            return "accepted"
+        expires = self.expires_at if self.expires_at.tzinfo else self.expires_at.replace(tzinfo=UTC)
+        if expires < datetime.now(UTC):
+            return "expired"
+        return "pending"

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "idna>=3.15",
     "orjson>=3.10.0",
     "xxhash>=3.4.0",
+    "posthog>=6.0.0",
 ]
 
 [tool.uv]

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -8,7 +8,7 @@ import re
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from models.user import UserRole
 
@@ -29,7 +29,17 @@ def _validate_username(v: str | None) -> str | None:
     return v
 
 
-class InitRequest(BaseModel):
+class UtmFields(BaseModel):
+    """First-touch acquisition attribution, captured by the web app on first
+    load and forwarded with signup requests. Used only for product analytics
+    (user_signed_up event); never persisted to the users table."""
+
+    utm_source: str | None = Field(default=None, max_length=255)
+    utm_medium: str | None = Field(default=None, max_length=255)
+    utm_campaign: str | None = Field(default=None, max_length=255)
+
+
+class InitRequest(UtmFields):
     email: EmailStr
     name: str
     username: str | None = None
@@ -62,8 +72,12 @@ class UserResponse(BaseModel):
     username: str | None = None
     name: str
     role: UserRole
+    org_id: uuid.UUID | None = None
     avatar_url: str | None = None
     created_at: datetime
+    # Populated from the org join in get_current_user; consumed by the web
+    # app to suppress product analytics for trace-private orgs.
+    trace_privacy: bool = False
 
     model_config = {"from_attributes": True}
 
@@ -75,7 +89,7 @@ class InitResponse(BaseModel):
     expires_in: int
 
 
-class CodeExchangeRequest(BaseModel):
+class CodeExchangeRequest(UtmFields):
     code: str
 
 

--- a/observal-server/schemas/invite.py
+++ b/observal-server/schemas/invite.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Schemas for teammate invites."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+from schemas.auth import UserResponse, _normalize_email, _validate_username
+
+
+class InviteCreateRequest(BaseModel):
+    # Pin the invite to an email (channel=email) or omit for a shareable link
+    email: EmailStr | None = None
+    role: str = "user"
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str | None) -> str | None:
+        return _normalize_email(v) if v else None
+
+
+class InviteResponse(BaseModel):
+    id: uuid.UUID
+    email: str | None = None
+    role: str
+    channel: str
+    status: str  # pending | accepted | expired | revoked
+    created_at: datetime
+    expires_at: datetime
+    accepted_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+    @field_validator("role", "channel", mode="before")
+    @classmethod
+    def _enum_value(cls, v: object) -> object:
+        return getattr(v, "value", v)
+
+
+class InviteCreateResponse(InviteResponse):
+    # Raw token + shareable URL, returned exactly once at creation time
+    token: str
+    invite_url: str
+
+
+class InviteLookupResponse(BaseModel):
+    """Public preview of an invite, shown on the acceptance page."""
+
+    valid: bool
+    reason: str | None = None  # set when invalid: expired | revoked | accepted | not_found
+    org_name: str | None = None
+    email: str | None = None
+    role: str | None = None
+    expires_at: datetime | None = None
+
+
+class InviteAcceptRequest(BaseModel):
+    token: str = Field(min_length=16, max_length=128)
+    # Required for link invites; must match the pinned address for email invites
+    email: EmailStr | None = None
+    name: str = Field(min_length=1, max_length=255)
+    username: str | None = None
+    password: str
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str | None) -> str | None:
+        return _normalize_email(v) if v else None
+
+    @field_validator("username", mode="before")
+    @classmethod
+    def _validate_un(cls, v: str | None) -> str | None:
+        return _validate_username(v)
+
+
+class InviteAcceptResponse(BaseModel):
+    user: UserResponse
+    access_token: str
+    refresh_token: str
+    expires_in: int

--- a/observal-server/services/events.py
+++ b/observal-server/services/events.py
@@ -37,6 +37,12 @@ class UserCreated(Event):
     email: str
     role: str
     is_demo: bool = False
+    org_id: str | None = None
+    auth_provider: str = "local"  # "local" | "oidc" | "saml" | "scim"
+    # First-touch acquisition attribution (None for SSO/SCIM-provisioned users)
+    utm_source: str | None = None
+    utm_medium: str | None = None
+    utm_campaign: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,6 +85,35 @@ class AlertRuleChanged(Event):
     action: str  # "created", "updated", "deleted"
     actor_id: str
     actor_email: str
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCreated(Event):
+    """A new agent was registered in the registry (POST agent create)."""
+
+    agent_id: str
+    org_id: str | None
+    category: str | None
+    created_by: str
+
+
+@dataclass(frozen=True, slots=True)
+class InviteSent(Event):
+    """A teammate invite was created (email-pinned or shareable link)."""
+
+    invite_id: str
+    org_id: str | None
+    channel: str  # "email" | "link"
+    invited_by: str
+
+
+@dataclass(frozen=True, slots=True)
+class InviteAccepted(Event):
+    """An invited user completed signup via an invite token."""
+
+    invite_id: str
+    org_id: str | None
+    user_id: str
 
 
 @dataclass(frozen=True, slots=True)

--- a/observal-server/services/product_analytics.py
+++ b/observal-server/services/product_analytics.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Product analytics (PostHog) capture - public-instance only, OFF by default.
+
+This is the single integration point with PostHog Cloud. Gating rules
+(all must be true for anything to be sent):
+
+1. ``PRODUCT_ANALYTICS_ENABLED=true``  (default: false)
+2. ``POSTHOG_API_KEY`` is non-empty
+3. The acting user's org has ``trace_privacy=false`` (checked per event
+   by :func:`org_trace_private` in the handlers module)
+
+Private / enterprise deployments must leave this off: enabling it sends
+usage events to PostHog Cloud US (subprocessor). See
+``docs/self-hosting/telemetry.md`` for the full event contract.
+
+PII rules: distinct_id is always the user UUID. Properties contain only
+UUIDs and enum-like strings - never email, name, username, prompts, or
+trace content. ``$ip`` is explicitly nulled so PostHog never stores or
+geolocates request IPs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger as optic
+
+from config import settings
+
+_client: Any = None
+_init_attempted = False
+
+
+def is_enabled() -> bool:
+    """Master gate: analytics flag on AND an API key configured."""
+    return bool(settings.PRODUCT_ANALYTICS_ENABLED and settings.POSTHOG_API_KEY)
+
+
+def _get_client() -> Any:
+    """Lazily build the PostHog client. Returns None when gated off."""
+    global _client, _init_attempted
+    if _init_attempted:
+        return _client
+    _init_attempted = True
+
+    if not is_enabled():
+        return None
+
+    try:
+        from posthog import Posthog
+
+        _client = Posthog(
+            project_api_key=settings.POSTHOG_API_KEY,
+            host=settings.POSTHOG_HOST,
+        )
+        optic.info("product analytics enabled (PostHog host: {})", settings.POSTHOG_HOST)
+    except Exception as e:  # missing package, bad config - never break the app
+        optic.warning("product analytics unavailable: {}", e)
+        _client = None
+    return _client
+
+
+async def capture(distinct_id: str, event: str, properties: dict | None = None) -> None:
+    """Fire-and-forget event capture. Never raises, never blocks a request.
+
+    The posthog client enqueues to an in-memory queue flushed by a
+    background thread, so this is a cheap synchronous enqueue. Any client
+    failure (bad key, network down) is swallowed and logged at debug level.
+    """
+    client = _get_client()
+    if client is None:
+        return
+
+    props = dict(properties or {})
+    # Never geolocate / store IPs (server-side captures would otherwise
+    # attribute the API server's IP, or a forwarded user IP, to the person).
+    props["$ip"] = None
+
+    try:
+        client.capture(event=event, distinct_id=distinct_id, properties=props)
+    except Exception as e:
+        optic.debug("product analytics capture failed for {}: {}", event, e)
+
+
+def shutdown() -> None:
+    """Flush the queue and stop the client. Called from app lifespan teardown."""
+    global _client, _init_attempted
+    if _client is not None:
+        try:
+            _client.shutdown()
+        except Exception as e:
+            optic.debug("product analytics shutdown error: {}", e)
+    _client = None
+    _init_attempted = False

--- a/observal-server/services/product_analytics_handlers.py
+++ b/observal-server/services/product_analytics_handlers.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Event-bus subscribers mapping domain events to PostHog product events.
+
+The full PostHog integration lives in this module plus
+``services.product_analytics`` so it can be found and audited in one place.
+
+Event contract (consumed verbatim by the GTM engine - names and property
+keys must not change):
+
+- ``UserCreated``    -> ``user_signed_up``   {utm_source, utm_medium,
+                                              utm_campaign, auth_provider, org_id}
+- ``AgentCreated``   -> ``agent_registered`` {workspace_id, agent_id, agent_type}
+- ``InviteSent``     -> ``invite_sent``      {workspace_id, invite_channel}
+- ``InviteAccepted`` -> ``invite_accepted``  {workspace_id}
+
+Policy decisions (documented per issue #1418):
+
+- Demo accounts are excluded entirely.
+- SCIM/SAML-provisioned users ARE counted as signups, with null UTMs
+  (the GTM engine buckets them as "organic").
+- Invite acceptances emit ``user_signed_up`` with ``utm_source="invite"``
+  (forced server-side in the accept route) plus ``invite_accepted``.
+- Orgs with ``trace_privacy=true`` emit nothing.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from loguru import logger as optic
+from sqlalchemy import select
+
+import services.product_analytics as product_analytics
+from services.events import AgentCreated, InviteAccepted, InviteSent, UserCreated, bus
+
+
+async def org_trace_private(org_id: str | None) -> bool:
+    """True when the org opted into trace privacy (=> drop all telemetry)."""
+    if not org_id:
+        return False
+    try:
+        org_uuid = uuid.UUID(org_id)
+    except (ValueError, TypeError):
+        return False
+
+    from database import async_session
+    from models.organization import Organization
+
+    try:
+        async with async_session() as db:
+            private = await db.scalar(select(Organization.trace_privacy).where(Organization.id == org_uuid))
+        return bool(private)
+    except Exception as e:
+        # Fail closed: if we cannot verify the privacy setting, drop the event.
+        optic.debug("trace_privacy lookup failed for org {}: {}", org_id, e)
+        return True
+
+
+@bus.on(UserCreated)
+async def _capture_user_signed_up(event: UserCreated) -> None:
+    if not product_analytics.is_enabled():
+        return
+    if event.is_demo:
+        return
+    if await org_trace_private(event.org_id):
+        return
+
+    await product_analytics.capture(
+        event.user_id,
+        "user_signed_up",
+        {
+            "utm_source": event.utm_source,
+            "utm_medium": event.utm_medium,
+            "utm_campaign": event.utm_campaign,
+            "auth_provider": event.auth_provider,
+            "org_id": event.org_id,
+        },
+    )
+
+
+@bus.on(AgentCreated)
+async def _capture_agent_registered(event: AgentCreated) -> None:
+    if not product_analytics.is_enabled():
+        return
+    if await org_trace_private(event.org_id):
+        return
+
+    await product_analytics.capture(
+        event.created_by,
+        "agent_registered",
+        {
+            "workspace_id": event.org_id,
+            "agent_id": event.agent_id,
+            "agent_type": event.category,
+        },
+    )
+
+
+@bus.on(InviteSent)
+async def _capture_invite_sent(event: InviteSent) -> None:
+    if not product_analytics.is_enabled():
+        return
+    if await org_trace_private(event.org_id):
+        return
+
+    await product_analytics.capture(
+        event.invited_by,
+        "invite_sent",
+        {
+            "workspace_id": event.org_id,
+            "invite_channel": event.channel,
+        },
+    )
+
+
+@bus.on(InviteAccepted)
+async def _capture_invite_accepted(event: InviteAccepted) -> None:
+    if not product_analytics.is_enabled():
+        return
+    if await org_trace_private(event.org_id):
+        return
+
+    await product_analytics.capture(
+        event.user_id,
+        "invite_accepted",
+        {
+            "workspace_id": event.org_id,
+        },
+    )

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -292,6 +292,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.81"
 source = { registry = "https://pypi.org/simple" }
@@ -1711,6 +1720,7 @@ dependencies = [
     { name = "loguru" },
     { name = "mako" },
     { name = "orjson" },
+    { name = "posthog" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1762,6 +1772,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "mako", specifier = ">=1.3.11" },
     { name = "orjson", specifier = ">=3.10.0" },
+    { name = "posthog", specifier = ">=6.0.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1953,6 +1964,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/56/49d06b64baf270f8ec7fdb9352eaf2469167fcf0a1cbd2facc9335ab52fb/posthog-7.18.1.tar.gz", hash = "sha256:a4a3496448aa2bc4e13880daab205d11c13f8a537570662dcf9e5ecef3696ca1", size = 231652, upload-time = "2026-06-10T14:22:28.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c5/0db39bdf91ae2e473ba139568ed24d631e87caac6c175f466d06eedc8747/posthog-7.18.1-py3-none-any.whl", hash = "sha256:54797ae8767911dfd83541f69a9e4fda65e100cb77dc0cf093fd98a3b84916a6", size = 270818, upload-time = "2026-06-10T14:22:26.849Z" },
 ]
 
 [[package]]

--- a/observal_cli/cmd_support.py
+++ b/observal_cli/cmd_support.py
@@ -63,6 +63,10 @@ CONFIG_ALLOWLIST = frozenset(
         "RATE_LIMIT_AUTH",
         "RATE_LIMIT_AUTH_STRICT",
         "DATA_RETENTION_DAYS",
+        "PRODUCT_ANALYTICS_ENABLED",
+        # Value is redacted by the Redaction Layer (key matches api_key pattern)
+        "POSTHOG_API_KEY",
+        "POSTHOG_HOST",
     }
 )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       lucide-react:
         specifier: ^1.7.0
         version: 1.16.0(react@19.2.6)
+      posthog-js:
+        specifier: ^1.386.1
+        version: 1.386.1
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -565,6 +568,12 @@ packages:
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@posthog/core@1.32.1':
+    resolution: {integrity: sha512-ELq0TQ/MCCj1bY/oFsX53HV6GjRgtzcixhvcPG3Rv+0tU+NaS5Seg1f4cRpfFDTQlIN0Fu+r9oHnFcnXrg7Eew==}
+
+  '@posthog/types@1.386.1':
+    resolution: {integrity: sha512-dsv3xOpKdJIIzcHLzSQ2SZtOvoN2zQMs2thrppTC5e3IVkJUxey+6bY9zOt8FoWHCwQ6jJbNtOp0lVanfbPNeA==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1532,6 +1541,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1645,6 +1657,9 @@ packages:
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1734,6 +1749,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dompurify@3.4.9:
+    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
 
   electron-to-chromium@1.5.331:
     resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
@@ -1841,6 +1859,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2294,6 +2315,12 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.386.1:
+    resolution: {integrity: sha512-RgrneDetc5RkkVvdBAxinbUTASRF3P6Bji5i6BxiYrhX3DH+3mmOo1E5jeW5J8WmLSjt6q0YgWHf+3upqW82Gw==}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2309,6 +2336,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -2622,6 +2652,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
@@ -2968,6 +3001,12 @@ snapshots:
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@posthog/core@1.32.1':
+    dependencies:
+      '@posthog/types': 1.386.1
+
+  '@posthog/types@1.386.1': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -3866,6 +3905,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -3978,6 +4020,8 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
+  core-js@3.49.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4049,6 +4093,10 @@ snapshots:
       dequal: 2.0.3
 
   diff@8.0.4: {}
+
+  dompurify@3.4.9:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.331: {}
 
@@ -4183,6 +4231,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.8: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4790,6 +4840,19 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.386.1:
+    dependencies:
+      '@posthog/core': 1.32.1
+      '@posthog/types': 1.386.1
+      core-js: 3.49.0
+      dompurify: 3.4.9
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
+  preact@10.29.2: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.3: {}
@@ -4797,6 +4860,8 @@ snapshots:
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -5147,6 +5212,8 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+
+  web-vitals@5.3.0: {}
 
   webpack-virtual-modules@0.6.2: {}
 

--- a/tests/test_cmd_support.py
+++ b/tests/test_cmd_support.py
@@ -43,8 +43,8 @@ class TestConfigAllowlist:
     def test_allowlist_is_frozenset(self):
         assert isinstance(CONFIG_ALLOWLIST, frozenset)
 
-    def test_allowlist_has_15_keys(self):
-        assert len(CONFIG_ALLOWLIST) == 15
+    def test_allowlist_has_18_keys(self):
+        assert len(CONFIG_ALLOWLIST) == 18
 
     def test_allowlist_contains_expected_keys(self):
         expected = {
@@ -63,6 +63,9 @@ class TestConfigAllowlist:
             "RATE_LIMIT_AUTH",
             "RATE_LIMIT_AUTH_STRICT",
             "DATA_RETENTION_DAYS",
+            "PRODUCT_ANALYTICS_ENABLED",
+            "POSTHOG_API_KEY",
+            "POSTHOG_HOST",
         }
         assert expected == CONFIG_ALLOWLIST
 

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for the teammate invite feature.
+
+Covers:
+- invite creation (link + email-pinned channels, role ceiling, dedupe)
+- token storage (raw token never persisted, only SHA-256 hash)
+- public lookup (uniform valid=false responses, never 404)
+- acceptance flow (account creation, pinned-email enforcement, single use)
+- revocation
+- bus events (InviteSent / InviteAccepted / UserCreated utm_source=invite)
+- PostHog handler contract (invite_sent / invite_accepted)
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+import services.product_analytics_handlers as handlers
+from models.base import Base
+from models.invite import Invite, InviteChannel
+from models.organization import Organization
+from models.user import User, UserRole
+from services.events import InviteAccepted, InviteSent, UserCreated
+
+STRONG_PASSWORD = "Str0ng!Passw0rd42"
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+        await session.rollback()
+    await engine.dispose()
+
+
+@pytest.fixture()
+async def org(db):
+    org = Organization(name="Acme Corp", slug="acme-corp")
+    db.add(org)
+    await db.commit()
+    await db.refresh(org)
+    return org
+
+
+@pytest.fixture()
+async def admin(db, org):
+    user = User(
+        email="admin@example.com",
+        username="acme-admin",
+        name="Acme Admin",
+        role=UserRole.admin,
+        org_id=org.id,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+class _RecordingBus:
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, event):
+        self.events.append(event)
+
+
+@pytest.fixture()
+def emitted(monkeypatch):
+    """Replace the route module's bus with a recorder."""
+    import api.routes.invite as invite_routes
+
+    recorder = _RecordingBus()
+    monkeypatch.setattr(invite_routes, "bus", recorder)
+    return recorder.events
+
+
+@pytest.fixture()
+def client(db, admin, monkeypatch):
+    from httpx import ASGITransport, AsyncClient
+
+    import api.routes.invite as invite_routes
+    from api.deps import get_current_user, get_db, require_password_auth
+    from api.ratelimit import limiter
+    from main import app
+
+    limiter.enabled = False
+    monkeypatch.setattr(invite_routes, "emit_security_event", AsyncMock())
+
+    async def _fake_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _fake_db
+    app.dependency_overrides[get_current_user] = lambda: admin
+    app.dependency_overrides[require_password_auth] = lambda: None
+
+    yield AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    )
+    app.dependency_overrides.clear()
+
+
+# ── Create ───────────────────────────────────────────────────────────
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_create_link_invite(self, client, db, emitted):
+        async with client as c:
+            r = await c.post("/api/v1/invites", json={})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["channel"] == "link"
+        assert body["email"] is None
+        assert body["status"] == "pending"
+        assert body["token"]
+        assert f"/invite/{body['token']}" in body["invite_url"]
+
+        # Raw token is never persisted, only its hash
+        invite = (await db.execute(select(Invite))).scalar_one()
+        assert invite.token_hash != body["token"]
+        assert len(invite.token_hash) == 64
+
+        sent = [e for e in emitted if isinstance(e, InviteSent)]
+        assert len(sent) == 1
+        assert sent[0].channel == "link"
+
+    @pytest.mark.asyncio
+    async def test_create_email_invite(self, client, emitted):
+        async with client as c:
+            r = await c.post("/api/v1/invites", json={"email": "new@example.com", "role": "reviewer"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["channel"] == "email"
+        assert body["email"] == "new@example.com"
+        assert body["role"] == "reviewer"
+        assert [e.channel for e in emitted if isinstance(e, InviteSent)] == ["email"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_pending_email_invite_rejected(self, client):
+        async with client as c:
+            r1 = await c.post("/api/v1/invites", json={"email": "dup@example.com"})
+            r2 = await c.post("/api/v1/invites", json={"email": "dup@example.com"})
+        assert r1.status_code == 200
+        assert r2.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_existing_user_email_rejected(self, client, admin):
+        async with client as c:
+            r = await c.post("/api/v1/invites", json={"email": admin.email})
+        assert r.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_cannot_invite_above_own_role(self, client):
+        async with client as c:
+            r = await c.post("/api/v1/invites", json={"role": "super_admin"})
+        assert r.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_invalid_role_rejected(self, client):
+        async with client as c:
+            r = await c.post("/api/v1/invites", json={"role": "emperor"})
+        assert r.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_anonymous_rejected(self, db):
+        from httpx import ASGITransport, AsyncClient
+
+        from main import app
+
+        app.dependency_overrides.clear()
+        async with AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False), base_url="http://test"
+        ) as c:
+            r = await c.post("/api/v1/invites", json={})
+        assert r.status_code == 401
+
+
+# ── List / revoke ────────────────────────────────────────────────────
+
+
+class TestListRevoke:
+    @pytest.mark.asyncio
+    async def test_list_and_revoke(self, client, emitted):
+        async with client as c:
+            created = (await c.post("/api/v1/invites", json={})).json()
+
+            listed = await c.get("/api/v1/invites")
+            assert listed.status_code == 200
+            assert [i["id"] for i in listed.json()] == [created["id"]]
+
+            revoked = await c.delete(f"/api/v1/invites/{created['id']}")
+            assert revoked.status_code == 204
+
+            after = (await c.get("/api/v1/invites")).json()
+            assert after[0]["status"] == "revoked"
+
+    @pytest.mark.asyncio
+    async def test_revoke_unknown_invite_404(self, client):
+        async with client as c:
+            r = await c.delete(f"/api/v1/invites/{uuid.uuid4()}")
+        assert r.status_code == 404
+
+
+# ── Lookup ───────────────────────────────────────────────────────────
+
+
+class TestLookup:
+    @pytest.mark.asyncio
+    async def test_lookup_unknown_token_is_uniform(self, client):
+        async with client as c:
+            r = await c.get("/api/v1/invites/lookup/this-token-does-not-exist")
+        assert r.status_code == 200
+        assert r.json() == {
+            "valid": False,
+            "reason": "not_found",
+            "org_name": None,
+            "email": None,
+            "role": None,
+            "expires_at": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_lookup_pending_invite(self, client, org):
+        async with client as c:
+            created = (await c.post("/api/v1/invites", json={"email": "peek@example.com"})).json()
+            r = await c.get(f"/api/v1/invites/lookup/{created['token']}")
+        body = r.json()
+        assert body["valid"] is True
+        assert body["org_name"] == org.name
+        assert body["email"] == "peek@example.com"
+
+    @pytest.mark.asyncio
+    async def test_lookup_revoked_invite(self, client):
+        async with client as c:
+            created = (await c.post("/api/v1/invites", json={})).json()
+            await c.delete(f"/api/v1/invites/{created['id']}")
+            r = await c.get(f"/api/v1/invites/lookup/{created['token']}")
+        assert r.json()["valid"] is False
+        assert r.json()["reason"] == "revoked"
+
+
+# ── Accept ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def issue_tokens(monkeypatch):
+    import api.routes.auth as auth_routes
+
+    monkeypatch.setattr(auth_routes, "_issue_tokens", AsyncMock(return_value=("access-token", "refresh-token", 900)))
+
+
+class TestAccept:
+    @pytest.mark.asyncio
+    async def test_accept_link_invite_creates_user(self, client, db, org, emitted, issue_tokens):
+        async with client as c:
+            created = (await c.post("/api/v1/invites", json={"role": "reviewer"})).json()
+            r = await c.post(
+                "/api/v1/invites/accept",
+                json={
+                    "token": created["token"],
+                    "email": "joiner@example.com",
+                    "name": "Joiner",
+                    "password": STRONG_PASSWORD,
+                },
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["access_token"] == "access-token"
+        assert body["user"]["email"] == "joiner@example.com"
+
+        user = (await db.execute(select(User).where(User.email == "joiner@example.com"))).scalar_one()
+        assert user.role == UserRole.reviewer
+        assert user.org_id == org.id
+
+        # Signup attribution is forced to the invite loop
+        signups = [e for e in emitted if isinstance(e, UserCreated)]
+        assert len(signups) == 1
+        assert signups[0].utm_source == "invite"
+        accepted = [e for e in emitted if isinstance(e, InviteAccepted)]
+        assert len(accepted) == 1
+        assert accepted[0].user_id == str(user.id)
+
+    @pytest.mark.asyncio
+    async def test_accept_is_single_use(self, client, issue_tokens):
+        async with client as c:
+            created = (await c.post("/api/v1/invites", json={})).json()
+            first = await c.post(
+                "/api/v1/invites/accept",
+                json={
+                    "token": created["token"],
+                    "email": "first@example.com",
+                    "name": "First",
+                    "password": STRONG_PASSWORD,
+                },
+            )
+            second = await c.post(
+                "/api/v1/invites/accept",
+                json={
+                    "token": created["token"],
+                    "email": "second@example.com",
+                    "name": "Second",
+                    "password": STRONG_PASSWORD,
+                },
+            )
+        assert first.status_code == 200
+        assert second.status_code == 410
+
+    @pytest.mark.asyncio
+    async def test_accept_pinned_email_mismatch_rejected(self, client, issue_tokens):
+        async with client as c:
+            created = (await c.post("/api/v1/invites", json={"email": "pinned@example.com"})).json()
+            r = await c.post(
+                "/api/v1/invites/accept",
+                json={
+                    "token": created["token"],
+                    "email": "other@example.com",
+                    "name": "Other",
+                    "password": STRONG_PASSWORD,
+                },
+            )
+        assert r.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_accept_link_invite_requires_email(self, client, issue_tokens):
+        async with client as c:
+            created = (await c.post("/api/v1/invites", json={})).json()
+            r = await c.post(
+                "/api/v1/invites/accept",
+                json={"token": created["token"], "name": "NoEmail", "password": STRONG_PASSWORD},
+            )
+        assert r.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_accept_revoked_invite_410(self, client, issue_tokens):
+        async with client as c:
+            created = (await c.post("/api/v1/invites", json={})).json()
+            await c.delete(f"/api/v1/invites/{created['id']}")
+            r = await c.post(
+                "/api/v1/invites/accept",
+                json={
+                    "token": created["token"],
+                    "email": "late@example.com",
+                    "name": "Late",
+                    "password": STRONG_PASSWORD,
+                },
+            )
+        assert r.status_code == 410
+
+    @pytest.mark.asyncio
+    async def test_accept_unknown_token_404(self, client, issue_tokens):
+        async with client as c:
+            r = await c.post(
+                "/api/v1/invites/accept",
+                json={
+                    "token": "x" * 43,
+                    "email": "ghost@example.com",
+                    "name": "Ghost",
+                    "password": STRONG_PASSWORD,
+                },
+            )
+        assert r.status_code == 404
+
+
+# ── Model status lifecycle ───────────────────────────────────────────
+
+
+class TestStatus:
+    def _invite(self, **kw) -> Invite:
+        defaults = dict(
+            org_id=uuid.uuid4(),
+            role=UserRole.user,
+            channel=InviteChannel.link,
+            token_hash="h" * 64,
+            expires_at=datetime.now(UTC) + timedelta(days=7),
+            revoked=False,
+        )
+        defaults.update(kw)
+        return Invite(**defaults)
+
+    def test_pending(self):
+        assert self._invite().status == "pending"
+
+    def test_expired(self):
+        assert self._invite(expires_at=datetime.now(UTC) - timedelta(minutes=1)).status == "expired"
+
+    def test_revoked_wins_over_everything(self):
+        inv = self._invite(revoked=True, accepted_at=datetime.now(UTC))
+        assert inv.status == "revoked"
+
+    def test_accepted(self):
+        assert self._invite(accepted_at=datetime.now(UTC)).status == "accepted"
+
+
+# ── PostHog handler contract ─────────────────────────────────────────
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    events: list[tuple[str, str, dict]] = []
+
+    async def fake_capture(distinct_id, event, properties=None):
+        events.append((distinct_id, event, properties or {}))
+
+    async def not_private(_org_id):
+        return False
+
+    monkeypatch.setattr(handlers.product_analytics, "is_enabled", lambda: True)
+    monkeypatch.setattr(handlers.product_analytics, "capture", fake_capture)
+    monkeypatch.setattr(handlers, "org_trace_private", not_private)
+    return events
+
+
+class TestAnalyticsContract:
+    @pytest.mark.asyncio
+    async def test_invite_sent_contract(self, captured):
+        await handlers._capture_invite_sent(
+            InviteSent(invite_id="inv-1", org_id="org-1", channel="email", invited_by="admin-1")
+        )
+        assert captured == [("admin-1", "invite_sent", {"workspace_id": "org-1", "invite_channel": "email"})]
+
+    @pytest.mark.asyncio
+    async def test_invite_accepted_contract(self, captured):
+        await handlers._capture_invite_accepted(InviteAccepted(invite_id="inv-1", org_id="org-1", user_id="user-1"))
+        assert captured == [("user-1", "invite_accepted", {"workspace_id": "org-1"})]
+
+    @pytest.mark.asyncio
+    async def test_handlers_respect_disable_gate(self, monkeypatch, captured):
+        monkeypatch.setattr(handlers.product_analytics, "is_enabled", lambda: False)
+        await handlers._capture_invite_sent(InviteSent(invite_id="i", org_id="o", channel="link", invited_by="a"))
+        await handlers._capture_invite_accepted(InviteAccepted(invite_id="i", org_id="o", user_id="u"))
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_trace_private_org_drops_invite_events(self, monkeypatch, captured):
+        async def private(_org_id):
+            return True
+
+        monkeypatch.setattr(handlers, "org_trace_private", private)
+        await handlers._capture_invite_sent(InviteSent(invite_id="i", org_id="o", channel="link", invited_by="a"))
+        await handlers._capture_invite_accepted(InviteAccepted(invite_id="i", org_id="o", user_id="u"))
+        assert captured == []

--- a/tests/test_product_analytics.py
+++ b/tests/test_product_analytics.py
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for the PostHog product analytics integration (issue #1418).
+
+Covers:
+- the enable gate matrix (flag x key x trace_privacy)
+- bus-subscriber mapping to the exact GTM event contract
+- fire-and-forget behaviour (client failures never propagate)
+- settings-export / support-bundle allowlists (key redacted)
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import services.product_analytics as pa
+import services.product_analytics_handlers as handlers
+from config import settings
+from services.events import AgentCreated, UserCreated
+
+
+@pytest.fixture(autouse=True)
+def _reset_client():
+    """Reset the lazily-initialized client between tests."""
+    pa._client = None
+    pa._init_attempted = False
+    yield
+    pa._client = None
+    pa._init_attempted = False
+
+
+def _fake_client():
+    client = MagicMock()
+    pa._client = client
+    pa._init_attempted = True
+    return client
+
+
+# ── Gate matrix ──────────────────────────────────────────────────────
+
+
+class TestGate:
+    @pytest.mark.parametrize(
+        ("enabled", "key", "expected"),
+        [
+            (False, "", False),
+            (False, "phc_test", False),
+            (True, "", False),
+            (True, "phc_test", True),
+        ],
+    )
+    def test_is_enabled_matrix(self, monkeypatch, enabled, key, expected):
+        monkeypatch.setattr(settings, "PRODUCT_ANALYTICS_ENABLED", enabled)
+        monkeypatch.setattr(settings, "POSTHOG_API_KEY", key)
+        assert pa.is_enabled() is expected
+
+    def test_default_settings_are_off(self):
+        from config import Settings
+
+        defaults = Settings.model_fields
+        assert defaults["PRODUCT_ANALYTICS_ENABLED"].default is False
+        assert defaults["POSTHOG_API_KEY"].default == ""
+        assert defaults["POSTHOG_HOST"].default == "https://us.i.posthog.com"
+
+    @pytest.mark.asyncio
+    async def test_capture_is_noop_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "PRODUCT_ANALYTICS_ENABLED", False)
+        monkeypatch.setattr(settings, "POSTHOG_API_KEY", "")
+        # Must not raise and must not create a client
+        await pa.capture("user-1", "user_signed_up", {"a": 1})
+        assert pa._client is None
+
+    @pytest.mark.asyncio
+    async def test_handlers_short_circuit_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(handlers.product_analytics, "is_enabled", lambda: False)
+        called = []
+
+        async def fake_capture(*a, **kw):
+            called.append(a)
+
+        monkeypatch.setattr(handlers.product_analytics, "capture", fake_capture)
+        await handlers._capture_user_signed_up(UserCreated(user_id="u1", email="a@b", role="user"))
+        await handlers._capture_agent_registered(
+            AgentCreated(agent_id="ag1", org_id="org1", category=None, created_by="u1")
+        )
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_trace_private_org_drops_events(self, monkeypatch):
+        monkeypatch.setattr(handlers.product_analytics, "is_enabled", lambda: True)
+
+        async def private(_org_id):
+            return True
+
+        monkeypatch.setattr(handlers, "org_trace_private", private)
+        called = []
+
+        async def fake_capture(*a, **kw):
+            called.append(a)
+
+        monkeypatch.setattr(handlers.product_analytics, "capture", fake_capture)
+        await handlers._capture_user_signed_up(UserCreated(user_id="u1", email="a@b", role="user", org_id="org1"))
+        await handlers._capture_agent_registered(
+            AgentCreated(agent_id="ag1", org_id="org1", category="coding", created_by="u1")
+        )
+        assert called == []
+
+
+# ── Bus-subscriber mapping (exact GTM contract) ──────────────────────
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    events: list[tuple[str, str, dict]] = []
+
+    async def fake_capture(distinct_id, event, properties=None):
+        events.append((distinct_id, event, properties or {}))
+
+    async def not_private(_org_id):
+        return False
+
+    monkeypatch.setattr(handlers.product_analytics, "is_enabled", lambda: True)
+    monkeypatch.setattr(handlers.product_analytics, "capture", fake_capture)
+    monkeypatch.setattr(handlers, "org_trace_private", not_private)
+    return events
+
+
+class TestSubscriberMapping:
+    @pytest.mark.asyncio
+    async def test_events_route_through_bus_to_capture(self, captured):
+        """Bus dispatch routes UserCreated/AgentCreated to the PostHog handlers.
+
+        Uses a fresh bus: other suites clear the global singleton's handlers.
+        """
+        from services.events import EventBus
+
+        local_bus = EventBus()
+        local_bus.register(UserCreated, handlers._capture_user_signed_up)
+        local_bus.register(AgentCreated, handlers._capture_agent_registered)
+
+        await local_bus.emit(UserCreated(user_id="u1", email="a@b", role="user", org_id="o1"))
+        await local_bus.emit(AgentCreated(agent_id="ag1", org_id="o1", category=None, created_by="u1"))
+
+        assert [(c[0], c[1]) for c in captured] == [("u1", "user_signed_up"), ("u1", "agent_registered")]
+
+    @pytest.mark.asyncio
+    async def test_user_signed_up_contract(self, captured):
+        await handlers._capture_user_signed_up(
+            UserCreated(
+                user_id="user-uuid",
+                email="a@b.com",
+                role="user",
+                org_id="org-uuid",
+                auth_provider="oidc",
+                utm_source="hn",
+                utm_medium="social",
+                utm_campaign="launch",
+            )
+        )
+        assert captured == [
+            (
+                "user-uuid",
+                "user_signed_up",
+                {
+                    "utm_source": "hn",
+                    "utm_medium": "social",
+                    "utm_campaign": "launch",
+                    "auth_provider": "oidc",
+                    "org_id": "org-uuid",
+                },
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_user_signed_up_null_utms_for_provisioned_users(self, captured):
+        await handlers._capture_user_signed_up(
+            UserCreated(user_id="u1", email="a@b", role="user", org_id="org1", auth_provider="scim")
+        )
+        _, _, props = captured[0]
+        assert props["utm_source"] is None
+        assert props["utm_medium"] is None
+        assert props["utm_campaign"] is None
+        assert props["auth_provider"] == "scim"
+
+    @pytest.mark.asyncio
+    async def test_demo_accounts_emit_nothing(self, captured):
+        await handlers._capture_user_signed_up(UserCreated(user_id="u1", email="demo@b", role="user", is_demo=True))
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_agent_registered_contract(self, captured):
+        await handlers._capture_agent_registered(
+            AgentCreated(agent_id="agent-uuid", org_id="org-uuid", category="coding", created_by="user-uuid")
+        )
+        assert captured == [
+            (
+                "user-uuid",
+                "agent_registered",
+                {
+                    "workspace_id": "org-uuid",
+                    "agent_id": "agent-uuid",
+                    "agent_type": "coding",
+                },
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_pii_in_properties(self, captured):
+        await handlers._capture_user_signed_up(
+            UserCreated(user_id="u1", email="secret@example.com", role="user", org_id="org1")
+        )
+        _, _, props = captured[0]
+        assert "email" not in props
+        assert "name" not in props
+        assert "secret@example.com" not in str(props.values())
+
+
+# ── Capture behaviour ────────────────────────────────────────────────
+
+
+class TestCapture:
+    @pytest.mark.asyncio
+    async def test_capture_nulls_ip(self):
+        client = _fake_client()
+        await pa.capture("u1", "user_signed_up", {"org_id": "o1"})
+        client.capture.assert_called_once_with(
+            event="user_signed_up",
+            distinct_id="u1",
+            properties={"org_id": "o1", "$ip": None},
+        )
+
+    @pytest.mark.asyncio
+    async def test_capture_swallows_client_errors(self):
+        client = _fake_client()
+        client.capture.side_effect = RuntimeError("network down")
+        # Must never raise into the request path
+        await pa.capture("u1", "agent_registered", {})
+
+    def test_shutdown_flushes_and_resets(self):
+        client = _fake_client()
+        pa.shutdown()
+        client.shutdown.assert_called_once()
+        assert pa._client is None
+        assert pa._init_attempted is False
+
+    def test_shutdown_swallows_errors(self):
+        client = _fake_client()
+        client.shutdown.side_effect = RuntimeError("boom")
+        pa.shutdown()  # must not raise
+
+
+# ── UTM threading through signup schemas ─────────────────────────────
+
+
+class TestSchemas:
+    def test_init_request_accepts_optional_utms(self):
+        from schemas.auth import InitRequest
+
+        req = InitRequest(email="a@b.com", name="A", utm_source="hn", utm_medium="social")
+        assert req.utm_source == "hn"
+        assert req.utm_medium == "social"
+        assert req.utm_campaign is None
+
+        # Omitted entirely -> all None (backward compatible)
+        req2 = InitRequest(email="a@b.com", name="A")
+        assert req2.utm_source is None
+
+    def test_exchange_request_accepts_optional_utms(self):
+        from schemas.auth import CodeExchangeRequest
+
+        req = CodeExchangeRequest(code="x", utm_source="invite")
+        assert req.utm_source == "invite"
+        assert CodeExchangeRequest(code="x").utm_source is None
+
+    def test_user_created_event_defaults(self):
+        e = UserCreated(user_id="1", email="a@b", role="user")
+        assert e.org_id is None
+        assert e.auth_provider == "local"
+        assert e.utm_source is None
+
+
+# ── Settings export / support bundle ─────────────────────────────────
+
+
+class TestSettingsExport:
+    def test_server_support_allowlist_includes_analytics_keys(self):
+        from api.routes.support import CONFIG_ALLOWLIST
+
+        assert "PRODUCT_ANALYTICS_ENABLED" in CONFIG_ALLOWLIST
+        assert "POSTHOG_API_KEY" in CONFIG_ALLOWLIST
+        assert "POSTHOG_HOST" in CONFIG_ALLOWLIST
+
+    def test_cli_support_allowlist_includes_analytics_keys(self):
+        from observal_cli.cmd_support import CONFIG_ALLOWLIST
+
+        assert "PRODUCT_ANALYTICS_ENABLED" in CONFIG_ALLOWLIST
+        assert "POSTHOG_API_KEY" in CONFIG_ALLOWLIST
+        assert "POSTHOG_HOST" in CONFIG_ALLOWLIST
+
+    def test_posthog_api_key_value_is_redacted(self):
+        from observal_cli.support.redaction import REDACTED, redact_value
+
+        redacted, count = redact_value(
+            {
+                "PRODUCT_ANALYTICS_ENABLED": True,
+                "POSTHOG_API_KEY": "phc_supersecretprojectkey",
+                "POSTHOG_HOST": "https://us.i.posthog.com",
+            }
+        )
+        assert redacted["POSTHOG_API_KEY"] == REDACTED
+        assert count >= 1
+        # Non-secret analytics settings remain readable for diagnostics
+        assert redacted["PRODUCT_ANALYTICS_ENABLED"] is True
+        assert redacted["POSTHOG_HOST"] == "https://us.i.posthog.com"

--- a/web/package.json
+++ b/web/package.json
@@ -46,6 +46,7 @@
     "graphql-ws": "^6.0.8",
     "js-yaml": "^4.1.1",
     "lucide-react": "^1.7.0",
+    "posthog-js": "^1.386.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",

--- a/web/src/hooks/use-admin-api.ts
+++ b/web/src/hooks/use-admin-api.ts
@@ -19,6 +19,7 @@ import { toast } from "sonner";
 import {
   auth,
   admin,
+  invites,
   telemetry,
   getUserRole,
 } from "@/lib/api";
@@ -107,6 +108,40 @@ export function useResetPassword() {
     },
     onError: (err: Error) => {
       toast.error(err.message || "Failed to reset password");
+    },
+  });
+}
+
+// ── Invites ─────────────────────────────────────────────────────────
+
+export function useInvites() {
+  return useQuery({ queryKey: ["admin", "invites"], queryFn: invites.list });
+}
+
+export function useCreateInvite() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: invites.create,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "invites"] });
+      toast.success("Invite created");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to create invite");
+    },
+  });
+}
+
+export function useRevokeInvite() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => invites.revoke(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "invites"] });
+      toast.success("Invite revoked");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to revoke invite");
     },
   });
 }

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -8,6 +8,7 @@
 import { useEffect, useSyncExternalStore } from "react";
 import { useRouter, useLocation } from "@tanstack/react-router";
 import { auth, setUserRole, getUserRole, clearSession, refreshAccessToken } from "@/lib/api";
+import { setAnalyticsUser } from "@/lib/analytics";
 
 function subscribe(cb: () => void) {
   window.addEventListener("storage", cb);
@@ -66,6 +67,7 @@ export function useAuthGuard() {
     if (snapshot === "pending") {
       auth.whoami().then((user) => {
         setUserRole(user.role);
+        setAnalyticsUser(user);
         window.dispatchEvent(new Event("storage"));
       }).catch(() => {
         clearSession();
@@ -94,6 +96,7 @@ export function useOptionalAuth() {
     if (hasToken && snapshot === "pending") {
       auth.whoami().then((user) => {
         setUserRole(user.role);
+        setAnalyticsUser(user);
         window.dispatchEvent(new Event("storage"));
       }).catch(() => {
         clearSession();

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Product analytics (PostHog) - public-instance only, off by default.
+ *
+ * posthog-js is initialized only when the server's public config says
+ * analytics is enabled (PRODUCT_ANALYTICS_ENABLED + key, server-side gate).
+ * Deliberate SOC 2 / privacy posture, not an oversight:
+ *   - no autocapture, no pageview capture, no session recording
+ *   - person profiles for identified users only (distinct id = user UUID)
+ *   - the ONLY frontend event is `insights_viewed`
+ *   - users in orgs with trace_privacy=true emit nothing
+ *
+ * This module also persists first-touch UTM attribution (90-day expiry,
+ * first touch wins) which signup flows forward to the server so the
+ * server-side `user_signed_up` event carries acquisition channel.
+ */
+
+import type { PostHog } from "posthog-js";
+import { auth, type ProductAnalyticsConfig } from "./api";
+
+// ── First-touch UTM attribution ──────────────────────────────────────
+
+const FIRST_TOUCH_KEY = "observal_first_touch";
+const FIRST_TOUCH_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+export type FirstTouch = {
+	utm_source: string | null;
+	utm_medium: string | null;
+	utm_campaign: string | null;
+};
+
+type StoredFirstTouch = FirstTouch & { captured_at: number };
+
+function readStoredFirstTouch(): StoredFirstTouch | null {
+	try {
+		const raw = localStorage.getItem(FIRST_TOUCH_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as StoredFirstTouch;
+		if (!parsed.captured_at || Date.now() - parsed.captured_at > FIRST_TOUCH_TTL_MS) {
+			localStorage.removeItem(FIRST_TOUCH_KEY);
+			return null;
+		}
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+/** Capture UTM params from the current URL. First touch wins: an existing
+ * unexpired record is never overwritten. Call as early as possible on load. */
+export function storeFirstTouch(): void {
+	try {
+		if (readStoredFirstTouch()) return;
+		const params = new URLSearchParams(window.location.search);
+		const source = params.get("utm_source");
+		const medium = params.get("utm_medium");
+		const campaign = params.get("utm_campaign");
+		if (!source && !medium && !campaign) return;
+		const record: StoredFirstTouch = {
+			utm_source: source,
+			utm_medium: medium,
+			utm_campaign: campaign,
+			captured_at: Date.now(),
+		};
+		localStorage.setItem(FIRST_TOUCH_KEY, JSON.stringify(record));
+	} catch {
+		// localStorage unavailable - attribution simply degrades to organic
+	}
+}
+
+/** Stored first-touch UTMs (nulls when absent/expired), for signup payloads. */
+export function getFirstTouch(): FirstTouch {
+	const stored = readStoredFirstTouch();
+	return {
+		utm_source: stored?.utm_source ?? null,
+		utm_medium: stored?.utm_medium ?? null,
+		utm_campaign: stored?.utm_campaign ?? null,
+	};
+}
+
+// ── PostHog client (gated) ───────────────────────────────────────────
+
+let client: PostHog | null = null;
+let workspaceId: string | null = null;
+// true once we know the user's org opted into trace privacy
+let suppressed = false;
+let userResolved = false;
+
+/** Initialize posthog-js. No-op unless the server-provided config says
+ * analytics is enabled. Never throws. */
+export async function initAnalytics(cfg: ProductAnalyticsConfig | undefined): Promise<void> {
+	if (!cfg?.enabled || !cfg.posthog_key) return;
+	try {
+		const { default: posthog } = await import("posthog-js");
+		posthog.init(cfg.posthog_key, {
+			api_host: cfg.posthog_host ?? undefined,
+			autocapture: false,
+			capture_pageview: false,
+			disable_session_recording: true,
+			person_profiles: "identified_only",
+		});
+		client = posthog;
+	} catch {
+		client = null;
+	}
+}
+
+/** Record the authenticated user: identify by UUID only (no email/name) and
+ * remember org context + trace-privacy suppression. */
+export function setAnalyticsUser(user: {
+	id: string;
+	org_id?: string | null;
+	trace_privacy?: boolean;
+}): void {
+	workspaceId = user.org_id ?? null;
+	suppressed = !!user.trace_privacy;
+	userResolved = true;
+	if (client && !suppressed) {
+		client.identify(user.id);
+	}
+}
+
+export function resetAnalyticsUser(): void {
+	workspaceId = null;
+	suppressed = false;
+	userResolved = false;
+	client?.reset();
+}
+
+// ── Events ───────────────────────────────────────────────────────────
+
+let lastInsightsKey: string | null = null;
+let lastInsightsAt = 0;
+
+/** Fire `insights_viewed` once per page visit (deduped against StrictMode
+ * double-mount and re-renders). */
+export async function trackInsightsViewed(reportId: string): Promise<void> {
+	if (!client) return;
+
+	const now = Date.now();
+	if (lastInsightsKey === reportId && now - lastInsightsAt < 5000) return;
+	lastInsightsKey = reportId;
+	lastInsightsAt = now;
+
+	if (!userResolved) {
+		try {
+			setAnalyticsUser(await auth.whoami());
+		} catch {
+			return;
+		}
+	}
+	if (suppressed) return;
+
+	client.capture("insights_viewed", { workspace_id: workspaceId });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -346,8 +346,14 @@ type AuthResponse = {
 };
 
 export const auth = {
-	init: (body: { email: string; name: string; password?: string }) =>
-		post<AuthResponse>("/auth/init", body),
+	init: (body: {
+		email: string;
+		name: string;
+		password?: string;
+		utm_source?: string | null;
+		utm_medium?: string | null;
+		utm_campaign?: string | null;
+	}) => post<AuthResponse>("/auth/init", body),
 	login: (body: { email: string; password: string }) =>
 		post<AuthResponse & { must_change_password?: boolean }>(
 			"/auth/login",
@@ -360,10 +366,16 @@ export const auth = {
 			username?: string | null;
 			name: string;
 			role: string;
+			org_id?: string | null;
 			avatar_url?: string | null;
+			trace_privacy?: boolean;
 		}>("/auth/whoami"),
-	exchangeCode: (body: { code: string }) =>
-		post<AuthResponse>("/auth/exchange", body),
+	exchangeCode: (body: {
+		code: string;
+		utm_source?: string | null;
+		utm_medium?: string | null;
+		utm_campaign?: string | null;
+	}) => post<AuthResponse>("/auth/exchange", body),
 	deviceConfirm: (userCode: string) =>
 		post<{ message: string }>("/auth/device/confirm", { user_code: userCode }),
 	changePassword: (body: { current_password: string; new_password: string }) =>
@@ -371,6 +383,48 @@ export const auth = {
 	uploadAvatar: (body: { avatar_url: string }) =>
 		put<{ avatar_url: string | null }>("/auth/profile/avatar", body),
 	deleteAvatar: () => del<{ avatar_url: null }>("/auth/profile/avatar"),
+};
+
+// ── Invites ─────────────────────────────────────────────────────────
+export type Invite = {
+	id: string;
+	email: string | null;
+	role: string;
+	channel: "email" | "link";
+	status: "pending" | "accepted" | "expired" | "revoked";
+	created_at: string;
+	expires_at: string;
+	accepted_at: string | null;
+};
+
+export type InviteCreated = Invite & {
+	token: string;
+	invite_url: string;
+};
+
+export type InviteLookup = {
+	valid: boolean;
+	reason?: "expired" | "revoked" | "accepted" | "not_found" | null;
+	org_name?: string | null;
+	email?: string | null;
+	role?: string | null;
+	expires_at?: string | null;
+};
+
+export const invites = {
+	create: (body: { email?: string | null; role?: string }) =>
+		post<InviteCreated>("/invites", body),
+	list: () => get<Invite[]>("/invites"),
+	revoke: (id: string) => del(`/invites/${id}`),
+	lookup: (token: string) =>
+		get<InviteLookup>(`/invites/lookup/${encodeURIComponent(token)}`),
+	accept: (body: {
+		token: string;
+		email?: string | null;
+		name: string;
+		username?: string;
+		password: string;
+	}) => post<AuthResponse>("/invites/accept", body),
 };
 
 // ── Registry (all 8 types) ─────────────────────────────────────────
@@ -752,6 +806,12 @@ export type RetentionWarnings = {
 };
 
 // ── Config ─────────────────────────────────────────────────────────
+export type ProductAnalyticsConfig = {
+	enabled: boolean;
+	posthog_key: string | null;
+	posthog_host: string | null;
+};
+
 export type PublicConfig = {
 	licensed: boolean;
 	sso_enabled: boolean;
@@ -762,6 +822,7 @@ export type PublicConfig = {
 	branding_logo: string | null;
 	branding_app_name: string | null;
 	branding_wordmark: string | null;
+	product_analytics?: ProductAnalyticsConfig;
 };
 
 export interface IdeEntry {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,6 +5,16 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
+import { config } from "./lib/api";
+import { initAnalytics, storeFirstTouch } from "./lib/analytics";
+
+// Persist first-touch UTM attribution before any routing strips the query
+// string; then initialize product analytics only if the server enables it.
+storeFirstTouch();
+config
+  .public()
+  .then((cfg) => initAnalytics(cfg.product_analytics))
+  .catch(() => {});
 
 const router = createRouter({
   routeTree,

--- a/web/src/pages/admin/insights/detail.tsx
+++ b/web/src/pages/admin/insights/detail.tsx
@@ -41,6 +41,7 @@ import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/layouts/page-header";
 import { ErrorState } from "@/components/shared/error-state";
 import { insights } from "@/lib/api";
+import { trackInsightsViewed } from "@/lib/analytics";
 import type { InsightReport } from "@/lib/types";
 
 // ── Status Indicator ──────────────────────────────────────────────────────
@@ -1684,6 +1685,11 @@ export default function InsightReportPage() {
 	const { reportId } = useParams({ from: "/_authed/insights/$reportId" });
 	const router = useRouter();
 	const { data: report, isLoading, isError } = useInsightReport(reportId);
+
+	// Product analytics: one event per page visit (no-op unless enabled)
+	React.useEffect(() => {
+		trackInsightsViewed(reportId);
+	}, [reportId]);
 
 	return (
 		<>

--- a/web/src/pages/admin/users.tsx
+++ b/web/src/pages/admin/users.tsx
@@ -8,10 +8,10 @@
 
 
 import { useState, useCallback } from "react";
-import { Users, Plus, Copy, Check, Loader2, Key, Trash2, RotateCcw } from "lucide-react";
+import { Users, Plus, Copy, Check, Loader2, Key, Trash2, RotateCcw, UserPlus, Link2, Mail, X } from "lucide-react";
 import { toast } from "sonner";
-import { useAdminUsers, useCreateUser, useUpdateUserRole, useUpdateUserDepartment, useDeleteUser, useResetPassword } from "@/hooks/use-api";
-import { admin } from "@/lib/api";
+import { useAdminUsers, useCreateUser, useUpdateUserRole, useUpdateUserDepartment, useDeleteUser, useResetPassword, useInvites, useCreateInvite, useRevokeInvite } from "@/hooks/use-api";
+import { admin, type Invite, type InviteCreated } from "@/lib/api";
 import type { AdminUser } from "@/lib/types";
 import { copyToClipboard } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -107,7 +107,10 @@ function DepartmentInput({ userId, currentDept }: { userId: string; currentDept:
 
 export default function UsersPage() {
   const { data: users, isLoading, isError, error, refetch } = useAdminUsers();
+  const { data: invitesList } = useInvites();
   const createUser = useCreateUser();
+  const createInvite = useCreateInvite();
+  const revokeInvite = useRevokeInvite();
   const deleteUser = useDeleteUser();
   const resetPassword = useResetPassword();
   const assignableRoles = useAssignableRoles();
@@ -126,6 +129,12 @@ export default function UsersPage() {
   const [createdPassword, setCreatedPassword] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [resetCopied, setResetCopied] = useState(false);
+
+  const [showInvite, setShowInvite] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<string>("user");
+  const [inviteResult, setInviteResult] = useState<InviteCreated | null>(null);
+  const [inviteCopied, setInviteCopied] = useState(false);
 
   const handleCreate = useCallback(async () => {
     if (!name.trim() || !email.trim()) return;
@@ -177,6 +186,31 @@ export default function UsersPage() {
     setRole("user");
   }, []);
 
+  const handleCreateInvite = useCallback(() => {
+    createInvite.mutate(
+      { email: inviteEmail.trim() || null, role: inviteRole },
+      { onSuccess: (data) => setInviteResult(data) },
+    );
+  }, [inviteEmail, inviteRole, createInvite]);
+
+  const handleCopyInviteUrl = useCallback(() => {
+    if (!inviteResult) return;
+    copyToClipboard(inviteResult.invite_url);
+    setInviteCopied(true);
+    toast.success("Invite link copied");
+    setTimeout(() => setInviteCopied(false), 2000);
+  }, [inviteResult]);
+
+  const closeInviteDialog = useCallback(() => {
+    setShowInvite(false);
+    setInviteResult(null);
+    setInviteEmail("");
+    setInviteRole("user");
+    setInviteCopied(false);
+  }, []);
+
+  const pendingInvites = (invitesList ?? []).filter((i: Invite) => i.status === "pending");
+
   const userCount = (users ?? []).length;
 
   return (
@@ -193,9 +227,14 @@ export default function UsersPage() {
               <Users className="mr-1 h-3.5 w-3.5" /> Bulk Departments
             </Button>
             {!ssoOnly && (
-              <Button size="sm" variant="outline" onClick={() => setShowCreate(true)} className="h-8">
-                <Plus className="mr-1 h-3.5 w-3.5" /> Add User
-              </Button>
+              <>
+                <Button size="sm" variant="outline" onClick={() => setShowInvite(true)} className="h-8">
+                  <UserPlus className="mr-1 h-3.5 w-3.5" /> Invite
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setShowCreate(true)} className="h-8">
+                  <Plus className="mr-1 h-3.5 w-3.5" /> Add User
+                </Button>
+              </>
             )}
           </div>
         }
@@ -269,6 +308,62 @@ export default function UsersPage() {
                         >
                           <Trash2 className="h-3.5 w-3.5" />
                         </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        )}
+
+        {pendingInvites.length > 0 && (
+          <div className="animate-in space-y-3 pt-2">
+            <p className="text-xs text-muted-foreground">
+              {pendingInvites.length} pending invite{pendingInvites.length !== 1 ? "s" : ""}
+            </p>
+            <div className="overflow-x-auto rounded-md border border-border">
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead className="h-8 text-xs">Invitee</TableHead>
+                    <TableHead className="h-8 text-xs">Role</TableHead>
+                    <TableHead className="h-8 text-xs">Channel</TableHead>
+                    <TableHead className="h-8 text-xs text-right">Expires</TableHead>
+                    <TableHead className="h-8 text-xs w-[40px]" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {pendingInvites.map((inv: Invite) => (
+                    <TableRow key={inv.id}>
+                      <TableCell className="py-1.5 text-sm text-muted-foreground font-[family-name:var(--font-mono)]">
+                        {inv.email ?? "Anyone with the link"}
+                      </TableCell>
+                      <TableCell className="py-1.5 text-sm">
+                        {ROLE_LABELS[inv.role as Role] ?? inv.role}
+                      </TableCell>
+                      <TableCell className="py-1.5">
+                        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                          {inv.channel === "email" ? <Mail className="h-3 w-3" /> : <Link2 className="h-3 w-3" />}
+                          {inv.channel}
+                        </span>
+                      </TableCell>
+                      <TableCell className="py-1.5 text-xs text-muted-foreground text-right tabular-nums">
+                        {new Date(inv.expires_at).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell className="py-1.5">
+                        <div className="flex items-center justify-end">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                            title="Revoke invite"
+                            onClick={() => revokeInvite.mutate(inv.id)}
+                            disabled={revokeInvite.isPending}
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </Button>
                         </div>
                       </TableCell>
                     </TableRow>
@@ -372,6 +467,87 @@ export default function UsersPage() {
                     <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> Creating...</>
                   ) : (
                     "Create User"
+                  )}
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Invite Dialog */}
+      <Dialog open={showInvite} onOpenChange={(open) => { if (!open) closeInviteDialog(); }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{inviteResult ? "Invite Created" : "Invite Teammate"}</DialogTitle>
+            <DialogDescription>
+              {inviteResult
+                ? "Share this link — it will not be shown again. It expires in 7 days."
+                : "Generate an invite link. Pin it to an email so only that address can accept, or leave email empty for a shareable link."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {inviteResult ? (
+            <div className="space-y-4">
+              <div className="rounded-md border border-border bg-muted/30 p-3">
+                <div className="flex items-center gap-2 mb-2">
+                  <Link2 className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Invite Link</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className="text-xs font-[family-name:var(--font-mono)] text-foreground break-all flex-1 select-all">
+                    {inviteResult.invite_url}
+                  </code>
+                  <Button variant="ghost" size="sm" className="h-7 w-7 p-0 shrink-0" onClick={handleCopyInviteUrl}>
+                    {inviteCopied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
+                  </Button>
+                </div>
+              </div>
+              <DialogFooter>
+                <Button variant="ghost" size="sm" onClick={closeInviteDialog}>Done</Button>
+                <Button size="sm" onClick={() => { setInviteResult(null); setInviteEmail(""); }}>Invite Another</Button>
+              </DialogFooter>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">Email (optional)</label>
+                <Input
+                  type="email"
+                  placeholder="teammate@example.com"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  className="h-8 text-sm"
+                  autoFocus
+                  onKeyDown={(e) => { if (e.key === "Enter") handleCreateInvite(); }}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">Role</label>
+                <Select value={inviteRole} onValueChange={setInviteRole}>
+                  <SelectTrigger className="h-8 text-sm">
+                    <SelectValue>
+                      {ROLE_LABELS[inviteRole as Role] ?? inviteRole}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {assignableRoles.map((r) => (
+                      <SelectItem key={r} value={r}>{ROLE_LABELS[r]}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <DialogFooter>
+                <Button variant="ghost" size="sm" onClick={closeInviteDialog}>Cancel</Button>
+                <Button
+                  size="sm"
+                  onClick={handleCreateInvite}
+                  disabled={createInvite.isPending}
+                >
+                  {createInvite.isPending ? (
+                    <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> Creating...</>
+                  ) : (
+                    "Create Invite"
                   )}
                 </Button>
               </DialogFooter>

--- a/web/src/pages/invite.tsx
+++ b/web/src/pages/invite.tsx
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Public invite acceptance page (/invite/$token).
+ *
+ * Previews the invite via the public lookup endpoint, then collects the
+ * acceptor's details and creates their account in the inviting org with
+ * the preassigned role. On success the user is logged in and redirected.
+ */
+
+import { Suspense, useState } from "react";
+import { useRouter, useParams } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { Eye, EyeOff, ArrowRight, Loader2, AlertCircle, MailX } from "lucide-react";
+import { toast } from "sonner";
+import {
+  invites,
+  setTokens,
+  setUserRole,
+  setUserName,
+  setUserEmail,
+  setUserUsername,
+} from "@/lib/api";
+import { useDeploymentConfig } from "@/hooks/use-deployment-config";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const INVALID_REASONS: Record<string, string> = {
+  expired: "This invite has expired. Ask your admin to send a new one.",
+  revoked: "This invite has been revoked. Ask your admin to send a new one.",
+  accepted: "This invite has already been used.",
+  not_found: "This invite link is invalid. Check the URL or ask your admin for a new one.",
+};
+
+function InviteContent() {
+  const router = useRouter();
+  const { token } = useParams({ from: "/(auth)/invite/$token" });
+  const { brandingAppName, brandingLogo, brandingWordmark } = useDeploymentConfig();
+
+  const lookup = useQuery({
+    queryKey: ["invite-lookup", token],
+    queryFn: () => invites.lookup(token),
+    retry: false,
+  });
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const pinnedEmail = lookup.data?.valid ? lookup.data.email : null;
+
+  async function handleAccept() {
+    setError("");
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await invites.accept({
+        token,
+        email: pinnedEmail ?? email.trim(),
+        name: name.trim(),
+        username: username.trim() || undefined,
+        password,
+      });
+      setTokens(res.access_token, res.refresh_token);
+      setUserRole(res.user.role);
+      setUserName(res.user.name);
+      setUserEmail(res.user.email);
+      if (res.user.username) setUserUsername(res.user.username);
+      window.dispatchEvent(new Event("storage"));
+      toast.success("Welcome aboard!");
+      router.navigate({ to: "/", replace: true });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to accept invite";
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const header = (
+    <div className="flex flex-col items-center gap-2 border-b px-8 pb-6 pt-8 animate-in">
+      {brandingLogo ? (
+        <img loading="lazy" src={brandingLogo} alt="" width={32} height={32} className="object-contain" />
+      ) : (
+        <img loading="lazy" src="/observal-logo.svg" alt="" width={32} height={32} className="object-contain" />
+      )}
+      {brandingWordmark ? (
+        <img loading="lazy" src={brandingWordmark} alt={brandingAppName || "Observal"} width={192} height={24} className="h-6 max-w-48 object-contain" />
+      ) : (
+        <h1 className="text-2xl font-semibold tracking-tight font-[family-name:var(--font-display)]">
+          {brandingAppName || "Observal"}
+        </h1>
+      )}
+      {lookup.data?.valid && (
+        <p className="text-sm text-muted-foreground text-center">
+          You&apos;ve been invited to join{" "}
+          <span className="font-medium text-foreground">{lookup.data.org_name || "the team"}</span>
+          {lookup.data.role ? ` as ${lookup.data.role.replace("_", " ")}` : ""}
+        </p>
+      )}
+    </div>
+  );
+
+  let body;
+  if (lookup.isLoading) {
+    body = (
+      <div className="flex items-center justify-center px-8 py-12">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  } else if (lookup.isError || !lookup.data || !lookup.data.valid) {
+    const reason = lookup.data?.reason ?? "not_found";
+    body = (
+      <div className="flex flex-col items-center gap-3 px-8 py-10 text-center animate-in">
+        <MailX className="h-8 w-8 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          {INVALID_REASONS[reason] ?? INVALID_REASONS.not_found}
+        </p>
+        <Button variant="outline" size="sm" onClick={() => router.navigate({ to: "/login" })}>
+          Go to sign in
+        </Button>
+      </div>
+    );
+  } else {
+    body = (
+      <div className="px-8 py-6">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleAccept();
+          }}
+          className="space-y-4"
+        >
+          <div className="space-y-2 animate-in">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              placeholder="Jane Smith"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              autoFocus
+            />
+          </div>
+          <div className="space-y-2 animate-in stagger-1">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="you@company.com"
+              value={pinnedEmail ?? email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={!!pinnedEmail}
+            />
+            {pinnedEmail && (
+              <p className="text-xs text-muted-foreground">This invite is pinned to this email address.</p>
+            )}
+          </div>
+          <div className="space-y-2 animate-in stagger-1">
+            <Label htmlFor="username">Username (optional)</Label>
+            <Input
+              id="username"
+              placeholder="jane_smith"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2 animate-in stagger-2">
+            <Label htmlFor="password">Password</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="Choose a password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="pr-10"
+              />
+              <button
+                type="button"
+                tabIndex={-1}
+                className="absolute right-0 top-0 flex h-full w-10 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+          <div className="space-y-2 animate-in stagger-2">
+            <Label htmlFor="confirm-password">Confirm Password</Label>
+            <Input
+              id="confirm-password"
+              type={showPassword ? "text" : "password"}
+              placeholder="Confirm password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+            />
+          </div>
+
+          {error && (
+            <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2.5 text-sm text-destructive animate-in">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <Button type="submit" disabled={loading} className="w-full animate-in stagger-3">
+            {loading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                Join team
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-surface-sunken p-6">
+      <div className="w-full max-w-md">
+        <div className="rounded-lg border bg-card shadow-sm">
+          {header}
+          {body}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function InvitePage() {
+  return (
+    <Suspense>
+      <InviteContent />
+    </Suspense>
+  );
+}

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -11,6 +11,7 @@ import { useRouter, useSearch } from "@tanstack/react-router";
 import { Eye, EyeOff, ArrowRight, Loader2, AlertCircle, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { auth, setTokens, clearSession, setUserRole, getUserRole, setUserName, setUserEmail, setUserUsername, setUserAvatar } from "@/lib/api";
+import { getFirstTouch } from "@/lib/analytics";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -80,7 +81,8 @@ function LoginContent() {
       setLoading(true);
       window.history.replaceState({}, "", "/login");
 
-      auth.exchangeCode({ code: ssoCode })
+      // Forward stored first-touch UTMs so OAuth signups carry attribution
+      auth.exchangeCode({ code: ssoCode, ...getFirstTouch() })
         .then((data) => {
           setTokens(data.access_token, data.refresh_token);
           setUserRole(data.user.role);

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as AuthedAdminErrorsRouteImport } from './routes/_authed/_admin/e
 import { Route as AuthedAdminDiagnosticsRouteImport } from './routes/_authed/_admin/diagnostics'
 import { Route as AuthedAdminDashboardRouteImport } from './routes/_authed/_admin/dashboard'
 import { Route as AuthedAdminAuditLogRouteImport } from './routes/_authed/_admin/audit-log'
+import { Route as authInviteTokenRouteImport } from './routes/(auth)/invite.$token'
 import { Route as AuthedUserTracesIndexRouteImport } from './routes/_authed/_user/traces/index'
 import { Route as AuthedUserTracesTraceIdRouteImport } from './routes/_authed/_user/traces/$traceId'
 
@@ -149,6 +150,11 @@ const AuthedAdminAuditLogRoute = AuthedAdminAuditLogRouteImport.update({
   path: '/audit-log',
   getParentRoute: () => AuthedAdminRoute,
 } as any)
+const authInviteTokenRoute = authInviteTokenRouteImport.update({
+  id: '/(auth)/invite/$token',
+  path: '/invite/$token',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthedUserTracesIndexRoute = AuthedUserTracesIndexRouteImport.update({
   id: '/traces/',
   path: '/traces/',
@@ -165,6 +171,7 @@ export interface FileRoutesByFullPath {
   '/device': typeof authDeviceRoute
   '/login': typeof authLoginRoute
   '/leaderboard': typeof AuthedLeaderboardRoute
+  '/invite/$token': typeof authInviteTokenRoute
   '/audit-log': typeof AuthedAdminAuditLogRoute
   '/dashboard': typeof AuthedAdminDashboardRoute
   '/diagnostics': typeof AuthedAdminDiagnosticsRoute
@@ -189,6 +196,7 @@ export interface FileRoutesByTo {
   '/login': typeof authLoginRoute
   '/': typeof AuthedIndexRoute
   '/leaderboard': typeof AuthedLeaderboardRoute
+  '/invite/$token': typeof authInviteTokenRoute
   '/audit-log': typeof AuthedAdminAuditLogRoute
   '/dashboard': typeof AuthedAdminDashboardRoute
   '/diagnostics': typeof AuthedAdminDiagnosticsRoute
@@ -217,6 +225,7 @@ export interface FileRoutesById {
   '/_authed/_user': typeof AuthedUserRouteWithChildren
   '/_authed/leaderboard': typeof AuthedLeaderboardRoute
   '/_authed/': typeof AuthedIndexRoute
+  '/(auth)/invite/$token': typeof authInviteTokenRoute
   '/_authed/_admin/audit-log': typeof AuthedAdminAuditLogRoute
   '/_authed/_admin/dashboard': typeof AuthedAdminDashboardRoute
   '/_authed/_admin/diagnostics': typeof AuthedAdminDiagnosticsRoute
@@ -243,6 +252,7 @@ export interface FileRouteTypes {
     | '/device'
     | '/login'
     | '/leaderboard'
+    | '/invite/$token'
     | '/audit-log'
     | '/dashboard'
     | '/diagnostics'
@@ -267,6 +277,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/'
     | '/leaderboard'
+    | '/invite/$token'
     | '/audit-log'
     | '/dashboard'
     | '/diagnostics'
@@ -294,6 +305,7 @@ export interface FileRouteTypes {
     | '/_authed/_user'
     | '/_authed/leaderboard'
     | '/_authed/'
+    | '/(auth)/invite/$token'
     | '/_authed/_admin/audit-log'
     | '/_authed/_admin/dashboard'
     | '/_authed/_admin/diagnostics'
@@ -318,6 +330,7 @@ export interface RootRouteChildren {
   AuthedRoute: typeof AuthedRouteWithChildren
   authDeviceRoute: typeof authDeviceRoute
   authLoginRoute: typeof authLoginRoute
+  authInviteTokenRoute: typeof authInviteTokenRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -483,6 +496,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAdminAuditLogRouteImport
       parentRoute: typeof AuthedAdminRoute
     }
+    '/(auth)/invite/$token': {
+      id: '/(auth)/invite/$token'
+      path: '/invite/$token'
+      fullPath: '/invite/$token'
+      preLoaderRoute: typeof authInviteTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authed/_user/traces/': {
       id: '/_authed/_user/traces/'
       path: '/traces'
@@ -577,6 +597,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthedRoute: AuthedRouteWithChildren,
   authDeviceRoute: authDeviceRoute,
   authLoginRoute: authLoginRoute,
+  authInviteTokenRoute: authInviteTokenRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/web/src/routes/(auth)/invite.$token.tsx
+++ b/web/src/routes/(auth)/invite.$token.tsx
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { createFileRoute } from "@tanstack/react-router";
+import { Suspense, lazy } from "react";
+import { Toaster } from "@/components/ui/sonner";
+
+const InvitePage = lazy(() => import("@/pages/invite"));
+
+function InviteRoute() {
+  return (
+    <div className="min-h-dvh bg-background">
+      <Suspense fallback={<div className="flex h-screen w-full items-center justify-center" />}>
+        <InvitePage />
+      </Suspense>
+      <Toaster visibleToasts={1} />
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/(auth)/invite/$token")({
+  component: InviteRoute,
+});


### PR DESCRIPTION
## Summary

- Adds single-use teammate invites (email-pinned or shareable link) with admin create/list/revoke endpoints and a public `/invite/$token` acceptance flow that creates the account in the inviting org and logs the user in.
- Wires invite lifecycle into the event bus: `invite_sent`, `invite_accepted`, and `user_signed_up` with `utm_source=invite` for PostHog GTM attribution (gated by existing product analytics settings).
- Adds admin Users page UI (invite dialog + pending invites table) and documents the telemetry contract in `docs/self-hosting/telemetry.md`.

## Environment variables

**Invites themselves require no new env vars.** Invite links are built from the `deployment.frontend_url` dynamic setting (Admin → Settings), falling back to `deployment.public_url` or request headers.

**PostHog product analytics** (optional, off by default):

| Variable | Default | When to set |
|---|---|---|
| `PRODUCT_ANALYTICS_ENABLED` | `false` | Set to `true` only on observal.io / deployments that should emit GTM events |
| `POSTHOG_API_KEY` | empty | Your PostHog project key (`phc_...`) — analytics stays off while empty |
| `POSTHOG_HOST` | `https://us.i.posthog.com` | Change only if using EU cloud or self-hosted PostHog |

**Recommended dynamic setting** (not an env var): set `deployment.frontend_url` to your public web origin (e.g. `https://app.example.com`) so generated invite links point at the correct host.

## Test plan

- [ ] Run DB migration: `007_invites` (Alembic upgrade)
- [ ] Admin → Users → **Invite**: create link invite, copy URL, verify pending row appears
- [ ] Open invite URL in incognito → complete signup → confirm user lands in inviting org with assigned role
- [ ] Revoke a pending invite → confirm lookup shows invalid and accept returns 410
- [ ] With `PRODUCT_ANALYTICS_ENABLED=true` + `POSTHOG_API_KEY` set, verify `invite_sent`, `invite_accepted`, and `user_signed_up` (utm_source=invite) in PostHog
- [ ] `pytest tests/test_invites.py tests/test_product_analytics.py`


Made with [Cursor](https://cursor.com)