### PR TITLE
refactor(cli): move layer attribution into adapters

### DIFF
--- a/docs/adding-an-ide.md
+++ b/docs/adding-an-ide.md
@@ -27,18 +27,18 @@ When a user runs `observal scan`, Observal reads those same locations to discove
 |---|------|-------------|
 | 1 | `observal-server/schemas/ide_registry.py` | IDE metadata: paths, keys, event maps, formats |
 | 2 | `observal_cli/ide_registry.py` | CLI mirror (must be identical, enforced by test) |
-| 3 | `observal_cli/ide/<ide_name>.py` | CLI adapter: scanning, hook detection, shim status |
+| 3 | `observal_cli/ide/<ide_name>.py` | CLI adapter: scanning, hook detection, shim status, managed file attribution |
 | 4 | `observal_cli/ide/load_all.py` | Add import line for auto-registration |
-| 5 | `observal_cli/ide/__init__.py` | Bump `_EXPECTED_ADAPTER_COUNT` |
+| 5 | `observal_cli/ide/__init__.py` | Adapter registry and protocol validation |
 | 6 | `observal-server/services/ide/<ide_name>.py` | Server adapter: config generation for install |
 | 7 | `observal-server/services/ide/load_all.py` | Add import line for server adapter |
 | 8 | `observal_cli/ide_specs/<ide_name>_hooks_spec.py` | Hook spec: what hooks to install, event names |
 | 9 | `observal_cli/sessions/<ide_name>.py` | Session parser (if IDE writes JSONL sessions) |
 | 10 | `observal_cli/hooks/<ide_name>_session_push.py` | Session push hook script |
 | 11 | `observal_cli/cmd_doctor.py` | Doctor diagnose/patch/cleanup coverage for the new IDE |
-| 12 | `observal_cli/layer.py` | Layer scanning globs (`IDE_LAYER_CONFIGS`) and managed file attribution |
+| 12 | `observal_cli/layer.py` | Layer scanning globs (`IDE_LAYER_CONFIGS`) and active IDE detection |
 | 13 | `tests/test_cli_ide_adapters.py` | Adapter unit tests |
-| 14 | `web/src/lib/ide-features.ts` | Frontend IDE display (name, icon, capabilities) |
+| 14 | `/api/v1/config/ides` consumers | Frontend uses server IDE metadata through `useIdes()` |
 
 ## Step 1: Research the IDE
 
@@ -137,8 +137,10 @@ Before moving on, always wire the new IDE into these shared paths:
   - Add `_cleanup_<ide>()` support in `doctor cleanup`
 - `observal_cli/layer.py`:
   - Add user/project file globs under `IDE_LAYER_CONFIGS`
-  - Update `_get_observal_managed_files()` for source attribution if needed
   - Ensure `_detect_active_ides()` has a reliable home-dir marker
+- `observal_cli/ide/<ide_name>.py`:
+  - Add `managed_agent_files`, `managed_skill_files`, and `managed_mcp_files` patterns for layer source attribution
+  - Override `get_observal_managed_files()` only if simple `{name}` patterns are not enough
 
 If these are skipped, the IDE can appear supported in pull/scan while doctor and layer observability remain incomplete.
 
@@ -177,6 +179,10 @@ from observal_cli.shared.utils import (
 
 
 class MyIdeAdapter(BaseAdapter):
+    managed_agent_files = ("user:agents/{name}.md", "project:.my-ide/agents/{name}.md")
+    managed_skill_files = ("user:skills/{name}/SKILL.md", "project:.my-ide/skills/{name}/SKILL.md")
+    managed_mcp_files = ("user:mcp.json", "project:.my-ide/mcp.json")
+
     @property
     def ide_name(self) -> str:
         return "my-ide"
@@ -454,7 +460,7 @@ custom session push script (most can reuse `session_push.py`).
    from observal_cli.ide import my_ide as _my_ide  # noqa: F401
    ```
 
-2. `observal_cli/ide/__init__.py`: bump `_EXPECTED_ADAPTER_COUNT`
+2. `observal_cli/ide/<ide_name>.py`: set managed file attribution patterns used by layer snapshots.
 
 3. `observal-server/services/ide/load_all.py`:
    ```python
@@ -516,6 +522,22 @@ class TestMyIdeAdapter:
         }))
         adapter = MyIdeAdapter()
         assert adapter.detect_hooks(tmp_path) == "installed"
