### PR TITLE
fix(insights): improve facet coverage

### DIFF
--- a/observal-server/services/insights/facets.py
+++ b/observal-server/services/insights/facets.py
@@ -135,15 +135,25 @@ async def store_facets(
 
 async def load_cached_facets(session_id: str, db) -> dict | None:
     """Load previously extracted facets from DB."""
+    cached = await load_cached_facets_batch([session_id], db)
+    return cached.get(session_id)
+
+
+async def load_cached_facets_batch(session_ids: list[str], db) -> dict[str, dict]:
+    """Load cached facets for many sessions in one DB query."""
+    if not session_ids:
+        return {}
+
     from sqlalchemy import select
 
     facets_model = get_facets_model()
-    stmt = select(facets_model).where(facets_model.session_id == session_id)
+    stmt = select(facets_model).where(facets_model.session_id.in_(session_ids))
     result = await db.execute(stmt)
-    row = result.scalar_one_or_none()
-    if row is None:
-        return None
-    return row.facets if hasattr(row, "facets") else None
+    return {
+        row.session_id: row.facets
+        for row in result.scalars().all()
+        if getattr(row, "session_id", None) and getattr(row, "facets", None)
+    }
 
 
 async def extract_and_cache_facets(

--- a/observal-server/services/insights/generator.py
+++ b/observal-server/services/insights/generator.py
@@ -22,7 +22,7 @@ import json
 import structlog
 
 from ._deps import get_db_session
-from .facets import aggregate_facets, extract_and_cache_facets
+from .facets import aggregate_facets, extract_and_cache_facets, load_cached_facets_batch
 from .sections import generate_sections
 from .session_meta_extractor import aggregate_metas, extract_all_session_metas
 from .transcript import build_session_transcript
@@ -125,14 +125,17 @@ async def _run_pipeline(
     # Aggregate deterministic stats
     agg = aggregate_metas(session_metas)
 
-    # ── Step 2: Build transcripts for top sessions ────────────────────────
-    # Sort by substantiveness (duration * tool_calls), take top N
+    session_ids = [m["session_id"] for m in session_metas]
+    facets_by_session = await load_cached_facets_batch(session_ids, db)
+    logger.info("insight_cached_facets_loaded", count=len(facets_by_session))
+
+    # Build transcripts only for top sessions that still need facets.
     ranked = sorted(
         session_metas,
         key=lambda m: m.get("duration_seconds", 0) * sum(m.get("tool_counts", {}).values()),
         reverse=True,
     )
-    top_sessions = ranked[:MAX_FACET_SESSIONS]
+    top_sessions = [m for m in ranked if m["session_id"] not in facets_by_session][:MAX_FACET_SESSIONS]
 
     transcripts: dict[str, str] = {}
     if top_sessions:
@@ -145,33 +148,25 @@ async def _run_pipeline(
     logger.info("insight_transcripts_built", count=len(transcripts))
     await _emit_progress(progress_callback, "extracting_facets", 3, 9, "Extracting qualitative session facets")
 
-    # ── Step 3: Extract facets (concurrency-limited Haiku calls) ──────────
     import services.dynamic_settings as ds
 
     max_concurrent = int(await ds.get("insights.facet_concurrency") or 5)
 
-    all_facets: list[dict] = []
     if transcripts:
-        all_facets = await _extract_facets_batch(
-            transcripts=transcripts,
-            session_metas={m["session_id"]: m for m in session_metas},
-            agent_id=agent_id or "",
-            db=db,
-            max_concurrent=max_concurrent,
+        facets_by_session.update(
+            await _extract_facets_batch(
+                transcripts=transcripts,
+                session_metas={m["session_id"]: m for m in session_metas},
+                agent_id=agent_id or "",
+                db=db,
+                max_concurrent=max_concurrent,
+            )
         )
+
+    all_facets = [facets_by_session[sid] for sid in session_ids if facets_by_session.get(sid)]
 
     logger.info("insight_facets_extracted", count=len(all_facets))
     await _emit_progress(progress_callback, "analyzing_versions", 4, 9, "Analyzing versions, layers, and dirty cohorts")
-
-    # ── Step 3b: Model efficiency analysis ─────────────────────────────────
-    # Cross-reference per-session model usage with facets to detect waste.
-    # Build session_id -> facets mapping from the extraction batch.
-    facets_by_session: dict[str, dict] = {}
-    if transcripts and all_facets:
-        session_ids_with_transcripts = list(transcripts.keys())
-        for sid, facet in zip(session_ids_with_transcripts, all_facets, strict=False):
-            if facet:
-                facets_by_session[sid] = facet
 
     model_efficiency: list[dict] = []
     estimated_waste = 0.0
@@ -283,11 +278,17 @@ async def _run_pipeline(
             )
             if prior_metas:
                 prior_agg = aggregate_metas(prior_metas)
-                prior_ranked = sorted(
-                    prior_metas,
-                    key=lambda m: m.get("duration_seconds", 0) * sum(m.get("tool_counts", {}).values()),
-                    reverse=True,
-                )[: min(MAX_FACET_SESSIONS, 25)]
+                prior_ids = [m["session_id"] for m in prior_metas]
+                prior_facets_by_session = await load_cached_facets_batch(prior_ids, db)
+                prior_ranked = [
+                    m
+                    for m in sorted(
+                        prior_metas,
+                        key=lambda m: m.get("duration_seconds", 0) * sum(m.get("tool_counts", {}).values()),
+                        reverse=True,
+                    )
+                    if m["session_id"] not in prior_facets_by_session
+                ][: min(MAX_FACET_SESSIONS, 25)]
                 prior_transcripts: dict[str, str] = {}
                 prior_results = await asyncio.gather(
                     *[build_session_transcript(m["session_id"]) for m in prior_ranked],
@@ -296,15 +297,17 @@ async def _run_pipeline(
                 for meta, result in zip(prior_ranked, prior_results, strict=False):
                     if isinstance(result, str) and result.strip():
                         prior_transcripts[meta["session_id"]] = result
-                prior_facets: list[dict] = []
                 if prior_transcripts:
-                    prior_facets = await _extract_facets_batch(
-                        transcripts=prior_transcripts,
-                        session_metas={m["session_id"]: m for m in prior_metas},
-                        agent_id=agent_id or "",
-                        db=db,
-                        max_concurrent=max_concurrent,
+                    prior_facets_by_session.update(
+                        await _extract_facets_batch(
+                            transcripts=prior_transcripts,
+                            session_metas={m["session_id"]: m for m in prior_metas},
+                            agent_id=agent_id or "",
+                            db=db,
+                            max_concurrent=max_concurrent,
+                        )
                     )
+                prior_facets = [prior_facets_by_session[sid] for sid in prior_ids if prior_facets_by_session.get(sid)]
                 comparison_cohort = {
                     "current_version": agent_version,
                     "prior_version": comparison_agent_version,
@@ -496,7 +499,7 @@ async def _extract_facets_batch(
     agent_id: str,
     db,
     max_concurrent: int = 5,
-) -> list[dict]:
+) -> dict[str, dict]:
     """Extract facets with concurrency limit."""
     semaphore = asyncio.Semaphore(max_concurrent)
 
@@ -510,14 +513,18 @@ async def _extract_facets_batch(
                 db=db,
             )
 
-    tasks = [_one(sid, t) for sid, t in transcripts.items()]
+    session_ids = list(transcripts)
+    tasks = [_one(sid, transcripts[sid]) for sid in session_ids]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    for r in results:
-        if isinstance(r, Exception):
-            logger.warning("facet_task_exception", error=str(r), type=type(r).__name__)
+    facets_by_session: dict[str, dict] = {}
+    for sid, result in zip(session_ids, results, strict=False):
+        if isinstance(result, Exception):
+            logger.warning("facet_task_exception", session_id=sid, error=str(result), type=type(result).__name__)
+        elif isinstance(result, dict) and result:
+            facets_by_session[sid] = result
 
-    return [r for r in results if isinstance(r, dict) and r]
+    return facets_by_session
 
 
 def _build_data_block(

--- a/observal-server/services/insights/transcript.py
+++ b/observal-server/services/insights/transcript.py
@@ -13,15 +13,30 @@ import json
 
 import structlog
 
-from ._deps import get_query
+from ._deps import get_call_model, get_query
 
 logger = structlog.get_logger(__name__)
 
 MAX_TRANSCRIPT_CHARS = 30000
+SUMMARY_CHUNK_CHARS = 25000
 MAX_PROMPT_CHARS = 500
 MAX_ASSISTANT_CHARS = 300
 MAX_TOOL_INPUT_CHARS = 200
 MAX_TOOL_OUTPUT_CHARS = 200
+
+CHUNK_SUMMARY_PROMPT = """Summarize this portion of a session transcript. Focus on:
+1. What the user asked for
+2. What the assistant did, including tools used and files modified
+3. Any friction or issues
+4. The outcome
+
+Keep it concise. Preserve specific file names, error messages, and user feedback.
+
+Respond with only this JSON shape:
+{"summary": "3 to 5 sentence summary"}
+
+TRANSCRIPT CHUNK:
+"""
 
 
 async def build_session_transcript(session_id: str) -> str:
@@ -33,7 +48,6 @@ async def build_session_transcript(session_id: str) -> str:
         FROM session_events FINAL
         WHERE session_id = {sid:String}
         ORDER BY line_offset ASC
-        LIMIT 500
         FORMAT JSON
     """
     params = {"param_sid": session_id}
@@ -49,13 +63,15 @@ async def build_session_transcript(session_id: str) -> str:
     if not rows:
         return ""
 
-    return _format_rows(rows)
+    transcript = _format_rows(rows)
+    if len(transcript) <= MAX_TRANSCRIPT_CHARS:
+        return transcript
+    return await _summarize_transcript(session_id, transcript)
 
 
 def _format_rows(rows: list[dict]) -> str:
     """Parse raw_line JSONL rows and format as readable transcript."""
     lines: list[str] = []
-    total_chars = 0
 
     for row in rows:
         event_type = row.get("event_type", "")
@@ -74,13 +90,38 @@ def _format_rows(rows: list[dict]) -> str:
         if not line:
             continue
 
-        if total_chars + len(line) > MAX_TRANSCRIPT_CHARS:
-            lines.append("[...truncated...]")
-            break
         lines.append(line)
-        total_chars += len(line) + 1
 
     return "\n".join(lines)
+
+
+async def _summarize_transcript(session_id: str, transcript: str) -> str:
+    """Summarize an oversized transcript instead of cutting off the tail."""
+    import services.dynamic_settings as ds
+
+    call_model = get_call_model()
+    model_override = await ds.get("insights.model_facets") or None
+    chunks = [transcript[i : i + SUMMARY_CHUNK_CHARS] for i in range(0, len(transcript), SUMMARY_CHUNK_CHARS)]
+    summaries: list[str] = []
+
+    for index, chunk in enumerate(chunks, start=1):
+        try:
+            result = await call_model(CHUNK_SUMMARY_PROMPT + chunk, model_override=model_override, max_tokens=700)
+            summary = result.get("summary", "") if isinstance(result, dict) else ""
+        except Exception as e:
+            logger.warning("transcript_summary_failed", session_id=session_id, chunk=index, error=str(e))
+            summary = ""
+
+        summaries.append(summary.strip() or chunk[:2000])
+
+    return "\n".join(
+        [
+            f"Session: {session_id[:8]}",
+            "[Long session summarized]",
+            "",
+            "\n\n[Next chunk]\n\n".join(summaries),
+        ]
+    )
 
 
 def _format_event(event_type: str, tool_name: str, parsed: dict) -> str:

--- a/observal_cli/skills/observal-ops/SKILL.md
+++ b/observal_cli/skills/observal-ops/SKILL.md
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 name: observal-ops
 command: observal
-description: View traces, spans, metrics, feedback, and telemetry health for Observal agents and MCPs. Use when the user wants to see recent traces, check metrics, view top items, submit ratings, or diagnose telemetry pipeline issues.
-version: 2.0.0
+description: View traces, spans, metrics, feedback, telemetry health, and agent insight reports. Use when the user wants to see traces, check metrics, view top items, submit ratings, diagnose telemetry, or discuss how an agent is doing.
+version: 2.1.0
 owner: observal
 ---
 
@@ -57,6 +57,68 @@ observal ops telemetry test
 `status` is the reliable check: it queries server event counts and local SQLite buffer. `test` may return 404 on newer servers (legacy endpoint). If `status` shows events flowing, telemetry is healthy.
 
 **Diagnosis:** status OK → healthy. No events → check `observal auth status`. Server reachable but no events → hooks not installed, suggest `observal doctor`.
+
+---
+
+## Procedure: Agent Insights
+
+Use this when the user asks how an agent is doing, what changed, why a version regressed, what to improve, or wants to talk through an insight report.
+
+Start with machine readable reports:
+
+```bash
+observal ops insights list AGENT_NAME --output json
+observal ops insights show AGENT_NAME latest --output json
+```
+
+Fetch one section when the user asks a narrow question:
+
+```bash
+observal ops insights show AGENT_NAME latest --section at_a_glance --output json
+observal ops insights show AGENT_NAME latest --section what_they_work_on --output json
+observal ops insights show AGENT_NAME latest --section interaction_style --output json
+observal ops insights show AGENT_NAME latest --section usage_patterns --output json
+observal ops insights show AGENT_NAME latest --section what_works --output json
+observal ops insights show AGENT_NAME latest --section friction_analysis --output json
+observal ops insights show AGENT_NAME latest --section suggestions --output json
+observal ops insights show AGENT_NAME latest --section usage_cost_analysis --output json
+observal ops insights show AGENT_NAME latest --section version_comparison --output json
+observal ops insights show AGENT_NAME latest --section regression_detection --output json
+observal ops insights show AGENT_NAME latest --section on_the_horizon --output json
+observal ops insights show AGENT_NAME latest --section fun_ending --output json
+```
+
+Section meanings:
+
+| Section | Use for |
+|---------|---------|
+| `at_a_glance` | Overall health, working areas, blockers, quick win |
+| `what_they_work_on` | Project areas and session counts |
+| `interaction_style` | User behavior and collaboration pattern |
+| `usage_patterns` | Session length, tool distribution, prompts |
+| `what_works` | Agent strengths and evidence |
+| `friction_analysis` | Recurring failures, severity, examples |
+| `suggestions` | Config changes, features, prompts, habits |
+| `usage_cost_analysis` | Cost, cache, model efficiency |
+| `version_comparison` | Current version versus baseline |
+| `regression_detection` | Improvements or degradations over time |
+| `on_the_horizon` | Higher leverage next workflows |
+| `fun_ending` | Memorable qualitative moment |
+
+If no completed report exists, generate one:
+
+```bash
+observal ops insights generate AGENT_NAME --period 14 --wait
+```
+
+For versioned analysis, request or infer versions from `list`, then generate or show version scoped reports:
+
+```bash
+observal ops insights generate AGENT_NAME --version 1.2.0 --compare 1.1.0 --period 30 --wait
+observal ops insights show AGENT_NAME latest --output json
+```
+
+Answer like an analyst: cite the report period, session count, strengths, friction, cost, version notes, and two or three concrete next actions. If data is thin, say so.
 
 ---
 

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 name: observal
 command: observal
-description: "Core Observal CLI operations: pull agents into your IDE, scan installed components, diagnose and patch IDE configs, authenticate, and manage CLI settings. Use when the user wants to install an agent, check their IDE setup, login, or configure the CLI."
-version: 2.0.0
+description: "Core Observal CLI operations: pull agents into your IDE, scan installed components, diagnose and patch IDE configs, authenticate, manage CLI settings, and discuss agent insights. Use when the user wants to install an agent, check setup, login, configure the CLI, or ask how an agent is doing."
+version: 2.1.0
 owner: observal
 ---
 
@@ -149,6 +149,45 @@ observal config set server_url https://observal.example.com
 observal config aliases
 observal config alias MY_AGENT abc-123
 ```
+
+---
+
+## Procedure: Discuss Agent Insights
+
+Use this when the user asks how an agent is doing, what is working, what is broken, why a version changed, or what to improve.
+
+Always fetch JSON first so you can reason over every report section, then answer conversationally.
+
+```bash
+observal ops insights list AGENT_NAME --output json
+observal ops insights show AGENT_NAME latest --output json
+observal ops insights show AGENT_NAME latest --section suggestions --output json
+observal ops insights show AGENT_NAME latest --section friction_analysis --output json
+```
+
+Available sections:
+
+- `at_a_glance`: health, working areas, blockers, quick win
+- `what_they_work_on`: project areas and session counts
+- `interaction_style`: how users interact with the agent
+- `usage_patterns`: session shape, tools, prompts, duration
+- `what_works`: strengths backed by sessions
+- `friction_analysis`: recurring failure modes and examples
+- `suggestions`: config additions, features to try, usage changes
+- `usage_cost_analysis`: cost, cache, and model efficiency
+- `version_comparison`: current version compared with a baseline
+- `regression_detection`: what improved or degraded versus previous data
+- `on_the_horizon`: higher leverage workflow opportunities
+- `fun_ending`: memorable qualitative moment
+
+For broad questions, run full `show` JSON and summarize health, top friction, top strengths, cost, and next actions. For narrow questions, fetch the specific section. If no completed report exists, offer to generate one:
+
+```bash
+observal ops insights generate AGENT_NAME --period 14 --wait
+observal ops insights generate AGENT_NAME --version 1.2.0 --compare 1.1.0 --period 30 --wait
+```
+
+Keep the answer grounded in the JSON. Say when the report is missing a section or has low session count.
 
 ---
 

--- a/tests/test_insights_facets_transcript.py
+++ b/tests/test_insights_facets_transcript.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _meta(session_id: str, duration: int, tool_count: int) -> dict:
+    return {
+        "session_id": session_id,
+        "total_messages": 3,
+        "duration_seconds": duration,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "total_cost": 0.0,
+        "credits": 0.0,
+        "lines_added": 0,
+        "lines_removed": 0,
+        "files_modified": 0,
+        "git_commits": 0,
+        "git_pushes": 0,
+        "tool_errors": 0,
+        "user_interruptions": 0,
+        "uses_subagent": False,
+        "uses_mcp": False,
+        "tool_counts": {"bash": tool_count} if tool_count else {},
+        "languages": {},
+        "model_usage": {},
+        "tool_error_categories": {},
+        "project_path": "/repo/app",
+        "user_response_times": [],
+        "message_hours": [],
+        "start_time": "2026-01-01T00:00:00Z",
+        "ide": "pi",
+        "user_message_count": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_report_uses_cached_facets_outside_top_sessions(monkeypatch):
+    import services.dynamic_settings as ds
+    from services.insights import generator
+
+    cached_facet = {
+        "underlying_goal": "fix a bug",
+        "goal_categories": ["fix_bug"],
+        "outcome": "mostly_achieved",
+        "user_satisfaction": "satisfied",
+        "agent_helpfulness": "very_helpful",
+        "session_type": "single_task",
+        "complexity": "low",
+        "friction_points": [],
+        "primary_success_factors": ["correct_code_edits"],
+        "tools_effective": ["bash"],
+        "tools_problematic": [],
+        "repeated_instructions": [],
+        "brief_summary": "cached session counted",
+    }
+    top_metas = [_meta(f"top-{i}", duration=1000 - i, tool_count=2) for i in range(50)]
+    metas = [*top_metas, _meta("cached-low", duration=1, tool_count=0)]
+
+    load_cached = AsyncMock(return_value={"cached-low": cached_facet})
+    monkeypatch.setattr(generator, "extract_all_session_metas", AsyncMock(return_value=metas))
+    monkeypatch.setattr(generator, "load_cached_facets_batch", load_cached)
+    monkeypatch.setattr(generator, "build_session_transcript", AsyncMock(return_value=""))
+    monkeypatch.setattr(generator, "generate_sections", AsyncMock(return_value={"ok": True}))
+    monkeypatch.setattr(ds, "get", AsyncMock(return_value=5))
+
+    report = await generator.generate_report_content(
+        agent_name="agent",
+        agent_id="agent-id",
+        period_start="2026-01-01",
+        period_end="2026-01-02",
+        db=SimpleNamespace(),
+    )
+
+    assert "cached-low" in load_cached.await_args.args[0]
+    assert report["facets_summary"]["sessions_with_facets"] == 1
+    assert report["facets_summary"]["goal_categories"] == [("fix_bug", 1)]
+
+
+@pytest.mark.asyncio
+async def test_build_session_transcript_summarizes_long_sessions(monkeypatch):
+    import services.dynamic_settings as ds
+    from services.insights import transcript
+
+    class Response:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            rows = []
+            for i in range(70):
+                rows.append(
+                    {
+                        "line_offset": i,
+                        "event_type": "user_prompt",
+                        "tool_name": "",
+                        "raw_line": '{"message":{"content":"' + ("x" * 600) + '"}}',
+                    }
+                )
+            return {"data": rows}
+
+    async def query(_sql: str, _params: dict) -> Response:
+        return Response()
+
+    summaries: list[str] = []
+
+    async def call_model(prompt: str, **_kwargs) -> dict:
+        summaries.append(prompt)
+        return {"summary": f"summary {len(summaries)}"}
+
+    monkeypatch.setattr(transcript, "get_query", lambda: query)
+    monkeypatch.setattr(transcript, "get_call_model", lambda: call_model)
+    monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+    result = await transcript.build_session_transcript("session-123456")
+
+    assert summaries
+    assert "[Long session summarized]" in result
+    assert "summary 1" in result
+    assert "[...truncated...]" not in result


### PR DESCRIPTION
## Purpose / Description
Improve agent insight coverage so cached qualitative facets from every matching session contribute to reports, not just the newly selected top sessions. Also make long transcript handling match the Pi insights behavior more closely by summarizing oversized transcripts before facet extraction instead of cutting them off.

## Fixes
No linked issue.

## Approach
- Load cached facets for all matching current version sessions before selecting new sessions for facet extraction.
- Select up to the facet cap from sessions that still need facets, preserving bounded new LLM work.
- Apply the same cached facet behavior to prior version comparison cohorts.
- Replace transcript truncation with chunk summaries for transcripts over 30000 characters.
- Update bundled Observal skills so agents can fetch every insight section through the CLI and discuss agent health, friction, suggestions, cost, and version changes.

## How Has This Been Tested?

Successful checks:

```bash
uv run ruff check observal-server/services/insights/transcript.py observal-server/services/insights/facets.py observal-server/services/insights/generator.py tests/test_insights_facets_transcript.py
uv run ruff format --check observal-server/services/insights/transcript.py observal-server/services/insights/facets.py observal-server/services/insights/generator.py tests/test_insights_facets_transcript.py
python -m pytest tests/test_insights_facets_transcript.py -q
uv run pytest tests/test_observal_skill_sync.py tests/test_observal_skill.py tests/test_insights_facets_transcript.py -q
```

The new tests cover cached facets outside the top session cohort and long transcript summarization.

<img width="1241" height="521" alt="image" src="https://github.com/user-attachments/assets/c9ceb3a9-e5af-4f3e-b867-03d49789bbe5" />


## Learning (optional, can help others)
Compared the server insight pipeline with the Pi insights TypeScript implementation. The useful parts to port were full cached facet participation and chunk summarization for oversized transcripts. Substantive session filtering and meta session filtering were intentionally not included in this PR.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

No UI screenshots included. This PR changes backend insight generation and CLI skill guidance only.

## AI Assistance

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
