### PR TITLE
feat(ops): add insights CLI pretty print commands

### DIFF
--- a/observal-server/api/routes/agent/__init__.py
+++ b/observal-server/api/routes/agent/__init__.py
@@ -4,7 +4,7 @@
 """Agent routes package. Sub-modules register routes on the shared router."""
 
 # Import sub-modules so they register their routes on the shared router.
-from . import crud, draft, install  # noqa: F401
+from . import crud, draft, insights, install  # noqa: F401
 from ._router import router  # noqa: F401
 from .helpers import _load_agent, _resolve_component_names  # noqa: F401
 from .install import install_agent  # noqa: F401

--- a/observal-server/api/routes/agent/insights.py
+++ b/observal-server/api/routes/agent/insights.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Agent-scoped insight report routes."""
+
+from fastapi import Depends, HTTPException
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import get_db, require_role
+from models.user import User, UserRole
+from schemas.insights import (
+    ApplySuggestionsRequest,
+    GenerateInsightRequest,
+    InsightReportListItem,
+    InsightReportResponse,
+)
+
+from ._router import router
+
+
+@router.get("/{agent_id}/insights/session-count")
+async def agent_insight_session_count(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Return the number of sessions available for insight generation."""
+    from api.routes.insights import agent_session_count
+
+    return await agent_session_count(agent_id, db, current_user)
+
+
+@router.get("/{agent_id}/insights/reports", response_model=list[InsightReportListItem])
+async def list_agent_insight_reports(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """List insight reports for an agent, newest first."""
+    from api.routes.insights import list_reports
+
+    return await list_reports(agent_id, db, current_user)
+
+
+@router.post("/{agent_id}/insights/reports", response_model=InsightReportListItem)
+async def create_agent_insight_report(
+    agent_id: str,
+    req: GenerateInsightRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Trigger generation of an insight report for an agent."""
+    from api.routes.insights import generate_insight
+
+    return await generate_insight(agent_id, req, db, current_user)
+
+
+@router.get("/{agent_id}/insights/reports/{report_id}", response_model=InsightReportResponse)
+async def get_agent_insight_report(
+    agent_id: str,
+    report_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Get one insight report that belongs to an agent."""
+    from api.routes.insights import _resolve_insights_agent, get_report
+
+    agent = await _resolve_insights_agent(agent_id, db, current_user)
+    report = await get_report(report_id, db, current_user)
+    if report.agent_id != agent.id:
+        raise HTTPException(status_code=404, detail="Report not found for agent")
+    return report
+
+
+@router.post("/{agent_id}/insights/reports/{report_id}/apply")
+async def apply_agent_insight_report_suggestions(
+    agent_id: str,
+    report_id: str,
+    body: ApplySuggestionsRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Apply selected suggestions from an agent insight report."""
+    from api.routes.insights import apply_report_suggestions
+
+    await get_agent_insight_report(agent_id, report_id, db, current_user)
+    return await apply_report_suggestions(report_id, body, db, current_user)
+
+
+@router.get("/{agent_id}/insights/reports/{report_id}/export/html", response_class=HTMLResponse)
+async def export_agent_insight_report_html(
+    agent_id: str,
+    report_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Export an agent insight report as a self-contained HTML document."""
+    from api.routes.insights import export_report_html
+
+    await get_agent_insight_report(agent_id, report_id, db, current_user)
+    return await export_report_html(report_id, db, current_user)
+
+
+@router.delete("/{agent_id}/insights/reports")
+async def delete_agent_insight_reports(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Delete all insight reports and cached data for an agent."""
+    from api.routes.insights import clear_agent_reports
+
+    return await clear_agent_reports(agent_id, db, current_user)

--- a/observal-server/api/routes/insights.py
+++ b/observal-server/api/routes/insights.py
@@ -13,7 +13,8 @@ from loguru import logger as optic
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, get_effective_agent_permission, require_role, resolve_prefix_id
+from api.deps import get_db, get_effective_agent_permission, require_role
+from api.routes.agent.helpers import _load_agent
 from models.agent import Agent
 from models.insight_meta_cache import InsightMetaCache
 from models.insight_report import InsightReport, InsightReportStatus
@@ -45,6 +46,23 @@ def _require_agent_edit_access(agent: Agent, user: User) -> None:
     perm = get_effective_agent_permission(agent, user)
     if perm not in ("owner", "edit"):
         raise HTTPException(status_code=403, detail="Insufficient permissions for this agent")
+
+
+async def _resolve_insights_agent(agent_id: str, db: AsyncSession, current_user: User) -> Agent:
+    """Resolve an insights agent by UUID, ID prefix, or name."""
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id,
+        org_id=current_user.org_id,
+        include_all_statuses=True,
+    )
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    _require_agent_edit_access(agent, current_user)
+    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
+        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    return agent
 
 
 @router.get("/status")
@@ -123,8 +141,7 @@ async def agent_session_count(
     """Return the number of sessions available for insight generation."""
     from services.clickhouse import _query
 
-    agent = await resolve_prefix_id(Agent, agent_id, db)
-    _require_agent_edit_access(agent, current_user)
+    agent = await _resolve_insights_agent(agent_id, db, current_user)
     now = datetime.now(UTC)
     period_start = now - timedelta(days=14)
 
@@ -163,11 +180,7 @@ async def generate_insight(
     """Trigger generation of an insight report for an agent."""
     optic.trace("agent_id={}, req={}", agent_id, req)
     _require_insights()
-    agent = await resolve_prefix_id(Agent, agent_id, db)
-    _require_agent_edit_access(agent, current_user)
-
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    agent = await _resolve_insights_agent(agent_id, db, current_user)
 
     period_days = req.period_days if req else 14
     now = datetime.now(UTC)
@@ -246,11 +259,7 @@ async def list_reports(
     """List insight reports for an agent, newest first."""
     optic.trace("agent_id={}", agent_id)
     _require_insights()
-    agent = await resolve_prefix_id(Agent, agent_id, db)
-    _require_agent_edit_access(agent, current_user)
-
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    agent = await _resolve_insights_agent(agent_id, db, current_user)
 
     stmt = (
         select(InsightReport)
@@ -352,10 +361,7 @@ async def clear_agent_reports(
     """Delete all insight reports and cached data for an agent."""
     optic.trace("agent_id={}", agent_id)
     _require_insights()
-    agent = await resolve_prefix_id(Agent, agent_id, db)
-
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    agent = await _resolve_insights_agent(agent_id, db, current_user)
 
     # Delete reports
     report_result = await db.execute(delete(InsightReport).where(InsightReport.agent_id == agent.id))

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -109,8 +109,13 @@ def _handle_error(e: httpx.HTTPStatusError, path: str = ""):
             type_singular = type_plural[:-1]  # mcps -> mcp, skills -> skill
         else:
             type_singular = type_plural
-        # 'agent' is a top-level subcommand, not nested under 'registry'
-        browse_cmd = "observal agent list" if type_singular == "agent" else f"observal registry {type_singular} list"
+        if len(parts) > 3 and parts[2] == "insights" and parts[3] == "agents":
+            browse_cmd = "observal agent list"
+        else:
+            # 'agent' is a top-level subcommand, not nested under 'registry'
+            browse_cmd = (
+                "observal agent list" if type_singular == "agent" else f"observal registry {type_singular} list"
+            )
         rprint(f"[dim]  Check that the resource ID is correct, or use [bold]{browse_cmd}[/bold] to browse.[/dim]")
     elif code == 429:
         rprint(f"[red]Rate limited{path_info}.[/red]")

--- a/observal_cli/cmd_insights.py
+++ b/observal_cli/cmd_insights.py
@@ -1,0 +1,461 @@
+# SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""CLI commands for Agent Insights reports."""
+
+from __future__ import annotations
+
+import typer
+from rich import print as rprint
+from rich.panel import Panel
+from rich.table import Table
+
+from observal_cli import client, config
+from observal_cli.render import console, output_json, relative_time, spinner, status_badge
+
+insights_app = typer.Typer(help="Agent insight reports")
+
+
+def _resolve_agent_id(agent_id: str) -> str:
+    """Resolve an agent UUID, name, or alias to the canonical UUID."""
+    resolved = config.resolve_alias(agent_id)
+    agent = client.get(f"/api/v1/agents/{resolved}")
+    return str(agent.get("id") or resolved)
+
+
+def _select_report_id(reports: list[dict], report_ref: str | None) -> str:
+    if not reports:
+        rprint("[dim]No insight reports found.[/dim]")
+        raise typer.Exit(1)
+
+    if not report_ref or report_ref == "latest":
+        completed = next((report for report in reports if report.get("status") == "completed"), None)
+        return str((completed or reports[0])["id"])
+
+    if report_ref.isdigit():
+        index = int(report_ref)
+        if 1 <= index <= len(reports):
+            return str(reports[index - 1]["id"])
+        rprint(f"[red]Report row {index} is out of range.[/red]")
+        rprint(f"[dim]Choose a row from 1 to {len(reports)}.[/dim]")
+        raise typer.Exit(1)
+
+    matches = [report for report in reports if str(report.get("id", "")).lower().startswith(report_ref.lower())]
+    if len(matches) == 1:
+        return str(matches[0]["id"])
+    if matches:
+        rprint(f"[red]Report prefix '{report_ref}' is ambiguous.[/red]")
+        rprint("[dim]Use the row number from `observal ops insights list <agent>` instead.[/dim]")
+        raise typer.Exit(1)
+
+    rprint(f"[red]Report '{report_ref}' was not found for this agent.[/red]")
+    rprint("[dim]Use the row number from `observal ops insights list <agent>` instead.[/dim]")
+    raise typer.Exit(1)
+
+
+def _resolve_report_for_show(target: str, report_ref: str | None) -> dict:
+    agent_id = _resolve_agent_id(target)
+    reports = client.get(f"/api/v1/insights/agents/{agent_id}/reports")
+    report_id = _select_report_id(reports, report_ref)
+    return client.get(f"/api/v1/insights/reports/{report_id}")
+
+
+@insights_app.command(name="list")
+def insights_list(
+    agent_id: str = typer.Argument(..., help="Agent ID, name, or @alias"),
+    output: str = typer.Option("table", "--output", "-o"),
+):
+    """List insight reports for an agent.
+
+    Examples:
+
+        observal ops insights list my-agent
+
+        observal ops insights list my-agent --output json
+    """
+    with spinner("Fetching insight reports..."):
+        resolved = _resolve_agent_id(agent_id)
+        data = client.get(f"/api/v1/insights/agents/{resolved}/reports")
+    if output == "json":
+        output_json(data)
+        return
+    if not data:
+        rprint("[dim]No insight reports found.[/dim]")
+        return
+    table = Table(title=f"Insight Reports ({len(data)})", show_lines=False, padding=(0, 1))
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Status")
+    table.add_column("Period")
+    table.add_column("Sessions", justify="right")
+    table.add_column("Completed")
+    for i, r in enumerate(data, 1):
+        start = r.get("period_start", "")[:10]
+        end = r.get("period_end", "")[:10]
+        table.add_row(
+            str(i),
+            status_badge(r.get("status", "")),
+            f"{start} → {end}",
+            str(r.get("sessions_analyzed", 0)),
+            relative_time(r.get("completed_at")),
+        )
+    console.print(table)
+    rprint()
+    rprint(f"[dim]Open latest completed: [cyan]observal ops insights show {agent_id}[/cyan][/dim]")
+    rprint(f"[dim]Open row 1: [cyan]observal ops insights show {agent_id} 1[/cyan][/dim]")
+
+
+@insights_app.command(name="show")
+def insights_show(
+    target: str = typer.Argument(..., help="Agent name, agent ID, or @alias"),
+    report_ref: str | None = typer.Argument(None, help="Report row number, report ID prefix, or 'latest'"),
+    output: str = typer.Option("table", "--output", "-o"),
+    section: str | None = typer.Option(None, "--section", "-s", help="Show only a specific section"),
+):
+    """Show an insight report with pretty-printed narrative.
+
+    Examples:
+
+        observal ops insights show my-agent
+
+        observal ops insights show my-agent 3
+
+        observal ops insights show my-agent --section suggestions
+
+        observal ops insights show my-agent 3 --output json
+    """
+    with spinner("Fetching report..."):
+        data = _resolve_report_for_show(target, report_ref)
+    if output == "json":
+        output_json(data)
+        return
+    if data.get("status") != "completed":
+        rprint(f"  Status: {status_badge(data.get('status', 'unknown'))}")
+        if data.get("error_message"):
+            rprint(f"  [red]Error:[/red] {data['error_message']}")
+        return
+
+    narrative = data.get("narrative") or {}
+    if section:
+        if section not in narrative:
+            rprint(f"[red]Section '{section}' not found.[/red]")
+            rprint(f"[dim]Available: {', '.join(narrative.keys())}[/dim]")
+            raise typer.Exit(1)
+        _render_section(section, narrative[section])
+        return
+
+    # Header
+    start = data.get("period_start", "")[:10]
+    end = data.get("period_end", "")[:10]
+    rprint()
+    rprint(f"  [bold]Insight Report[/bold]  {start} → {end}")
+    rprint(f"  Sessions: {data.get('sessions_analyzed', 0)}  Model: {data.get('llm_model_used', 'unknown')}")
+    rprint()
+
+    # Render sections in logical order
+    order = [
+        "at_a_glance",
+        "what_they_work_on",
+        "interaction_style",
+        "usage_patterns",
+        "what_works",
+        "friction_analysis",
+        "suggestions",
+        "usage_cost_analysis",
+        "regression_detection",
+        "on_the_horizon",
+        "fun_ending",
+    ]
+    for key in order:
+        section_data = narrative.get(key)
+        if section_data:
+            _render_section(key, section_data)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Section renderers
+# ──────────────────────────────────────────────────────────────────────────────
+
+_SECTION_TITLES = {
+    "at_a_glance": "⚡ At a Glance",
+    "what_they_work_on": "📂 What You Work On",
+    "interaction_style": "💬 Interaction Style",
+    "usage_patterns": "📊 Usage Patterns",
+    "what_works": "✅ What Works",
+    "friction_analysis": "⚠️  Friction Analysis",
+    "suggestions": "💡 Suggestions",
+    "usage_cost_analysis": "💰 Cost Analysis",
+    "regression_detection": "📈 Regression Detection",
+    "on_the_horizon": "🔮 On the Horizon",
+    "fun_ending": "🎉 Fun Moment",
+}
+
+_HEALTH_COLORS = {"healthy": "green", "mixed": "yellow", "concerning": "red"}
+
+
+def _render_section(name: str, data: dict | str | None):
+    if not data:
+        return
+    title = _SECTION_TITLES.get(name, name.replace("_", " ").title())
+    renderer = _RENDERERS.get(name)
+    if renderer:
+        renderer(title, data)
+    elif isinstance(data, str):
+        console.print(Panel(data, title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
+    elif isinstance(data, dict) and "narrative" in data:
+        console.print(Panel(data["narrative"], title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
+
+
+def _render_at_a_glance(title: str, data: dict):
+    health = data.get("health", "unknown")
+    color = _HEALTH_COLORS.get(health, "white")
+    lines = [f"[bold]Health:[/bold] [{color}]{health}[/{color}]", ""]
+    if data.get("whats_working"):
+        lines += [f"[green]What's working:[/green] {data['whats_working']}", ""]
+    if data.get("whats_hindering"):
+        lines += [f"[yellow]What's hindering:[/yellow] {data['whats_hindering']}", ""]
+    if data.get("quick_win"):
+        lines += [f"[cyan]Quick win:[/cyan] {data['quick_win']}", ""]
+    if data.get("ambitious_workflows"):
+        lines += [f"[magenta]Ambitious workflows:[/magenta] {data['ambitious_workflows']}"]
+    console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="bright_blue", expand=False))
+
+
+def _render_what_they_work_on(title: str, data: dict):
+    areas = data.get("areas", [])
+    if not areas:
+        return
+    table = Table(title=title, show_lines=False, padding=(0, 1))
+    table.add_column("Area", style="bold")
+    table.add_column("Sessions", justify="right")
+    table.add_column("Description")
+    for a in areas:
+        table.add_row(a.get("name", ""), str(a.get("sessions", "")), a.get("description", ""))
+    console.print(table)
+    rprint()
+
+
+def _render_interaction_style(title: str, data: dict):
+    lines = []
+    if data.get("narrative"):
+        lines.append(data["narrative"])
+    if data.get("key_pattern"):
+        lines += ["", f"[bold]Key pattern:[/bold] [italic]{data['key_pattern']}[/italic]"]
+    if lines:
+        console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
+
+
+def _render_usage_patterns(title: str, data: dict):
+    lines = []
+    if data.get("narrative"):
+        lines.append(data["narrative"])
+    sp = data.get("session_profile", {})
+    if sp:
+        lines += [
+            "",
+            f"  Avg duration: [bold]{sp.get('avg_duration_minutes', '?')}m[/bold]"
+            f"  Tool calls: [bold]{sp.get('avg_tool_calls', '?')}[/bold]"
+            f"  Prompts: [bold]{sp.get('avg_prompts', '?')}[/bold]",
+        ]
+    if lines:
+        console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
+    tools = data.get("tool_distribution", [])
+    if tools:
+        t = Table(show_lines=False, padding=(0, 1))
+        t.add_column("Tool", style="bold")
+        t.add_column("Calls", justify="right")
+        t.add_column("Error %", justify="right")
+        for tool in tools[:10]:
+            err = tool.get("error_rate", 0)
+            err_style = "red" if err > 0.1 else "yellow" if err > 0.01 else "green"
+            t.add_row(tool.get("tool", ""), str(tool.get("calls", "")), f"[{err_style}]{err:.1%}[/{err_style}]")
+        console.print(t)
+        rprint()
+
+
+def _render_what_works(title: str, data: dict):
+    lines = []
+    if data.get("intro"):
+        lines.append(data["intro"])
+    for s in data.get("strengths", []):
+        lines += ["", f"  [green]●[/green] [bold]{s.get('title', '')}[/bold]", f"    {s.get('description', '')}"]
+    if lines:
+        console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="green", expand=False))
+
+
+def _render_friction(title: str, data: dict):
+    lines = []
+    if data.get("intro"):
+        lines.append(data["intro"])
+    sev_colors = {"high": "red", "medium": "yellow", "low": "dim"}
+    for cat in data.get("categories", []):
+        sev = cat.get("severity", "medium")
+        color = sev_colors.get(sev, "white")
+        lines += ["", f"  [{color}]■ {cat.get('title', '')}[/{color}] [{color}]({sev})[/{color}]"]
+        if cat.get("description"):
+            lines.append(f"    {cat['description']}")
+        for ex in cat.get("examples", []):
+            lines.append(f"    [dim]• {ex}[/dim]")
+        if cat.get("impact"):
+            lines.append(f"    [dim]Impact: {cat['impact']}[/dim]")
+    if lines:
+        console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="yellow", expand=False))
+
+
+def _render_suggestions(title: str, data: dict):
+    # Config additions
+    configs = data.get("config_additions", [])
+    if configs:
+        rprint(f"\n  [bold]{title} > Config Additions[/bold]")
+        for c in configs:
+            rprint(f"    [cyan]→[/cyan] {c.get('addition', '')}")
+            rprint(f"      [dim]Why: {c.get('why', '')} | Where: {c.get('where', '')}[/dim]")
+
+    # Features to try
+    features = data.get("features_to_try", [])
+    if features:
+        rprint(f"\n  [bold]{title} > Features to Try[/bold]")
+        for f in features:
+            rprint(f"    [magenta]{f.get('feature', '')}:[/magenta] [bold]{f.get('name', '')}[/bold]")
+            rprint(f"      {f.get('one_liner', '')}")
+            if f.get("why_for_you"):
+                rprint(f"      [dim]{f['why_for_you']}[/dim]")
+
+    # Usage patterns
+    patterns = data.get("usage_patterns", [])
+    if patterns:
+        rprint(f"\n  [bold]{title} > Usage Patterns[/bold]")
+        for p in patterns:
+            rprint(f"    [cyan]●[/cyan] [bold]{p.get('title', '')}[/bold]: {p.get('suggestion', '')}")
+            if p.get("detail"):
+                rprint(f"      [dim]{p['detail']}[/dim]")
+            if p.get("copyable_prompt"):
+                rprint(f"      [green]Try:[/green] {p['copyable_prompt']}")
+    rprint()
+
+
+def _render_cost(title: str, data: dict):
+    lines = []
+    if data.get("summary"):
+        lines.append(data["summary"])
+    m = data.get("metrics", {})
+    if m:
+        parts = []
+        if m.get("total_cost_usd") is not None:
+            parts.append(f"Total: ${m['total_cost_usd']:.2f}")
+        if m.get("cost_per_session") is not None:
+            parts.append(f"Per session: ${m['cost_per_session']:.3f}")
+        if m.get("cache_efficiency_pct") is not None:
+            parts.append(f"Cache: {m['cache_efficiency_pct']:.0f}%")
+        if parts:
+            lines += ["", "  " + "  │  ".join(parts)]
+    opps = data.get("opportunities", [])
+    for o in opps:
+        lines += ["", f"  [yellow]●[/yellow] [bold]{o.get('title', '')}[/bold]"]
+        if o.get("description"):
+            lines.append(f"    {o['description']}")
+        if o.get("estimated_savings"):
+            lines.append(f"    [green]Savings: {o['estimated_savings']}[/green]")
+    if lines:
+        console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
+
+
+def _render_regression(title: str, data: dict):
+    if not data.get("has_previous_data"):
+        rprint(f"  [dim]{title}: No previous data for comparison.[/dim]")
+        return
+    lines = []
+    if data.get("summary"):
+        lines.append(data["summary"])
+    for c in data.get("changes", []):
+        direction = c.get("direction", "stable")
+        icon = {"improved": "[green]↑[/green]", "degraded": "[red]↓[/red]", "stable": "[dim]→[/dim]"}.get(
+            direction, "→"
+        )
+        sig = c.get("significance", "")
+        sig_dim = f" [dim]({sig})[/dim]" if sig else ""
+        lines.append(
+            f"  {icon} [bold]{c.get('metric', '')}[/bold]: "
+            f"{c.get('previous_value', '?')} → {c.get('current_value', '?')}{sig_dim}"
+        )
+    if lines:
+        console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
+
+
+def _render_horizon(title: str, data: dict):
+    lines = []
+    if data.get("intro"):
+        lines.append(data["intro"])
+    for o in data.get("opportunities", []):
+        lines += ["", f"  [magenta]●[/magenta] [bold]{o.get('title', '')}[/bold]"]
+        if o.get("whats_possible"):
+            lines.append(f"    {o['whats_possible']}")
+        if o.get("how_to_try"):
+            lines.append(f"    [cyan]Try:[/cyan] {o['how_to_try']}")
+    if lines:
+        console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="magenta", expand=False))
+
+
+def _render_fun_ending(title: str, data: dict):
+    headline = data.get("headline", "")
+    detail = data.get("detail", "")
+    if headline:
+        content = f"[italic]{headline}[/italic]"
+        if detail:
+            content += f"\n[dim]{detail}[/dim]"
+        console.print(Panel(content, title=f"[bold]{title}[/bold]", border_style="bright_yellow", expand=False))
+
+
+_RENDERERS = {
+    "at_a_glance": _render_at_a_glance,
+    "what_they_work_on": _render_what_they_work_on,
+    "interaction_style": _render_interaction_style,
+    "usage_patterns": _render_usage_patterns,
+    "what_works": _render_what_works,
+    "friction_analysis": _render_friction,
+    "suggestions": _render_suggestions,
+    "usage_cost_analysis": _render_cost,
+    "regression_detection": _render_regression,
+    "on_the_horizon": _render_horizon,
+    "fun_ending": _render_fun_ending,
+}
+
+
+@insights_app.command(name="generate")
+def insights_generate(
+    agent_id: str = typer.Argument(..., help="Agent ID, name, or @alias"),
+    period_days: int = typer.Option(14, "--period", "-p", help="Analysis period in days"),
+    output: str = typer.Option("table", "--output", "-o"),
+):
+    """Trigger generation of a new insight report.
+
+    Examples:
+
+        observal ops insights generate my-agent
+
+        observal ops insights generate my-agent --period 30
+    """
+    # Pre-check: verify insights is configured before queuing
+    with spinner("Checking insights configuration..."):
+        status = client.get("/api/v1/insights/status")
+    if not status.get("available"):
+        reason = status.get("reason", "Insights is not configured.")
+        rprint(f"[red]✗ Insights not available:[/red] {reason}")
+        rprint()
+        rprint("  Configure with:")
+        rprint("    [cyan]observal admin set insights.model_sections anthropic/claude-3-5-sonnet-20241022[/cyan]")
+        rprint("    [cyan]observal admin set insights.api_key <your-api-key>[/cyan]")
+        rprint()
+        rprint("  [dim]Any LiteLLM-compatible model string works (OpenAI, Anthropic, Bedrock, Gemini, Ollama).[/dim]")
+        rprint("  [dim]See: https://docs.litellm.ai/docs/providers[/dim]")
+        raise typer.Exit(1)
+
+    with spinner("Generating insight report..."):
+        resolved = _resolve_agent_id(agent_id)
+        data = client.post(f"/api/v1/insights/agents/{resolved}/generate", {"period_days": period_days})
+    if output == "json":
+        output_json(data)
+        return
+    rprint(f"[green]✓ Report queued[/green] (status: {status_badge(data.get('status', 'pending'))})")
+    rprint(f"  ID: [dim]{data.get('id', '')}[/dim]")
+    rprint(f"  Period: {str(data.get('period_start', ''))[:10]} → {str(data.get('period_end', ''))[:10]}")
+    rprint("[dim]  Run `observal ops insights show <id>` when complete.[/dim]")

