### PR TITLE
bump(release): v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.7.0] - 2026-06-21
+## [1.8.0] - 2026-06-21
 
 ### Added
 
@@ -882,6 +882,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- bundle shared CLI package (**release**) ([994d6ed](https://github.com/BlazeUp-AI/Observal/commit/994d6ed2d97917a516e7895a2f02d9a3c1194b52))
 - improve facet coverage (**insights**) ([2c2fffb](https://github.com/BlazeUp-AI/Observal/commit/2c2fffb3ec958c38e070cc105190b9cc7b123b9d))
 - link component leaderboard rows (**web**) ([807f317](https://github.com/BlazeUp-AI/Observal/commit/807f317bf0b79ad8d12a6b5d3215ac286de51341))
 - consolidate management sidebar (**web**) ([f58ed0e](https://github.com/BlazeUp-AI/Observal/commit/f58ed0ec541bced18f5b1f777cd1e3ec09bf5456))

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.7.0"
+version = "1.8.0"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "AGPL-3.0-only"

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1684,7 +1684,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.7.0"
+version = "1.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [
     "pi-package",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.7.0"
+version = "1.8.0"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Release v1.8.0 (feature)

Bumps version `1.7.0` → `1.8.0` and regenerates changelog.

**Merging this PR will automatically trigger the release pipeline.**

### What happens after merge
- CLI binaries built for 6 platforms (Linux/macOS/Windows, x64/arm64)
- Docker images pushed to GHCR
- Server deployment tarball packaged
- PyPI package published
- **Approval required** in the `production` environment before GitHub Release publishes