### PR TITLE
feat(deploy): make observability optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset rebuild rebuild-enterprise rebuild-local release-major release-feature release-patch sync-skill
+.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset rebuild rebuild-prometheus rebuild-observability rebuild-enterprise rebuild-local reset-prometheus reset-observability up-prometheus up-observability down-prometheus down-observability logs-prometheus logs-observability release-major release-feature release-patch sync-skill
 
 # ── Linting ──────────────────────────────────────────────
 
@@ -55,12 +55,25 @@ ifneq (,$(wildcard ee/observal_insights/__init__.py))
   COMPOSE_FILES += -f docker-compose.enterprise.yml
   $(info [enterprise mode] ee/observal_insights/ detected)
 endif
+OBSERVABILITY_COMPOSE_FILES := $(COMPOSE_FILES) -f docker-compose.observability.yml
 
 up:  ## Start Docker stack
 	cd docker && docker compose $(COMPOSE_FILES) up -d
 
-down:  ## Stop Docker stack
-	cd docker && docker compose $(COMPOSE_FILES) down
+up-prometheus:  ## Start Docker stack with Prometheus
+	cd docker && docker compose $(OBSERVABILITY_COMPOSE_FILES) up -d
+
+up-observability:  ## Start Docker stack with Prometheus and Grafana
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) up -d
+
+down:  ## Stop Docker stack, including optional Prometheus and Grafana
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) down
+
+down-prometheus:  ## Stop Docker stack with Prometheus
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) down
+
+down-observability:  ## Stop Docker stack with Prometheus and Grafana
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) down
 
 migrate:  ## Run database migrations
 	cd docker && docker compose $(COMPOSE_FILES) exec observal-api /app/.venv/bin/python -m alembic upgrade head
@@ -79,6 +92,20 @@ rebuild:  ## Rebuild and restart Docker stack (runs migrations automatically)
 	cd docker && docker compose $(COMPOSE_FILES) restart observal-lb
 	@echo "API is healthy."
 
+rebuild-prometheus:  ## Rebuild and restart Docker stack with Prometheus
+	cd docker && docker compose $(OBSERVABILITY_COMPOSE_FILES) up --build -d
+	@echo "Waiting for API to be healthy..."
+	@cd docker && until docker compose $(OBSERVABILITY_COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && docker compose $(OBSERVABILITY_COMPOSE_FILES) restart observal-lb
+	@echo "API is healthy."
+
+rebuild-observability:  ## Rebuild and restart Docker stack with Prometheus and Grafana
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) up --build -d
+	@echo "Waiting for API to be healthy..."
+	@cd docker && until COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) restart observal-lb
+	@echo "API is healthy."
+
 rebuild-enterprise:  ## Rebuild in enterprise mode (insights enabled)
 	cd docker && docker compose -f docker-compose.yml -f docker-compose.enterprise.yml up --build -d
 	@echo "Waiting for API to be healthy..."
@@ -93,16 +120,32 @@ rebuild-local:  ## Rebuild in local mode (no enterprise features)
 	cd docker && docker compose -f docker-compose.yml restart observal-lb
 	@echo "✓ Running in local mode (DEPLOYMENT_MODE=local)"
 
-reset:  ## Nuke all Docker volumes and rebuild from scratch (fresh app, no file changes)
-	cd docker && docker compose $(COMPOSE_FILES) down -v
+reset:  ## Nuke all Docker volumes, including optional observability, and rebuild core
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) down -v
 	cd docker && docker compose $(COMPOSE_FILES) up --build -d
 	@echo "Waiting for API to be healthy..."
 	@cd docker && until docker compose $(COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
 	cd docker && docker compose $(COMPOSE_FILES) restart observal-lb
 	@echo "API is healthy — all data has been reset."
 
+reset-prometheus:  ## Nuke all Docker volumes and rebuild with Prometheus
+	cd docker && docker compose $(OBSERVABILITY_COMPOSE_FILES) down -v
+	cd docker && docker compose $(OBSERVABILITY_COMPOSE_FILES) up --build -d
+	@echo "Waiting for API to be healthy..."
+	@cd docker && until docker compose $(OBSERVABILITY_COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && docker compose $(OBSERVABILITY_COMPOSE_FILES) restart observal-lb
+	@echo "API is healthy: all data has been reset."
+
+reset-observability:  ## Nuke all Docker volumes and rebuild with Prometheus and Grafana
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) down -v
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) up --build -d
+	@echo "Waiting for API to be healthy..."
+	@cd docker && until COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) restart observal-lb
+	@echo "API is healthy: all data has been reset."
+
 rebuild-clean:  ## Rebuild from scratch (no Docker cache), remove volumes, and restart
-	cd docker && docker compose $(COMPOSE_FILES) down -v && docker compose $(COMPOSE_FILES) build --no-cache && docker compose $(COMPOSE_FILES) up -d
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) down -v && docker compose $(COMPOSE_FILES) build --no-cache && docker compose $(COMPOSE_FILES) up -d
 	@echo "Waiting for API to be healthy..."
 	@cd docker && until docker compose $(COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
 	cd docker && docker compose $(COMPOSE_FILES) restart observal-lb
@@ -110,6 +153,12 @@ rebuild-clean:  ## Rebuild from scratch (no Docker cache), remove volumes, and r
 
 logs:  ## Tail Docker logs
 	cd docker && docker compose logs -f --tail=50
+
+logs-prometheus:  ## Tail Docker logs with Prometheus
+	cd docker && docker compose $(OBSERVABILITY_COMPOSE_FILES) logs -f --tail=50
+
+logs-observability:  ## Tail Docker logs with Prometheus and Grafana
+	cd docker && COMPOSE_PROFILES=grafana docker compose $(OBSERVABILITY_COMPOSE_FILES) logs -f --tail=50
 
 # ── Cleanup ──────────────────────────────────────────────
 

--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+services:
+  observal-prometheus:
+    image: prom/prometheus:v3.12.0
+    ports:
+      - "127.0.0.1:${PROMETHEUS_HOST_PORT:-9090}:9090"
+    volumes:
+      - ../prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      observal-api:
+        condition: service_healthy
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - observal-net
+
+  observal-grafana:
+    profiles: ["grafana"]
+    image: grafana/grafana-oss:11.6.5
+    ports:
+      - "127.0.0.1:${GRAFANA_HOST_PORT:-3001}:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-clickhouse}
+    volumes:
+      - ../grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    depends_on:
+      observal-clickhouse:
+        condition: service_healthy
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    networks:
+      - observal-net
+
+volumes:
+  grafanadata:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -256,54 +256,11 @@ services:
     networks:
       - observal-net
 
-  observal-prometheus:
-    image: prom/prometheus:v3.12.0
-    ports:
-      - "127.0.0.1:${PROMETHEUS_HOST_PORT:-9090}:9090"
-    volumes:
-      - ../prometheus.yml:/etc/prometheus/prometheus.yml:ro
-    depends_on:
-      observal-api:
-        condition: service_healthy
-    restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-    deploy:
-      resources:
-        limits:
-          memory: 256M
-    networks:
-      - observal-net
-
-  observal-grafana:
-    image: grafana/grafana-oss:11.6.5
-    ports:
-      - "127.0.0.1:${GRAFANA_HOST_PORT:-3001}:3000"
-    environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
-      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
-      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-clickhouse}
-    volumes:
-      - ../grafana/provisioning:/etc/grafana/provisioning:ro
-      - ../grafana/dashboards:/var/lib/grafana/dashboards:ro
-      - grafanadata:/var/lib/grafana
-    depends_on:
-      observal-clickhouse:
-        condition: service_healthy
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-    networks:
-      - observal-net
 
 volumes:
   pgdata:
   chdata:
   redisdata:
-  grafanadata:
   apidata:
 
 networks:

--- a/docker/server-package/docker-compose.observability.yml
+++ b/docker/server-package/docker-compose.observability.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+services:
+  observal-prometheus:
+    image: prom/prometheus:v3.12.0
+    ports:
+      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      observal-api:
+        condition: service_healthy
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - observal-net
+
+  observal-grafana:
+    profiles: ["grafana"]
+    image: grafana/grafana-oss:11.6.5
+    ports:
+      - "${GRAFANA_HOST_PORT:-3001}:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-clickhouse}
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    depends_on:
+      observal-clickhouse:
+        condition: service_healthy
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    networks:
+      - observal-net
+
+volumes:
+  grafanadata:

--- a/docker/server-package/docker-compose.yml
+++ b/docker/server-package/docker-compose.yml
@@ -143,7 +143,6 @@ services:
     command: ["/app/.venv/bin/python", "-c", "import asyncio; asyncio.set_event_loop(asyncio.new_event_loop()); from arq import run_worker; from worker import WorkerSettings; run_worker(WorkerSettings)"]
     env_file:
       - ./.env
-    environment:
     depends_on:
       observal-init:
         condition: service_completed_successfully
@@ -200,54 +199,11 @@ services:
     networks:
       - observal-net
 
-  observal-prometheus:
-    image: prom/prometheus:v3.12.0
-    ports:
-      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-    depends_on:
-      observal-api:
-        condition: service_healthy
-    restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-    deploy:
-      resources:
-        limits:
-          memory: 256M
-    networks:
-      - observal-net
-
-  observal-grafana:
-    image: grafana/grafana-oss:11.6.5
-    ports:
-      - "${GRAFANA_HOST_PORT:-3001}:3000"
-    environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
-      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
-      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-clickhouse}
-    volumes:
-      - ./grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
-      - grafanadata:/var/lib/grafana
-    depends_on:
-      observal-clickhouse:
-        condition: service_healthy
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-    networks:
-      - observal-net
 
 volumes:
   pgdata:
   chdata:
   redisdata:
-  grafanadata:
   apidata:
 
 networks:

--- a/docker/server-package/prometheus.yml
+++ b/docker/server-package/prometheus.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "observal-api"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["observal-api:8000"]
+        labels:
+          service: "observal-api"

--- a/docker/server-package/setup.sh
+++ b/docker/server-package/setup.sh
@@ -52,6 +52,24 @@ prompt_secret() {
     eval "$var_name=\"\$value\""
 }
 
