### PR TITLE
refactor(cli): move active IDE detection into adapters

### DIFF
--- a/docs/adding-an-ide.md
+++ b/docs/adding-an-ide.md
@@ -137,8 +137,8 @@ Before moving on, always wire the new IDE into these shared paths:
   - Add `_cleanup_<ide>()` support in `doctor cleanup`
 - `observal_cli/layer.py`:
   - Add user/project file globs under `IDE_LAYER_CONFIGS`
-  - Ensure `_detect_active_ides()` has a reliable home-dir marker
 - `observal_cli/ide/<ide_name>.py`:
+  - Add `home_markers` for active IDE detection when the IDE has a reliable home config marker. Glob patterns are supported.
   - Add `managed_agent_files`, `managed_skill_files`, and `managed_mcp_files` patterns for layer source attribution
   - Override `get_observal_managed_files()` only if simple `{name}` patterns are not enough
 
@@ -179,6 +179,7 @@ from observal_cli.shared.utils import (
 
 
 class MyIdeAdapter(BaseAdapter):
+    home_markers = (".my-ide",)
     managed_agent_files = ("user:agents/{name}.md", "project:.my-ide/agents/{name}.md")
     managed_skill_files = ("user:skills/{name}/SKILL.md", "project:.my-ide/skills/{name}/SKILL.md")
     managed_mcp_files = ("user:mcp.json", "project:.my-ide/mcp.json")
@@ -460,7 +461,7 @@ custom session push script (most can reuse `session_push.py`).
    from observal_cli.ide import my_ide as _my_ide  # noqa: F401
    ```
 
-2. `observal_cli/ide/<ide_name>.py`: set managed file attribution patterns used by layer snapshots.
+2. `observal_cli/ide/<ide_name>.py`: set `home_markers` and managed file attribution patterns used by layer snapshots.
 
 3. `observal-server/services/ide/load_all.py`:
    ```python
@@ -483,6 +484,12 @@ class TestMyIdeAdapter:
         result = adapter.scan_home(tmp_path)
         assert result.mcps == []
         assert result.skills == []
+
+    def test_is_installed_uses_home_marker(self, tmp_path):
+        adapter = MyIdeAdapter()
+        assert adapter.is_installed(tmp_path) is False
+        (tmp_path / ".my-ide").mkdir()
+        assert adapter.is_installed(tmp_path) is True
 
     def test_scan_home_discovers_mcps(self, tmp_path):
         ide_dir = tmp_path / ".my-ide"

--- a/observal_cli/ide/__init__.py
+++ b/observal_cli/ide/__init__.py
@@ -60,6 +60,7 @@ def register_adapter(adapter: IdeAdapter) -> None:
     required = (
         "ide_name",
         "scan_home",
+        "is_installed",
         "scan_project",
         "get_hook_spec",
         "generate_hook_config",

--- a/observal_cli/ide/antigravity.py
+++ b/observal_cli/ide/antigravity.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 class AntigravityAdapter(BaseAdapter):
     """Adapter for Antigravity CLI."""
 
+    home_markers = (".gemini/antigravity-cli",)
+
     @property
     def ide_name(self) -> str:
         return "antigravity"

--- a/observal_cli/ide/base.py
+++ b/observal_cli/ide/base.py
@@ -10,10 +10,8 @@ methods they support; the feature gate runs before the override.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
+from typing import Any
 
 from observal_cli.ide.protocol import (
     METHOD_FEATURE_MAP,
@@ -50,6 +48,7 @@ class BaseAdapter:
     method body. Subclasses override methods they support.
     """
 
+    home_markers: tuple[str, ...] = ()
     managed_agent_files: tuple[str, ...] = ()
     managed_skill_files: tuple[str, ...] = ()
     managed_mcp_files: tuple[str, ...] = ()
@@ -95,6 +94,19 @@ class BaseAdapter:
         if shimmed == len(mcps):
             return "all"
         return "partial"
+
+    def is_installed(self, home: Path | None = None) -> bool:
+        """Return whether this IDE has a detectable home config marker."""
+        if not self.home_markers:
+            return False
+        home = home or Path.home()
+        for marker in self.home_markers:
+            if any(char in marker for char in "*?["):
+                if any(path.exists() for path in home.glob(marker)):
+                    return True
+            elif (home / marker).exists():
+                return True
+        return False
 
     def get_observal_managed_files(self, lockfile_data: dict, project_dir: str | None = None) -> set[str]:
         """Return layer snapshot display paths managed by Observal for this IDE."""

--- a/observal_cli/ide/claude_code.py
+++ b/observal_cli/ide/claude_code.py
@@ -31,6 +31,7 @@ from observal_cli.shared.utils import (
 class ClaudeCodeAdapter(BaseAdapter):
     """Adapter for Claude Code (Anthropic)."""
 
+    home_markers = (".claude",)
     managed_agent_files = ("user:agents/{name}.md", "project:.claude/agents/{name}.md")
     managed_skill_files = ("user:skills/{name}/SKILL.md",)
 

--- a/observal_cli/ide/codex.py
+++ b/observal_cli/ide/codex.py
@@ -43,6 +43,7 @@ def _load_toml(path: Path) -> dict:
 class CodexAdapter(BaseAdapter):
     """Adapter for Codex CLI (OpenAI)."""
 
+    home_markers = (".codex",)
     managed_agent_files = ("user:AGENTS.md", "project:AGENTS.md")
     managed_mcp_files = ("user:config.toml",)
 

--- a/observal_cli/ide/copilot.py
+++ b/observal_cli/ide/copilot.py
@@ -35,6 +35,7 @@ def _vscode_user_settings_path(home: Path | None = None) -> Path:
 class CopilotAdapter(BaseAdapter):
     """Adapter for GitHub Copilot (VS Code based)."""
 
+    home_markers = (".vscode/extensions/github.copilot-*", ".vscode/extensions/github.copilot-chat-*")
     managed_agent_files = ("project:.github/agents/{name}.agent.md",)
 
     @property

--- a/observal_cli/ide/copilot_cli.py
+++ b/observal_cli/ide/copilot_cli.py
@@ -29,6 +29,7 @@ from observal_cli.shared.utils import (
 class CopilotCliAdapter(BaseAdapter):
     """Adapter for GitHub Copilot CLI."""
 
+    home_markers = (".copilot",)
     managed_agent_files = ("project:.github/agents/{name}.agent.md",)
     managed_skill_files = ("project:.agents/skills/{name}/SKILL.md", "user:skills/{name}/SKILL.md")
 

--- a/observal_cli/ide/cursor.py
+++ b/observal_cli/ide/cursor.py
@@ -21,6 +21,7 @@ from observal_cli.shared.utils import extract_mcp_servers
 class CursorAdapter(BaseAdapter):
     """Adapter for Cursor."""
 
+    home_markers = (".cursor",)
     managed_agent_files = (
         "user:rules/{name}.mdc",
         "user:agents/{name}.md",

--- a/observal_cli/ide/kiro.py
+++ b/observal_cli/ide/kiro.py
@@ -30,6 +30,7 @@ from observal_cli.shared.utils import (
 class KiroAdapter(BaseAdapter):
     """Adapter for Kiro (AWS)."""
 
+    home_markers = (".kiro",)
     managed_agent_files = ("user:agents/{name}.json", "project:.kiro/agents/{name}.json")
     managed_skill_files = ("user:skills/{name}/SKILL.md",)
 

--- a/observal_cli/ide/opencode.py
+++ b/observal_cli/ide/opencode.py
@@ -45,6 +45,7 @@ def _strip_jsonc_comments(text: str) -> str:
 class OpenCodeAdapter(BaseAdapter):
     """Adapter for OpenCode."""
 
+    home_markers = (".config/opencode",)
     managed_agent_files = ("user:agents/{name}.md", "project:.opencode/agents/{name}.md")
     managed_skill_files = ("user:skills/{name}/SKILL.md", "project:.opencode/skills/{name}/SKILL.md")
 

--- a/observal_cli/ide/pi.py
+++ b/observal_cli/ide/pi.py
@@ -27,6 +27,7 @@ class PiAdapter(BaseAdapter):
     Hooks are delivered as the observal-pi package.
     """
 
+    home_markers = (".pi/agent",)
     managed_agent_files = ("user:AGENTS.md",)
     managed_skill_files = ("user:skills/{name}/SKILL.md",)
 

--- a/observal_cli/ide/protocol.py
+++ b/observal_cli/ide/protocol.py
@@ -169,6 +169,14 @@ class IdeAdapter(Protocol):
         """
         ...
 
+    def is_installed(self, home: Path | None = None) -> bool:
+        """Return whether this IDE has a detectable home config marker.
+
+        Args:
+            home: Override home directory (defaults to Path.home()).
+        """
+        ...
+
     def scan_project(self, project_dir: Path) -> ScanResult:
         """Scan a project directory for this IDE's configuration.
 

--- a/observal_cli/layer.py
+++ b/observal_cli/layer.py
@@ -427,24 +427,23 @@ def _get_observal_managed_files(lockfile_data: dict, ide: str, project_dir: str 
 
 
 def _detect_active_ides() -> list[str]:
-    """Detect which first-class IDEs are installed by checking their config directories."""
+    """Detect installed IDEs by asking CLI adapters for their home markers."""
     from pathlib import Path
 
-    # First-class IDEs (full session parsing, hooks, scanning, e2e tested).
-    # copilot-cli is detected via ~/.copilot (its own home dir).
-    # VS Code copilot has no reliable home-dir marker (uses .github/ + VS Code
-    # settings); its project files are still scanned via project-scope globs
-    # when another IDE triggers a scan.
-    ide_dirs = {
-        "claude-code": Path.home() / ".claude",
-        "cursor": Path.home() / ".cursor",
-        "kiro": Path.home() / ".kiro",
-        "pi": Path.home() / ".pi" / "agent",
-        "codex": Path.home() / ".codex",
-        "copilot-cli": Path.home() / ".copilot",
-        "opencode": Path.home() / ".config" / "opencode",
-    }
-    return [ide for ide, path in ide_dirs.items() if path.is_dir()]
+    from observal_cli.ide import ensure_loaded, get_adapter
+    from observal_cli.ide_registry import IDE_REGISTRY
+
+    ensure_loaded()
+    home = Path.home()
+    active: list[str] = []
+    for ide in IDE_REGISTRY:
+        try:
+            adapter = get_adapter(ide)
+        except KeyError:
+            continue
+        if adapter.is_installed(home):
+            active.append(ide)
+    return active
 
 
 def compute_layer_hash(ide: str | None = None, project_dir: str | None = None) -> str:

--- a/tests/test_cli_ide_adapters.py
+++ b/tests/test_cli_ide_adapters.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from observal_cli.ide import (
@@ -47,6 +49,7 @@ class TestAdapterRegistry:
     def test_all_adapters_have_required_methods(self):
         required_methods = [
             "scan_home",
+            "is_installed",
             "scan_project",
             "get_hook_spec",
             "generate_hook_config",
@@ -171,6 +174,40 @@ class TestManagedLayerFiles:
             "project:AGENTS.md",
             "user:config.toml",
         }
+
+
+class TestActiveIdeDetection:
+    """Test adapter-owned active IDE detection."""
+
+    @pytest.mark.parametrize(
+        ("ide_name", "marker"),
+        [
+            ("claude-code", ".claude"),
+            ("cursor", ".cursor"),
+            ("kiro", ".kiro"),
+            ("codex", ".codex"),
+            ("copilot", ".vscode/extensions/github.copilot-1.0.0"),
+            ("copilot-cli", ".copilot"),
+            ("opencode", ".config/opencode"),
+            ("antigravity", ".gemini/antigravity-cli"),
+            ("pi", ".pi/agent"),
+        ],
+    )
+    def test_adapter_is_installed_uses_home_markers(self, ide_name, marker, tmp_path):
+        adapter = get_adapter(ide_name)
+        assert adapter.is_installed(tmp_path) is False
+        (tmp_path / Path(marker)).mkdir(parents=True)
+        assert adapter.is_installed(tmp_path) is True
+
+    def test_layer_detect_active_ides_delegates_to_adapters(self, tmp_path, monkeypatch):
+        from observal_cli.layer import _detect_active_ides
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".cursor").mkdir()
+        (tmp_path / ".codex").mkdir()
+        (tmp_path / ".pi" / "agent").mkdir(parents=True)
+
+        assert _detect_active_ides() == ["cursor", "codex", "pi"]
 
 
 class TestAdapterProtocol:


### PR DESCRIPTION
## Purpose / Description
Continue the IDE adapter migration by moving active IDE home detection out of the central layer scanner and into CLI IDE adapters.

## Fixes
Not applicable.

## Approach
- Added `is_installed()` to the CLI IDE adapter protocol.
- Added `home_markers` support to `BaseAdapter`, including glob markers for extension directories.
- Declared home markers in CLI IDE adapters.
- Updated layer active IDE detection to iterate registry adapters instead of using a central hardcoded map.
- Added adapter tests for marker-based detection and layer delegation.
- Updated `docs/adding-an-ide.md` to document `home_markers`.

## How Has This Been Tested?
Ran these checks:

- `uv run pytest tests/test_cli_ide_adapters.py tests/test_constants_sync.py tests/test_antigravity_adapter.py -q`
- `uv run ruff check observal_cli/ide observal_cli/layer.py tests/test_cli_ide_adapters.py`
- Ruff format check on `observal_cli/ide`, `observal_cli/layer.py`, and `tests/test_cli_ide_adapters.py`
- Smoke tested active IDE detection with temporary Cursor, Copilot, and Antigravity markers.

## Learning (optional, can help others)
Copilot CLI documents `~/.copilot` as its config directory. Antigravity CLI documents `~/.gemini/antigravity-cli/settings.json`, so `~/.gemini/antigravity-cli` is a usable marker. VS Code Copilot can be detected by its extension directory using a glob marker.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
