### PR TITLE
fix(insights): count legacy unversioned sessions

### DIFF
--- a/observal-server/api/routes/insights.py
+++ b/observal-server/api/routes/insights.py
@@ -26,6 +26,7 @@ from schemas.insights import (
     InsightReportListItem,
     InsightReportResponse,
 )
+from services.insight_version_filters import agent_version_filter
 from services.insights import INSIGHTS_AVAILABLE, render_report_html
 from services.redis import _get_arq_pool
 
@@ -139,7 +140,7 @@ async def _count_insight_sessions(
         "param_t_end": period_end.strftime("%Y-%m-%d %H:%M:%S"),
     }
     if agent_version:
-        base_where += "AND agent_version = {agent_version:String} "
+        base_where += f"AND {agent_version_filter()} "
         params["param_agent_version"] = agent_version
 
     count_sql = "SELECT count() AS cnt FROM session_stats_agg FINAL " + base_where + "FORMAT JSON"
@@ -157,7 +158,7 @@ async def _count_insight_sessions(
         "AND timestamp <= {t_end:String} "
     )
     if agent_version:
-        fallback_where += "AND agent_version = {agent_version:String} "
+        fallback_where += f"AND {agent_version_filter(nullable=True)} "
     fallback_sql = (
         "SELECT count(DISTINCT session_id) AS cnt FROM session_events FINAL " + fallback_where + "FORMAT JSON"
     )

--- a/observal-server/services/clickhouse/schema.py
+++ b/observal-server/services/clickhouse/schema.py
@@ -622,9 +622,11 @@ async def _migrate_session_stats_partition():
             project_id          String,
             session_id          String,
             agent_id            LowCardinality(String) DEFAULT '',
+            agent_version       LowCardinality(String) DEFAULT '',
             user_id             String                 DEFAULT '',
             parent_session_id   String                 DEFAULT '',
             ide                 LowCardinality(String) DEFAULT '',
+            layer_hash          String                 DEFAULT '',
             first_event_time    SimpleAggregateFunction(min,     DateTime64(3, 'UTC')),
             last_event_time     SimpleAggregateFunction(max,     DateTime64(3, 'UTC')),
             event_count         SimpleAggregateFunction(sum,     Int64),
@@ -637,8 +639,9 @@ async def _migrate_session_stats_partition():
             cache_write_tokens  SimpleAggregateFunction(sum,     Int64),
             total_credits       SimpleAggregateFunction(max,     Float64),
             model               SimpleAggregateFunction(anyLast, String),