+prompt_observability_stack() {
+    local value
+    while true; do
+        printf 'Bundled observability stack (none, prometheus, grafana) [none]: '
+        read -r value
+        value="${value:-none}"
+        case "$value" in
+            none | prometheus | grafana)
+                OBSERVABILITY_STACK="$value"
+                return 0
+                ;;
+            *)
+                warn "Choose one of: none, prometheus, grafana"
+                ;;
+        esac
+    done
+}
+
 generate_secret() {
     python3 -c "import secrets; print(secrets.token_urlsafe(32))" 2>/dev/null ||
         openssl rand -base64 32 2>/dev/null ||
@@ -169,6 +187,7 @@ echo ""
 SECRET_KEY_DEFAULT=$(generate_secret)
 POSTGRES_PW_DEFAULT=$(generate_secret | head -c 24)
 CLICKHOUSE_PW_DEFAULT=$(generate_secret | head -c 24)
+GRAFANA_PW_DEFAULT=$(generate_secret | head -c 24)
 
 if [ "$EDITION" = "enterprise" ]; then
     LICENSE_PROMPT="Enterprise license key"
@@ -181,6 +200,10 @@ prompt_with_default FRONTEND_URL "Frontend URL (your public domain)" "http://loc
 prompt_secret SECRET_KEY "Secret key" "$SECRET_KEY_DEFAULT"
 prompt_secret POSTGRES_PASSWORD "PostgreSQL password" "$POSTGRES_PW_DEFAULT"
 prompt_secret CLICKHOUSE_PASSWORD "ClickHouse password" "$CLICKHOUSE_PW_DEFAULT"
+prompt_observability_stack
+if [ "$OBSERVABILITY_STACK" = "grafana" ]; then
+    prompt_secret GRAFANA_ADMIN_PASSWORD "Grafana admin password" "$GRAFANA_PW_DEFAULT"
+fi
 
 echo ""
 
@@ -205,16 +228,24 @@ if [ "$EDITION" = "enterprise" ] && [ -n "$LICENSE_KEY" ]; then
     echo "OBSERVAL_LICENSE_KEY=$LICENSE_KEY" >>"$ENV_FILE"
 fi
 
+if [ "$OBSERVABILITY_STACK" = "grafana" ]; then
+    echo "" >>"$ENV_FILE"
+    echo "# Optional bundled observability" >>"$ENV_FILE"
+    echo "GRAFANA_ADMIN_USER=admin" >>"$ENV_FILE"
+    echo "GRAFANA_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD" >>"$ENV_FILE"
+fi
+
 chmod 600 "$ENV_FILE"
 
 # ── Enterprise: authenticate to private registry ────────────
 
 COMPOSE_FILES="-f docker-compose.yml"
+COMPOSE_PROFILE_ARGS=""
 
 if [ "$EDITION" = "enterprise" ]; then
     # Enterprise uses the enterprise compose overlay with ee/ services
     if [ -f "$INSTALL_DIR/docker-compose.enterprise.yml" ]; then
-        COMPOSE_FILES="-f docker-compose.yml -f docker-compose.enterprise.yml"
+        COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.enterprise.yml"
         info "Enterprise compose overlay enabled."
     fi
 
@@ -227,27 +258,40 @@ if [ "$EDITION" = "enterprise" ]; then
     fi
 fi
 
+if [ "$OBSERVABILITY_STACK" != "none" ]; then
+    if [ -f "$INSTALL_DIR/docker-compose.observability.yml" ]; then
+        COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.observability.yml"
+        info "Bundled observability stack enabled: $OBSERVABILITY_STACK"
+    else
+        die "docker-compose.observability.yml is missing from $INSTALL_DIR"
+    fi
+fi
+
+if [ "$OBSERVABILITY_STACK" = "grafana" ]; then
+    COMPOSE_PROFILE_ARGS="--profile grafana"
+fi
+
 # ── Start services ───────────────────────────────────────────
 
 info "Starting Observal services..."
 
 cd "$INSTALL_DIR"
-docker compose $COMPOSE_FILES --env-file .env up -d
+docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES --env-file .env up -d
 
 info "Waiting for API to be healthy..."
 for i in $(seq 1 60); do
-    if docker compose $COMPOSE_FILES exec -T observal-api \
+    if docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES exec -T observal-api \
         python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/readyz')" 2>/dev/null; then
         break
     fi
     if [ "$i" -eq 60 ]; then
-        die "API did not become healthy in 5 minutes. Check logs: docker compose $COMPOSE_FILES logs"
+        die "API did not become healthy in 5 minutes. Check logs: docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES logs"
     fi
     sleep 5
 done
 
 # Restart LB to pick up new API container IP
-docker compose $COMPOSE_FILES restart observal-lb
+docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES restart observal-lb
 sleep 2
 
 info ""
@@ -255,12 +299,14 @@ info "Observal is running! [$EDITION edition]"
 info ""
 info "  Dashboard:  $FRONTEND_URL"
 info "  API:        ${FRONTEND_URL%:*}:8000"
-info "  Grafana:    ${FRONTEND_URL%:*}:3001 (admin/admin)"
+if [ "$OBSERVABILITY_STACK" = "grafana" ]; then
+    info "  Grafana:    ${FRONTEND_URL%:*}:3001 (admin/$GRAFANA_ADMIN_PASSWORD)"
+fi
 info ""
 info "  Config:     $ENV_FILE"
-info "  Start:      cd $INSTALL_DIR && docker compose $COMPOSE_FILES up -d"
-info "  Stop:       cd $INSTALL_DIR && docker compose $COMPOSE_FILES down"
-info "  Logs:       cd $INSTALL_DIR && docker compose $COMPOSE_FILES logs -f"
+info "  Start:      cd $INSTALL_DIR && docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES up -d"
+info "  Stop:       cd $INSTALL_DIR && docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES down"
+info "  Logs:       cd $INSTALL_DIR && docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES logs -f"
 info ""
 if [ "$EDITION" = "enterprise" ]; then
     info "Enterprise features: SAML, SCIM, insights, self-learning"

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -210,8 +210,8 @@ docker compose -f docker/docker-compose.yml ps
 | --------------- | ----------------------- |
 | LB (all traffic)| `http://localhost`      |
 | Web UI (direct) | `http://localhost:3000` |
-| Grafana         | `http://localhost:3001` |
-| Prometheus      | `http://localhost:9090` |
+| Prometheus, optional | `http://localhost:9090` |
+| Grafana, optional | `http://localhost:3001` |
 | ClickHouse HTTP | `http://localhost:8123` |
 
 ### Install the CLI
@@ -281,7 +281,7 @@ scripts/            Dev tooling scripts
 
 They are not interchangeable. Never write telemetry to Postgres or relational data to ClickHouse.
 
-**Supporting services:** Redis (pub/sub + arq job queue), arq worker, nginx reverse proxy, Prometheus, Grafana.
+**Supporting services:** Redis (pub/sub + arq job queue), arq worker, nginx reverse proxy. Prometheus and Grafana are optional.
 
 See [AGENTS.md](../../AGENTS.md) for a complete map of every important file and service.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,7 @@ Observal has two parts: a **server** you self-host and a **CLI** installed on ea
 
 ## Install the server
 
-The server runs as a Docker Compose stack (API, web UI, PostgreSQL, ClickHouse, Redis, worker, load balancer, Prometheus, Grafana).
+The server runs as a Docker Compose stack (API, web UI, PostgreSQL, ClickHouse, Redis, worker, load balancer). Prometheus and Grafana are optional deployment overlays.
 
 > [!NOTE]
 > Requires Docker Engine ≥ 24.0 with Compose v2 (`docker compose`, not `docker-compose`). Homebrew's Docker formula is outdated. Install [Docker Desktop](https://docs.docker.com/get-docker/) or use your distro's upstream packages. Verify with `docker version` and `docker compose version`.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -38,7 +38,7 @@ cp .env.example .env
 docker compose -f docker/docker-compose.yml up --build -d
 ```
 
-That's it. The `.env.example` ships with working defaults. Ten services come up:
+That's it. The `.env.example` ships with working defaults. The core services come up:
 
 | Service               | URL                     | Purpose                        |
 | --------------------- | ----------------------- | ------------------------------ |
@@ -50,8 +50,8 @@ That's it. The `.env.example` ships with working defaults. Ten services come up:
 | `observal-db`         | `localhost:5432`        | PostgreSQL 16                  |
 | `observal-clickhouse` | `localhost:8123`        | ClickHouse                     |
 | `observal-redis`      | `localhost:6379`        | Redis                          |
-| `observal-prometheus` | `http://localhost:9090` | Prometheus                     |
-| `observal-grafana`    | `http://localhost:3001` | Grafana                        |
+
+Optional monitoring can be enabled with `make up-prometheus` or `make up-observability`. Prometheus listens on `http://localhost:9090`; Grafana listens on `http://localhost:3001` when the Grafana profile is enabled.
 
 The API waits for Postgres, ClickHouse, and Redis to pass health checks before starting. Expect 15–30 seconds. Confirm it is up:
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -92,7 +92,7 @@ These environment variables are **not required** if you use Bedrock API keys (re
 
 ### Docker host ports
 
-Used only by `docker/docker-compose.yml`. Remap if a default is already in use.
+Used only by Docker Compose. Prometheus and Grafana ports apply only when `docker-compose.observability.yml` is included. Remap if a default is already in use.
 
 | Variable               | Default | Service                |
 | ---------------------- | ------- | ---------------------- |
@@ -101,9 +101,12 @@ Used only by `docker/docker-compose.yml`. Remap if a default is already in use.
 | `POSTGRES_HOST_PORT`   | `5432`  | Postgres               |
 | `CLICKHOUSE_HOST_PORT` | `8123`  | ClickHouse             |
 | `REDIS_HOST_PORT`      | `6379`  | Redis                  |
-| `GRAFANA_HOST_PORT`    | `3001`  | Grafana                |
+| `PROMETHEUS_HOST_PORT` | `9090`  | Prometheus, optional   |
+| `GRAFANA_HOST_PORT`    | `3001`  | Grafana, optional      |
 
 ### Grafana
+
+Only used when the optional Grafana overlay or Terraform `observability_stack = "grafana"` is enabled.
 
 | Variable                 | Default | Description            |
 | ------------------------ | ------- | ---------------------- |

--- a/docs/self-hosting/aws-terraform.md
+++ b/docs/self-hosting/aws-terraform.md
@@ -3,7 +3,7 @@
 
 # AWS deployment with Terraform
 
-End state: an Observal install running in your own AWS account, fronted by an Application Load Balancer with HTTPS, with managed Postgres + Redis, ECS Fargate for the stateless app tier, and a single EC2 host for ClickHouse + Grafana + Prometheus.
+End state: an Observal install running in your own AWS account, fronted by an Application Load Balancer with HTTPS, with managed Postgres + Redis, ECS Fargate for the stateless app tier, and a single EC2 host for ClickHouse. Prometheus and Grafana are optional through `observability_stack`.
 
 This is the recommended path for enterprise self-hosting on AWS. If you only want to evaluate Observal, use [Docker Compose setup](docker-compose.md) instead.
 
@@ -12,7 +12,7 @@ This is the recommended path for enterprise self-hosting on AWS. If you only wan
 A single `terraform apply` creates:
 
 - **VPC** with public + private subnets across two availability zones, NAT gateway, VPC flow logs
-- **Application Load Balancer** with HTTPS (ACM certificate, DNS-validated) when you supply a domain; HTTP-only otherwise. Path-based rules: `/api/*` → api service, `/grafana/*` → Grafana, default → web
+- **Application Load Balancer** with HTTPS (ACM certificate, DNS-validated) when you supply a domain; HTTP-only otherwise. Path-based rules: `/api/*` → api service, optional `/grafana/*` → Grafana, default → web
 - **ECS Fargate cluster** running:
     - `api` (FastAPI): 2 tasks by default, autoscales 2–10 on CPU
     - `web` (Next.js): 2 tasks by default, autoscales 2–6 on CPU
@@ -20,10 +20,10 @@ A single `terraform apply` creates:
     - `init` (one-shot migrations + seeds): runs as a Fargate `RunTask` whenever `image_tag` changes
 - **RDS Postgres 16**: Multi-AZ on `prod`, encrypted, automated daily backups, Performance Insights, Enhanced Monitoring, log exports
 - **ElastiCache Redis 7**: 2-node replication group with automatic failover on `prod`, slow-log to CloudWatch
-- **Data tier EC2** (Amazon Linux 2023): single host running ClickHouse + Grafana + Prometheus on EBS gp3, ENI with static private IP, internal Route 53 zone for DNS, daily ClickHouse → S3 snapshot via systemd timer
+- **Data tier EC2** (Amazon Linux 2023): single host running ClickHouse on EBS gp3, optional Prometheus and Grafana, ENI with static private IP, internal Route 53 zone for DNS, daily ClickHouse → S3 snapshot via systemd timer
 - **S3 backups bucket**: versioned, AES256, lifecycle to STANDARD_IA → GLACIER_IR → expire, TLS-only
 - **CloudWatch log groups**: per ECS service, data host, RDS, Redis slow log, VPC flow logs
-- **SSM Parameter Store**: generated DB / ClickHouse / SECRET_KEY / Grafana passwords, plus pre-built connection URLs injected into ECS tasks
+- **SSM Parameter Store**: generated DB / ClickHouse / SECRET_KEY / optional Grafana passwords, plus pre-built connection URLs injected into ECS tasks
 - **SSM Session Manager**: shell access to the data host, no SSH
 
 ClickHouse runs on EC2 because AWS does not offer a managed ClickHouse service. The data volume keeps it durable across instance replacements. For real ClickHouse HA, set `clickhouse_mode = "cloud"` and point at ClickHouse Cloud.
@@ -138,9 +138,10 @@ api_autoscale_max    = 10
 web_desired_count    = 2
 worker_desired_count = 1
 
-# Data tier (ClickHouse + Grafana + Prometheus)
+# Data tier (ClickHouse)
 data_instance_type   = "t3.large"   # 8 GB - minimum viable for ClickHouse
 data_volume_size_gb  = 100
+observability_stack  = "none"       # none | prometheus | grafana
 
 db_instance_class    = "db.t4g.small"
 redis_node_type      = "cache.t4g.micro"
@@ -157,7 +158,7 @@ clickhouse_cloud_user     = "default"
 clickhouse_cloud_password = "..."
 ```
 
-The EC2 data host, EBS volume, internal DNS records, Grafana, and Prometheus are all skipped. You become responsible for Grafana hosting yourself (typically AWS Managed Grafana).
+The EC2 data host, EBS volume, internal DNS records, and bundled observability are all skipped. You become responsible for monitoring and dashboards yourself, typically AWS Managed Grafana or Grafana Cloud.
 
 ### Application options
 

--- a/docs/self-hosting/docker-compose.md
+++ b/docs/self-hosting/docker-compose.md
@@ -5,7 +5,7 @@
 
 # Docker Compose setup
 
-Step-by-step bring-up of the Observal stack. End state: ten healthy services, API responding at `http://localhost/health`, web UI at `http://localhost`.
+Step-by-step bring-up of the Observal stack. End state: the core services are healthy, API responding at `http://localhost/health`, web UI at `http://localhost`. Prometheus and Grafana are optional.
 
 ## 1. Clone and configure
 
@@ -22,8 +22,22 @@ The `.env.example` ships with working defaults for every setting, including demo
 
 ## 2. Start the stack
 
+Core stack only:
+
 ```bash
 docker compose -f docker/docker-compose.yml up --build -d
+```
+
+With Prometheus only:
+
+```bash
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml up --build -d
+```
+
+With Prometheus and Grafana:
+
+```bash
+COMPOSE_PROFILES=grafana docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml up --build -d
 ```
 
 First build takes a few minutes (pulls images, builds `observal-api` and `observal-web`). Subsequent starts are fast.
@@ -96,11 +110,11 @@ observal registry mcp list         # empty list - you haven't added anything yet
 ## 7. Stop, restart, rebuild
 
 ```bash
-# Stop
-docker compose -f docker/docker-compose.yml down
+# Stop core and any optional monitoring containers
+make down
 
-# Stop + DELETE all data (wipes volumes - be careful)
-docker compose -f docker/docker-compose.yml down -v
+# Stop and delete all data, including optional monitoring volumes
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml --profile grafana down -v
 
 # Restart one service
 docker compose -f docker/docker-compose.yml restart observal-api
@@ -112,8 +126,12 @@ docker compose -f docker/docker-compose.yml up --build -d observal-api
 Makefile shortcuts from the repo root:
 
 ```bash
-make logs       # tail all service logs
-make rebuild    # rebuild and restart everything
+make logs                  # tail core service logs
+make rebuild               # rebuild and restart core services
+make up-prometheus         # start core services with Prometheus
+make up-observability      # start core services with Prometheus and Grafana
+make rebuild-prometheus    # rebuild core services with Prometheus
+make rebuild-observability # rebuild core services with Prometheus and Grafana
 ```
 
 ## 8. Logs

--- a/docs/self-hosting/gcp-terraform.md
+++ b/docs/self-hosting/gcp-terraform.md
@@ -16,7 +16,7 @@ A single `terraform apply` creates:
 - **Cloud Run v2 job**: `init` (one-shot migrations + seeds)
 - **Cloud SQL Postgres** (Enterprise edition): optional HA, encrypted, automated backups
 - **Memorystore Redis**: BASIC or STANDARD_HA tier
-- **GCE instance** (data host): ClickHouse + Grafana + Prometheus on a persistent disk, accessible via IAP SSH tunnel
+- **GCE instance** (data host): ClickHouse on a persistent disk, with optional Prometheus and Grafana, accessible via IAP SSH tunnel
 - **Global HTTPS Load Balancer** with managed SSL certificate (when domain is supplied)
 - **Cloud DNS** A record pointing to the load balancer
 - **Secret Manager**: generated DB / ClickHouse / SECRET_KEY passwords, plus connection URLs injected into Cloud Run services

--- a/docs/self-hosting/ports-and-volumes.md
+++ b/docs/self-hosting/ports-and-volumes.md
@@ -15,7 +15,8 @@ Every exposed port and persistent volume, at a glance.
 | Postgres | 5432 | `POSTGRES_HOST_PORT` | TCP |
 | ClickHouse | 8123 | `CLICKHOUSE_HOST_PORT` | HTTP |
 | Redis | 6379 | `REDIS_HOST_PORT` | TCP |
-| Grafana | 3001 | `GRAFANA_HOST_PORT` | HTTP |
+| Prometheus, optional | 9090 | `PROMETHEUS_HOST_PORT` | HTTP |
+| Grafana, optional | 3001 | `GRAFANA_HOST_PORT` | HTTP |
 
 The worker has no exposed port; it talks to Redis and ClickHouse internally only.
 
@@ -46,7 +47,7 @@ All volumes are named and managed by Docker. They survive `docker compose down` 
 | `pgdata` | `/var/lib/postgresql/data` | Postgres data (users, registry, RBAC) | Catastrophic - all accounts, agents, MCPs lost |
 | `chdata` | `/var/lib/clickhouse` | ClickHouse data (traces, spans, scores) | High - all telemetry lost; accounts and registry survive |
 | `redisdata` | `/data` | Redis persistence | Low - job queue lost; pending jobs need to be re-kicked |
-| `grafanadata` | `/var/lib/grafana` | Grafana dashboards and config | Medium - custom dashboards lost; defaults are re-provisioned |
+| `grafanadata`, optional | `/var/lib/grafana` | Grafana dashboards and config | Medium - custom dashboards lost; defaults are re-provisioned |
 | `apidata` | `/data` (API container) | **JWT signing keys** | Catastrophic - every session invalidated, users must re-login; backup/restore required |
 
 **Back up `apidata` and `pgdata` before any upgrade.** See [Backup and restore](backup-and-restore.md).

--- a/docs/self-hosting/single-node-deploy.md
+++ b/docs/self-hosting/single-node-deploy.md
@@ -328,7 +328,19 @@ observal server upgrade --version 1.5.0
 
 ## Monitoring
 
-The stack includes Prometheus and Grafana. Access Grafana at `http://your-server:3001` (default admin/admin).
+Prometheus and Grafana are optional. Start the core stack with Prometheus only:
+
+```bash
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml up -d
+```
+
+Start Prometheus and Grafana:
+
+```bash
+COMPOSE_PROFILES=grafana docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml up -d
+```
+
+Access Grafana at `http://your-server:3001` when the Grafana profile is enabled.
 
 For basic alerting without Grafana, add a health check cron:
 

--- a/infra/terraform/aws-ec2/deploy.sh
+++ b/infra/terraform/aws-ec2/deploy.sh
@@ -20,6 +20,7 @@ IMAGE_TAG=$(terraform output -raw image_tag)
 OBSERVAL_REF=$(terraform output -raw observal_ref)
 OBSERVAL_REPO=$(terraform output -raw observal_repo)
 ENV_OVERRIDES=$(terraform output -json env_overrides 2>/dev/null || echo "{}")
+OBSERVABILITY_STACK=$(terraform output -raw observability_stack 2>/dev/null || echo "none")
 
 echo "=== Observal EC2 Deploy ==="
 echo "  Instance:  $INSTANCE_ID"
@@ -27,6 +28,7 @@ echo "  IP:        $PUBLIC_IP"
 echo "  Region:    $REGION"
 echo "  Domain:    ${DOMAIN:-"(none — HTTP only)"}"
 echo "  Image:     ghcr.io/blazeup-ai/observal-api:$IMAGE_TAG"
+echo "  Observability: $OBSERVABILITY_STACK"
 echo ""
 
 # ── Helper: run command on instance via SSM ──────────────────────────────────
@@ -126,12 +128,17 @@ echo "Configuring environment..."
 SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))" 2>/dev/null || openssl rand -base64 32)
 POSTGRES_PW=$(python3 -c "import secrets; print(secrets.token_urlsafe(18))" 2>/dev/null || openssl rand -base64 18)
 CLICKHOUSE_PW=$(python3 -c "import secrets; print(secrets.token_urlsafe(18))" 2>/dev/null || openssl rand -base64 18)
