### PR TITLE
fix(web): update favicon dynamically when branding icon changes

### DIFF
--- a/web/src/components/dynamic-title.tsx
+++ b/web/src/components/dynamic-title.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+// SPDX-FileCopyrightText: 2026 dexterhere-2k <deepakmirchandani.ai28@jecrc.ac.in>
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
@@ -6,11 +7,20 @@ import { useEffect } from "react";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 
 export function DynamicTitle() {
-  const { brandingAppName } = useDeploymentConfig();
+  const { brandingAppName, brandingLogo } = useDeploymentConfig();
 
   useEffect(() => {
     document.title = brandingAppName || "Observal";
   }, [brandingAppName]);
+
+  useEffect(() => {
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    if (link && brandingLogo) {
+      link.href = brandingLogo;
+    } else if (link) {
+      link.href = "/favicon.ico";
+    }
+  }, [brandingLogo]);
 
   return null;
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Currently, when an admin uploads a custom icon in the Branding settings, the browser tab still displays the default Observal favicon. This PR ensures that the favicon updates dynamically across the entire application whenever the branding logo is changed or reset.

## Fixes
* Fixes #1406

## Approach
Modified `web/src/components/dynamic-title.tsx` to watch the `brandingLogo` state:
* Destructured `brandingLogo` from the `useDeploymentConfig` hook.
* Added a `useEffect` hook to target the `<link rel="icon">` element in `index.html`.
* Implemented logic to update the `href` attribute to the new `brandingLogo` URL.
* Added a fallback to the default `/favicon.ico` if no custom branding logo is detected.

## How Has This Been Tested?
* Verified that `DynamicTitle` is correctly mounted in the `__root.tsx` route, ensuring the favicon logic runs globally.
* Performed a code-level review of the DOM manipulation logic to ensure it correctly selects and updates the favicon link tag.
* Confirmed that the `brandingLogo` dependency in the effect ensures real-time updates without page refreshes.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [x] UI changes: include screenshots of all affected screens.
<img width="1546" height="828" alt="image" src="https://github.com/user-attachments/assets/723b3b50-045d-47d5-afeb-5f792913e0a2" />

## AI Assistance
*Was generative AI tooling used to co-author this PR?*
- [x] No