+
+    def test_managed_files_for_layer_source_attribution(self):
+        lockfile = {
+            "ides": {
+                "my-ide": {
+                    "agents": [{"name": "agent-one", "components": [{"type": "skill", "name": "helper"}]}],
+                }
+            }
+        }
+        adapter = MyIdeAdapter()
+        assert adapter.get_observal_managed_files(lockfile) == {
+            "user:agents/agent-one.md",
+            "project:.my-ide/agents/agent-one.md",
+            "user:skills/helper/SKILL.md",
+            "project:.my-ide/skills/helper/SKILL.md",
+        }
 ```
 
 ## Step 10: Verify

--- a/observal_cli/ide/__init__.py
+++ b/observal_cli/ide/__init__.py
@@ -65,6 +65,7 @@ def register_adapter(adapter: IdeAdapter) -> None:
         "generate_hook_config",
         "detect_hooks",
         "shim_status",
+        "get_observal_managed_files",
     )
     for method in required:
         if not hasattr(adapter, method) or not callable(getattr(adapter, method, None)):

--- a/observal_cli/ide/base.py
+++ b/observal_cli/ide/base.py
@@ -50,6 +50,10 @@ class BaseAdapter:
     method body. Subclasses override methods they support.
     """
 
+    managed_agent_files: tuple[str, ...] = ()
+    managed_skill_files: tuple[str, ...] = ()
+    managed_mcp_files: tuple[str, ...] = ()
+
     @property
     def ide_name(self) -> str:
         raise NotImplementedError("Subclasses must define ide_name")
@@ -91,3 +95,34 @@ class BaseAdapter:
         if shimmed == len(mcps):
             return "all"
         return "partial"
+
+    def get_observal_managed_files(self, lockfile_data: dict, project_dir: str | None = None) -> set[str]:
+        """Return layer snapshot display paths managed by Observal for this IDE."""
+        managed: set[str] = set()
+        ide_section = lockfile_data.get("ides", {}).get(self.ide_name, {})
+
+        for agent in ide_section.get("agents", []):
+            agent_name = agent.get("name", "")
+            if agent_name:
+                managed.update(self._format_managed_paths(self.managed_agent_files, agent_name))
+
+            for component in agent.get("components", []):
+                managed.update(self._managed_component_files(component.get("type", ""), component.get("name", "")))
+
+        for item in ide_section.get("standalone", []):
+            managed.update(self._managed_component_files(item.get("type", ""), item.get("name", "")))
+
+        return managed
+
+    def _managed_component_files(self, component_type: str, component_name: str) -> set[str]:
+        if not component_name:
+            return set()
+        if component_type == "skill":
+            return self._format_managed_paths(self.managed_skill_files, component_name)
+        if component_type == "mcp":
+            return self._format_managed_paths(self.managed_mcp_files, component_name)
+        return set()
+
+    @staticmethod
+    def _format_managed_paths(patterns: tuple[str, ...], name: str) -> set[str]:
+        return {pattern.format(name=name) for pattern in patterns}

--- a/observal_cli/ide/claude_code.py
+++ b/observal_cli/ide/claude_code.py
@@ -31,6 +31,9 @@ from observal_cli.shared.utils import (
 class ClaudeCodeAdapter(BaseAdapter):
     """Adapter for Claude Code (Anthropic)."""
 
+    managed_agent_files = ("user:agents/{name}.md", "project:.claude/agents/{name}.md")
+    managed_skill_files = ("user:skills/{name}/SKILL.md",)
+
     @property
     def ide_name(self) -> str:
         return "claude-code"

--- a/observal_cli/ide/codex.py
+++ b/observal_cli/ide/codex.py
@@ -43,6 +43,9 @@ def _load_toml(path: Path) -> dict:
 class CodexAdapter(BaseAdapter):
     """Adapter for Codex CLI (OpenAI)."""
 
+    managed_agent_files = ("user:AGENTS.md", "project:AGENTS.md")
+    managed_mcp_files = ("user:config.toml",)
+
     @property
     def ide_name(self) -> str:
         return "codex"

--- a/observal_cli/ide/copilot.py
+++ b/observal_cli/ide/copilot.py
@@ -35,6 +35,8 @@ def _vscode_user_settings_path(home: Path | None = None) -> Path:
 class CopilotAdapter(BaseAdapter):
     """Adapter for GitHub Copilot (VS Code based)."""
 
+    managed_agent_files = ("project:.github/agents/{name}.agent.md",)
+
     @property
     def ide_name(self) -> str:
         return "copilot"

--- a/observal_cli/ide/copilot_cli.py
+++ b/observal_cli/ide/copilot_cli.py
@@ -29,6 +29,9 @@ from observal_cli.shared.utils import (
 class CopilotCliAdapter(BaseAdapter):
     """Adapter for GitHub Copilot CLI."""
 
+    managed_agent_files = ("project:.github/agents/{name}.agent.md",)
+    managed_skill_files = ("project:.agents/skills/{name}/SKILL.md", "user:skills/{name}/SKILL.md")
+
     @property
     def ide_name(self) -> str:
         return "copilot-cli"

--- a/observal_cli/ide/cursor.py
+++ b/observal_cli/ide/cursor.py
@@ -21,6 +21,14 @@ from observal_cli.shared.utils import extract_mcp_servers
 class CursorAdapter(BaseAdapter):
     """Adapter for Cursor."""
 
+    managed_agent_files = (
+        "user:rules/{name}.mdc",
+        "user:agents/{name}.md",
+        "project:.cursor/rules/{name}.mdc",
+        "project:.cursor/agents/{name}.md",
+    )
+    managed_skill_files = ("user:rules/{name}.mdc", "user:skills/{name}/SKILL.md")
+
     @property
     def ide_name(self) -> str:
         return "cursor"

--- a/observal_cli/ide/kiro.py
+++ b/observal_cli/ide/kiro.py
@@ -30,6 +30,9 @@ from observal_cli.shared.utils import (
 class KiroAdapter(BaseAdapter):
     """Adapter for Kiro (AWS)."""
 
+    managed_agent_files = ("user:agents/{name}.json", "project:.kiro/agents/{name}.json")
+    managed_skill_files = ("user:skills/{name}/SKILL.md",)
+
     @property
     def ide_name(self) -> str:
         return "kiro"

--- a/observal_cli/ide/opencode.py
+++ b/observal_cli/ide/opencode.py
@@ -45,6 +45,9 @@ def _strip_jsonc_comments(text: str) -> str:
 class OpenCodeAdapter(BaseAdapter):
     """Adapter for OpenCode."""
 
+    managed_agent_files = ("user:agents/{name}.md", "project:.opencode/agents/{name}.md")
+    managed_skill_files = ("user:skills/{name}/SKILL.md", "project:.opencode/skills/{name}/SKILL.md")
+
     @property
     def ide_name(self) -> str:
         return "opencode"

--- a/observal_cli/ide/pi.py
+++ b/observal_cli/ide/pi.py
@@ -27,6 +27,9 @@ class PiAdapter(BaseAdapter):
     Hooks are delivered as the observal-pi package.
     """
 
+    managed_agent_files = ("user:AGENTS.md",)
+    managed_skill_files = ("user:skills/{name}/SKILL.md",)
+
     @property
     def ide_name(self) -> str:
         return "pi"

--- a/observal_cli/ide/protocol.py
+++ b/observal_cli/ide/protocol.py
@@ -243,3 +243,15 @@ class IdeAdapter(Protocol):
             NotSupportedError: If this IDE does not have mcp_servers feature.
         """
         ...
+
+    def get_observal_managed_files(self, lockfile_data: dict, project_dir: str | None = None) -> set[str]:
+        """Return layer snapshot display paths managed by Observal for this IDE.
+
+        Args:
+            lockfile_data: Parsed Observal lockfile content.
+            project_dir: Optional project directory for project-scoped installs.
+
+        Returns:
+            Display paths that correspond to Observal-installed files.
+        """
+        ...

--- a/observal_cli/layer.py
+++ b/observal_cli/layer.py
@@ -410,83 +410,15 @@ def build_layer_manifest(
 
 
 def _get_observal_managed_files(lockfile_data: dict, ide: str, project_dir: str | None) -> set[str]:
-    """Determine which display paths are managed by Observal (from the lock file).
+    """Determine which display paths are managed by Observal from the lock file."""
+    from observal_cli.ide import ensure_loaded, get_adapter
 
-    Returns a set of display_path strings that correspond to Observal-installed components.
-    """
-    managed: set[str] = set()
-    ide_section = lockfile_data.get("ides", {}).get(ide, {})
-
-    for agent in ide_section.get("agents", []):
-        agent_name = agent.get("name", "")
-        if agent_name:
-            # Agent rules files, depends on IDE
-            if ide == "claude-code":
-                managed.add(f"user:agents/{agent_name}.md")
-                managed.add(f"project:.claude/agents/{agent_name}.md")
-            elif ide == "cursor":
-                managed.add(f"user:rules/{agent_name}.mdc")
-                managed.add(f"user:agents/{agent_name}.md")
-                managed.add(f"project:.cursor/rules/{agent_name}.mdc")
-                managed.add(f"project:.cursor/agents/{agent_name}.md")
-            elif ide == "kiro":
-                managed.add(f"user:agents/{agent_name}.json")
-                managed.add(f"project:.kiro/agents/{agent_name}.json")
-            elif ide == "codex":
-                managed.add("user:AGENTS.md")
-                managed.add("project:AGENTS.md")
-            elif ide in ("copilot", "copilot-cli"):
-                # Both generate .github/agents/{name}.agent.md (project scope)
-                managed.add(f"project:.github/agents/{agent_name}.agent.md")
-            elif ide == "pi":
-                managed.add("user:AGENTS.md")
-            elif ide == "opencode":
-                managed.add(f"user:agents/{agent_name}.md")
-                managed.add(f"project:.opencode/agents/{agent_name}.md")
-
-        # Component files
-        for comp in agent.get("components", []):
-            comp_name = comp.get("name", "")
-            comp_type = comp.get("type", "")
-            if comp_type == "skill" and comp_name:
-                if ide == "claude-code" or ide == "kiro":
-                    managed.add(f"user:skills/{comp_name}/SKILL.md")
-                elif ide == "cursor":
-                    managed.add(f"user:rules/{comp_name}.mdc")
-                    managed.add(f"user:skills/{comp_name}/SKILL.md")
-                elif ide == "opencode":
-                    managed.add(f"user:skills/{comp_name}/SKILL.md")
-                    managed.add(f"project:.opencode/skills/{comp_name}/SKILL.md")
-                elif ide == "pi":
-                    managed.add(f"user:skills/{comp_name}/SKILL.md")
-            elif comp_type == "mcp" and comp_name and ide == "codex":
-                managed.add("user:config.toml")
-            elif comp_type == "skill" and comp_name and ide == "copilot-cli":
-                # Copilot CLI skills: project .agents/skills/ + user ~/.copilot/skills/
-                managed.add(f"project:.agents/skills/{comp_name}/SKILL.md")
-                managed.add(f"user:skills/{comp_name}/SKILL.md")
-
-    for item in ide_section.get("standalone", []):
-        item_name = item.get("name", "")
-        item_type = item.get("type", "")
-        if item_type == "skill" and item_name:
-            if ide == "claude-code" or ide == "kiro":
-                managed.add(f"user:skills/{item_name}/SKILL.md")
-            elif ide == "cursor":
-                managed.add(f"user:rules/{item_name}.mdc")
-                managed.add(f"user:skills/{item_name}/SKILL.md")
-            elif ide == "opencode":
-                managed.add(f"user:skills/{item_name}/SKILL.md")
-                managed.add(f"project:.opencode/skills/{item_name}/SKILL.md")
-            elif ide == "pi":
-                managed.add(f"user:skills/{item_name}/SKILL.md")
-        elif item_type == "mcp" and item_name and ide == "codex":
-            managed.add("user:config.toml")
-        elif item_type == "skill" and item_name and ide == "copilot-cli":
-            managed.add(f"project:.agents/skills/{item_name}/SKILL.md")
-            managed.add(f"user:skills/{item_name}/SKILL.md")
-
-    return managed
+    ensure_loaded()
+    try:
+        adapter = get_adapter(ide)
+    except KeyError:
+        return set()
+    return adapter.get_observal_managed_files(lockfile_data, project_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_ide_adapters.py
+++ b/tests/test_cli_ide_adapters.py
@@ -52,11 +52,125 @@ class TestAdapterRegistry:
             "generate_hook_config",
             "detect_hooks",
             "shim_status",
+            "get_observal_managed_files",
         ]
         for name, adapter in get_all_adapters().items():
             for method in required_methods:
                 assert hasattr(adapter, method), f"{name} missing {method}"
                 assert callable(getattr(adapter, method)), f"{name}.{method} not callable"
+
+
+class TestManagedLayerFiles:
+    """Test adapter-owned layer source attribution."""
+
+    @staticmethod
+    def _lockfile_for(ide_name: str) -> dict:
+        return {
+            "ides": {
+                ide_name: {
+                    "agents": [
+                        {
+                            "name": "agent-one",
+                            "components": [
+                                {"type": "skill", "name": "skill-one"},
+                                {"type": "mcp", "name": "mcp-one"},
+                            ],
+                        }
+                    ],
+                    "standalone": [
+                        {"type": "skill", "name": "standalone-skill"},
+                        {"type": "mcp", "name": "standalone-mcp"},
+                    ],
+                }
+            }
+        }
+
+    @pytest.mark.parametrize(
+        ("ide_name", "expected"),
+        [
+            (
+                "claude-code",
+                {
+                    "user:agents/agent-one.md",
+                    "project:.claude/agents/agent-one.md",
+                    "user:skills/skill-one/SKILL.md",
+                    "user:skills/standalone-skill/SKILL.md",
+                },
+            ),
+            (
+                "cursor",
+                {
+                    "user:rules/agent-one.mdc",
+                    "user:agents/agent-one.md",
+                    "project:.cursor/rules/agent-one.mdc",
+                    "project:.cursor/agents/agent-one.md",
+                    "user:rules/skill-one.mdc",
+                    "user:skills/skill-one/SKILL.md",
+                    "user:rules/standalone-skill.mdc",
+                    "user:skills/standalone-skill/SKILL.md",
+                },
+            ),
+            (
+                "kiro",
+                {
+                    "user:agents/agent-one.json",
+                    "project:.kiro/agents/agent-one.json",
+                    "user:skills/skill-one/SKILL.md",
+                    "user:skills/standalone-skill/SKILL.md",
+                },
+            ),
+            (
+                "codex",
+                {"user:AGENTS.md", "project:AGENTS.md", "user:config.toml"},
+            ),
+            (
+                "copilot",
+                {"project:.github/agents/agent-one.agent.md"},
+            ),
+            (
+                "copilot-cli",
+                {
+                    "project:.github/agents/agent-one.agent.md",
+                    "project:.agents/skills/skill-one/SKILL.md",
+                    "user:skills/skill-one/SKILL.md",
+                    "project:.agents/skills/standalone-skill/SKILL.md",
+                    "user:skills/standalone-skill/SKILL.md",
+                },
+            ),
+            (
+                "opencode",
+                {
+                    "user:agents/agent-one.md",
+                    "project:.opencode/agents/agent-one.md",
+                    "user:skills/skill-one/SKILL.md",
+                    "project:.opencode/skills/skill-one/SKILL.md",
+                    "user:skills/standalone-skill/SKILL.md",
+                    "project:.opencode/skills/standalone-skill/SKILL.md",
+                },
+            ),
+            (
+                "pi",
+                {
+                    "user:AGENTS.md",
+                    "user:skills/skill-one/SKILL.md",
+                    "user:skills/standalone-skill/SKILL.md",
+                },
+            ),
+        ],
+    )
+    def test_adapter_managed_files_match_existing_layer_paths(self, ide_name, expected):
+        adapter = get_adapter(ide_name)
+        assert adapter.get_observal_managed_files(self._lockfile_for(ide_name)) == expected
+
+    def test_layer_managed_files_delegates_to_adapter(self):
+        from observal_cli.layer import _get_observal_managed_files
+
+        lockfile = self._lockfile_for("codex")
+        assert _get_observal_managed_files(lockfile, "codex", None) == {
+            "user:AGENTS.md",
+            "project:AGENTS.md",
+            "user:config.toml",
+        }
 
 
 class TestAdapterProtocol:


### PR DESCRIPTION
## Purpose / Description
Continue the IDE adapter migration by moving layer snapshot source attribution out of the central layer scanner and into CLI IDE adapters.

## Fixes
Not applicable.

## Approach
- Added `get_observal_managed_files()` to the CLI IDE adapter protocol.
- Added shared managed file pattern handling to `BaseAdapter`.
- Declared managed agent, skill, and MCP file patterns in the IDE adapters that previously relied on central branching.
- Changed `observal_cli/layer.py` to delegate Observal-managed file attribution to the selected adapter.
- Added adapter tests to lock the existing source attribution paths.
- Updated `docs/adding-an-ide.md` so new IDEs put managed file attribution in adapters.

## How Has This Been Tested?
Ran these checks:

- `uv run pytest tests/test_cli_ide_adapters.py tests/test_constants_sync.py tests/test_antigravity_adapter.py -q`
- `uv run ruff check observal_cli/ide observal_cli/layer.py tests/test_cli_ide_adapters.py`
- Ruff format check on `observal_cli/ide`, `observal_cli/layer.py`, and `tests/test_cli_ide_adapters.py`
- Confirmed `observal_cli/layer.py` no longer has IDE-specific managed file attribution branches.

## Learning (optional, can help others)
The layer scanner already had display path conventions per IDE. Keeping those patterns on each adapter makes new IDE support easier to audit and removes another central IDE condition chain.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?