### PR TITLE
feat(registry): archive components

### DIFF
--- a/observal-server/api/routes/_component_archive.py
+++ b/observal-server/api/routes/_component_archive.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import commit_or_name_conflict, get_effective_component_permission, resolve_listing
+from models.mcp import ListingStatus
+from models.user import User
+
+
+async def archive_listing(model, listing_id: str, db: AsyncSession, current_user: User, item_type: str) -> dict:
+    listing = await resolve_listing(model, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if get_effective_component_permission(listing, current_user) != "owner":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    if listing.status != ListingStatus.approved:
+        raise HTTPException(status_code=400, detail=f"Only approved {item_type}s can be archived")
+
+    listing.status = ListingStatus.archived
+    await commit_or_name_conflict(db, item_type)
+    return {"id": str(listing.id), "name": listing.name, "status": "archived"}
+
+
+async def unarchive_listing(model, listing_id: str, db: AsyncSession, current_user: User, item_type: str) -> dict:
+    listing = await resolve_listing(model, listing_id, db)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    if get_effective_component_permission(listing, current_user) != "owner":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    if listing.status != ListingStatus.archived:
+        raise HTTPException(status_code=400, detail=f"{item_type.title()} is not archived")
+
+    listing.status = ListingStatus.approved
+    await commit_or_name_conflict(db, item_type)
+    return {"id": str(listing.id), "name": listing.name, "status": "approved"}
+
+
+def archived_install_warning(item_type: str, name: str) -> str:
+    return f"Archived {item_type} '{name}' is deprecated and may be removed from future agent pulls."

--- a/observal-server/api/routes/agent/__init__.py
+++ b/observal-server/api/routes/agent/__init__.py
@@ -6,5 +6,5 @@
 # Import sub-modules so they register their routes on the shared router.
 from . import crud, draft, insights, install  # noqa: F401
 from ._router import router  # noqa: F401
-from .helpers import _load_agent, _resolve_component_names  # noqa: F401
+from .helpers import _load_agent, _resolve_component_names, _resolve_component_statuses  # noqa: F401
 from .install import install_agent  # noqa: F401

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -42,6 +42,7 @@ from .helpers import (
     _agent_to_response,
     _load_agent,
     _resolve_component_names,
+    _resolve_component_statuses,
     _validate_mcp_ids,
 )
 
@@ -430,6 +431,7 @@ async def get_agent(
     if perm == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view this agent")
     name_map = await _resolve_component_names(agent.components, db)
+    status_map = await _resolve_component_statuses(agent.components, db)
     user_row = (await db.execute(select(User.email, User.username).where(User.id == agent.created_by))).first()
     return _agent_to_response(
         agent,
@@ -437,6 +439,7 @@ async def get_agent(
         created_by_email=user_row[0] if user_row else "",
         created_by_username=user_row[1] if user_row else None,
         user_permission=perm,
+        status_map=status_map,
     )
 
 

--- a/observal-server/api/routes/agent/helpers.py
+++ b/observal-server/api/routes/agent/helpers.py
@@ -74,8 +74,10 @@ def _agent_to_response(
     created_by_email: str = "",
     created_by_username: str | None = None,
     user_permission: str | None = None,
+    status_map: dict[str, str] | None = None,
 ) -> AgentResponse:
     name_map = name_map or {}
+    status_map = status_map or {}
     # Build mcp_links from components with component_type='mcp' (backwards compat)
     mcp_components = [c for c in agent.components if c.component_type == "mcp"]
     mcp_links = [
@@ -95,6 +97,7 @@ def _agent_to_response(
             version_ref=comp.resolved_version,
             order=comp.order_index,
             config_override=comp.config_override,
+            status=status_map.get(str(comp.component_id)),
         )
         for comp in agent.components
     ]
@@ -138,7 +141,6 @@ async def _resolve_component_names(components: list, db: AsyncSession) -> dict[s
         return {}
     from services.agent_resolver import _LISTING_MODELS
 
-    # Group component_ids by type
     by_type: dict[str, list[uuid.UUID]] = {}
     for comp in components:
         by_type.setdefault(comp.component_type, []).append(comp.component_id)
@@ -152,6 +154,47 @@ async def _resolve_component_names(components: list, db: AsyncSession) -> dict[s
         for row in rows:
             name_map[str(row[0])] = row[1]
     return name_map
+
+
+async def _resolve_component_statuses(components: list, db: AsyncSession) -> dict[str, str]:
+    """Batch-resolve component_id to current listing status for all component types."""
+    if not components:
+        return {}
+    from models.hook import HookVersion
+    from models.mcp import McpVersion
+    from models.prompt import PromptVersion
+    from models.sandbox import SandboxVersion
+    from models.skill import SkillVersion
+    from services.agent_resolver import _LISTING_MODELS
+
+    version_models = {
+        "mcp": McpVersion,
+        "skill": SkillVersion,
+        "hook": HookVersion,
+        "prompt": PromptVersion,
+        "sandbox": SandboxVersion,
+    }
+
+    by_type: dict[str, list[uuid.UUID]] = {}
+    for comp in components:
+        by_type.setdefault(comp.component_type, []).append(comp.component_id)
+
+    status_map: dict[str, str] = {}
+    for comp_type, ids in by_type.items():
+        model = _LISTING_MODELS.get(comp_type)
+        version_model = version_models.get(comp_type)
+        if not model or not version_model:
+            continue
+        rows = (
+            await db.execute(
+                select(model.id, version_model.status)
+                .join(version_model, model.latest_version_id == version_model.id)
+                .where(model.id.in_(ids))
+            )
+        ).all()
+        for row in rows:
+            status_map[str(row[0])] = getattr(row[1], "value", str(row[1]))
+    return status_map
 
 
 async def _validate_mcp_ids(mcp_ids: list[uuid.UUID], db: AsyncSession) -> list[McpListing]:

--- a/observal-server/api/routes/agent/install.py
+++ b/observal-server/api/routes/agent/install.py
@@ -16,9 +16,10 @@ from api.deps import (
     optional_current_user,
     require_role,
 )
+from api.routes._component_archive import archived_install_warning
 from models.agent import AgentStatus
 from models.hook import HookListing
-from models.mcp import McpListing
+from models.mcp import ListingStatus, McpListing
 from models.prompt import PromptListing
 from models.sandbox import SandboxListing
 from models.skill import SkillListing
@@ -150,6 +151,18 @@ async def install_agent(
         )
         sandbox_listings_map = {row.id: row for row in sandbox_rows}
 
+    archived_warnings = []
+    for item_type, rows in (
+        ("MCP", mcp_listings_map.values()),
+        ("skill", skill_listings_map.values()),
+        ("hook", hook_listings_map.values()),
+        ("prompt", prompt_listings_map.values()),
+        ("sandbox", sandbox_listings_map.values()),
+    ):
+        for row in rows:
+            if row.status == ListingStatus.archived:
+                archived_warnings.append(archived_install_warning(item_type, row.name))
+
     # Resolve all component names for rules file content
     name_map = await _resolve_component_names(agent.components, db)
 
@@ -212,7 +225,7 @@ async def install_agent(
         metadata={"ide": req.ide},
     )
 
-    warnings = snippet.pop("_warnings", [])
+    warnings = archived_warnings + snippet.pop("_warnings", [])
     return AgentInstallResponse(agent_id=resolved_agent_id, ide=req.ide, config_snippet=snippet, warnings=warnings)
 
 

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -170,13 +170,16 @@ async def _get_agent_version(
     if not ver:
         raise HTTPException(status_code=404, detail="Version not found")
 
-    from api.routes.agent import _resolve_component_names
+    from api.routes.agent import _resolve_component_names, _resolve_component_statuses
 
-    name_map = await _resolve_component_names(ver.components or [], db)
+    components = ver.components or []
+    name_map = await _resolve_component_names(components, db)
+    status_map = await _resolve_component_statuses(components, db)
     detail = _version_to_detail(ver)
     for comp in detail.get("components", []):
         if not comp.get("name"):
             comp["name"] = name_map.get(comp["component_id"], "")
+        comp["status"] = status_map.get(comp["component_id"])
     return detail
 
 

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -25,6 +25,7 @@ from api.deps import (
     require_role,
     resolve_listing,
 )
+from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.hook import HookDownload, HookListing, HookVersion
@@ -180,8 +181,17 @@ async def install_hook(
     listing = await resolve_listing(HookListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
         listing = await resolve_listing(HookListing, listing_id, db)
-        if not listing or get_effective_component_permission(listing, current_user) != "owner":
+        if not listing or not check_listing_visibility(listing, current_user):
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
+        if (
+            listing.status != ListingStatus.archived
+            and get_effective_component_permission(listing, current_user) != "owner"
+        ):
+            raise HTTPException(status_code=404, detail="Listing not found or not approved")
+
+    warnings = []
+    if listing.status == ListingStatus.archived:
+        warnings.append(archived_install_warning("hook", listing.name))
 
     db.add(HookDownload(listing_id=listing.id, user_id=current_user.id, ide=req.ide))
     latest_version = getattr(listing, "latest_version", None)
@@ -201,6 +211,7 @@ async def install_hook(
         requirements=result.get("requirements", []),
         source_fetch=result.get("source_fetch"),
         notes=result.get("notes", []),
+        warnings=warnings,
     )
 
 
@@ -378,6 +389,24 @@ async def submit_hook_draft(
     await commit_or_name_conflict(db, "hook")
     await db.refresh(listing)
     return HookListingResponse.model_validate(listing)
+
+
+@router.patch("/{listing_id}/archive")
+async def archive_hook(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await archive_listing(HookListing, listing_id, db, current_user, "hook")
+
+
+@router.patch("/{listing_id}/unarchive")
+async def unarchive_hook(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await unarchive_listing(HookListing, listing_id, db, current_user, "hook")
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -25,6 +25,7 @@ from api.deps import (
     require_role,
     resolve_listing,
 )
+from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from database import async_session
@@ -263,8 +264,17 @@ async def install_mcp(
     listing = await resolve_listing(McpListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
         listing = await resolve_listing(McpListing, listing_id, db)
-        if not listing or get_effective_component_permission(listing, current_user) != "owner":
+        if not listing or not check_listing_visibility(listing, current_user):
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
+        if (
+            listing.status != ListingStatus.archived
+            and get_effective_component_permission(listing, current_user) != "owner"
+        ):
+            raise HTTPException(status_code=404, detail="Listing not found or not approved")
+
+    warnings = []
+    if listing.status == ListingStatus.archived:
+        warnings.append(archived_install_warning("MCP", listing.name))
 
     db.add(McpDownload(listing_id=listing.id, user_id=current_user.id, ide=req.ide))
     latest_version = getattr(listing, "latest_version", None)
@@ -282,7 +292,7 @@ async def install_mcp(
         env_values=req.env_values,
         header_values=req.header_values,
     )
-    return McpInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=snippet)
+    return McpInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=snippet, warnings=warnings)
 
 
 @router.post("/draft", response_model=McpListingResponse)
@@ -464,6 +474,24 @@ async def submit_mcp_draft(
     await commit_or_name_conflict(db, "listing")
     await db.refresh(listing)
     return McpListingResponse.model_validate(listing)
+
+
+@router.patch("/{listing_id}/archive")
+async def archive_mcp(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await archive_listing(McpListing, listing_id, db, current_user, "listing")
+
+
+@router.patch("/{listing_id}/unarchive")
+async def unarchive_mcp(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await unarchive_listing(McpListing, listing_id, db, current_user, "listing")
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -26,6 +26,7 @@ from api.deps import (
     require_role,
     resolve_listing,
 )
+from api.routes._component_archive import archive_listing, unarchive_listing
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
@@ -366,6 +367,24 @@ async def submit_prompt_draft(
     await commit_or_name_conflict(db, "prompt")
     await db.refresh(listing)
     return PromptListingResponse.model_validate(listing)
+
+
+@router.patch("/{listing_id}/archive")
+async def archive_prompt(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await archive_listing(PromptListing, listing_id, db, current_user, "prompt")
+
+
+@router.patch("/{listing_id}/unarchive")
+async def unarchive_prompt(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await unarchive_listing(PromptListing, listing_id, db, current_user, "prompt")
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -24,6 +24,7 @@ from api.deps import (
     require_role,
     resolve_listing,
 )
+from api.routes._component_archive import archive_listing, unarchive_listing
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
@@ -324,6 +325,24 @@ async def submit_sandbox_draft(
     await commit_or_name_conflict(db, "sandbox")
     await db.refresh(listing)
     return SandboxListingResponse.model_validate(listing)
+
+
+@router.patch("/{listing_id}/archive")
+async def archive_sandbox(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await archive_listing(SandboxListing, listing_id, db, current_user, "sandbox")
+
+
+@router.patch("/{listing_id}/unarchive")
+async def unarchive_sandbox(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await unarchive_listing(SandboxListing, listing_id, db, current_user, "sandbox")
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -26,6 +26,7 @@ from api.deps import (
     require_role,
     resolve_listing,
 )
+from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
 from api.sanitize import escape_like
 from models.mcp import ListingStatus
@@ -259,8 +260,17 @@ async def install_skill(
     listing = await resolve_listing(SkillListing, listing_id, db, require_status=ListingStatus.approved)
     if not listing:
         listing = await resolve_listing(SkillListing, listing_id, db)
-        if not listing or get_effective_component_permission(listing, current_user) != "owner":
+        if not listing or not check_listing_visibility(listing, current_user):
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
+        if (
+            listing.status != ListingStatus.archived
+            and get_effective_component_permission(listing, current_user) != "owner"
+        ):
+            raise HTTPException(status_code=404, detail="Listing not found or not approved")
+
+    warnings = []
+    if listing.status == ListingStatus.archived:
+        warnings.append(archived_install_warning("skill", listing.name))
 
     # Resolve specific version if requested
     version_override = None
@@ -270,7 +280,7 @@ async def install_skill(
         ver_stmt = select(SkillVersion).where(
             SkillVersion.listing_id == listing.id,
             SkillVersion.version == req.version,
-            SkillVersion.status == "approved",
+            SkillVersion.status.in_([ListingStatus.approved, listing.status]),
         )
         ver_result = await db.execute(ver_stmt)
         version_override = ver_result.scalar_one_or_none()
@@ -297,7 +307,7 @@ async def install_skill(
         scope=req.scope,
         version_override=version_override,
     )
-    return SkillInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config)
+    return SkillInstallResponse(listing_id=listing.id, ide=req.ide, config_snippet=config, warnings=warnings)
 
 
 @router.post("/draft", response_model=SkillListingResponse)
@@ -493,6 +503,24 @@ async def submit_skill_draft(
     await commit_or_name_conflict(db, "skill")
     await db.refresh(listing)
     return SkillListingResponse.model_validate(listing)
+
+
+@router.patch("/{listing_id}/archive")
+async def archive_skill(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await archive_listing(SkillListing, listing_id, db, current_user, "skill")
+
+
+@router.patch("/{listing_id}/unarchive")
+async def unarchive_skill(
+    listing_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    return await unarchive_listing(SkillListing, listing_id, db, current_user, "skill")
 
 
 @router.delete("/{listing_id}")

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -128,6 +128,7 @@ class ComponentLinkResponse(BaseModel):
     version_ref: str
     order: int
     config_override: dict | None = None
+    status: str | None = None
     model_config = {"from_attributes": True}
 
 

--- a/observal-server/schemas/hook.py
+++ b/observal-server/schemas/hook.py
@@ -161,3 +161,4 @@ class HookInstallResponse(BaseModel):
     requirements: list[str] = []
     source_fetch: dict | None = None
     notes: list[str] = []
+    warnings: list[str] = []

--- a/observal-server/schemas/mcp.py
+++ b/observal-server/schemas/mcp.py
@@ -205,6 +205,7 @@ class McpInstallResponse(BaseModel):
     listing_id: uuid.UUID
     ide: str
     config_snippet: dict
+    warnings: list[str] = []
 
 
 class McpAnalyzeRequest(BaseModel):

--- a/observal-server/schemas/skill.py
+++ b/observal-server/schemas/skill.py
@@ -145,3 +145,4 @@ class SkillInstallResponse(BaseModel):
     listing_id: uuid.UUID
     ide: str
     config_snippet: dict
+    warnings: list[str] = []

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -110,7 +110,7 @@ async def _load_registry_catalog(db) -> dict:
     Returns a compact catalog for the LLM to reference when suggesting
     new components the agent could benefit from.
     """
-    from models.mcp import McpListing, McpVersion
+    from models.mcp import ListingStatus, McpListing, McpVersion
     from models.skill import SkillListing, SkillVersion
 
     catalog: dict = {"mcps": [], "skills": []}
@@ -119,7 +119,7 @@ async def _load_registry_catalog(db) -> dict:
     mcp_stmt = (
         select(McpListing.id, McpListing.name, McpListing.category, McpVersion.description)
         .join(McpVersion, McpListing.latest_version_id == McpVersion.id, isouter=True)
-        .where(McpListing.is_private == False)  # noqa: E712 — SQLAlchemy requires ==
+        .where(McpListing.is_private == False, McpVersion.status == ListingStatus.approved)  # noqa: E712
     )
     mcp_result = await db.execute(mcp_stmt)
     for row in mcp_result.all():
@@ -136,7 +136,7 @@ async def _load_registry_catalog(db) -> dict:
     skill_stmt = (
         select(SkillListing.id, SkillListing.name, SkillVersion.description)
         .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id, isouter=True)
-        .where(SkillListing.is_private == False)  # noqa: E712
+        .where(SkillListing.is_private == False, SkillVersion.status == ListingStatus.approved)  # noqa: E712
     )
     skill_result = await db.execute(skill_stmt)
     for row in skill_result.all():

--- a/observal-server/services/insights/self_learn.py
+++ b/observal-server/services/insights/self_learn.py
@@ -146,6 +146,8 @@ async def apply_insight_suggestions(
             except ValueError:
                 cid = None
             if cid and _is_skill_suggestion(feature):
+                if not await _is_active_skill(cid, db):
+                    continue
                 existing_skill_ids.append(cid)
                 applied["linked_existing"].append(
                     {
@@ -157,6 +159,8 @@ async def apply_insight_suggestions(
                     }
                 )
             elif cid and _is_hook_suggestion(feature):
+                if not await _is_active_hook(cid, db):
+                    continue
                 existing_hook_ids.append(cid)
                 applied["linked_existing"].append(
                     {
@@ -704,6 +708,24 @@ def _slugify(text: str) -> str:
     slug = re.sub(r"[^a-z0-9\-]", "-", slug)
     slug = re.sub(r"-+", "-", slug)
     return slug.strip("-")
+
+
+async def _is_active_skill(component_id: uuid.UUID, db: AsyncSession) -> bool:
+    result = await db.execute(
+        select(SkillListing.id)
+        .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id, isouter=True)
+        .where(SkillListing.id == component_id, SkillVersion.status == ListingStatus.approved)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _is_active_hook(component_id: uuid.UUID, db: AsyncSession) -> bool:
+    result = await db.execute(
+        select(HookListing.id)
+        .join(HookVersion, HookListing.latest_version_id == HookVersion.id, isouter=True)
+        .where(HookListing.id == component_id, HookVersion.status == ListingStatus.approved)
+    )
+    return result.scalar_one_or_none() is not None
 
 
 async def _find_existing_skill_match(feature: dict, db: AsyncSession) -> SkillListing | None:

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -700,22 +700,7 @@ def agent_install(
     console.print_json(_json.dumps(snippet, indent=2))
 
 
-@agent_app.command(name="delete")
-def agent_delete(
-    agent_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
-):
-    """Archive an agent (soft delete).
-
-    Marks the agent as archived. It will no longer appear in public
-    listings but can be restored with the unarchive command. Prompts
-    for confirmation unless --yes is provided.
-
-    Examples:
-      observal agent delete my-agent
-      observal agent delete my-agent --yes
-      observal agent delete @myalias
-    """
+def _archive_agent(agent_id: str, yes: bool) -> None:
     resolved = config.resolve_alias(agent_id)
     if not yes:
         with spinner():
@@ -725,6 +710,28 @@ def agent_delete(
     with spinner("Archiving..."):
         client.patch(f"/api/v1/agents/{resolved}/archive")
     rprint("[green]✓ Agent archived[/green]")
+
+
+@agent_app.command(name="archive")
+def agent_archive(
+    agent_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+):
+    """Archive an agent.
+
+    Marks the agent as archived. It will no longer appear in public
+    listings but can be restored with the unarchive command.
+    """
+    _archive_agent(agent_id, yes)
+
+
+@agent_app.command(name="delete")
+def agent_delete(
+    agent_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+):
+    """Archive an agent. Prefer the archive command."""
+    _archive_agent(agent_id, yes)
 
 
 @agent_app.command(name="unarchive")

--- a/observal_cli/cmd_archive.py
+++ b/observal_cli/cmd_archive.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""CLI commands for archiving registry components."""
+
+from __future__ import annotations
+
+import typer
+from rich import print as rprint
+
+from observal_cli import client, config
+
+_ENTITY_LABELS = {
+    "mcps": "MCP server",
+    "skills": "skill",
+    "hooks": "hook",
+    "prompts": "prompt",
+    "sandboxes": "sandbox",
+}
+
+
+def _archive_component(entity_type: str, entity_id: str, yes: bool) -> None:
+    resolved = config.resolve_alias(entity_id)
+    label = _ENTITY_LABELS.get(entity_type, entity_type)
+    if not yes:
+        item = client.get(f"/api/v1/{entity_type}/{resolved}")
+        if not typer.confirm(f"Archive {label} [bold]{item['name']}[/bold] ({resolved})?"):
+            raise typer.Abort()
+    client.patch(f"/api/v1/{entity_type}/{resolved}/archive")
+    rprint(f"[green]✓ {label.title()} archived[/green]")
+
+
+def _unarchive_component(entity_type: str, entity_id: str, yes: bool) -> None:
+    resolved = config.resolve_alias(entity_id)
+    label = _ENTITY_LABELS.get(entity_type, entity_type)
+    if not yes:
+        item = client.get(f"/api/v1/{entity_type}/{resolved}")
+        if not typer.confirm(f"Restore {label} [bold]{item['name']}[/bold] ({resolved})?"):
+            raise typer.Abort()
+    client.patch(f"/api/v1/{entity_type}/{resolved}/unarchive")
+    rprint(f"[green]✓ {label.title()} restored[/green]")
+
+
+def add_archive_commands(app: typer.Typer, entity_type: str) -> None:
+    @app.command(name="archive")
+    def archive(
+        entity_id: str = typer.Argument(help="Entity UUID or name"),
+        yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+    ):
+        """Archive this component."""
+        _archive_component(entity_type, entity_id, yes)
+
+    @app.command(name="unarchive")
+    def unarchive(
+        entity_id: str = typer.Argument(help="Entity UUID or name"),
+        yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+    ):
+        """Restore an archived component."""
+        _unarchive_component(entity_type, entity_id, yes)

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -307,6 +307,7 @@ def hook_install(
     files = result.get("files", [])
     requirements = result.get("requirements", [])
     notes = result.get("notes", [])
+    warnings = result.get("warnings", [])
     config_path = result.get("config_path", "")
 
     if raw:
@@ -351,6 +352,9 @@ def hook_install(
         else:
             cfg_file.write_text(_json.dumps(config_snippet, indent=2) + "\n")
             rprint(f"  [green]✓[/green] Created {config_path}")
+
+    for warning in warnings:
+        rprint(f"\n[yellow]Warning:[/yellow] {warning}")
 
     # Print requirements warning
     if requirements:

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1144,6 +1144,9 @@ def _install_impl(
         rprint(f"\n[dim]Add to:[/dim] [bold]{config_path}[/bold]")
         rprint(f"[dim]Or pipe:[/dim] observal install {mcp_id} --ide {ide} --raw > {config_path}")
 
+    for warning in result.get("warnings") or []:
+        rprint(f"\n[yellow]Warning:[/yellow] {warning}")
+
     # Warn about any empty env vars the user skipped
     missing = [k for k, v in env_values.items() if not v or v.startswith("<")]
     if missing:

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -789,7 +789,7 @@ def register_pull(app: typer.Typer):
             style = "dim" if dry_run else "green"
             rprint(f"  [{style}]{status}[/{style}]  {path}")
 
-        warnings_list = snippet.get("_warnings") or []
+        warnings_list = list(result.get("warnings") or []) + (snippet.get("_warnings") or [])
         if warnings_list:
             rprint("")
             for w in warnings_list:

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -484,6 +484,9 @@ def skill_install(
         except Exception:
             pass  # Never block install on lockfile failure
 
+    for warning in result.get("warnings") or []:
+        rprint(f"\n[yellow]Warning:[/yellow] {warning}")
+
     rprint(f"\n[bold]Config for {ide}:[/bold]\n")
     console.print_json(_json.dumps(snippet, indent=2))
 

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -150,6 +150,7 @@ def _try_lockfile_migration() -> None:
 # ── Register command groups ──────────────────────────────
 
 from observal_cli.cmd_agent import agent_app
+from observal_cli.cmd_archive import add_archive_commands
 from observal_cli.cmd_auth import auth_app, register_config
 from observal_cli.cmd_co_authors import make_co_authors_typer
 from observal_cli.cmd_component import version_app
@@ -206,6 +207,11 @@ add_transfer_owner_command(hook_app, "hooks")
 add_transfer_owner_command(prompt_app, "prompts")
 add_transfer_owner_command(sandbox_app, "sandboxes")
 add_transfer_owner_command(agent_app, "agents")
+add_archive_commands(mcp_app, "mcps")
+add_archive_commands(skill_app, "skills")
+add_archive_commands(hook_app, "hooks")
+add_archive_commands(prompt_app, "prompts")
+add_archive_commands(sandbox_app, "sandboxes")
 
 # ── Auth subgroup ────────────────────────────────────────
 app.add_typer(auth_app, name="auth")

--- a/observal_cli/skills/observal-agents/SKILL.md
+++ b/observal_cli/skills/observal-agents/SKILL.md
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 name: observal-agents
 command: observal
-description: Create, update, version, and manage Observal agents. Use when the user wants to create a new agent, update an existing one, release a new version, scaffold a YAML project, add components, build, publish, bulk-create, delete, or restore agents.
+description: Create, update, version, and manage Observal agents. Use when the user wants to create a new agent, update an existing one, release a new version, scaffold a YAML project, add components, build, publish, bulk-create, archive, delete, or restore agents.
 version: 2.0.0
 owner: observal
 ---
@@ -15,7 +15,7 @@ owner: observal
 1. **EXECUTE commands**: run them in your shell. Set timeout to 60 seconds.
 2. **Use single quotes** for `--prompt` and `--description` values.
 3. **Pass `--output json`** on list/show/versions commands.
-4. **Pass `--yes`** on destructive commands (`delete`, `unarchive`, `bulk-create`).
+4. **Pass `--yes`** on destructive commands (`archive`, `delete`, `unarchive`, `bulk-create`).
 5. **Resolve 409:** `observal agent publish --update` for in-place edits, `observal agent release --bump` for reviewed releases.
 6. **When in doubt about a flag, run `<command> --help` first.**
 
@@ -110,9 +110,10 @@ observal agent bulk-create --from-file agents.json --yes
 
 ---
 
-## Procedure: Delete / Restore
+## Procedure: Archive / Restore
 
 ```bash
+observal agent archive AGENT_NAME --yes
 observal agent delete AGENT_NAME --yes
 observal agent transfer-owner AGENT_NAME @username -y
 observal agent unarchive AGENT_NAME --yes

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 name: observal-registry
 command: observal
-description: Submit, browse, install, edit, delete, and version MCPs, skills, hooks, prompts, and sandboxes in the Observal registry. Use when the user wants to submit a component, install one, edit a draft, publish a new version, or browse the component library.
+description: Submit, browse, install, edit, archive, restore, transfer, and version MCPs, skills, hooks, prompts, and sandboxes in the Observal registry. Use when the user wants to submit a component, install one, edit a draft, publish a new version, or browse the component library.
 version: 2.0.0
 owner: observal
 ---
@@ -14,7 +14,7 @@ owner: observal
 
 1. **EXECUTE commands**: run them in your shell. Set timeout to 60 seconds.
 2. **Pass `--output json`** on list/show commands.
-3. **Pass `--yes`** on destructive commands (`delete`, `submit --git`).
+3. **Pass `--yes`** on destructive commands (`archive`, `unarchive`, `delete`, `submit --git`).
 4. **When in doubt about a flag, run `<command> --help` first.**
 5. **`--from-file` does NOT exist on `mcp submit`**: that flag is on `mcp edit`.
 
@@ -161,14 +161,17 @@ observal registry version list mcp NAME --output json
 
 ---
 
-## Procedure: Delete Component
+## Procedure: Archive / Restore Component
 
 ```bash
-observal registry mcp delete NAME --yes
-observal registry skill delete NAME --yes
-observal registry hook delete NAME --yes
-observal registry prompt delete NAME --yes
-observal registry sandbox delete NAME --yes
+observal registry mcp archive NAME --yes
+observal registry skill archive NAME --yes
+observal registry hook archive NAME --yes
+observal registry prompt archive NAME --yes
+observal registry sandbox archive NAME --yes
+
+observal registry mcp unarchive NAME --yes
+observal registry skill unarchive NAME --yes
 observal registry mcp transfer-owner NAME @username -y
 observal registry skill transfer-owner NAME @username -y
 ```

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -121,6 +121,7 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal registry hook co-authors add`: Add a co-author.
   - `observal registry hook co-authors list`: List co-authors.
   - `observal registry hook co-authors remove`: Remove a co-author.
+  - `observal registry hook archive`: Archive this component.
   - `observal registry hook delete`: Delete a hook from the registry.
   - `observal registry hook edit`: Edit a draft, rejected, or pending hook submission.
   - `observal registry hook install`: Install a hook for a specific IDE.
@@ -128,6 +129,7 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal registry hook show`: Show detailed information for a single hook.
   - `observal registry hook submit`: Submit a new hook for review.
   - `observal registry hook transfer-owner`: Transfer ownership to another username.
+  - `observal registry hook unarchive`: Restore an archived component.
 - `observal registry mcp`: MCP server registry commands
 - `observal registry mcp co-authors`: Manage co-authors for mcps
   - `observal registry mcp co-authors add`: Add a co-author.
@@ -136,11 +138,13 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal registry mcp submit`: Submit an MCP server to the registry.
   - `observal registry mcp show`: Show full details of an MCP server.
   - `observal registry mcp install`: Generate an install config snippet for an MCP server.
+  - `observal registry mcp archive`: Archive this component.
   - `observal registry mcp delete`: Delete an MCP server from the registry.
   - `observal registry mcp edit`: Edit an MCP server submission.
   - `observal registry mcp list`: List approved MCP servers in the registry.
   - `observal registry mcp my`: List your own MCP servers across all statuses.
   - `observal registry mcp transfer-owner`: Transfer ownership to another username.
+  - `observal registry mcp unarchive`: Restore an archived component.
 - `observal registry models`: Inspect the model catalog (live from models.dev with offline fallback).
   - `observal registry models list`: Show models from the registry.
 - `observal registry prompt`: Prompt registry commands
@@ -148,6 +152,7 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal registry prompt co-authors add`: Add a co-author.
   - `observal registry prompt co-authors list`: List co-authors.
   - `observal registry prompt co-authors remove`: Remove a co-author.
+  - `observal registry prompt archive`: Archive this component.
   - `observal registry prompt delete`: Delete a prompt from the registry.
   - `observal registry prompt edit`: Edit a draft, rejected, or pending prompt submission.
   - `observal registry prompt list`: List approved prompts in the registry.
@@ -156,22 +161,26 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal registry prompt show`: Show detailed information about a prompt.
   - `observal registry prompt submit`: Submit a new prompt template for review.
   - `observal registry prompt transfer-owner`: Transfer ownership to another username.
+  - `observal registry prompt unarchive`: Restore an archived component.
 - `observal registry sandbox`: Sandbox registry commands
 - `observal registry sandbox co-authors`: Manage co-authors for sandboxes
   - `observal registry sandbox co-authors add`: Add a co-author.
   - `observal registry sandbox co-authors list`: List co-authors.
   - `observal registry sandbox co-authors remove`: Remove a co-author.
+  - `observal registry sandbox archive`: Archive this component.
   - `observal registry sandbox delete`: Delete a sandbox from the registry.
   - `observal registry sandbox edit`: Edit a draft, rejected, or pending sandbox submission.
   - `observal registry sandbox list`: List approved sandboxes in the registry.
   - `observal registry sandbox show`: Show detailed information about a sandbox.
   - `observal registry sandbox submit`: Submit a new sandbox environment for review.
   - `observal registry sandbox transfer-owner`: Transfer ownership to another username.
+  - `observal registry sandbox unarchive`: Restore an archived component.
 - `observal registry skill`: Skill registry commands
 - `observal registry skill co-authors`: Manage co-authors for skills
   - `observal registry skill co-authors add`: Add a co-author.
   - `observal registry skill co-authors list`: List co-authors.
   - `observal registry skill co-authors remove`: Remove a co-author.
+  - `observal registry skill archive`: Archive this component.
   - `observal registry skill delete`: Delete a skill from the registry.
   - `observal registry skill edit`: Edit a draft, rejected, or pending skill submission.
   - `observal registry skill install`: Install a skill by fetching the full skill directory from git.
@@ -180,6 +189,7 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal registry skill show`: Show detailed information about a skill.
   - `observal registry skill submit`: Submit a new skill for review.
   - `observal registry skill transfer-owner`: Transfer ownership to another username.
+  - `observal registry skill unarchive`: Restore an archived component.
 - `observal registry version`: Manage component versions
   - `observal registry version list`: List version history for a registry component.
   - `observal registry version publish`: Publish a new version for a registry component.

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -51,6 +51,7 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal agent build`: Validate agent definition against the server (dry-run).
   - `observal agent bulk-create`: Bulk-create agents from a JSON file.
   - `observal agent create`: Create a new agent (interactive wizard, from file, or via flags).
+  - `observal agent archive`: Archive an agent.
   - `observal agent delete`: Archive an agent (soft delete).
   - `observal agent init`: Scaffold an observal-agent.yaml definition file.
   - `observal agent install`: Get install config for an agent.

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -48,11 +48,11 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal agent co-authors list`: List co-authors.
   - `observal agent co-authors remove`: Remove a co-author.
   - `observal agent add`: Add a component reference to observal-agent.yaml.
+  - `observal agent archive`: Archive an agent.
   - `observal agent build`: Validate agent definition against the server (dry-run).
   - `observal agent bulk-create`: Bulk-create agents from a JSON file.
   - `observal agent create`: Create a new agent (interactive wizard, from file, or via flags).
-  - `observal agent archive`: Archive an agent.
-  - `observal agent delete`: Archive an agent (soft delete).
+  - `observal agent delete`: Archive an agent. Prefer the archive command.
   - `observal agent init`: Scaffold an observal-agent.yaml definition file.
   - `observal agent install`: Get install config for an agent.
   - `observal agent list`: List active agents (paginated).

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -959,6 +959,7 @@ class TestComponentLinkResponseInAgentResponse:
         assert data["component_type"] == "skill"
         assert data["component_id"] == cid
         assert data["config_override"] == {"key": "val"}
+        assert data["status"] is None
 
     def test_component_link_response_no_override(self):
         from schemas.agent import ComponentLinkResponse
@@ -968,8 +969,10 @@ class TestComponentLinkResponseInAgentResponse:
             component_id=uuid.uuid4(),
             version_ref="1.0",
             order=0,
+            status="archived",
         )
         assert link.config_override is None
+        assert link.status == "archived"
 
 
 class TestPydanticValidation:

--- a/tests/test_component_archive.py
+++ b/tests/test_component_archive.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.routes._component_archive import archive_listing, unarchive_listing
+from models.mcp import ListingStatus
+from models.user import UserRole
+
+
+class _Listing:
+    def __init__(self, status=ListingStatus.approved):
+        self.id = uuid.uuid4()
+        self.name = "archivable"
+        self.status = status
+        self.submitted_by = uuid.uuid4()
+        self.co_authors = []
+        self.is_private = False
+
+
+def _user(listing):
+    user = MagicMock()
+    user.id = listing.submitted_by
+    user.role = UserRole.user
+    user.org_id = None
+    return user
+
+
+@pytest.mark.asyncio
+async def test_archive_listing_marks_component_archived(monkeypatch):
+    listing = _Listing()
+    db = AsyncMock()
+    monkeypatch.setattr("api.routes._component_archive.resolve_listing", AsyncMock(return_value=listing))
+
+    result = await archive_listing(MagicMock(), str(listing.id), db, _user(listing), "skill")
+
+    assert listing.status == ListingStatus.archived
+    assert result == {"id": str(listing.id), "name": "archivable", "status": "archived"}
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unarchive_listing_restores_component(monkeypatch):
+    listing = _Listing(status=ListingStatus.archived)
+    db = AsyncMock()
+    monkeypatch.setattr("api.routes._component_archive.resolve_listing", AsyncMock(return_value=listing))
+
+    result = await unarchive_listing(MagicMock(), str(listing.id), db, _user(listing), "skill")
+
+    assert listing.status == ListingStatus.approved
+    assert result == {"id": str(listing.id), "name": "archivable", "status": "approved"}
+    db.commit.assert_awaited_once()

--- a/web/src/components/registry/co-author-input.tsx
+++ b/web/src/components/registry/co-author-input.tsx
@@ -3,7 +3,7 @@
 
 
 import { useState, useCallback } from "react";
-import { X, Plus, Loader2 } from "lucide-react";
+import { X, Plus, Loader2, ArrowRightLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -42,6 +42,10 @@ interface CoAuthorInputProps {
 	onChange: (coAuthors: CoAuthor[]) => void;
 	/** Whether the current user can manage co-authors */
 	canManage?: boolean;
+	/** Whether the current user can transfer ownership */
+	canTransferOwnership?: boolean;
+	/** Callback after ownership changes */
+	onTransferOwnership?: () => void;
 }
 
 export function CoAuthorInput({
@@ -50,14 +54,18 @@ export function CoAuthorInput({
 	coAuthors,
 	onChange,
 	canManage = true,
+	canTransferOwnership = false,
+	onTransferOwnership,
 }: CoAuthorInputProps) {
 	const [input, setInput] = useState("");
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [transferTarget, setTransferTarget] = useState("");
 
 	// Confirmation dialog state
 	const [confirmAdd, setConfirmAdd] = useState<string | null>(null);
 	const [confirmRemove, setConfirmRemove] = useState<CoAuthor | null>(null);
+	const [confirmTransfer, setConfirmTransfer] = useState<string | null>(null);
 
 	const executeAdd = useCallback(async (value: string) => {
 		setLoading(true);
@@ -138,10 +146,52 @@ export function CoAuthorInput({
 		[entityType, entityId, coAuthors, onChange],
 	);
 
+	const executeTransfer = useCallback(
+		async (target: string) => {
+			setLoading(true);
+			setError(null);
+
+			try {
+				const headers: Record<string, string> = {
+					"Content-Type": "application/json",
+				};
+				const token = getAccessToken();
+				if (token) headers["Authorization"] = `Bearer ${token}`;
+
+				const res = await fetch(`${API}/${entityType}/${entityId}/transfer-ownership`, {
+					method: "POST",
+					headers,
+					body: JSON.stringify({ username: target.replace(/^@/, "") }),
+				});
+
+				if (!res.ok) {
+					const data = await res.json().catch(() => ({}));
+					setError(data.detail || `Failed to transfer ownership (${res.status})`);
+					return;
+				}
+
+				setTransferTarget("");
+				onTransferOwnership?.();
+			} catch {
+				setError("Network error");
+			} finally {
+				setLoading(false);
+				setConfirmTransfer(null);
+			}
+		},
+		[entityType, entityId, onTransferOwnership],
+	);
+
 	const handleAdd = () => {
 		const value = input.trim();
 		if (!value) return;
 		setConfirmAdd(value);
+	};
+
+	const handleTransfer = () => {
+		const value = transferTarget.trim();
+		if (!value) return;
+		setConfirmTransfer(value);
 	};
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -216,6 +266,36 @@ export function CoAuthorInput({
 				</div>
 			)}
 
+			{canTransferOwnership && (
+				<div className="space-y-2 rounded-md border border-border p-3">
+					<div className="space-y-0.5">
+						<Label className="text-xs">Transfer owner</Label>
+						<p className="text-xs text-muted-foreground">Move ownership to another username.</p>
+					</div>
+					<div className="flex gap-2">
+						<Input
+							placeholder="@username"
+							value={transferTarget}
+							onChange={(e) => {
+								setTransferTarget(e.target.value);
+								setError(null);
+							}}
+							disabled={loading}
+							className="flex-1"
+						/>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={handleTransfer}
+							disabled={loading || !transferTarget.trim()}
+						>
+							{loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRightLeft className="h-4 w-4" />}
+						</Button>
+					</div>
+				</div>
+			)}
+
 			{error && <p className="text-xs text-destructive">{error}</p>}
 
 			{/* Add confirmation dialog */}
@@ -255,6 +335,27 @@ export function CoAuthorInput({
 						<Button variant="destructive" onClick={() => confirmRemove && executeRemove(confirmRemove.id)} disabled={loading}>
 							{loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
 							Remove
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Transfer confirmation dialog */}
+			<Dialog open={!!confirmTransfer} onOpenChange={(open) => { if (!open) setConfirmTransfer(null); }}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Transfer ownership</DialogTitle>
+						<DialogDescription>
+							Transfer ownership to <span className="font-medium text-foreground">{confirmTransfer}</span>? You will lose owner-only controls immediately.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setConfirmTransfer(null)} disabled={loading}>
+							Cancel
+						</Button>
+						<Button onClick={() => confirmTransfer && executeTransfer(confirmTransfer)} disabled={loading}>
+							{loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+							Transfer
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/web/src/components/registry/co-author-input.tsx
+++ b/web/src/components/registry/co-author-input.tsx
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-
 import { useState, useCallback } from "react";
 import { X, Plus, Loader2, ArrowRightLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -58,39 +57,49 @@ export function CoAuthorInput({
 	onTransferOwnership,
 }: CoAuthorInputProps) {
 	const [input, setInput] = useState("");
+	const [transferTarget, setTransferTarget] = useState("");
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [transferTarget, setTransferTarget] = useState("");
-
-	// Confirmation dialog state
-	const [confirmAdd, setConfirmAdd] = useState<string | null>(null);
+	const [addOpen, setAddOpen] = useState(false);
+	const [transferOpen, setTransferOpen] = useState(false);
 	const [confirmRemove, setConfirmRemove] = useState<CoAuthor | null>(null);
-	const [confirmTransfer, setConfirmTransfer] = useState<string | null>(null);
 
-	const executeAdd = useCallback(async (value: string) => {
+	const headers = useCallback(() => {
+		const h: Record<string, string> = { "Content-Type": "application/json" };
+		const token = getAccessToken();
+		if (token) h.Authorization = `Bearer ${token}`;
+		return h;
+	}, []);
+
+	const resetAdd = () => {
+		setAddOpen(false);
+		setInput("");
+		setError(null);
+	};
+
+	const resetTransfer = () => {
+		setTransferOpen(false);
+		setTransferTarget("");
+		setError(null);
+	};
+
+	const executeAdd = useCallback(async () => {
+		const value = input.trim();
+		if (!value) return;
 		setLoading(true);
 		setError(null);
 
 		try {
-			const headers: Record<string, string> = {
-				"Content-Type": "application/json",
-			};
-			const token = getAccessToken();
-			if (token) headers["Authorization"] = `Bearer ${token}`;
-
 			const isEmail = value.includes("@") && !value.startsWith("@") && value.indexOf("@") < value.length - 1;
 			const body = isEmail
 				? { email: value.toLowerCase() }
 				: { username: value.replace(/^@/, "") };
 
-			const res = await fetch(
-				`${API}/${entityType}/${entityId}/co-authors`,
-				{
-					method: "POST",
-					headers,
-					body: JSON.stringify(body),
-				},
-			);
+			const res = await fetch(`${API}/${entityType}/${entityId}/co-authors`, {
+				method: "POST",
+				headers: headers(),
+				body: JSON.stringify(body),
+			});
 
 			if (!res.ok) {
 				const data = await res.json().catch(() => ({}));
@@ -100,14 +109,13 @@ export function CoAuthorInput({
 
 			const added: CoAuthor = await res.json();
 			onChange([...coAuthors, added]);
-			setInput("");
+			resetAdd();
 		} catch {
 			setError("Network error");
 		} finally {
 			setLoading(false);
-			setConfirmAdd(null);
 		}
-	}, [entityType, entityId, coAuthors, onChange]);
+	}, [entityType, entityId, coAuthors, onChange, headers, input]);
 
 	const executeRemove = useCallback(
 		async (userId: string) => {
@@ -115,113 +123,80 @@ export function CoAuthorInput({
 			setError(null);
 
 			try {
-				const headers: Record<string, string> = {};
-				const token = getAccessToken();
-				if (token) headers["Authorization"] = `Bearer ${token}`;
-
-				const res = await fetch(
-					`${API}/${entityType}/${entityId}/co-authors/${userId}`,
-					{
-						method: "DELETE",
-						headers,
-					},
-				);
-
-				if (!res.ok) {
-					const data = await res.json().catch(() => ({}));
-					setError(
-						data.detail || `Failed to remove co-author (${res.status})`,
-					);
-					return;
-				}
-
-				onChange(coAuthors.filter((c) => c.id !== userId));
-			} catch {
-				setError("Network error");
-			} finally {
-				setLoading(false);
-				setConfirmRemove(null);
-			}
-		},
-		[entityType, entityId, coAuthors, onChange],
-	);
-
-	const executeTransfer = useCallback(
-		async (target: string) => {
-			setLoading(true);
-			setError(null);
-
-			try {
-				const headers: Record<string, string> = {
-					"Content-Type": "application/json",
-				};
-				const token = getAccessToken();
-				if (token) headers["Authorization"] = `Bearer ${token}`;
-
-				const res = await fetch(`${API}/${entityType}/${entityId}/transfer-ownership`, {
-					method: "POST",
-					headers,
-					body: JSON.stringify({ username: target.replace(/^@/, "") }),
+				const h = headers();
+				delete h["Content-Type"];
+				const res = await fetch(`${API}/${entityType}/${entityId}/co-authors/${userId}`, {
+					method: "DELETE",
+					headers: h,
 				});
 
 				if (!res.ok) {
 					const data = await res.json().catch(() => ({}));
-					setError(data.detail || `Failed to transfer ownership (${res.status})`);
+					setError(data.detail || `Failed to remove co-author (${res.status})`);
 					return;
 				}
 
-				setTransferTarget("");
-				onTransferOwnership?.();
+				onChange(coAuthors.filter((c) => c.id !== userId));
+				setConfirmRemove(null);
 			} catch {
 				setError("Network error");
 			} finally {
 				setLoading(false);
-				setConfirmTransfer(null);
 			}
 		},
-		[entityType, entityId, onTransferOwnership],
+		[entityType, entityId, coAuthors, onChange, headers],
 	);
 
-	const handleAdd = () => {
-		const value = input.trim();
-		if (!value) return;
-		setConfirmAdd(value);
-	};
+	const executeTransfer = useCallback(async () => {
+		const target = transferTarget.trim().replace(/^@/, "");
+		if (!target) return;
+		setLoading(true);
+		setError(null);
 
-	const handleTransfer = () => {
-		const value = transferTarget.trim();
-		if (!value) return;
-		setConfirmTransfer(value);
-	};
+		try {
+			const res = await fetch(`${API}/${entityType}/${entityId}/transfer-ownership`, {
+				method: "POST",
+				headers: headers(),
+				body: JSON.stringify({ username: target }),
+			});
 
-	const handleKeyDown = (e: React.KeyboardEvent) => {
-		if (e.key === "Enter") {
-			e.preventDefault();
-			handleAdd();
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				setError(data.detail || `Failed to transfer ownership (${res.status})`);
+				return;
+			}
+
+			resetTransfer();
+			onTransferOwnership?.();
+		} catch {
+			setError("Network error");
+		} finally {
+			setLoading(false);
 		}
-	};
+	}, [entityType, entityId, headers, onTransferOwnership, transferTarget]);
 
 	return (
-		<div className="space-y-2">
-			<Label>Co-Authors</Label>
+		<div className="space-y-3">
+			<div className="flex items-center justify-between gap-3">
+				<Label>Co-Authors</Label>
+				{canManage && (
+					<Button type="button" variant="outline" size="sm" className="h-8" onClick={() => setAddOpen(true)}>
+						<Plus className="h-3.5 w-3.5" />
+						Add
+					</Button>
+				)}
+			</div>
 
-			{/* Current co-authors */}
-			{coAuthors.length > 0 && (
+			{coAuthors.length > 0 ? (
 				<div className="flex flex-wrap gap-2">
 					{coAuthors.map((author) => (
-						<Badge
-							key={author.id}
-							variant="secondary"
-							className="flex items-center gap-1 py-1 px-2"
-						>
-							<span className="text-xs">
-								{author.username || author.email}
-							</span>
+						<Badge key={author.id} variant="secondary" className="flex items-center gap-1 px-2 py-1">
+							<span className="text-xs">{author.username || author.email}</span>
 							{canManage && (
 								<button
 									type="button"
 									onClick={() => setConfirmRemove(author)}
-									className="ml-1 rounded-full hover:bg-muted-foreground/20 p-0.5"
+									className="ml-1 rounded-full p-0.5 hover:bg-muted-foreground/20"
 									disabled={loading}
 								>
 									<X className="h-3 w-3" />
@@ -230,96 +205,65 @@ export function CoAuthorInput({
 						</Badge>
 					))}
 				</div>
-			)}
-
-			{coAuthors.length === 0 && !canManage && (
+			) : (
 				<p className="text-xs text-muted-foreground">No co-authors</p>
 			)}
 
-			{/* Add input */}
-			{canManage && (
-				<div className="flex gap-2">
-					<Input
-						placeholder="Email or username"
-						value={input}
-						onChange={(e) => {
-							setInput(e.target.value);
-							setError(null);
-						}}
-						onKeyDown={handleKeyDown}
-						disabled={loading}
-						className="flex-1"
-					/>
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						onClick={handleAdd}
-						disabled={loading || !input.trim()}
-					>
-						{loading ? (
-							<Loader2 className="h-4 w-4 animate-spin" />
-						) : (
-							<Plus className="h-4 w-4" />
-						)}
-					</Button>
-				</div>
-			)}
-
 			{canTransferOwnership && (
-				<div className="space-y-2 rounded-md border border-border p-3">
-					<div className="space-y-0.5">
-						<Label className="text-xs">Transfer owner</Label>
-						<p className="text-xs text-muted-foreground">Move ownership to another username.</p>
-					</div>
-					<div className="flex gap-2">
-						<Input
-							placeholder="@username"
-							value={transferTarget}
-							onChange={(e) => {
-								setTransferTarget(e.target.value);
-								setError(null);
-							}}
-							disabled={loading}
-							className="flex-1"
-						/>
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={handleTransfer}
-							disabled={loading || !transferTarget.trim()}
-						>
-							{loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRightLeft className="h-4 w-4" />}
+				<div className="border-t border-border pt-3">
+					<div className="flex items-center justify-between gap-3">
+						<div className="space-y-0.5">
+							<p className="text-sm font-medium">Transfer owner</p>
+							<p className="text-xs text-muted-foreground">Move ownership to another username.</p>
+						</div>
+						<Button type="button" variant="outline" size="sm" className="h-8" onClick={() => setTransferOpen(true)}>
+							<ArrowRightLeft className="h-3.5 w-3.5" />
+							Transfer
 						</Button>
 					</div>
 				</div>
 			)}
 
-			{error && <p className="text-xs text-destructive">{error}</p>}
+			{error && !addOpen && !transferOpen && <p className="text-xs text-destructive">{error}</p>}
 
-			{/* Add confirmation dialog */}
-			<Dialog open={!!confirmAdd} onOpenChange={(open) => { if (!open) setConfirmAdd(null); }}>
+			<Dialog open={addOpen} onOpenChange={(open) => { if (!open) resetAdd(); else setAddOpen(true); }}>
 				<DialogContent>
 					<DialogHeader>
 						<DialogTitle>Add co-author</DialogTitle>
 						<DialogDescription>
-							Are you sure you want to add <span className="font-medium text-foreground">{confirmAdd}</span> as a co-author? They will have full edit and publish access.
+							Co-authors can edit, publish, and manage this item with owner-level access.
 						</DialogDescription>
 					</DialogHeader>
+					<div className="space-y-2">
+						<Label htmlFor="co-author-user">Email or username</Label>
+						<Input
+							id="co-author-user"
+							placeholder="Email or @username"
+							value={input}
+							onChange={(e) => {
+								setInput(e.target.value);
+								setError(null);
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									executeAdd();
+								}
+							}}
+							disabled={loading}
+						/>
+						{error && <p className="text-xs text-destructive">{error}</p>}
+					</div>
 					<DialogFooter>
-						<Button variant="outline" onClick={() => setConfirmAdd(null)} disabled={loading}>
-							Cancel
-						</Button>
-						<Button onClick={() => confirmAdd && executeAdd(confirmAdd)} disabled={loading}>
+						<Button variant="outline" onClick={resetAdd} disabled={loading}>Cancel</Button>
+						<Button onClick={executeAdd} disabled={loading || !input.trim()}>
 							{loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-							Confirm
+							Add co-author
 						</Button>
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
 
-			{/* Remove confirmation dialog */}
 			<Dialog open={!!confirmRemove} onOpenChange={(open) => { if (!open) setConfirmRemove(null); }}>
 				<DialogContent>
 					<DialogHeader>
@@ -329,9 +273,7 @@ export function CoAuthorInput({
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="outline" onClick={() => setConfirmRemove(null)} disabled={loading}>
-							Cancel
-						</Button>
+						<Button variant="outline" onClick={() => setConfirmRemove(null)} disabled={loading}>Cancel</Button>
 						<Button variant="destructive" onClick={() => confirmRemove && executeRemove(confirmRemove.id)} disabled={loading}>
 							{loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
 							Remove
@@ -340,22 +282,39 @@ export function CoAuthorInput({
 				</DialogContent>
 			</Dialog>
 
-			{/* Transfer confirmation dialog */}
-			<Dialog open={!!confirmTransfer} onOpenChange={(open) => { if (!open) setConfirmTransfer(null); }}>
+			<Dialog open={transferOpen} onOpenChange={(open) => { if (!open) resetTransfer(); else setTransferOpen(true); }}>
 				<DialogContent>
 					<DialogHeader>
 						<DialogTitle>Transfer ownership</DialogTitle>
 						<DialogDescription>
-							Transfer ownership to <span className="font-medium text-foreground">{confirmTransfer}</span>? You will lose owner-only controls immediately.
+							Transfer ownership to another user. You will lose owner-only controls immediately.
 						</DialogDescription>
 					</DialogHeader>
+					<div className="space-y-2">
+						<Label htmlFor="transfer-owner-user">New owner username</Label>
+						<Input
+							id="transfer-owner-user"
+							placeholder="@username"
+							value={transferTarget}
+							onChange={(e) => {
+								setTransferTarget(e.target.value);
+								setError(null);
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									executeTransfer();
+								}
+							}}
+							disabled={loading}
+						/>
+						{error && <p className="text-xs text-destructive">{error}</p>}
+					</div>
 					<DialogFooter>
-						<Button variant="outline" onClick={() => setConfirmTransfer(null)} disabled={loading}>
-							Cancel
-						</Button>
-						<Button onClick={() => confirmTransfer && executeTransfer(confirmTransfer)} disabled={loading}>
+						<Button variant="outline" onClick={resetTransfer} disabled={loading}>Cancel</Button>
+						<Button onClick={executeTransfer} disabled={loading || !transferTarget.trim()}>
 							{loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-							Transfer
+							Transfer owner
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/web/src/components/registry/status-badge.tsx
+++ b/web/src/components/registry/status-badge.tsx
@@ -15,7 +15,7 @@ const statusConfig: Record<string, { bg: string; text: string; dot?: string; pin
   running:   { bg: "bg-light-blue",   text: "text-dark-blue",   dot: "bg-dark-blue",   ping: true },
   completed: { bg: "bg-light-green",  text: "text-dark-green" },
   success:   { bg: "bg-light-green",  text: "text-dark-green" },
-  archived:  { bg: "bg-muted", text: "text-muted-foreground" },
+  archived:  { bg: "bg-light-yellow", text: "text-dark-yellow" },
 };
 
 const fallback = { bg: "bg-muted", text: "text-muted-foreground" };

--- a/web/src/hooks/use-registry-api.ts
+++ b/web/src/hooks/use-registry-api.ts
@@ -129,6 +129,34 @@ export function useComponentDelete(type: RegistryType) {
   });
 }
 
+export function useComponentArchive(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.archiveComponent(type, id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", type] });
+      toast.success("Component archived");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to archive component");
+    },
+  });
+}
+
+export function useComponentUnarchive(type: RegistryType) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.unarchiveComponent(type, id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", type] });
+      toast.success("Component restored");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to restore component");
+    },
+  });
+}
+
 // ── Component Versions ─────────────────────────────────────────────
 
 export function useComponentVersions(type: RegistryType | undefined, listingId: string | undefined) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -423,6 +423,8 @@ export const registry = {
 	archived: () => get<RegistryItem[]>("/agents/archived"),
 	archive: (id: string) => patch(`/agents/${id}/archive`),
 	unarchive: (id: string) => patch(`/agents/${id}/unarchive`),
+	archiveComponent: (type: RegistryType, id: string) => patch(`/${type}/${id}/archive`),
+	unarchiveComponent: (type: RegistryType, id: string) => patch(`/${type}/${id}/unarchive`),
 	draft: (body: unknown, type?: RegistryType) =>
 		post<RegistryItem>(`/${type ?? "agents"}/draft`, body),
 	updateDraft: (id: string, body: unknown, type?: RegistryType) =>

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -16,6 +16,7 @@ import {
   Loader2,
   Archive,
   ArchiveRestore,
+  Trash2,
   Play,
   CheckCircle2,
   XCircle,
@@ -353,6 +354,46 @@ function AgentVersionContents({
         )}
       </section>
     </div>
+  );
+}
+
+function AgentDeleteButton({ agentId, agentName, onSuccess }: { agentId: string; agentName: string; onSuccess: () => void }) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const archiveMutation = useArchiveAgent();
+
+  function submit() {
+    archiveMutation.mutate(agentId, {
+      onSuccess: () => {
+        setConfirmOpen(false);
+        onSuccess();
+      },
+    });
+  }
+
+  return (
+    <>
+      <Button variant="destructive" size="sm" className="h-8" onClick={() => setConfirmOpen(true)} disabled={archiveMutation.isPending}>
+        <Trash2 className="mr-1 h-3.5 w-3.5" />
+        Delete
+      </Button>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {agentName}?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This archives the agent and hides it from registry lists. It can be restored later.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>Cancel</Button>
+            <Button variant="destructive" onClick={submit} disabled={archiveMutation.isPending}>
+              {archiveMutation.isPending ? <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Deleting...</> : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
@@ -982,40 +1023,35 @@ export default function AgentDetailPage() {
                 </div>
               )}
 
-              {/* Co-Authors: visible to owner/co-authors */}
-              {(a?.user_permission === "owner") && (
-                <div className="border border-border rounded-md p-4 space-y-3">
-                  <CoAuthorInput
-                    entityType="agents"
-                    entityId={id}
-                    coAuthors={coAuthors}
-                    onChange={setCoAuthors}
-                    canManage={true}
-                    canTransferOwnership={canTransferOwnership}
-                    onTransferOwnership={() => refetch()}
-                  />
-                </div>
-              )}
-              {/* Show co-authors read-only to everyone if any exist */}
-              {a?.user_permission !== "owner" && coAuthors.length > 0 && (
-                <div className="border border-border rounded-md p-4 space-y-2">
+              {(a?.user_permission === "owner" || coAuthors.length > 0 || canManageLifecycle) && (
+                <div className="border border-border rounded-md p-4 space-y-4">
                   <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
-                    Co-Authors
+                    Danger zone
                   </h3>
-                  <div className="space-y-1">
-                    {coAuthors.map((c) => (
-                      <p key={c.id} className="text-sm text-muted-foreground">{c.username || c.email}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
 
-              {canManageLifecycle && (agentStatus === "approved" || agentStatus === "archived") && (
-                <div className="border border-border rounded-md p-4 space-y-3">
-                  <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
-                    Lifecycle
-                  </h3>
-                  <AgentArchiveButton agentId={id} agentName={agentName} status={agentStatus} onSuccess={() => refetch()} />
+                  {(a?.user_permission === "owner" || coAuthors.length > 0) && (
+                    <CoAuthorInput
+                      entityType="agents"
+                      entityId={id}
+                      coAuthors={coAuthors}
+                      onChange={setCoAuthors}
+                      canManage={a?.user_permission === "owner"}
+                      canTransferOwnership={canTransferOwnership}
+                      onTransferOwnership={() => refetch()}
+                    />
+                  )}
+
+                  {canManageLifecycle && (agentStatus === "approved" || agentStatus === "archived") && (
+                    <div className="border-t border-border pt-3 space-y-2">
+                      <p className="text-sm font-medium">Lifecycle</p>
+                      <div className="flex flex-wrap gap-2">
+                        <AgentArchiveButton agentId={id} agentName={agentName} status={agentStatus} onSuccess={() => refetch()} />
+                        {agentStatus === "approved" && (
+                          <AgentDeleteButton agentId={id} agentName={agentName} onSuccess={() => refetch()} />
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
             </aside>

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -624,6 +624,7 @@ export default function AgentDetailPage() {
   const versionRequiredFeatures = vd?.required_ide_features ?? (selectedVersion ? undefined : a?.required_ide_features);
   const versionInferredIdes = vd?.inferred_supported_ides ?? (selectedVersion ? undefined : a?.inferred_supported_ides);
   const isOwner = !!(whoami?.id && a?.created_by && whoami.id === String(a.created_by));
+  const canTransferOwnership = isOwner;
   const canManageLifecycle = isAdmin || isOwner;
   const agentStatus = a?.status as string | undefined;
   const canEdit = (isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit") && ["approved", "pending", "draft", "rejected"].includes(agentStatus ?? "");
@@ -990,6 +991,8 @@ export default function AgentDetailPage() {
                     coAuthors={coAuthors}
                     onChange={setCoAuthors}
                     canManage={true}
+                    canTransferOwnership={canTransferOwnership}
+                    onTransferOwnership={() => refetch()}
                   />
                 </div>
               )}

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -7,14 +7,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
-import { Link, useParams, useRouter } from "@tanstack/react-router";
+import { Link, useParams } from "@tanstack/react-router";
 import {
   ArrowDownToLine,
   Puzzle,
   Star,
   Users,
   Loader2,
-  Trash2,
+  Archive,
+  ArchiveRestore,
   Play,
   CheckCircle2,
   XCircle,
@@ -24,8 +25,6 @@ import {
 } from "lucide-react";
 import { useState, useEffect, useCallback, useMemo, useSyncExternalStore } from "react";
 
-import { toast } from "sonner";
-import { useQueryClient } from "@tanstack/react-query";
 import {
   useRegistryItem,
   useAgentDownloads,
@@ -39,8 +38,10 @@ import {
   useInsightSessionCount,
   useGenerateInsight,
   useInsightsStatus,
+  useArchiveAgent,
+  useUnarchiveAgent,
 } from "@/hooks/use-api";
-import { registry, getUserRole } from "@/lib/api";
+import { getUserRole } from "@/lib/api";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import type {
   AgentComponentReference,
@@ -355,45 +356,55 @@ function AgentVersionContents({
   );
 }
 
-function DeleteButton({ agentId, agentName }: { agentId: string; agentName: string }) {
+function AgentArchiveButton({ agentId, agentName, status, onSuccess }: { agentId: string; agentName: string; status?: string; onSuccess: () => void }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const router = useRouter();
-  const qc = useQueryClient();
+  const archiveMutation = useArchiveAgent();
+  const unarchiveMutation = useUnarchiveAgent();
+  const isArchived = status === "archived";
+  const isBusy = archiveMutation.isPending || unarchiveMutation.isPending;
 
-  async function handleDelete() {
-    setDeleting(true);
-    try {
-      await registry.delete("agents", agentId);
-      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
-      toast.success("Agent deleted");
-      router.navigate({ to: "/agents" });
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to delete agent");
-      setDeleting(false);
-      setConfirmOpen(false);
-    }
+  function submit() {
+    const mutation = isArchived ? unarchiveMutation : archiveMutation;
+    mutation.mutate(agentId, {
+      onSuccess: () => {
+        setConfirmOpen(false);
+        onSuccess();
+      },
+    });
   }
 
   return (
     <>
-      <Button variant="destructive" size="sm" className="h-8" onClick={() => setConfirmOpen(true)}>
-        <Trash2 className="mr-1 h-3.5 w-3.5" />
-        Delete
+      <Button
+        variant="outline"
+        size="sm"
+        className={isArchived ? "h-8" : "h-8 border-dark-yellow/40 bg-light-yellow text-dark-yellow hover:bg-light-yellow/80"}
+        onClick={() => setConfirmOpen(true)}
+        disabled={isBusy}
+      >
+        {isArchived ? <ArchiveRestore className="mr-1 h-3.5 w-3.5" /> : <Archive className="mr-1 h-3.5 w-3.5" />}
+        {isArchived ? "Restore" : "Archive"}
       </Button>
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete {agentName}?</DialogTitle>
+            <DialogTitle>{isArchived ? `Restore ${agentName}?` : `Archive ${agentName}?`}</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            This will permanently delete this agent and all associated data. This action cannot be undone.
+            {isArchived
+              ? "This makes the agent discoverable again."
+              : "Archived agents stop appearing in registry lists. Direct pulls still work by ID."}
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>Cancel</Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
-              {deleting ? <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Deleting...</> : "Delete"}
+            <Button
+              variant={isArchived ? "default" : "outline"}
+              className={isArchived ? undefined : "border-dark-yellow/40 bg-light-yellow text-dark-yellow hover:bg-light-yellow/80"}
+              onClick={submit}
+              disabled={isBusy}
+            >
+              {isBusy ? <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Saving...</> : isArchived ? "Restore" : "Archive"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -612,7 +623,8 @@ export default function AgentDetailPage() {
   const versionSupportedIdes = vd?.supported_ides ?? selectedVersionSummary?.supported_ides ?? a?.supported_ides;
   const versionRequiredFeatures = vd?.required_ide_features ?? (selectedVersion ? undefined : a?.required_ide_features);
   const versionInferredIdes = vd?.inferred_supported_ides ?? (selectedVersion ? undefined : a?.inferred_supported_ides);
-  const canDelete = isAdmin || (whoami?.id && a?.created_by && whoami.id === String(a.created_by));
+  const isOwner = !!(whoami?.id && a?.created_by && whoami.id === String(a.created_by));
+  const canManageLifecycle = isAdmin || isOwner;
   const agentStatus = a?.status as string | undefined;
   const canEdit = (isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit") && ["approved", "pending", "draft", "rejected"].includes(agentStatus ?? "");
   const agentName = a?.name ?? id.slice(0, 8);
@@ -995,12 +1007,12 @@ export default function AgentDetailPage() {
                 </div>
               )}
 
-              {canDelete && (
+              {canManageLifecycle && (agentStatus === "approved" || agentStatus === "archived") && (
                 <div className="border border-border rounded-md p-4 space-y-3">
                   <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
-                    Danger zone
+                    Lifecycle
                   </h3>
-                  <DeleteButton agentId={id} agentName={agentName} />
+                  <AgentArchiveButton agentId={id} agentName={agentName} status={agentStatus} onSuccess={() => refetch()} />
                 </div>
               )}
             </aside>

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -20,6 +20,7 @@ import {
   XCircle,
   Clock,
   Sparkles,
+  AlertTriangle,
 } from "lucide-react";
 import { useState, useEffect, useCallback, useMemo, useSyncExternalStore } from "react";
 
@@ -189,6 +190,25 @@ function VersionContentLoading() {
   );
 }
 
+function ArchivedComponentsBanner({ components }: { components: ComponentLink[] }) {
+  const names = components.slice(0, 3).map(getComponentName).join(", ");
+  const extra = components.length > 3 ? ` and ${components.length - 3} more` : "";
+
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-dark-yellow/30 bg-light-yellow px-4 py-3 text-dark-yellow">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <div className="space-y-1 text-sm">
+        <p className="font-medium">
+          This agent includes archived components: {names}{extra}.
+        </p>
+        <p className="text-xs text-dark-yellow/80">
+          Users can still pull the agent, but installs will show archived component warnings.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 function AgentVersionContents({
   description,
   modelName,
@@ -296,6 +316,9 @@ function AgentVersionContents({
                               <Badge variant="outline" className="shrink-0 text-[10px]">
                                 {componentType.singular}
                               </Badge>
+                              {component.status === "archived" && (
+                                <StatusBadge status="archived" className="shrink-0" />
+                              )}
                               <span className="truncate text-sm font-medium">{componentName}</span>
                               {component.resolved_version && (
                                 <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
@@ -303,7 +326,7 @@ function AgentVersionContents({
                                 </span>
                               )}
                             </div>
-                            {component.status && <StatusBadge status={component.status} />}
+                            {component.status && component.status !== "archived" && <StatusBadge status={component.status} />}
                           </div>
                         );
 
@@ -595,6 +618,7 @@ export default function AgentDetailPage() {
   const agentName = a?.name ?? id.slice(0, 8);
   const totalDownloads = downloadData?.total ?? a?.download_count;
   const uniqueUsers = downloadData?.unique_users;
+  const archivedComponents = components.filter((component) => component.status === "archived");
   const avgRating = feedbackSummary?.average_rating;
   const totalReviews = feedbackSummary?.total_reviews ?? 0;
 
@@ -620,6 +644,10 @@ export default function AgentDetailPage() {
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-8 items-start">
             {/* Main content */}
             <div className="space-y-6 min-w-0 animate-in">
+              {canEdit && archivedComponents.length > 0 && (
+                <ArchivedComponentsBanner components={archivedComponents} />
+              )}
+
               {/* Header */}
               <div className="space-y-2">
                 <div className="flex items-start gap-3 flex-wrap">

--- a/web/src/pages/registry/agents/index.tsx
+++ b/web/src/pages/registry/agents/index.tsx
@@ -172,7 +172,8 @@ function ArchiveAgentButton({ agent }: { agent: RegistryItem }) {
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>Cancel</Button>
             <Button
-              variant="destructive"
+              variant="outline"
+              className="border-dark-yellow/40 bg-light-yellow text-dark-yellow hover:bg-light-yellow/80"
               onClick={(e) => {
                 e.stopPropagation();
                 archiveMutation.mutate(agent.id, {

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -438,40 +438,28 @@ export default function ComponentDetailPage() {
                 </div>
               )}
 
-              {/* Co-Authors (manageable by owner/co-author/admin) */}
-              {canEdit && (
-                <div className="border border-border rounded-md p-4 space-y-3">
+              {(canEdit || coAuthors.length > 0) && (
+                <div className="border border-border rounded-md p-4 space-y-4">
+                  <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
+                    Danger zone
+                  </h3>
+
                   <CoAuthorInput
                     entityType={type}
                     entityId={id}
                     coAuthors={coAuthors}
                     onChange={setCoAuthors}
-                    canManage={true}
+                    canManage={canEdit}
                     canTransferOwnership={canTransferOwnership}
                     onTransferOwnership={() => refetch()}
                   />
-                </div>
-              )}
-              {/* Read-only co-authors for non-owners */}
-              {!canEdit && coAuthors.length > 0 && (
-                <div className="border border-border rounded-md p-4 space-y-2">
-                  <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
-                    Co-Authors
-                  </h3>
-                  <div className="space-y-1">
-                    {coAuthors.map((c) => (
-                      <p key={c.id} className="text-sm text-muted-foreground">{c.username || c.email}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
 
-              {canEdit && (
-                <div className="border border-border rounded-md p-4 space-y-3">
-                  <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
-                    Lifecycle
-                  </h3>
-                  <ComponentArchiveButton type={type} item={item} onSuccess={() => refetch()} />
+                  {canEdit && (
+                    <div className="border-t border-border pt-3 space-y-2">
+                      <p className="text-sm font-medium">Lifecycle</p>
+                      <ComponentArchiveButton type={type} item={item} onSuccess={() => refetch()} />
+                    </div>
+                  )}
                 </div>
               )}
             </aside>

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -19,6 +19,7 @@ import {
   useComponentVersionDetail,
   useComponentArchive,
   useComponentUnarchive,
+  useWhoami,
 } from "@/hooks/use-api";
 import type { RegistryType } from "@/lib/api";
 import type { FeedbackItem, RegistryItem, ComponentVersionSummary } from "@/lib/types";
@@ -87,6 +88,7 @@ export default function ComponentDetailPage() {
   const { data: versionsData, isLoading: versionsLoading } = useComponentVersions(type, id);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const { data: versionDetail } = useComponentVersionDetail(type, id, selectedVersion);
+  const { data: whoami } = useWhoami();
 
   const storeSub = useCallback((cb: () => void) => {
     window.addEventListener("storage", cb);
@@ -98,6 +100,7 @@ export default function ComponentDetailPage() {
     () => false,
   );
   const canEdit = isAuthenticated && (item?.user_permission === "owner");
+  const canTransferOwnership = !!(whoami?.id && item?.submitted_by && whoami.id === String(item.submitted_by));
 
   // Co-authors
   const [coAuthors, setCoAuthors] = useState<CoAuthor[]>([]);
@@ -444,6 +447,8 @@ export default function ComponentDetailPage() {
                     coAuthors={coAuthors}
                     onChange={setCoAuthors}
                     canManage={true}
+                    canTransferOwnership={canTransferOwnership}
+                    onTransferOwnership={() => refetch()}
                   />
                 </div>
               )}

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -8,7 +8,7 @@
 
 import { Link, useParams, useSearch } from "@tanstack/react-router";
 import { useState, useEffect, useCallback, useSyncExternalStore } from "react";
-import { Star, ArrowLeft, History, Loader2, ArrowDownToLine } from "lucide-react";
+import { Star, ArrowLeft, History, Loader2, ArrowDownToLine, Archive, ArchiveRestore } from "lucide-react";
 import {
   useRegistryItem,
   useFeedback,
@@ -17,6 +17,8 @@ import {
   useRegistryMetrics,
   useComponentVersions,
   useComponentVersionDetail,
+  useComponentArchive,
+  useComponentUnarchive,
 } from "@/hooks/use-api";
 import type { RegistryType } from "@/lib/api";
 import type { FeedbackItem, RegistryItem, ComponentVersionSummary } from "@/lib/types";
@@ -29,6 +31,7 @@ import { ComponentEditForm } from "@/components/registry/component-edit-form";
 import { ComponentInstallCommand } from "@/components/registry/component-install-command";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/layouts/page-header";
@@ -419,11 +422,80 @@ export default function ComponentDetailPage() {
                   </div>
                 </div>
               )}
+
+              {canEdit && (
+                <div className="border border-border rounded-md p-4 space-y-3">
+                  <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
+                    Danger zone
+                  </h3>
+                  <ComponentArchiveButton type={type} item={item} onSuccess={() => refetch()} />
+                </div>
+              )}
             </aside>
             </div>
           </div>
         )}
       </div>
+    </>
+  );
+}
+
+function ComponentArchiveButton({
+  type,
+  item,
+  onSuccess,
+}: {
+  type: RegistryType;
+  item: RegistryItem;
+  onSuccess: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const archiveMutation = useComponentArchive(type);
+  const unarchiveMutation = useComponentUnarchive(type);
+  const isArchived = item.status === "archived";
+  const isBusy = archiveMutation.isPending || unarchiveMutation.isPending;
+
+  function submit() {
+    const mutation = isArchived ? unarchiveMutation : archiveMutation;
+    mutation.mutate(item.id, {
+      onSuccess: () => {
+        setOpen(false);
+        onSuccess();
+      },
+    });
+  }
+
+  return (
+    <>
+      <Button
+        variant={isArchived ? "outline" : "destructive"}
+        size="sm"
+        className="h-8"
+        onClick={() => setOpen(true)}
+        disabled={isBusy}
+      >
+        {isArchived ? <ArchiveRestore className="mr-1 h-3.5 w-3.5" /> : <Archive className="mr-1 h-3.5 w-3.5" />}
+        {isArchived ? "Restore" : "Archive"}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{isArchived ? `Restore ${item.name}?` : `Archive ${item.name}?`}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            {isArchived
+              ? "This makes the component discoverable again and removes archived install warnings."
+              : "Archived components stop appearing in registry lists and insight suggestions. Direct installs and agent pulls still work, but users will see a warning."}
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button variant={isArchived ? "default" : "destructive"} onClick={submit} disabled={isBusy}>
+              {isBusy ? <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Saving...</> : isArchived ? "Restore" : "Archive"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -8,7 +8,7 @@
 
 import { Link, useParams, useSearch } from "@tanstack/react-router";
 import { useState, useEffect, useCallback, useSyncExternalStore } from "react";
-import { Star, ArrowLeft, History, Loader2, ArrowDownToLine, Archive, ArchiveRestore } from "lucide-react";
+import { Star, ArrowLeft, History, Loader2, ArrowDownToLine, Archive, ArchiveRestore, AlertTriangle } from "lucide-react";
 import {
   useRegistryItem,
   useFeedback,
@@ -45,6 +45,33 @@ function statusVariant(status?: string) {
   if (status === "approved") return "default" as const;
   if (status === "rejected") return "destructive" as const;
   return "secondary" as const;
+}
+
+function formatArchiveDate(item: RegistryItem) {
+  const value = item.updated_at ?? item.created_at;
+  return value ? new Date(value).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }) : null;
+}
+
+function ArchivedComponentBanner({ item, type, canRestore }: { item: RegistryItem; type: string; canRestore: boolean }) {
+  const date = formatArchiveDate(item);
+
+  return (
+    <div className="flex items-start justify-between gap-4 rounded-md border border-dark-yellow/30 bg-light-yellow px-4 py-3 text-dark-yellow">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="space-y-1 text-sm">
+          <p className="font-medium">
+            This {type} was archived{date ? ` on ${date}` : ""}. It is hidden from registry lists.
+          </p>
+          <p className="text-xs text-dark-yellow/80">
+            Installs still work by direct reference, but users will see an archived component warning.
+            {canRestore ? " Restore it from the lifecycle panel when it should be discoverable again." : ""}
+          </p>
+        </div>
+      </div>
+      <Archive className="mt-0.5 h-4 w-4 shrink-0" />
+    </div>
+  );
 }
 
 export default function ComponentDetailPage() {
@@ -130,12 +157,23 @@ export default function ComponentDetailPage() {
           <ErrorState message="Component not found" />
         ) : (
           <div className="animate-in space-y-6">
+            {item.status === "archived" && (
+              <ArchivedComponentBanner item={item} type={singularType} canRestore={canEdit} />
+            )}
+
             {/* Header */}
             <div className="space-y-2">
               <div className="flex items-start gap-3 flex-wrap">
                 <h1 className="text-2xl font-display font-bold tracking-tight">{item.name}</h1>
                 <Badge variant="outline" className="text-xs">{singularType}</Badge>
-                {item.status && <Badge variant={statusVariant(item.status)}>{item.status}</Badge>}
+                {item.status && (
+                  <Badge
+                    variant={statusVariant(item.status)}
+                    className={item.status === "archived" ? "bg-light-yellow text-dark-yellow" : undefined}
+                  >
+                    {item.status}
+                  </Badge>
+                )}
                 {versionsForDropdown.length > 0 ? (
                   <VersionDropdown
                     versions={versionsForDropdown}
@@ -426,7 +464,7 @@ export default function ComponentDetailPage() {
               {canEdit && (
                 <div className="border border-border rounded-md p-4 space-y-3">
                   <h3 className="text-xs font-semibold font-display uppercase tracking-wider text-muted-foreground">
-                    Danger zone
+                    Lifecycle
                   </h3>
                   <ComponentArchiveButton type={type} item={item} onSuccess={() => refetch()} />
                 </div>
@@ -468,9 +506,9 @@ function ComponentArchiveButton({
   return (
     <>
       <Button
-        variant={isArchived ? "outline" : "destructive"}
+        variant="outline"
         size="sm"
-        className="h-8"
+        className={isArchived ? "h-8" : "h-8 border-dark-yellow/40 bg-light-yellow text-dark-yellow hover:bg-light-yellow/80"}
         onClick={() => setOpen(true)}
         disabled={isBusy}
       >
@@ -490,7 +528,12 @@ function ComponentArchiveButton({
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
-            <Button variant={isArchived ? "default" : "destructive"} onClick={submit} disabled={isBusy}>
+            <Button
+              variant={isArchived ? "default" : "outline"}
+              className={isArchived ? undefined : "border-dark-yellow/40 bg-light-yellow text-dark-yellow hover:bg-light-yellow/80"}
+              onClick={submit}
+              disabled={isBusy}
+            >
               {isBusy ? <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Saving...</> : isArchived ? "Restore" : "Archive"}
             </Button>
           </DialogFooter>

--- a/web/src/pages/registry/components/index.tsx
+++ b/web/src/pages/registry/components/index.tsx
@@ -183,7 +183,7 @@ export default function ComponentsPage() {
 
   const { data: myItems } = useMyComponents(activeType);
   const myDrafts = useMemo(
-    () => (myItems ?? []).filter((i) => i.status === "draft" || i.status === "pending" || i.status === "rejected"),
+    () => (myItems ?? []).filter((i) => ["draft", "pending", "rejected", "archived"].includes(i.status ?? "")),
     [myItems],
   );
 

--- a/web/src/pages/registry/leaderboard.tsx
+++ b/web/src/pages/registry/leaderboard.tsx
@@ -26,6 +26,16 @@ import type { LeaderboardWindow } from "@/lib/types";
 type TopTab = "agents" | "components";
 type SubTab = "leaderboard" | "users";
 
+function componentRouteType(type: string) {
+  return ({
+    mcp: "mcps",
+    skill: "skills",
+    hook: "hooks",
+    prompt: "prompts",
+    sandbox: "sandboxes",
+  } as const)[type] ?? "mcps";
+}
+
 interface UserAggregate {
   email: string;
   username?: string | null;
@@ -315,15 +325,18 @@ export default function LeaderboardPage() {
                     </div>
 
                     {rankedComponents.map((item, i) => (
-                      <div
+                      <Link
                         key={item.id}
-                        className="flex items-center gap-4 rounded-md px-3 py-3 transition-colors hover:bg-accent/40"
+                        to="/components/$componentId"
+                        params={{ componentId: item.id }}
+                        search={{ type: componentRouteType(item.component_type) }}
+                        className="flex items-center gap-4 rounded-md px-3 py-3 transition-colors hover:bg-accent/40 group"
                       >
                         <span className={`w-8 text-right font-mono font-semibold ${i < 3 ? "text-foreground" : "text-muted-foreground"}`}>
                           {i + 1}
                         </span>
                         <div className="flex-1 min-w-0">
-                          <span className="text-sm font-medium truncate block">
+                          <span className="text-sm font-medium truncate block group-hover:underline underline-offset-4">
                             {item.name}
                           </span>
                           <span className="text-xs text-muted-foreground/70 truncate block">
@@ -350,7 +363,7 @@ export default function LeaderboardPage() {
                           <ArrowDownToLine className="h-3 w-3" />
                           {compactNumber(item.download_count)}
                         </span>
-                      </div>
+                      </Link>
                     ))}
                   </div>
                 )}


### PR DESCRIPTION
## Purpose / Description
Add a reversible archive flow for registry components so teams can deprecate unsafe or outdated components without breaking existing installs.

## Fixes
* No linked issue

## Approach
* Add archive and restore endpoints for MCPs, skills, hooks, prompts, and sandboxes.
* Keep archived direct installs working for MCPs, skills, and hooks, but return warnings.
* Warn during agent pulls when the agent includes archived components.
* Exclude archived registry items from insight catalog lookup and self-learn component linking.
* Add archive and restore controls in the component detail Danger zone.
* Keep archived owned components reachable through My Submissions.
* Add a small shared archive helper and unit coverage for archive and restore behavior.

## How Has This Been Tested?
* Ruff check across the repository.
* Ruff format check across the repository.
* Component archive unit tests.
* Registry type route tests.
* Web lint.
* Web typecheck.
* Fast Docker rebuild target, API reached healthy state.
* API smoke test for archived direct MCP install warning.
* API smoke test for archived component warning during agent install.
* Playwright CLI smoke test for component archive and restore in the UI.
* Editable CLI reinstall followed by archived MCP install warning smoke test.

<img width="1242" height="525" alt="image" src="https://github.com/user-attachments/assets/ba66dfc5-d732-4064-8896-1018c0aff432" />

<img width="1946" height="1254" alt="image" src="https://github.com/user-attachments/assets/668dc00c-37a2-4ac5-b2c6-99b0a53663b4" />


## Learning (optional, can help others)
Archive is a soft deprecation state, not a hard delete. Existing installs continue to work, while registry discovery and insights avoid recommending archived components.

No external libraries or addons were used.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). 

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
