### PR TITLE
fix(insights): include untagged sessions in session count

### DIFF
--- a/observal-server/api/routes/insights.py
+++ b/observal-server/api/routes/insights.py
@@ -139,7 +139,9 @@ async def _count_insight_sessions(
         "param_t_end": period_end.strftime("%Y-%m-%d %H:%M:%S"),
     }
     if agent_version:
-        base_where += "AND agent_version = {agent_version:String} "
+        # Include sessions with matching version OR untagged sessions (agent_version = '')
+        # because most sessions are ingested without explicit version tagging.
+        base_where += "AND (agent_version = {agent_version:String} OR agent_version = '') "
         params["param_agent_version"] = agent_version
 
     count_sql = "SELECT count() AS cnt FROM session_stats_agg FINAL " + base_where + "FORMAT JSON"
@@ -157,7 +159,7 @@ async def _count_insight_sessions(
         "AND timestamp <= {t_end:String} "
     )
     if agent_version:
-        fallback_where += "AND agent_version = {agent_version:String} "
+        fallback_where += "AND (agent_version = {agent_version:String} OR agent_version IS NULL OR agent_version = '') "
     fallback_sql = (
         "SELECT count(DISTINCT session_id) AS cnt FROM session_events FINAL " + fallback_where + "FORMAT JSON"
     )

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 license = "AGPL-3.0-only"
 dependencies = [
     "fastapi>=0.136.0,!=0.136.3",
-    "starlette>=1.0.1",
+    "starlette>=1.3.1",
     "uvicorn[standard]",
     "sqlalchemy[asyncio]",
     "asyncpg",
@@ -30,15 +30,15 @@ dependencies = [
     "strawberry-graphql[fastapi]>=0.315.4",
     "authlib>=1.6.11",
     "itsdangerous",
-    "cryptography>=44.0.0",
+    "cryptography>=48.0.1",
     "python3-saml>=1.16.0",
     "cffi",
     "slowapi",
     "PyJWT>=2.13.0",
-    "aiohttp>=3.14.0",
+    "aiohttp>=3.14.1",
     "aiosqlite>=0.22.1",
     "tenacity>=8.0.0",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.31",
     "fastapi-cache2>=0.2.2",
     "jinja2>=3.1.0",
     "mako>=1.3.11",
@@ -57,7 +57,7 @@ dependencies = [
 # runtime-compatible with 1.x (only a type annotation differs).
 # Remove this override when upstream releases starlette 1.x support.
 override-dependencies = [
-    "starlette>=1.0.1",
+    "starlette>=1.3.1",
 ]
 
 [dependency-groups]

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -308,7 +308,7 @@ async def _count_agent_sessions(agent_id: str, agent_name: str, since: str, agen
         FROM session_stats_agg FINAL
         WHERE (agent_id = {agent_id:String} OR agent_id = {aname:String})
           AND last_event_time >= {t_start:String}
-          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+          AND ({agent_version:String} = '' OR agent_version = {agent_version:String} OR agent_version = '')
         FORMAT JSON
     """
     params = {
@@ -330,7 +330,7 @@ async def _count_agent_sessions(agent_id: str, agent_name: str, since: str, agen
         FROM session_events FINAL
         WHERE (agent_id = {agent_id:String} OR agent_id = {aname:String})
           AND timestamp >= {t_start:String}
-          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+          AND ({agent_version:String} = '' OR agent_version = {agent_version:String} OR agent_version IS NULL OR agent_version = '')
         FORMAT JSON
     """
     try:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
         specifier: ^6.0.8
         version: 6.0.8(graphql@16.13.2)
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.2.0
+        version: 4.2.0
       lucide-react:
         specifier: ^1.7.0
         version: 1.16.0(react@19.2.6)
@@ -2219,8 +2219,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4900,7 +4900,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 

--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "graphql-ws": "^6.0.8",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.15.0",
     "react": "19.2.6",


### PR DESCRIPTION
## Purpose / Description
Insights session count endpoint returns 0 even when sessions exist for an agent, because sessions ingested via hooks do not carry `agent_version` (resolves to empty string in ClickHouse). The version filter was excluding all untagged sessions.

## Fixes
* Fixes the "0 sessions available" display on the Insights tab when sessions exist

## Approach
Modified the version filter in `_count_insight_sessions` (insights.py) and `_count_agent_sessions` (batch.py) to also match `agent_version = ''` (untagged sessions). The fallback query on `session_events` additionally matches `agent_version IS NULL`.

This does not affect `version_impact.py` or `session_meta_extractor.py` — those either pass `None` (matches all) or intentionally require strict version grouping for comparison.

## How Has This Been Tested?

- Ruff lint passes on both modified files
- AST parse verification passes
- Local Docker stack tested with a dummy agent (`test-dummy-agent`) and session ingest
- Reviewed version_impact and session_meta_extractor queries to confirm no regression

## Learning (optional, can help others)
ClickHouse `session_stats_agg` MV coalesces NULL agent_version to empty string. Most sessions ingested via hooks only carry agent_id (name or UUID), not agent_version, because `_resolve_agent()` returns version only from lockfile lookups.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes(Please Specify the tool): Kiro CLI
- [x] Was the generated code manually reviewed and tested?