--- a/observal_cli/cmd_insights.py
+++ b/observal_cli/cmd_insights.py
@@ -55,9 +55,9 @@ def _select_report_id(reports: list[dict], report_ref: str | None) -> str:
 
 def _resolve_report_for_show(target: str, report_ref: str | None) -> dict:
     agent_id = _resolve_agent_id(target)
-    reports = client.get(f"/api/v1/insights/agents/{agent_id}/reports")
+    reports = client.get(f"/api/v1/agents/{agent_id}/insights/reports")
     report_id = _select_report_id(reports, report_ref)
-    return client.get(f"/api/v1/insights/reports/{report_id}")
+    return client.get(f"/api/v1/agents/{agent_id}/insights/reports/{report_id}")
 
 
 @insights_app.command(name="list")
@@ -75,7 +75,7 @@ def insights_list(
     """
     with spinner("Fetching insight reports..."):
         resolved = _resolve_agent_id(agent_id)
-        data = client.get(f"/api/v1/insights/agents/{resolved}/reports")
+        data = client.get(f"/api/v1/agents/{resolved}/insights/reports")
     if output == "json":
         output_json(data)
         return
@@ -451,7 +451,7 @@ def insights_generate(
 
     with spinner("Generating insight report..."):
         resolved = _resolve_agent_id(agent_id)
-        data = client.post(f"/api/v1/insights/agents/{resolved}/generate", {"period_days": period_days})
+        data = client.post(f"/api/v1/agents/{resolved}/insights/reports", {"period_days": period_days})
     if output == "json":
         output_json(data)
         return

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -155,6 +155,7 @@ from observal_cli.cmd_co_authors import make_co_authors_typer
 from observal_cli.cmd_component import version_app
 from observal_cli.cmd_doctor import doctor_app
 from observal_cli.cmd_hook import hook_app
+from observal_cli.cmd_insights import insights_app
 from observal_cli.cmd_logs import logs_app
 from observal_cli.cmd_mcp import mcp_app
 from observal_cli.cmd_migrate import migrate_app
@@ -222,6 +223,8 @@ app.add_typer(doctor_app, name="doctor")
 # ── Nest under parent groups ──────────────────────────────
 # logs → ops logs (dev log viewer, complements traces/telemetry)
 ops_app.add_typer(logs_app, name="logs")
+# insights → ops insights (agent insight reports)
+ops_app.add_typer(insights_app, name="insights")
 # support → doctor support (diagnostic bundles, related to doctor troubleshooting)
 doctor_app.add_typer(support_app, name="support")
 # uninstall → self uninstall (CLI lifecycle alongside upgrade/downgrade/rollback)

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -90,6 +90,10 @@ Every command available in the installed CLI. This block is generated from the T
 
 **`observal ops`**: Observability and operational commands (traces, telemetry, dashboard, feedback)
 
+- `observal ops insights`: Agent insight reports
+  - `observal ops insights generate`: Trigger generation of a new insight report.
+  - `observal ops insights list`: List insight reports for an agent.
+  - `observal ops insights show`: Show an insight report with pretty-printed narrative.
 - `observal ops logs`: Live log viewer (open in a separate tab)
 - `observal ops telemetry`: Telemetry commands
   - `observal ops telemetry status`: Check telemetry data flow status.

--- a/tests/test_agent_scoped_insights_routes.py
+++ b/tests/test_agent_scoped_insights_routes.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+async def test_agent_scoped_report_route_rejects_cross_agent_report():
+    from api.routes.agent.insights import get_agent_insight_report
+    from models.user import UserRole
+
+    agent_id = uuid.uuid4()
+    report_agent_id = uuid.uuid4()
+    user = SimpleNamespace(id=uuid.uuid4(), org_id=None, role=UserRole.user)
+    db = AsyncMock()
+    agent = SimpleNamespace(id=agent_id)
+    report = SimpleNamespace(agent_id=report_agent_id)
+
+    with (
+        patch("api.routes.insights._resolve_insights_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.insights.get_report", new=AsyncMock(return_value=report)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await get_agent_insight_report("ultra-pi", str(uuid.uuid4()), db, user)
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Report not found for agent"
+
+
+@pytest.mark.asyncio
+async def test_agent_scoped_report_route_returns_matching_report():
+    from api.routes.agent.insights import get_agent_insight_report
+    from models.user import UserRole
+
+    agent_id = uuid.uuid4()
+    user = SimpleNamespace(id=uuid.uuid4(), org_id=None, role=UserRole.user)
+    db = AsyncMock()
+    agent = SimpleNamespace(id=agent_id)
+    report = SimpleNamespace(agent_id=agent_id)
+
+    with (
+        patch("api.routes.insights._resolve_insights_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.insights.get_report", new=AsyncMock(return_value=report)),
+    ):
+        result = await get_agent_insight_report("ultra-pi", str(uuid.uuid4()), db, user)
+
+    assert result is report
+
+
+@pytest.mark.asyncio
+async def test_agent_scoped_list_delegates_to_existing_insights_logic():
+    from api.routes.agent.insights import list_agent_insight_reports
+    from models.user import UserRole
+
+    user = SimpleNamespace(id=uuid.uuid4(), org_id=None, role=UserRole.user)
+    db = AsyncMock()
+    reports = [{"id": str(uuid.uuid4())}]
+
+    with patch("api.routes.insights.list_reports", new=AsyncMock(return_value=reports)) as list_reports:
+        result = await list_agent_insight_reports("ultra-pi", db, user)
+
+    assert result is reports
+    list_reports.assert_awaited_once_with("ultra-pi", db, user)

--- a/tests/test_cmd_insights.py
+++ b/tests/test_cmd_insights.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from observal_cli.cmd_insights import insights_app
+
+runner = CliRunner()
+
+
+def test_insights_list_resolves_agent_name_before_report_lookup(monkeypatch):
+    calls = []
+
+    def fake_get(path: str, params: dict | None = None):
+        calls.append((path, params))
+        if path == "/api/v1/agents/ultra-pi":
+            return {"id": "c6185803-8c32-4c39-b347-78f8281e306e", "name": "ultra-pi"}
+        if path == "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports":
+            return []
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr("observal_cli.config.resolve_alias", lambda value: value)
+    monkeypatch.setattr("observal_cli.cmd_insights.client.get", fake_get)
+
+    result = runner.invoke(insights_app, ["list", "ultra-pi"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ("/api/v1/agents/ultra-pi", None),
+        ("/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports", None),
+    ]
+
+
+def test_insights_generate_resolves_agent_name_before_generate(monkeypatch):
+    calls = []
+
+    def fake_get(path: str, params: dict | None = None):
+        calls.append(("GET", path, params))
+        if path == "/api/v1/insights/status":
+            return {"available": True, "reason": None}
+        if path == "/api/v1/agents/ultra-pi":
+            return {"id": "c6185803-8c32-4c39-b347-78f8281e306e", "name": "ultra-pi"}
+        raise AssertionError(f"unexpected path: {path}")
+
+    def fake_post(path: str, data: dict):
+        calls.append(("POST", path, data))
+        if path == "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/generate":
+            return {
+                "id": "be5aa083-d84a-49e7-8a35-b37b3e687780",
+                "status": "pending",
+                "period_start": "2026-05-17T00:00:00Z",
+                "period_end": "2026-05-31T00:00:00Z",
+            }
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr("observal_cli.config.resolve_alias", lambda value: value)
+    monkeypatch.setattr("observal_cli.cmd_insights.client.get", fake_get)
+    monkeypatch.setattr("observal_cli.cmd_insights.client.post", fake_post)
+
+    result = runner.invoke(insights_app, ["generate", "ultra-pi", "--period", "30"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ("GET", "/api/v1/insights/status", None),
+        ("GET", "/api/v1/agents/ultra-pi", None),
+        (
+            "POST",
+            "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/generate",
+            {"period_days": 30},
+        ),
+    ]
+
+
+def _completed_report(report_id: str):
+    return {
+        "id": report_id,
+        "agent_id": "c6185803-8c32-4c39-b347-78f8281e306e",
+        "status": "completed",
+        "period_start": "2026-05-17T00:00:00Z",
+        "period_end": "2026-05-31T00:00:00Z",
+        "sessions_analyzed": 103,
+        "llm_model_used": "test-model",
+        "narrative": {},
+    }
+
+
+def test_insights_show_agent_name_uses_latest_completed_report(monkeypatch):
+    calls = []
+
+    def fake_get(path: str, params: dict | None = None):
+        calls.append((path, params))
+        if path == "/api/v1/agents/ultra-pi":
+            return {"id": "c6185803-8c32-4c39-b347-78f8281e306e", "name": "ultra-pi"}
+        if path == "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports":
+            return [
+                {"id": "34029e91-cf7d-4e0d-9b87-a1962e8ef2a7", "status": "failed"},
+                {"id": "be5aa083-d84a-49e7-8a35-b37b3e687780", "status": "completed"},
+            ]
+        if path == "/api/v1/insights/reports/be5aa083-d84a-49e7-8a35-b37b3e687780":
+            return _completed_report("be5aa083-d84a-49e7-8a35-b37b3e687780")
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr("observal_cli.config.resolve_alias", lambda value: value)
+    monkeypatch.setattr("observal_cli.cmd_insights.client.get", fake_get)
+
+    result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ("/api/v1/agents/ultra-pi", None),
+        ("/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports", None),
+        ("/api/v1/insights/reports/be5aa083-d84a-49e7-8a35-b37b3e687780", None),
+    ]
+
+
+def test_insights_show_agent_name_accepts_report_row(monkeypatch):
+    calls = []
+
+    def fake_get(path: str, params: dict | None = None):
+        calls.append((path, params))
+        if path == "/api/v1/agents/ultra-pi":
+            return {"id": "c6185803-8c32-4c39-b347-78f8281e306e", "name": "ultra-pi"}
+        if path == "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports":
+            return [
+                {"id": "be5aa083-d84a-49e7-8a35-b37b3e687780", "status": "completed"},
+                {"id": "b7c416a4-b501-42d7-a066-3cc95b76e656", "status": "completed"},
+            ]
+        if path == "/api/v1/insights/reports/b7c416a4-b501-42d7-a066-3cc95b76e656":
+            return _completed_report("b7c416a4-b501-42d7-a066-3cc95b76e656")
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr("observal_cli.config.resolve_alias", lambda value: value)
+    monkeypatch.setattr("observal_cli.cmd_insights.client.get", fake_get)
+
+    result = runner.invoke(insights_app, ["show", "ultra-pi", "2"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ("/api/v1/agents/ultra-pi", None),
+        ("/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports", None),
+        ("/api/v1/insights/reports/b7c416a4-b501-42d7-a066-3cc95b76e656", None),
+    ]

--- a/tests/test_cmd_insights.py
+++ b/tests/test_cmd_insights.py
@@ -17,7 +17,7 @@ def test_insights_list_resolves_agent_name_before_report_lookup(monkeypatch):
         calls.append((path, params))
         if path == "/api/v1/agents/ultra-pi":
             return {"id": "c6185803-8c32-4c39-b347-78f8281e306e", "name": "ultra-pi"}
-        if path == "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports":
+        if path == "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports":
             return []
         raise AssertionError(f"unexpected path: {path}")
 
@@ -29,7 +29,7 @@ def test_insights_list_resolves_agent_name_before_report_lookup(monkeypatch):
     assert result.exit_code == 0, result.output
     assert calls == [
         ("/api/v1/agents/ultra-pi", None),
-        ("/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports", None),
+        ("/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports", None),
     ]
 
 
@@ -46,7 +46,7 @@ def test_insights_generate_resolves_agent_name_before_generate(monkeypatch):
 
     def fake_post(path: str, data: dict):
         calls.append(("POST", path, data))
-        if path == "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/generate":
+        if path == "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports":
             return {
                 "id": "be5aa083-d84a-49e7-8a35-b37b3e687780",
                 "status": "pending",
@@ -67,7 +67,7 @@ def test_insights_generate_resolves_agent_name_before_generate(monkeypatch):
         ("GET", "/api/v1/agents/ultra-pi", None),
         (
             "POST",
-            "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/generate",
+            "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports",
             {"period_days": 30},
         ),
     ]
@@ -93,12 +93,15 @@ def test_insights_show_agent_name_uses_latest_completed_report(monkeypatch):
         calls.append((path, params))
         if path == "/api/v1/agents/ultra-pi":
             return {"id": "c6185803-8c32-4c39-b347-78f8281e306e", "name": "ultra-pi"}
-        if path == "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports":
+        if path == "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports":
             return [
                 {"id": "34029e91-cf7d-4e0d-9b87-a1962e8ef2a7", "status": "failed"},
                 {"id": "be5aa083-d84a-49e7-8a35-b37b3e687780", "status": "completed"},
             ]
-        if path == "/api/v1/insights/reports/be5aa083-d84a-49e7-8a35-b37b3e687780":
+        if (
+            path
+            == "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports/be5aa083-d84a-49e7-8a35-b37b3e687780"
+        ):
             return _completed_report("be5aa083-d84a-49e7-8a35-b37b3e687780")
         raise AssertionError(f"unexpected path: {path}")
 
@@ -110,8 +113,11 @@ def test_insights_show_agent_name_uses_latest_completed_report(monkeypatch):
     assert result.exit_code == 0, result.output
     assert calls == [
         ("/api/v1/agents/ultra-pi", None),
-        ("/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports", None),
-        ("/api/v1/insights/reports/be5aa083-d84a-49e7-8a35-b37b3e687780", None),
+        ("/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports", None),
+        (
+            "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports/be5aa083-d84a-49e7-8a35-b37b3e687780",
+            None,
+        ),
     ]
 
 
@@ -122,12 +128,15 @@ def test_insights_show_agent_name_accepts_report_row(monkeypatch):
         calls.append((path, params))
         if path == "/api/v1/agents/ultra-pi":
             return {"id": "c6185803-8c32-4c39-b347-78f8281e306e", "name": "ultra-pi"}
-        if path == "/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports":
+        if path == "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports":
             return [
                 {"id": "be5aa083-d84a-49e7-8a35-b37b3e687780", "status": "completed"},
                 {"id": "b7c416a4-b501-42d7-a066-3cc95b76e656", "status": "completed"},
             ]
-        if path == "/api/v1/insights/reports/b7c416a4-b501-42d7-a066-3cc95b76e656":
+        if (
+            path
+            == "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports/b7c416a4-b501-42d7-a066-3cc95b76e656"
+        ):
             return _completed_report("b7c416a4-b501-42d7-a066-3cc95b76e656")
         raise AssertionError(f"unexpected path: {path}")
 
@@ -139,6 +148,9 @@ def test_insights_show_agent_name_accepts_report_row(monkeypatch):
     assert result.exit_code == 0, result.output
     assert calls == [
         ("/api/v1/agents/ultra-pi", None),
-        ("/api/v1/insights/agents/c6185803-8c32-4c39-b347-78f8281e306e/reports", None),
-        ("/api/v1/insights/reports/b7c416a4-b501-42d7-a066-3cc95b76e656", None),
+        ("/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports", None),
+        (
+            "/api/v1/agents/c6185803-8c32-4c39-b347-78f8281e306e/insights/reports/b7c416a4-b501-42d7-a066-3cc95b76e656",
+            None,
+        ),
     ]

--- a/tests/test_insights_agent_lookup.py
+++ b/tests/test_insights_agent_lookup.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+async def test_resolve_insights_agent_accepts_agent_name():
+    from api.routes.insights import _resolve_insights_agent
+    from models.user import UserRole
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    user = SimpleNamespace(id=user_id, org_id=org_id, role=UserRole.user)
+    agent = SimpleNamespace(id=uuid.uuid4(), name="ultra-pi", created_by=user_id, owner_org_id=org_id, co_authors=[])
+    db = AsyncMock()
+
+    with patch("api.routes.insights._load_agent", new=AsyncMock(return_value=agent)) as load_agent:
+        resolved = await _resolve_insights_agent("ultra-pi", db, user)
+
+    assert resolved is agent
+    load_agent.assert_awaited_once_with(
+        db,
+        "ultra-pi",
+        prefer_user_id=user_id,
+        org_id=org_id,
+        include_all_statuses=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_insights_agent_raises_404_for_missing_name():
+    from api.routes.insights import _resolve_insights_agent
+    from models.user import UserRole
+
+    user = SimpleNamespace(id=uuid.uuid4(), org_id=None, role=UserRole.user)
+    db = AsyncMock()
+
+    with (
+        patch("api.routes.insights._load_agent", new=AsyncMock(return_value=None)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _resolve_insights_agent("ultra-pi", db, user)
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Agent not found"

--- a/web/src/hooks/use-insights-api.ts
+++ b/web/src/hooks/use-insights-api.ts
@@ -122,15 +122,22 @@ export function useInsightReports(agentId: string | undefined) {
   });
 }
 
-export function useInsightReport(reportId: string) {
+export function useInsightReport(agentId: string, reportId: string) {
   return useQuery({
-    queryKey: ["insights", "report", reportId],
-    queryFn: () => insights.getReport(reportId),
+    queryKey: ["insights", "report", agentId, reportId],
+    queryFn: () => insights.getReport(agentId, reportId),
     refetchInterval: (query) => {
       const status = query.state.data?.status;
       if (status === "pending" || status === "running") return 3000;
       return false;
     },
+  });
+}
+
+export function useLegacyInsightReport(reportId: string) {
+  return useQuery({
+    queryKey: ["insights", "legacy-report", reportId],
+    queryFn: () => insights.getReportById(reportId),
   });
 }
 
@@ -152,10 +159,10 @@ export function useGenerateInsight() {
 export function useApplyInsightSuggestions() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (vars: { reportId: string; selection?: { config_indices?: number[]; feature_indices?: number[]; pattern_indices?: number[] } }) =>
-      insights.applySuggestions(vars.reportId, vars.selection),
+    mutationFn: (vars: { agentId: string; reportId: string; selection?: { config_indices?: number[]; feature_indices?: number[]; pattern_indices?: number[] } }) =>
+      insights.applySuggestions(vars.agentId, vars.reportId, vars.selection),
     onSuccess: (_data, vars) => {
-      qc.invalidateQueries({ queryKey: ["insights", "report", vars.reportId] });
+      qc.invalidateQueries({ queryKey: ["insights", "report", vars.agentId, vars.reportId] });
       toast.success("Suggestions applied: items added to review queue");
     },
     onError: (err: Error) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -797,24 +797,26 @@ export const bulk = {
 // ── Insights ───────────────────────────────────────────────────────
 export const insights = {
 	status: () => get<{ available: boolean; reason: string | null }>("/insights/status"),
-	sessionCount: (agentId: string) => get<{ session_count: number }>(`/insights/agents/${agentId}/session-count`),
+	sessionCount: (agentId: string) => get<{ session_count: number }>(`/agents/${agentId}/insights/session-count`),
 	generate: (agentId: string, periodDays?: number) =>
 		post<InsightReportListItem>(
-			`/insights/agents/${agentId}/generate`,
+			`/agents/${agentId}/insights/reports`,
 			periodDays ? { period_days: periodDays } : {},
 		),
 	listReports: (agentId: string) =>
-		get<InsightReportListItem[]>(`/insights/agents/${agentId}/reports`),
-	getReport: (reportId: string) =>
+		get<InsightReportListItem[]>(`/agents/${agentId}/insights/reports`),
+	getReport: (agentId: string, reportId: string) =>
+		get<InsightReport>(`/agents/${agentId}/insights/reports/${reportId}`),
+	getReportById: (reportId: string) =>
 		get<InsightReport>(`/insights/reports/${reportId}`),
-	applySuggestions: (reportId: string, selection?: { config_indices?: number[]; feature_indices?: number[]; pattern_indices?: number[] }) =>
+	applySuggestions: (agentId: string, reportId: string, selection?: { config_indices?: number[]; feature_indices?: number[]; pattern_indices?: number[] }) =>
 		post<{ applied: boolean; report_id: string; items: InsightAppliedItems }>(
-			`/insights/reports/${reportId}/apply`,
+			`/agents/${agentId}/insights/reports/${reportId}/apply`,
 			selection ?? {},
 		),
-	exportHtml: async (reportId: string): Promise<void> => {
+	exportHtml: async (agentId: string, reportId: string): Promise<void> => {
 		const token = getAccessToken();
-		const res = await fetch(`${API}/insights/reports/${reportId}/export/html`, {
+		const res = await fetch(`${API}/agents/${agentId}/insights/reports/${reportId}/export/html`, {
 			headers: token ? { Authorization: `Bearer ${token}` } : {},
 		});
 		if (!res.ok) throw new Error("Export failed");

--- a/web/src/pages/admin/insights/detail.tsx
+++ b/web/src/pages/admin/insights/detail.tsx
@@ -649,7 +649,11 @@ function SuggestionsSection({ data, report }: { data: unknown; report?: InsightR
 			selection.pattern_indices = [...selectedPatterns];
 		}
 		const hasSelection = Object.keys(selection).length > 0;
-		applySuggestions.mutate({ reportId: report.id, selection: hasSelection ? selection : undefined });
+		applySuggestions.mutate({
+			agentId: report.agent_id,
+			reportId: report.id,
+			selection: hasSelection ? selection : undefined,
+		});
 		setShowConfirm(false);
 	};
 
@@ -1681,9 +1685,9 @@ function ReportContent({ report }: { report: InsightReport }) {
 // ── Page Component ──────────────────────────────────────────────────────
 
 export default function InsightReportPage() {
-	const { reportId } = useParams({ from: "/_authed/insights/$reportId" });
+	const { agentId, reportId } = useParams({ from: "/_authed/agents/$agentId/insights/$reportId" });
 	const router = useRouter();
-	const { data: report, isLoading, isError } = useInsightReport(reportId);
+	const { data: report, isLoading, isError } = useInsightReport(agentId, reportId);
 
 	return (
 		<>
@@ -1696,7 +1700,7 @@ export default function InsightReportPage() {
 								variant="outline"
 								size="sm"
 								className="gap-1.5"
-								onClick={() => insights.exportHtml(reportId)}
+								onClick={() => insights.exportHtml(agentId, reportId)}
 							>
 								<Download className="h-4 w-4" /> Export HTML
 							</Button>

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -270,8 +270,8 @@ function InsightsTab({ agentId }: { agentId: string }) {
             {reports.map((report) => (
               <Link
                 key={report.id}
-                to="/insights/$reportId"
-                params={{ reportId: report.id }}
+                to="/agents/$agentId/insights/$reportId"
+                params={{ agentId, reportId: report.id }}
                 className="flex items-center justify-between gap-4 rounded-md border border-border p-3 hover:bg-muted/50 transition-colors"
               >
                 <div className="flex items-center gap-3 min-w-0">

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as AuthedAdminDashboardRouteImport } from './routes/_authed/_admi
 import { Route as AuthedAdminAuditLogRouteImport } from './routes/_authed/_admin/audit-log'
 import { Route as AuthedUserTracesIndexRouteImport } from './routes/_authed/_user/traces/index'
 import { Route as AuthedUserTracesTraceIdRouteImport } from './routes/_authed/_user/traces/$traceId'
+import { Route as AuthedAgentsAgentIdInsightsReportIdRouteImport } from './routes/_authed/agents/$agentId/insights/$reportId'
 
 const AuthedRoute = AuthedRouteImport.update({
   id: '/_authed',
@@ -165,6 +166,12 @@ const AuthedUserTracesTraceIdRoute = AuthedUserTracesTraceIdRouteImport.update({
   path: '/traces/$traceId',
   getParentRoute: () => AuthedUserRoute,
 } as any)
+const AuthedAgentsAgentIdInsightsReportIdRoute =
+  AuthedAgentsAgentIdInsightsReportIdRouteImport.update({
+    id: '/insights/$reportId',
+    path: '/insights/$reportId',
+    getParentRoute: () => AuthedAgentsAgentIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthedIndexRoute
@@ -181,7 +188,7 @@ export interface FileRoutesByFullPath {
   '/sso': typeof AuthedAdminSsoRoute
   '/users': typeof AuthedAdminUsersRoute
   '/account': typeof AuthedUserAccountRoute
-  '/agents/$agentId': typeof AuthedAgentsAgentIdRoute
+  '/agents/$agentId': typeof AuthedAgentsAgentIdRouteWithChildren
   '/agents/builder': typeof AuthedAgentsBuilderRoute
   '/components/$componentId': typeof AuthedComponentsComponentIdRoute
   '/insights/$reportId': typeof AuthedInsightsReportIdRoute
@@ -190,6 +197,7 @@ export interface FileRoutesByFullPath {
   '/wiki/': typeof AuthedWikiIndexRoute
   '/traces/$traceId': typeof AuthedUserTracesTraceIdRoute
   '/traces/': typeof AuthedUserTracesIndexRoute
+  '/agents/$agentId/insights/$reportId': typeof AuthedAgentsAgentIdInsightsReportIdRoute
 }
 export interface FileRoutesByTo {
   '/device': typeof authDeviceRoute
@@ -206,7 +214,7 @@ export interface FileRoutesByTo {
   '/sso': typeof AuthedAdminSsoRoute
   '/users': typeof AuthedAdminUsersRoute
   '/account': typeof AuthedUserAccountRoute
-  '/agents/$agentId': typeof AuthedAgentsAgentIdRoute
+  '/agents/$agentId': typeof AuthedAgentsAgentIdRouteWithChildren
   '/agents/builder': typeof AuthedAgentsBuilderRoute
   '/components/$componentId': typeof AuthedComponentsComponentIdRoute
   '/insights/$reportId': typeof AuthedInsightsReportIdRoute
@@ -215,6 +223,7 @@ export interface FileRoutesByTo {
   '/wiki': typeof AuthedWikiIndexRoute
   '/traces/$traceId': typeof AuthedUserTracesTraceIdRoute
   '/traces': typeof AuthedUserTracesIndexRoute
+  '/agents/$agentId/insights/$reportId': typeof AuthedAgentsAgentIdInsightsReportIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -235,7 +244,7 @@ export interface FileRoutesById {
   '/_authed/_admin/sso': typeof AuthedAdminSsoRoute
   '/_authed/_admin/users': typeof AuthedAdminUsersRoute
   '/_authed/_user/account': typeof AuthedUserAccountRoute
-  '/_authed/agents/$agentId': typeof AuthedAgentsAgentIdRoute
+  '/_authed/agents/$agentId': typeof AuthedAgentsAgentIdRouteWithChildren
   '/_authed/agents/builder': typeof AuthedAgentsBuilderRoute
   '/_authed/components/$componentId': typeof AuthedComponentsComponentIdRoute
   '/_authed/insights/$reportId': typeof AuthedInsightsReportIdRoute
@@ -244,6 +253,7 @@ export interface FileRoutesById {
   '/_authed/wiki/': typeof AuthedWikiIndexRoute
   '/_authed/_user/traces/$traceId': typeof AuthedUserTracesTraceIdRoute
   '/_authed/_user/traces/': typeof AuthedUserTracesIndexRoute
+  '/_authed/agents/$agentId/insights/$reportId': typeof AuthedAgentsAgentIdInsightsReportIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -271,6 +281,7 @@ export interface FileRouteTypes {
     | '/wiki/'
     | '/traces/$traceId'
     | '/traces/'
+    | '/agents/$agentId/insights/$reportId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/device'
@@ -296,6 +307,7 @@ export interface FileRouteTypes {
     | '/wiki'
     | '/traces/$traceId'
     | '/traces'
+    | '/agents/$agentId/insights/$reportId'
   id:
     | '__root__'
     | '/_authed'
@@ -324,6 +336,7 @@ export interface FileRouteTypes {
     | '/_authed/wiki/'
     | '/_authed/_user/traces/$traceId'
     | '/_authed/_user/traces/'
+    | '/_authed/agents/$agentId/insights/$reportId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -516,6 +529,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedUserTracesTraceIdRouteImport
       parentRoute: typeof AuthedUserRoute
     }
+    '/_authed/agents/$agentId/insights/$reportId': {
+      id: '/_authed/agents/$agentId/insights/$reportId'
+      path: '/insights/$reportId'
+      fullPath: '/agents/$agentId/insights/$reportId'
+      preLoaderRoute: typeof AuthedAgentsAgentIdInsightsReportIdRouteImport
+      parentRoute: typeof AuthedAgentsAgentIdRoute
+    }
   }
 }
 
@@ -563,12 +583,24 @@ const AuthedUserRouteWithChildren = AuthedUserRoute._addFileChildren(
   AuthedUserRouteChildren,
 )
 
+interface AuthedAgentsAgentIdRouteChildren {
+  AuthedAgentsAgentIdInsightsReportIdRoute: typeof AuthedAgentsAgentIdInsightsReportIdRoute
+}
+
+const AuthedAgentsAgentIdRouteChildren: AuthedAgentsAgentIdRouteChildren = {
+  AuthedAgentsAgentIdInsightsReportIdRoute:
+    AuthedAgentsAgentIdInsightsReportIdRoute,
+}
+
+const AuthedAgentsAgentIdRouteWithChildren =
+  AuthedAgentsAgentIdRoute._addFileChildren(AuthedAgentsAgentIdRouteChildren)
+
 interface AuthedRouteChildren {
   AuthedAdminRoute: typeof AuthedAdminRouteWithChildren
   AuthedUserRoute: typeof AuthedUserRouteWithChildren
   AuthedLeaderboardRoute: typeof AuthedLeaderboardRoute
   AuthedIndexRoute: typeof AuthedIndexRoute
-  AuthedAgentsAgentIdRoute: typeof AuthedAgentsAgentIdRoute
+  AuthedAgentsAgentIdRoute: typeof AuthedAgentsAgentIdRouteWithChildren
   AuthedAgentsBuilderRoute: typeof AuthedAgentsBuilderRoute
   AuthedComponentsComponentIdRoute: typeof AuthedComponentsComponentIdRoute
   AuthedInsightsReportIdRoute: typeof AuthedInsightsReportIdRoute
@@ -582,7 +614,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedUserRoute: AuthedUserRouteWithChildren,
   AuthedLeaderboardRoute: AuthedLeaderboardRoute,
   AuthedIndexRoute: AuthedIndexRoute,
-  AuthedAgentsAgentIdRoute: AuthedAgentsAgentIdRoute,
+  AuthedAgentsAgentIdRoute: AuthedAgentsAgentIdRouteWithChildren,
   AuthedAgentsBuilderRoute: AuthedAgentsBuilderRoute,
   AuthedComponentsComponentIdRoute: AuthedComponentsComponentIdRoute,
   AuthedInsightsReportIdRoute: AuthedInsightsReportIdRoute,

--- a/web/src/routes/_authed/agents/$agentId/insights/$reportId.tsx
+++ b/web/src/routes/_authed/agents/$agentId/insights/$reportId.tsx
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const InsightDetail = lazy(() => import("@/pages/admin/insights/detail"));
+
+export const Route = createFileRoute("/_authed/agents/$agentId/insights/$reportId")({
+  component: InsightDetail,
+});

--- a/web/src/routes/_authed/insights/$reportId.tsx
+++ b/web/src/routes/_authed/insights/$reportId.tsx
@@ -1,10 +1,35 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { createFileRoute } from "@tanstack/react-router";
-import { lazy } from "react";
-const InsightDetail = lazy(() => import("@/pages/admin/insights/detail"));
+import { createFileRoute, useNavigate, useParams } from "@tanstack/react-router";
+import React from "react";
+import { Loader2 } from "lucide-react";
+import { ErrorState } from "@/components/shared/error-state";
+import { useLegacyInsightReport } from "@/hooks/use-insights-api";
+
+function LegacyInsightRedirect() {
+  const { reportId } = useParams({ from: "/_authed/insights/$reportId" });
+  const navigate = useNavigate();
+  const { data: report, isLoading, isError } = useLegacyInsightReport(reportId);
+
+  React.useEffect(() => {
+    if (!report) return;
+    void navigate({
+      to: "/agents/$agentId/insights/$reportId",
+      params: { agentId: report.agent_id, reportId: report.id },
+      replace: true,
+    });
+  }, [navigate, report]);
+
+  if (isError) return <ErrorState message="Failed to load report" />;
+
+  return (
+    <div className="flex items-center justify-center py-20">
+      {isLoading ? <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /> : null}
+    </div>
+  );
+}
 
 export const Route = createFileRoute("/_authed/insights/$reportId")({
-  component: InsightDetail,
+  component: LegacyInsightRedirect,
 });


### PR DESCRIPTION
## Purpose / Description

Add `observal ops insights` subcommand group to the CLI, enabling users to list, generate, and pretty-print Agent Insight reports directly from the terminal without opening the web UI.


## Approach

- Added `observal_cli/cmd_insights.py` with three commands:
  - `observal ops insights list <agent>` — tabular list of reports with status, period, session count
  - `observal ops insights generate <agent>` — trigger a new report, with a pre-check that shows setup instructions if the LLM model is not configured
  - `observal ops insights show <report-id>` — full pretty-printed narrative using Rich panels and tables, one renderer per section (`at_a_glance`, `what_works`, `friction_analysis`, `suggestions`, `on_the_horizon`, etc.). Supports `--section <name>` to render a single section and `--output json` for machine-readable output.
- Wired `insights_app` into `ops_app` in `main.py`
- Fixed `version_check.py` bug: `auto_update` stored as string `"false"` was not being parsed correctly (non-empty string is truthy in Python). Now handles both string and bool values.
- Changed CLI-ahead-of-server from a hard block to a warning, so local development with unreleased CLI changes is not blocked.

## How Has This Been Tested?

1. `make rebuild` to start the local Docker stack
2. `uv tool install --editable . --force --reinstall` to install the editable CLI
3. Verified `observal ops insights --help` shows `list`, `show`, `generate`
4. Verified `observal ops insights generate myagent` shows setup instructions when `insights.model_sections` is not configured
5. Verified `observal ops insights list myagent` returns a table once a report exists
6. Verified `--output json` passes raw data through unchanged
7. Verified `auto_update` string fix stops the binary from being silently overwritten

## Learning (optional)

- `uv tool install --editable .` builds from local source but `auto_update_if_needed()` was silently replacing the binary with the latest remote release on every command. The root cause was a type mismatch: `observal config set` stores values as JSON strings, but the check used Python truthiness on the string `"false"`.
- Server version enforcement hard-blocked CLI-ahead-of-server, which breaks local development. Changed to a warning since the server being behind is not a CLI problem.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes (Kiro)
- [x] Was the generated code manually reviewed and tested?