+GRAFANA_PW=$(python3 -c "import secrets; print(secrets.token_urlsafe(18))" 2>/dev/null || openssl rand -base64 18)
 
 FRONTEND_URL="${DOMAIN:+https://$DOMAIN}"
 FRONTEND_URL="${FRONTEND_URL:-http://$PUBLIC_IP}"
 
 # Generate .env from template
 run_remote "cd /opt/observal && cp env.template .env && sed -i 's|__SECRET_KEY__|$SECRET_KEY|g' .env && sed -i 's|__POSTGRES_PASSWORD__|$POSTGRES_PW|g' .env && sed -i 's|__CLICKHOUSE_PASSWORD__|$CLICKHOUSE_PW|g' .env && sed -i 's|__FRONTEND_URL__|$FRONTEND_URL|g' .env && echo 'OBSERVAL_VERSION=$IMAGE_TAG' >> .env && chmod 600 .env"
+
+if [ "$OBSERVABILITY_STACK" = "grafana" ]; then
+  run_remote "cd /opt/observal && echo 'GRAFANA_ADMIN_USER=admin' >> .env && echo 'GRAFANA_ADMIN_PASSWORD=$GRAFANA_PW' >> .env"
+fi
 
 # Apply env overrides (skip empty values)
 while IFS='=' read -r key value; do
