### PR TITLE
docs(readme): clarify registry positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
  ╚═════╝ ╚═════╝ ╚══════╝╚══════╝╚═╝  ╚═╝  ╚═══╝  ╚═╝  ╚═╝╚══════╝
 </pre>
 
-**A self-hosted unified agent registry with built in analytics. Enterprise edition adds SSO (OIDC and SAML), Audit Logs, Security Events and organizational AI insights.**
+**A registry and insight platform for portable AI coding agents. Define context once, install it across tools, and learn what works.**
 
 <p>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License"></a>
@@ -35,6 +35,22 @@
 </p>
 
 > If you find Observal useful, please consider giving it a star. It helps others discover the project and keeps development going.
+
+---
+
+## What Observal is for
+
+Observal is for teams doing context engineering across AI coding tools. If your organization maintains Skills, AGENTS files, MCP servers, hooks, prompts, sandboxes, or subagent definitions, Observal gives you one place to package them into versioned agents, publish them to a registry, and install them into the IDE or harness your developers use.
+
+Define an agent once. Observal renders the right configuration for Claude Code, Cursor, Kiro, Pi, Copilot, Codex, OpenCode, and other supported tools. As teams use those agents, Observal turns real usage into insights about which prompts, skills, tools, and policies are helping.
+
+### Why teams use Observal
+
+- **Package context into reusable agents:** Bundle Skills, MCP servers, hooks, prompts, sandboxes, and policy into one versioned unit.
+- **Run a governed registry:** Review submissions, approve internal agents, inspect version diffs, and give developers one trusted place to install from.
+- **Render across coding tools:** Generate the correct config for each supported IDE instead of maintaining separate setup instructions for every harness.
+- **Learn what works:** Use real adoption and session data to find which agents, tools, prompts, and workflows are helping teams.
+- **Replay sessions when needed:** Use traces as evidence for debugging, review, audits, and deeper analysis without making observability the main workflow.
 
 ---
 
@@ -99,7 +115,7 @@ observal auth login
 observal doctor --patch
 ```
 
-This authenticates with your server, detects your IDE, installs telemetry hooks, and starts capturing sessions automatically.
+This authenticates with your server, detects your IDE, installs telemetry hooks, starts capturing sessions automatically, and prepares it for agent installs and registry commands.
 
 Once logged in, run `/observal` inside your IDE and it takes the wheel. Pull agents, submit components, browse the registry, run diagnostics:
 
@@ -113,23 +129,27 @@ Or just tell your agent what you want and it figures out the right commands.
 
 ---
 
-## What Observal Does
+## How Observal works
 
-### Agents are the primary unit
+### Agents are portable context packages
 
-An agent bundles 5 component types into a single installable package: **MCP servers**, **skills**, **hooks**, **prompts**, and **sandboxes**. You define them in YAML, publish to the registry, and anyone can pull them with one command. The platform generates the right config files for whichever IDE the user runs.
+An agent bundles 5 component types into a single installable package: **MCP servers**, **skills**, **hooks**, **prompts**, and **sandboxes**. You define the agent once, publish it to the registry, and Observal generates the right config files for whichever supported IDE or harness the user runs.
 
 ```bash
 observal pull security-auditor --ide pi
 ```
 
-### Every session becomes a trace
+### The registry is the distribution layer
 
-Once connected, Observal captures your entire coding session: every user prompt, every thinking block, every assistant response, every tool call with its full input and output. No sampling, no summarization. The raw session flows into ClickHouse for querying and analysis.
+Browse published agents, see which IDEs they support, check download counts and ratings, and install with one command. Admins review submissions before they go live. Version diffs show exactly what changed between releases, so teams can safely evolve shared context.
 
-### The registry is a package manager for agents
+### Insights show what is helping
 
-Browse published agents, see which IDEs they support, check download counts and ratings, and install with one command. Admins review submissions before they go live. Version diffs show exactly what changed between releases.
+Observal turns real usage into reports about which agents, prompts, tools, and workflows are working or getting in the way. Use those insights to improve shared context instead of guessing from anecdotes.
+
+### Session traces provide the evidence
+
+When you need to debug, audit, or understand a result, Observal can replay the full coding session: user prompts, thinking blocks, assistant responses, and tool calls with their inputs and outputs. The traces support registry and insight workflows rather than defining the product.
 
 ---
 
@@ -146,6 +166,16 @@ Browse published agents, see which IDEs they support, check download counts and 
 **Components library: MCPs, Skills, Hooks, Prompts, Sandboxes:**
 
 ![Component registry showing MCP servers](docs/img/component_registry.png)
+
+---
+
+## Agent Insights
+
+**AI-powered insight reports** analyze usage patterns across all sessions, what's working, what's hindering, and quick wins. Powered by [LiteLLM](https://docs.litellm.ai/docs/providers), works with any provider (Anthropic, OpenAI, Bedrock, Gemini, Azure, Ollama).
+
+![Insight report with What's Working, What's Hindering, Quick Wins](docs/img/insights.png)
+
+See [Insights LLM Setup](docs/insights-setup.md) for configuration.
 
 ---
 
@@ -178,16 +208,6 @@ Browse published agents, see which IDEs they support, check download counts and 
 **Leaderboard tracks top agents and components by downloads:**
 
 ![Leaderboard with rankings](docs/img/leaderboard.png)
-
----
-
-## Agent Insights
-
-**AI-powered insight reports** analyze usage patterns across all sessions — what's working, what's hindering, and quick wins. Powered by [LiteLLM](https://docs.litellm.ai/docs/providers), works with any provider (Anthropic, OpenAI, Bedrock, Gemini, Azure, Ollama).
-
-![Insight report with What's Working, What's Hindering, Quick Wins](docs/img/insights.png)
-
-See [Insights LLM Setup](docs/insights-setup.md) for configuration.
 
 ---
 


### PR DESCRIPTION
## Purpose / Description
The README led with observability and infrastructure language, which made it harder for new readers to understand the core product. This updates the opening to explain Observal as a registry and insight platform for teams doing context engineering across AI coding tools.

## Fixes
No linked issue.

## Approach
Repositioned the README around registry, portable agent context, and insights. Added a new "What Observal is for" section, reframed the workflow around packaging context into reusable agents, moved Agent Insights before Session Replay, and softened session capture language so observability reads as supporting evidence rather than the main goal.

## Learning (optional, can help others)
The README should lead with the user problem: teams maintaining Skills, AGENTS files, MCP definitions, hooks, prompts, sandboxes, and subagents across incompatible coding tools need a governed registry and insight loop.

No external resources were used.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas, not applicable for documentation only.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens, not applicable for README copy only.

## AI Assistance
Was generative AI tooling used to co-author this PR?

- [x] Yes, Pi coding agent.
- [x] Was the generated code manually reviewed and tested?
