### PR TITLE
fix(home): clean up cockpit overview

### DIFF
--- a/observal-server/api/routes/sessions.py
+++ b/observal-server/api/routes/sessions.py
@@ -77,6 +77,7 @@ async def list_sessions(
     days: int | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
+    mine: bool = Query(False),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("status={}, platform={}", status, platform)
@@ -85,11 +86,12 @@ async def list_sessions(
     capped_days = min(days, 365) if days is not None and days > 0 else days
 
     optic.debug(
-        "list_sessions: user={}, is_admin={}, platform={}, days={}",
+        "list_sessions: user={}, is_admin={}, platform={}, days={}, mine={}",
         uid_str,
         is_admin,
         platform,
         capped_days,
+        mine,
     )
 
     rows = await _list_sessions_query(
@@ -99,6 +101,7 @@ async def list_sessions(
         uid=uid_str,
         limit=limit,
         offset=offset,
+        mine=mine,
     )
 
     # Resolve user display names from PostgreSQL
@@ -184,6 +187,7 @@ async def _list_sessions_query(
     uid: str,
     limit: int = 50,
     offset: int = 0,
+    mine: bool = False,
 ) -> list[dict]:
     """Session list from session_stats_agg FINAL.
 
@@ -195,7 +199,7 @@ async def _list_sessions_query(
     where_parts = ["session_id != ''", "parent_session_id = ''", "prompt_count > 0"]
     params: dict[str, str] = {}
 
-    if not is_admin:
+    if mine or not is_admin:
         where_parts.append("user_id = {uid:String}")
         params["param_uid"] = uid
     if days is not None and days > 0:

--- a/web/src/hooks/use-sessions-api.ts
+++ b/web/src/hooks/use-sessions-api.ts
@@ -28,15 +28,17 @@ export function useSessions2(options?: {
   days?: number;
   limit?: number;
   offset?: number;
+  mine?: boolean;
 }) {
   return useQuery({
-    queryKey: ['sessions', 'list', options?.platform, options?.days, options?.limit, options?.offset],
+    queryKey: ['sessions', 'list', options?.platform, options?.days, options?.limit, options?.offset, options?.mine],
     queryFn: () =>
       dashboard.sessions({
         platform: options?.platform,
         days: options?.days,
         limit: options?.limit,
         offset: options?.offset,
+        mine: options?.mine,
       }),
     refetchInterval: options?.refetchInterval,
     refetchOnMount: "always",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -539,6 +539,7 @@ export const dashboard = {
 		days?: number;
 		limit?: number;
 		offset?: number;
+		mine?: boolean;
 	}) => {
 		const qs = new URLSearchParams();
 		if (params?.status) qs.set("status", params.status);
@@ -546,6 +547,7 @@ export const dashboard = {
 		if (params?.days) qs.set("days", String(params.days));
 		if (params?.limit) qs.set("limit", String(params.limit));
 		if (params?.offset) qs.set("offset", String(params.offset));
+		if (params?.mine) qs.set("mine", "true");
 		const suffix = qs.toString() ? `?${qs}` : "";
 		return get<Session[]>(`/sessions${suffix}`);
 	},

--- a/web/src/pages/registry/home.tsx
+++ b/web/src/pages/registry/home.tsx
@@ -2,48 +2,356 @@
 // SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-
 import { Link, useRouter } from "@tanstack/react-router";
-import { useState, useCallback } from "react";
+import { useMemo, useState } from "react";
 import {
+  Activity,
+  ArrowDownToLine,
+  ArrowRight,
+  Bot,
+  CircleAlert,
+  Clock3,
+  FileEdit,
+  Gauge,
+  Medal,
   Search,
-  TrendingUp,
-  Clock,
-  Check,
-  Copy,
+  Sparkles,
+  Star,
   Terminal,
   Trophy,
-  ArrowRight,
-  ArrowDownToLine,
-  Star,
+  WandSparkles,
+  Zap,
+  type LucideIcon,
 } from "lucide-react";
-import { toast } from "sonner";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AgentCard } from "@/components/registry/agent-card";
-import {
-  useRegistryList,
-  useTopAgents,
-  useOverviewStats,
-  useLeaderboard,
-} from "@/hooks/use-api";
-import { copyToClipboard } from "@/lib/utils";
 import { PageHeader } from "@/components/layouts/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
-import { compactNumber } from "@/lib/utils";
+import {
+  useLeaderboard,
+  useMyAgents,
+  useRegistryList,
+  useSessions2,
+  useTopAgents,
+  useWhoami,
+} from "@/hooks/use-api";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
-import type { LeaderboardWindow, TopAgentItem, RegistryItem } from "@/lib/types";
+import { compactNumber, formatNumber } from "@/lib/utils";
+import type { LeaderboardItem, RegistryItem, Session, TopAgentItem } from "@/lib/types";
+
+const TOKEN_FORMATTER = Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 });
+const TIME_FORMATTER = new Intl.DateTimeFormat("en", { hour: "numeric", minute: "2-digit" });
+
+interface HomeAction {
+  title: string;
+  description: string;
+  href: string;
+  icon: LucideIcon;
+  priority?: boolean;
+}
+
+function maybeNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function toNumber(value: unknown): number {
+  return maybeNumber(value) ?? 0;
+}
+
+function toDate(ts?: string): Date | null {
+  if (!ts) return null;
+  if (ts.endsWith("Z") || /[+-]\d{2}:\d{2}$/.test(ts)) return new Date(ts);
+  return new Date(`${ts.replace(" ", "T")}Z`);
+}
+
+function formatTokens(value: number): string {
+  return TOKEN_FORMATTER.format(value);
+}
+
+function formatMaybeTime(value?: string): string {
+  const parsed = toDate(value);
+  if (!parsed || Number.isNaN(parsed.getTime())) return "No activity";
+  return TIME_FORMATTER.format(parsed);
+}
+
+function normalizeText(value?: string | null): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function getAgentDownloads(agent: RegistryItem): number {
+  return toNumber(agent.download_count);
+}
+
+function getAgentRating(agent: RegistryItem): number | null {
+  const rating = toNumber(agent.average_rating);
+  return rating > 0 ? rating : null;
+}
+
+function getAgentStatus(agent: RegistryItem): string {
+  return typeof agent.status === "string" ? agent.status : "";
+}
+
+function getAgentOwner(agent: RegistryItem): string {
+  return typeof agent.owner === "string" ? agent.owner : "";
+}
+
+function isApproved(agent: RegistryItem): boolean {
+  const status = getAgentStatus(agent);
+  return !status || status === "approved";
+}
+
+function sessionPlatform(session: Session): string {
+  return session.platform || session.service_name || "Unknown IDE";
+}
+
+function sessionAgentLabel(session: Session): string | null {
+  return session.agent_name || session.agent_id || null;
+}
+
+function sessionTitle(session: Session): string {
+  const prompts = toNumber(session.prompt_count);
+  const promptLabel = prompts === 1 ? "prompt" : "prompts";
+  const agent = session.agent_name ? `${session.agent_name} · ` : "";
+  return `${agent}${prompts} ${promptLabel}`;
+}
+
+function computeTodayStats(sessions: Session[]) {
+  const totals = sessions.reduce(
+    (acc, session) => {
+      const inputTokens = maybeNumber(session.total_input_tokens);
+      const outputTokens = maybeNumber(session.total_output_tokens);
+      acc.input += inputTokens ?? 0;
+      acc.output += outputTokens ?? 0;
+      acc.hasTokenData ||= inputTokens != null || outputTokens != null;
+      acc.tools += toNumber(session.tool_result_count);
+      acc.prompts += toNumber(session.prompt_count);
+      if (session.is_active) acc.active += 1;
+
+      const agent = sessionAgentLabel(session);
+      if (agent) acc.agents.add(agent);
+
+      const platform = sessionPlatform(session);
+      if (platform) acc.platforms.add(platform);
+
+      return acc;
+    },
+    {
+      input: 0,
+      output: 0,
+      tools: 0,
+      prompts: 0,
+      active: 0,
+      agents: new Set<string>(),
+      platforms: new Set<string>(),
+      hasTokenData: false,
+    },
+  );
+
+  return {
+    sessions: sessions.length,
+    active: totals.active,
+    prompts: totals.prompts,
+    input: totals.input,
+    output: totals.output,
+    totalTokens: totals.input + totals.output,
+    hasTokenData: totals.hasTokenData,
+    tools: totals.tools,
+    agentCount: totals.agents.size,
+    platformCount: totals.platforms.size,
+    platforms: Array.from(totals.platforms),
+  };
+}
+
+function rankForUser(
+  leaderboard: LeaderboardItem[] | undefined,
+  email?: string,
+  username?: string | null,
+  name?: string,
+): { item: LeaderboardItem; rank: number } | null {
+  const emailKey = normalizeText(email);
+  const usernameKey = normalizeText(username);
+  const nameKey = normalizeText(name);
+
+  const index = (leaderboard ?? []).findIndex((item) => {
+    const itemEmail = normalizeText(item.created_by_email);
+    const itemUsername = normalizeText(item.created_by_username);
+    const itemOwner = normalizeText(item.owner);
+    return (
+      (emailKey && itemEmail === emailKey) ||
+      (usernameKey && itemUsername === usernameKey) ||
+      (nameKey && itemOwner === nameKey)
+    );
+  });
+
+  if (index === -1 || !leaderboard) return null;
+  return { item: leaderboard[index], rank: index + 1 };
+}
+
+function BriefMetric({ label, value, detail }: { label: string; value: string; detail?: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 truncate font-mono text-xl font-semibold tracking-tight text-foreground">{value}</p>
+      {detail && <p className="mt-1 truncate text-xs text-muted-foreground">{detail}</p>}
+    </div>
+  );
+}
+
+function SectionHeader({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 border-b border-border px-4 py-3">
+      <div className="min-w-0">
+        <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+        {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+function ActionRow({ action }: { action: HomeAction }) {
+  const Icon = action.icon;
+  return (
+    <Link
+      to={action.href}
+      className="group flex items-center gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-accent/40"
+    >
+      <span className={action.priority ? "text-primary" : "text-muted-foreground"}>
+        <Icon className="h-4 w-4" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-foreground">{action.title}</span>
+        <span className="block truncate text-xs text-muted-foreground">{action.description}</span>
+      </span>
+      <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
+    </Link>
+  );
+}
+
+function AgentImpactRow({ agent, index }: { agent: RegistryItem; index: number }) {
+  const rating = getAgentRating(agent);
+  return (
+    <Link
+      to="/agents/$agentId"
+      params={{ agentId: agent.id }}
+      className="grid grid-cols-[2rem_minmax(0,1fr)_5rem_4rem] items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors hover:bg-accent/40"
+    >
+      <span className="text-right font-mono text-xs font-medium text-muted-foreground">{index + 1}</span>
+      <div className="min-w-0">
+        <span className="block truncate font-medium text-foreground">{agent.name}</span>
+        <span className="block truncate text-xs text-muted-foreground">{getAgentOwner(agent) || "Owned agent"}</span>
+      </div>
+      <span className="inline-flex items-center justify-end gap-1 font-mono text-xs text-muted-foreground">
+        <ArrowDownToLine className="h-3 w-3" />
+        {compactNumber(getAgentDownloads(agent))}
+      </span>
+      <span className="inline-flex items-center justify-end gap-1 text-xs text-muted-foreground">
+        {rating ? (
+          <>
+            <Star className="h-3 w-3" />
+            {rating.toFixed(1)}
+          </>
+        ) : (
+          "None"
+        )}
+      </span>
+    </Link>
+  );
+}
+
+function SessionRow({ session, showTokens }: { session: Session; showTokens: boolean }) {
+  return (
+    <Link
+      to="/traces/$traceId"
+      params={{ traceId: session.session_id }}
+      className={`grid ${showTokens ? "grid-cols-[minmax(0,1fr)_4.5rem_5rem]" : "grid-cols-[minmax(0,1fr)_5rem]"} items-center gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-accent/40`}
+    >
+      <div className="min-w-0">
+        <span className="block truncate text-sm font-medium text-foreground">{sessionTitle(session)}</span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {sessionPlatform(session)} · {session.model || "Unknown model"}
+        </span>
+      </div>
+      {showTokens && (
+        <span className="text-right font-mono text-xs text-muted-foreground">
+          {formatTokens(toNumber(session.total_input_tokens) + toNumber(session.total_output_tokens))}
+        </span>
+      )}
+      <span className="text-right text-xs text-muted-foreground">{formatMaybeTime(session.last_event_time)}</span>
+    </Link>
+  );
+}
+
+function RankSummary({
+  rank,
+  isLoading,
+}: {
+  rank: { item: LeaderboardItem; rank: number } | null;
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return <div className="h-20 animate-pulse rounded-md bg-muted/40" />;
+  }
+
+  if (!rank) {
+    return (
+      <div className="rounded-md bg-muted/35 px-4 py-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+          <Medal className="h-4 w-4 text-muted-foreground" />
+          Not ranked this week
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">Your agents are not in the top 50 for 7 day installs yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      to="/agents/$agentId"
+      params={{ agentId: rank.item.id }}
+      className="flex items-center justify-between gap-4 rounded-md bg-primary/5 px-4 py-3 transition-colors hover:bg-primary/10"
+    >
+      <div className="min-w-0">
+        <p className="text-xs text-muted-foreground">Best 7 day rank</p>
+        <p className="mt-1 truncate text-sm font-medium text-foreground">{rank.item.name}</p>
+      </div>
+      <div className="text-right">
+        <p className="font-mono text-3xl font-semibold tracking-tight text-foreground">#{rank.rank}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{compactNumber(rank.item.download_count)} installs</p>
+      </div>
+    </Link>
+  );
+}
 
 export default function RegistryHome() {
   const [search, setSearch] = useState("");
-  const [heroCopied, setHeroCopied] = useState(false);
-  const [leaderboardWindow, setLeaderboardWindow] =
-    useState<LeaderboardWindow>("7d");
   const router = useRouter();
+  const { data: whoami } = useWhoami();
+  const { data: sessionsToday, isLoading: sessionsLoading } = useSessions2({
+    days: 1,
+    limit: 200,
+    mine: true,
+    refetchInterval: 30_000,
+  });
+  const { data: myAgents, isLoading: myAgentsLoading } = useMyAgents();
+  const { data: leaderboard, isLoading: leaderboardLoading } = useLeaderboard("7d", 50);
+  const { data: topAgents, isLoading: topLoading } = useTopAgents(6);
   const {
     data: agents,
     isLoading: agentsLoading,
@@ -51,11 +359,93 @@ export default function RegistryHome() {
     error: agentsErr,
     refetch: refetchAgents,
   } = useRegistryList("agents");
-  const { data: topAgents, isLoading: topLoading } = useTopAgents();
-  const { data: stats } = useOverviewStats();
-  const { data: leaderboard, isLoading: leaderboardLoading } =
-    useLeaderboard(leaderboardWindow, 10);
-  const { brandingAppName, brandingWordmark } = useDeploymentConfig();
+  const { brandingAppName } = useDeploymentConfig();
+
+  const todayStats = useMemo(() => computeTodayStats(sessionsToday ?? []), [sessionsToday]);
+  const bestRank = useMemo(
+    () => rankForUser(leaderboard, whoami?.email, whoami?.username, whoami?.name),
+    [leaderboard, whoami?.email, whoami?.name, whoami?.username],
+  );
+
+  const approvedAgents = useMemo(() => (myAgents ?? []).filter(isApproved), [myAgents]);
+  const draftAgents = useMemo(
+    () => (myAgents ?? []).filter((agent) => ["draft", "pending", "rejected"].includes(getAgentStatus(agent))),
+    [myAgents],
+  );
+  const ownedInstallTotal = useMemo(
+    () => (myAgents ?? []).reduce((total, agent) => total + getAgentDownloads(agent), 0),
+    [myAgents],
+  );
+  const averageRating = useMemo(() => {
+    const ratings = (myAgents ?? []).map(getAgentRating).filter((rating): rating is number => rating != null);
+    if (ratings.length === 0) return null;
+    return ratings.reduce((total, rating) => total + rating, 0) / ratings.length;
+  }, [myAgents]);
+  const topOwnedAgents = useMemo(
+    () => [...(myAgents ?? [])].sort((a, b) => getAgentDownloads(b) - getAgentDownloads(a)).slice(0, 5),
+    [myAgents],
+  );
+
+  const recentSessions = (sessionsToday ?? []).slice(0, 5);
+  const trending = (topAgents ?? []).slice(0, 4);
+  const recentlyAdded = useMemo(
+    () =>
+      [...(agents ?? [])]
+        .sort((a: RegistryItem, b: RegistryItem) => {
+          const da = a.created_at ? new Date(a.created_at).getTime() : 0;
+          const db = b.created_at ? new Date(b.created_at).getTime() : 0;
+          return db - da;
+        })
+        .slice(0, 4),
+    [agents],
+  );
+
+  const actions = useMemo<HomeAction[]>(() => {
+    const items: HomeAction[] = [];
+    const latestSession = recentSessions[0];
+    if (latestSession) {
+      items.push({
+        title: "Resume last trace",
+        description: `${sessionPlatform(latestSession)} at ${formatMaybeTime(latestSession.last_event_time)}`,
+        href: `/traces/${latestSession.session_id}`,
+        icon: Activity,
+        priority: true,
+      });
+    } else {
+      items.push({
+        title: "Start capturing sessions",
+        description: "Patch your IDE and send your first coding trace into Observal.",
+        href: "/wiki",
+        icon: Terminal,
+        priority: true,
+      });
+    }
+
+    if (draftAgents.length > 0) {
+      items.push({
+        title: `Finish ${draftAgents.length} draft${draftAgents.length === 1 ? "" : "s"}`,
+        description: "Complete and submit unfinished agents for review.",
+        href: "/agents",
+        icon: FileEdit,
+      });
+    } else {
+      items.push({
+        title: "Build an agent",
+        description: "Bundle prompts, skills, MCPs, hooks, and sandboxes.",
+        href: "/agents/builder",
+        icon: WandSparkles,
+      });
+    }
+
+    items.push({
+      title: "Browse agents",
+      description: "Find a ready-made agent and pull it into your IDE.",
+      href: "/agents",
+      icon: Bot,
+    });
+
+    return items;
+  }, [draftAgents.length, recentSessions]);
 
   function handleSearch(e: React.FormEvent) {
     e.preventDefault();
@@ -64,277 +454,268 @@ export default function RegistryHome() {
     }
   }
 
-  const handleHeroCopy = useCallback(() => {
-    copyToClipboard("observal agent pull my-agent --ide cursor");
-    setHeroCopied(true);
-    toast.success("Copied to clipboard");
-    setTimeout(() => setHeroCopied(false), 2000);
-  }, []);
-
-  const trending = (topAgents ?? []).slice(0, 6);
-  const recentlyAdded = (agents ?? [])
-    .sort((a: RegistryItem, b: RegistryItem) => {
-      const da = a.created_at ? new Date(a.created_at).getTime() : 0;
-      const db = b.created_at ? new Date(b.created_at).getTime() : 0;
-      return db - da;
-    })
-    .slice(0, 6);
+  const displayName = whoami?.name || whoami?.username || whoami?.email || "there";
+  const primarySummary = sessionsLoading
+    ? "Loading today's activity"
+    : todayStats.sessions > 0 && todayStats.hasTokenData
+      ? `${todayStats.sessions} session${todayStats.sessions === 1 ? "" : "s"} today using ${formatTokens(todayStats.totalTokens)} tokens.`
+      : todayStats.sessions > 0
+        ? `${todayStats.sessions} session${todayStats.sessions === 1 ? "" : "s"} captured today.`
+        : "No coding sessions captured today.";
 
   return (
     <>
-      <PageHeader
-        title="Agent Registry"
-        breadcrumbs={[{ label: "Registry" }]}
-      />
+      <PageHeader title="Home" breadcrumbs={[{ label: "Registry" }]} />
 
-      <div className="p-6 lg:p-8 w-full mx-auto space-y-12">
-        {/* Hero section */}
-        <section className="animate-in space-y-6 pt-2">
-          <div className="space-y-3 max-w-2xl">
-            {brandingWordmark ? (
-              <img loading="lazy" src={brandingWordmark} alt={brandingAppName || "Observal"} width={224} height={32} className="h-8 max-w-56 object-contain object-left" />
-            ) : (
-              <h1 className="text-2xl sm:text-3xl font-display font-bold tracking-tight text-foreground">
-                {brandingAppName || "Observal"}
-              </h1>
-            )}
-            <p className="text-base text-muted-foreground leading-relaxed max-w-lg">
-              The open registry for AI agents. Browse, install, and discover
-              agents across your team.
-            </p>
+      <div className="w-full space-y-8 p-6 lg:p-8">
+        <section className="animate-in space-y-5">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+            <div className="max-w-3xl space-y-3">
+              <div className="space-y-2">
+                <h1 className="text-2xl font-display font-semibold tracking-tight text-foreground sm:text-3xl">
+                  {displayName}, here is your day in {brandingAppName || "Observal"}.
+                </h1>
+                <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+                  {primarySummary} Track coding activity, registry impact, and the next useful move.
+                </p>
+              </div>
+            </div>
+            <form onSubmit={handleSearch} className="relative w-full max-w-md">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Search agents by name, owner, or description..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="h-10 pl-9"
+              />
+            </form>
           </div>
 
-          {/* Stats bar */}
-          {stats && (
-            <div className="flex items-center gap-6 text-sm text-muted-foreground">
-              <span className="font-mono font-medium text-foreground">
-                {stats.total_agents}
-              </span>{" "}
-              agents
-              <span className="text-border">·</span>
-              <span className="font-mono font-medium text-foreground">
-                {stats.total_mcps}
-              </span>{" "}
-              components
-              <span className="text-border">·</span>
-              <span className="font-mono font-medium text-foreground">
-                {stats.total_users}
-              </span>{" "}
-              engineers
+          <div className="rounded-md border border-border bg-card">
+            <div className="grid gap-6 px-4 py-4 md:grid-cols-3 xl:grid-cols-6">
+              <BriefMetric
+                label="Sessions today"
+                value={sessionsLoading ? "..." : formatNumber(todayStats.sessions)}
+                detail={todayStats.active > 0 ? `${todayStats.active} active now` : `${todayStats.prompts} prompts`}
+              />
+              {(sessionsLoading || todayStats.hasTokenData) && (
+                <BriefMetric
+                  label="Tokens"
+                  value={sessionsLoading ? "..." : formatTokens(todayStats.totalTokens)}
+                  detail={todayStats.hasTokenData ? `${formatTokens(todayStats.input)} in · ${formatTokens(todayStats.output)} out` : undefined}
+                />
+              )}
+              <BriefMetric
+                label="Tool calls"
+                value={sessionsLoading ? "..." : formatNumber(todayStats.tools)}
+                detail={`${todayStats.agentCount} agents · ${todayStats.platformCount} IDEs`}
+              />
+              <BriefMetric
+                label="Best rank"
+                value={leaderboardLoading ? "..." : bestRank ? `#${bestRank.rank}` : "Unranked"}
+                detail={bestRank ? bestRank.item.name : "7 day board"}
+              />
+              <BriefMetric
+                label="Owned installs"
+                value={myAgentsLoading ? "..." : compactNumber(ownedInstallTotal)}
+                detail={`${approvedAgents.length} published agents`}
+              />
+              <BriefMetric
+                label="Avg rating"
+                value={myAgentsLoading ? "..." : averageRating ? averageRating.toFixed(1) : "New"}
+                detail={draftAgents.length > 0 ? `${draftAgents.length} drafts or pending` : "No drafts waiting"}
+              />
             </div>
-          )}
+          </div>
+        </section>
 
-          {/* Search bar */}
-          <form onSubmit={handleSearch} className="relative max-w-lg">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Search agents by name, owner, or description..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-9 h-10"
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(360px,420px)]">
+          <div className="rounded-md border border-border bg-card">
+            <SectionHeader
+              title="Coding activity today"
+              description="Input, output, tools, and recent sessions from your IDEs."
+              action={
+                <Button asChild variant="outline" size="sm">
+                  <Link to="/traces">View traces</Link>
+                </Button>
+              }
             />
-          </form>
 
-          {/* Terminal snippet */}
-          <div className="max-w-lg">
-            <div className="flex items-center gap-2 rounded-md border border-border bg-surface-sunken px-3 py-2.5">
-              <Terminal className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-              <code className="flex-1 text-sm font-mono text-foreground select-all">
-                <span className="text-muted-foreground">$</span>{" "}
-                observal agent pull my-agent --ide cursor
-              </code>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 shrink-0"
-                onClick={handleHeroCopy}
-                aria-label="Copy command"
-              >
-                {heroCopied ? (
-                  <Check className="h-3.5 w-3.5 text-success" />
-                ) : (
-                  <Copy className="h-3.5 w-3.5" />
+            {(sessionsLoading || todayStats.hasTokenData || todayStats.platforms.length > 0) && (
+              <div className={`grid border-b border-border ${sessionsLoading || todayStats.hasTokenData ? "md:grid-cols-3" : "md:grid-cols-1"}`}>
+                {(sessionsLoading || todayStats.hasTokenData) && (
+                  <>
+                    <div className="border-b border-border px-4 py-3 md:border-b-0 md:border-r">
+                      <p className="text-xs text-muted-foreground">Input tokens</p>
+                      <p className="mt-2 font-mono text-xl font-semibold text-foreground">
+                        {sessionsLoading ? "..." : formatTokens(todayStats.input)}
+                      </p>
+                    </div>
+                    <div className="border-b border-border px-4 py-3 md:border-b-0 md:border-r">
+                      <p className="text-xs text-muted-foreground">Output tokens</p>
+                      <p className="mt-2 font-mono text-xl font-semibold text-foreground">
+                        {sessionsLoading ? "..." : formatTokens(todayStats.output)}
+                      </p>
+                    </div>
+                  </>
                 )}
-              </Button>
-            </div>
-          </div>
-        </section>
+                <div className="px-4 py-3">
+                  <p className="text-xs text-muted-foreground">Platforms</p>
+                  <p className="mt-2 truncate text-sm font-medium text-foreground">
+                    {todayStats.platforms.length > 0 ? todayStats.platforms.slice(0, 3).join(", ") : "No IDE activity"}
+                  </p>
+                </div>
+              </div>
+            )}
 
-        {/* Trending Agents */}
-        <section className="animate-in stagger-1 space-y-4">
-          <div className="flex items-center gap-2">
-            <TrendingUp className="h-4 w-4 text-muted-foreground" />
-            <h2 className="text-sm font-semibold font-display uppercase tracking-wider text-muted-foreground">
-              Trending
-            </h2>
-          </div>
-          {topLoading ? (
-            <CardSkeleton count={3} columns={3} />
-          ) : trending.length === 0 ? (
-            <EmptyState
-              icon={TrendingUp}
-              title="No trending agents"
-              description="Agents with the most downloads will appear here."
-            />
-          ) : (
-            <div
-              className="grid gap-4"
-              style={{
-                gridTemplateColumns:
-                  "repeat(auto-fill, minmax(min(320px, 100%), 1fr))",
-              }}
-            >
-              {trending.map((item: TopAgentItem, i: number) => (
-                <AgentCard
-                  key={item.id}
-                  id={item.id}
-                  name={item.name}
-                  downloads={item.download_count}
-                  score={item.average_rating ?? undefined}
-                  description={item.description}
-                  owner={item.owner}
-                  version={item.version}
-                  className={`animate-in stagger-${Math.min(i + 1, 5)}`}
-                />
-              ))}
-            </div>
-          )}
-        </section>
-
-        {/* Leaderboard */}
-        <section className="animate-in stagger-2 space-y-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Trophy className="h-4 w-4 text-muted-foreground" />
-              <h2 className="text-sm font-semibold font-display uppercase tracking-wider text-muted-foreground">
-                Leaderboard
-              </h2>
-            </div>
-            <Link
-              to="/leaderboard"
-              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              View all <ArrowRight className="h-3 w-3" />
-            </Link>
-          </div>
-
-          <Tabs
-            value={leaderboardWindow}
-            onValueChange={(v) =>
-              setLeaderboardWindow(v as LeaderboardWindow)
-            }
-          >
-            <TabsList>
-              <TabsTrigger value="24h">24h</TabsTrigger>
-              <TabsTrigger value="7d">7d</TabsTrigger>
-              <TabsTrigger value="30d">30d</TabsTrigger>
-              <TabsTrigger value="all">All time</TabsTrigger>
-            </TabsList>
-          </Tabs>
-
-          {leaderboardLoading ? (
-            <TableSkeleton rows={5} cols={4} />
-          ) : !leaderboard || leaderboard.length === 0 ? (
-            <EmptyState
-              icon={Trophy}
-              title="No leaderboard data"
-              description="Install agents to see rankings appear here."
-            />
-          ) : (
-            <div className="space-y-1">
-              {leaderboard.map((item, i) => (
-                <Link
-                  key={item.id}
-                  to="/agents/$agentId" params={{ agentId: item.id }}
-                  className="flex items-center gap-4 rounded-md px-3 py-2.5 transition-colors hover:bg-accent/40"
-                >
-                  <span className="w-6 text-right text-sm font-mono font-medium text-muted-foreground">
-                    {i + 1}
-                  </span>
-                  <div className="flex-1 min-w-0">
-                    <span className="text-sm font-medium truncate block">
-                      {item.name}
-                    </span>
-                    {item.owner && (
-                      <span className="text-xs text-muted-foreground/70">
-                        {item.owner}
-                      </span>
-                    )}
+            <div className="p-2">
+              {sessionsLoading ? (
+                <TableSkeleton rows={5} cols={3} />
+              ) : recentSessions.length === 0 ? (
+                <div className="p-6">
+                  <EmptyState
+                    icon={Activity}
+                    title="No sessions today"
+                    description="Run a coding session with Observal telemetry enabled to see tokens, tools, and traces here."
+                    actionLabel="Open setup docs"
+                    actionHref="/wiki"
+                  />
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  <div className={`grid ${todayStats.hasTokenData ? "grid-cols-[minmax(0,1fr)_4.5rem_5rem]" : "grid-cols-[minmax(0,1fr)_5rem]"} gap-3 px-3 py-2 text-xs font-medium text-muted-foreground`}>
+                    <span>Session</span>
+                    {todayStats.hasTokenData && <span className="text-right">Tokens</span>}
+                    <span className="text-right">Latest</span>
                   </div>
-                  <div className="flex items-center gap-4 shrink-0 text-xs text-muted-foreground">
-                    <span className="inline-flex items-center gap-1">
-                      <ArrowDownToLine className="h-3 w-3" />
-                      {compactNumber(item.download_count)}
-                    </span>
-                    {item.average_rating != null && (
-                      <span className="inline-flex items-center gap-1">
-                        <Star className="h-3 w-3" />
-                        {item.average_rating.toFixed(1)}
-                      </span>
-                    )}
-                    {item.version && (
-                      <Badge
-                        variant="secondary"
-                        className="text-[10px] px-1.5 py-0"
-                      >
-                        {item.version}
-                      </Badge>
-                    )}
-                  </div>
-                </Link>
-              ))}
+                  {recentSessions.map((session) => (
+                    <SessionRow key={session.session_id} session={session} showTokens={todayStats.hasTokenData} />
+                  ))}
+                </div>
+              )}
             </div>
-          )}
+          </div>
+
+          <aside className="rounded-md border border-border bg-card">
+            <SectionHeader title="Registry impact" description="Rank, owned agents, and immediate follow-ups." />
+            <div className="space-y-4 p-4">
+              <RankSummary rank={bestRank} isLoading={leaderboardLoading} />
+
+              <div>
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <h3 className="text-xs font-medium text-muted-foreground">Your agents</h3>
+                  <Link to="/agents" className="text-xs text-muted-foreground hover:text-foreground">
+                    Manage
+                  </Link>
+                </div>
+                {myAgentsLoading ? (
+                  <TableSkeleton rows={3} cols={3} />
+                ) : topOwnedAgents.length === 0 ? (
+                  <EmptyState
+                    icon={Bot}
+                    title="No agents owned yet"
+                    description="Create your first reusable coding agent and track installs here."
+                    actionLabel="Open builder"
+                    actionHref="/agents/builder"
+                  />
+                ) : (
+                  <div className="space-y-1">
+                    {topOwnedAgents.map((agent, index) => (
+                      <AgentImpactRow key={agent.id} agent={agent} index={index} />
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-xs font-medium text-muted-foreground">Next up</h3>
+                <div className="space-y-1">
+                  {actions.map((action) => (
+                    <ActionRow key={action.title} action={action} />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </aside>
         </section>
 
-        {/* Recently Added */}
-        <section className="animate-in stagger-3 space-y-4">
-          <div className="flex items-center gap-2">
-            <Clock className="h-4 w-4 text-muted-foreground" />
-            <h2 className="text-sm font-semibold font-display uppercase tracking-wider text-muted-foreground">
-              Recently Added
-            </h2>
-          </div>
-          {agentsLoading ? (
-            <CardSkeleton count={3} columns={3} />
-          ) : agentsError ? (
-            <ErrorState
-              message={agentsErr?.message}
-              onRetry={() => refetchAgents()}
-            />
-          ) : recentlyAdded.length === 0 ? (
-            <EmptyState
-              icon={Clock}
-              title="No agents yet"
-              description="Agents will appear here once published. Submit your first agent to get started."
-              actionLabel="Browse Agents"
-              actionHref="/agents"
-            />
-          ) : (
-            <div
-              className="grid gap-4"
-              style={{
-                gridTemplateColumns:
-                  "repeat(auto-fill, minmax(min(320px, 100%), 1fr))",
-              }}
-            >
-              {recentlyAdded.map((agent: RegistryItem, i: number) => (
-                <AgentCard
-                  key={agent.id}
-                  id={agent.id}
-                  name={agent.name}
-                  description={agent.description as string | undefined}
-                  owner={agent.owner as string | undefined}
-                  version={agent.version as string | undefined}
-                  downloads={agent.download_count as number | undefined}
-                  score={(agent.average_rating as number | null) ?? undefined}
-                  component_count={agent.component_count as number | undefined}
-                  className={`animate-in stagger-${Math.min(i + 1, 5)}`}
-                />
-              ))}
+        <section className="grid gap-6 xl:grid-cols-2">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Sparkles className="h-4 w-4 text-muted-foreground" />
+                <h2 className="text-sm font-semibold text-foreground">Trending agents</h2>
+              </div>
+              <Link to="/leaderboard" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+                View rankings <ArrowRight className="h-3 w-3" />
+              </Link>
             </div>
-          )}
+            {topLoading ? (
+              <CardSkeleton count={4} columns={4} />
+            ) : trending.length === 0 ? (
+              <EmptyState
+                icon={CircleAlert}
+                title="No trending agents yet"
+                description="Agents with recent installs will appear here after your team starts pulling them."
+              />
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2">
+                {trending.map((item: TopAgentItem) => (
+                  <AgentCard
+                    key={item.id}
+                    id={item.id}
+                    name={item.name}
+                    downloads={item.download_count}
+                    score={item.average_rating ?? undefined}
+                    description={item.description}
+                    owner={item.owner}
+                    version={item.version}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Clock3 className="h-4 w-4 text-muted-foreground" />
+                <h2 className="text-sm font-semibold text-foreground">Recently added</h2>
+              </div>
+              <Link to="/agents" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+                Browse agents <ArrowRight className="h-3 w-3" />
+              </Link>
+            </div>
+            {agentsLoading ? (
+              <CardSkeleton count={4} columns={4} />
+            ) : agentsError ? (
+              <ErrorState message={agentsErr?.message} onRetry={() => refetchAgents()} />
+            ) : recentlyAdded.length === 0 ? (
+              <EmptyState
+                icon={Bot}
+                title="No agents yet"
+                description="Published agents will appear here once your registry has content."
+                actionLabel="Create an agent"
+                actionHref="/agents/builder"
+              />
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2">
+                {recentlyAdded.map((agent: RegistryItem) => (
+                  <AgentCard
+                    key={agent.id}
+                    id={agent.id}
+                    name={agent.name}
+                    description={agent.description as string | undefined}
+                    owner={agent.owner as string | undefined}
+                    version={agent.version as string | undefined}
+                    downloads={agent.download_count as number | undefined}
+                    score={(agent.average_rating as number | null) ?? undefined}
+                    component_count={agent.component_count as number | undefined}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         </section>
       </div>
     </>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
Clean up the authenticated homepage so it behaves like a useful personal cockpit instead of a generic registry landing page. The page now focuses on daily coding sessions, token usage when available, registry impact, owned agents, and useful next actions.

## Fixes
* N/A, direct homepage cleanup request.

## Approach
Reworked the registry home surface to remove the generic hero, install snippet, duplicate leaderboard tabs, and noisy bento layout. Added a compact daily stats strip, a coding activity table, a registry impact panel, and lower priority discovery sections. Added a `mine=true` sessions query option so admins can view their own homepage activity instead of workspace-wide sessions. Token UI is hidden when token data is not available.

## How Has This Been Tested?

Ran the following checks locally:

```bash
pnpm --dir web typecheck
pnpm --dir web lint
pnpm --dir web build
uv run ruff check observal-server/api/routes/sessions.py
```

Also reviewed the updated homepage visually with provided screenshots and local browser rendering during implementation.

<img width="2295" height="1256" alt="image" src="https://github.com/user-attachments/assets/0f541dcf-6054-4be3-834f-1a6a218e72bd" />


## Learning (optional, can help others)
The homepage should prioritize personal daily activity and owned registry impact over generic marketplace content. Token totals are useful only when real token data is present, so the UI now hides token sections when that data is unavailable.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