@@ -149,11 +156,20 @@ fi
 
 # ── Pull and start (pre-built images — fast) ────────────────────────────────
 
+COMPOSE_FILES="-f docker-compose.yml"
+COMPOSE_PROFILE_ARGS=""
+if [ "$OBSERVABILITY_STACK" != "none" ]; then
+  COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.observability.yml"
+fi
+if [ "$OBSERVABILITY_STACK" = "grafana" ]; then
+  COMPOSE_PROFILE_ARGS="--profile grafana"
+fi
+
 echo "Pulling pre-built images from GHCR..."
-run_remote "cd /opt/observal && docker compose pull" 300
+run_remote "cd /opt/observal && docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES pull" 300
 
 echo "Starting services..."
-run_remote "cd /opt/observal && docker compose --env-file .env up -d"
+run_remote "cd /opt/observal && docker compose $COMPOSE_PROFILE_ARGS $COMPOSE_FILES --env-file .env up -d"
 
 # ── Health check ─────────────────────────────────────────────────────────────
 

--- a/infra/terraform/aws-ec2/main.tf
+++ b/infra/terraform/aws-ec2/main.tf
@@ -108,6 +108,17 @@ resource "aws_security_group" "observal" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  dynamic "ingress" {
+    for_each = var.observability_stack == "grafana" ? [1] : []
+    content {
+      description = "Grafana"
+      from_port   = 3001
+      to_port     = 3001
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/infra/terraform/aws-ec2/outputs.tf
+++ b/infra/terraform/aws-ec2/outputs.tf
@@ -42,6 +42,11 @@ output "env_overrides" {
   sensitive   = true
 }
 
+output "observability_stack" {
+  description = "Bundled observability stack"
+  value       = var.observability_stack
+}
+
 output "observal_repo" {
   description = "Git repository URL"
   value       = var.observal_repo

--- a/infra/terraform/aws-ec2/variables.tf
+++ b/infra/terraform/aws-ec2/variables.tf
@@ -48,6 +48,17 @@ variable "env_overrides" {
   default     = {}
 }
 
+variable "observability_stack" {
+  description = "Bundled observability stack to deploy: none, prometheus, or grafana. grafana includes prometheus."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "prometheus", "grafana"], var.observability_stack)
+    error_message = "observability_stack must be one of: none, prometheus, grafana."
+  }
+}
+
 variable "image_tag" {
   description = "Observal image tag to deploy from GHCR (e.g. 'latest', 'v1.5.0')"
   type        = string

--- a/infra/terraform/aws-standard/alb.tf
+++ b/infra/terraform/aws-standard/alb.tf
@@ -57,6 +57,7 @@ resource "aws_lb_target_group" "web" {
 }
 
 resource "aws_lb_target_group" "grafana" {
+  count       = local.observability_grafana_enabled ? 1 : 0
   name        = "${local.name}-grafana-tg"
   port        = 3001
   protocol    = "HTTP"
@@ -78,7 +79,8 @@ resource "aws_lb_target_group" "grafana" {
 }
 
 resource "aws_lb_target_group_attachment" "grafana" {
-  target_group_arn = aws_lb_target_group.grafana.arn
+  count            = local.observability_grafana_enabled ? 1 : 0
+  target_group_arn = aws_lb_target_group.grafana[0].arn
   target_id        = aws_network_interface.data_host.private_ip
   port             = 3001
 }
@@ -126,13 +128,13 @@ resource "aws_lb_listener_rule" "http_api" {
 }
 
 resource "aws_lb_listener_rule" "http_grafana" {
-  count        = local.enable_tls ? 0 : 1
+  count        = (local.enable_tls ? 0 : 1) * (local.observability_grafana_enabled ? 1 : 0)
   listener_arn = aws_lb_listener.http.arn
   priority     = 200
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.grafana.arn
+    target_group_arn = aws_lb_target_group.grafana[0].arn
   }
 
   condition {
@@ -211,13 +213,13 @@ resource "aws_lb_listener_rule" "https_api" {
 }
 
 resource "aws_lb_listener_rule" "https_grafana" {
-  count        = local.enable_tls ? 1 : 0
+  count        = (local.enable_tls ? 1 : 0) * (local.observability_grafana_enabled ? 1 : 0)
   listener_arn = aws_lb_listener.https[0].arn
   priority     = 200
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.grafana.arn
+    target_group_arn = aws_lb_target_group.grafana[0].arn
   }
 
   condition {

--- a/infra/terraform/aws-standard/data-host.tf
+++ b/infra/terraform/aws-standard/data-host.tf
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 BlazeUp AI
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Data tier: a single EC2 host running Postgres + Redis + ClickHouse + Grafana + Prometheus.
+# Data tier: a single EC2 host running Postgres, Redis, ClickHouse, and optional observability.
 # All services run via Docker Compose, bootstrapped from user-data.
 
 data "aws_ami" "al2023" {
@@ -37,13 +37,15 @@ resource "aws_ebs_volume" "data" {
 
 locals {
   data_host_user_data = templatefile("${path.module}/data-user-data.sh.tftpl", {
-    region              = var.region
-    ssm_prefix          = local.ssm_prefix
-    db_password         = random_password.db.result
-    clickhouse_password = random_password.clickhouse.result
-    data_volume_size_gb = local.effective_data_volume_size_gb
-    log_group           = aws_cloudwatch_log_group.data_host.name
-    grafana_root_url    = local.app_url
+    region                           = var.region
+    ssm_prefix                       = local.ssm_prefix
+    db_password                      = random_password.db.result
+    clickhouse_password              = random_password.clickhouse.result
+    data_volume_size_gb              = local.effective_data_volume_size_gb
+    log_group                        = aws_cloudwatch_log_group.data_host.name
+    grafana_root_url                 = local.app_url
+    observability_prometheus_enabled = local.observability_prometheus_enabled
+    observability_grafana_enabled    = local.observability_grafana_enabled
   })
 }
 
@@ -113,6 +115,7 @@ resource "aws_route53_record" "clickhouse_internal" {
 }
 
 resource "aws_route53_record" "grafana_internal" {
+  count   = local.observability_grafana_enabled ? 1 : 0
   zone_id = aws_route53_zone.internal.zone_id
   name    = "grafana.${var.internal_dns_zone}"
   type    = "A"

--- a/infra/terraform/aws-standard/data-user-data.sh.tftpl
+++ b/infra/terraform/aws-standard/data-user-data.sh.tftpl
@@ -4,7 +4,7 @@
 
 set -eo pipefail
 
-# Bootstrap the data tier host: Postgres + Redis + ClickHouse + Grafana + Prometheus via Docker Compose.
+# Bootstrap the data tier host: Postgres, Redis, ClickHouse, and optional observability via Docker Compose.
 
 exec > >(tee /var/log/observal-bootstrap.log | logger -t observal-bootstrap -s 2>/dev/console) 2>&1
 echo "Observal data-host bootstrap starting at $(date -u)"
@@ -36,12 +36,22 @@ mkdir -p /data
 UUID=$(blkid -s UUID -o value "$DEVICE")
 grep -q "$UUID" /etc/fstab || echo "UUID=$UUID /data ext4 defaults,nofail 0 2" >> /etc/fstab
 mount -a
-mkdir -p /data/postgres /data/redis /data/clickhouse /data/grafana /data/prometheus
+mkdir -p /data/postgres /data/redis /data/clickhouse
+%{ if observability_grafana_enabled }
+mkdir -p /data/grafana
+%{ endif }
+%{ if observability_prometheus_enabled }
+mkdir -p /data/prometheus
+%{ endif }
 chown -R 999:999 /data/postgres      || true   # postgres user
 chown -R 999:1000 /data/redis        || true   # redis user
 chown -R 101:101 /data/clickhouse    || true   # clickhouse user
+%{ if observability_grafana_enabled }
 chown -R 472:472 /data/grafana       || true   # grafana user
+%{ endif }
+%{ if observability_prometheus_enabled }
 chown -R 65534:65534 /data/prometheus || true   # nobody
+%{ endif }
 
 # ── Pull secrets from SSM ────────────────────────────────────────
 set +x
@@ -87,6 +97,7 @@ cat > "$INSTALL_DIR/clickhouse/users.d/default-user.xml" <<CHUSER
 </clickhouse>
 CHUSER
 
+%{ if observability_prometheus_enabled }
 # Prometheus config
 cat > "$INSTALL_DIR/prometheus.yml" <<'PROM'
 global:
@@ -100,6 +111,7 @@ scrape_configs:
       - targets: ['localhost:9187']
 PROM
 
+%{ endif }
 cat > "$INSTALL_DIR/docker-compose.yml" <<COMPOSE
 services:
   postgres:
@@ -156,6 +168,7 @@ services:
       timeout: 5s
       retries: 5
 
+%{ if observability_grafana_enabled }
   grafana:
     image: grafana/grafana-oss:11.6.5
     container_name: observal-grafana
@@ -173,7 +186,8 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
-
+%{ endif }
+%{ if observability_prometheus_enabled }
   prometheus:
     image: prom/prometheus:v3.11.3
     container_name: observal-prometheus
@@ -187,6 +201,7 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=15d
+%{ endif }
 COMPOSE
 
 # ── Start ────────────────────────────────────────────────────────

--- a/infra/terraform/aws-standard/locals.tf
+++ b/infra/terraform/aws-standard/locals.tf
@@ -24,6 +24,9 @@ locals {
   is_enterprise = var.observal_license_key != ""
   ssm_prefix    = "/${local.name}"
 
+  observability_prometheus_enabled = contains(["prometheus", "grafana"], var.observability_stack)
+  observability_grafana_enabled    = var.observability_stack == "grafana"
+
   api_image = "${var.image_repo_api}:${var.image_tag}"
   web_image = "${var.image_repo_web}:${var.image_tag}"
 

--- a/infra/terraform/aws-standard/security.tf
+++ b/infra/terraform/aws-standard/security.tf
@@ -67,7 +67,7 @@ resource "aws_security_group" "ecs_instances" {
   tags = { Name = "${local.name}-ecs-instances-sg" }
 }
 
-# ── Data host (Postgres + Redis + ClickHouse + Grafana + Prometheus) ──────
+# ── Data host (Postgres, Redis, ClickHouse, optional observability) ───────
 resource "aws_security_group" "data_host" {
   name        = "${local.name}-data-host"
   description = "Data tier EC2: Postgres, Redis, ClickHouse, Grafana, Prometheus."
@@ -105,12 +105,15 @@ resource "aws_security_group" "data_host" {
     security_groups = [aws_security_group.ecs_instances.id]
   }
 
-  ingress {
-    description     = "Grafana UI from ALB"
-    from_port       = 3001
-    to_port         = 3001
-    protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id]
+  dynamic "ingress" {
+    for_each = local.observability_grafana_enabled ? [1] : []
+    content {
+      description     = "Grafana UI from ALB"
+      from_port       = 3001
+      to_port         = 3001
+      protocol        = "tcp"
+      security_groups = [aws_security_group.alb.id]
+    }
   }
 
   egress {

--- a/infra/terraform/aws-standard/terraform.tfvars.example
+++ b/infra/terraform/aws-standard/terraform.tfvars.example
@@ -34,9 +34,10 @@ image_tag = "latest"
 # worker_memory        = 1024
 # worker_desired_count = 1
 
-# ── Data tier EC2 (Postgres + Redis + ClickHouse + Grafana + Prometheus) ──
+# ── Data tier EC2 (Postgres, Redis, ClickHouse) ───────────────────────
 # data_instance_type   = "t3.medium"
 # data_volume_size_gb  = 100
+# observability_stack  = "none"            # one of: none, prometheus, grafana
 
 # ── Access ────────────────────────────────────────────────────────────
 # Restrict ALB ingress for private installs (e.g. office VPN, corporate egress).

--- a/infra/terraform/aws-standard/variables.tf
+++ b/infra/terraform/aws-standard/variables.tf
@@ -214,6 +214,17 @@ variable "alb_scheme" {
 
 # ── Application ───────────────────────────────────────────────────────────────
 
+variable "observability_stack" {
+  description = "Bundled observability stack to deploy: none, prometheus, or grafana. grafana includes prometheus."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "prometheus", "grafana"], var.observability_stack)
+    error_message = "observability_stack must be one of: none, prometheus, grafana."
+  }
+}
+
 variable "observal_license_key" {
   description = "Observal Enterprise license key. Leave empty for community."
   type        = string

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -10,10 +10,10 @@ Production-shaped self-hosted Observal in your own AWS account. One `terraform a
 - **ECS Fargate cluster** - `api`, `web`, `worker` as separate services with target-tracking CPU autoscaling. `init` runs as a one-shot `RunTask` on every image bump
 - **RDS Postgres 16** - Multi-AZ on `prod`, encrypted, automated backups, Performance Insights, Enhanced Monitoring, log exports
 - **ElastiCache Redis 7** - 2-node replication group with automatic failover on `prod`, slow-log to CloudWatch
-- **Data tier EC2**: single host running ClickHouse + Grafana + Prometheus on EBS gp3, ENI with static private IP, internal Route 53 zone for DNS, daily ClickHouse → S3 snapshot via systemd timer
+- **Data tier EC2**: single host running ClickHouse on EBS gp3, optional Prometheus and Grafana, ENI with static private IP, internal Route 53 zone for DNS, daily ClickHouse → S3 snapshot via systemd timer
 - **S3 backups bucket**: versioned, AES256, lifecycle to STANDARD_IA → GLACIER_IR → expire, TLS-only access
 - **CloudWatch log groups**: per-service for ECS tasks, data host, RDS, Redis, VPC flow logs
-- **SSM Parameter Store**: generated DB / ClickHouse / SECRET_KEY / Grafana passwords, plus pre-built connection URLs injected into ECS tasks
+- **SSM Parameter Store**: generated DB / ClickHouse / SECRET_KEY / optional Grafana passwords, plus pre-built connection URLs injected into ECS tasks
 - **SSM Session Manager**: shell access to the data host, no SSH
 
 ## Architecture
@@ -22,14 +22,14 @@ Production-shaped self-hosted Observal in your own AWS account. One `terraform a
                       ┌──────────────────────────┐
                 Internet → │   ALB (443)   │
                       └──┬─────┬─────┬──────────┘
-              path /api/*│     │/grafana/*
+              path /api/*│     │/grafana/* optional
                          ▼     ▼     ▼ default
               ┌──────────────┐  ┌────────────────┐  ┌──────────┐
               │ ECS Fargate  │  │  EC2 data host │  │   ECS    │
               │ api service  │  │  (single AZ)   │  │   web    │
               │  2..10×      │  │  ClickHouse    │  │ 2..6×    │
-              └─────┬────────┘  │  Grafana 3001  │  └──────────┘
-                    │           │  Prometheus    │
+              └─────┬────────┘  │  optional      │  └──────────┘
+                    │           │  observability │
               ┌─────┴────────┐  └────────┬───────┘
               │ ECS Fargate  │           │
               │   worker     │           │
@@ -43,7 +43,7 @@ Production-shaped self-hosted Observal in your own AWS account. One `terraform a
          └──────────────────────────────┘
 ```
 
-The stateless app tier (api/web/worker) lives on Fargate across both AZs with autoscaling and rolling deploys. The stateful data tier (ClickHouse + Grafana + Prometheus) lives on a single EC2 with EBS so ClickHouse keeps its disk across instance replacements. Real ClickHouse HA is out of scope; set `clickhouse_mode = "cloud"` and point at ClickHouse Cloud when you need it.
+The stateless app tier (api/web/worker) lives on Fargate across both AZs with autoscaling and rolling deploys. The stateful data tier lives on a single EC2 with EBS so ClickHouse keeps its disk across instance replacements. Prometheus and Grafana are enabled with `observability_stack`. Real ClickHouse HA is out of scope; set `clickhouse_mode = "cloud"` and point at ClickHouse Cloud when you need it.
 
 ## Prerequisites
 
@@ -304,14 +304,14 @@ iam.tf                     # ECS execution + task roles, EC2 data-host role
 secrets.tf                 # random_password + SSM Parameter Store (raw + URLs)
 postgresql.tf              # RDS Postgres + Enhanced Monitoring role
 redis.tf                   # ElastiCache replication group
-clickhouse.tf              # data-tier EC2 (CH + Grafana + Prometheus), private DNS
+clickhouse.tf              # data-tier EC2 (CH plus optional observability), private DNS
 ecs.tf                     # Fargate cluster, task defs, services, autoscaling, init
 alb.tf                     # ALB, target groups, listeners, listener rules, ACM
 s3.tf                      # backups bucket with lifecycle and TLS-only policy
 logs.tf                    # CloudWatch log groups
 dns.tf                     # public Route 53 record (alias to ALB)
 outputs.tf                 # app_url, ecs cluster/services, log groups, ...
-user-data.sh.tftpl         # cloud-init for the data host (CH + Grafana + Prometheus)
+user-data.sh.tftpl         # cloud-init for the data host
 terraform.tfvars.example
 examples/minimal/          # ready-to-apply module-call example
 ```

--- a/infra/terraform/aws/alb.tf
+++ b/infra/terraform/aws/alb.tf
@@ -58,7 +58,7 @@ resource "aws_lb_target_group" "api" {
 }
 
 resource "aws_lb_target_group" "grafana" {
-  count       = local.clickhouse_self_hosted ? 1 : 0
+  count       = local.bundled_grafana_available ? 1 : 0
   name        = "${local.name}-grafana-tg"
   port        = 3001
   protocol    = "HTTP"
@@ -80,7 +80,7 @@ resource "aws_lb_target_group" "grafana" {
 }
 
 resource "aws_lb_target_group_attachment" "grafana" {
-  count            = local.clickhouse_self_hosted ? 1 : 0
+  count            = local.bundled_grafana_available ? 1 : 0
   target_group_arn = aws_lb_target_group.grafana[0].arn
   target_id        = aws_network_interface.data_host[0].private_ip
   port             = 3001
@@ -171,7 +171,7 @@ resource "aws_lb_listener_rule" "http_api_docs" {
 }
 
 resource "aws_lb_listener_rule" "http_grafana" {
-  count        = (local.enable_tls ? 0 : 1) * (local.clickhouse_self_hosted ? 1 : 0)
+  count        = (local.enable_tls ? 0 : 1) * (local.bundled_grafana_available ? 1 : 0)
   listener_arn = aws_lb_listener.http.arn
   priority     = 200
 
@@ -294,7 +294,7 @@ resource "aws_lb_listener_rule" "https_api_docs" {
 }
 
 resource "aws_lb_listener_rule" "https_grafana" {
-  count        = (local.enable_tls ? 1 : 0) * (local.clickhouse_self_hosted ? 1 : 0)
+  count        = (local.enable_tls ? 1 : 0) * (local.bundled_grafana_available ? 1 : 0)
   listener_arn = aws_lb_listener.https[0].arn
   priority     = 200
 

--- a/infra/terraform/aws/clickhouse.tf
+++ b/infra/terraform/aws/clickhouse.tf
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Data tier: a single EC2 host running ClickHouse + Grafana + Prometheus.
+# Data tier: a single EC2 host running ClickHouse plus optional observability.
 #
-# Why one host: ClickHouse needs persistent disk (no managed AWS offering); Grafana
-# queries ClickHouse heavily so co-locating avoids cross-AZ latency; Prometheus is
-# small and pairs naturally with Grafana. All three are managed via docker-compose
-# bootstrapped from user-data.
+# Why one host: ClickHouse needs persistent disk (no managed AWS offering). When
+# bundled observability is enabled, Prometheus and Grafana run on the same host.
+# The stack is managed via docker-compose bootstrapped from user-data.
 #
 # Why not an ASG: a 1-instance ASG buys nothing for HA (CH state lives on EBS,
 # not the instance) and complicates DNS. An aws_instance with a static private IP
@@ -14,8 +13,7 @@
 # the same either way; the answer for real CH HA is ClickHouse Cloud.
 #
 # When clickhouse_mode = "cloud", none of the resources in this file are created;
-# Grafana + Prometheus are skipped entirely (Grafana with Cloud is left to the
-# user — typically AWS Managed Grafana or Grafana Cloud).
+# Bundled observability is also skipped. Use AWS Managed Grafana or Grafana Cloud.
 
 data "aws_ami" "al2023" {
   count       = local.clickhouse_self_hosted ? 1 : 0
@@ -54,15 +52,17 @@ resource "aws_network_interface" "data_host" {
 
 locals {
   data_host_user_data = local.clickhouse_self_hosted ? templatefile("${path.module}/user-data.sh.tftpl", {
-    region                 = var.region
-    ssm_prefix             = local.ssm_prefix
-    image_tag              = var.image_tag
-    log_group              = aws_cloudwatch_log_group.data_host.name
-    backups_bucket         = aws_s3_bucket.backups.bucket
-    grafana_admin_user     = "admin"
-    clickhouse_db          = "observal"
-    grafana_root_url       = local.app_url
-    grafana_subpath_prefix = "/grafana"
+    region                           = var.region
+    ssm_prefix                       = local.ssm_prefix
+    image_tag                        = var.image_tag
+    log_group                        = aws_cloudwatch_log_group.data_host.name
+    backups_bucket                   = aws_s3_bucket.backups.bucket
+    grafana_admin_user               = "admin"
+    clickhouse_db                    = "observal"
+    grafana_root_url                 = local.app_url
+    grafana_subpath_prefix           = "/grafana"
+    observability_prometheus_enabled = local.observability_prometheus_enabled
+    observability_grafana_enabled    = local.observability_grafana_enabled
   }) : ""
 }
 
@@ -106,7 +106,7 @@ resource "aws_volume_attachment" "data" {
   instance_id = aws_instance.data_host[0].id
 }
 
-# ── Internal DNS so ECS tasks can reach ClickHouse + Grafana ───────────────
+# ── Internal DNS so ECS tasks can reach ClickHouse and optional Grafana ────
 
 resource "aws_route53_record" "clickhouse_internal" {
   count   = local.clickhouse_self_hosted ? 1 : 0
@@ -118,7 +118,7 @@ resource "aws_route53_record" "clickhouse_internal" {
 }
 
 resource "aws_route53_record" "grafana_internal" {
-  count   = local.clickhouse_self_hosted ? 1 : 0
+  count   = local.bundled_grafana_available ? 1 : 0
   zone_id = aws_route53_zone.internal.zone_id
   name    = "grafana.${var.internal_dns_zone}"
   type    = "A"

--- a/infra/terraform/aws/examples/minimal/README.md
+++ b/infra/terraform/aws/examples/minimal/README.md
@@ -33,7 +33,7 @@ Everything the parent module provisions. See [`../../README.md`](../../README.md
 - ECS Fargate: 2× api, 2× web, 1× worker
 - RDS Postgres 16 (Multi-AZ on `prod`)
 - ElastiCache Redis 7 (2-node failover on `prod`)
-- One EC2 (t3.large) hosting ClickHouse + Grafana + Prometheus, 100 GB EBS
+- One EC2 (t3.large) hosting ClickHouse, 100 GB EBS. Set `observability_stack = "grafana"` for bundled dashboards.
 - S3 backups bucket with lifecycle to Glacier
 - CloudWatch log groups per service
 

--- a/infra/terraform/aws/iam.tf
+++ b/infra/terraform/aws/iam.tf
@@ -80,7 +80,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_backups" {
   policy_arn = aws_iam_policy.ecs_task_backups.arn
 }
 
-# ── EC2 instance role for the data tier host (CH + Grafana + Prometheus) ──
+# ── EC2 instance role for the data tier host ──────────────────────────────
 
 data "aws_iam_policy_document" "ec2_assume" {
   statement {

--- a/infra/terraform/aws/locals.tf
+++ b/infra/terraform/aws/locals.tf
@@ -121,6 +121,10 @@ locals {
 
   clickhouse_self_hosted = var.clickhouse_mode == "self_hosted"
 
+  observability_prometheus_enabled = contains(["prometheus", "grafana"], var.observability_stack)
+  observability_grafana_enabled    = var.observability_stack == "grafana"
+  bundled_grafana_available        = local.clickhouse_self_hosted && local.observability_grafana_enabled
+
   # Internal DNS name for ClickHouse
   clickhouse_host_internal = local.clickhouse_self_hosted ? "clickhouse.${var.internal_dns_zone}" : ""
 
@@ -135,6 +139,15 @@ data "aws_vpc" "vpc" {
 }
 
 # Cross-variable validation: subnets required when using BYO-VPC.
+resource "terraform_data" "observability_validation" {
+  lifecycle {
+    precondition {
+      condition     = var.observability_stack == "none" || local.clickhouse_self_hosted
+      error_message = "Bundled observability requires clickhouse_mode = self_hosted. Use your cloud provider observability stack when ClickHouse Cloud is enabled."
+    }
+  }
+}
+
 resource "terraform_data" "byovpc_validation" {
   count = local.should_create_vpc ? 0 : 1
 

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -43,7 +43,7 @@ output "redis_endpoint" {
 }
 
 output "data_host_instance_id" {
-  description = "EC2 instance id for the ClickHouse + Grafana + Prometheus host. Empty when clickhouse_mode = 'cloud'."
+  description = "EC2 instance id for the ClickHouse data host. Empty when clickhouse_mode = 'cloud'."
   value       = local.clickhouse_self_hosted ? aws_instance.data_host[0].id : ""
 }
 

--- a/infra/terraform/aws/secrets.tf
+++ b/infra/terraform/aws/secrets.tf
@@ -31,12 +31,14 @@ resource "random_password" "grafana_admin" {
 #      logic that splices passwords into URLs at container start.
 
 locals {
-  raw_secrets = {
-    "DB_PASSWORD"            = random_password.db.result
-    "CLICKHOUSE_PASSWORD"    = local.clickhouse_self_hosted ? random_password.clickhouse.result : var.clickhouse_cloud_password
-    "SECRET_KEY"             = random_password.secret_key.result
-    "GRAFANA_ADMIN_PASSWORD" = random_password.grafana_admin.result
-  }
+  raw_secrets = merge(
+    {
+      "DB_PASSWORD"         = random_password.db.result
+      "CLICKHOUSE_PASSWORD" = local.clickhouse_self_hosted ? random_password.clickhouse.result : var.clickhouse_cloud_password
+      "SECRET_KEY"          = random_password.secret_key.result
+    },
+    local.observability_grafana_enabled ? { "GRAFANA_ADMIN_PASSWORD" = random_password.grafana_admin.result } : {}
+  )
 
   derived_urls = {
     "DATABASE_URL"   = "postgresql+asyncpg://observal:${random_password.db.result}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/observal"

--- a/infra/terraform/aws/security.tf
+++ b/infra/terraform/aws/security.tf
@@ -73,19 +73,22 @@ resource "aws_security_group" "ecs_tasks" {
   tags = { Name = "${local.name}-ecs-tasks-sg" }
 }
 
-# ── Data tier EC2 (ClickHouse + Grafana + Prometheus) ──────────────────────
+# ── Data tier EC2 (ClickHouse plus optional observability) ─────────────────
 resource "aws_security_group" "data_host" {
   count       = local.clickhouse_self_hosted ? 1 : 0
   name        = "${local.name}-data-host"
-  description = "ClickHouse + Grafana + Prometheus EC2. Inbound from ALB (Grafana) and ECS tasks (ClickHouse)."
+  description = "ClickHouse EC2 with optional observability. Inbound from ALB and ECS tasks."
   vpc_id      = local.vpc_id
 
-  ingress {
-    description     = "Grafana UI from ALB"
-    from_port       = 3001
-    to_port         = 3001
-    protocol        = "tcp"
-    security_groups = [local.alb_sg_id]
+  dynamic "ingress" {
+    for_each = local.bundled_grafana_available ? [1] : []
+    content {
+      description     = "Grafana UI from ALB"
+      from_port       = 3001
+      to_port         = 3001
+      protocol        = "tcp"
+      security_groups = [local.alb_sg_id]
+    }
   }
 
   ingress {

--- a/infra/terraform/aws/terraform.tfvars.example
+++ b/infra/terraform/aws/terraform.tfvars.example
@@ -24,10 +24,11 @@ image_tag = "latest"
 # web_desired_count    = 2
 # worker_desired_count = 1
 
-# ── Data tier (ClickHouse + Grafana + Prometheus on one EC2) ──────────
-# clickhouse_mode      = "self_hosted"     # or "cloud" — see below
+# ── Data tier (ClickHouse on one EC2) ────────────────────────────────
+# clickhouse_mode      = "self_hosted"     # or "cloud", see below
 # data_instance_type   = "t3.large"
 # data_volume_size_gb  = 100
+# observability_stack  = "none"            # one of: none, prometheus, grafana
 
 # ── ClickHouse Cloud (uncomment if clickhouse_mode = "cloud") ─────────
 # clickhouse_mode           = "cloud"

--- a/infra/terraform/aws/user-data.sh.tftpl
+++ b/infra/terraform/aws/user-data.sh.tftpl
@@ -4,7 +4,7 @@
 
 set -eo pipefail
 
-# Bootstrap the data tier host: ClickHouse + Grafana + Prometheus via docker compose.
+# Bootstrap the data tier host: ClickHouse plus optional observability via docker compose.
 # api/web/worker run on ECS Fargate — they are NOT started here.
 
 exec > >(tee /var/log/observal-bootstrap.log | logger -t observal-bootstrap -s 2>/dev/console) 2>&1
@@ -37,10 +37,20 @@ mkdir -p /data
 UUID=$(blkid -s UUID -o value "$DEVICE")
 grep -q "$UUID" /etc/fstab || echo "UUID=$UUID /data ext4 defaults,nofail 0 2" >> /etc/fstab
 mount -a
-mkdir -p /data/clickhouse /data/grafana /data/prometheus
+mkdir -p /data/clickhouse
+%{ if observability_grafana_enabled }
+mkdir -p /data/grafana
+%{ endif }
+%{ if observability_prometheus_enabled }
+mkdir -p /data/prometheus
+%{ endif }
 chown -R 101:101 /data/clickhouse  || true   # clickhouse user inside the official image
+%{ if observability_grafana_enabled }
 chown -R 472:472 /data/grafana     || true   # grafana user
+%{ endif }
+%{ if observability_prometheus_enabled }
 chown -R 65534:65534 /data/prometheus || true # nobody
+%{ endif }
 
 # ── Pull secrets from SSM ────────────────────────────────────────
 # Disable xtrace here so secrets are not echoed to CloudWatch logs (SEC-020).
@@ -48,7 +58,9 @@ set +x
 fetch() { aws ssm get-parameter --with-decryption --name "$1" --region "${region}" --query Parameter.Value --output text; }
 
 CLICKHOUSE_PASSWORD=$(fetch "${ssm_prefix}/CLICKHOUSE_PASSWORD")
+%{ if observability_grafana_enabled }
 GRAFANA_ADMIN_PASSWORD=$(fetch "${ssm_prefix}/GRAFANA_ADMIN_PASSWORD")
+%{ endif }
 set -x  # re-enable tracing for non-sensitive operations
 
 # ── CloudWatch agent (ship docker logs + system logs) ────────────
@@ -186,7 +198,7 @@ cat > "$INSTALL_DIR/docker/clickhouse/users.d/memory.xml" <<'CHPROF'
 </clickhouse>
 CHPROF
 
-# ── Render the data-tier compose file (CH + Grafana + Prometheus only) ──
+# ── Render the data-tier compose file ──
 cat > "$INSTALL_DIR/docker-compose.data.yml" <<'COMPOSE'
 services:
   clickhouse:
@@ -211,6 +223,7 @@ services:
       timeout: 5s
       retries: 5
 
+%{ if observability_grafana_enabled }
   grafana:
     image: grafana/grafana-oss:11.6.5
     container_name: observal-grafana
@@ -231,7 +244,8 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
-
+%{ endif }
+%{ if observability_prometheus_enabled }
   prometheus:
     image: prom/prometheus:v3.11.3
     container_name: observal-prometheus
@@ -245,16 +259,19 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=15d
+%{ endif }
 COMPOSE
 
 # Render the .env consumed by docker-compose
 cat > "$INSTALL_DIR/.env" <<EOF
 CLICKHOUSE_DB=${clickhouse_db}
 CLICKHOUSE_PASSWORD=$${CLICKHOUSE_PASSWORD}
+%{ if observability_grafana_enabled }
 GRAFANA_ADMIN_USER=${grafana_admin_user}
 GRAFANA_ADMIN_PASSWORD=$${GRAFANA_ADMIN_PASSWORD}
 GRAFANA_ROOT_URL=${grafana_root_url}
 GRAFANA_SUBPATH_PREFIX=${grafana_subpath_prefix}
+%{ endif }
 EOF
 chmod 600 "$INSTALL_DIR/.env"
 
@@ -264,7 +281,8 @@ cd "$INSTALL_DIR"
 # Clear stale preprocessed configs from previous ClickHouse versions
 rm -rf /data/clickhouse/preprocessed_configs
 
-# Create prometheus.yml (compose bind-mounts it; without it Docker creates a directory)
+%{ if observability_prometheus_enabled }
+# Create prometheus.yml because compose bind-mounts it.
 cat > "$INSTALL_DIR/prometheus.yml" <<'PROM'
 global:
   scrape_interval: 30s
@@ -274,6 +292,7 @@ scrape_configs:
       - targets: ['localhost:9363']
 PROM
 
+%{ endif }
 docker compose --env-file "$INSTALL_DIR/.env" -f docker-compose.data.yml pull
 docker compose --env-file "$INSTALL_DIR/.env" -f docker-compose.data.yml up -d
 

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -217,7 +217,7 @@ variable "run_init_on_apply" {
   default     = true
 }
 
-# ── Data tier (ClickHouse + Grafana + Prometheus on EC2) ───────────────────
+# ── Data tier (ClickHouse plus optional observability on EC2) ───────────────
 
 variable "clickhouse_mode" {
   description = "Where ClickHouse lives. 'self_hosted' = EC2 + EBS managed by this module. 'cloud' = ClickHouse Cloud, supply clickhouse_cloud_url + clickhouse_cloud_password."
@@ -244,7 +244,7 @@ variable "clickhouse_cloud_password" {
 }
 
 variable "data_instance_type" {
-  description = "EC2 instance type for the ClickHouse + Grafana + Prometheus host. 8 GB RAM is the floor for light use."
+  description = "EC2 instance type for the ClickHouse data host. 8 GB RAM is the floor for light use."
   type        = string
   default     = "t3.large"
 }
@@ -290,6 +290,17 @@ variable "alb_ingress_cidrs" {
 }
 
 # ── Application config ─────────────────────────────────────────────────────
+
+variable "observability_stack" {
+  description = "Bundled observability stack to deploy: none, prometheus, or grafana. grafana includes prometheus."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "prometheus", "grafana"], var.observability_stack)
+    error_message = "observability_stack must be one of: none, prometheus, grafana."
+  }
+}
 
 variable "log_retention_days" {
   description = "CloudWatch log retention for application + infrastructure log groups."

--- a/infra/terraform/azure/clickhouse.tf
+++ b/infra/terraform/azure/clickhouse.tf
@@ -60,8 +60,9 @@ resource "azurerm_linux_virtual_machine" "clickhouse" {
   }
 
   custom_data = base64encode(templatefile("${path.module}/cloud-init.yaml.tftpl", {
-    clickhouse_password = random_password.clickhouse.result
-    clickhouse_db       = "observal"
+    clickhouse_password              = random_password.clickhouse.result
+    clickhouse_db                    = "observal"
+    observability_prometheus_enabled = local.observability_prometheus_enabled
   }))
 
   identity {

--- a/infra/terraform/azure/cloud-init.yaml.tftpl
+++ b/infra/terraform/azure/cloud-init.yaml.tftpl
@@ -42,6 +42,7 @@ write_files:
             resources:
               limits:
                 memory: 768M
+%{ if observability_prometheus_enabled }
 
         prometheus:
           image: prom/prometheus:v3.12.0
@@ -55,7 +56,9 @@ write_files:
             resources:
               limits:
                 memory: 512M
+%{ endif }
 
+%{ if observability_prometheus_enabled }
   - path: /opt/observal/prometheus.yml
     content: |
       global:
@@ -65,6 +68,7 @@ write_files:
           metrics_path: /metrics
           static_configs:
             - targets: []
+%{ endif }
 
 runcmd:
   # Format and mount data disk
@@ -75,7 +79,11 @@ runcmd:
     mkdir -p /data
     mount /dev/sdc /data
     echo '/dev/sdc /data ext4 defaults,nofail 0 2' >> /etc/fstab
+%{ if observability_prometheus_enabled }
   - mkdir -p /data/clickhouse /data/prometheus /data/redis
+%{ else }
+  - mkdir -p /data/clickhouse /data/redis
+%{ endif }
   - systemctl enable docker
   - systemctl start docker
   - cd /opt/observal && docker compose up -d

--- a/infra/terraform/azure/grafana.tf
+++ b/infra/terraform/azure/grafana.tf
@@ -3,7 +3,7 @@
 
 # Azure Monitor Workspace (required for Managed Grafana integration)
 resource "azurerm_monitor_workspace" "main" {
-  count               = var.grafana_enabled ? 1 : 0
+  count               = local.observability_grafana_enabled ? 1 : 0
   name                = "${local.name}-monitor"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -13,7 +13,7 @@ resource "azurerm_monitor_workspace" "main" {
 
 # Azure Managed Grafana - enterprise-ready observability dashboard.
 resource "azurerm_dashboard_grafana" "main" {
-  count               = var.grafana_enabled ? 1 : 0
+  count               = local.observability_grafana_enabled ? 1 : 0
   name                = "${var.name_prefix}-${var.environment}-gf"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -34,7 +34,7 @@ resource "azurerm_dashboard_grafana" "main" {
 
 # Grant the current user Grafana Admin role
 resource "azurerm_role_assignment" "grafana_admin" {
-  count                = var.grafana_enabled ? 1 : 0
+  count                = local.observability_grafana_enabled ? 1 : 0
   scope                = azurerm_dashboard_grafana.main[0].id
   role_definition_name = "Grafana Admin"
   principal_id         = data.azurerm_client_config.current.object_id

--- a/infra/terraform/azure/locals.tf
+++ b/infra/terraform/azure/locals.tf
@@ -7,21 +7,34 @@ locals {
   location = var.location
 
   clickhouse_self_hosted = var.clickhouse_mode == "self_hosted"
-  # VM is needed if either ClickHouse or Redis is self-hosted
-  needs_vm = local.clickhouse_self_hosted || var.redis_mode == "self_hosted"
+
+  observability_prometheus_enabled = contains(["prometheus", "grafana"], var.observability_stack)
+  observability_grafana_enabled    = var.observability_stack == "grafana"
+
+  # VM is needed if ClickHouse, Redis, or bundled Prometheus is self-hosted.
+  needs_vm = local.clickhouse_self_hosted || var.redis_mode == "self_hosted" || local.observability_prometheus_enabled
 
   api_image = "${azurerm_container_registry.main.login_server}/${var.name_prefix}-api:${var.image_tag}"
   web_image = "${azurerm_container_registry.main.login_server}/${var.name_prefix}-web:${var.image_tag}"
 
   # Connection strings built from managed resources
-  database_url   = "postgresql+asyncpg://${azurerm_postgresql_flexible_server.main.administrator_login}:${random_password.db.result}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/observal?ssl=require"
+  database_url      = "postgresql+asyncpg://${azurerm_postgresql_flexible_server.main.administrator_login}:${random_password.db.result}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/observal?ssl=require"
   redis_self_hosted = var.redis_mode == "self_hosted"
-  redis_url        = local.redis_self_hosted ? "redis://${azurerm_network_interface.clickhouse[0].private_ip_address}:6379" : "rediss://:${azurerm_redis_enterprise_database.main[0].primary_access_key}@${azurerm_redis_enterprise_cluster.main[0].hostname}:10000"
-  clickhouse_url = local.clickhouse_self_hosted ? "clickhouse://default:${random_password.clickhouse.result}@${azurerm_network_interface.clickhouse[0].private_ip_address}:8123/observal" : var.clickhouse_cloud_url
+  redis_url         = local.redis_self_hosted ? "redis://${azurerm_network_interface.clickhouse[0].private_ip_address}:6379" : "rediss://:${azurerm_redis_enterprise_database.main[0].primary_access_key}@${azurerm_redis_enterprise_cluster.main[0].hostname}:10000"
+  clickhouse_url    = local.clickhouse_self_hosted ? "clickhouse://default:${random_password.clickhouse.result}@${azurerm_network_interface.clickhouse[0].private_ip_address}:8123/observal" : var.clickhouse_cloud_url
 
   tags = {
     Project     = "observal"
     Environment = var.environment
     ManagedBy   = "terraform"
+  }
+}
+
+resource "terraform_data" "observability_validation" {
+  lifecycle {
+    precondition {
+      condition     = var.observability_stack == "none" || local.clickhouse_self_hosted
+      error_message = "Bundled observability requires clickhouse_mode = self_hosted. Use your cloud provider observability stack when ClickHouse Cloud is enabled."
+    }
   }
 }

--- a/infra/terraform/azure/network.tf
+++ b/infra/terraform/azure/network.tf
@@ -80,28 +80,34 @@ resource "azurerm_network_security_group" "vm" {
     destination_address_prefix = "*"
   }
 
-  security_rule {
-    name                       = "AllowGrafanaFromVNet"
-    priority                   = 110
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "3001"
-    source_address_prefix      = var.vnet_cidr
-    destination_address_prefix = "*"
+  dynamic "security_rule" {
+    for_each = local.observability_grafana_enabled ? [1] : []
+    content {
+      name                       = "AllowGrafanaFromVNet"
+      priority                   = 110
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "Tcp"
+      source_port_range          = "*"
+      destination_port_range     = "3001"
+      source_address_prefix      = var.vnet_cidr
+      destination_address_prefix = "*"
+    }
   }
 
-  security_rule {
-    name                       = "AllowPrometheusFromVNet"
-    priority                   = 120
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "9090"
-    source_address_prefix      = var.vnet_cidr
-    destination_address_prefix = "*"
+  dynamic "security_rule" {
+    for_each = local.observability_prometheus_enabled ? [1] : []
+    content {
+      name                       = "AllowPrometheusFromVNet"
+      priority                   = 120
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "Tcp"
+      source_port_range          = "*"
+      destination_port_range     = "9090"
+      source_address_prefix      = var.vnet_cidr
+      destination_address_prefix = "*"
+    }
   }
 
   security_rule {

--- a/infra/terraform/azure/outputs.tf
+++ b/infra/terraform/azure/outputs.tf
@@ -13,7 +13,7 @@ output "web_url" {
 
 output "grafana_url" {
   description = "URL of the Azure Managed Grafana instance."
-  value       = var.grafana_enabled ? azurerm_dashboard_grafana.main[0].endpoint : "disabled"
+  value       = local.observability_grafana_enabled ? azurerm_dashboard_grafana.main[0].endpoint : "disabled"
 }
 
 output "postgresql_fqdn" {

--- a/infra/terraform/azure/prod.tfvars
+++ b/infra/terraform/azure/prod.tfvars
@@ -28,8 +28,8 @@ worker_max_replicas = 5
 clickhouse_vm_size      = "Standard_D4ads_v7"
 clickhouse_disk_size_gb = 200
 
-# Managed Grafana
-grafana_enabled = true
+# Bundled observability
+observability_stack = "grafana"
 
 # 30-day log retention
 log_retention_days = 30

--- a/infra/terraform/azure/staging.tfvars
+++ b/infra/terraform/azure/staging.tfvars
@@ -27,8 +27,8 @@ worker_max_replicas = 2
 clickhouse_vm_size      = "Standard_D2ads_v7"
 clickhouse_disk_size_gb = 50
 
-# Managed Grafana
-grafana_enabled = true
+# Bundled observability
+observability_stack = "grafana"
 
 # Minimum allowed by Azure is 30
 log_retention_days = 30

--- a/infra/terraform/azure/variables.tf
+++ b/infra/terraform/azure/variables.tf
@@ -226,10 +226,15 @@ variable "redis_enterprise_sku" {
 
 # -- Observability -----------------------------------------------------------
 
-variable "grafana_enabled" {
-  description = "Deploy Azure Managed Grafana instance."
-  type        = bool
-  default     = true
+variable "observability_stack" {
+  description = "Bundled observability stack to deploy: none, prometheus, or grafana. grafana includes prometheus."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "prometheus", "grafana"], var.observability_stack)
+    error_message = "observability_stack must be one of: none, prometheus, grafana."
+  }
 }
 
 # -- Application config ------------------------------------------------------

--- a/infra/terraform/gcp/README.md
+++ b/infra/terraform/gcp/README.md
@@ -15,7 +15,7 @@ Deploy a production-ready Observal instance on Google Cloud Platform.
 | Web frontend | Cloud Run (v2) |
 | PostgreSQL | Cloud SQL |
 | Redis | Memorystore |
-| ClickHouse + Grafana + Prometheus | GCE instance (Docker Compose) |
+| ClickHouse, optional Prometheus and Grafana | GCE instance (Docker Compose) |
 | Load balancer / TLS | Global HTTPS LB + Managed SSL Certificate |
 | DNS | Cloud DNS |
 | Secrets | Secret Manager |

--- a/infra/terraform/gcp/data-host.tf
+++ b/infra/terraform/gcp/data-host.tf
@@ -4,7 +4,7 @@
 resource "google_service_account" "data_host" {
   count        = local.clickhouse_self_hosted ? 1 : 0
   account_id   = "${var.name_prefix}-data"
-  display_name = "Observal data host (ClickHouse + Grafana + Prometheus)"
+  display_name = "Observal data host"
 }
 
 resource "google_project_iam_member" "data_host_log_writer" {
@@ -70,12 +70,14 @@ resource "google_compute_instance" "data_host" {
   }
 
   metadata_startup_script = templatefile("${path.module}/user-data.sh.tftpl", {
-    clickhouse_password = random_password.clickhouse.result
-    clickhouse_db       = "observal"
-    data_retention_days = var.data_retention_days
-    backups_bucket      = google_storage_bucket.backups.name
-    grafana_admin_user  = "admin"
-    grafana_root_url    = local.enable_custom_domain ? "https://${var.domain_name}" : ""
+    clickhouse_password              = random_password.clickhouse.result
+    clickhouse_db                    = "observal"
+    data_retention_days              = var.data_retention_days
+    backups_bucket                   = google_storage_bucket.backups.name
+    grafana_admin_user               = "admin"
+    grafana_root_url                 = local.enable_custom_domain ? "https://${var.domain_name}" : ""
+    observability_prometheus_enabled = local.observability_prometheus_enabled
+    observability_grafana_enabled    = local.observability_grafana_enabled
   })
 
   allow_stopping_for_update = true

--- a/infra/terraform/gcp/locals.tf
+++ b/infra/terraform/gcp/locals.tf
@@ -9,6 +9,9 @@ locals {
 
   clickhouse_self_hosted = var.clickhouse_mode == "self_hosted"
 
+  observability_prometheus_enabled = contains(["prometheus", "grafana"], var.observability_stack)
+  observability_grafana_enabled    = var.observability_stack == "grafana"
+
   effective_edition = var.edition == "auto" ? (var.observal_license_key != "" ? "enterprise" : "community") : var.edition
   is_enterprise     = local.effective_edition == "enterprise"
 
@@ -23,4 +26,13 @@ locals {
   database_url   = "postgresql+asyncpg://${google_sql_user.app.name}:${random_password.db.result}@${google_sql_database_instance.postgres.private_ip_address}:5432/${google_sql_database.app.name}"
   redis_url      = "redis://${google_redis_instance.main.host}:${google_redis_instance.main.port}"
   clickhouse_url = local.clickhouse_self_hosted ? "clickhouse://default:${random_password.clickhouse.result}@${google_compute_instance.data_host[0].network_interface[0].network_ip}:8123/observal" : var.clickhouse_cloud_url
+}
+
+resource "terraform_data" "observability_validation" {
+  lifecycle {
+    precondition {
+      condition     = var.observability_stack == "none" || local.clickhouse_self_hosted
+      error_message = "Bundled observability requires clickhouse_mode = self_hosted. Use your cloud provider observability stack when ClickHouse Cloud is enabled."
+    }
+  }
 }

--- a/infra/terraform/gcp/network.tf
+++ b/infra/terraform/gcp/network.tf
@@ -81,7 +81,11 @@ resource "google_compute_firewall" "allow_health_check" {
 
   allow {
     protocol = "tcp"
-    ports    = ["8123", "3000", "9090"]
+    ports = compact(concat(
+      ["8123"],
+      local.observability_grafana_enabled ? ["3000"] : [],
+      local.observability_prometheus_enabled ? ["9090"] : []
+    ))
   }
 
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]

--- a/infra/terraform/gcp/terraform.tfvars.example
+++ b/infra/terraform/gcp/terraform.tfvars.example
@@ -22,10 +22,11 @@ db_ha_enabled  = false
 redis_memory_size_gb = 1
 redis_tier           = "BASIC"
 
-# Data host (ClickHouse + Grafana + Prometheus)
-clickhouse_mode   = "self_hosted"
-data_machine_type = "e2-standard-2"
-data_disk_size_gb = 100
+# Data host (ClickHouse)
+clickhouse_mode      = "self_hosted"
+data_machine_type    = "e2-standard-2"
+data_disk_size_gb    = 100
+observability_stack  = "none"
 
 # Application
 data_retention_days = 90

--- a/infra/terraform/gcp/user-data.sh.tftpl
+++ b/infra/terraform/gcp/user-data.sh.tftpl
@@ -13,7 +13,13 @@ mkdir -p "$${DATA_DIR}"
 mount -o discard,defaults "$${DATA_DEVICE}" "$${DATA_DIR}"
 echo "UUID=$(blkid -s UUID -o value $${DATA_DEVICE}) $${DATA_DIR} ext4 discard,defaults,nofail 0 2" >> /etc/fstab
 
-mkdir -p "$${DATA_DIR}/clickhouse" "$${DATA_DIR}/grafana" "$${DATA_DIR}/prometheus"
+mkdir -p "$${DATA_DIR}/clickhouse"
+%{ if observability_grafana_enabled }
+mkdir -p "$${DATA_DIR}/grafana"
+%{ endif }
+%{ if observability_prometheus_enabled }
+mkdir -p "$${DATA_DIR}/prometheus"
+%{ endif }
 
 # Install Docker (COS has Docker pre-installed, but ensure compose plugin)
 DOCKER_COMPOSE_VERSION="v2.36.0"
@@ -43,6 +49,7 @@ services:
       timeout: 5s
       retries: 5
 
+%{ if observability_grafana_enabled }
   grafana:
     image: grafana/grafana-oss:11.6.5
     restart: unless-stopped
@@ -59,7 +66,8 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
-
+%{ endif }
+%{ if observability_prometheus_enabled }
   prometheus:
     image: prom/prometheus:v3.11.3
     restart: unless-stopped
@@ -68,8 +76,10 @@ services:
     volumes:
       - /data/prometheus:/prometheus
       - /data/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+%{ endif }
 COMPOSE
 
+%{ if observability_prometheus_enabled }
 # Write prometheus config
 cat > "$${DATA_DIR}/prometheus.yml" <<'PROM'
 global:
@@ -82,6 +92,7 @@ scrape_configs:
       - targets: ["clickhouse:8123"]
 PROM
 
+%{ endif }
 # Start the data stack
 cd "$${DATA_DIR}"
 docker compose up -d

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -170,7 +170,7 @@ variable "clickhouse_cloud_url" {
 }
 
 variable "data_machine_type" {
-  description = "Machine type for the ClickHouse + Grafana + Prometheus GCE instance."
+  description = "Machine type for the ClickHouse data host."
   type        = string
   default     = "e2-standard-2"
 }
@@ -224,6 +224,17 @@ variable "redis_tier" {
 }
 
 # ── Application config ────────────────────────────────────────────────────
+
+variable "observability_stack" {
+  description = "Bundled observability stack to deploy: none, prometheus, or grafana. grafana includes prometheus."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "prometheus", "grafana"], var.observability_stack)
+    error_message = "observability_stack must be one of: none, prometheus, grafana."
+  }
+}
 
 variable "data_retention_days" {
   description = "ClickHouse data retention in days."


### PR DESCRIPTION
## Purpose / Description
Make Prometheus and Grafana optional across Docker Compose, server package installs, and Terraform deployments. The core stack now stays smaller by default while preserving an opt in path for bundled monitoring.

## Fixes
No linked issue.

## Approach
Move Prometheus and Grafana out of the core Docker Compose files into observability overlays. Add make targets for Prometheus only and Prometheus plus Grafana. Add a shared Terraform `observability_stack` setting with `none`, `prometheus`, and `grafana` values across AWS, AWS standard, AWS EC2, GCP, and Azure. Update installer behavior so Grafana secrets are only written when Grafana is enabled.

## How Has This Been Tested?

Ran Docker Compose config checks for core, Prometheus only, and Grafana profile variants in both root Docker Compose and server package Compose files.

Ran local smoke tests:

```bash
make up-prometheus
make up-observability
make down
curl -fsS http://localhost/health
curl -fsS http://127.0.0.1:9090/-/ready
curl -fsS http://127.0.0.1:3001/api/health
```

Confirmed `make down` removes core services, Prometheus, Grafana, and the Docker network.

Ran formatting and static checks:

```bash
terraform fmt -check -recursive infra/terraform/aws infra/terraform/aws-standard infra/terraform/gcp infra/terraform/azure infra/terraform/aws-ec2
bash -n docker/server-package/setup.sh
bash -n infra/terraform/aws-ec2/deploy.sh
```

Ran the standard Git whitespace checker.

Rendered Terraform templates for AWS, AWS standard, GCP, and Azure with observability disabled and enabled.

## Learning (optional, can help others)
Compose profiles are a good fit for Grafana because Prometheus can run alone, while Grafana should be an explicit profile layered on top of the observability overlay.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). 
## AI Assistance

Was generative AI tooling used to co-author this PR?

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
