### PR TITLE
feat(insights): add version-aware report generation

### DIFF
--- a/docs/self-hosting/data-retention.md
+++ b/docs/self-hosting/data-retention.md
@@ -7,6 +7,19 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 Control how long telemetry is stored and how aggressively expensive API responses are cached.
 
+## Purge Traces and Insights {#purge-traces-and-insights}
+
+The **Purge Traces & Insights** danger-zone action permanently deletes telemetry and generated insight data for the current project/organization.
+
+It removes:
+
+- ClickHouse telemetry traces, spans, scores, session events, and session aggregates for the current project.
+- Agent insight reports and insight caches/facets for agents in the current organization.
+
+It does **not** delete registry agents, versions, skills, hooks, prompts, users, reviews, or audit/security logs.
+
+Use this only when you intentionally need a clean telemetry slate, for example before handing over a demo instance or after importing accidental/private trace data. The action cannot be undone from Observal; take database backups first if you may need the data later.
+
 ## Data Retention {#data-retention}
 
 Maximum age, in days, for telemetry data such as traces, spans, scores, and derived analytics.

--- a/observal-server/alembic/versions/009_insights_version_progress.py
+++ b/observal-server/alembic/versions/009_insights_version_progress.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Add version scope and progress fields to insight reports.
+
+Revision ID: 009_insights_version_progress
+Revises: 008_remove_invites
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision = "009_insights_version_progress"
+down_revision = "008_remove_invites"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("insight_reports", sa.Column("agent_version_id", UUID(as_uuid=True), nullable=True))
+    op.add_column("insight_reports", sa.Column("agent_version", sa.String(50), nullable=True))
+    op.add_column(
+        "insight_reports",
+        sa.Column("version_scope", sa.String(50), nullable=True, server_default="canonical_and_dirty"),
+    )
+    op.add_column("insight_reports", sa.Column("comparison_agent_version_id", UUID(as_uuid=True), nullable=True))
+    op.add_column("insight_reports", sa.Column("comparison_agent_version", sa.String(50), nullable=True))
+    op.add_column("insight_reports", sa.Column("progress_phase", sa.String(50), nullable=True, server_default="queued"))
+    op.add_column("insight_reports", sa.Column("progress_current", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("insight_reports", sa.Column("progress_total", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("insight_reports", sa.Column("progress_percent", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("insight_reports", sa.Column("progress_message", sa.Text(), nullable=True))
+    op.add_column("insight_reports", sa.Column("progress_updated_at", sa.DateTime(timezone=True), nullable=True))
+
+    op.create_foreign_key(
+        "fk_insight_reports_agent_version_id",
+        "insight_reports",
+        "agent_versions",
+        ["agent_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "fk_insight_reports_comparison_agent_version_id",
+        "insight_reports",
+        "agent_versions",
+        ["comparison_agent_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_insight_reports_agent_version_id", "insight_reports", ["agent_version_id"])
+    op.create_index("ix_insight_reports_agent_version", "insight_reports", ["agent_version"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_insight_reports_agent_version", table_name="insight_reports")
+    op.drop_index("ix_insight_reports_agent_version_id", table_name="insight_reports")
+    op.drop_constraint("fk_insight_reports_comparison_agent_version_id", "insight_reports", type_="foreignkey")
+    op.drop_constraint("fk_insight_reports_agent_version_id", "insight_reports", type_="foreignkey")
+    op.drop_column("insight_reports", "progress_updated_at")
+    op.drop_column("insight_reports", "progress_message")
+    op.drop_column("insight_reports", "progress_percent")
+    op.drop_column("insight_reports", "progress_total")
+    op.drop_column("insight_reports", "progress_current")
+    op.drop_column("insight_reports", "progress_phase")
+    op.drop_column("insight_reports", "comparison_agent_version")
+    op.drop_column("insight_reports", "comparison_agent_version_id")
+    op.drop_column("insight_reports", "version_scope")
+    op.drop_column("insight_reports", "agent_version")
+    op.drop_column("insight_reports", "agent_version_id")

--- a/observal-server/api/routes/admin/enterprise_settings.py
+++ b/observal-server/api/routes/admin/enterprise_settings.py
@@ -14,9 +14,14 @@ from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import services.dynamic_settings as ds
-from api.deps import get_db, require_role
+from api.deps import get_db, get_project_id, require_role
 from config import HAS_LICENSE, settings
+from models.agent import Agent
 from models.enterprise_config import EnterpriseConfig
+from models.insight_meta_cache import InsightMetaCache
+from models.insight_report import InsightReport
+from models.insight_session_facets import InsightSessionFacets
+from models.insight_session_meta import InsightSessionMeta
 from models.user import User, UserRole
 from schemas.admin import EnterpriseConfigResponse, EnterpriseConfigUpdate, SettingRevokedResponse
 from services.insights import _normalize_model_id
@@ -326,6 +331,75 @@ async def apply_resources(
         "applied": {k: current[k] for k in applied_keys},
         "message": "ClickHouse resource settings applied",
     }
+
+
+# ── Danger Zone Purge ───────────────────────────────
+
+
+class _PurgeTracesInsightsResponse(BaseModel):
+    project_id: str
+    clickhouse_tables: list[str]
+    deleted_reports: int | None = None
+    deleted_facets: int | None = None
+    deleted_session_meta: int | None = None
+    deleted_meta_cache: int | None = None
+
+
+@router.post("/settings/danger/purge-traces-insights", response_model=_PurgeTracesInsightsResponse)
+async def purge_traces_and_insights(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Danger-zone purge: delete all telemetry traces/sessions and insight reports for this org."""
+    optic.warning("danger purge traces+insights requested by user={}", current_user.id)
+    project_id = get_project_id(current_user)
+
+    from services.clickhouse.client import _query as ch_query
+
+    clickhouse_tables = ["traces", "spans", "scores", "session_events", "session_stats_agg"]
+    for table in clickhouse_tables:
+        try:
+            await ch_query(
+                f"ALTER TABLE {table} DELETE WHERE project_id = {{project_id:String}}",
+                {"param_project_id": project_id},
+            )
+        except Exception as e:
+            optic.warning("danger purge failed for ClickHouse table {}: {}", table, e)
+
+    agent_ids_stmt = select(Agent.id)
+    if current_user.org_id is not None:
+        agent_ids_stmt = agent_ids_stmt.where(Agent.owner_org_id == current_user.org_id)
+
+    report_result = await db.execute(delete(InsightReport).where(InsightReport.agent_id.in_(agent_ids_stmt)))
+    facets_result = await db.execute(
+        delete(InsightSessionFacets).where(InsightSessionFacets.agent_id.in_(agent_ids_stmt))
+    )
+    meta_result = await db.execute(delete(InsightSessionMeta).where(InsightSessionMeta.agent_id.in_(agent_ids_stmt)))
+    cache_result = await db.execute(delete(InsightMetaCache).where(InsightMetaCache.agent_id.in_(agent_ids_stmt)))
+    await db.commit()
+
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.SETTING_CHANGED,
+            severity=Severity.CRITICAL,
+            outcome="success",
+            actor_id=str(current_user.id),
+            actor_email=current_user.email,
+            actor_role=current_user.role.value,
+            target_id="danger.purge_traces_insights",
+            target_type="danger_zone",
+            detail="Purged telemetry traces/session data and insight reports for current project/org",
+        )
+    )
+
+    return _PurgeTracesInsightsResponse(
+        project_id=project_id,
+        clickhouse_tables=clickhouse_tables,
+        deleted_reports=report_result.rowcount,
+        deleted_facets=facets_result.rowcount,
+        deleted_session_meta=meta_result.rowcount,
+        deleted_meta_cache=cache_result.rowcount,
+    )
 
 
 # ── Insights Test Connection ───────────────────────────────

--- a/observal-server/api/routes/agent/insights.py
+++ b/observal-server/api/routes/agent/insights.py
@@ -3,7 +3,7 @@
 
 """Agent-scoped insight report routes."""
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,13 +22,14 @@ from ._router import router
 @router.get("/{agent_id}/insights/session-count")
 async def agent_insight_session_count(
     agent_id: str,
+    agent_version: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Return the number of sessions available for insight generation."""
     from api.routes.insights import agent_session_count
 
-    return await agent_session_count(agent_id, db, current_user)
+    return await agent_session_count(agent_id, agent_version, db, current_user)
 
 
 @router.get("/{agent_id}/insights/reports", response_model=list[InsightReportListItem])

--- a/observal-server/api/routes/insights.py
+++ b/observal-server/api/routes/insights.py
@@ -7,7 +7,7 @@
 
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from loguru import logger as optic
 from sqlalchemy import delete, select
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, get_effective_agent_permission, require_role
 from api.routes.agent.helpers import _load_agent
-from models.agent import Agent
+from models.agent import Agent, AgentStatus, AgentVersion
 from models.insight_meta_cache import InsightMetaCache
 from models.insight_report import InsightReport, InsightReportStatus
 from models.insight_session_facets import InsightSessionFacets
@@ -63,6 +63,111 @@ async def _resolve_insights_agent(agent_id: str, db: AsyncSession, current_user:
     if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
     return agent
+
+
+async def _resolve_insight_agent_version(
+    agent: Agent,
+    db: AsyncSession,
+    requested_version: str | None = None,
+) -> AgentVersion:
+    """Resolve the requested version or the latest approved version for a report."""
+    stmt = select(AgentVersion).where(
+        AgentVersion.agent_id == agent.id,
+        AgentVersion.status == AgentStatus.approved,
+    )
+    if requested_version:
+        stmt = stmt.where(AgentVersion.version == requested_version)
+    else:
+        stmt = stmt.order_by(AgentVersion.released_at.desc(), AgentVersion.created_at.desc()).limit(1)
+
+    result = await db.execute(stmt)
+    version = result.scalar_one_or_none()
+    if not version:
+        detail = (
+            f"Approved version {requested_version!r} not found"
+            if requested_version
+            else "No approved agent version found"
+        )
+        raise HTTPException(status_code=404, detail=detail)
+    return version
+
+
+async def _previous_approved_version(
+    agent: Agent, db: AsyncSession, current_version: AgentVersion
+) -> AgentVersion | None:
+    """Return a bounded default comparison target: the previous approved version."""
+    from services.versioning import parse_semver
+
+    current_parsed = parse_semver(current_version.version) or (0, 0, 0)
+    stmt = select(AgentVersion).where(
+        AgentVersion.agent_id == agent.id,
+        AgentVersion.status == AgentStatus.approved,
+        AgentVersion.id != current_version.id,
+    )
+    result = await db.execute(stmt)
+    candidates = list(result.scalars().all())
+    older: list[tuple[tuple[int, int, int], AgentVersion]] = []
+    for candidate in candidates:
+        parsed = parse_semver(candidate.version) or (0, 0, 0)
+        if parsed < current_parsed:
+            older.append((parsed, candidate))
+    if not older:
+        return None
+    older.sort(key=lambda item: item[0], reverse=True)
+    return older[0][1]
+
+
+async def _count_insight_sessions(
+    *,
+    agent: Agent,
+    period_start: datetime,
+    period_end: datetime,
+    agent_version: str | None = None,
+) -> int:
+    """Count sessions for an agent, optionally scoped to telemetry agent_version."""
+    from services.clickhouse import _query
+
+    base_where = (
+        "WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String}) "
+        "AND last_event_time >= {t_start:String} "
+        "AND last_event_time <= {t_end:String} "
+    )
+    params = {
+        "param_agent_id": str(agent.id),
+        "param_agent_name": agent.name,
+        "param_t_start": period_start.strftime("%Y-%m-%d %H:%M:%S"),
+        "param_t_end": period_end.strftime("%Y-%m-%d %H:%M:%S"),
+    }
+    if agent_version:
+        base_where += "AND agent_version = {agent_version:String} "
+        params["param_agent_version"] = agent_version
+
+    count_sql = "SELECT count() AS cnt FROM session_stats_agg FINAL " + base_where + "FORMAT JSON"
+    try:
+        r = await _query(count_sql, params)
+        count_data = r.json().get("data", []) if r.status_code == 200 else []
+        return int(count_data[0]["cnt"]) if count_data else 0
+    except Exception as e:
+        optic.warning("insight_session_count_agg_failed", agent=str(agent.id), version=agent_version, error=str(e))
+
+    # Safe fallback for older ClickHouse aggregates that do not yet expose agent_version.
+    fallback_where = (
+        "WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String}) "
+        "AND timestamp >= {t_start:String} "
+        "AND timestamp <= {t_end:String} "
+    )
+    if agent_version:
+        fallback_where += "AND agent_version = {agent_version:String} "
+    fallback_sql = (
+        "SELECT count(DISTINCT session_id) AS cnt FROM session_events FINAL " + fallback_where + "FORMAT JSON"
+    )
+    try:
+        r = await _query(fallback_sql, params)
+        count_data = r.json().get("data", []) if r.status_code == 200 else []
+        return int(count_data[0]["cnt"]) if count_data else 0
+    except Exception as e:
+        optic.warning("insight_session_count_fallback_failed", agent=str(agent.id), version=agent_version, error=str(e))
+        return 0
 
 
 @router.get("/status")
@@ -135,39 +240,23 @@ async def insights_status(current_user: User = Depends(require_role(UserRole.use
 @router.get("/agents/{agent_id}/session-count")
 async def agent_session_count(
     agent_id: str,
+    agent_version: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Return the number of sessions available for insight generation."""
-    from services.clickhouse import _query
-
     agent = await _resolve_insights_agent(agent_id, db, current_user)
+    version = await _resolve_insight_agent_version(agent, db, agent_version)
     now = datetime.now(UTC)
     period_start = now - timedelta(days=14)
-
-    count_sql = (
-        "SELECT count() AS cnt FROM session_stats_agg FINAL "
-        "WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String}) "
-        "AND last_event_time >= {t_start:String} "
-        "AND last_event_time <= {t_end:String} "
-        "FORMAT JSON"
+    count = await _count_insight_sessions(
+        agent=agent,
+        period_start=period_start,
+        period_end=now,
+        agent_version=version.version,
     )
-    try:
-        r = await _query(
-            count_sql,
-            {
-                "param_agent_id": str(agent.id),
-                "param_agent_name": agent.name,
-                "param_t_start": period_start.strftime("%Y-%m-%d %H:%M:%S"),
-                "param_t_end": now.strftime("%Y-%m-%d %H:%M:%S"),
-            },
-        )
-        count_data = r.json().get("data", []) if r.status_code == 200 else []
-        count = int(count_data[0]["cnt"]) if count_data else 0
-    except Exception:
-        count = 0
 
-    return {"session_count": count}
+    return {"session_count": count, "agent_version": version.version, "agent_version_id": str(version.id)}
 
 
 @router.post("/agents/{agent_id}/generate", response_model=InsightReportListItem)
@@ -183,38 +272,29 @@ async def generate_insight(
     agent = await _resolve_insights_agent(agent_id, db, current_user)
 
     period_days = req.period_days if req else 14
+    requested_version = req.agent_version if req else None
+    version_scope = (req.version_scope if req else None) or "canonical_and_dirty"
+    agent_version = await _resolve_insight_agent_version(agent, db, requested_version)
+    comparison_version = (
+        await _resolve_insight_agent_version(agent, db, req.comparison_agent_version)
+        if req and req.comparison_agent_version
+        else await _previous_approved_version(agent, db, agent_version)
+    )
     now = datetime.now(UTC)
     period_start = now - timedelta(days=period_days)
 
-    # Check if there are any sessions for this agent in the period
-    from services.clickhouse import _query
-
-    count_sql = (
-        "SELECT count() AS cnt FROM session_stats_agg FINAL "
-        "WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String}) "
-        "AND last_event_time >= {t_start:String} "
-        "AND last_event_time <= {t_end:String} "
-        "FORMAT JSON"
+    # Check if there are any sessions for this agent/version in the period.
+    session_count = await _count_insight_sessions(
+        agent=agent,
+        period_start=period_start,
+        period_end=now,
+        agent_version=agent_version.version,
     )
-    try:
-        r = await _query(
-            count_sql,
-            {
-                "param_agent_id": str(agent.id),
-                "param_agent_name": agent.name,
-                "param_t_start": period_start.strftime("%Y-%m-%d %H:%M:%S"),
-                "param_t_end": now.strftime("%Y-%m-%d %H:%M:%S"),
-            },
-        )
-        count_data = r.json().get("data", []) if r.status_code == 200 else []
-        session_count = int(count_data[0]["cnt"]) if count_data else 0
-    except Exception:
-        session_count = 0
 
     if session_count == 0:
         raise HTTPException(
             status_code=422,
-            detail=f"No sessions found for this agent in the last {period_days} days. Cannot generate a report.",
+            detail=f"No sessions found for this agent version ({agent_version.version}) in the last {period_days} days. Cannot generate a report.",
         )
 
     # Find previous completed report for regression linking
@@ -222,6 +302,7 @@ async def generate_insight(
         select(InsightReport)
         .where(
             InsightReport.agent_id == agent.id,
+            InsightReport.agent_version == agent_version.version,
             InsightReport.status == InsightReportStatus.completed,
         )
         .order_by(InsightReport.created_at.desc())
@@ -238,6 +319,14 @@ async def generate_insight(
         period_end=now,
         started_at=now,
         previous_report_id=prev_report.id if prev_report else None,
+        agent_version_id=agent_version.id,
+        agent_version=agent_version.version,
+        version_scope=version_scope,
+        comparison_agent_version_id=comparison_version.id if comparison_version else None,
+        comparison_agent_version=comparison_version.version if comparison_version else None,
+        progress_phase="queued",
+        progress_message="Queued for generation",
+        progress_updated_at=now,
     )
     db.add(report)
     await db.flush()
@@ -334,6 +423,8 @@ async def export_report_html(
     report_data = {
         "id": str(report.id),
         "agent_id": str(report.agent_id),
+        "agent_version": report.agent_version,
+        "comparison_agent_version": report.comparison_agent_version,
         "status": report.status.value if hasattr(report.status, "value") else str(report.status),
         "period_start": report.period_start,
         "period_end": report.period_end,

--- a/observal-server/api/routes/layer_snapshot.py
+++ b/observal-server/api/routes/layer_snapshot.py
@@ -34,6 +34,8 @@ class LayerSnapshotRequest(BaseModel):
     hash: str = Field(..., min_length=8, max_length=64)
     ides: dict[str, list[LayerFile]] = Field(default_factory=dict)  # {ide_name: [files]}
     lockfile_hash: str = Field("", max_length=64)
+    pinned_versions: dict = Field(default_factory=dict)
+    drift: dict = Field(default_factory=dict)
 
 
 class LayerSnapshotResponse(BaseModel):
@@ -151,11 +153,15 @@ async def upload_layer_snapshot(
             total_file_count += 1
         redacted_ides[ide_name] = redacted_files
 
-    # Serialize the full manifest (with redacted content)
+    # Serialize the full manifest (with redacted content). Preserve version pins
+    # and drift metadata so version-aware insights can distinguish canonical vs
+    # dirty installs and compare component/version cohorts.
     content_json = json.dumps(
         {
             "ides": redacted_ides,
             "lockfile_hash": req.lockfile_hash,
+            "pinned_versions": req.pinned_versions or {},
+            "drift": req.drift or {},
         }
     )
 

--- a/observal-server/models/insight_report.py
+++ b/observal-server/models/insight_report.py
@@ -38,6 +38,19 @@ class InsightReport(Base):
     period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     period_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
+    # Version scope for version-aware reports. `agent_version` is a denormalized
+    # snapshot used for telemetry filtering/display even if the AgentVersion row
+    # is later changed or removed.
+    agent_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agent_versions.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    agent_version: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
+    version_scope: Mapped[str | None] = mapped_column(String(50), nullable=True, default="canonical_and_dirty")
+    comparison_agent_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agent_versions.id", ondelete="SET NULL"), nullable=True
+    )
+    comparison_agent_version: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
     # Deterministic metrics from ClickHouse
     metrics: Mapped[dict | None] = mapped_column(JSON, nullable=True)
 
@@ -62,3 +75,11 @@ class InsightReport(Base):
     # Self-learn fields
     applied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     applied_items: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
+    # Progress fields for long-running report generation.
+    progress_phase: Mapped[str | None] = mapped_column(String(50), nullable=True, default="queued")
+    progress_current: Mapped[int] = mapped_column(Integer, default=0)
+    progress_total: Mapped[int] = mapped_column(Integer, default=0)
+    progress_percent: Mapped[int] = mapped_column(Integer, default=0)
+    progress_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    progress_updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/observal-server/schemas/insights.py
+++ b/observal-server/schemas/insights.py
@@ -11,6 +11,9 @@ from models.insight_report import InsightReportStatus
 
 class GenerateInsightRequest(BaseModel):
     period_days: int = 14
+    agent_version: str | None = None
+    comparison_agent_version: str | None = None
+    version_scope: str | None = "canonical_and_dirty"
 
 
 class ApplySuggestionsRequest(BaseModel):
@@ -24,18 +27,32 @@ class ApplySuggestionsRequest(BaseModel):
 class InsightReportListItem(BaseModel):
     id: uuid.UUID
     agent_id: uuid.UUID
+    agent_version_id: uuid.UUID | None = None
+    agent_version: str | None = None
+    version_scope: str | None = None
     status: InsightReportStatus
     period_start: datetime
     period_end: datetime
     sessions_analyzed: int
     created_at: datetime
     completed_at: datetime | None
+    progress_phase: str | None = None
+    progress_current: int = 0
+    progress_total: int = 0
+    progress_percent: int = 0
+    progress_message: str | None = None
+    progress_updated_at: datetime | None = None
     model_config = {"from_attributes": True}
 
 
 class InsightReportResponse(BaseModel):
     id: uuid.UUID
     agent_id: uuid.UUID
+    agent_version_id: uuid.UUID | None = None
+    agent_version: str | None = None
+    version_scope: str | None = None
+    comparison_agent_version_id: uuid.UUID | None = None
+    comparison_agent_version: str | None = None
     triggered_by: uuid.UUID | None
     status: InsightReportStatus
     period_start: datetime
@@ -48,6 +65,12 @@ class InsightReportResponse(BaseModel):
     started_at: datetime
     completed_at: datetime | None
     created_at: datetime
+    progress_phase: str | None = None
+    progress_current: int = 0
+    progress_total: int = 0
+    progress_percent: int = 0
+    progress_message: str | None = None
+    progress_updated_at: datetime | None = None
     # V2+ fields
     previous_report_id: uuid.UUID | None = None
     aggregated_data: dict | None = None

--- a/observal-server/services/clickhouse/schema.py
+++ b/observal-server/services/clickhouse/schema.py
@@ -329,6 +329,7 @@ INIT_SQL = [
         project_id          String,
         session_id          String,
         agent_id            LowCardinality(String) DEFAULT '',
+        agent_version       LowCardinality(String) DEFAULT '',
         user_id             String                 DEFAULT '',
         parent_session_id   String                 DEFAULT '',
         ide                 LowCardinality(String) DEFAULT '',
@@ -441,8 +442,10 @@ INIT_SQL = [
     # Previously this TRUNCATED session_stats_agg and backfilled on every deploy,
     # wiping all trace data. Removed: the partition migration handles backfill
     # correctly and only runs once. The MV filters timestamps going forward.
-    # ── Add layer_hash to session_stats_agg for version-aware insights ─────────
+    # ── Add layer_hash and agent_version to session_stats_agg for version-aware insights ─────────
     """ALTER TABLE session_stats_agg ADD COLUMN IF NOT EXISTS layer_hash String DEFAULT ''""",
+    """ALTER TABLE session_stats_agg ADD COLUMN IF NOT EXISTS agent_version LowCardinality(String) DEFAULT ''""",
+    """ALTER TABLE session_stats_agg ADD INDEX IF NOT EXISTS idx_ssa_agent_version agent_version TYPE bloom_filter(0.01) GRANULARITY 1""",
     """DROP VIEW IF EXISTS session_stats_mv""",
     """CREATE MATERIALIZED VIEW IF NOT EXISTS session_stats_mv
     TO session_stats_agg AS
@@ -450,6 +453,7 @@ INIT_SQL = [
         project_id,
         session_id,
         coalesce(anyIf(agent_id, agent_id IS NOT NULL AND agent_id != ''), '') AS agent_id,
+        coalesce(anyIf(agent_version, agent_version IS NOT NULL AND agent_version != ''), '') AS agent_version,
         coalesce(anyIf(user_id, user_id != ''), '')                             AS user_id,
         coalesce(anyIf(parent_session_id, parent_session_id IS NOT NULL AND parent_session_id != ''), '') AS parent_session_id,
         coalesce(anyIf(ide, ide != ''), '')                                     AS ide,

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -172,6 +172,8 @@ DEFAULTS: dict[str, str] = {
     "deployment.frontend_url": "http://localhost",
     "deployment.public_url": "",
     "deployment.cors_origins": "http://localhost:3000",
+    # Danger-zone actions (rendered as buttons; value is informational only)
+    "danger.purge_traces_insights": "",
     # Security
     "security.allow_internal_git_urls": "false",
     "security.allow_draft_install": "false",
@@ -237,6 +239,14 @@ SECTIONS: list[dict[str, Any]] = [
         "description": "Configure LLM provider for the insights engine. Supports any LiteLLM-compatible provider (Anthropic, OpenAI, Bedrock, Gemini, Azure, Ollama, etc).",
         "icon": "sparkles",
         "keys": [k for k in DEFAULTS if k.startswith("insights.")],
+    },
+    {
+        "id": "danger",
+        "title": "Danger Zone",
+        "description": "Destructive maintenance actions. Use only when you intentionally want to purge stored data.",
+        "icon": "alert-triangle",
+        "danger": True,
+        "keys": [k for k in DEFAULTS if k.startswith("danger.")],
     },
     {
         "id": "deployment",

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -48,11 +48,27 @@ async def _load_agent_config(db, agent_id) -> dict | None:
     # Build a summary of configured MCPs
     mcp_names = []
     skill_names = []
+    hook_names = []
+    prompt_names = []
+    current_components = []
     for comp in version.components or []:
+        comp_name = comp.component_name or str(comp.component_id)[:8]
+        current_components.append(
+            {
+                "type": comp.component_type,
+                "id": str(comp.component_id),
+                "name": comp_name,
+                "resolved_version": comp.resolved_version,
+            }
+        )
         if comp.component_type == "mcp":
-            mcp_names.append(comp.component_name or str(comp.component_id)[:8])
+            mcp_names.append(comp_name)
         elif comp.component_type == "skill":
-            skill_names.append(comp.component_name or str(comp.component_id)[:8])
+            skill_names.append(comp_name)
+        elif comp.component_type == "hook":
+            hook_names.append(comp_name)
+        elif comp.component_type == "prompt":
+            prompt_names.append(comp_name)
 
     # Also include external MCPs from the version config
     for ext_mcp in version.external_mcps or []:
@@ -75,6 +91,12 @@ async def _load_agent_config(db, agent_id) -> dict | None:
         config["configured_mcps"] = mcp_names
     if skill_names:
         config["configured_skills"] = skill_names
+    if hook_names:
+        config["configured_hooks"] = hook_names
+    if prompt_names:
+        config["configured_prompts"] = prompt_names
+    if current_components:
+        config["current_components"] = current_components
     if version.model_config_json:
         config["model_config"] = version.model_config_json
 
@@ -156,6 +178,19 @@ async def _reap_stale_reports() -> int:
     return len(stale)
 
 
+async def _update_report_progress(
+    db, report: InsightReport, phase: str, current: int, total: int, message: str
+) -> None:
+    now = datetime.now(UTC)
+    report.progress_phase = phase
+    report.progress_current = current
+    report.progress_total = total
+    report.progress_percent = int((current / total) * 100) if total else 0
+    report.progress_message = message
+    report.progress_updated_at = now
+    await db.commit()
+
+
 async def run_single_report(report_id: str) -> None:
     """Generate an insight report: load from DB, run pipeline, save results.
 
@@ -178,7 +213,7 @@ async def run_single_report(report_id: str) -> None:
         # Mark as running
         report.status = InsightReportStatus.running
         report.started_at = datetime.now(UTC)
-        await db.commit()
+        await _update_report_progress(db, report, "loading_sessions", 0, 9, "Loading report and agent context")
 
         try:
             # Load agent
@@ -205,17 +240,25 @@ async def run_single_report(report_id: str) -> None:
             # Load registry catalog for component-aware suggestions
             registry_catalog = await _load_registry_catalog(db)
 
+            async def progress_callback(phase: str, current: int, total: int, message: str) -> None:
+                await _update_report_progress(db, report, phase, current, total, message)
+
             # Run the insights pipeline
             content = await generate_report_content(
                 agent_name=agent_name,
                 agent_id=str(report.agent_id),
+                agent_version=report.agent_version,
+                comparison_agent_version=report.comparison_agent_version,
                 period_start=start_str,
                 period_end=end_str,
                 previous_metrics=previous_metrics,
                 agent_config=agent_config,
                 registry_catalog=registry_catalog,
                 db=db,
+                progress_callback=progress_callback,
             )
+
+            await _update_report_progress(db, report, "saving", 9, 9, "Saving report")
 
             # Persist results
             report.metrics = content.get("metrics")
@@ -234,6 +277,10 @@ async def run_single_report(report_id: str) -> None:
 
             report.status = InsightReportStatus.completed
             report.completed_at = datetime.now(UTC)
+            report.progress_phase = "completed"
+            report.progress_percent = 100
+            report.progress_message = "Report completed"
+            report.progress_updated_at = report.completed_at
             await db.commit()
 
             logger.info(
@@ -247,29 +294,54 @@ async def run_single_report(report_id: str) -> None:
             report.status = InsightReportStatus.failed
             report.error_message = str(e)
             report.completed_at = datetime.now(UTC)
+            report.progress_phase = "failed"
+            report.progress_message = str(e)
+            report.progress_updated_at = report.completed_at
             await db.commit()
             logger.exception("insight_report_failed", report_id=report_id, error=str(e))
 
 
-async def _count_agent_sessions(agent_name: str, since: str) -> int:
-    """Count sessions in otel_logs for an agent since a given timestamp."""
+async def _count_agent_sessions(agent_id: str, agent_name: str, since: str, agent_version: str | None = None) -> int:
+    """Count sessions for an agent/version since a given timestamp."""
     sql = """
-        SELECT count(DISTINCT LogAttributes['session.id']) AS cnt
-        FROM otel_logs
-        WHERE (LogAttributes['agent_type'] = {aname:String}
-               OR LogAttributes['agent_name'] = {aname:String})
-          AND Timestamp >= {t_start:String}
-          AND LogAttributes['session.id'] != ''
+        SELECT count() AS cnt
+        FROM session_stats_agg FINAL
+        WHERE (agent_id = {agent_id:String} OR agent_id = {aname:String})
+          AND last_event_time >= {t_start:String}
+          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
         FORMAT JSON
     """
-    params = {"param_aname": agent_name, "param_t_start": since}
+    params = {
+        "param_agent_id": agent_id,
+        "param_aname": agent_name,
+        "param_t_start": since,
+        "param_agent_version": agent_version or "",
+    }
     try:
         r = await _query(sql, params)
         r.raise_for_status()
         data = r.json().get("data", [])
         return int(data[0]["cnt"]) if data else 0
     except Exception as e:
-        logger.warning("insight_batch_count_failed", agent_name=agent_name, error=str(e))
+        logger.warning("insight_batch_count_agg_failed", agent_name=agent_name, version=agent_version, error=str(e))
+
+    fallback_sql = """
+        SELECT count(DISTINCT session_id) AS cnt
+        FROM session_events FINAL
+        WHERE (agent_id = {agent_id:String} OR agent_id = {aname:String})
+          AND timestamp >= {t_start:String}
+          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+        FORMAT JSON
+    """
+    try:
+        r = await _query(fallback_sql, params)
+        r.raise_for_status()
+        data = r.json().get("data", [])
+        return int(data[0]["cnt"]) if data else 0
+    except Exception as e:
+        logger.warning(
+            "insight_batch_count_fallback_failed", agent_name=agent_name, version=agent_version, error=str(e)
+        )
         return 0
 
 
@@ -330,9 +402,17 @@ async def discover_and_queue_reports() -> int:
                 if latest_report and latest_report.created_at > period_start:
                     continue
 
-                # Count new sessions for this agent
+                # Count new sessions for the latest approved version by default.
+                latest_version = agent.latest_version
+                if not latest_version or latest_version.status != AgentStatus.approved:
+                    continue
                 since_str = period_start.strftime("%Y-%m-%d %H:%M:%S")
-                session_count = await _count_agent_sessions(agent.name, since_str)
+                session_count = await _count_agent_sessions(
+                    str(agent.id),
+                    agent.name,
+                    since_str,
+                    latest_version.version,
+                )
 
                 if session_count < min_sessions:
                     logger.debug(
@@ -348,6 +428,7 @@ async def discover_and_queue_reports() -> int:
                     select(InsightReport)
                     .where(
                         InsightReport.agent_id == agent.id,
+                        InsightReport.agent_version == latest_version.version,
                         InsightReport.status == InsightReportStatus.completed,
                     )
                     .order_by(InsightReport.created_at.desc())
@@ -366,6 +447,12 @@ async def discover_and_queue_reports() -> int:
                     started_at=now,
                     created_at=now,
                     previous_report_id=prev_report.id if prev_report else None,
+                    agent_version_id=latest_version.id,
+                    agent_version=latest_version.version,
+                    version_scope="canonical_and_dirty",
+                    progress_phase="queued",
+                    progress_message="Queued by scheduled insights batch",
+                    progress_updated_at=now,
                 )
                 db.add(report)
                 await db.flush()

--- a/observal-server/services/insights/generator.py
+++ b/observal-server/services/insights/generator.py
@@ -38,12 +38,15 @@ MAX_FACET_SESSIONS = 50
 async def generate_report_content(
     agent_name: str,
     agent_id: str | None = None,
+    agent_version: str | None = None,
+    comparison_agent_version: str | None = None,
     period_start: str = "",
     period_end: str = "",
     previous_metrics: dict | None = None,
     agent_config: dict | None = None,
     registry_catalog: dict | None = None,
     db=None,
+    progress_callback=None,
 ) -> dict:
     """Generate a complete insight report for an agent.
 
@@ -60,12 +63,15 @@ async def generate_report_content(
         return await _run_pipeline(
             agent_name=agent_name,
             agent_id=agent_id,
+            agent_version=agent_version,
+            comparison_agent_version=comparison_agent_version,
             period_start=period_start,
             period_end=period_end,
             previous_metrics=previous_metrics,
             agent_config=agent_config,
             registry_catalog=registry_catalog,
             db=db,
+            progress_callback=progress_callback,
         )
     finally:
         if owns_session:
@@ -75,12 +81,15 @@ async def generate_report_content(
 async def _run_pipeline(
     agent_name: str,
     agent_id: str | None,
+    agent_version: str | None,
+    comparison_agent_version: str | None,
     period_start: str,
     period_end: str,
     previous_metrics: dict | None,
     agent_config: dict | None,
     registry_catalog: dict | None,
     db=None,
+    progress_callback=None,
 ) -> dict:
     """Core pipeline execution."""
 
@@ -88,8 +97,11 @@ async def _run_pipeline(
         "insight_pipeline_started",
         agent=agent_name,
         agent_id=agent_id,
+        agent_version=agent_version,
         period=f"{period_start} to {period_end}",
     )
+
+    await _emit_progress(progress_callback, "extracting_metadata", 1, 9, "Extracting deterministic session metadata")
 
     # ── Step 1: Deterministic metadata extraction from raw JSONL ──────────
     # This reads actual session content from ClickHouse and computes:
@@ -100,6 +112,7 @@ async def _run_pipeline(
         period_start=period_start,
         period_end=period_end,
         agent_name=agent_name,
+        agent_version=agent_version,
     )
 
     if not session_metas:
@@ -107,6 +120,7 @@ async def _run_pipeline(
         return _empty_report()
 
     logger.info("insight_metas_extracted", count=len(session_metas))
+    await _emit_progress(progress_callback, "building_transcripts", 2, 9, "Building session transcripts")
 
     # Aggregate deterministic stats
     agg = aggregate_metas(session_metas)
@@ -129,6 +143,7 @@ async def _run_pipeline(
                 transcripts[meta["session_id"]] = result
 
     logger.info("insight_transcripts_built", count=len(transcripts))
+    await _emit_progress(progress_callback, "extracting_facets", 3, 9, "Extracting qualitative session facets")
 
     # ── Step 3: Extract facets (concurrency-limited Haiku calls) ──────────
     import services.dynamic_settings as ds
@@ -146,6 +161,7 @@ async def _run_pipeline(
         )
 
     logger.info("insight_facets_extracted", count=len(all_facets))
+    await _emit_progress(progress_callback, "analyzing_versions", 4, 9, "Analyzing versions, layers, and dirty cohorts")
 
     # ── Step 3b: Model efficiency analysis ─────────────────────────────────
     # Cross-reference per-session model usage with facets to detect waste.
@@ -252,8 +268,68 @@ async def _run_pipeline(
     model_efficiency.sort(key=lambda x: -x.get("cost", 0))
     model_efficiency = model_efficiency[:20]
 
+    component_utilization = _analyze_component_utilization(agent_config or {}, session_metas, all_facets)
+
+    # ── Step 3c: Facet a bounded prior-version cohort for A/B comparison ──
+    comparison_cohort: dict | None = None
+    if comparison_agent_version and comparison_agent_version != agent_version:
+        try:
+            prior_metas = await extract_all_session_metas(
+                agent_id=agent_id or "",
+                period_start=period_start,
+                period_end=period_end,
+                agent_name=agent_name,
+                agent_version=comparison_agent_version,
+            )
+            if prior_metas:
+                prior_agg = aggregate_metas(prior_metas)
+                prior_ranked = sorted(
+                    prior_metas,
+                    key=lambda m: m.get("duration_seconds", 0) * sum(m.get("tool_counts", {}).values()),
+                    reverse=True,
+                )[: min(MAX_FACET_SESSIONS, 25)]
+                prior_transcripts: dict[str, str] = {}
+                prior_results = await asyncio.gather(
+                    *[build_session_transcript(m["session_id"]) for m in prior_ranked],
+                    return_exceptions=True,
+                )
+                for meta, result in zip(prior_ranked, prior_results, strict=False):
+                    if isinstance(result, str) and result.strip():
+                        prior_transcripts[meta["session_id"]] = result
+                prior_facets: list[dict] = []
+                if prior_transcripts:
+                    prior_facets = await _extract_facets_batch(
+                        transcripts=prior_transcripts,
+                        session_metas={m["session_id"]: m for m in prior_metas},
+                        agent_id=agent_id or "",
+                        db=db,
+                        max_concurrent=max_concurrent,
+                    )
+                comparison_cohort = {
+                    "current_version": agent_version,
+                    "prior_version": comparison_agent_version,
+                    "prior_sessions": len(prior_metas),
+                    "prior_metrics": prior_agg,
+                    "prior_facets_summary": aggregate_facets(prior_facets),
+                    "prior_faceted_sessions": len(prior_facets),
+                }
+                logger.info(
+                    "insight_prior_version_cohort_faceted",
+                    current_version=agent_version,
+                    prior_version=comparison_agent_version,
+                    sessions=len(prior_metas),
+                    facets=len(prior_facets),
+                )
+        except Exception as e:
+            logger.warning("prior_version_comparison_failed", prior_version=comparison_agent_version, error=str(e))
+
     # ── Step 4: Build the data block (pi-style focused format) ────────────
     facets_summary = aggregate_facets(all_facets)
+    cache_read_tokens = agg.get("total_cache_read_tokens", 0)
+    cache_write_tokens = agg.get("total_cache_write_tokens", 0)
+    input_tokens = agg.get("total_input_tokens", 0)
+    cache_denominator = input_tokens + cache_read_tokens + cache_write_tokens
+    cache_hit_rate_pct = round((cache_read_tokens / cache_denominator) * 100, 1) if cache_denominator else None
     data_block = _build_data_block(
         agent_name=agent_name,
         agg=agg,
@@ -264,9 +340,13 @@ async def _run_pipeline(
         agent_config=agent_config,
         model_efficiency=model_efficiency,
         estimated_waste=estimated_waste,
+        component_utilization=component_utilization,
     )
+    if comparison_cohort:
+        data_block += f"\n\n## Prior Version Comparison Cohort\n{json.dumps(comparison_cohort, indent=2, default=str)}"
 
     # ── Step 4b: Version impact analysis ─────────────────────────────────
+    version_impact = None
     try:
         from .version_impact import build_version_impact_data
 
@@ -275,6 +355,7 @@ async def _run_pipeline(
             period_start=period_start,
             period_end=period_end,
             agent_name=agent_name,
+            agent_version=agent_version,
             project_id="default",
         )
         if version_impact:
@@ -284,11 +365,14 @@ async def _run_pipeline(
         logger.warning("version_impact_analysis_failed", error=str(e))
 
     # ── Step 5: Generate narrative sections (7 parallel + 1 synthesis) ────
+    await _emit_progress(progress_callback, "generating_sections", 7, 9, "Generating report sections")
     narrative = await generate_sections(
         data_block=data_block,
         previous_report=previous_metrics,
         registry_catalog=registry_catalog,
     )
+
+    await _emit_progress(progress_callback, "synthesizing", 8, 9, "Synthesizing report")
 
     logger.info(
         "insight_pipeline_complete",
@@ -317,8 +401,11 @@ async def _run_pipeline(
             "total_credits": round(agg.get("total_credits", 0), 4),
             "total_input_tokens": agg.get("total_input_tokens", 0),
             "total_output_tokens": agg.get("total_output_tokens", 0),
-            "total_cache_read_tokens": agg.get("total_cache_read_tokens", 0),
-            "total_cache_write_tokens": agg.get("total_cache_write_tokens", 0),
+            "total_cache_read_tokens": cache_read_tokens,
+            "total_cache_write_tokens": cache_write_tokens,
+            "cache_hit_rate_pct": cache_hit_rate_pct,
+            "estimated_uncached_input_tokens": input_tokens + cache_read_tokens,
+            "cache_tokens_saved": cache_read_tokens,
             "top_tools": agg.get("top_tools", [])[:15],
             "top_languages": agg.get("top_languages", [])[:10],
             "tool_error_categories": agg.get("tool_error_categories", {}),
@@ -337,6 +424,11 @@ async def _run_pipeline(
             },
             "model_efficiency": model_efficiency[:10],
             "estimated_waste_usd": round(estimated_waste, 2),
+            "version_comparison_baseline": comparison_cohort,
+            "canonical_dirty_summary": (version_impact or {}).get("canonical_dirty_summary"),
+            "inspiration_candidates": (version_impact or {}).get("inspiration_candidates", []),
+            "isolated_regressions": (version_impact or {}).get("isolated_regressions", []),
+            "component_utilization": component_utilization,
         },
         "overview": {
             "total_sessions": agg.get("total_sessions", 0),
@@ -354,6 +446,48 @@ async def _run_pipeline(
         "facets_summary": facets_summary,
         "cross_user_patterns": {},
     }
+
+
+async def _emit_progress(progress_callback, phase: str, current: int, total: int, message: str) -> None:
+    if not progress_callback:
+        return
+    try:
+        await progress_callback(phase, current, total, message)
+    except Exception as e:
+        logger.debug("insight_progress_callback_failed", phase=phase, error=str(e))
+
+
+def _analyze_component_utilization(agent_config: dict, session_metas: list[dict], all_facets: list[dict]) -> list[dict]:
+    """Best-effort deterministic utilization for currently attached components."""
+    components = []
+    for name in agent_config.get("configured_skills", []) or []:
+        components.append(("skill", str(name)))
+    for name in agent_config.get("configured_hooks", []) or []:
+        components.append(("hook", str(name)))
+    if not components:
+        return []
+
+    searchable = "\n".join(
+        [str(m.get("first_prompt", "")) for m in session_metas]
+        + [str(f.get("brief_summary", "")) for f in all_facets if f]
+        + [" ".join(m.get("tool_counts", {}).keys()) for m in session_metas]
+    ).lower()
+    results = []
+    for comp_type, name in components:
+        key = name.lower().replace("-", " ")
+        compact = name.lower()
+        mentions = searchable.count(key) + searchable.count(compact)
+        status = "used" if mentions > 0 else "unused_or_unobserved"
+        results.append(
+            {
+                "type": comp_type,
+                "name": name,
+                "observed_mentions": mentions,
+                "status": status,
+                "confidence": "medium" if mentions > 0 else "low",
+            }
+        )
+    return results
 
 
 async def _extract_facets_batch(
@@ -396,6 +530,7 @@ def _build_data_block(
     agent_config: dict | None = None,
     model_efficiency: list[dict] | None = None,
     estimated_waste: float = 0.0,
+    component_utilization: list[dict] | None = None,
 ) -> str:
     """Build the DATA_BLOCK for section prompts.
 
@@ -421,6 +556,31 @@ def _build_data_block(
         "commits": agg.get("git_commits", 0),
         "pushes": agg.get("git_pushes", 0),
         "cost_usd": round(agg.get("total_cost", 0), 2),
+        "cache_efficiency": {
+            "cache_read_tokens": agg.get("total_cache_read_tokens", 0),
+            "cache_write_tokens": agg.get("total_cache_write_tokens", 0),
+            "input_tokens": agg.get("total_input_tokens", 0),
+            "cache_hit_rate_pct": (
+                round(
+                    agg.get("total_cache_read_tokens", 0)
+                    / max(
+                        1,
+                        agg.get("total_input_tokens", 0)
+                        + agg.get("total_cache_read_tokens", 0)
+                        + agg.get("total_cache_write_tokens", 0),
+                    )
+                    * 100,
+                    1,
+                )
+                if (
+                    agg.get("total_input_tokens", 0)
+                    or agg.get("total_cache_read_tokens", 0)
+                    or agg.get("total_cache_write_tokens", 0)
+                )
+                else None
+            ),
+            "cache_tokens_saved": agg.get("total_cache_read_tokens", 0),
+        },
         "lines_added": agg.get("total_lines_added", 0),
         "lines_removed": agg.get("total_lines_removed", 0),
         "files_modified": agg.get("total_files_modified", 0),
@@ -513,6 +673,10 @@ def _build_data_block(
             "\nREPEATED INSTRUCTIONS (by frequency):\n"
             + "\n".join(f'- "{r["instruction"]}" (frequency: {r["frequency"]})' for r in repeated[:10])
         )
+
+    # Component utilization analysis (pre-computed, constrains suggestions)
+    if component_utilization:
+        sections.append("\nCOMPONENT UTILIZATION:\n" + json.dumps(component_utilization, indent=2))
 
     # Model efficiency analysis (pre-computed, helps LLM write cost section)
     if model_efficiency:

--- a/observal-server/services/insights/html_export.py
+++ b/observal-server/services/insights/html_export.py
@@ -140,6 +140,8 @@ def render_report_html(report: dict) -> str:
     period_end = report.get("period_end", "")
     sessions_analyzed = report.get("sessions_analyzed", 0)
     report_id = report.get("id", "")
+    agent_version = report.get("agent_version") or ""
+    comparison_agent_version = report.get("comparison_agent_version") or ""
 
     # Format dates
     if isinstance(period_start, datetime):
@@ -161,6 +163,7 @@ def render_report_html(report: dict) -> str:
     suggestions = narrative.get("suggestions") or {}
     usage_cost = narrative.get("usage_cost_analysis") or {}
     regression = narrative.get("regression_detection") or {}
+    version_comparison = narrative.get("version_comparison") or {}
     fun_ending = narrative.get("fun_ending") or {}
 
     # Metrics sub-dicts
@@ -248,6 +251,9 @@ def render_report_html(report: dict) -> str:
     rich_top_tools = rich.get("top_tools", [])
     rich_top_langs = rich.get("top_languages", [])
     rich_error_cats = rich.get("tool_error_categories", {})
+    cache_hit_rate = rich.get("cache_hit_rate_pct")
+    cache_tokens_saved = rich.get("cache_tokens_saved") or rich.get("total_cache_read_tokens", 0)
+    canonical_dirty = rich.get("canonical_dirty_summary") or {}
 
     def _fmt_tokens(n: int | float) -> str:
         if n >= 1_000_000:
@@ -281,6 +287,10 @@ def render_report_html(report: dict) -> str:
         ("Tool Errors", _format_number(tool_errors_total), ""),
         ("Interruptions", _format_number(interruptions_total), ""),
     ]
+    if cache_hit_rate is not None:
+        stat_items.append(
+            ("Cache Efficiency", f"{float(cache_hit_rate):.1f}%", f"{_fmt_tokens(cache_tokens_saved)} tokens saved")
+        )
     if subagent_sessions:
         stat_items.append(("Subagent Sessions", _format_number(subagent_sessions), ""))
 
@@ -297,6 +307,18 @@ def render_report_html(report: dict) -> str:
 <section class="stats-row-section">
   <div class="stats-row">
     {stat_cells}
+  </div>
+</section>""")
+
+    if canonical_dirty:
+        sections_html.append(f"""
+<section class="content-section">
+  <h2>Canonical vs Dirty Installs</h2>
+  <div class="stats-row">
+    <div class="stat-item"><span class="stat-value">{_format_number(canonical_dirty.get("canonical_sessions", 0))}</span><span class="stat-label">Canonical Sessions</span></div>
+    <div class="stat-item"><span class="stat-value">{_format_number(canonical_dirty.get("dirty_sessions", 0))}</span><span class="stat-label">Dirty Sessions</span></div>
+    <div class="stat-item"><span class="stat-value">{_format_number(canonical_dirty.get("canonical_users", 0))}</span><span class="stat-label">Canonical Users</span></div>
+    <div class="stat-item"><span class="stat-value">{_format_number(canonical_dirty.get("dirty_users", 0))}</span><span class="stat-label">Dirty Users</span></div>
   </div>
 </section>""")
 
@@ -824,6 +846,27 @@ def render_report_html(report: dict) -> str:
 </section>""")
 
     # ══════════════════════════════════════════════════════════════════════════
+    # VERSION COMPARISON
+    # ══════════════════════════════════════════════════════════════════════════
+    if version_comparison:
+        changes_html = ""
+        for change in version_comparison.get("changes", [])[:8]:
+            changes_html += f"""
+    <div class="insight-card">
+      <h4>{_esc(change.get("metric", "Change"))}: {_esc(change.get("direction", ""))}</h4>
+      <p>{_esc(change.get("prior_value", "?"))} &rarr; {_esc(change.get("current_value", "?"))}</p>
+      <p class="muted">Attribution: {_esc(change.get("attribution", "unknown"))} &middot; Risk: {_esc(change.get("risk", "none"))}</p>
+      <p>{_esc(change.get("evidence", ""))}</p>
+    </div>"""
+        sections_html.append(f"""
+<section class="content-section">
+  <h2>Version Comparison</h2>
+  <p>{_esc(version_comparison.get("summary", ""))}</p>
+  <p class="muted">Confidence: {_esc(version_comparison.get("confidence", ""))}</p>
+  <div class="insights-list">{changes_html}</div>
+</section>""")
+
+    # ══════════════════════════════════════════════════════════════════════════
     # FUN ENDING
     # ══════════════════════════════════════════════════════════════════════════
     if fun_ending and fun_ending.get("headline"):
@@ -840,6 +883,12 @@ def render_report_html(report: dict) -> str:
     # ══════════════════════════════════════════════════════════════════════════
     body_content = "\n".join(sections_html)
     now_str = datetime.now().strftime("%Y-%m-%d %H:%M UTC")
+    version_bits = []
+    if agent_version:
+        version_bits.append(f"Version v{_esc(agent_version)}")
+    if comparison_agent_version:
+        version_bits.append(f"Compared to v{_esc(comparison_agent_version)}")
+    version_text = " &nbsp;&middot;&nbsp; ".join(version_bits)
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -1708,6 +1757,7 @@ def render_report_html(report: dict) -> str:
       <div class="brand">OBSERVAL AGENT INSIGHTS</div>
       <h1>{_esc(agent_name)}</h1>
       <p class="subtitle">
+        {version_text + " &nbsp;&middot;&nbsp;" if version_text else ""}
         Period: {_esc(period_start)} &mdash; {_esc(period_end)} &nbsp;&middot;&nbsp;
         {sessions_analyzed} sessions analyzed &nbsp;&middot;&nbsp;
         Report {_esc(str(report_id)[:8])}

--- a/observal-server/services/insights/sections.py
+++ b/observal-server/services/insights/sections.py
@@ -194,18 +194,25 @@ RESPOND WITH ONLY A VALID JSON OBJECT:
   "suggestions": {{
     "config_additions": [
       {{
+        "action_type": "modify_prompt",
         "addition": "exact text to add to the agent's system prompt or AGENTS.md",
         "why": "1 sentence explaining why based on actual sessions",
-        "where": "system_prompt | AGENTS.md | agent_config"
+        "where": "system_prompt | AGENTS.md | agent_config",
+        "confidence": "high | medium | low | insufficient_data",
+        "risk": "low | medium | high"
       }}
     ],
     "features_to_try": [
       {{
-        "feature": "Skill | Hook",
+        "action_type": "reuse_existing_component | attach_registry_component | remove_component | create_new_skill | create_new_hook | no_action",
+        "feature": "Skill | Hook | Prompt | Component",
         "name": "short-kebab-name (max 30 chars, e.g. 'scope-guard', 'pr-review', 'test-runner')",
+        "existing_component_id": "registry/current component id when action_type is reuse/attach/remove, else null",
         "one_liner": "what it does in one sentence",
         "why_for_you": "why this would help YOU based on your sessions",
-        "example": "see format rules below"
+        "confidence": "high | medium | low | insufficient_data",
+        "risk": "low | medium | high",
+        "example": "required only for create_new_skill/create_new_hook; see format rules below"
       }}
     ],
     "usage_patterns": [
@@ -221,9 +228,11 @@ RESPOND WITH ONLY A VALID JSON OBJECT:
 
 Rules:
 - config_additions: PRIORITIZE instructions from USER INSTRUCTIONS and REPEATED INSTRUCTIONS sections. These are things the user has ALREADY told the agent but it keeps forgetting. Maximum 7.
-- features_to_try: 2-3 concrete suggestions. ONLY suggest Skills or Hooks. NEVER suggest MCP servers.
+- features_to_try: 2-3 concrete suggestions. Prefer reuse_existing_component or attach_registry_component when the registry/current agent already has a matching component. ONLY create new Skills or Hooks when no existing component fits. NEVER suggest MCP servers.
 - usage_patterns: 2-4 suggestions for how to prompt differently. Each must include a copyable prompt the user can try immediately.
 - NEVER suggest vague improvements. Be specific: include the exact text, command, or config.
+- If COMPONENT UTILIZATION marks a component unused/harmful, you may suggest action_type=remove_component with the existing component id/name and risk.
+- Every suggested action must include confidence and risk.
 
 FEATURE FORMAT REQUIREMENTS:
 
@@ -311,6 +320,35 @@ Rules:
 - Maximum 3 opportunities, empty array is fine.
 - If cache efficiency is above 90%, just note it's good and move on.
 - Use plain language, not statistical jargon.""",
+    "version_comparison": """Compare this selected agent version against the prior approved version.
+
+{data_block}
+
+Use the 'Prior Version Comparison Cohort' data if present. This cohort has its own deterministic metrics and facets; do not base improvement/degradation only on stale aggregate report numbers.
+
+RESPOND WITH ONLY A VALID JSON OBJECT:
+{{
+  "version_comparison": {{
+    "has_comparison": <true|false>,
+    "current_version": "version string or null",
+    "prior_version": "version string or null",
+    "summary": "1-2 sentences stating whether the current version improved, degraded, or is inconclusive. Use 'you'.",
+    "confidence": "high | medium | low | insufficient_data",
+    "changes": [
+      {{
+        "metric": "metric name",
+        "direction": "improved | degraded | stable | inconclusive",
+        "current_value": "formatted value",
+        "prior_value": "formatted value",
+        "evidence": "specific evidence from current and prior cohorts",
+        "attribution": "prompt changed | skill changed | hook changed | model changed | dirty user edit | external/environment | unknown",
+        "risk": "low | medium | high | none"
+      }}
+    ]
+  }}
+}}
+
+If no prior cohort exists, return {{"version_comparison": {{"has_comparison": false, "summary": "No prior approved version cohort was available.", "confidence": "insufficient_data", "changes": []}}}}""",
     "regression_detection": """Compare current and previous period metrics for this agent.
 
 {data_block}

--- a/observal-server/services/insights/self_learn.py
+++ b/observal-server/services/insights/self_learn.py
@@ -99,6 +99,8 @@ async def apply_insight_suggestions(
         "skills": [],
         "hooks": [],
         "prompts": [],
+        "linked_existing": [],
+        "removed_components": [],
     }
 
     # Determine which indices to apply per category
@@ -115,19 +117,89 @@ async def apply_insight_suggestions(
         suggestions.get("usage_patterns", []),
     )
 
+    # Regeneration semantics: applying a newer report hard-replaces older
+    # pending insight-generated versions so users do not see competing fixes.
+    superseded_versions = await _withdraw_stale_insight_generated_versions(agent, db)
+    if superseded_versions:
+        applied["superseded_agent_versions"] = superseded_versions
+
     # 1. Create SkillListings and HookListings from features_to_try
     features_to_try = suggestions.get("features_to_try", [])
     created_skill_ids: list[uuid.UUID] = []
     created_hook_ids: list[uuid.UUID] = []
+    existing_skill_ids: list[uuid.UUID] = []
+    existing_hook_ids: list[uuid.UUID] = []
+    removed_component_ids: list[uuid.UUID] = []
 
     for idx in feature_indices:
         if idx >= len(features_to_try):
             continue
         feature = features_to_try[idx]
+        action_type = str(feature.get("action_type") or "").lower()
+        existing_id = feature.get("existing_component_id")
         # Never create MCPs from insights
         if _is_mcp_suggestion(feature):
             continue
+        if action_type in {"reuse_existing_component", "attach_registry_component"} and existing_id:
+            try:
+                cid = uuid.UUID(str(existing_id))
+            except ValueError:
+                cid = None
+            if cid and _is_skill_suggestion(feature):
+                existing_skill_ids.append(cid)
+                applied["linked_existing"].append(
+                    {
+                        "type": "skill",
+                        "id": str(cid),
+                        "reason": feature.get("why_for_you"),
+                        "confidence": feature.get("confidence"),
+                        "risk": feature.get("risk"),
+                    }
+                )
+            elif cid and _is_hook_suggestion(feature):
+                existing_hook_ids.append(cid)
+                applied["linked_existing"].append(
+                    {
+                        "type": "hook",
+                        "id": str(cid),
+                        "reason": feature.get("why_for_you"),
+                        "confidence": feature.get("confidence"),
+                        "risk": feature.get("risk"),
+                    }
+                )
+            continue
+        if action_type == "remove_component" and existing_id:
+            try:
+                cid = uuid.UUID(str(existing_id))
+            except ValueError:
+                cid = None
+            if cid:
+                removed_component_ids.append(cid)
+                applied["removed_components"].append(
+                    {
+                        "id": str(cid),
+                        "name": feature.get("name"),
+                        "reason": feature.get("why_for_you"),
+                        "confidence": feature.get("confidence"),
+                        "risk": feature.get("risk"),
+                    }
+                )
+            continue
         if _is_skill_suggestion(feature):
+            existing_match = await _find_existing_skill_match(feature, db)
+            if existing_match:
+                existing_skill_ids.append(existing_match.id)
+                applied["linked_existing"].append(
+                    {
+                        "type": "skill",
+                        "id": str(existing_match.id),
+                        "name": existing_match.name,
+                        "reason": "matched existing registry skill",
+                        "confidence": feature.get("confidence"),
+                        "risk": feature.get("risk") or "low",
+                    }
+                )
+                continue
             skill_info = await _create_skill_listing(
                 agent=agent,
                 feature=feature,
@@ -135,6 +207,9 @@ async def apply_insight_suggestions(
                 db=db,
             )
             if skill_info:
+                skill_info["confidence"] = feature.get("confidence")
+                skill_info["risk"] = feature.get("risk")
+                skill_info["why"] = feature.get("why_for_you")
                 applied["skills"].append(skill_info)
                 created_skill_ids.append(uuid.UUID(skill_info["id"]))
         elif _is_hook_suggestion(feature):
@@ -145,6 +220,9 @@ async def apply_insight_suggestions(
                 db=db,
             )
             if hook_info:
+                hook_info["confidence"] = feature.get("confidence")
+                hook_info["risk"] = feature.get("risk")
+                hook_info["why"] = feature.get("why_for_you")
                 applied["hooks"].append(hook_info)
                 created_hook_ids.append(uuid.UUID(hook_info["id"]))
 
@@ -170,16 +248,31 @@ async def apply_insight_suggestions(
     # 3. Create new AgentVersion with selected config additions + linked components
     config_additions = suggestions.get("config_additions", [])
     selected_additions = [config_additions[i] for i in config_indices if i < len(config_additions)]
+    if selected_additions:
+        applied["prompt_additions"] = [
+            {
+                "addition": item.get("addition"),
+                "where": item.get("where"),
+                "why": item.get("why"),
+                "confidence": item.get("confidence"),
+                "risk": item.get("risk") or "low",
+            }
+            for item in selected_additions
+        ]
 
-    if selected_additions or created_skill_ids or created_hook_ids or created_prompt_ids:
+    linked_skill_ids = created_skill_ids + existing_skill_ids
+    linked_hook_ids = created_hook_ids + existing_hook_ids
+
+    if selected_additions or linked_skill_ids or linked_hook_ids or created_prompt_ids or removed_component_ids:
         version_info = await _create_agent_version_with_additions(
             agent=agent,
             config_additions=selected_additions,
             submitter_id=submitter_id,
             db=db,
-            linked_skill_ids=created_skill_ids,
-            linked_hook_ids=created_hook_ids,
+            linked_skill_ids=linked_skill_ids,
+            linked_hook_ids=linked_hook_ids,
             linked_prompt_ids=created_prompt_ids,
+            removed_component_ids=removed_component_ids,
         )
         if version_info:
             applied["agent_version"] = version_info
@@ -201,6 +294,23 @@ async def apply_insight_suggestions(
     )
 
     return applied
+
+
+async def _withdraw_stale_insight_generated_versions(agent: Agent, db: AsyncSession) -> list[dict]:
+    stmt = select(AgentVersion).where(
+        AgentVersion.agent_id == agent.id,
+        AgentVersion.status == AgentStatus.pending,
+    )
+    result = await db.execute(stmt)
+    withdrawn = []
+    for version in result.scalars().all():
+        if not (version.description or "").startswith("Self-learned from insights"):
+            continue
+        version.status = AgentStatus.rejected
+        version.rejection_reason = "Superseded by newer insight-generated proposal"
+        withdrawn.append({"id": str(version.id), "version": version.version})
+    await db.flush()
+    return withdrawn
 
 
 async def handle_component_rejection(
@@ -290,6 +400,7 @@ async def _create_agent_version_with_additions(
     linked_skill_ids: list[uuid.UUID] | None = None,
     linked_hook_ids: list[uuid.UUID] | None = None,
     linked_prompt_ids: list[uuid.UUID] | None = None,
+    removed_component_ids: list[uuid.UUID] | None = None,
 ) -> dict | None:
     """Create a new pending AgentVersion with config_additions appended to the prompt.
 
@@ -313,12 +424,24 @@ async def _create_agent_version_with_additions(
         optic.warning("self_learn_no_approved_version", agent=agent.name)
         return None
 
-    # Build the new prompt with additions
+    # Build the new prompt with additions, skipping exact duplicates already present.
     current_prompt = latest_version.prompt or ""
+    existing_prompt_lower = current_prompt.lower()
+    config_additions = [
+        item
+        for item in config_additions
+        if item.get("addition") and item.get("addition", "").strip().lower() not in existing_prompt_lower
+    ]
     additions_text = _build_additions_text(config_additions)
 
     # Even without text additions, we might be linking new components
-    if not additions_text.strip() and not linked_skill_ids and not linked_hook_ids and not linked_prompt_ids:
+    if (
+        not additions_text.strip()
+        and not linked_skill_ids
+        and not linked_hook_ids
+        and not linked_prompt_ids
+        and not removed_component_ids
+    ):
         return None
 
     new_prompt = current_prompt
@@ -353,6 +476,8 @@ async def _create_agent_version_with_additions(
         desc_parts.append(f"{len(config_additions)} prompt additions")
     if total_linked:
         desc_parts.append(f"{total_linked} linked components")
+    if removed_component_ids:
+        desc_parts.append(f"{len(removed_component_ids)} removed components")
     description = "Self-learned from insights: " + ", ".join(desc_parts)
 
     now = datetime.now(UTC)
@@ -378,7 +503,10 @@ async def _create_agent_version_with_additions(
     from models.agent_component import AgentComponent
 
     order_idx = 0
+    removed_set = set(removed_component_ids or [])
     for comp in latest_version.components or []:
+        if comp.component_id in removed_set:
+            continue
         db.add(
             AgentComponent(
                 agent_version_id=new_version.id,
@@ -439,6 +567,7 @@ async def _create_agent_version_with_additions(
         "version": new_ver,
         "additions_count": len(config_additions),
         "linked_components": total_linked,
+        "removed_components": len(removed_component_ids or []),
     }
 
 
@@ -575,6 +704,35 @@ def _slugify(text: str) -> str:
     slug = re.sub(r"[^a-z0-9\-]", "-", slug)
     slug = re.sub(r"-+", "-", slug)
     return slug.strip("-")
+
+
+async def _find_existing_skill_match(feature: dict, db: AsyncSession) -> SkillListing | None:
+    """Deterministically find an existing approved skill before creating a duplicate."""
+    raw_name = _slugify(str(feature.get("name") or ""))
+    one_liner = str(feature.get("one_liner") or feature.get("why_for_you") or "")
+    keywords = set(_extract_keywords(f"{raw_name} {one_liner}", max_words=6).split("-"))
+    if not raw_name and not keywords:
+        return None
+
+    rows = (
+        (
+            await db.execute(
+                select(SkillListing)
+                .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id, isouter=True)
+                .where(SkillVersion.status == ListingStatus.approved)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for listing in rows:
+        listing_slug = _slugify(listing.name or "")
+        if raw_name and (listing_slug == raw_name or raw_name in listing_slug or listing_slug in raw_name):
+            return listing
+        haystack = f"{listing.name} {getattr(listing.latest_version, 'description', '')}".lower()
+        if keywords and sum(1 for kw in keywords if kw and kw in haystack) >= min(3, len(keywords)):
+            return listing
+    return None
 
 
 async def _create_skill_listing(

--- a/observal-server/services/insights/session_meta_extractor.py
+++ b/observal-server/services/insights/session_meta_extractor.py
@@ -425,6 +425,7 @@ async def fetch_session_stats(
     period_start: str,
     period_end: str,
     agent_name: str = "",
+    agent_version: str | None = None,
 ) -> dict[str, dict]:
     """Fetch per-session stats (credits, ide) from session_stats_agg.
 
@@ -438,6 +439,7 @@ async def fetch_session_stats(
         WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
           AND last_event_time >= {t_start:String}
           AND last_event_time <= {t_end:String}
+          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
         GROUP BY session_id, total_credits, ide, layer_hash
         FORMAT JSON
     """
@@ -446,6 +448,7 @@ async def fetch_session_stats(
         "param_agent_name": agent_name,
         "param_t_start": period_start,
         "param_t_end": period_end,
+        "param_agent_version": agent_version or "",
     }
 
     try:
@@ -461,7 +464,36 @@ async def fetch_session_stats(
             for row in rows
         }
     except Exception as e:
-        logger.warning("fetch_session_stats_failed", error=str(e))
+        logger.warning("fetch_session_stats_agg_failed", error=str(e))
+
+    fallback_sql = """
+        SELECT
+            session_id,
+            max(credits) AS total_credits,
+            anyIf(ide, ide != '') AS ide,
+            anyIf(layer_hash, layer_hash IS NOT NULL AND layer_hash != '') AS layer_hash
+        FROM session_events FINAL
+        WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
+          AND timestamp >= {t_start:String}
+          AND timestamp <= {t_end:String}
+          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+        GROUP BY session_id
+        FORMAT JSON
+    """
+    try:
+        r = await query(fallback_sql, params)
+        r.raise_for_status()
+        rows = r.json().get("data", [])
+        return {
+            row["session_id"]: {
+                "credits": float(row.get("total_credits") or 0),
+                "ide": row.get("ide", ""),
+                "layer_hash": row.get("layer_hash", ""),
+            }
+            for row in rows
+        }
+    except Exception as e:
+        logger.warning("fetch_session_stats_fallback_failed", error=str(e))
         return {}
 
 
@@ -470,6 +502,7 @@ async def fetch_all_session_transcripts(
     period_start: str,
     period_end: str,
     agent_name: str = "",
+    agent_version: str | None = None,
     batch_size: int = 50,
 ) -> dict[str, list[str]]:
     """Fetch raw JSONL lines for all sessions of an agent from ClickHouse.
@@ -488,6 +521,7 @@ async def fetch_all_session_transcripts(
         WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
           AND last_event_time >= {t_start:String}
           AND last_event_time <= {t_end:String}
+          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
         GROUP BY session_id
         ORDER BY min(last_event_time)
         FORMAT JSON
@@ -497,6 +531,7 @@ async def fetch_all_session_transcripts(
         "param_agent_name": agent_name,
         "param_t_start": period_start,
         "param_t_end": period_end,
+        "param_agent_version": agent_version or "",
     }
 
     try:
@@ -504,8 +539,24 @@ async def fetch_all_session_transcripts(
         r.raise_for_status()
         session_ids = [row["session_id"] for row in r.json().get("data", [])]
     except Exception as e:
-        logger.error("fetch_session_ids_failed", error=str(e))
-        return {}
+        logger.warning("fetch_session_ids_agg_failed", error=str(e))
+        fallback_id_sql = """
+            SELECT DISTINCT session_id
+            FROM session_events FINAL
+            WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
+              AND timestamp >= {t_start:String}
+              AND timestamp <= {t_end:String}
+              AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+            ORDER BY session_id
+            FORMAT JSON
+        """
+        try:
+            r = await query(fallback_id_sql, params)
+            r.raise_for_status()
+            session_ids = [row["session_id"] for row in r.json().get("data", [])]
+        except Exception as fallback_error:
+            logger.error("fetch_session_ids_failed", error=str(fallback_error))
+            return {}
 
     if not session_ids:
         return {}
@@ -553,6 +604,7 @@ async def extract_all_session_metas(
     period_start: str,
     period_end: str,
     agent_name: str = "",
+    agent_version: str | None = None,
 ) -> list[dict]:
     """Fetch transcripts and extract deterministic metadata for all sessions.
 
@@ -560,18 +612,32 @@ async def extract_all_session_metas(
     then runs extract_session_meta on each session.
     Also enriches each meta with credits and IDE info from session_stats_agg.
     """
-    transcripts = await fetch_all_session_transcripts(agent_id, period_start, period_end, agent_name=agent_name)
+    transcripts = await fetch_all_session_transcripts(
+        agent_id,
+        period_start,
+        period_end,
+        agent_name=agent_name,
+        agent_version=agent_version,
+    )
 
-    # Fetch per-session stats (credits, ide) for enrichment
-    session_stats = await fetch_session_stats(agent_id, period_start, period_end, agent_name=agent_name)
+    # Fetch per-session stats (credits, ide, layer hash) for enrichment
+    session_stats = await fetch_session_stats(
+        agent_id,
+        period_start,
+        period_end,
+        agent_name=agent_name,
+        agent_version=agent_version,
+    )
 
     metas = []
     for session_id, lines in transcripts.items():
         meta = extract_session_meta(session_id, lines)
-        # Enrich with credits and IDE from session_stats_agg
+        # Enrich with credits, IDE, layer hash, and report version scope from session_stats_agg
         stats = session_stats.get(session_id, {})
         meta["credits"] = stats.get("credits", 0.0)
         meta["ide"] = stats.get("ide", "")
+        meta["layer_hash"] = stats.get("layer_hash", "")
+        meta["agent_version"] = agent_version or ""
         metas.append(meta)
 
     logger.info(

--- a/observal-server/services/insights/version_impact.py
+++ b/observal-server/services/insights/version_impact.py
@@ -24,11 +24,55 @@ from ._deps import get_query
 logger = structlog.get_logger(__name__)
 
 
+def _median(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def _robust_outlier_labels(groups: list[dict], metric: str) -> dict[str, str]:
+    """Label layer cohorts using median/MAD so outliers do not poison means."""
+    values = [float(g.get(metric, 0) or 0) for g in groups]
+    if len(values) < 3:
+        return {g["layer_hash"]: "normal" for g in groups}
+    med = _median(values)
+    deviations = [abs(v - med) for v in values]
+    mad = _median(deviations) or 1e-9
+    labels: dict[str, str] = {}
+    for group in groups:
+        value = float(group.get(metric, 0) or 0)
+        robust_z = 0.6745 * (value - med) / mad
+        if robust_z >= 2.5:
+            labels[group["layer_hash"]] = "positive_outlier"
+        elif robust_z <= -2.5:
+            labels[group["layer_hash"]] = "negative_outlier"
+        else:
+            labels[group["layer_hash"]] = "normal"
+    return labels
+
+
+def _confidence_for_groups(groups: list[dict], significant: bool) -> str:
+    total_sessions = sum(int(g.get("sessions", 0)) for g in groups)
+    multi_user_groups = sum(1 for g in groups if int(g.get("users", 0)) >= 2)
+    if total_sessions < 10 or len(groups) < 2:
+        return "insufficient_data"
+    if significant and total_sessions >= 30 and multi_user_groups >= 2:
+        return "high"
+    if significant and total_sessions >= 15:
+        return "medium"
+    return "low"
+
+
 async def detect_layer_groups(
     agent_id: str,
     period_start: str,
     period_end: str,
     agent_name: str = "",
+    agent_version: str | None = None,
 ) -> list[dict]:
     """Group sessions by layer_hash and compute metrics per group.
 
@@ -53,6 +97,7 @@ async def detect_layer_groups(
 
     sql = """
         SELECT
+            coalesce(agent_version, '') AS agent_version,
             layer_hash,
             count() AS sessions,
             uniq(user_id) AS users,
@@ -71,7 +116,8 @@ async def detect_layer_groups(
           AND last_event_time >= {t_start:String}
           AND last_event_time <= {t_end:String}
           AND layer_hash != ''
-        GROUP BY layer_hash
+          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+        GROUP BY agent_version, layer_hash
         HAVING sessions >= 3
         ORDER BY sessions DESC
         LIMIT 20
@@ -82,6 +128,7 @@ async def detect_layer_groups(
         "param_agent_name": agent_name,
         "param_t_start": period_start,
         "param_t_end": period_end,
+        "param_agent_version": agent_version or "",
     }
 
     try:
@@ -94,6 +141,7 @@ async def detect_layer_groups(
 
     return [
         {
+            "agent_version": row.get("agent_version", ""),
             "layer_hash": row["layer_hash"],
             "sessions": int(row.get("sessions", 0)),
             "users": int(row.get("users", 0)),
@@ -217,6 +265,7 @@ async def build_version_impact_data(
     period_start: str,
     period_end: str,
     agent_name: str = "",
+    agent_version: str | None = None,
     project_id: str = "default",
 ) -> dict | None:
     """Build the complete version impact data block for the insight report.
@@ -233,6 +282,7 @@ async def build_version_impact_data(
         period_start=period_start,
         period_end=period_end,
         agent_name=agent_name,
+        agent_version=agent_version,
     )
 
     if len(groups) < 2:
@@ -246,9 +296,14 @@ async def build_version_impact_data(
 
     success_gap = best_success - worst_success
     error_gap = worst_error - best_error
+    outlier_labels = _robust_outlier_labels(groups, "success_proxy")
 
-    # Threshold: at least 20% absolute gap in success or 15% in error rate
-    significant = success_gap >= 0.20 or error_gap >= 0.15
+    # Threshold: at least 20% absolute gap in success or 15% in error rate.
+    # Robust outlier labels add sensitivity without letting outliers poison means.
+    significant = (
+        success_gap >= 0.20 or error_gap >= 0.15 or any(label != "normal" for label in outlier_labels.values())
+    )
+    confidence = _confidence_for_groups(groups, significant)
 
     if not significant:
         # Return lightweight summary (no snapshot content, saves context)
@@ -257,6 +312,7 @@ async def build_version_impact_data(
             "total_sessions": sum(g["sessions"] for g in groups),
             "total_users": sum(g["users"] for g in groups),
             "significant": False,
+            "confidence": confidence,
             "groups": [
                 {
                     "layer_hash": g["layer_hash"],
@@ -264,6 +320,7 @@ async def build_version_impact_data(
                     "users": g["users"],
                     "success_proxy": g["success_proxy"],
                     "tool_error_rate": g["tool_error_rate"],
+                    "outlier_label": outlier_labels.get(g["layer_hash"], "normal"),
                 }
                 for g in groups[:5]
             ],
@@ -279,6 +336,20 @@ async def build_version_impact_data(
     if len(groups_with_data) < 2:
         return None
 
+    canonical_sessions = 0
+    dirty_sessions = 0
+    canonical_users = 0
+    dirty_users = 0
+    for group in groups_with_data:
+        snap = snapshots.get(group["layer_hash"], {})
+        is_canonical = snap.get("drift", {}).get("is_canonical", None)
+        if is_canonical is True:
+            canonical_sessions += group["sessions"]
+            canonical_users += group["users"]
+        elif is_canonical is False:
+            dirty_sessions += group["sessions"]
+            dirty_users += group["users"]
+
     # Sort by success_proxy (higher = better)
     sorted_by_success = sorted(groups_with_data, key=lambda g: g["success_proxy"], reverse=True)
     best_group = sorted_by_success[0]
@@ -293,6 +364,42 @@ async def build_version_impact_data(
     best_summary = extract_content_summary(best_snap)
     worst_summary = extract_content_summary(worst_snap)
 
+    # Extract positive dirty/canonical outlier inspiration candidates and
+    # negative isolated regressions. These are kept separate from baseline means.
+    inspiration_candidates = []
+    isolated_regressions = []
+    for group in groups_with_data:
+        label = outlier_labels.get(group["layer_hash"], "normal")
+        if group.get("sessions", 0) < 3:
+            continue
+        snap = snapshots.get(group["layer_hash"], {})
+        candidate = {
+            "layer_hash": group["layer_hash"],
+            "agent_version": group.get("agent_version", ""),
+            "sessions": group["sessions"],
+            "users": group["users"],
+            "success_proxy": group["success_proxy"],
+            "tool_error_rate": group["tool_error_rate"],
+            "is_canonical": snap.get("drift", {}).get("is_canonical", None),
+            "content_summary": extract_content_summary(snap),
+            "confidence": confidence,
+        }
+        if label == "positive_outlier":
+            inspiration_candidates.append(
+                {
+                    **candidate,
+                    "diff_vs_baseline": diff_snapshots(worst_snap, snap) if worst_snap else {},
+                }
+            )
+        elif label == "negative_outlier":
+            isolated_regressions.append(
+                {
+                    **candidate,
+                    "diff_vs_best": diff_snapshots(best_snap, snap) if best_snap else {},
+                    "baseline_policy": "excluded_from_canonical_mean",
+                }
+            )
+
     # Extract version pins if available
     best_versions = best_snap.get("pinned_versions", {})
     worst_versions = worst_snap.get("pinned_versions", {})
@@ -302,8 +409,15 @@ async def build_version_impact_data(
         "total_sessions": sum(g["sessions"] for g in groups),
         "total_users": sum(g["users"] for g in groups),
         "significant": True,
+        "confidence": confidence,
         "success_gap_pct": round(success_gap * 100, 1),
         "error_gap_pct": round(error_gap * 100, 1),
+        "canonical_dirty_summary": {
+            "canonical_sessions": canonical_sessions,
+            "dirty_sessions": dirty_sessions,
+            "canonical_users": canonical_users,
+            "dirty_users": dirty_users,
+        },
         "groups": [
             {
                 "layer_hash": g["layer_hash"],
@@ -313,6 +427,7 @@ async def build_version_impact_data(
                 "tool_error_rate": g["tool_error_rate"],
                 "avg_cost": g["avg_cost"],
                 "avg_duration_seconds": g["avg_duration_seconds"],
+                "outlier_label": outlier_labels.get(g["layer_hash"], "normal"),
                 "is_canonical": snapshots.get(g["layer_hash"], {}).get("drift", {}).get("is_canonical", None),
             }
             for g in groups_with_data
@@ -330,4 +445,6 @@ async def build_version_impact_data(
             "versions": worst_versions,
         },
         "config_diff_best_vs_worst": config_diff,
+        "inspiration_candidates": inspiration_candidates,
+        "isolated_regressions": isolated_regressions,
     }

--- a/observal_cli/cmd_insights.py
+++ b/observal_cli/cmd_insights.py
@@ -85,6 +85,7 @@ def insights_list(
     table = Table(title=f"Insight Reports ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
     table.add_column("Status")
+    table.add_column("Version")
     table.add_column("Period")
     table.add_column("Sessions", justify="right")
     table.add_column("Completed")
@@ -94,6 +95,7 @@ def insights_list(
         table.add_row(
             str(i),
             status_badge(r.get("status", "")),
+            str(r.get("agent_version") or "-"),
             f"{start} → {end}",
             str(r.get("sessions_analyzed", 0)),
             relative_time(r.get("completed_at")),
@@ -130,6 +132,13 @@ def insights_show(
         return
     if data.get("status") != "completed":
         rprint(f"  Status: {status_badge(data.get('status', 'unknown'))}")
+        if data.get("progress_phase"):
+            rprint(
+                f"  Phase: [cyan]{str(data.get('progress_phase')).replace('_', ' ')}[/cyan] "
+                f"({data.get('progress_percent', 0)}%)"
+            )
+        if data.get("progress_message"):
+            rprint(f"  [dim]{data['progress_message']}[/dim]")
         if data.get("error_message"):
             rprint(f"  [red]Error:[/red] {data['error_message']}")
         return
@@ -147,8 +156,17 @@ def insights_show(
     start = data.get("period_start", "")[:10]
     end = data.get("period_end", "")[:10]
     rprint()
-    rprint(f"  [bold]Insight Report[/bold]  {start} → {end}")
-    rprint(f"  Sessions: {data.get('sessions_analyzed', 0)}  Model: {data.get('llm_model_used', 'unknown')}")
+    version = data.get("agent_version") or "unknown"
+    comparison = data.get("comparison_agent_version")
+    comparison_text = f"  Compared to: v{comparison}" if comparison else ""
+    rprint(f"  [bold]Insight Report[/bold]  v{version}  {start} → {end}")
+    rprint(
+        f"  Sessions: {data.get('sessions_analyzed', 0)}  Model: {data.get('llm_model_used', 'unknown')}"
+        f"{comparison_text}"
+    )
+    rich = (data.get("metrics") or {}).get("rich") or {}
+    if rich.get("cache_hit_rate_pct") is not None:
+        rprint(f"  Cache: {rich.get('cache_hit_rate_pct')}% hit rate, {rich.get('cache_tokens_saved', 0)} tokens saved")
     rprint()
 
     # Render sections in logical order
@@ -161,6 +179,7 @@ def insights_show(
         "friction_analysis",
         "suggestions",
         "usage_cost_analysis",
+        "version_comparison",
         "regression_detection",
         "on_the_horizon",
         "fun_ending",
@@ -184,6 +203,7 @@ _SECTION_TITLES = {
     "friction_analysis": "⚠️  Friction Analysis",
     "suggestions": "💡 Suggestions",
     "usage_cost_analysis": "💰 Cost Analysis",
+    "version_comparison": "🧪 Version Comparison",
     "regression_detection": "📈 Regression Detection",
     "on_the_horizon": "🔮 On the Horizon",
     "fun_ending": "🎉 Fun Moment",
@@ -395,6 +415,25 @@ def _render_horizon(title: str, data: dict):
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="magenta", expand=False))
 
 
+def _render_version_comparison(title: str, data: dict):
+    lines = []
+    if data.get("summary"):
+        lines.append(data["summary"])
+    if data.get("confidence"):
+        lines.append(f"[dim]Confidence: {data['confidence']}[/dim]")
+    for change in data.get("changes", [])[:6]:
+        lines.append(
+            f"\n[bold]{change.get('metric', '')}[/bold]: {change.get('direction', '')} "
+            f"({change.get('prior_value', '?')} → {change.get('current_value', '?')})"
+        )
+        if change.get("attribution"):
+            lines.append(f"[dim]Attribution: {change['attribution']}[/dim]")
+        if change.get("evidence"):
+            lines.append(f"[dim]{change['evidence']}[/dim]")
+    if lines:
+        console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
+
+
 def _render_fun_ending(title: str, data: dict):
     headline = data.get("headline", "")
     detail = data.get("detail", "")
@@ -414,6 +453,7 @@ _RENDERERS = {
     "friction_analysis": _render_friction,
     "suggestions": _render_suggestions,
     "usage_cost_analysis": _render_cost,
+    "version_comparison": _render_version_comparison,
     "regression_detection": _render_regression,
     "on_the_horizon": _render_horizon,
     "fun_ending": _render_fun_ending,
@@ -424,7 +464,10 @@ _RENDERERS = {
 def insights_generate(
     agent_id: str = typer.Argument(..., help="Agent ID, name, or @alias"),
     period_days: int = typer.Option(14, "--period", "-p", help="Analysis period in days"),
+    agent_version: str | None = typer.Option(None, "--version", "-v", help="Agent version to analyze"),
+    compare_version: str | None = typer.Option(None, "--compare", help="Baseline agent version for A/B comparison"),
     output: str = typer.Option("table", "--output", "-o"),
+    wait: bool = typer.Option(False, "--wait", help="Poll until the report completes"),
 ):
     """Trigger generation of a new insight report.
 
@@ -451,11 +494,38 @@ def insights_generate(
 
     with spinner("Generating insight report..."):
         resolved = _resolve_agent_id(agent_id)
-        data = client.post(f"/api/v1/agents/{resolved}/insights/reports", {"period_days": period_days})
+        body = {"period_days": period_days}
+        if agent_version:
+            body["agent_version"] = agent_version
+        if compare_version:
+            body["comparison_agent_version"] = compare_version
+        data = client.post(f"/api/v1/agents/{resolved}/insights/reports", body)
+
+    if wait and output != "json":
+        import time
+
+        report_id = str(data.get("id"))
+        for _ in range(120):
+            current = client.get(f"/api/v1/agents/{resolved}/insights/reports/{report_id}")
+            phase = str(current.get("progress_phase") or current.get("status") or "queued").replace("_", " ")
+            percent = current.get("progress_percent", 0)
+            rprint(f"\r  {status_badge(current.get('status', 'pending'))} {phase} ({percent}%)", end="")
+            if current.get("status") in {"completed", "failed"}:
+                rprint()
+                data = current
+                break
+            time.sleep(3)
+
     if output == "json":
         output_json(data)
         return
     rprint(f"[green]✓ Report queued[/green] (status: {status_badge(data.get('status', 'pending'))})")
     rprint(f"  ID: [dim]{data.get('id', '')}[/dim]")
+    if data.get("agent_version"):
+        rprint(f"  Version: v{data.get('agent_version')}")
+    if data.get("comparison_agent_version"):
+        rprint(f"  Compare: v{data.get('comparison_agent_version')}")
     rprint(f"  Period: {str(data.get('period_start', ''))[:10]} → {str(data.get('period_end', ''))[:10]}")
-    rprint("[dim]  Run `observal ops insights show <id>` when complete.[/dim]")
+    if data.get("progress_phase"):
+        rprint(f"  Phase: {str(data.get('progress_phase')).replace('_', ' ')} ({data.get('progress_percent', 0)}%)")
+    rprint("[dim]  Run `observal ops insights show <agent>` when complete.[/dim]")

--- a/web/src/hooks/use-insights-api.ts
+++ b/web/src/hooks/use-insights-api.ts
@@ -98,10 +98,10 @@ export function useInsightsStatus() {
   });
 }
 
-export function useInsightSessionCount(agentId: string | undefined) {
+export function useInsightSessionCount(agentId: string | undefined, agentVersion?: string | null) {
   return useQuery({
-    queryKey: ["insights", "session-count", agentId],
-    queryFn: () => insights.sessionCount(agentId!),
+    queryKey: ["insights", "session-count", agentId, agentVersion],
+    queryFn: () => insights.sessionCount(agentId!, agentVersion ?? undefined),
     enabled: !!agentId,
     refetchInterval: 30_000,
   });
@@ -144,8 +144,8 @@ export function useLegacyInsightReport(reportId: string) {
 export function useGenerateInsight() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (vars: { agentId: string; periodDays?: number }) =>
-      insights.generate(vars.agentId, vars.periodDays),
+    mutationFn: (vars: { agentId: string; periodDays?: number; agentVersion?: string; comparisonAgentVersion?: string }) =>
+      insights.generate(vars.agentId, vars.periodDays, vars.agentVersion, vars.comparisonAgentVersion),
     onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: ["insights", "reports", vars.agentId] });
       toast.success("Insight report queued");

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -601,6 +601,15 @@ export const admin = {
 			error?: string;
 			hint?: string;
 		}>("/admin/insights/test-connection", body ?? {}),
+	purgeTracesAndInsights: () =>
+		post<{
+			project_id: string;
+			clickhouse_tables: string[];
+			deleted_reports?: number;
+			deleted_facets?: number;
+			deleted_session_meta?: number;
+			deleted_meta_cache?: number;
+		}>("/admin/settings/danger/purge-traces-insights", {}),
 	users: () => get<AdminUser[]>("/admin/users"),
 	createUser: (body: {
 		email: string;
@@ -797,12 +806,16 @@ export const bulk = {
 // ── Insights ───────────────────────────────────────────────────────
 export const insights = {
 	status: () => get<{ available: boolean; reason: string | null }>("/insights/status"),
-	sessionCount: (agentId: string) => get<{ session_count: number }>(`/agents/${agentId}/insights/session-count`),
-	generate: (agentId: string, periodDays?: number) =>
-		post<InsightReportListItem>(
-			`/agents/${agentId}/insights/reports`,
-			periodDays ? { period_days: periodDays } : {},
+	sessionCount: (agentId: string, agentVersion?: string) =>
+		get<{ session_count: number; agent_version?: string; agent_version_id?: string }>(
+			`/agents/${agentId}/insights/session-count${agentVersion ? `?agent_version=${encodeURIComponent(agentVersion)}` : ""}`,
 		),
+	generate: (agentId: string, periodDays?: number, agentVersion?: string, comparisonAgentVersion?: string) =>
+		post<InsightReportListItem>(`/agents/${agentId}/insights/reports`, {
+			...(periodDays ? { period_days: periodDays } : {}),
+			...(agentVersion ? { agent_version: agentVersion } : {}),
+			...(comparisonAgentVersion ? { comparison_agent_version: comparisonAgentVersion } : {}),
+		}),
 	listReports: (agentId: string) =>
 		get<InsightReportListItem[]>(`/agents/${agentId}/insights/reports`),
 	getReport: (agentId: string, reportId: string) =>

--- a/web/src/lib/docs-map.ts
+++ b/web/src/lib/docs-map.ts
@@ -78,6 +78,7 @@ export const SETTING_DOCS: Record<string, DocRef> = {
 	"resource.join_memory_mb": { file: "self-hosting/resource-tuning.md", anchor: "join-memory-limit", label: "JOIN Memory Limit" },
 
 	// Data & Retention
+	"danger.purge_traces_insights": { file: "self-hosting/data-retention.md", anchor: "purge-traces-and-insights", label: "Purge Traces & Insights" },
 	"data.retention_days": { file: "self-hosting/data-retention.md", anchor: "data-retention", label: "Data Retention" },
 	"data.cache_ttl_default": { file: "self-hosting/data-retention.md", anchor: "default-cache-ttl", label: "Default Cache TTL" },
 	"data.cache_ttl_dashboard": { file: "self-hosting/data-retention.md", anchor: "dashboard-cache-ttl", label: "Dashboard Cache TTL" },
@@ -106,6 +107,7 @@ export const SECTION_DOCS: Record<string, DocRef> = {
 	"JWT Token Expiry": { file: "self-hosting/token-expiry.md", label: "Token Expiry Settings" },
 	"Resource Tuning": { file: "self-hosting/resource-tuning.md", label: "Resource Tuning" },
 	"Data & Retention": { file: "self-hosting/data-retention.md", label: "Data & Retention Settings" },
+	"Telemetry Purge": { file: "self-hosting/data-retention.md", anchor: "purge-traces-and-insights", label: "Purge Traces & Insights" },
 	"Observability": { file: "self-hosting/observability-settings.md", label: "Observability Settings" },
 	"Miscellaneous": { file: "self-hosting/miscellaneous.md", label: "Miscellaneous Settings" },
 };

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -79,12 +79,21 @@ export interface DiagnosticsResponse {
 export interface InsightReportListItem {
 	id: string;
 	agent_id: string;
+	agent_version_id?: string | null;
+	agent_version?: string | null;
+	version_scope?: string | null;
 	status: "pending" | "running" | "completed" | "failed";
 	period_start: string;
 	period_end: string;
 	sessions_analyzed: number;
 	created_at: string;
 	completed_at: string | null;
+	progress_phase?: string | null;
+	progress_current?: number;
+	progress_total?: number;
+	progress_percent?: number;
+	progress_message?: string | null;
+	progress_updated_at?: string | null;
 }
 
 export interface InsightCostMetrics {
@@ -199,6 +208,11 @@ export interface InsightRegression {
 export interface InsightReport {
 	id: string;
 	agent_id: string;
+	agent_version_id?: string | null;
+	agent_version?: string | null;
+	version_scope?: string | null;
+	comparison_agent_version_id?: string | null;
+	comparison_agent_version?: string | null;
 	triggered_by: string | null;
 	status: "pending" | "running" | "completed" | "failed";
 	period_start: string;
@@ -212,6 +226,12 @@ export interface InsightReport {
 	started_at: string;
 	completed_at: string | null;
 	created_at: string;
+	progress_phase?: string | null;
+	progress_current?: number;
+	progress_total?: number;
+	progress_percent?: number;
+	progress_message?: string | null;
+	progress_updated_at?: string | null;
 	applied_at: string | null;
 	applied_items: InsightAppliedItems | null;
 }

--- a/web/src/pages/admin/insights/detail.tsx
+++ b/web/src/pages/admin/insights/detail.tsx
@@ -602,8 +602,8 @@ function SuggestionsSection({ data, report }: { data: unknown; report?: InsightR
 	const obj = data as Record<string, unknown>;
 
 	// V4 format
-	const configAdditions = obj.config_additions as { addition: string; why: string; where: string }[] | undefined;
-	const featuresToTry = obj.features_to_try as { feature: string; one_liner: string; why_for_you: string; example: string }[] | undefined;
+	const configAdditions = obj.config_additions as { addition: string; why: string; where: string; confidence?: string; risk?: string }[] | undefined;
+	const featuresToTry = obj.features_to_try as { feature: string; action_type?: string; one_liner: string; why_for_you: string; example: string; confidence?: string; risk?: string }[] | undefined;
 	const usagePatterns = obj.usage_patterns as { title: string; suggestion: string; detail: string; copyable_prompt: string }[] | undefined;
 
 	// V3 fallback
@@ -728,6 +728,8 @@ function SuggestionsSection({ data, report }: { data: unknown; report?: InsightR
 										)}
 										<div className="flex-1">
 											<span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground mr-2">{c.where}</span>
+											{c.confidence && <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground mr-2">{c.confidence} confidence</span>}
+											{c.risk && <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground mr-2">{c.risk} risk</span>}
 											<span className="text-sm font-medium">{c.addition}</span>
 										</div>
 										<CopyButton text={c.addition} />
@@ -751,7 +753,9 @@ function SuggestionsSection({ data, report }: { data: unknown; report?: InsightR
 											<input type="checkbox" checked={selectedFeatures.has(i)} onChange={() => toggleFeature(i)} className="mt-1 h-4 w-4 rounded border-border" />
 										)}
 										<div className="flex-1">
-											<span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">{f.feature}</span>
+											<span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">{f.action_type ?? f.feature}</span>
+											{f.confidence && <span className="ml-1 text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">{f.confidence} confidence</span>}
+											{f.risk && <span className="ml-1 text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">{f.risk} risk</span>}
 											<div className="font-medium text-sm mt-2">{f.one_liner}</div>
 											<p className="text-xs text-foreground/60 mt-1">{f.why_for_you}</p>
 											{f.example && (
@@ -1518,6 +1522,7 @@ function ReportContent({ report }: { report: InsightReport }) {
 	const outputTokens = Number(rich?.total_output_tokens || metrics?.tokens?.total_output_tokens) || 0;
 	const cacheReadTokens = Number(rich?.total_cache_read_tokens || metrics?.tokens?.total_cache_read_tokens) || 0;
 	const cacheWriteTokens = Number(rich?.total_cache_write_tokens || metrics?.tokens?.total_cache_write_tokens) || 0;
+	const cacheHitRate = typeof rich?.cache_hit_rate_pct === "number" ? rich.cache_hit_rate_pct : (cacheReadTokens + inputTokens + cacheWriteTokens > 0 ? (cacheReadTokens / (cacheReadTokens + inputTokens + cacheWriteTokens)) * 100 : null);
 	const totalCost = Number(rich?.total_cost_usd || metrics?.cost?.total_cost_usd) || 0;
 	const activeHours = Number(rich?.active_hours) || 0;
 	const daysActive = Number(rich?.days_active) || 0;
@@ -1538,6 +1543,7 @@ function ReportContent({ report }: { report: InsightReport }) {
 	const topTools = (rich?.top_tools || []) as [string, number][];
 	const topLanguages = (rich?.top_languages || []) as [string, number][];
 	const toolErrorCats = (rich?.tool_error_categories || {}) as Record<string, number>;
+	const canonicalDirty = (rich?.canonical_dirty_summary || {}) as Record<string, number>;
 
 	const fmt = (n: number) => {
 		if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -1561,7 +1567,7 @@ function ReportContent({ report }: { report: InsightReport }) {
 				{sessionsWithTokens > 0 && <MetricCard label="Tokens Out" value={fmt(outputTokens)} icon={Database} />}
 				{cacheReadTokens > 0 && <MetricCard label="Cache Read" value={fmt(cacheReadTokens)} icon={Database} />}
 				{cacheWriteTokens > 0 && <MetricCard label="Cache Write" value={fmt(cacheWriteTokens)} icon={Database} />}
-				{cacheReadTokens > 0 && <MetricCard label="Cache Efficiency" value={`${((cacheReadTokens / (cacheReadTokens + inputTokens)) * 100).toFixed(1)}%`} icon={Zap} />}
+				{cacheHitRate != null && <MetricCard label="Cache Efficiency" value={`${cacheHitRate.toFixed(1)}%`} icon={Zap} subtext={`${fmt(cacheReadTokens)} tokens saved`} />}
 				{totalCost > 0 && <MetricCard label="Total Cost" value={`$${totalCost.toFixed(2)}`} icon={DollarSign} subtext={totalSessions > 0 ? `$${(totalCost / totalSessions).toFixed(2)}/session` : undefined} />}
 				{sessionsWithCredits > 0 && <MetricCard label="Credits Used" value={totalCredits.toFixed(2)} icon={Coins} subtext={totalSessions > 0 ? `${(totalCredits / totalSessions).toFixed(2)}/session` : undefined} />}
 				<MetricCard label="Lines Added" value={fmt(linesAdded)} icon={Zap} />
@@ -1573,6 +1579,18 @@ function ReportContent({ report }: { report: InsightReport }) {
 				{subagentSessions > 0 && <MetricCard label="Subagent Sessions" value={subagentSessions} icon={Users} />}
 				{mcpSessions > 0 && <MetricCard label="MCP Sessions" value={mcpSessions} icon={Wrench} />}
 			</div>
+
+			{(canonicalDirty.canonical_sessions || canonicalDirty.dirty_sessions) && (
+				<div className="rounded-lg border border-border bg-card p-4">
+					<div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">Canonical vs Dirty Installs</div>
+					<div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+						<div><div className="text-lg font-bold tabular-nums">{canonicalDirty.canonical_sessions ?? 0}</div><div className="text-xs text-muted-foreground">canonical sessions</div></div>
+						<div><div className="text-lg font-bold tabular-nums">{canonicalDirty.dirty_sessions ?? 0}</div><div className="text-xs text-muted-foreground">dirty sessions</div></div>
+						<div><div className="text-lg font-bold tabular-nums">{canonicalDirty.canonical_users ?? 0}</div><div className="text-xs text-muted-foreground">canonical users</div></div>
+						<div><div className="text-lg font-bold tabular-nums">{canonicalDirty.dirty_users ?? 0}</div><div className="text-xs text-muted-foreground">dirty users</div></div>
+					</div>
+				</div>
+			)}
 
 			{/* Top Tools + Languages (bar charts like pi /insights) */}
 			{(topTools.length > 0 || topLanguages.length > 0) && (
@@ -1727,6 +1745,8 @@ export default function InsightReportPage() {
 						<div className="flex items-center justify-between">
 							<StatusIndicator status={report.status} />
 							<div className="text-xs text-muted-foreground space-x-3">
+								{report.agent_version && <span>Version v{report.agent_version}</span>}
+								{report.comparison_agent_version && <span>Compared to v{report.comparison_agent_version}</span>}
 								<span>
 									{new Date(report.period_start).toLocaleDateString()} -{" "}
 									{new Date(report.period_end).toLocaleDateString()}
@@ -1739,13 +1759,21 @@ export default function InsightReportPage() {
 
 						{/* Loading state */}
 						{(report.status === "pending" || report.status === "running") && (
-							<div className="flex flex-col items-center justify-center py-16 gap-3">
+							<div className="flex flex-col items-center justify-center py-16 gap-4">
 								<Loader2 className="h-8 w-8 animate-spin text-primary-accent" />
-								<p className="text-sm text-muted-foreground">
-									{report.status === "pending"
-										? "Waiting in queue..."
-										: "Computing metrics and generating analysis..."}
-								</p>
+								<div className="w-full max-w-md space-y-2">
+									<div className="h-2 rounded-full bg-muted overflow-hidden">
+										<div className="h-full bg-primary-accent transition-all" style={{ width: `${report.progress_percent ?? 0}%` }} />
+									</div>
+									<p className="text-sm text-center text-muted-foreground">
+										{report.progress_message || (report.status === "pending" ? "Waiting in queue..." : "Computing metrics and generating analysis...")}
+									</p>
+									{report.progress_phase && (
+										<p className="text-xs text-center text-muted-foreground font-mono">
+											{report.progress_phase.replace(/_/g, " ")} · {report.progress_percent ?? 0}%
+										</p>
+									)}
+								</div>
 							</div>
 						)}
 

--- a/web/src/pages/admin/settings.tsx
+++ b/web/src/pages/admin/settings.tsx
@@ -269,6 +269,22 @@ const SETTING_SECTIONS: SettingSection[] = [
 		],
 	},
 	{
+		title: "Telemetry Purge",
+		icon: <AlertTriangle className="h-3.5 w-3.5" />,
+		description:
+			"Irreversible data purge actions for telemetry and generated insights.",
+		danger: true,
+		settings: [
+			{
+				key: "danger.purge_traces_insights",
+				label: "Purge Traces & Insights",
+				subtitle: "Delete all traces, sessions, scores, and insight reports",
+				tooltip:
+					"Irreversibly deletes all ClickHouse telemetry traces/session data for the current project and all agent insight reports/caches for this organization. Registry agents and components are not deleted.",
+			},
+		],
+	},
+	{
 		title: "Deployment",
 		icon: <Shield className="h-3.5 w-3.5" />,
 		description:
@@ -766,6 +782,7 @@ export default function SettingsPage() {
 	const [revokeConfirmKey, setRevokeConfirmKey] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
 	const [applyingResources, setApplyingResources] = useState(false);
+	const [purgingTracesInsights, setPurgingTracesInsights] = useState(false);
 	const [tracePrivacy, setTracePrivacy] = useState(false);
 	const [tracePrivacyLoading, setTracePrivacyLoading] = useState(true);
 	const [tracePrivacyToggling, setTracePrivacyToggling] = useState(false);
@@ -850,6 +867,22 @@ export default function SettingsPage() {
 			.catch(() => {})
 			.finally(() => setRetentionLoading(false));
 	}, []);
+
+	const handlePurgeTracesInsights = useCallback(async () => {
+		if (!window.confirm("Permanently delete all traces/session telemetry and insight reports for this project/org? This cannot be undone.")) {
+			return;
+		}
+		setPurgingTracesInsights(true);
+		try {
+			const res = await admin.purgeTracesAndInsights();
+			queryClient.invalidateQueries();
+			toast.success(`Purged telemetry and insights (${res.deleted_reports ?? 0} reports removed)`);
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : "Failed to purge traces and insights");
+		} finally {
+			setPurgingTracesInsights(false);
+		}
+	}, [queryClient]);
 
 	const handleTracePrivacyToggle = useCallback(async (checked: boolean) => {
 		setTracePrivacyToggling(true);
@@ -1869,6 +1902,19 @@ export default function SettingsPage() {
 														)}
 														<div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
 															{visibleDangerSettings.map((d) => {
+														if (d.key === "danger.purge_traces_insights") {
+															return (
+																<div key={d.key} className={`rounded-md border-2 border-destructive/40 bg-destructive/5 p-3 relative ${helpTargetClass(d.key)}`}>
+																	<SettingHelpIcon settingKey={d.key} tooltip={d.tooltip} openHelp={openHelp} />
+																	<span className="text-sm font-semibold text-destructive">{d.label}</span>
+																	<p className="text-xs text-foreground/60 mt-1 pr-6">{d.subtitle}</p>
+																	<Button variant="destructive" size="sm" className="mt-3 h-8" onClick={handlePurgeTracesInsights} disabled={purgingTracesInsights}>
+																		{purgingTracesInsights ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Trash2 className="mr-1 h-3.5 w-3.5" />}
+																		Purge traces & insights
+																	</Button>
+																</div>
+															);
+														}
 														const existing = entries.find((e) => e.key === d.key);
 														const isEditing = editingKey === d.key;
 														if (isEditing) {

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -201,9 +201,9 @@ function InsightStatusBadge({ status }: { status: InsightReportListItem["status"
   }
 }
 
-function InsightsTab({ agentId }: { agentId: string }) {
+function InsightsTab({ agentId, agentVersion }: { agentId: string; agentVersion?: string | null }) {
   const { data: reports, isLoading: reportsLoading } = useInsightReports(agentId);
-  const { data: sessionCountData, isLoading: countLoading } = useInsightSessionCount(agentId);
+  const { data: sessionCountData, isLoading: countLoading } = useInsightSessionCount(agentId, agentVersion);
   const { data: insightsStatus } = useInsightsStatus();
   const generateInsight = useGenerateInsight();
 
@@ -223,7 +223,7 @@ function InsightsTab({ agentId }: { agentId: string }) {
           <p className="text-xs text-muted-foreground">
             {countLoading
               ? "Checking sessions..."
-              : `${availableSessions} session${availableSessions !== 1 ? "s" : ""} available (last 14 days)`}
+              : `${availableSessions} session${availableSessions !== 1 ? "s" : ""} available for ${sessionCountData?.agent_version ?? agentVersion ?? "latest approved"} (last 14 days)`}
           </p>
         </div>
         <Button
@@ -235,7 +235,7 @@ function InsightsTab({ agentId }: { agentId: string }) {
             generateInsight.isPending ||
             hasRunning
           }
-          onClick={() => generateInsight.mutate({ agentId })}
+          onClick={() => generateInsight.mutate({ agentId, agentVersion: agentVersion ?? undefined })}
         >
           {generateInsight.isPending ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -283,9 +283,19 @@ function InsightsTab({ agentId }: { agentId: string }) {
                       year: "numeric",
                     })}
                   </span>
+                  {report.agent_version && (
+                    <span className="text-xs text-muted-foreground">
+                      v{report.agent_version}
+                    </span>
+                  )}
                   {report.sessions_analyzed > 0 && (
                     <span className="text-xs text-muted-foreground">
                       {report.sessions_analyzed} sessions analyzed
+                    </span>
+                  )}
+                  {(report.status === "pending" || report.status === "running") && report.progress_phase && (
+                    <span className="text-xs text-muted-foreground">
+                      {report.progress_phase.replace(/_/g, " ")}
                     </span>
                   )}
                 </div>
@@ -667,7 +677,7 @@ export default function AgentDetailPage() {
                 )}
                 {canEdit && (
                   <TabsContent value="insights" className="mt-6">
-                    <InsightsTab agentId={id} />
+                    <InsightsTab agentId={id} agentVersion={effectiveVersion} />
                   </TabsContent>
                 )}
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description

Make Agent Insights version-aware and more actionable. Reports now scope to a selected/latest approved agent version, expose generation progress, analyze canonical vs dirty layer states, compare against a prior approved version, and produce safer self-learn suggestions.

This also adds a Danger Zone purge action for admins to clear telemetry traces/session data and all generated insight reports/caches for the current project/org.

## Fixes

* Fixes #<!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach

- Add version/progress fields to `insight_reports` with migration `009_insights_version_progress`.
- Scope session counting/report generation to `agent_version`, with ClickHouse aggregate support and `session_events` fallbacks.
- Preserve layer snapshot `pinned_versions` and `drift` metadata for dirty/canonical analysis.
- Add prior-version comparison cohort faceting so A/B comparison is not based only on stale aggregate data.
- Add canonical-vs-dirty cohort counts, robust outlier labels, inspiration candidates, isolated regressions, cache-efficiency metrics, and component utilization context.
- Improve self-learn apply so it can reuse matching existing skills, link existing components, remove components in the pending agent version, store confidence/risk details, and supersede stale insight-generated pending versions.
- Surface version/progress/cache/canonical-dirty data in API schemas, CLI, web report UI, agent Insights tab, and HTML export.
- Add `danger.purge_traces_insights` under Danger Zone with an admin-only purge endpoint, UI button, and wiki/help docs.

## How Has This Been Tested?

Ran:

```bash
uv run --with ruff==0.15.12 ruff check .
cd web && pnpm build
cd observal-server && uv run pytest ../tests/test_cmd_insights.py ../tests/test_agent_scoped_insights_routes.py ../tests/test_insights_agent_lookup.py ../tests/test_self_learn.py -q
```

Notes:

- Live validation for multi-version agents, dirty-layer inspiration, and registry-skill reuse still needs production-like telemetry data.
- The purge action is admin-only and scoped to the current project/org.

## Learning (optional, can help others)

The key architectural shift is treating “agent version” as the report scope while still faceting a bounded prior-version cohort for comparison. Dirty/user-layer sessions are analyzed separately so they can inspire future agent changes without poisoning the canonical baseline.

## Checklist

_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi
- [x] Was the generated code manually reviewed and tested?