-            INDEX idx_ssa_user_id  user_id  TYPE bloom_filter(0.01) GRANULARITY 1,
-            INDEX idx_ssa_agent_id agent_id TYPE bloom_filter(0.01) GRANULARITY 1
+            INDEX idx_ssa_user_id       user_id       TYPE bloom_filter(0.01) GRANULARITY 1,
+            INDEX idx_ssa_agent_id      agent_id      TYPE bloom_filter(0.01) GRANULARITY 1,
+            INDEX idx_ssa_agent_version agent_version TYPE bloom_filter(0.01) GRANULARITY 1
         ) ENGINE = AggregatingMergeTree()
         PARTITION BY toYYYYMM(first_event_time)
         ORDER BY (project_id, session_id)""",
@@ -647,9 +650,11 @@ async def _migrate_session_stats_partition():
         SELECT
             project_id, session_id,
             coalesce(anyIf(agent_id, agent_id IS NOT NULL AND agent_id != ''), '') AS agent_id,
+            coalesce(anyIf(agent_version, agent_version IS NOT NULL AND agent_version != ''), '') AS agent_version,
             coalesce(anyIf(user_id, user_id != ''), '') AS user_id,
             coalesce(anyIf(parent_session_id, parent_session_id IS NOT NULL AND parent_session_id != ''), '') AS parent_session_id,
             coalesce(anyIf(ide, ide != ''), '') AS ide,
+            coalesce(anyIf(layer_hash, layer_hash IS NOT NULL AND layer_hash != ''), '') AS layer_hash,
             minIf(timestamp, timestamp > '1971-01-01' AND timestamp < '2099-01-01') AS first_event_time,
             maxIf(timestamp, timestamp > '1971-01-01' AND timestamp < '2099-01-01') AS last_event_time,
             count() AS event_count,
@@ -668,9 +673,11 @@ async def _migrate_session_stats_partition():
         SELECT
             project_id, session_id,
             coalesce(anyIf(agent_id, agent_id IS NOT NULL AND agent_id != ''), '') AS agent_id,
+            coalesce(anyIf(agent_version, agent_version IS NOT NULL AND agent_version != ''), '') AS agent_version,
             coalesce(anyIf(user_id, user_id != ''), '') AS user_id,
             coalesce(anyIf(parent_session_id, parent_session_id IS NOT NULL AND parent_session_id != ''), '') AS parent_session_id,
             coalesce(anyIf(ide, ide != ''), '') AS ide,
+            coalesce(anyIf(layer_hash, layer_hash IS NOT NULL AND layer_hash != ''), '') AS layer_hash,
             minIf(timestamp, timestamp > '1971-01-01' AND timestamp < '2099-01-01') AS first_event_time,
             maxIf(timestamp, timestamp > '1971-01-01' AND timestamp < '2099-01-01') AS last_event_time,
             count() AS event_count,

--- a/observal-server/services/insight_version_filters.py
+++ b/observal-server/services/insight_version_filters.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""ClickHouse filters for insights agent version compatibility."""
+
+from __future__ import annotations
+
+LEGACY_UNVERSIONED_AGENT_VERSION = "1.0.0"
+
+
+def agent_version_filter(
+    *, nullable: bool = False, column: str = "agent_version", parameter: str = "agent_version"
+) -> str:
+    """Return a ClickHouse predicate for version scoped insights telemetry.
+
+    Older Observal releases ingested session telemetry without agent_version.
+    Insights treated that telemetry as the first published agent version, so
+    v1.0.0 reports should continue to include unversioned rows. Later versions
+    still require an exact telemetry version match.
+    """
+    param = "{" + parameter + ":String}"
+    column_expr = f"coalesce({column}, '')" if nullable else column
+    return (
+        f"({param} = '' OR {column_expr} = {param} "
+        f"OR ({param} = '{LEGACY_UNVERSIONED_AGENT_VERSION}' AND {column_expr} = ''))"
+    )

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -19,6 +19,7 @@ from database import async_session
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.insight_report import InsightReport, InsightReportStatus
 from services.clickhouse import _query
+from services.insight_version_filters import agent_version_filter
 from services.redis import _get_arq_pool
 from services.secrets_redactor import redact_secrets
 
