### PR TITLE
build: add fast Docker rebuild target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,14 @@ No configuration needed for local development. All settings have working default
 
 ```bash
 cp .env.example .env
-docker compose -f docker/docker-compose.yml up --build -d
+make rebuild-fast
 ```
+
+For normal backend, frontend, and dependency changes, use `make rebuild-fast`. It builds the shared API image once, reuses it for the API, init, and worker services, then builds the web image.
+
+Use `make rebuild` when the Compose topology changes, such as adding services, changing build contexts, changing image names, or updating volumes and networks.
+
+For schema, migration, ClickHouse setup, init path, or worker changes, use `make rebuild-fast` so the shared API image used by `observal-init` and `observal-worker` is refreshed.
 
 Wait for services to be healthy, then:
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset rebuild rebuild-prometheus rebuild-observability rebuild-enterprise rebuild-local reset-prometheus reset-observability up-prometheus up-observability down-prometheus down-observability logs-prometheus logs-observability release-major release-feature release-patch sync-skill
+.PHONY: lint format check test test-adversarial test-eval-completeness test-all hooks clean migrate check-migrations new-migration reset rebuild rebuild-fast rebuild-prometheus rebuild-observability rebuild-enterprise rebuild-local reset-prometheus reset-observability up-prometheus up-observability down-prometheus down-observability logs-prometheus logs-observability release-major release-feature release-patch sync-skill
 
 # ── Linting ──────────────────────────────────────────────
 
@@ -87,6 +87,14 @@ new-migration:  ## Create a new migration: make new-migration MSG="add foo to ba
 
 rebuild:  ## Rebuild and restart Docker stack (runs migrations automatically)
 	cd docker && docker compose $(COMPOSE_FILES) up --build -d
+	@echo "Waiting for API to be healthy..."
+	@cd docker && until docker compose $(COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
+	cd docker && docker compose $(COMPOSE_FILES) restart observal-lb
+	@echo "API is healthy."
+
+rebuild-fast:  ## Fast app rebuild: build shared API and web images once
+	cd docker && docker compose $(COMPOSE_FILES) build observal-api observal-web
+	cd docker && docker compose $(COMPOSE_FILES) up -d --no-build
 	@echo "Waiting for API to be healthy..."
 	@cd docker && until docker compose $(COMPOSE_FILES) exec observal-api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" >/dev/null 2>&1; do sleep 1; done
 	cd docker && docker compose $(COMPOSE_FILES) restart observal-lb

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -191,11 +191,26 @@ cp .env.example .env
 make up
 ```
 
-The first build takes several minutes while Docker downloads and compiles images. Subsequent starts are fast. Watch progress with:
+The first build takes several minutes while Docker downloads and compiles images. Subsequent starts are fast.
+
+Watch progress with:
 
 ```bash
 make logs
 ```
+
+For normal code and dependency changes, prefer the fast rebuild target:
+
+```bash
+make rebuild-fast
+```
+
+`make rebuild-fast` is not a separate dev profile and does not enable hot reload. It uses the same Docker Compose stack as `make rebuild`, but only builds the two app images that contain local code:
+
+- `observal-api`, shared by the API, init, and worker services
+- `observal-web`, used by the web service
+
+Then it starts the full stack with the freshly built images.
 
 Wait until all services are healthy:
 
@@ -244,18 +259,33 @@ Seeded automatically on first startup:
 ## Make Targets Reference
 
 ```bash
-make up          # start the full Docker stack
-make down        # stop the stack
-make rebuild     # rebuild images and restart (use after code changes)
-make logs        # tail logs from all services
-make test        # run the test suite quickly
-make test-v      # verbose test output
-make lint        # ruff check + hadolint
-make format      # ruff format (auto-fix)
-make check       # pre-commit on all files
-make hooks       # install pre-commit hooks
-make reset       # nuke all volumes and rebuild from scratch (destructive)
+make up            # start the full Docker stack
+make down          # stop the stack
+make rebuild-fast  # fast app rebuild for code and dependency changes
+make rebuild       # rebuild every service image and restart
+make logs          # tail logs from all services
+make test          # run the test suite quickly
+make test-v        # verbose test output
+make lint          # ruff check + hadolint
+make format        # ruff format (auto-fix)
+make check         # pre-commit on all files
+make hooks         # install pre-commit hooks
+make reset         # nuke all volumes and rebuild from scratch (destructive)
 ```
+
+### Which rebuild target should I use?
+
+| Situation | Target | Notes |
+| --------- | ------ | ----- |
+| Backend source changed | `make rebuild-fast` | Rebuilds the shared API image used by API, init, and worker. |
+| Worker, init, migration, or ClickHouse setup code changed | `make rebuild-fast` | These services use the same `observal-api` image. This is the safe path for schema and init path changes because it refreshes the image used by `observal-init` and `observal-worker`. |
+| Python dependencies changed in `observal-server/pyproject.toml` or `observal-server/uv.lock` | `make rebuild-fast` | Docker reruns the Python dependency layer when those files change. |
+| Frontend source changed | `make rebuild-fast` | Rebuilds the web image. |
+| Frontend dependencies changed in `package.json`, `web/package.json`, or `pnpm-lock.yaml` | `make rebuild-fast` | Docker reruns the pnpm dependency layer when those files change. |
+| Compose topology changed | `make rebuild` | Use this for new services, changed image names, changed build contexts, changed profiles, or volume and network changes. |
+| Cache looks stale or the stack behaves unexpectedly | `make rebuild` first | Use `make rebuild-clean` only when you intentionally want a no-cache rebuild with volumes removed. |
+
+`make down` stops containers started by either `make rebuild` or `make rebuild-fast`. Both targets use the same Compose project and the same volumes.
 
 ---
 


### PR DESCRIPTION
## Purpose / Description
Speed up the local Docker rebuild loop. The existing rebuild path asks Compose to build every service image, even though the API, init, and worker services all use the same API image.

## Fixes
No linked issue.

## Approach
* Add `make rebuild-fast` as the single fast local rebuild target.
* Build only the shared API image and the web image, then start the full Compose stack with those images.
* Document that the target is for normal code and dependency changes.
* Document that schema, migration, ClickHouse setup, init path, and worker changes are also covered because init and worker use the shared API image.
* Document when to use the full `make rebuild` path instead.
* Document that `make down` stops containers created by either rebuild path.

## How Has This Been Tested?

Ran these checks:

```bash
make help | rg "rebuild-fast"
! rg -n "rebuild-dev|rebuilt-dev" Makefile docs/DEVELOPMENT_GUIDE.md CONTRIBUTING.md
make -n rebuild-fast
make rebuild-fast
```

Smoke checked the running stack:

```text
http://localhost/health returned 200
http://localhost:3000/ returned 200
```

## Learning (optional, can help others)
Inspected the existing Docker Compose services and Dockerfiles. The API, init, and worker services all use the same `ghcr.io/blazeup-ai/observal-api:latest` image, so building only `observal-api` still refreshes all three services.

## Checklist

- [x] You have a descriptive commit message with a short title, first line max 50 chars.
- [x] No code comments were needed because this changes Make targets and docs.
- [x] You have performed a self-review of your own code.
- [x] UI changes are not included, screenshots are not applicable.

## AI Assistance

- [x] Yes, Pi coding agent was used.
- [x] The generated changes were manually reviewed and tested.
