### PR TITLE
fix(attribution): resolve agent version from lockfile on session push

### DIFF
--- a/observal-server/services/clickhouse/schema.py
+++ b/observal-server/services/clickhouse/schema.py
@@ -421,6 +421,7 @@ INIT_SQL = [
         project_id,
         session_id,
         coalesce(anyIf(agent_id, agent_id IS NOT NULL AND agent_id != ''), '') AS agent_id,
+        coalesce(anyIf(agent_version, agent_version IS NOT NULL AND agent_version != ''), '') AS agent_version,
         coalesce(anyIf(user_id, user_id != ''), '')                             AS user_id,
         coalesce(anyIf(parent_session_id, parent_session_id IS NOT NULL AND parent_session_id != ''), '') AS parent_session_id,
         coalesce(anyIf(ide, ide != ''), '')                                     AS ide,

--- a/observal_cli/sessions/base.py
+++ b/observal_cli/sessions/base.py
@@ -447,38 +447,70 @@ def _maybe_upload_layer_snapshot(
 
 
 def _resolve_agent(cwd: str, lines: list[str], session_jsonl: Path | None) -> tuple[str | None, str | None]:
-    """Resolve agent identity from multiple sources (priority order).
+    """Resolve agent identity from multiple sources.
 
-    1. OBSERVAL_AGENT_NAME env var (Kiro per-agent hook commands)
-    2. agent-setting line in JSONL (Claude Code embeds active agent)
-    3. Lock file lookup by cwd + IDE
+    Name resolution (first match wins):
+      1. OBSERVAL_AGENT_NAME env var (Kiro per-agent hook commands)
+      2. agent-setting line in JSONL (Claude Code embeds active agent)
+      3. Lock file lookup by cwd + IDE
+
+    Version resolution always comes from the lockfile. Steps 1 and 2 only
+    provide the agent name; the lockfile is the authoritative source for
+    the installed version.
     """
     import os
+
+    # Resolve agent name from env var or JSONL
+    agent_name: str | None = None
 
     # 1. Env var (Kiro per-agent hooks embed this)
     env_agent = os.environ.get("OBSERVAL_AGENT_NAME", "")
     if env_agent:
-        return env_agent, None
+        agent_name = env_agent
 
     # 2. Parse agent-setting from JSONL lines (Claude Code)
-    agent_from_jsonl = _parse_agent_from_lines(lines)
-    if agent_from_jsonl:
-        return agent_from_jsonl, None
+    if not agent_name:
+        agent_name = _parse_agent_from_lines(lines)
 
-    # 3. Lock file lookup
-    if cwd:
-        try:
-            from observal_cli.lockfile import get_agent_for_directory
+    # Look up version from lockfile (authoritative source for version attribution)
+    lockfile_entry = _lookup_lockfile_agent(cwd) if cwd else None
 
-            # Try common IDEs (the caller may override ide later)
-            for ide in ("claude-code", "cursor", "kiro", "pi"):
-                agent = get_agent_for_directory(ide, cwd)
-                if agent:
-                    return agent.get("id") or agent.get("name"), agent.get("version")
-        except Exception:
-            pass
+    if agent_name:
+        # Only use lockfile version when the entry matches this agent
+        agent_id = agent_name
+        version = None
+        if lockfile_entry:
+            lf_name = lockfile_entry.get("name", "")
+            lf_id = lockfile_entry.get("id", "")
+            if lf_name == agent_name or lf_id == agent_name:
+                agent_id = lf_id or lf_name or agent_name
+                version = lockfile_entry.get("version")
+        return agent_id, version
+
+    # 3. No name from env/JSONL; fall back to lockfile entirely
+    if lockfile_entry:
+        return lockfile_entry.get("id") or lockfile_entry.get("name"), lockfile_entry.get("version")
 
     return None, None
+
+
+def _lookup_lockfile_agent(cwd: str) -> dict | None:
+    """Find the agent entry in the lockfile for the given directory.
+
+    Checks all IDEs since the calling hook may not know which IDE wrote
+    the lockfile entry.
+    """
+    try:
+        from observal_cli.ide_registry import get_valid_ides
+        from observal_cli.lockfile import get_agent_for_directory
+
+        for ide in get_valid_ides():
+            agent = get_agent_for_directory(ide, cwd)
+            if agent:
+                return agent
+    except Exception:
+        pass
+    return None
 
 
 def _parse_agent_from_lines(lines: list[str]) -> str | None:

--- a/tests/test_resolve_agent_version.py
+++ b/tests/test_resolve_agent_version.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for _resolve_agent version attribution from lockfile."""
+
+import json
+from unittest.mock import patch
+
+from observal_cli.sessions.base import _resolve_agent
+
+
+def _make_lockfile_entry(
+    name: str = "my-agent",
+    agent_id: str = "uuid-123",
+    version: str = "1.2.0",
+    directory: str = "/projects/app",
+    scope: str = "project",
+) -> dict:
+    """Build a lockfile agent entry matching the real format from upsert_agent."""
+    return {
+        "name": name,
+        "id": agent_id,
+        "version": version,
+        "pulled_at": "2026-06-17T00:00:00+00:00",
+        "scope": scope,
+        "directory": directory,
+        "components": [
+            {"type": "skill", "name": "pr-review", "id": "comp-1", "version": "1.0.0"},
+        ],
+    }
+
+
+class TestResolveAgentVersionFromLockfile:
+    """Verify that _resolve_agent enriches agent name with version from lockfile."""
+
+    def test_env_var_gets_version_from_lockfile(self, tmp_path):
+        """When OBSERVAL_AGENT_NAME is set, version should come from lockfile."""
+        entry = _make_lockfile_entry(name="my-agent", agent_id="uuid-123", version="1.2.0", directory=str(tmp_path))
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_AGENT_NAME": "my-agent"}),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent", return_value=entry),
+        ):
+            agent_id, agent_version = _resolve_agent(str(tmp_path), [], None)
+
+        assert agent_id == "uuid-123"
+        assert agent_version == "1.2.0"
+
+    def test_env_var_without_lockfile_returns_none_version(self):
+        """When lockfile is missing, version should be None (graceful degradation)."""
+        with (
+            patch.dict("os.environ", {"OBSERVAL_AGENT_NAME": "my-agent"}),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent", return_value=None),
+        ):
+            agent_id, agent_version = _resolve_agent("/some/dir", [], None)
+
+        assert agent_id == "my-agent"
+        assert agent_version is None
+
+    def test_jsonl_agent_setting_gets_version_from_lockfile(self, tmp_path):
+        """When agent is resolved from JSONL, version should come from lockfile."""
+        lines = [json.dumps({"type": "agent-setting", "agentSetting": "cc-agent"})]
+        entry = _make_lockfile_entry(name="cc-agent", agent_id="uuid-456", version="2.0.1", directory=str(tmp_path))
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent", return_value=entry),
+        ):
+            import os
+
+            os.environ.pop("OBSERVAL_AGENT_NAME", None)
+            agent_id, agent_version = _resolve_agent(str(tmp_path), lines, None)
+
+        assert agent_id == "uuid-456"
+        assert agent_version == "2.0.1"
+
+    def test_lockfile_fallback_when_no_env_or_jsonl(self, tmp_path):
+        """When neither env var nor JSONL match, lockfile provides both name and version."""
+        entry = _make_lockfile_entry(
+            name="fallback-agent", agent_id="uuid-789", version="3.0.0", directory=str(tmp_path)
+        )
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent", return_value=entry),
+        ):
+            import os
+
+            os.environ.pop("OBSERVAL_AGENT_NAME", None)
+            agent_id, agent_version = _resolve_agent(str(tmp_path), [], None)
+
+        assert agent_id == "uuid-789"
+        assert agent_version == "3.0.0"
+
+    def test_no_sources_returns_none(self):
+        """When nothing matches, returns (None, None)."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent", return_value=None),
+        ):
+            import os
+
+            os.environ.pop("OBSERVAL_AGENT_NAME", None)
+            agent_id, agent_version = _resolve_agent("/empty/dir", [], None)
+
+        assert agent_id is None
+        assert agent_version is None
+
+    def test_env_var_name_mismatch_returns_none_version(self, tmp_path):
+        """When env agent name differs from lockfile name, version is None.
+
+        We only attribute a version when the lockfile confirms the agent.
+        """
+        entry = _make_lockfile_entry(
+            name="other-agent", agent_id="uuid-other", version="1.0.0", directory=str(tmp_path)
+        )
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_AGENT_NAME": "my-agent"}),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent", return_value=entry),
+        ):
+            agent_id, agent_version = _resolve_agent(str(tmp_path), [], None)
+
+        # Name comes from env var (not lockfile) since they don't match
+        assert agent_id == "my-agent"
+        # Version is None because lockfile entry doesn't match this agent
+        assert agent_version is None
+
+    def test_empty_cwd_skips_lockfile(self):
+        """When cwd is empty, lockfile lookup is skipped."""
+        with patch.dict("os.environ", {"OBSERVAL_AGENT_NAME": "my-agent"}):
+            agent_id, agent_version = _resolve_agent("", [], None)
+
+        assert agent_id == "my-agent"
+        assert agent_version is None


### PR DESCRIPTION
## Purpose / Description

Session push hooks were always sending `agent_version=NULL` to the server because `_resolve_agent()` returned early at step 1 (env var) or step 2 (JSONL parsing) before reaching the lockfile lookup in step 3. This caused the Insights page to show "0 sessions available for v1.0.0" even when sessions existed, because ClickHouse had no version tag on any ingested session.

## Fixes

* Fixes version-scoped insights showing 0 sessions despite sessions being attributed to the agent

## Approach

The lockfile (`~/.observal/lockfile.json`) is the authoritative source for which version of an agent is installed. Previously, `_resolve_agent()` had three steps with early returns:

1. `OBSERVAL_AGENT_NAME` env var (Kiro) -> returned `(name, None)` immediately
2. JSONL `agent-setting` line (Claude Code) -> returned `(name, None)` immediately
3. Lockfile lookup -> only reached if steps 1 and 2 both missed

Since Kiro hooks always set the env var, step 3 was never reached for Kiro. Similarly, Claude Code sessions always have the JSONL line, so step 3 was dead code for all first-class IDEs.

The fix decouples name resolution from version resolution:
- Steps 1/2 resolve the agent **name** (no early return)
- The lockfile is **always consulted** for version, regardless of how the name was found
- If the lockfile entry matches the resolved name, the lockfile UUID is also used as the canonical `agent_id`

## How Has This Been Tested?

- 7 new unit tests covering all resolution paths (env var + lockfile, JSONL + lockfile, lockfile-only, no sources, name mismatch, empty cwd)
- Existing cursor session push tests (15) continue to pass
- CLI test suite (32) passes

## Learning (optional, can help others)

The regression was introduced in `eb6ab0ae` (PR #1257, May 28) which replaced `read_agent_marker()` with `_resolve_agent()`. The lockfile infrastructure added in `d45ae2e7` (PR #1342, June 3) partially addressed it by adding step 3, but the early returns in steps 1/2 meant no first-class IDE ever reached it.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes (Pi): Used to trace the regression through git history and implement the fix
- [x] Was the generated code manually reviewed and tested?