@@ -308,9 +309,9 @@ async def _count_agent_sessions(agent_id: str, agent_name: str, since: str, agen
         FROM session_stats_agg FINAL
         WHERE (agent_id = {agent_id:String} OR agent_id = {aname:String})
           AND last_event_time >= {t_start:String}
-          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+          AND __AGENT_VERSION_FILTER__
         FORMAT JSON
-    """
+    """.replace("__AGENT_VERSION_FILTER__", agent_version_filter())
     params = {
         "param_agent_id": agent_id,
         "param_aname": agent_name,
@@ -330,9 +331,9 @@ async def _count_agent_sessions(agent_id: str, agent_name: str, since: str, agen
         FROM session_events FINAL
         WHERE (agent_id = {agent_id:String} OR agent_id = {aname:String})
           AND timestamp >= {t_start:String}
-          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+          AND __AGENT_VERSION_FILTER__
         FORMAT JSON
-    """
+    """.replace("__AGENT_VERSION_FILTER__", agent_version_filter(nullable=True))
     try:
         r = await _query(fallback_sql, params)
         r.raise_for_status()

--- a/observal-server/services/insights/session_meta_extractor.py
+++ b/observal-server/services/insights/session_meta_extractor.py
@@ -21,6 +21,8 @@ from datetime import datetime
 
 import structlog
 
+from services.insight_version_filters import agent_version_filter
+
 from ._deps import get_query
 
 logger = structlog.get_logger(__name__)
@@ -439,10 +441,10 @@ async def fetch_session_stats(
         WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
           AND last_event_time >= {t_start:String}
           AND last_event_time <= {t_end:String}
-          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+          AND __AGENT_VERSION_FILTER__
         GROUP BY session_id, total_credits, ide, layer_hash
         FORMAT JSON
-    """
+    """.replace("__AGENT_VERSION_FILTER__", agent_version_filter())
     params = {
         "param_agent_id": agent_id,
         "param_agent_name": agent_name,
@@ -476,10 +478,10 @@ async def fetch_session_stats(
         WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
           AND timestamp >= {t_start:String}
           AND timestamp <= {t_end:String}
-          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+          AND __AGENT_VERSION_FILTER__
         GROUP BY session_id
         FORMAT JSON
-    """
+    """.replace("__AGENT_VERSION_FILTER__", agent_version_filter(nullable=True))
     try:
         r = await query(fallback_sql, params)
         r.raise_for_status()
@@ -521,11 +523,11 @@ async def fetch_all_session_transcripts(
         WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
           AND last_event_time >= {t_start:String}
           AND last_event_time <= {t_end:String}
-          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+          AND __AGENT_VERSION_FILTER__
         GROUP BY session_id
         ORDER BY min(last_event_time)
         FORMAT JSON
-    """
+    """.replace("__AGENT_VERSION_FILTER__", agent_version_filter())
     params = {
         "param_agent_id": agent_id,
         "param_agent_name": agent_name,
@@ -546,10 +548,10 @@ async def fetch_all_session_transcripts(
             WHERE (agent_id = {agent_id:String} OR agent_id = {agent_name:String})
               AND timestamp >= {t_start:String}
               AND timestamp <= {t_end:String}
-              AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
+              AND __AGENT_VERSION_FILTER__
             ORDER BY session_id
             FORMAT JSON
-        """
+        """.replace("__AGENT_VERSION_FILTER__", agent_version_filter(nullable=True))
         try:
             r = await query(fallback_id_sql, params)
             r.raise_for_status()

--- a/observal-server/services/insights/version_impact.py
+++ b/observal-server/services/insights/version_impact.py
@@ -19,6 +19,8 @@ import json
 
 import structlog
 
+from services.insight_version_filters import LEGACY_UNVERSIONED_AGENT_VERSION, agent_version_filter
+
 from ._deps import get_query
 
 logger = structlog.get_logger(__name__)
@@ -97,7 +99,11 @@ async def detect_layer_groups(
 
     sql = """
         SELECT
-            coalesce(agent_version, '') AS agent_version,
+            if(
+                agent_version = '' AND {agent_version:String} = '__LEGACY_VERSION__',
+                '__LEGACY_VERSION__',
+                agent_version
+            ) AS agent_version,
             layer_hash,
             count() AS sessions,
             uniq(user_id) AS users,
@@ -116,13 +122,21 @@ async def detect_layer_groups(
           AND last_event_time >= {t_start:String}
           AND last_event_time <= {t_end:String}
           AND layer_hash != ''
-          AND ({agent_version:String} = '' OR agent_version = {agent_version:String})
-        GROUP BY agent_version, layer_hash
+          AND __AGENT_VERSION_FILTER__
+        GROUP BY
+            if(
+                agent_version = '' AND {agent_version:String} = '__LEGACY_VERSION__',
+                '__LEGACY_VERSION__',
+                agent_version
+            ),
+            layer_hash
         HAVING sessions >= 3
         ORDER BY sessions DESC
         LIMIT 20
         FORMAT JSON
-    """
+    """.replace("__LEGACY_VERSION__", LEGACY_UNVERSIONED_AGENT_VERSION).replace(
+        "__AGENT_VERSION_FILTER__", agent_version_filter()
+    )
     params = {
         "param_agent_id": agent_id,
         "param_agent_name": agent_name,

--- a/tests/test_insights_legacy_version.py
+++ b/tests/test_insights_legacy_version.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class _Response:
+    status_code = 200
+
+    def json(self) -> dict:
+        return {"data": [{"cnt": "2"}]}
+
+
+def test_agent_version_filter_treats_unversioned_as_v1() -> None:
+    from services.insight_version_filters import agent_version_filter
+
+    condition = agent_version_filter(nullable=True)
+
+    assert "coalesce(agent_version, '') = {agent_version:String}" in condition
+    assert "{agent_version:String} = '1.0.0'" in condition
+    assert "coalesce(agent_version, '') = ''" in condition
+
+
+@pytest.mark.asyncio
+async def test_count_insight_sessions_matches_legacy_v1_rows() -> None:
+    from api.routes.insights import _count_insight_sessions
+
+    query = AsyncMock(return_value=_Response())
+    agent = SimpleNamespace(id="agent-id", name="agent-name")
+
+    with patch("services.clickhouse._query", new=query):
+        count = await _count_insight_sessions(
+            agent=agent,
+            period_start=datetime(2026, 1, 1, tzinfo=UTC),
+            period_end=datetime(2026, 1, 2, tzinfo=UTC),
+            agent_version="1.0.0",
+        )
+
+    assert count == 2
+    sql = query.await_args.args[0]
+    assert "agent_version = {agent_version:String}" in sql
+    assert "{agent_version:String} = '1.0.0'" in sql
+    assert "agent_version = ''" in sql
+
+
+@pytest.mark.asyncio
+async def test_count_insight_sessions_fallback_matches_nullable_legacy_rows() -> None:
+    from api.routes.insights import _count_insight_sessions
+
+    query = AsyncMock(side_effect=[RuntimeError("aggregate failed"), _Response()])
+    agent = SimpleNamespace(id="agent-id", name="agent-name")
+
+    with patch("services.clickhouse._query", new=query):
+        count = await _count_insight_sessions(
+            agent=agent,
+            period_start=datetime(2026, 1, 1, tzinfo=UTC),
+            period_end=datetime(2026, 1, 2, tzinfo=UTC),
+            agent_version="1.0.0",
+        )
+
+    assert count == 2
+    fallback_sql = query.await_args_list[1].args[0]
+    assert "coalesce(agent_version, '') = {agent_version:String}" in fallback_sql
+    assert "{agent_version:String} = '1.0.0'" in fallback_sql
+    assert "coalesce(agent_version, '') = ''" in fallback_sql

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -190,6 +190,7 @@ export interface InsightNarrative {
 	suggestions: unknown;
 	usage_cost_analysis?: unknown;
 	token_optimization?: unknown;
+	version_comparison?: unknown;
 	regression_detection?: unknown;
 	on_the_horizon?: unknown;
 	fun_ending?: unknown;

--- a/web/src/pages/admin/insights/detail.tsx
+++ b/web/src/pages/admin/insights/detail.tsx
@@ -105,6 +105,18 @@ function MetricCard({
 	);
 }
 
+function hasText(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasPositiveNumber(value: unknown): boolean {
+	return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function formatInsightLabel(value: string): string {
+	return value.replace(/_/g, " ");
+}
+
 // ── At a Glance (executive summary) ──────────────────────────────────────
 
 function AtAGlance({ data }: { data: unknown }) {
@@ -890,17 +902,25 @@ function TokenSection({
 	// If we have structured V2 data
 	if (data && typeof data === "object" && !Array.isArray(data)) {
 		const obj = data as Record<string, unknown>;
-		const summary = obj.summary as string | undefined;
+		const summary = hasText(obj.summary) ? obj.summary : undefined;
 		const costMetrics = obj.metrics as
 			| {
-					total_cost_usd: number;
-					cost_per_session: number;
-					cache_efficiency_pct: number;
+					total_cost_usd?: number;
+					cost_per_session?: number;
+					cache_efficiency_pct?: number;
 			  }
 			| undefined;
 		const opportunities = obj.opportunities as
 			| { title: string; description: string; estimated_savings: string }[]
 			| undefined;
+		const hasCostMetrics = Boolean(
+			costMetrics &&
+				(hasPositiveNumber(costMetrics.total_cost_usd) ||
+					hasPositiveNumber(costMetrics.cost_per_session) ||
+					hasPositiveNumber(costMetrics.cache_efficiency_pct))
+		);
+		const hasOpportunities = Boolean(opportunities && opportunities.length > 0);
+		if (!summary && !hasCostMetrics && !hasOpportunities) return null;
 
 		return (
 			<div className="rounded-lg border border-border bg-card">
@@ -913,23 +933,23 @@ function TokenSection({
 				<div className="px-5 py-4 space-y-4">
 					{summary && <p className="text-sm text-foreground/80">{summary}</p>}
 
-					{costMetrics && (
+					{hasCostMetrics && costMetrics && (
 						<div className="grid grid-cols-3 gap-3">
 							<div className="text-center p-2 rounded bg-muted/30">
 								<div className="text-lg font-bold">
-									${costMetrics.total_cost_usd?.toFixed(4)}
+									${Number(costMetrics.total_cost_usd || 0).toFixed(4)}
 								</div>
 								<div className="text-xs text-muted-foreground">total cost</div>
 							</div>
 							<div className="text-center p-2 rounded bg-muted/30">
 								<div className="text-lg font-bold">
-									${costMetrics.cost_per_session?.toFixed(4)}
+									${Number(costMetrics.cost_per_session || 0).toFixed(4)}
 								</div>
 								<div className="text-xs text-muted-foreground">per session</div>
 							</div>
 							<div className="text-center p-2 rounded bg-muted/30">
 								<div className="text-lg font-bold">
-									{costMetrics.cache_efficiency_pct?.toFixed(0)}%
+									{Number(costMetrics.cache_efficiency_pct || 0).toFixed(0)}%
 								</div>
 								<div className="text-xs text-muted-foreground">
 									cache efficiency
@@ -1103,6 +1123,85 @@ function UserExperienceSection({ data }: { data: unknown }) {
 								</div>
 							</div>
 						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ── Version Comparison Section ──────────────────────────────────────────
+
+function VersionComparisonSection({ data }: { data: unknown }) {
+	if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+
+	const obj = data as Record<string, unknown>;
+	if (obj.has_comparison === false) return null;
+
+	const summary = hasText(obj.summary) ? obj.summary : undefined;
+	const confidence = hasText(obj.confidence) ? obj.confidence : undefined;
+	const changes = (obj.changes as
+		| {
+				metric?: string;
+				direction?: string;
+				prior_value?: string;
+				current_value?: string;
+				attribution?: string;
+				risk?: string;
+				evidence?: string;
+		  }[]
+		| undefined) ?? [];
+
+	if (!summary && !confidence && changes.length === 0) return null;
+
+	return (
+		<div className="rounded-lg border border-border bg-card">
+			<div className="flex items-center gap-2 px-5 py-3 border-b border-border">
+				<TrendingUp className="h-4 w-4 text-primary-accent" />
+				<h3 className="text-sm font-semibold">Version Comparison</h3>
+			</div>
+			<div className="px-5 py-4 space-y-4">
+				{summary && <p className="text-sm text-foreground/80">{summary}</p>}
+				{confidence && (
+					<div className="text-xs text-muted-foreground">
+						Confidence: <span className="font-medium">{confidence}</span>
+					</div>
+				)}
+				{changes.length > 0 && (
+					<div className="space-y-3">
+						{changes.slice(0, 8).map((change, i) => {
+							const direction = change.direction || "stable";
+							const directionClass =
+								direction === "improved"
+									? "text-success"
+									: direction === "degraded"
+										? "text-destructive"
+										: "text-muted-foreground";
+							return (
+								<div key={i} className="rounded-md border border-border bg-muted/10 p-3">
+									<div className="flex flex-wrap items-center gap-2 text-sm">
+										<span className="font-medium">
+											{formatInsightLabel(change.metric || "change")}
+										</span>
+										<span className={directionClass}>{direction}</span>
+									</div>
+									{(change.prior_value || change.current_value) && (
+										<div className="mt-1 text-sm text-muted-foreground">
+											{change.prior_value || "?"} → {change.current_value || "?"}
+										</div>
+									)}
+									{(change.attribution || change.risk) && (
+										<div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+											{change.attribution && <span>Attribution: {change.attribution}</span>}
+											{change.risk && <span>Risk: {change.risk}</span>}
+										</div>
+									)}
+									{change.evidence && (
+										<p className="mt-2 text-sm text-foreground/70">{change.evidence}</p>
+									)}
+								</div>
+							);
+						})}
 					</div>
 				)}
 			</div>
@@ -1540,6 +1639,7 @@ function ReportContent({ report }: { report: InsightReport }) {
 	const sessionsWithTokens = Number(rich?.sessions_with_tokens) || 0;
 	const sessionsWithCredits = Number(rich?.sessions_with_credits) || 0;
 	const toolCalls = Number(metrics?.errors?.total_tool_calls) || 0;
+	const showTokenSection = sessionsWithTokens > 0 || totalCost > 0;
 	const topTools = (rich?.top_tools || []) as [string, number][];
 	const topLanguages = (rich?.top_languages || []) as [string, number][];
 	const toolErrorCats = (rich?.tool_error_categories || {}) as Record<string, number>;
@@ -1675,8 +1775,10 @@ function ReportContent({ report }: { report: InsightReport }) {
 			{/* On the Horizon */}
 			<OnTheHorizon data={narrative?.on_the_horizon} />
 
-			{/* Cost & Token Efficiency: show when any billing data exists (tokens or credits) */}
-			{(sessionsWithTokens > 0 || sessionsWithCredits > 0 || totalCost > 0) && <TokenSection data={narrative?.usage_cost_analysis || narrative?.token_optimization} metrics={metrics} />}
+			{/* Cost and token efficiency needs actual token or pay as you go cost data. */}
+			{showTokenSection && <TokenSection data={narrative?.usage_cost_analysis || narrative?.token_optimization} metrics={metrics} />}
+
+			<VersionComparisonSection data={narrative?.version_comparison} />
 
 			{/* Regression Detection */}
 			<RegressionSection


### PR DESCRIPTION
## Purpose / Description

Insights queries were filtering by exact telemetry agent version. Older Observal sessions stored missing versions as either null in session_events or an empty string in session_stats_agg, so reports for v1.0.0 could see zero sessions even when data existed.

The completed report page also missed the generated Version Comparison narrative that was already present in HTML export and CLI output. Its cost section could render an empty Cost & Token Efficiency card for subscription credit data such as Kiro.

## Fixes

* No linked issue.

## Approach

Added a shared ClickHouse version filter that treats unversioned session telemetry as v1.0.0 only for insights compatibility. Newer versions still require exact agent_version matches. Applied the filter to report counts, batch discovery, transcript and session stat collection, and version impact layer groups. Also updated the session_stats_agg partition migration so rebuilt aggregates keep agent_version and layer_hash columns.

Updated the web report detail view to render Version Comparison from the narrative and to hide Cost & Token Efficiency unless there is actual token data or pay as you go cost data. Empty structured cost data now returns no card.

## How Has This Been Tested?

Ran these checks:

* Ruff check on changed Python files
* Targeted insights pytest suite from the server workspace
* Python compile check on changed server files
* Web TypeScript typecheck
* Web lint

<img width="1446" height="626" alt="image" src="https://github.com/user-attachments/assets/03ae932f-db9a-416e-bd46-676f8e742379" />


## Learning (optional, can help others)

The issue was not only nullable versus empty string storage. Version scoped insights needed a compatibility rule for telemetry from older Observal releases that did not attach an agent version.

The web detail page had separate render coverage from HTML export and CLI, so newly generated narrative sections need to be wired into all three surfaces.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings).

## AI Assistance

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
