### PR TITLE
fix(cli): stream remote logs

### DIFF
--- a/observal_cli/cmd_logs.py
+++ b/observal_cli/cmd_logs.py
@@ -95,6 +95,7 @@ def _stream_remote(console: Console, *, level: str, filter_text: str, no_color: 
     import httpx
 
     from observal_cli import config
+    from observal_cli.client import _get_cli_version
 
     cfg = config.get_or_exit()
     base_url = cfg["server_url"].rstrip("/")
@@ -112,7 +113,10 @@ def _stream_remote(console: Console, *, level: str, filter_text: str, no_color: 
             "GET",
             url,
             params=params,
-            headers={"Authorization": f"Bearer {token}"},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "X-Observal-CLI-Version": _get_cli_version(),
+            },
             timeout=None,
         ) as resp:
             if resp.status_code == 401:


### PR DESCRIPTION
## Purpose / Description
Remote optic log streaming failed from the CLI because the direct SSE client did not send the CLI version header required by server version enforcement. The server rejected the request with HTTP 426 before the log stream opened.

## Fixes
* No linked issue.

## Approach
Add the existing CLI version value to the remote log stream request headers so the SSE endpoint passes version enforcement, matching the rest of the CLI client behavior.

## How Has This Been Tested?

Ran these checks locally from the worktree:

* `make rebuild-fast`
* Logged into the local server using a temp HOME and demo admin credentials
* Connected to the remote optic log stream through `observal ops logs` in remote mode and confirmed TRACE and DEBUG entries arrived from the ring buffer sink
* `uv run --with ruff==0.15.10 ruff check observal_cli/cmd_logs.py`

## Learning (optional, can help others)
The log stream code bypasses the shared CLI client helper because it needs an open SSE stream. That meant it also bypassed the shared request headers. Server version enforcement treats httpx clients as CLI clients, so the missing version header caused HTTP 426.

No external references used.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. Not applicable, the change is a single request header.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). Not applicable, no UI changes.

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
