### PR TITLE
feat: update agent targets and cursor output

### DIFF
--- a/observal-server/alembic/versions/1caa45d85720_soft_delete_agents.py
+++ b/observal-server/alembic/versions/1caa45d85720_soft_delete_agents.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""soft delete agents
+
+Revision ID: 1caa45d85720
+Revises: 010_global_unique_names
+Create Date: 2026-06-21 16:35:54.480327
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1caa45d85720"
+down_revision: str | Sequence[str] | None = "010_global_unique_names"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("agents", sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True))
+    op.drop_constraint("uq_agents_name", "agents", type_="unique")
+    op.create_index(
+        "uq_agents_active_name",
+        "agents",
+        ["name"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+        sqlite_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "uq_agents_active_name",
+        table_name="agents",
+        postgresql_where=sa.text("deleted_at IS NULL"),
+        sqlite_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_unique_constraint("uq_agents_name", "agents", ["name"])
+    op.drop_column("agents", "deleted_at")

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -4,6 +4,7 @@
 """Agent CRUD routes: create, list, get, update, delete, archive, unarchive."""
 
 import uuid  # noqa: TC003
+from datetime import UTC, datetime
 
 from fastapi import Depends, HTTPException, Query, Response
 from loguru import logger as optic
@@ -24,12 +25,12 @@ from models.agent import (
     AgentVersion,
 )
 from models.agent_component import AgentComponent
-from models.download import AgentDownloadRecord
 from models.skill import SkillListing
 from models.user import User, UserRole
 from schemas.agent import (
     AgentCreateRequest,
     AgentResponse,
+    AgentRestoreRequest,
     AgentSummary,
     AgentUpdateRequest,
 )
@@ -95,7 +96,7 @@ async def create_agent(
     # Pre-check uniqueness before insert for a clean 409 (the DB constraint
     # remains the source of truth, but checking first avoids triggering an
     # IntegrityError mid-flush which would corrupt the savepoint state).
-    existing = await db.execute(select(Agent.id).where(Agent.name == req.name))
+    existing = await db.execute(select(Agent.id).where(Agent.name == req.name, Agent.deleted_at.is_(None)))
     if existing.scalar_one_or_none() is not None:
         raise HTTPException(
             status_code=409,
@@ -190,7 +191,7 @@ async def create_agent(
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
-        if "uq_agents_name" in str(exc.orig) or "uq_agents_name_created_by" in str(exc.orig):
+        if "uq_agents_active_name" in str(exc.orig) or "uq_agents_name" in str(exc.orig):
             raise HTTPException(
                 status_code=409,
                 detail=f"An agent named '{req.name}' already exists. Pick a different name.",
@@ -227,7 +228,7 @@ async def list_agents(
     optic.debug("listing agents")
     from models.feedback import Feedback
 
-    base_filter = AgentVersion.status == AgentStatus.approved
+    base_filter = (AgentVersion.status == AgentStatus.approved) & (Agent.deleted_at.is_(None))
     search_filter = None
     if search:
         safe = escape_like(search)
@@ -311,7 +312,11 @@ async def my_agents(
     optic.debug("my_agents called")
     from models.feedback import Feedback
 
-    stmt = select(Agent).where(Agent.created_by == current_user.id).order_by(Agent.created_at.desc())
+    stmt = (
+        select(Agent)
+        .where(Agent.created_by == current_user.id, Agent.deleted_at.is_(None))
+        .order_by(Agent.created_at.desc())
+    )
     agents = (await db.execute(stmt)).scalars().all()
 
     agent_ids = [a.id for a in agents]
@@ -359,7 +364,7 @@ async def archived_agents(
     stmt = (
         select(Agent)
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
-        .where(AgentVersion.status == AgentStatus.archived)
+        .where(AgentVersion.status == AgentStatus.archived, Agent.deleted_at.is_(None))
         .order_by(Agent.created_at.desc())
     )
     if current_user.org_id is not None:
@@ -404,6 +409,68 @@ async def archived_agents(
             created_by_email=email_map.get(a.created_by, ""),
             created_by_username=username_map.get(a.created_by),
             created_at=a.created_at,
+            updated_at=a.updated_at,
+        )
+        for a in agents
+    ]
+
+
+@router.get("/deleted", response_model=list[AgentSummary])
+async def deleted_agents(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    optic.debug("deleted_agents called")
+    from models.feedback import Feedback
+
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
+    stmt = select(Agent).where(Agent.deleted_at.is_not(None)).order_by(Agent.deleted_at.desc())
+    if is_admin:
+        if current_user.org_id is not None:
+            stmt = stmt.where(Agent.owner_org_id == current_user.org_id)
+    else:
+        stmt = stmt.where(Agent.created_by == current_user.id)
+
+    agents = (await db.execute(stmt)).scalars().all()
+
+    agent_ids = [a.id for a in agents]
+    rating_map: dict[uuid.UUID, float] = {}
+    if agent_ids:
+        rows = await db.execute(
+            select(Feedback.listing_id, func.avg(Feedback.rating))
+            .where(Feedback.listing_id.in_(agent_ids), Feedback.listing_type == "agent")
+            .group_by(Feedback.listing_id)
+        )
+        rating_map = {r[0]: round(float(r[1]), 2) for r in rows.all()}
+
+    user_ids = {a.created_by for a in agents}
+    email_map: dict[uuid.UUID, str] = {}
+    username_map: dict[uuid.UUID, str | None] = {}
+    if user_ids:
+        rows = await db.execute(select(User.id, User.email, User.username).where(User.id.in_(user_ids)))
+        for r in rows.all():
+            email_map[r[0]] = r[1]
+            username_map[r[0]] = r[2]
+
+    return [
+        AgentSummary(
+            id=a.id,
+            name=a.name,
+            version=a.version,
+            description=a.description,
+            owner=a.owner,
+            model_name=a.model_name,
+            supported_ides=a.supported_ides,
+            status=a.status,
+            rejection_reason=a.rejection_reason,
+            download_count=a.download_count,
+            average_rating=rating_map.get(a.id),
+            component_count=len(a.components),
+            created_by=a.created_by,
+            created_by_email=email_map.get(a.created_by, ""),
+            created_by_username=username_map.get(a.created_by),
+            created_at=a.created_at,
+            deleted_at=a.deleted_at,
             updated_at=a.updated_at,
         )
         for a in agents
@@ -507,6 +574,13 @@ async def update_agent(
         from services.versioning import bump_version
 
         req.version = bump_version(agent.version, req.version_bump_type)
+
+    if req.name is not None and req.name != agent.name:
+        existing = await db.execute(
+            select(Agent.id).where(Agent.name == req.name, Agent.deleted_at.is_(None), Agent.id != agent.id)
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise HTTPException(status_code=409, detail=f"An active agent named '{req.name}' already exists.")
 
     for field in (
         "name",
@@ -654,8 +728,7 @@ async def delete_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    optic.debug("deleting agent")
-    from models.feedback import Feedback
+    optic.debug("soft deleting agent")
 
     agent = await _load_agent(
         db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id, include_all_statuses=True
@@ -668,35 +741,8 @@ async def delete_agent(
     perm = get_effective_agent_permission(agent, current_user)
     if perm != "owner" and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
-    if agent.status == AgentStatus.approved and not is_admin:
-        raise HTTPException(status_code=400, detail="Cannot delete an approved listing. Contact an admin.")
 
-    # Delete related records with correct type filters
-    for r in (
-        (await db.execute(select(Feedback).where(Feedback.listing_id == agent.id, Feedback.listing_type == "agent")))
-        .scalars()
-        .all()
-    ):
-        await db.delete(r)
-    for r in (
-        (await db.execute(select(AgentDownloadRecord).where(AgentDownloadRecord.agent_id == agent.id))).scalars().all()
-    ):
-        await db.delete(r)
-    # Break circular FK (Agent.latest_version_id ↔ AgentVersion.agent_id)
-    # then delete via raw SQL to avoid ORM cascade circular dependency.
-    from sqlalchemy import delete as sql_delete
-
-    agent_id_str = str(agent.id)
-    agent_name = agent.name
-
-    # Null out the self-referential FK first
-    agent.latest_version_id = None
-    await db.flush()
-
-    # Delete versions via SQL (DB-level CASCADE handles children: components, goals)
-    await db.execute(sql_delete(AgentVersion).where(AgentVersion.agent_id == agent.id))
-    # Delete agent via SQL (avoids ORM cascade re-triggering on stale identity map)
-    await db.execute(sql_delete(Agent).where(Agent.id == agent.id))
+    agent.deleted_at = datetime.now(UTC)
     await db.commit()
 
     emit_registry_event(
@@ -704,11 +750,59 @@ async def delete_agent(
         user_id=str(current_user.id),
         user_email=current_user.email,
         user_role=current_user.role.value,
-        agent_id=agent_id_str,
-        resource_name=agent_name,
+        agent_id=str(agent.id),
+        resource_name=agent.name,
     )
 
-    return {"deleted": agent_id_str}
+    return {"deleted": str(agent.id), "name": agent.name, "deleted_at": agent.deleted_at.isoformat()}
+
+
+@router.patch("/{agent_id}/restore")
+async def restore_deleted_agent(
+    agent_id: str,
+    req: AgentRestoreRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    optic.trace("agent_id={}", agent_id)
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id,
+        org_id=current_user.org_id,
+        include_all_statuses=True,
+        include_deleted=True,
+    )
+    if not agent or agent.deleted_at is None:
+        raise HTTPException(status_code=404, detail="Deleted agent not found")
+    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
+    if not is_admin and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
+        raise HTTPException(status_code=404, detail="Deleted agent not found")
+    perm = get_effective_agent_permission(agent, current_user)
+    if perm != "owner" and not is_admin:
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    restore_name = req.name if req and req.name else agent.name
+    existing = await db.execute(
+        select(Agent.id).where(Agent.name == restore_name, Agent.deleted_at.is_(None), Agent.id != agent.id)
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="An active agent already uses this name. Restore with a new name.")
+
+    agent.name = restore_name
+    agent.deleted_at = None
+    await db.commit()
+
+    emit_registry_event(
+        action="agent.restore",
+        user_id=str(current_user.id),
+        user_email=current_user.email,
+        user_role=current_user.role.value,
+        agent_id=str(agent.id),
+        resource_name=agent.name,
+    )
+
+    return {"id": str(agent.id), "name": agent.name, "status": agent.status}
 
 
 @router.patch("/{agent_id}/archive")

--- a/observal-server/api/routes/agent/helpers.py
+++ b/observal-server/api/routes/agent/helpers.py
@@ -27,6 +27,7 @@ async def _load_agent(
     prefer_user_id: uuid.UUID | None = None,
     org_id: uuid.UUID | None = None,
     include_all_statuses: bool = False,
+    include_deleted: bool = False,
 ) -> Agent | None:
     """Load an agent by UUID, prefix, or name with eager loading.
 
@@ -38,16 +39,20 @@ async def _load_agent(
     Set *include_all_statuses* to find agents regardless of version status
     (needed for unarchive, delete, etc.).
     """
+    conditions = list(extra_conditions or [])
+    if not include_deleted:
+        conditions.append(Agent.deleted_at.is_(None))
+
     try:
-        return await resolve_prefix_id(Agent, agent_id, db, extra_conditions=extra_conditions)
+        return await resolve_prefix_id(Agent, agent_id, db, extra_conditions=conditions)
     except HTTPException:
         pass
 
     # Try the caller's own agent first
     if prefer_user_id is not None:
         stmt = select(Agent).where(Agent.name == agent_id, Agent.created_by == prefer_user_id)
-        if extra_conditions:
-            stmt = stmt.where(*extra_conditions)
+        if conditions:
+            stmt = stmt.where(*conditions)
         mine = (await db.execute(stmt)).scalar_one_or_none()
         if mine:
             return mine
@@ -56,8 +61,8 @@ async def _load_agent(
     stmt = select(Agent).join(AgentVersion, Agent.latest_version_id == AgentVersion.id).where(Agent.name == agent_id)
     if not include_all_statuses:
         stmt = stmt.where(AgentVersion.status == AgentStatus.approved)
-    if extra_conditions:
-        stmt = stmt.where(*extra_conditions)
+    if conditions:
+        stmt = stmt.where(*conditions)
     if org_id is not None:
         stmt = stmt.where(Agent.owner_org_id == org_id)
     results = (await db.execute(stmt)).scalars().all()

--- a/observal-server/api/routes/preview.py
+++ b/observal-server/api/routes/preview.py
@@ -9,14 +9,13 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 from loguru import logger as optic
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from api.deps import get_current_user, get_db
-from api.ratelimit import limiter
 from models.hook import HookListing
 from models.mcp import McpListing
 from models.prompt import PromptListing
@@ -88,17 +87,15 @@ class _TransientAgent:
 
 
 @router.post("/preview-config", response_model=PreviewConfigResponse)
-@limiter.limit("10/minute")
 async def preview_config(
     req: PreviewConfigRequest,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     optic.debug("preview config")
     target_ides = [ide for ide in req.target_ides if ide in _VALID_IDES]
     if not target_ides:
-        target_ides = [ide for ide in IDE_REGISTRY if ide != "copilot-cli"]
+        target_ides = list(IDE_REGISTRY)
 
     components = [
         _TransientComponent(

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -80,7 +80,6 @@ class AgentVersion(Base):
 
 class Agent(Base):
     __tablename__ = "agents"
-    __table_args__ = (UniqueConstraint("name", name="uq_agents_name"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -97,10 +96,21 @@ class Agent(Base):
     category: Mapped[str | None] = mapped_column(String(100), nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        Index(
+            "uq_agents_active_name",
+            "name",
+            unique=True,
+            postgresql_where=deleted_at.is_(None),
+            sqlite_where=deleted_at.is_(None),
+        ),
     )
 
     versions: Mapped[list["AgentVersion"]] = relationship(

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -152,6 +152,7 @@ class AgentResponse(BaseModel):
     created_by_email: str = ""
     created_by_username: str | None = None
     created_at: datetime
+    deleted_at: datetime | None = None
     updated_at: datetime
     mcp_links: list[McpLinkResponse] = []
     component_links: list[ComponentLinkResponse] = []
@@ -181,6 +182,7 @@ class AgentSummary(BaseModel):
     created_by_email: str = ""
     created_by_username: str | None = None
     created_at: datetime | None = None
+    deleted_at: datetime | None = None
     updated_at: datetime | None = None
     components_ready: bool = True
     blocking_components: list = []
@@ -238,6 +240,24 @@ class AgentVersionCreateRequest(BaseModel):
     def _validate_version(cls, v: str) -> str:
         if not validate_semver(v):
             raise ValueError(f"Invalid version '{v}'. Must be semver format: x.y.z (e.g. 1.0.0)")
+        return v
+
+
+class AgentRestoreRequest(BaseModel):
+    name: str | None = None
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _validate_name(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if len(v) > 64:
+            raise ValueError("name must be at most 64 characters")
+        if not AGENT_NAME_REGEX.match(v):
+            raise ValueError(
+                f"Invalid name '{v}'. "
+                "Must start with a letter or digit and contain only lowercase letters, digits, hyphens, and underscores."
+            )
         return v
 
 

--- a/observal-server/schemas/ide_registry.py
+++ b/observal-server/schemas/ide_registry.py
@@ -221,7 +221,7 @@ IDE_REGISTRY: dict[str, dict] = {
         "default_scope": "project",
         "scope_labels": None,
         "rules_file": {
-            "project": ".github/copilot-instructions.md",
+            "project": ".github/agents/{name}.agent.md",
         },
         "rules_format": "markdown",
         "mcp_config_path": {

--- a/observal-server/schemas/ide_registry.py
+++ b/observal-server/schemas/ide_registry.py
@@ -296,8 +296,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "features": {"hooks", "mcp_servers", "skills"},
         "session_parser": "antigravity",
         "scopes": ["project", "user"],
-        "default_scope": "project",
-        "scope_labels": ("project (.agents/)", "user (~/.gemini/antigravity-cli/)"),
+        "default_scope": "user",
+        "scope_labels": ("project (.agents/)", "user (~/.gemini/config/)"),
         "rules_file": {
             "project": "AGENTS.md",
             "user": "~/.gemini/GEMINI.md",

--- a/observal-server/schemas/ide_registry.py
+++ b/observal-server/schemas/ide_registry.py
@@ -305,7 +305,7 @@ IDE_REGISTRY: dict[str, dict] = {
         "rules_format": "markdown",
         "mcp_config_path": {
             "project": ".agents/mcp_config.json",
-            "user": "~/.gemini/antigravity-cli/mcp_config.json",
+            "user": "~/.gemini/config/mcp_config.json",
         },
         "mcp_servers_key": "mcpServers",
         "skill_file": {
@@ -313,7 +313,7 @@ IDE_REGISTRY: dict[str, dict] = {
             "user": "~/.gemini/config/skills/{name}/SKILL.md",
         },
         "skill_format": "yaml_frontmatter",
-        "home_mcp_config": "~/.gemini/antigravity-cli/mcp_config.json",
+        "home_mcp_config": "~/.gemini/config/mcp_config.json",
         "hook_type": "command",
         "hook_config_path": {
             "project": ".agents/hooks.json",

--- a/observal-server/schemas/ide_registry.py
+++ b/observal-server/schemas/ide_registry.py
@@ -183,7 +183,7 @@ IDE_REGISTRY: dict[str, dict] = {
         "default_scope": "project",
         "scope_labels": None,
         "rules_file": {
-            "project": ".github/copilot-instructions.md",
+            "project": ".github/agents/{name}.agent.md",
         },
         "rules_format": "markdown",
         "mcp_config_path": {

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -524,14 +524,19 @@ def _generate_codex(manifest: AgentManifest) -> IdeAgentConfig:
 
 
 def _generate_copilot(manifest: AgentManifest) -> IdeAgentConfig:
-    """Generate GitHub Copilot agent config (.github/copilot-instructions.md + .vscode/mcp.json)."""
+    """Generate GitHub Copilot custom agent config."""
+    safe_name = _sanitize_name(manifest.name)
     mcp_entries = _build_mcp_entries(manifest)
     rules_content = _build_rules_markdown(manifest)
+    desc_line = (manifest.description or safe_name).replace("\n", " ").strip()[:200]
+    agent_content = (
+        f"---\nname: {safe_name}\ndescription: \"{desc_line}\"\ntarget: vscode\ntools: ['*']\n---\n\n{rules_content}"
+    )
 
     files = [
         AgentFile(
-            path=".github/copilot-instructions.md",
-            content=rules_content,
+            path=f".github/agents/{safe_name}.agent.md",
+            content=agent_content,
             format="markdown",
         ),
     ]

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -13,11 +13,13 @@ Generates IDE-specific agent files from a ResolvedAgent:
 - Cursor: .cursor/agents/<name>.md (subagent markdown) + .cursor/mcp.json
 - Gemini CLI: GEMINI.md (markdown) + MCP JSON config
 - Kiro: ~/.kiro/agents/<name>.json (JSON)
-- Codex: AGENTS.md (markdown)
+- Codex: ~/.codex/agents/<name>.toml (custom agent)
 - GitHub Copilot: .github/copilot-instructions.md (markdown)
 - OpenCode: .opencode/agents/<name>.md (markdown) + opencode.json (MCP config)
 
 """
+
+import json
 
 from loguru import logger as optic
 
@@ -491,31 +493,29 @@ def _generate_kiro(manifest: AgentManifest) -> IdeAgentConfig:
 
 
 def _generate_codex(manifest: AgentManifest) -> IdeAgentConfig:
-    """Generate Codex agent config (AGENTS.md + ~/.codex/config.toml)."""
+    """Generate Codex custom agent config."""
+    safe_name = _sanitize_name(manifest.name)
     rules_content = _build_rules_markdown(manifest)
+    desc_line = (manifest.description or safe_name).replace("\n", " ").strip()[:200]
+    saved_model = _saved_model_for(manifest, "codex")
+    agent_lines = [
+        f"name = {json.dumps(safe_name)}",
+        f"description = {json.dumps(desc_line or safe_name)}",
+        f"developer_instructions = {json.dumps(rules_content)}",
+    ]
+    if saved_model:
+        agent_lines.append(f"model = {json.dumps(saved_model)}")
 
     files = [
         AgentFile(
-            path="AGENTS.md",
-            content=rules_content,
-            format="markdown",
+            path=f"~/.codex/agents/{safe_name}.toml",
+            content="\n".join(agent_lines) + "\n",
+            format="toml",
         ),
     ]
 
     skill_files = _build_skill_files(manifest, "codex")
     files.extend(skill_files)
-
-    saved_model = _saved_model_for(manifest, "codex")
-    if saved_model:
-        toml_lines: list[str] = [f'model = "{saved_model}"', ""]
-        toml_snippet = "\n".join(toml_lines) + "\n"
-        files.append(
-            AgentFile(
-                path="~/.codex/config.toml",
-                content=toml_snippet,
-                format="toml",
-            ),
-        )
 
     return IdeAgentConfig(
         ide="codex",

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -10,7 +10,7 @@
 
 Generates IDE-specific agent files from a ResolvedAgent:
 - Claude Code: .claude/agents/<name>.md (markdown) + MCP JSON config
-- Cursor: .cursor/rules/<name>.md (markdown) + .cursor/mcp.json
+- Cursor: .cursor/agents/<name>.md (subagent markdown) + .cursor/mcp.json
 - Gemini CLI: GEMINI.md (markdown) + MCP JSON config
 - Kiro: ~/.kiro/agents/<name>.json (JSON)
 - Codex: AGENTS.md (markdown)
@@ -372,10 +372,13 @@ def _generate_claude_code(manifest: AgentManifest) -> IdeAgentConfig:
 
 
 def _generate_cursor(manifest: AgentManifest) -> IdeAgentConfig:
-    """Generate Cursor agent config (.cursor/rules/<name>.md + .cursor/mcp.json)."""
+    """Generate Cursor subagent config (.cursor/agents/<name>.md + .cursor/mcp.json)."""
     safe_name = _sanitize_name(manifest.name)
     mcp_entries = _build_mcp_entries(manifest)
     rules_content = _build_rules_markdown(manifest)
+    desc_line = (manifest.description or safe_name).replace("\n", " ").strip()[:200]
+    model = manifest.model_name or "inherit"
+    agent_content = f"---\nname: {safe_name}\ndescription: {desc_line!r}\nmodel: {model}\n---\n\n{rules_content}"
 
     skill_files = _build_skill_files(manifest, "cursor")
 
@@ -383,8 +386,8 @@ def _generate_cursor(manifest: AgentManifest) -> IdeAgentConfig:
         ide="cursor",
         files=[
             AgentFile(
-                path=f".cursor/rules/{safe_name}.md",
-                content=rules_content,
+                path=f".cursor/agents/{safe_name}.md",
+                content=agent_content,
                 format="markdown",
             ),
             AgentFile(

--- a/observal-server/services/ide/antigravity.py
+++ b/observal-server/services/ide/antigravity.py
@@ -49,11 +49,6 @@ class AntigravityAdapter:
         if skill_files:
             result["skill_files"] = skill_files
 
-        # Model choice
-        model = options.get("_resolved_model")
-        if model:
-            mcp_content["model"] = model
-
         warnings = list(ctx.compatibility_warnings)
         warnings.extend(options.get("_model_warnings") or [])
         if warnings:

--- a/observal-server/services/ide/antigravity.py
+++ b/observal-server/services/ide/antigravity.py
@@ -23,29 +23,33 @@ class AntigravityAdapter:
         spec = IDE_REGISTRY["antigravity"]
         options = ctx.options
         scope = options.get("scope", spec["default_scope"])
+        desc = (getattr(ctx.agent, "description", "") or ctx.safe_name).replace("\n", " ").strip()[:200]
 
-        # MCP config
-        mcp_path = spec["mcp_config_path"].get(scope, spec["mcp_config_path"]["project"])
-        mcp_content = {spec["mcp_servers_key"]: ctx.mcp_configs}
+        result: dict = {
+            "agent_file": {
+                "path": f"~/.gemini/antigravity-cli/agents/{ctx.safe_name}/agent.json",
+                "content": {
+                    "name": ctx.safe_name,
+                    "description": desc,
+                    "system_prompt": ctx.rules_content,
+                    "enable_mcp_tools": True,
+                    "enable_write_tools": True,
+                    "enable_subagent_tools": True,
+                },
+            },
+            "scope": scope,
+        }
 
-        # Rules file
-        rules_path = spec["rules_file"].get(scope, spec["rules_file"]["project"])
-        rules_path = rules_path.replace("{name}", ctx.safe_name)
+        if ctx.mcp_configs:
+            mcp_path = spec["mcp_config_path"].get(scope, spec["mcp_config_path"]["user"])
+            result["mcp_config"] = {"path": mcp_path, "content": {spec["mcp_servers_key"]: ctx.mcp_configs}}
 
-        # Skill files
         skill_files = []
-        skill_path_template = spec["skill_file"].get(scope, spec["skill_file"]["project"])
+        skill_path_template = spec["skill_file"].get(scope, spec["skill_file"]["user"])
         for skill in ctx.skill_configs:
             skill_name = skill.get("name", "unnamed")
             skill_path = skill_path_template.replace("{name}", skill_name)
             skill_files.append({"path": skill_path, "content": skill.get("content", "")})
-
-        result: dict = {
-            "rules_file": {"path": rules_path, "content": ctx.rules_content},
-            "mcp_config": {"path": mcp_path, "content": mcp_content},
-            "scope": scope,
-        }
-
         if skill_files:
             result["skill_files"] = skill_files
 

--- a/observal-server/services/ide/codex.py
+++ b/observal-server/services/ide/codex.py
@@ -5,12 +5,29 @@
 
 from __future__ import annotations
 
+import json
+
 from loguru import logger as optic
 
 from schemas.ide_registry import IDE_REGISTRY
 from services.ide import ConfigContext, register_adapter
 
 _CODEX_SESSION_PUSH_CMD = "python3 -m observal_cli.hooks.codex_session_push"
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _codex_agent_toml(name: str, description: str, instructions: str, model: str | None) -> str:
+    lines = [
+        f"name = {_toml_string(name)}",
+        f"description = {_toml_string(description or name)}",
+        f"developer_instructions = {_toml_string(instructions)}",
+    ]
+    if model:
+        lines.append(f"model = {_toml_string(model)}")
+    return "\n".join(lines) + "\n"
 
 
 def _codex_hooks_config(agent_name: str = "") -> dict:
@@ -43,11 +60,17 @@ class CodexAdapter:
         codex_scope = codex_spec["default_scope"]
         codex_content: dict = {"mcp.servers": mcp_configs}
         codex_model = options.get("_resolved_model")
-        if codex_model:
-            codex_content["model"] = codex_model
 
         result: dict = {
-            "rules_file": {"path": codex_spec["rules_file"][codex_scope], "content": rules_content},
+            "agent_file": {
+                "path": f"~/.codex/agents/{ctx.safe_name}.toml",
+                "content": _codex_agent_toml(
+                    ctx.safe_name,
+                    (ctx.agent.description or ctx.safe_name).replace("\n", " ").strip()[:200],
+                    rules_content,
+                    codex_model,
+                ),
+            },
             "mcp_config": {"path": codex_spec["mcp_config_path"][codex_scope], "content": codex_content},
             "hooks_config": {
                 "path": "~/.codex/hooks.json",

--- a/observal-server/services/ide/copilot.py
+++ b/observal-server/services/ide/copilot.py
@@ -45,31 +45,15 @@ class CopilotAdapter:
 
         copilot_spec = IDE_REGISTRY["copilot"]
 
-        # Build .agent.md (no hooks in frontmatter - VS Code doesn't support them)
-        agent_desc = getattr(ctx.agent, "description", "") or ""
+        agent_desc = getattr(ctx.agent, "description", "") or safe_name
         frontmatter_lines = [
             "---",
             f"name: {safe_name}",
+            f'description: "{agent_desc}"',
+            "target: vscode",
+            "tools: ['*']",
+            "---",
         ]
-        if agent_desc:
-            frontmatter_lines.append(f'description: "{agent_desc}"')
-        frontmatter_lines.append("tools: ['*']")
-        # Add mcp-servers to frontmatter
-        if copilot_configs:
-            frontmatter_lines.append("mcp-servers:")
-            for mcp_name in copilot_configs:
-                cfg = copilot_configs[mcp_name]
-                frontmatter_lines.append(f"  {mcp_name}:")
-                if cfg.get("type"):
-                    frontmatter_lines.append(f"    type: {cfg['type']}")
-                if cfg.get("command"):
-                    frontmatter_lines.append(f"    command: {cfg['command']}")
-                if cfg.get("args"):
-                    args_str = ", ".join(str(a) for a in cfg["args"])
-                    frontmatter_lines.append(f"    args: [{args_str}]")
-                if cfg.get("url"):
-                    frontmatter_lines.append(f"    url: {cfg['url']}")
-        frontmatter_lines.append("---")
         agent_content = "\n".join(frontmatter_lines) + "\n\n" + rules_content
 
         result: dict = {

--- a/observal-server/services/ide/copilot_cli.py
+++ b/observal-server/services/ide/copilot_cli.py
@@ -80,14 +80,13 @@ class CopilotCliAdapter:
         copilot_cli_spec = IDE_REGISTRY["copilot-cli"]
 
         # Build .agent.md with YAML frontmatter
-        agent_desc = getattr(ctx.agent, "description", "") or ""
+        agent_desc = getattr(ctx.agent, "description", "") or safe_name
         frontmatter_lines = [
             "---",
             f"name: {safe_name}",
+            f'description: "{agent_desc}"',
+            "tools: ['*']",
         ]
-        if agent_desc:
-            frontmatter_lines.append(f'description: "{agent_desc}"')
-        frontmatter_lines.append("tools: ['*']")
         # Add mcp-servers to frontmatter if present
         if copilot_cli_configs:
             frontmatter_lines.append("mcp-servers:")

--- a/observal-server/services/ide/cursor.py
+++ b/observal-server/services/ide/cursor.py
@@ -35,24 +35,20 @@ class CursorAdapter:
 
         spec = IDE_REGISTRY["cursor"]
         ide_scope = options.get("scope", spec.get("default_scope", "project"))
-        rules_paths = spec.get("rules_file", {})
-        rules_path = rules_paths.get(ide_scope, next(iter(rules_paths.values()), f".rules/{safe_name}.md"))
         mcp_paths = spec.get("mcp_config_path", {})
         mcp_path = mcp_paths.get(ide_scope, next(iter(mcp_paths.values()), ".mcp.json"))
 
-        # Cursor uses .cursor/agents/<name>.md for subagent registration
-        # and .cursor/rules/<name>.mdc for context rules
         desc_line = (ctx.agent.description or safe_name).replace("\n", " ").strip()[:200]
-        cursor_rules_content = f"---\ndescription: {desc_line}\nalwaysApply: false\n---\n\n{rules_content}"
-        cursor_agent_content = f"---\nname: {safe_name}\ndescription: {desc_line}\n---\n\n{rules_content}"
+        model = options.get("_resolved_model") or "inherit"
+        cursor_agent_content = (
+            f"---\nname: {safe_name}\ndescription: {desc_line!r}\nmodel: {model}\n---\n\n{rules_content}"
+        )
 
         result: dict = {
-            "rules_file": {"path": rules_path.format(name=safe_name), "content": cursor_rules_content},
             "mcp_config": {"path": mcp_path, "content": {spec.get("mcp_servers_key", "mcpServers"): mcp_configs}},
             "scope": ide_scope,
         }
 
-        # Agent file for subagent registration
         agent_dir = ".cursor/agents" if ide_scope == "project" else "~/.cursor/agents"
         result["agent_file"] = {"path": f"{agent_dir}/{safe_name}.md", "content": cursor_agent_content}
 

--- a/observal_cli/ide/antigravity.py
+++ b/observal_cli/ide/antigravity.py
@@ -22,6 +22,7 @@ from observal_cli.shared.utils import (
     extract_mcp_servers,
     first_content_line,
     parse_frontmatter_field,
+    resolve_antigravity_config_dir,
 )
 
 if TYPE_CHECKING:
@@ -31,7 +32,8 @@ if TYPE_CHECKING:
 class AntigravityAdapter(BaseAdapter):
     """Adapter for Antigravity CLI."""
 
-    home_markers = (".gemini/antigravity-cli",)
+    home_markers = (".gemini/antigravity-cli", ".gemini/config")
+    managed_agent_files = ("user:agents/{name}/agent.json", "project:.agents/agents/{name}/agent.json")
 
     @property
     def ide_name(self) -> str:
@@ -48,12 +50,16 @@ class AntigravityAdapter(BaseAdapter):
     def scan_home(self, home: Path | None = None) -> ScanResult:
         """Discover MCPs, skills, hooks, agents from ~/.gemini/antigravity-cli/."""
         ag_dir = self._resolve_ag_dir(home)
-        if ag_dir is None:
+        config_dir = resolve_antigravity_config_dir(home)
+        if ag_dir is None and config_dir is None:
             return ScanResult()
-
-        mcps = self._scan_mcps(ag_dir / "mcp_config.json", "antigravity:global")
-        skills = self._scan_skills(ag_dir / "skills")
-        hooks = self._scan_hooks(ag_dir / "settings.json")
+        if ag_dir is None:
+            ag_dir = config_dir
+        if config_dir is None:
+            config_dir = ag_dir
+        mcps = self._scan_mcps(config_dir / "mcp_config.json", "antigravity:global")
+        skills = self._scan_skills(config_dir / "skills")
+        hooks = self._scan_hooks(config_dir / "hooks.json")
         agents = self._scan_agents(ag_dir / "agents")
         return ScanResult(mcps=mcps, skills=skills, hooks=hooks, agents=agents)
 
@@ -159,22 +165,29 @@ class AntigravityAdapter(BaseAdapter):
             return []
         try:
             data = json.loads(settings_file.read_text())
-            hooks_data = data.get("hooks", {})
             hooks: list[DiscoveredHook] = []
-            for event, entries in hooks_data.items():
-                if isinstance(entries, list):
-                    for h in entries:
-                        if isinstance(h, dict):
-                            hooks.append(
-                                DiscoveredHook(
-                                    name=h.get("command", event)[:40],
-                                    event=event,
-                                    handler_type="command",
-                                    handler_config=h,
-                                    description=f"Hook: {event}",
-                                    source="antigravity:hooks",
+            for hook_name, hook_def in data.items():
+                if not isinstance(hook_def, dict):
+                    continue
+                for event, entries in hook_def.items():
+                    if event == "enabled" or not isinstance(entries, list):
+                        continue
+                    for entry in entries:
+                        if not isinstance(entry, dict):
+                            continue
+                        handlers = entry.get("hooks") if isinstance(entry.get("hooks"), list) else [entry]
+                        for handler in handlers:
+                            if isinstance(handler, dict):
+                                hooks.append(
+                                    DiscoveredHook(
+                                        name=hook_name,
+                                        event=event,
+                                        handler_type="command",
+                                        handler_config=handler,
+                                        description=f"Hook: {event}",
+                                        source="antigravity:hooks",
+                                    )
                                 )
-                            )
             return hooks
         except (json.JSONDecodeError, OSError):
             return []
@@ -183,23 +196,27 @@ class AntigravityAdapter(BaseAdapter):
         if not agents_dir.is_dir():
             return []
         agents = []
-        for agent_file in sorted(agents_dir.glob("*.md")):
-            name = agent_file.stem
+        for agent_file in sorted(agents_dir.glob("*/agent.json")):
+            name = agent_file.parent.name
             content = ""
             desc = ""
             model = ""
+            prompt = ""
             try:
                 content = agent_file.read_text()
-                desc = parse_frontmatter_field(content, "description") or ""
-                model = parse_frontmatter_field(content, "model") or ""
-            except OSError:
+                data = json.loads(content)
+                name = data.get("name") or name
+                desc = data.get("description") or ""
+                model = data.get("model") or ""
+                prompt = data.get("system_prompt") or ""
+            except (json.JSONDecodeError, OSError):
                 pass
             agents.append(
                 DiscoveredAgent(
                     name=name,
                     description=desc or f"Agent: {name}",
                     model_name=model,
-                    prompt=content[:500],
+                    prompt=(prompt or content)[:500],
                     source_file=str(agent_file),
                 )
             )

--- a/observal_cli/ide/codex.py
+++ b/observal_cli/ide/codex.py
@@ -44,7 +44,7 @@ class CodexAdapter(BaseAdapter):
     """Adapter for Codex CLI (OpenAI)."""
 
     home_markers = (".codex",)
-    managed_agent_files = ("user:AGENTS.md", "project:AGENTS.md")
+    managed_agent_files = ("user:agents/{name}.toml", "project:.codex/agents/{name}.toml")
     managed_mcp_files = ("user:config.toml",)
 
     @property

--- a/observal_cli/ide/cursor.py
+++ b/observal_cli/ide/cursor.py
@@ -23,9 +23,7 @@ class CursorAdapter(BaseAdapter):
 
     home_markers = (".cursor",)
     managed_agent_files = (
-        "user:rules/{name}.mdc",
         "user:agents/{name}.md",
-        "project:.cursor/rules/{name}.mdc",
         "project:.cursor/agents/{name}.md",
     )
     managed_skill_files = ("user:rules/{name}.mdc", "user:skills/{name}/SKILL.md")

--- a/observal_cli/ide_registry.py
+++ b/observal_cli/ide_registry.py
@@ -216,7 +216,7 @@ IDE_REGISTRY: dict[str, dict] = {
         "default_scope": "project",
         "scope_labels": None,
         "rules_file": {
-            "project": ".github/copilot-instructions.md",
+            "project": ".github/agents/{name}.agent.md",
         },
         "rules_format": "markdown",
         "mcp_config_path": {

--- a/observal_cli/ide_registry.py
+++ b/observal_cli/ide_registry.py
@@ -178,7 +178,7 @@ IDE_REGISTRY: dict[str, dict] = {
         "default_scope": "project",
         "scope_labels": None,
         "rules_file": {
-            "project": ".github/copilot-instructions.md",
+            "project": ".github/agents/{name}.agent.md",
         },
         "rules_format": "markdown",
         "mcp_config_path": {

--- a/observal_cli/ide_registry.py
+++ b/observal_cli/ide_registry.py
@@ -300,7 +300,7 @@ IDE_REGISTRY: dict[str, dict] = {
         "rules_format": "markdown",
         "mcp_config_path": {
             "project": ".agents/mcp_config.json",
-            "user": "~/.gemini/antigravity-cli/mcp_config.json",
+            "user": "~/.gemini/config/mcp_config.json",
         },
         "mcp_servers_key": "mcpServers",
         "skill_file": {
@@ -308,7 +308,7 @@ IDE_REGISTRY: dict[str, dict] = {
             "user": "~/.gemini/config/skills/{name}/SKILL.md",
         },
         "skill_format": "yaml_frontmatter",
-        "home_mcp_config": "~/.gemini/antigravity-cli/mcp_config.json",
+        "home_mcp_config": "~/.gemini/config/mcp_config.json",
         "hook_type": "command",
         "hook_config_path": {
             "project": ".agents/hooks.json",

--- a/observal_cli/ide_registry.py
+++ b/observal_cli/ide_registry.py
@@ -291,8 +291,8 @@ IDE_REGISTRY: dict[str, dict] = {
         "features": {"hooks", "mcp_servers", "skills"},
         "session_parser": "antigravity",
         "scopes": ["project", "user"],
-        "default_scope": "project",
-        "scope_labels": ("project (.agents/)", "user (~/.gemini/antigravity-cli/)"),
+        "default_scope": "user",
+        "scope_labels": ("project (.agents/)", "user (~/.gemini/config/)"),
         "rules_file": {
             "project": "AGENTS.md",
             "user": "~/.gemini/GEMINI.md",

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -1240,15 +1240,15 @@ class TestGenerateIdeAgentFiles:
 
     # ── GitHub Copilot ─────────────────────────────────────────
 
-    def test_copilot_generates_instructions_md(self):
+    def test_copilot_generates_agent_md(self):
         from services.agent_builder import generate_ide_agent_files
 
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "copilot")
         assert config.ide == "copilot"
         paths = [f.path for f in config.files]
-        assert ".github/copilot-instructions.md" in paths
-        md = next(f for f in config.files if f.path == ".github/copilot-instructions.md")
+        assert ".github/agents/test-agent.agent.md" in paths
+        md = next(f for f in config.files if f.path == ".github/agents/test-agent.agent.md")
         assert md.format == "markdown"
         assert "You are a helpful coding assistant." in md.content
 

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -1190,15 +1190,15 @@ class TestGenerateIdeAgentFiles:
 
     # ── Cursor ─────────────────────────────────────────────────
 
-    def test_cursor_generates_rules_and_mcp_json(self):
+    def test_cursor_generates_subagent_and_mcp_json(self):
         from services.agent_builder import generate_ide_agent_files
 
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "cursor")
         assert config.ide == "cursor"
-        rules = next(f for f in config.files if f.path == ".cursor/rules/test-agent.md")
+        agent = next(f for f in config.files if f.path == ".cursor/agents/test-agent.md")
         mcp_json = next(f for f in config.files if f.format == "json")
-        assert rules.format == "markdown"
+        assert agent.format == "markdown"
         assert mcp_json.path == ".cursor/mcp.json"
         assert "mcpServers" in mcp_json.content
         assert "github-mcp" in mcp_json.content["mcpServers"]

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -1228,15 +1228,15 @@ class TestGenerateIdeAgentFiles:
 
     # ── Codex ──────────────────────────────────────────────────
 
-    def test_codex_generates_agents_md(self):
+    def test_codex_generates_custom_agent(self):
         from services.agent_builder import generate_ide_agent_files
 
         manifest = self._make_manifest()
         config = generate_ide_agent_files(manifest, "codex")
         assert config.ide == "codex"
         assert len(config.files) >= 1
-        md_file = next(f for f in config.files if f.format == "markdown")
-        assert md_file.path == "AGENTS.md"
+        agent_file = next(f for f in config.files if f.path == "~/.codex/agents/test-agent.toml")
+        assert agent_file.format == "toml"
 
     # ── GitHub Copilot ─────────────────────────────────────────
 

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -724,7 +724,7 @@ class TestBuilderCopilot:
         manifest = _make_manifest()
         result = generate_ide_agent_files(manifest, "copilot")
         paths = [f.path for f in result.files]
-        assert ".github/copilot-instructions.md" in paths
+        assert ".github/agents/test-agent.agent.md" in paths
 
     def test_mcp_json_path(self):
         manifest = _make_manifest(

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -328,13 +328,14 @@ class TestGenerateCursorVscode:
     def test_cursor_paths(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "cursor")
-        assert cfg["rules_file"]["path"] == ".cursor/rules/test-agent.mdc"
+        assert cfg["agent_file"]["path"] == ".cursor/agents/test-agent.md"
         assert cfg["mcp_config"]["path"] == ".cursor/mcp.json"
+        assert "rules_file" not in cfg
 
-    def test_rules_content_not_empty(self):
+    def test_agent_content_not_empty(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "cursor")
-        assert len(cfg["rules_file"]["content"]) > 0
+        assert len(cfg["agent_file"]["content"]) > 0
 
     def test_mcp_config_has_mcpservers_key(self):
         agent = _make_agent()
@@ -677,11 +678,12 @@ class TestBuilderClaudeCode:
 
 
 class TestBuilderCursor:
-    def test_files_include_rules_and_mcp_json(self):
+    def test_files_include_subagent_and_mcp_json(self):
         manifest = _make_manifest()
         result = generate_ide_agent_files(manifest, "cursor")
         paths = [f.path for f in result.files]
-        assert any(".cursor/rules/" in p for p in paths)
+        assert any(".cursor/agents/" in p for p in paths)
+        assert not any(".cursor/rules/" in p for p in paths)
         assert any("mcp.json" in p for p in paths)
 
 

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -443,10 +443,11 @@ class TestGenerateKiro:
 
 
 class TestGenerateCodex:
-    def test_rules_path(self):
+    def test_agent_path(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "codex")
-        assert cfg["rules_file"]["path"] == "AGENTS.md"
+        assert cfg["agent_file"]["path"] == "~/.codex/agents/test-agent.toml"
+        assert "rules_file" not in cfg
 
     def test_mcp_config_present(self):
         agent = _make_agent()
@@ -463,7 +464,7 @@ class TestGenerateCodex:
     def test_content_not_empty(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "codex")
-        assert len(cfg["rules_file"]["content"]) > 0
+        assert len(cfg["agent_file"]["content"]) > 0
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -704,18 +705,17 @@ class TestBuilderKiro:
 
 
 class TestBuilderCodex:
-    def test_rules_path(self):
+    def test_agent_path(self):
         manifest = _make_manifest()
         result = generate_ide_agent_files(manifest, "codex")
         paths = [f.path for f in result.files]
-        assert "AGENTS.md" in paths
+        assert "~/.codex/agents/test-agent.toml" in paths
 
-    def test_codex_only_agents_md_without_otlp_url(self):
+    def test_codex_only_agent_without_otlp_url(self):
         manifest = _make_manifest()
         result = generate_ide_agent_files(manifest, "codex")
         paths = [f.path for f in result.files]
-        # Without explicit OTLP URL, only AGENTS.md is generated
-        assert "AGENTS.md" in paths
+        assert "~/.codex/agents/test-agent.toml" in paths
         assert len(paths) == 1
 
 

--- a/tests/test_agent_name_lookup.py
+++ b/tests/test_agent_name_lookup.py
@@ -80,6 +80,7 @@ def _agent_mock(status=AgentStatus.approved, created_by=None, **extra):
     m.git_url = None
     m.created_by = created_by or uuid.uuid4()
     m.created_at = datetime.now(UTC)
+    m.deleted_at = None
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
     col_keys = [
@@ -101,6 +102,7 @@ def _agent_mock(status=AgentStatus.approved, created_by=None, **extra):
         "unique_users",
         "created_by",
         "created_at",
+        "deleted_at",
         "updated_at",
     ]
     cols = []

--- a/tests/test_agent_review.py
+++ b/tests/test_agent_review.py
@@ -65,6 +65,7 @@ def _agent_mock(status=AgentStatus.pending, **extra):
     m.rejection_reason = None
     m.created_by = extra.get("created_by", uuid.uuid4())
     m.created_at = datetime.now(UTC)
+    m.deleted_at = None
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
     m.latest_version = extra.get("latest_version")

--- a/tests/test_antigravity_adapter.py
+++ b/tests/test_antigravity_adapter.py
@@ -76,7 +76,7 @@ def test_scan_home_empty_dir(tmp_path):
 
 
 def test_scan_home_reads_global_mcps(tmp_path):
-    ag_dir = tmp_path / ".gemini" / "antigravity-cli"
+    ag_dir = tmp_path / ".gemini" / "config"
     ag_dir.mkdir(parents=True)
     mcp_data = {
         "mcpServers": {
@@ -93,7 +93,7 @@ def test_scan_home_reads_global_mcps(tmp_path):
 
 
 def test_scan_home_remote_mcp_uses_server_url(tmp_path):
-    ag_dir = tmp_path / ".gemini" / "antigravity-cli"
+    ag_dir = tmp_path / ".gemini" / "config"
     ag_dir.mkdir(parents=True)
     mcp_data = {"mcpServers": {"remote": {"serverUrl": "https://api.example.com/mcp/"}}}
     (ag_dir / "mcp_config.json").write_text(json.dumps(mcp_data))
@@ -103,19 +103,19 @@ def test_scan_home_remote_mcp_uses_server_url(tmp_path):
     assert remote.url == "https://api.example.com/mcp/"
 
 
-def test_scan_home_reads_hooks_from_settings(tmp_path):
-    ag_dir = tmp_path / ".gemini" / "antigravity-cli"
+def test_scan_home_reads_hooks_from_config(tmp_path):
+    ag_dir = tmp_path / ".gemini" / "config"
     ag_dir.mkdir(parents=True)
-    settings = {"hooks": {"pre_turn": [{"command": "observal-push"}]}}
-    (ag_dir / "settings.json").write_text(json.dumps(settings))
+    hooks = {"my-hook": {"PreInvocation": [{"command": "observal-push"}]}}
+    (ag_dir / "hooks.json").write_text(json.dumps(hooks))
 
     result = get_adapter("antigravity").scan_home(home=tmp_path)
     assert len(result.hooks) == 1
-    assert result.hooks[0].event == "pre_turn"
+    assert result.hooks[0].event == "PreInvocation"
 
 
 def test_scan_home_reads_skills(tmp_path):
-    skills_dir = tmp_path / ".gemini" / "antigravity-cli" / "skills" / "my-skill"
+    skills_dir = tmp_path / ".gemini" / "config" / "skills" / "my-skill"
     skills_dir.mkdir(parents=True)
     (skills_dir / "SKILL.md").write_text("---\ndescription: A test skill\n---\nContent here.")
 
@@ -199,3 +199,14 @@ def test_detect_hooks_missing_when_no_observal_marker(tmp_path):
 
 def test_shim_status_no_mcps():
     assert get_adapter("antigravity").shim_status([]) == "none"
+
+
+def test_scan_home_reads_agent_json(tmp_path):
+    agents_dir = tmp_path / ".gemini" / "antigravity-cli" / "agents" / "reviewer"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "agent.json").write_text(
+        json.dumps({"name": "reviewer", "description": "Reviews code", "system_prompt": "Review carefully"})
+    )
+
+    result = get_adapter("antigravity").scan_home(home=tmp_path)
+    assert any(a.name == "reviewer" and a.description == "Reviews code" for a in result.agents)

--- a/tests/test_antigravity_sessions.py
+++ b/tests/test_antigravity_sessions.py
@@ -228,7 +228,7 @@ class TestAntigravityServerAdapter:
         assert result["scope"] == "project"
         assert "mcp_config" in result
         assert result["mcp_config"]["content"]["mcpServers"]["my-mcp"]["command"] == "node"
-        assert result["rules_file"]["content"] == "# Test rules"
+        assert result["agent_file"]["content"]["system_prompt"] == "# Test rules"
         assert len(result["skill_files"]) == 1
 
     def test_format_config_user_scope(self):
@@ -248,6 +248,7 @@ class TestAntigravityServerAdapter:
         )
         result = adapter.format_config(ctx)
         assert result["scope"] == "user"
+        assert result["agent_file"]["path"] == "~/.gemini/antigravity-cli/agents/test-agent/agent.json"
 
     def test_format_config_with_model(self):
         import sys
@@ -266,7 +267,7 @@ class TestAntigravityServerAdapter:
             options={"_resolved_model": "gemini-2.5-pro"},
         )
         result = adapter.format_config(ctx)
-        assert result["mcp_config"]["content"]["model"] == "gemini-2.5-pro"
+        assert "mcp_config" not in result
 
     def test_format_config_warnings(self):
         import sys

--- a/tests/test_cli_ide_adapters.py
+++ b/tests/test_cli_ide_adapters.py
@@ -103,9 +103,7 @@ class TestManagedLayerFiles:
             (
                 "cursor",
                 {
-                    "user:rules/agent-one.mdc",
                     "user:agents/agent-one.md",
-                    "project:.cursor/rules/agent-one.mdc",
                     "project:.cursor/agents/agent-one.md",
                     "user:rules/skill-one.mdc",
                     "user:skills/skill-one/SKILL.md",

--- a/tests/test_cli_ide_adapters.py
+++ b/tests/test_cli_ide_adapters.py
@@ -122,7 +122,7 @@ class TestManagedLayerFiles:
             ),
             (
                 "codex",
-                {"user:AGENTS.md", "project:AGENTS.md", "user:config.toml"},
+                {"user:agents/agent-one.toml", "project:.codex/agents/agent-one.toml", "user:config.toml"},
             ),
             (
                 "copilot",
@@ -168,8 +168,8 @@ class TestManagedLayerFiles:
 
         lockfile = self._lockfile_for("codex")
         assert _get_observal_managed_files(lockfile, "codex", None) == {
-            "user:AGENTS.md",
-            "project:AGENTS.md",
+            "user:agents/agent-one.toml",
+            "project:.codex/agents/agent-one.toml",
             "user:config.toml",
         }
 

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -81,6 +81,7 @@ def _agent_mock(status=AgentStatus.draft, created_by=None, **extra):
     m.git_url = None
     m.created_by = created_by or uuid.uuid4()
     m.created_at = datetime.now(UTC)
+    m.deleted_at = None
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
     # Edit-lock fields on the latest_version mock
@@ -108,6 +109,7 @@ def _agent_mock(status=AgentStatus.draft, created_by=None, **extra):
         "unique_users",
         "created_by",
         "created_at",
+        "deleted_at",
         "updated_at",
     ]
     cols = []

--- a/tests/test_global_unique_names.py
+++ b/tests/test_global_unique_names.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
+from sqlalchemy import Index
+
 from models.agent import Agent
 from models.hook import HookListing
 from models.mcp import McpListing
@@ -11,13 +13,17 @@ from models.skill import SkillListing
 
 def test_registry_models_have_global_name_constraints():
     expected = {
-        Agent: "uq_agents_name",
         McpListing: "uq_mcp_listings_name",
         SkillListing: "uq_skill_listings_name",
         HookListing: "uq_hook_listings_name",
         PromptListing: "uq_prompt_listings_name",
         SandboxListing: "uq_sandbox_listings_name",
     }
+
+    agent_indexes = {index.name: index for index in Agent.__table__.indexes if isinstance(index, Index)}
+    assert "uq_agents_active_name" in agent_indexes
+    assert agent_indexes["uq_agents_active_name"].unique is True
+    assert {column.name for column in agent_indexes["uq_agents_active_name"].columns} == {"name"}
 
     for model, constraint_name in expected.items():
         constraints = {constraint.name: constraint for constraint in model.__table__.constraints}

--- a/tests/test_ide_config_e2e.py
+++ b/tests/test_ide_config_e2e.py
@@ -136,10 +136,11 @@ class TestConstants:
 
 
 class TestGenerateCodexConfig:
-    def test_rules_path_is_agents_md(self):
+    def test_agent_path_is_codex_agent_toml(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "codex")
-        assert cfg["rules_file"]["path"] == "AGENTS.md"
+        assert cfg["agent_file"]["path"] == "~/.codex/agents/test-agent.toml"
+        assert "rules_file" not in cfg
 
     def test_mcp_config_path(self):
         agent = _make_agent()
@@ -173,10 +174,10 @@ class TestGenerateCodexConfig:
         cfg = generate_agent_config(agent, "codex")
         assert cfg["scope"] == "user"
 
-    def test_rules_content_not_empty(self):
+    def test_agent_content_not_empty(self):
         agent = _make_agent()
         cfg = generate_agent_config(agent, "codex")
-        assert len(cfg["rules_file"]["content"]) > 0
+        assert len(cfg["agent_file"]["content"]) > 0
 
     def test_empty_mcp_configs_still_produces_valid_structure(self):
         agent = _make_agent()
@@ -185,10 +186,10 @@ class TestGenerateCodexConfig:
         assert "mcp.servers" in cfg["mcp_config"]["content"]
         assert cfg["mcp_config"]["content"]["mcp.servers"] == {}
 
-    def test_rules_content_uses_agent_prompt(self):
+    def test_agent_content_uses_agent_prompt(self):
         agent = _make_agent(prompt="Always use Python.")
         cfg = generate_agent_config(agent, "codex")
-        assert "Always use Python." in cfg["rules_file"]["content"]
+        assert "Always use Python." in cfg["agent_file"]["content"]
 
 
 class TestGenerateCopilotConfig:
@@ -610,12 +611,12 @@ def _patch_get_agent(detail=None):
 
 
 class TestPullCodex:
-    def test_writes_agents_md_and_mcp_toml(self, tmp_path):
+    def test_writes_custom_agent_and_mcp_toml(self, tmp_path):
         snippet = {
             "config_snippet": {
-                "rules_file": {
-                    "path": "AGENTS.md",
-                    "content": "# Codex Rules\n\nBe precise.\n",
+                "agent_file": {
+                    "path": ".codex/agents/test-agent.toml",
+                    "content": 'name = "test-agent"\ndeveloper_instructions = "Be precise."\n',
                 },
                 "mcp_config": {
                     "path": "~/.codex/config.toml",
@@ -636,21 +637,21 @@ class TestPullCodex:
                 cli_app, ["agent", "pull", "abc123", "--ide", "codex", "--dir", str(tmp_path), "--no-prompt"]
             )
         assert result.exit_code == 0, result.output
-        rules = tmp_path / "AGENTS.md"
-        assert rules.exists()
-        assert "Codex Rules" in rules.read_text()
+        agent = tmp_path / ".codex" / "agents" / "test-agent.toml"
+        assert agent.exists()
+        assert "Be precise" in agent.read_text()
         config = tmp_path / ".codex" / "config.toml"
         assert config.exists()
         content = config.read_text()
         assert "mcp.servers" in content
         assert "observal-shim" in content
 
-    def test_writes_only_rules_when_no_mcp(self, tmp_path):
+    def test_writes_only_agent_when_no_mcp(self, tmp_path):
         snippet = {
             "config_snippet": {
-                "rules_file": {
-                    "path": "AGENTS.md",
-                    "content": "# Simple Agent\n",
+                "agent_file": {
+                    "path": ".codex/agents/simple-agent.toml",
+                    "content": 'name = "simple-agent"\ndeveloper_instructions = "Simple Agent"\n',
                 },
             }
         }
@@ -659,7 +660,7 @@ class TestPullCodex:
                 cli_app, ["agent", "pull", "abc123", "--ide", "codex", "--dir", str(tmp_path), "--no-prompt"]
             )
         assert result.exit_code == 0, result.output
-        assert (tmp_path / "AGENTS.md").exists()
+        assert (tmp_path / ".codex" / "agents" / "simple-agent.toml").exists()
 
 
 class TestPullCopilot:
@@ -780,14 +781,15 @@ class TestPullDryRunAllIdes:
     @pytest.mark.parametrize("ide", ["codex", "copilot", "opencode"])
     def test_dry_run_does_not_write_files(self, tmp_path, ide):
         path_map = {
-            "codex": "AGENTS.md",
+            "codex": ".codex/agents/test-agent.toml",
             "copilot": ".github/copilot-instructions.md",
             "opencode": ".opencode/agents/test-agent.md",
         }
         rules_path = path_map[ide]
+        file_key = "agent_file" if ide == "codex" else "rules_file"
         snippet = {
             "config_snippet": {
-                "rules_file": {
+                file_key: {
                     "path": rules_path,
                     "content": "# Test\n",
                 },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -286,7 +286,7 @@ class TestAgentLifecycle:
     @pytest.mark.asyncio
     async def test_delete_agent(self, client, admin_headers):
         # Create
-        await client.post(
+        created = await client.post(
             "/api/v1/agents",
             headers=admin_headers,
             json={
@@ -298,11 +298,33 @@ class TestAgentLifecycle:
                 "prompt": "You are a test agent.",
             },
         )
+        agent_id = created.json()["id"]
         r = await client.delete(f"/api/v1/agents/{self.agent_name}", headers=admin_headers)
         assert r.status_code == 200
 
         r2 = await client.get(f"/api/v1/agents/{self.agent_name}", headers=admin_headers)
         assert r2.status_code == 404
+
+        deleted = await client.get("/api/v1/agents/deleted", headers=admin_headers)
+        assert deleted.status_code == 200
+        assert self.agent_name in {a["name"] for a in deleted.json()}
+
+        recreated = await client.post(
+            "/api/v1/agents",
+            headers=admin_headers,
+            json={
+                "name": self.agent_name,
+                "description": "Reused name",
+                "version": "1.0.0",
+                "owner": "admin",
+                "model_name": "claude-sonnet-4-20250514",
+                "prompt": "You are a test agent.",
+            },
+        )
+        assert recreated.status_code == 200, recreated.text
+
+        restore = await client.patch(f"/api/v1/agents/{agent_id}/restore", headers=admin_headers, json={})
+        assert restore.status_code == 409
 
 
 # ── Prompt CRUD ──────────────────────────────────────────────────────────────

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -535,7 +535,7 @@ class TestBuilderModelEmission:
 
         manifest = _empty_manifest(models_by_ide={"codex": "gpt-5"})
         cfg = _generate_codex(manifest)
-        toml = next(f for f in cfg.files if f.path == "~/.codex/config.toml").content
+        toml = next(f for f in cfg.files if f.path == "~/.codex/agents/test-agent.toml").content
         assert isinstance(toml, str)
         assert 'model = "gpt-5"' in toml
 

--- a/tests/test_preview_config.py
+++ b/tests/test_preview_config.py
@@ -78,7 +78,7 @@ class TestPreviewConfigNoComponents:
         assert "codex" in configs
         assert "copilot" in configs
         assert "opencode" in configs
-        assert "copilot-cli" not in configs
+        assert "copilot-cli" in configs
 
     async def test_claude_code_has_agent_file(self):
         app, db, _user = _app_with()

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -128,9 +128,9 @@ def _kiro_snippet() -> dict:
 def _codex_snippet() -> dict:
     return {
         "config_snippet": {
-            "rules_file": {
-                "path": "AGENTS.md",
-                "content": "# Codex Agent\n\nRules for Codex.\n",
+            "agent_file": {
+                "path": ".codex/agents/my-agent.toml",
+                "content": 'name = "my-agent"\ndeveloper_instructions = "Rules for Codex."\n',
             }
         }
     }
@@ -351,21 +351,21 @@ class TestPullKiro:
 
 
 # ═══════════════════════════════════════════════════════════════
-# 5. Codex format (rules_file only)
+# 5. Codex format
 # ═══════════════════════════════════════════════════════════════
 
 
 class TestPullCodex:
-    def test_writes_agents_md(self, tmp_path: Path):
+    def test_writes_custom_agent(self, tmp_path: Path):
         with _patch_config(), _patch_get_agent(), _patch_post(_codex_snippet()):
             result = runner.invoke(
                 cli_app, ["agent", "pull", "abc123", "--ide", "codex", "--dir", str(tmp_path), "--no-prompt"]
             )
 
         assert result.exit_code == 0, result.output
-        rules = tmp_path / "AGENTS.md"
-        assert rules.exists()
-        assert "Codex Agent" in rules.read_text()
+        agent = tmp_path / ".codex" / "agents" / "my-agent.toml"
+        assert agent.exists()
+        assert "Rules for Codex" in agent.read_text()
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -69,9 +69,9 @@ def _patch_get_agent(detail: dict = _AGENT_DETAIL_NO_ENV):
 def _cursor_snippet() -> dict:
     return {
         "config_snippet": {
-            "rules_file": {
-                "path": ".cursor/rules/my-agent.md",
-                "content": "# My Agent Rules\n\nDo the thing.\n",
+            "agent_file": {
+                "path": ".cursor/agents/my-agent.md",
+                "content": "# My Agent\n\nDo the thing.\n",
             },
             "mcp_config": {
                 "path": ".cursor/mcp.json",
@@ -176,7 +176,7 @@ def _opencode_snippet() -> dict:
 
 
 class TestPullCursor:
-    def test_writes_rules_and_mcp(self, tmp_path: Path):
+    def test_writes_agent_and_mcp(self, tmp_path: Path):
         with _patch_config(), _patch_get_agent(), _patch_post(_cursor_snippet()):
             result = runner.invoke(
                 cli_app, ["agent", "pull", "abc123", "--ide", "cursor", "--dir", str(tmp_path), "--no-prompt"]
@@ -184,9 +184,9 @@ class TestPullCursor:
 
         assert result.exit_code == 0, result.output
 
-        rules = tmp_path / ".cursor" / "rules" / "my-agent.md"
-        assert rules.exists()
-        assert "My Agent Rules" in rules.read_text()
+        agent = tmp_path / ".cursor" / "agents" / "my-agent.md"
+        assert agent.exists()
+        assert "My Agent" in agent.read_text()
 
         mcp = tmp_path / ".cursor" / "mcp.json"
         assert mcp.exists()
@@ -501,7 +501,7 @@ class TestPullDryRun:
         assert "would write" in result.output
 
         # No files should exist
-        assert not (tmp_path / ".cursor" / "rules" / "my-agent.md").exists()
+        assert not (tmp_path / ".cursor" / "agents" / "my-agent.md").exists()
         assert not (tmp_path / ".cursor" / "mcp.json").exists()
 
     def test_dry_run_still_shows_paths(self, tmp_path: Path):

--- a/tests/test_sec027_registry_sc.py
+++ b/tests/test_sec027_registry_sc.py
@@ -71,6 +71,7 @@ def _agent_mock(status=AgentStatus.pending, created_by=None, **extra):
     m.git_url = None
     m.created_by = created_by or uuid.uuid4()
     m.created_at = datetime.now(UTC)
+    m.deleted_at = None
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
     m.latest_version = MagicMock()
@@ -97,6 +98,7 @@ def _agent_mock(status=AgentStatus.pending, created_by=None, **extra):
         "unique_users",
         "created_by",
         "created_at",
+        "deleted_at",
         "updated_at",
     ]
     cols = []

--- a/web/src/components/builder/model-picker.tsx
+++ b/web/src/components/builder/model-picker.tsx
@@ -18,42 +18,61 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useModels } from "@/hooks/use-api";
+import { useIdes } from "@/hooks/use-ides";
 import { annotateForDisplay, formatModel } from "@/lib/model-display";
+import type { CatalogModel } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 interface ModelPickerProps {
   modelName: string;
   onModelNameChange: (value: string) => void;
+  modelsByIde: Record<string, string>;
+  onModelsByIdeChange: (value: Record<string, string>) => void;
 }
 
-export function ModelPicker({
-  modelName,
-  onModelNameChange,
-}: ModelPickerProps) {
-  const inputId = useId();
+function ModelCombobox({
+  id,
+  value,
+  onChange,
+  rows,
+  placeholder,
+  autoLabel,
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  rows: CatalogModel[];
+  placeholder: string;
+  autoLabel: string;
+}) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
-  const [inputValue, setInputValue] = useState(modelName);
-  const { data: catalog, isLoading } = useModels();
-  const models = useMemo(() => catalog?.models ?? [], [catalog]);
-  const rows = useMemo(() => annotateForDisplay(models), [models]);
+  const [inputValue, setInputValue] = useState(value);
 
   useEffect(() => {
-    setInputValue(modelName);
-  }, [modelName]);
+    setInputValue(value);
+  }, [value]);
 
+  const annotated = useMemo(() => annotateForDisplay(rows), [rows]);
   const filtered = useMemo(() => {
     const q = inputValue.trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter((m) =>
+    if (!q) return annotated;
+    return annotated.filter((m) =>
       [m.model_id, m.display_name, m.provider, m.family]
         .filter(Boolean)
         .some((v) => v.toLowerCase().includes(q)),
     );
-  }, [inputValue, rows]);
+  }, [annotated, inputValue]);
 
-  function labelForModel(m: (typeof rows)[number]) {
+  function labelForModel(m: (typeof annotated)[number]) {
     const fm = formatModel({
       display_name: m.display_name,
       model_id: m.model_id,
@@ -63,147 +82,246 @@ export function ModelPicker({
     return fm.secondary ? `${fm.primary} (${fm.secondary})` : fm.primary;
   }
 
-  function commit(value: string) {
-    setInputValue(value);
-    onModelNameChange(value);
+  function commit(next: string) {
+    setInputValue(next);
+    onChange(next);
   }
 
   function handleBlur() {
     setTimeout(() => {
-      if (inputValue !== modelName) onModelNameChange(inputValue);
+      if (inputValue !== value) onChange(inputValue);
       setOpen(false);
     }, 150);
   }
 
   return (
-    <div className="space-y-2">
-      <Label htmlFor={inputId} className="text-sm font-medium">
-        Default model
-      </Label>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <div className="relative">
-            <input
-              ref={inputRef}
-              id={inputId}
-              type="text"
-              placeholder={isLoading ? "Loading models…" : "auto (let the IDE pick)"}
-              value={inputValue}
-              onChange={(e) => {
-                setInputValue(e.target.value);
-                if (!open) setOpen(true);
-              }}
-              onFocus={() => setOpen(true)}
-              onBlur={handleBlur}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  commit(inputValue);
-                  setOpen(false);
-                }
-                if (e.key === "Escape") setOpen(false);
-              }}
-              className={cn(
-                "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors",
-                "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                "pr-16",
-              )}
-            />
-            <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
-              {inputValue ? (
-                <button
-                  type="button"
-                  className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                  onClick={() => {
-                    commit("");
-                    inputRef.current?.focus();
-                  }}
-                  tabIndex={-1}
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              ) : null}
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <div className="relative">
+          <input
+            ref={inputRef}
+            id={id}
+            type="text"
+            placeholder={placeholder}
+            value={inputValue}
+            onChange={(e) => {
+              setInputValue(e.target.value);
+              if (!open) setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onBlur={handleBlur}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commit(inputValue);
+                setOpen(false);
+              }
+              if (e.key === "Escape") setOpen(false);
+            }}
+            className={cn(
+              "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors",
+              "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              "pr-16",
+            )}
+          />
+          <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
+            {inputValue ? (
               <button
                 type="button"
                 className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 onClick={() => {
-                  setOpen((v) => !v);
+                  commit("");
                   inputRef.current?.focus();
                 }}
                 tabIndex={-1}
               >
-                <ChevronDown className="h-4 w-4" />
+                <X className="h-3.5 w-3.5" />
               </button>
-            </div>
+            ) : null}
+            <button
+              type="button"
+              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              onClick={() => {
+                setOpen((v) => !v);
+                inputRef.current?.focus();
+              }}
+              tabIndex={-1}
+            >
+              <ChevronDown className="h-4 w-4" />
+            </button>
           </div>
-        </PopoverTrigger>
-        <PopoverContent
-          className="w-[var(--radix-popover-trigger-width)] p-0"
-          align="start"
-          onOpenAutoFocus={(e) => e.preventDefault()}
-        >
-          <Command shouldFilter={false}>
-            <CommandList>
-              <CommandEmpty>
-                {inputValue ? (
-                  <span className="text-xs text-muted-foreground">
-                    Press Enter to use <span className="font-mono font-medium">{inputValue}</span>
-                  </span>
-                ) : (
-                  <span className="text-xs text-muted-foreground">Type a model ID or choose from the catalog</span>
-                )}
-              </CommandEmpty>
-              <CommandGroup heading="Default">
-                <CommandItem
-                  value="auto"
-                  onSelect={() => {
-                    commit("");
-                    setOpen(false);
-                  }}
-                  onMouseDown={(e) => e.preventDefault()}
-                >
-                  <Check className={cn("mr-2 h-3.5 w-3.5", modelName ? "opacity-0" : "opacity-100")} />
-                  <span>auto (let the IDE pick)</span>
-                </CommandItem>
-              </CommandGroup>
-              {filtered.length > 0 ? (
-                <CommandGroup heading="Models">
-                  {filtered.slice(0, 100).map((m) => (
-                    <CommandItem
-                      key={m.model_id}
-                      value={m.model_id}
-                      onSelect={() => {
-                        commit(m.model_id);
-                        setOpen(false);
-                      }}
-                      onMouseDown={(e) => e.preventDefault()}
-                    >
-                      <Check
-                        className={cn(
-                          "mr-2 h-3.5 w-3.5 shrink-0",
-                          modelName === m.model_id ? "opacity-100" : "opacity-0",
-                        )}
-                      />
-                      <div className="min-w-0">
-                        <div className="truncate text-sm">
-                          {labelForModel(m)}{m.deprecated ? " · deprecated" : ""}
-                        </div>
-                        <div className="truncate font-mono text-xs text-muted-foreground">
-                          {m.model_id}
-                        </div>
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <Command shouldFilter={false}>
+          <CommandList>
+            <CommandEmpty>
+              {inputValue ? (
+                <span className="text-xs text-muted-foreground">
+                  Press Enter to use <span className="font-mono font-medium">{inputValue}</span>
+                </span>
+              ) : (
+                <span className="text-xs text-muted-foreground">Type a model ID or choose from the catalog</span>
+              )}
+            </CommandEmpty>
+            <CommandGroup heading="Default">
+              <CommandItem
+                value="auto"
+                onSelect={() => {
+                  commit("");
+                  setOpen(false);
+                }}
+                onMouseDown={(e) => e.preventDefault()}
+              >
+                <Check className={cn("mr-2 h-3.5 w-3.5", value ? "opacity-0" : "opacity-100")} />
+                <span>{autoLabel}</span>
+              </CommandItem>
+            </CommandGroup>
+            {filtered.length > 0 ? (
+              <CommandGroup heading="Models">
+                {filtered.slice(0, 100).map((m) => (
+                  <CommandItem
+                    key={m.model_id}
+                    value={m.model_id}
+                    onSelect={() => {
+                      commit(m.model_id);
+                      setOpen(false);
+                    }}
+                    onMouseDown={(e) => e.preventDefault()}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-3.5 w-3.5 shrink-0",
+                        value === m.model_id ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    <div className="min-w-0">
+                      <div className="truncate text-sm">
+                        {labelForModel(m)}{m.deprecated ? " · deprecated" : ""}
                       </div>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              ) : null}
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
-      <p className="text-xs text-muted-foreground">
-        Pick from the models.dev catalog or type any model ID. Leave blank to let
-        the IDE choose.
-      </p>
+                      <div className="truncate font-mono text-xs text-muted-foreground">
+                        {m.model_id}
+                      </div>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function ModelPicker({
+  modelName,
+  onModelNameChange,
+  modelsByIde,
+  onModelsByIdeChange,
+}: ModelPickerProps) {
+  const inputId = useId();
+  const { data: catalog, isLoading } = useModels();
+  const { data: ides, defaultIde } = useIdes();
+  const models = useMemo(() => catalog?.models ?? [], [catalog]);
+  const idesWithChoice = useMemo(
+    () => (ides ?? []).filter((ide) => ide.accepts_model_choice),
+    [ides],
+  );
+  const [selectedIde, setSelectedIde] = useState("");
+
+  useEffect(() => {
+    if (idesWithChoice.length === 0) return;
+    const fallback = defaultIde && idesWithChoice.some((ide) => ide.name === defaultIde)
+      ? defaultIde
+      : idesWithChoice[0].name;
+    if (!selectedIde || !idesWithChoice.some((ide) => ide.name === selectedIde)) {
+      setSelectedIde(fallback);
+    }
+  }, [defaultIde, idesWithChoice, selectedIde]);
+
+  const selectedIdeMeta = idesWithChoice.find((ide) => ide.name === selectedIde);
+  const overrideRows = useMemo(() => {
+    if (!selectedIde) return models;
+    const supported = models.filter((m) => (m.supported_ides ?? []).includes(selectedIde));
+    return supported.length > 0 ? supported : models;
+  }, [models, selectedIde]);
+
+  function setOverride(ide: string, value: string) {
+    const next = { ...modelsByIde };
+    if (value) next[ide] = value;
+    else delete next[ide];
+    onModelsByIdeChange(next);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor={inputId} className="text-sm font-medium">
+          Default model
+        </Label>
+        <ModelCombobox
+          id={inputId}
+          value={modelName}
+          onChange={onModelNameChange}
+          rows={models}
+          placeholder={isLoading ? "Loading models…" : "auto (let the IDE pick)"}
+          autoLabel="auto (let the IDE pick)"
+        />
+        <p className="text-xs text-muted-foreground">
+          Pick from the models.dev catalog or type any model ID. Leave blank to let
+          the IDE choose.
+        </p>
+      </div>
+
+      {idesWithChoice.length > 0 ? (
+        <div className="space-y-3 rounded-md border border-border bg-muted/20 p-3">
+          <div className="space-y-1">
+            <Label className="text-sm font-medium">Per harness override</Label>
+            <p className="text-xs text-muted-foreground">
+              Choose a harness from the allowed IDE list and set a model just for that harness.
+            </p>
+          </div>
+          <div className="grid gap-3 md:grid-cols-[minmax(160px,220px)_1fr]">
+            <Select value={selectedIde} onValueChange={setSelectedIde}>
+              <SelectTrigger className="h-10">
+                <SelectValue placeholder="Select harness" />
+              </SelectTrigger>
+              <SelectContent>
+                {idesWithChoice.map((ide) => (
+                  <SelectItem key={ide.name} value={ide.name}>
+                    {ide.display_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <ModelCombobox
+              value={modelsByIde[selectedIde] ?? ""}
+              onChange={(value) => setOverride(selectedIde, value)}
+              rows={overrideRows}
+              placeholder={selectedIdeMeta ? `Use default for ${selectedIdeMeta.display_name}` : "Use default"}
+              autoLabel="Use default model"
+            />
+          </div>
+          {Object.keys(modelsByIde).length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {Object.entries(modelsByIde).map(([ide, model]) => {
+                const label = ides?.find((item) => item.name === ide)?.display_name ?? ide;
+                return (
+                  <span key={ide} className="rounded bg-primary/10 px-2 py-1 text-xs text-primary">
+                    {label}: <span className="font-mono">{model}</span>
+                  </span>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       {catalog?.degraded ? (
         <p className="text-xs text-amber-700 dark:text-amber-400">
           Catalog is using the offline snapshot. Typed model IDs still save.

--- a/web/src/components/builder/model-picker.tsx
+++ b/web/src/components/builder/model-picker.tsx
@@ -2,178 +2,213 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
-import { useMemo } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, X } from "lucide-react";
 
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { useModels } from "@/hooks/use-api";
-import { useIdes } from "@/hooks/use-ides";
 import { annotateForDisplay, formatModel } from "@/lib/model-display";
-import type { CatalogModel } from "@/lib/types";
-
-const AUTO_VALUE = "__auto__";
-
-function modelsForIde(catalog: CatalogModel[], ide: string): CatalogModel[] {
-  return catalog.filter((m) => (m.supported_ides ?? []).includes(ide));
-}
+import { cn } from "@/lib/utils";
 
 interface ModelPickerProps {
-  /** The default model_id used when no per-IDE override is set. */
   modelName: string;
   onModelNameChange: (value: string) => void;
-  /** Per-IDE overrides keyed by IDE name. */
-  modelsByIde: Record<string, string>;
-  onModelsByIdeChange: (next: Record<string, string>) => void;
-  /** When false, hide the per-IDE overrides UI to keep the simple form simple. */
-  showPerIdeOverrides?: boolean;
 }
 
-/**
- * Reusable model picker shared by the agent builder and the agent edit form.
- *
- * - Default model: a single ``Select`` against the live catalog.
- * - Per-IDE overrides: optional ``Select`` per IDE that ``accepts_model_choice``.
- *   Empty value = "auto" sentinel; the server will substitute the IDE's auto
- *   equivalent at install time and warn the user if the saved value is gone.
- */
 export function ModelPicker({
   modelName,
   onModelNameChange,
-  modelsByIde,
-  onModelsByIdeChange,
-  showPerIdeOverrides = true,
 }: ModelPickerProps) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState(modelName);
   const { data: catalog, isLoading } = useModels();
-  const { data: ides, isLoading: idesLoading } = useIdes();
   const models = useMemo(() => catalog?.models ?? [], [catalog]);
-  const annotated = useMemo(() => annotateForDisplay(models), [models]);
-  const idesWithChoice = useMemo(
-    () => (ides ?? []).filter((ide) => ide.accepts_model_choice),
-    [ides],
-  );
+  const rows = useMemo(() => annotateForDisplay(models), [models]);
 
-  function renderSelect(
-    value: string,
-    onChange: (next: string) => void,
-    rows: CatalogModel[],
-    placeholder: string,
-    {
-      includeAuto,
-      autoLabel,
-    }: { includeAuto: boolean; autoLabel: string },
-  ) {
-    return (
-      <Select
-        value={value || AUTO_VALUE}
-        onValueChange={(v) => onChange(v === AUTO_VALUE ? "" : v)}
-      >
-        <SelectTrigger>
-          <SelectValue placeholder={placeholder} />
-        </SelectTrigger>
-        <SelectContent>
-          {includeAuto && (
-            <SelectGroup>
-              <SelectItem value={AUTO_VALUE}>{autoLabel}</SelectItem>
-            </SelectGroup>
-          )}
-          <SelectGroup>
-            <SelectLabel>Models</SelectLabel>
-            {rows.map((m) => {
-              const fm = formatModel({
-                display_name: m.display_name,
-                model_id: m.model_id,
-                release_date: m.release_date,
-                disambiguate: true,
-              });
-              const label = fm.secondary
-                ? `${fm.primary} (${fm.secondary})`
-                : fm.primary;
-              return (
-                <SelectItem key={m.model_id} value={m.model_id}>
-                  {label}
-                  {m.deprecated ? " · deprecated" : ""}
-                </SelectItem>
-              );
-            })}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+  useEffect(() => {
+    setInputValue(modelName);
+  }, [modelName]);
+
+  const filtered = useMemo(() => {
+    const q = inputValue.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((m) =>
+      [m.model_id, m.display_name, m.provider, m.family]
+        .filter(Boolean)
+        .some((v) => v.toLowerCase().includes(q)),
     );
+  }, [inputValue, rows]);
+
+  function labelForModel(m: (typeof rows)[number]) {
+    const fm = formatModel({
+      display_name: m.display_name,
+      model_id: m.model_id,
+      release_date: m.release_date,
+      disambiguate: true,
+    });
+    return fm.secondary ? `${fm.primary} (${fm.secondary})` : fm.primary;
   }
 
-  const defaultRows = annotated;
+  function commit(value: string) {
+    setInputValue(value);
+    onModelNameChange(value);
+  }
+
+  function handleBlur() {
+    setTimeout(() => {
+      if (inputValue !== modelName) onModelNameChange(inputValue);
+      setOpen(false);
+    }, 150);
+  }
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="agent-model" className="text-sm font-medium">
-          Default model
-        </Label>
-        {renderSelect(
-          modelName,
-          onModelNameChange,
-          defaultRows,
-          isLoading ? "Loading models…" : "Select a default model",
-          { includeAuto: true, autoLabel: "auto (let the IDE pick)" },
-        )}
-        <p className="text-xs text-muted-foreground">
-          Used as the fallback for IDEs that accept a model choice and don&apos;t
-          have an explicit override below.
-        </p>
-      </div>
-
-      {showPerIdeOverrides && (
-        <details className="rounded-md border border-border bg-muted/30 p-3">
-          <summary className="cursor-pointer select-none text-xs font-medium text-muted-foreground">
-            Per-IDE overrides{" "}
-            {Object.keys(modelsByIde || {}).length > 0 ? (
-              <span className="ml-1 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">
-                {Object.keys(modelsByIde).length} set
-              </span>
-            ) : null}
-          </summary>
-          <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            {idesWithChoice.map((ide) => {
-              const rows = modelsForIde(models, ide.name);
-              const value = modelsByIde[ide.name] ?? "";
-              return (
-                <div key={ide.name} className="space-y-1.5">
-                  <Label className="text-xs font-medium">
-                    {ide.display_name}
-                  </Label>
-                  {renderSelect(
-                    value,
-                    (next) => {
-                      const copy: Record<string, string> = { ...modelsByIde };
-                      if (!next) delete copy[ide.name];
-                      else copy[ide.name] = next;
-                      onModelsByIdeChange(copy);
-                    },
-                    rows,
-                    isLoading || idesLoading ? "Loading…" : "Use default",
-                    { includeAuto: true, autoLabel: "Use default" },
-                  )}
-                </div>
-              );
-            })}
+    <div className="space-y-2">
+      <Label htmlFor={inputId} className="text-sm font-medium">
+        Default model
+      </Label>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <div className="relative">
+            <input
+              ref={inputRef}
+              id={inputId}
+              type="text"
+              placeholder={isLoading ? "Loading models…" : "auto (let the IDE pick)"}
+              value={inputValue}
+              onChange={(e) => {
+                setInputValue(e.target.value);
+                if (!open) setOpen(true);
+              }}
+              onFocus={() => setOpen(true)}
+              onBlur={handleBlur}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commit(inputValue);
+                  setOpen(false);
+                }
+                if (e.key === "Escape") setOpen(false);
+              }}
+              className={cn(
+                "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors",
+                "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                "pr-16",
+              )}
+            />
+            <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
+              {inputValue ? (
+                <button
+                  type="button"
+                  className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={() => {
+                    commit("");
+                    inputRef.current?.focus();
+                  }}
+                  tabIndex={-1}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                onClick={() => {
+                  setOpen((v) => !v);
+                  inputRef.current?.focus();
+                }}
+                tabIndex={-1}
+              >
+                <ChevronDown className="h-4 w-4" />
+              </button>
+            </div>
           </div>
-          {catalog?.degraded ? (
-            <p className="mt-3 text-xs text-amber-700 dark:text-amber-400">
-              Catalog is in degraded mode (offline snapshot). Saved selections
-              will still install, admins can refresh from the diagnostics
-              page.
-            </p>
-          ) : null}
-        </details>
-      )}
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[var(--radix-popover-trigger-width)] p-0"
+          align="start"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <Command shouldFilter={false}>
+            <CommandList>
+              <CommandEmpty>
+                {inputValue ? (
+                  <span className="text-xs text-muted-foreground">
+                    Press Enter to use <span className="font-mono font-medium">{inputValue}</span>
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">Type a model ID or choose from the catalog</span>
+                )}
+              </CommandEmpty>
+              <CommandGroup heading="Default">
+                <CommandItem
+                  value="auto"
+                  onSelect={() => {
+                    commit("");
+                    setOpen(false);
+                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                >
+                  <Check className={cn("mr-2 h-3.5 w-3.5", modelName ? "opacity-0" : "opacity-100")} />
+                  <span>auto (let the IDE pick)</span>
+                </CommandItem>
+              </CommandGroup>
+              {filtered.length > 0 ? (
+                <CommandGroup heading="Models">
+                  {filtered.slice(0, 100).map((m) => (
+                    <CommandItem
+                      key={m.model_id}
+                      value={m.model_id}
+                      onSelect={() => {
+                        commit(m.model_id);
+                        setOpen(false);
+                      }}
+                      onMouseDown={(e) => e.preventDefault()}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-3.5 w-3.5 shrink-0",
+                          modelName === m.model_id ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm">
+                          {labelForModel(m)}{m.deprecated ? " · deprecated" : ""}
+                        </div>
+                        <div className="truncate font-mono text-xs text-muted-foreground">
+                          {m.model_id}
+                        </div>
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              ) : null}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      <p className="text-xs text-muted-foreground">
+        Pick from the models.dev catalog or type any model ID. Leave blank to let
+        the IDE choose.
+      </p>
+      {catalog?.degraded ? (
+        <p className="text-xs text-amber-700 dark:text-amber-400">
+          Catalog is using the offline snapshot. Typed model IDs still save.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/builder/model-picker.tsx
+++ b/web/src/components/builder/model-picker.tsx
@@ -2,22 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
-import { useEffect, useId, useMemo, useRef, useState } from "react";
-import { Check, ChevronDown, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -25,11 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useModels } from "@/hooks/use-api";
 import { useIdes } from "@/hooks/use-ides";
-import { annotateForDisplay, formatModel } from "@/lib/model-display";
-import type { CatalogModel } from "@/lib/types";
-import { cn } from "@/lib/utils";
 
 interface ModelPickerProps {
   modelName: string;
@@ -38,222 +22,34 @@ interface ModelPickerProps {
   onModelsByIdeChange: (value: Record<string, string>) => void;
 }
 
-function ModelCombobox({
-  id,
-  value,
-  onChange,
-  rows,
-  placeholder,
-  autoLabel,
-}: {
-  id?: string;
-  value: string;
-  onChange: (value: string) => void;
-  rows: CatalogModel[];
-  placeholder: string;
-  autoLabel: string;
-}) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [open, setOpen] = useState(false);
-  const [inputValue, setInputValue] = useState(value);
-
-  useEffect(() => {
-    setInputValue(value);
-  }, [value]);
-
-  const annotated = useMemo(() => annotateForDisplay(rows), [rows]);
-  const filtered = useMemo(() => {
-    const q = inputValue.trim().toLowerCase();
-    if (!q) return annotated;
-    return annotated.filter((m) =>
-      [m.model_id, m.display_name, m.provider, m.family]
-        .filter(Boolean)
-        .some((v) => v.toLowerCase().includes(q)),
-    );
-  }, [annotated, inputValue]);
-
-  function labelForModel(m: (typeof annotated)[number]) {
-    const fm = formatModel({
-      display_name: m.display_name,
-      model_id: m.model_id,
-      release_date: m.release_date,
-      disambiguate: true,
-    });
-    return fm.secondary ? `${fm.primary} (${fm.secondary})` : fm.primary;
-  }
-
-  function commit(next: string) {
-    setInputValue(next);
-    onChange(next);
-  }
-
-  function handleBlur() {
-    setTimeout(() => {
-      if (inputValue !== value) onChange(inputValue);
-      setOpen(false);
-    }, 150);
-  }
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <div className="relative">
-          <input
-            ref={inputRef}
-            id={id}
-            type="text"
-            placeholder={placeholder}
-            value={inputValue}
-            onChange={(e) => {
-              setInputValue(e.target.value);
-              if (!open) setOpen(true);
-            }}
-            onFocus={() => setOpen(true)}
-            onBlur={handleBlur}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                commit(inputValue);
-                setOpen(false);
-              }
-              if (e.key === "Escape") setOpen(false);
-            }}
-            className={cn(
-              "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors",
-              "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              "pr-16",
-            )}
-          />
-          <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
-            {inputValue ? (
-              <button
-                type="button"
-                className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                onClick={() => {
-                  commit("");
-                  inputRef.current?.focus();
-                }}
-                tabIndex={-1}
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            ) : null}
-            <button
-              type="button"
-              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              onClick={() => {
-                setOpen((v) => !v);
-                inputRef.current?.focus();
-              }}
-              tabIndex={-1}
-            >
-              <ChevronDown className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-[var(--radix-popover-trigger-width)] p-0"
-        align="start"
-        onOpenAutoFocus={(e) => e.preventDefault()}
-      >
-        <Command shouldFilter={false}>
-          <CommandList>
-            <CommandEmpty>
-              {inputValue ? (
-                <span className="text-xs text-muted-foreground">
-                  Press Enter to use <span className="font-mono font-medium">{inputValue}</span>
-                </span>
-              ) : (
-                <span className="text-xs text-muted-foreground">Type a model ID or choose from the catalog</span>
-              )}
-            </CommandEmpty>
-            <CommandGroup heading="Default">
-              <CommandItem
-                value="auto"
-                onSelect={() => {
-                  commit("");
-                  setOpen(false);
-                }}
-                onMouseDown={(e) => e.preventDefault()}
-              >
-                <Check className={cn("mr-2 h-3.5 w-3.5", value ? "opacity-0" : "opacity-100")} />
-                <span>{autoLabel}</span>
-              </CommandItem>
-            </CommandGroup>
-            {filtered.length > 0 ? (
-              <CommandGroup heading="Models">
-                {filtered.slice(0, 100).map((m) => (
-                  <CommandItem
-                    key={m.model_id}
-                    value={m.model_id}
-                    onSelect={() => {
-                      commit(m.model_id);
-                      setOpen(false);
-                    }}
-                    onMouseDown={(e) => e.preventDefault()}
-                  >
-                    <Check
-                      className={cn(
-                        "mr-2 h-3.5 w-3.5 shrink-0",
-                        value === m.model_id ? "opacity-100" : "opacity-0",
-                      )}
-                    />
-                    <div className="min-w-0">
-                      <div className="truncate text-sm">
-                        {labelForModel(m)}{m.deprecated ? " · deprecated" : ""}
-                      </div>
-                      <div className="truncate font-mono text-xs text-muted-foreground">
-                        {m.model_id}
-                      </div>
-                    </div>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            ) : null}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
 export function ModelPicker({
   modelName,
   onModelNameChange,
   modelsByIde,
   onModelsByIdeChange,
 }: ModelPickerProps) {
-  const inputId = useId();
-  const { data: catalog, isLoading } = useModels();
   const { data: ides, defaultIde } = useIdes();
-  const models = useMemo(() => catalog?.models ?? [], [catalog]);
-  const idesWithChoice = useMemo(
-    () => (ides ?? []).filter((ide) => ide.accepts_model_choice),
-    [ides],
-  );
+  const allIdes = useMemo(() => ides ?? [], [ides]);
   const [selectedIde, setSelectedIde] = useState("");
 
   useEffect(() => {
-    if (idesWithChoice.length === 0) return;
-    const fallback = defaultIde && idesWithChoice.some((ide) => ide.name === defaultIde)
+    if (allIdes.length === 0) return;
+    const fallback = defaultIde && allIdes.some((ide) => ide.name === defaultIde)
       ? defaultIde
-      : idesWithChoice[0].name;
-    if (!selectedIde || !idesWithChoice.some((ide) => ide.name === selectedIde)) {
+      : allIdes[0].name;
+    if (!selectedIde || !allIdes.some((ide) => ide.name === selectedIde)) {
       setSelectedIde(fallback);
     }
-  }, [defaultIde, idesWithChoice, selectedIde]);
+  }, [allIdes, defaultIde, selectedIde]);
 
-  const selectedIdeMeta = idesWithChoice.find((ide) => ide.name === selectedIde);
-  const overrideRows = useMemo(() => {
-    if (!selectedIde) return models;
-    const supported = models.filter((m) => (m.supported_ides ?? []).includes(selectedIde));
-    return supported.length > 0 ? supported : models;
-  }, [models, selectedIde]);
+  const selectedIdeMeta = allIdes.find((ide) => ide.name === selectedIde);
+  const overrideCount = Object.keys(modelsByIde).length;
 
   function setOverride(ide: string, value: string) {
+    if (!ide) return;
     const next = { ...modelsByIde };
-    if (value) next[ide] = value;
+    const trimmed = value.trim();
+    if (trimmed) next[ide] = trimmed;
     else delete next[ide];
     onModelsByIdeChange(next);
   }
@@ -261,71 +57,82 @@ export function ModelPicker({
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label htmlFor={inputId} className="text-sm font-medium">
+        <Label htmlFor="agent-default-model" className="text-sm font-medium">
           Default model
         </Label>
-        <ModelCombobox
-          id={inputId}
+        <Input
+          id="agent-default-model"
           value={modelName}
-          onChange={onModelNameChange}
-          rows={models}
-          placeholder={isLoading ? "Loading models…" : "auto (let the IDE pick)"}
-          autoLabel="auto (let the IDE pick)"
+          onChange={(event) => onModelNameChange(event.target.value)}
+          placeholder="auto (let the IDE pick)"
         />
         <p className="text-xs text-muted-foreground">
-          Pick from the models.dev catalog or type any model ID. Leave blank to let
-          the IDE choose.
+          Type the model value that your target harness accepts. Leave blank to let the IDE choose.
         </p>
       </div>
 
-      {idesWithChoice.length > 0 ? (
+      {allIdes.length > 0 ? (
         <div className="space-y-3 rounded-md border border-border bg-muted/20 p-3">
-          <div className="space-y-1">
-            <Label className="text-sm font-medium">Per harness override</Label>
-            <p className="text-xs text-muted-foreground">
-              Choose a harness from the allowed IDE list and set a model just for that harness.
-            </p>
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <Label className="text-sm font-medium">Per harness override</Label>
+              <p className="text-xs text-muted-foreground">
+                Pick any supported harness, then enter the exact model value that harness accepts.
+              </p>
+            </div>
+            {overrideCount > 0 ? (
+              <span className="rounded bg-primary/10 px-2 py-1 text-xs text-primary">
+                {overrideCount} set
+              </span>
+            ) : null}
           </div>
+
           <div className="grid gap-3 md:grid-cols-[minmax(160px,220px)_1fr]">
             <Select value={selectedIde} onValueChange={setSelectedIde}>
               <SelectTrigger className="h-10">
                 <SelectValue placeholder="Select harness" />
               </SelectTrigger>
               <SelectContent>
-                {idesWithChoice.map((ide) => (
+                {allIdes.map((ide) => (
                   <SelectItem key={ide.name} value={ide.name}>
                     {ide.display_name}
+                    {!ide.accepts_model_choice ? " · no model setting" : ""}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
-            <ModelCombobox
+            <Input
               value={modelsByIde[selectedIde] ?? ""}
-              onChange={(value) => setOverride(selectedIde, value)}
-              rows={overrideRows}
+              onChange={(event) => setOverride(selectedIde, event.target.value)}
               placeholder={selectedIdeMeta ? `Use default for ${selectedIdeMeta.display_name}` : "Use default"}
-              autoLabel="Use default model"
+              disabled={!selectedIdeMeta?.accepts_model_choice}
             />
           </div>
-          {Object.keys(modelsByIde).length > 0 ? (
+
+          {selectedIdeMeta && !selectedIdeMeta.accepts_model_choice ? (
+            <p className="text-xs text-muted-foreground">
+              {selectedIdeMeta.display_name} does not accept a saved model choice. It is shown here because it is an available harness.
+            </p>
+          ) : null}
+
+          {overrideCount > 0 ? (
             <div className="flex flex-wrap gap-1.5">
               {Object.entries(modelsByIde).map(([ide, model]) => {
-                const label = ides?.find((item) => item.name === ide)?.display_name ?? ide;
+                const label = allIdes.find((item) => item.name === ide)?.display_name ?? ide;
                 return (
-                  <span key={ide} className="rounded bg-primary/10 px-2 py-1 text-xs text-primary">
+                  <button
+                    key={ide}
+                    type="button"
+                    className="rounded bg-primary/10 px-2 py-1 text-left text-xs text-primary hover:bg-primary/15"
+                    onClick={() => setSelectedIde(ide)}
+                  >
                     {label}: <span className="font-mono">{model}</span>
-                  </span>
+                  </button>
                 );
               })}
             </div>
           ) : null}
         </div>
-      ) : null}
-
-      {catalog?.degraded ? (
-        <p className="text-xs text-amber-700 dark:text-amber-400">
-          Catalog is using the offline snapshot. Typed model IDs still save.
-        </p>
       ) : null}
     </div>
   );

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
-import { useState, useCallback, useEffect, useMemo, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { CheckCircle2, XCircle, Loader2, Maximize2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -26,7 +26,6 @@ interface PreviewPanelProps {
 	modelName?: string;
 	selectedComponents: Record<string, { id: string; name: string }[]>;
 	prompt?: string;
-	targetIdes?: string[];
 	pendingComponentBodies?: Record<string, Record<string, unknown>>; // tempId -> body
 	validationResult: ValidationResult | null;
 }
@@ -92,15 +91,10 @@ export function PreviewPanel({
 	modelName,
 	selectedComponents,
 	prompt,
-	targetIdes = [],
 	pendingComponentBodies,
 	validationResult,
 }: PreviewPanelProps) {
 	const { data: ideList } = useIdes();
-	const visibleIdes = useMemo(
-		() => (ideList ?? []).filter((opt) => targetIdes.length === 0 || targetIdes.includes(opt.name)),
-		[ideList, targetIdes],
-	);
 	const [ide, setIde] = useState("claude-code");
 	const [modalOpen, setModalOpen] = useState(false);
 	const [modalIde, setModalIde] = useState("claude-code");
@@ -113,10 +107,10 @@ export function PreviewPanel({
 	const modalScrollRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		if (visibleIdes.length === 0) return;
-		if (!visibleIdes.some((opt) => opt.name === ide)) setIde(visibleIdes[0].name);
-		if (!visibleIdes.some((opt) => opt.name === modalIde)) setModalIde(visibleIdes[0].name);
-	}, [visibleIdes, ide, modalIde]);
+		if (!ideList || ideList.length === 0) return;
+		if (!ideList.some((opt) => opt.name === ide)) setIde(ideList[0].name);
+		if (!ideList.some((opt) => opt.name === modalIde)) setModalIde(ideList[0].name);
+	}, [ideList, ide, modalIde]);
 
 	const body = buildMarkdownBody(
 		description,
@@ -161,7 +155,6 @@ export function PreviewPanel({
 				prompt: body,
 				model_name: modelName ?? "",
 				components,
-				target_ides: targetIdes,
 			});
 			setFullConfigs(res.configs);
 		} catch (e) {
@@ -171,7 +164,7 @@ export function PreviewPanel({
 		} finally {
 			setFullLoading(false);
 		}
-	}, [name, description, body, modelName, selectedComponents, targetIdes]);
+	}, [name, description, body, modelName, selectedComponents]);
 
 	useEffect(() => {
 		const timer = window.setTimeout(() => {
@@ -237,7 +230,7 @@ export function PreviewPanel({
 
 			{/* IDE selector */}
 			<div className="flex flex-wrap gap-1">
-				{visibleIdes.map((opt) => (
+				{(ideList ?? []).map((opt) => (
 					<button
 						key={opt.name}
 						type="button"
@@ -310,7 +303,7 @@ export function PreviewPanel({
 
 					{/* IDE tabs inside modal */}
 					<div className="flex flex-wrap gap-1 px-6 pt-3">
-						{visibleIdes.map((opt) => (
+						{(ideList ?? []).map((opt) => (
 							<button
 								key={opt.name}
 								type="button"

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -136,14 +136,17 @@ function generateClaudeCode(
 
 function generateCursor(
 	name: string,
+	description: string,
+	modelName: string,
 	mcps: { id: string; name: string }[],
 	body: string,
 ): PreviewFile[] {
-	const safeName = name || "(untitled)";
+	const safeName = name || "untitled";
+	const desc = description || safeName;
 	const files: PreviewFile[] = [
 		{
-			path: `.cursor/rules/${safeName}.mdc`,
-			content: body || `# ${safeName}`,
+			path: `.cursor/agents/${safeName}.md`,
+			content: `---\nname: ${safeName}\ndescription: ${JSON.stringify(desc)}\nmodel: ${modelName || "inherit"}\n---\n\n${body || `# ${safeName}`}`,
 		},
 	];
 	if (mcps.length > 0) {
@@ -357,7 +360,7 @@ export function PreviewPanel({
 			);
 			break;
 		case "cursor":
-			files = generateCursor(name, mcps, body);
+			files = generateCursor(name, description, modelName ?? "", mcps, body);
 			break;
 		case "kiro":
 			files = generateKiro(name, description, mcps, body);

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -232,11 +232,27 @@ function generateGemini(
 	return files;
 }
 
+function tomlString(value: string): string {
+	return JSON.stringify(value);
+}
+
 function generateCodex(
+	name: string,
+	description: string,
+	modelName: string,
 	mcps: { id: string; name: string }[],
 	body: string,
 ): PreviewFile[] {
-	const files: PreviewFile[] = [{ path: "AGENTS.md", content: body || "" }];
+	const safeName = name || "untitled";
+	const lines = [
+		`name = ${tomlString(safeName)}`,
+		`description = ${tomlString(description || safeName)}`,
+		`developer_instructions = ${tomlString(body || `# ${safeName}`)}`,
+	];
+	if (modelName) lines.push(`model = ${tomlString(modelName)}`);
+	const files: PreviewFile[] = [
+		{ path: `~/.codex/agents/${safeName}.toml`, content: lines.join("\n") + "\n" },
+	];
 	if (mcps.length > 0) {
 		const tomlLines = ["[mcp.servers]"];
 		for (const mcp of mcps) {
@@ -271,6 +287,34 @@ function generateCopilot(
 		files.push({
 			path: ".vscode/mcp.json",
 			content: buildMcpJson(mcps, "servers"),
+		});
+	}
+	return files;
+}
+
+function generateAntigravity(
+	mcps: { id: string; name: string }[],
+	body: string,
+): PreviewFile[] {
+	const files: PreviewFile[] = [{ path: "AGENTS.md", content: body || "" }];
+	if (mcps.length > 0) {
+		files.push({
+			path: ".agents/mcp_config.json",
+			content: buildMcpJson(mcps, "mcpServers"),
+		});
+	}
+	return files;
+}
+
+function generatePi(
+	mcps: { id: string; name: string }[],
+	body: string,
+): PreviewFile[] {
+	const files: PreviewFile[] = [{ path: "~/.pi/agent/AGENTS.md", content: body || "" }];
+	if (mcps.length > 0) {
+		files.push({
+			path: "~/.pi/agent/mcp.json",
+			content: buildMcpJson(mcps, "mcpServers"),
 		});
 	}
 	return files;
@@ -369,13 +413,19 @@ export function PreviewPanel({
 			files = generateGemini(mcps, body);
 			break;
 		case "codex":
-			files = generateCodex(mcps, body);
+			files = generateCodex(name, description, modelName ?? "", mcps, body);
 			break;
 		case "copilot":
 			files = generateCopilot(name, mcps, body);
 			break;
 		case "opencode":
 			files = generateOpenCode(mcps, body);
+			break;
+		case "antigravity":
+			files = generateAntigravity(mcps, body);
+			break;
+		case "pi":
+			files = generatePi(mcps, body);
 			break;
 		default:
 			files = generateClaudeCode(name, description, modelName ?? "", mcps, body);

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { CheckCircle2, XCircle, Loader2, Maximize2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -26,6 +26,7 @@ interface PreviewPanelProps {
 	modelName?: string;
 	selectedComponents: Record<string, { id: string; name: string }[]>;
 	prompt?: string;
+	targetIdes?: string[];
 	pendingComponentBodies?: Record<string, Record<string, unknown>>; // tempId -> body
 	validationResult: ValidationResult | null;
 }
@@ -309,10 +310,15 @@ export function PreviewPanel({
 	modelName,
 	selectedComponents,
 	prompt,
+	targetIdes = [],
 	pendingComponentBodies,
 	validationResult,
 }: PreviewPanelProps) {
 	const { data: ideList } = useIdes();
+	const visibleIdes = useMemo(
+		() => (ideList ?? []).filter((opt) => targetIdes.length === 0 || targetIdes.includes(opt.name)),
+		[ideList, targetIdes],
+	);
 	const [ide, setIde] = useState("claude-code");
 	const [modalOpen, setModalOpen] = useState(false);
 	const [modalIde, setModalIde] = useState("claude-code");
@@ -323,6 +329,12 @@ export function PreviewPanel({
 	const [fullLoading, setFullLoading] = useState(false);
 	const [fullError, setFullError] = useState<string | null>(null);
 	const modalScrollRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (visibleIdes.length === 0) return;
+		if (!visibleIdes.some((opt) => opt.name === ide)) setIde(visibleIdes[0].name);
+		if (!visibleIdes.some((opt) => opt.name === modalIde)) setModalIde(visibleIdes[0].name);
+	}, [visibleIdes, ide, modalIde]);
 
 	const mcps = selectedComponents.mcps ?? [];
 	const body = buildMarkdownBody(
@@ -399,6 +411,7 @@ export function PreviewPanel({
 				prompt: body,
 				model_name: modelName ?? "",
 				components,
+				target_ides: targetIdes,
 			});
 			setFullConfigs(res.configs);
 		} catch (e) {
@@ -408,7 +421,7 @@ export function PreviewPanel({
 		} finally {
 			setFullLoading(false);
 		}
-	}, [name, description, body, modelName, selectedComponents]);
+	}, [name, description, body, modelName, selectedComponents, targetIdes]);
 
 	const handleOpenFullPreview = useCallback(() => {
 		setModalIde(ide);
@@ -468,7 +481,7 @@ export function PreviewPanel({
 
 			{/* IDE selector */}
 			<div className="flex flex-wrap gap-1">
-				{(ideList ?? []).map((opt) => (
+				{visibleIdes.map((opt) => (
 					<button
 						key={opt.name}
 						type="button"
@@ -525,7 +538,7 @@ export function PreviewPanel({
 
 					{/* IDE tabs inside modal */}
 					<div className="flex flex-wrap gap-1 px-6 pt-3">
-						{(ideList ?? []).map((opt) => (
+						{visibleIdes.map((opt) => (
 							<button
 								key={opt.name}
 								type="button"

--- a/web/src/components/builder/preview-panel.tsx
+++ b/web/src/components/builder/preview-panel.tsx
@@ -79,274 +79,9 @@ function buildMarkdownBody(
 	return lines.join("\n");
 }
 
-function buildMcpJson(
-	mcps: { id: string; name: string }[],
-	key: string = "mcpServers",
-): string {
-	if (mcps.length === 0) return "";
-	const servers: Record<string, object> = {};
-	for (const mcp of mcps) {
-		servers[mcp.name] = {
-			command: "observal-shim",
-			args: ["--mcp-id", mcp.id, "--", "python", "-m", mcp.name],
-		};
-	}
-	return JSON.stringify({ [key]: servers }, null, 2);
-}
-
-// ── Per-IDE preview generators (simplified mode) ─────────────
-
 interface PreviewFile {
 	path: string;
 	content: string;
-}
-
-function generateClaudeCode(
-	name: string,
-	description: string,
-	modelName: string,
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const safeName = name || "(untitled)";
-	const lines: string[] = [];
-
-	lines.push("---");
-	lines.push(`name: ${safeName}`);
-	if (modelName) {
-		lines.push(`model: ${modelName}`);
-	}
-	if (mcps.length > 0) {
-		lines.push("mcpServers:");
-		mcps.forEach((m) => lines.push(`  - ${m.name}`));
-	}
-	lines.push("---");
-	if (body) {
-		lines.push("");
-		lines.push(body);
-	}
-
-	return [
-		{
-			path: `.claude/agents/${safeName}.md`,
-			content: lines.join("\n"),
-		},
-	];
-}
-
-function generateCursor(
-	name: string,
-	description: string,
-	modelName: string,
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const safeName = name || "untitled";
-	const desc = description || safeName;
-	const files: PreviewFile[] = [
-		{
-			path: `.cursor/agents/${safeName}.md`,
-			content: `---\nname: ${safeName}\ndescription: ${JSON.stringify(desc)}\nmodel: ${modelName || "inherit"}\n---\n\n${body || `# ${safeName}`}`,
-		},
-	];
-	if (mcps.length > 0) {
-		files.push({
-			path: ".cursor/mcp.json",
-			content: buildMcpJson(mcps, "mcpServers"),
-		});
-	}
-	return files;
-}
-
-function generateKiro(
-	name: string,
-	description: string,
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const safeName = name || "(untitled)";
-	const servers: Record<string, object> = {};
-	for (const mcp of mcps) {
-		servers[mcp.name] = {
-			command: "observal-shim",
-			args: ["--mcp-id", mcp.id, "--", "python", "-m", mcp.name],
-		};
-	}
-
-	const wrappedPrompt = body
-		? `# ${safeName} — Agent Specialization\n\nYou are a Kiro agent with the following specialization.\n\n## Instructions\n\n${body}`
-		: "";
-
-	const agent: Record<string, unknown> = {
-		name: safeName,
-		description: (description || "").slice(0, 200),
-		prompt: wrappedPrompt,
-		mcpServers: servers,
-		tools: ["*"],
-		toolAliases: {},
-		allowedTools: [],
-		resources: [
-			"file://AGENTS.md",
-			"file://README.md",
-			"skill://.kiro/skills/*/SKILL.md",
-			"skill://~/.kiro/skills/*/SKILL.md",
-		],
-		hooks: {
-			agentSpawn: [{ command: "..." }],
-			userPromptSubmit: [{ command: "..." }],
-			preToolUse: [{ matcher: "*", command: "..." }],
-			postToolUse: [{ matcher: "*", command: "..." }],
-			stop: [{ command: "..." }],
-		},
-		toolsSettings: {},
-		includeMcpJson: true,
-		model: null,
-	};
-
-	return [
-		{
-			path: `~/.kiro/agents/${safeName}.json`,
-			content: JSON.stringify(agent, null, 2),
-		},
-	];
-}
-
-function generateGemini(
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const files: PreviewFile[] = [{ path: "GEMINI.md", content: body || "" }];
-	if (mcps.length > 0) {
-		const servers: Record<string, object> = {};
-		for (const mcp of mcps) {
-			servers[mcp.name] = {
-				command: "observal-shim",
-				args: ["--mcp-id", mcp.id, "--", "python", "-m", mcp.name],
-			};
-		}
-		files.push({
-			path: ".gemini/settings.json",
-			content: JSON.stringify({ mcpServers: servers }, null, 2),
-		});
-	}
-	return files;
-}
-
-function tomlString(value: string): string {
-	return JSON.stringify(value);
-}
-
-function generateCodex(
-	name: string,
-	description: string,
-	modelName: string,
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const safeName = name || "untitled";
-	const lines = [
-		`name = ${tomlString(safeName)}`,
-		`description = ${tomlString(description || safeName)}`,
-		`developer_instructions = ${tomlString(body || `# ${safeName}`)}`,
-	];
-	if (modelName) lines.push(`model = ${tomlString(modelName)}`);
-	const files: PreviewFile[] = [
-		{ path: `~/.codex/agents/${safeName}.toml`, content: lines.join("\n") + "\n" },
-	];
-	if (mcps.length > 0) {
-		const tomlLines = ["[mcp.servers]"];
-		for (const mcp of mcps) {
-			tomlLines.push("");
-			tomlLines.push(`[mcp.servers.${mcp.name}]`);
-			tomlLines.push(`command = "observal-shim"`);
-			tomlLines.push(
-				`args = ["--mcp-id", "${mcp.id}", "--", "python", "-m", "${mcp.name}"]`,
-			);
-		}
-		files.push({
-			path: "~/.codex/config.toml",
-			content: tomlLines.join("\n"),
-		});
-	}
-	return files;
-}
-
-function generateCopilot(
-	name: string,
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const safeName = name || "(untitled)";
-	const files: PreviewFile[] = [
-		{
-			path: `.github/agents/${safeName}.agent.md`,
-			content: body || "",
-		},
-	];
-	if (mcps.length > 0) {
-		files.push({
-			path: ".vscode/mcp.json",
-			content: buildMcpJson(mcps, "servers"),
-		});
-	}
-	return files;
-}
-
-function generateAntigravity(
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const files: PreviewFile[] = [{ path: "AGENTS.md", content: body || "" }];
-	if (mcps.length > 0) {
-		files.push({
-			path: ".agents/mcp_config.json",
-			content: buildMcpJson(mcps, "mcpServers"),
-		});
-	}
-	return files;
-}
-
-function generatePi(
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const files: PreviewFile[] = [{ path: "~/.pi/agent/AGENTS.md", content: body || "" }];
-	if (mcps.length > 0) {
-		files.push({
-			path: "~/.pi/agent/mcp.json",
-			content: buildMcpJson(mcps, "mcpServers"),
-		});
-	}
-	return files;
-}
-
-function generateOpenCode(
-	mcps: { id: string; name: string }[],
-	body: string,
-): PreviewFile[] {
-	const files: PreviewFile[] = [{ path: "AGENTS.md", content: body || "" }];
-	if (mcps.length > 0) {
-		const mcp: Record<string, object> = {};
-		for (const m of mcps) {
-			mcp[m.name] = {
-				type: "local",
-				command: [
-					"observal-shim",
-					"--mcp-id",
-					m.id,
-					"--",
-					"python",
-					"-m",
-					m.name,
-				],
-			};
-		}
-		files.push({
-			path: "~/.config/opencode/opencode.json",
-			content: JSON.stringify({ mcp }, null, 2),
-		});
-	}
-	return files;
 }
 
 // ── Main component ────────────────────────────────────────────
@@ -383,7 +118,6 @@ export function PreviewPanel({
 		if (!visibleIdes.some((opt) => opt.name === modalIde)) setModalIde(visibleIdes[0].name);
 	}, [visibleIdes, ide, modalIde]);
 
-	const mcps = selectedComponents.mcps ?? [];
 	const body = buildMarkdownBody(
 		description,
 		selectedComponents,
@@ -391,46 +125,9 @@ export function PreviewPanel({
 		pendingComponentBodies,
 	);
 
-	// Simplified mode: client-side generators
-	let files: PreviewFile[];
-	switch (ide) {
-		case "claude-code":
-			files = generateClaudeCode(
-				name,
-				description,
-				modelName ?? "",
-				mcps,
-				body,
-			);
-			break;
-		case "cursor":
-			files = generateCursor(name, description, modelName ?? "", mcps, body);
-			break;
-		case "kiro":
-			files = generateKiro(name, description, mcps, body);
-			break;
-		case "gemini-cli":
-			files = generateGemini(mcps, body);
-			break;
-		case "codex":
-			files = generateCodex(name, description, modelName ?? "", mcps, body);
-			break;
-		case "copilot":
-			files = generateCopilot(name, mcps, body);
-			break;
-		case "opencode":
-			files = generateOpenCode(mcps, body);
-			break;
-		case "antigravity":
-			files = generateAntigravity(mcps, body);
-			break;
-		case "pi":
-			files = generatePi(mcps, body);
-			break;
-		default:
-			files = generateClaudeCode(name, description, modelName ?? "", mcps, body);
-			break;
-	}
+	const files: PreviewFile[] = fullConfigs?.[ide]
+		? Object.entries(fullConfigs[ide]).map(([path, content]) => ({ path, content }))
+		: [];
 
 	const fetchFullConfig = useCallback(async () => {
 		const components: { component_type: string; component_id: string }[] = [];
@@ -476,11 +173,17 @@ export function PreviewPanel({
 		}
 	}, [name, description, body, modelName, selectedComponents, targetIdes]);
 
+	useEffect(() => {
+		const timer = window.setTimeout(() => {
+			void fetchFullConfig();
+		}, 300);
+		return () => window.clearTimeout(timer);
+	}, [fetchFullConfig]);
+
 	const handleOpenFullPreview = useCallback(() => {
 		setModalIde(ide);
 		setModalOpen(true);
-		fetchFullConfig();
-	}, [ide, fetchFullConfig]);
+	}, [ide]);
 
 	// Files for the modal view
 	const modalFiles: PreviewFile[] =
@@ -550,19 +253,35 @@ export function PreviewPanel({
 				))}
 			</div>
 
-			{/* Simplified file previews */}
+			{/* Server-generated file previews */}
 			<Card>
 				<CardContent className="p-0 divide-y">
-					{files.map((file) => (
-						<div key={file.path}>
-							<div className="px-4 py-2 text-[11px] font-medium text-muted-foreground bg-muted/40 font-[family-name:var(--font-mono)]">
-								{file.path}
-							</div>
-							<pre className="overflow-x-auto min-h-[100px] whitespace-pre p-4 text-sm leading-relaxed font-[family-name:var(--font-mono)] text-foreground/80">
-								{file.content}
-							</pre>
+					{fullLoading ? (
+						<div className="flex items-center justify-center py-12 text-muted-foreground">
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							<span className="text-sm">Generating preview...</span>
 						</div>
-					))}
+					) : fullError ? (
+						<div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+							<XCircle className="mb-2 h-5 w-5 text-destructive" />
+							<span className="text-sm">{fullError}</span>
+						</div>
+					) : files.length === 0 ? (
+						<div className="flex items-center justify-center py-12 text-muted-foreground">
+							<span className="text-sm">No config generated for this IDE.</span>
+						</div>
+					) : (
+						files.map((file) => (
+							<div key={file.path}>
+								<div className="px-4 py-2 text-[11px] font-medium text-muted-foreground bg-muted/40 font-[family-name:var(--font-mono)]">
+									{file.path}
+								</div>
+								<pre className="overflow-x-auto min-h-[100px] whitespace-pre p-4 text-sm leading-relaxed font-[family-name:var(--font-mono)] text-foreground/80">
+									{file.content}
+								</pre>
+							</div>
+						))
+					)}
 				</CardContent>
 			</Card>
 

--- a/web/src/components/registry/agent-edit-form.tsx
+++ b/web/src/components/registry/agent-edit-form.tsx
@@ -47,7 +47,6 @@ import type {
   ValidationResult,
 } from "@/lib/types";
 import type { RegistryType } from "@/lib/api";
-import { useIdes } from "@/hooks/use-ides";
 import { ModelPicker } from "@/components/builder/model-picker";
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
 import { ValidationPanel } from "@/components/builder/validation-panel";
@@ -66,6 +65,7 @@ interface AgentDetail {
   description?: string;
   prompt?: string;
   model_name?: string;
+  models_by_ide?: Record<string, string>;
   component_links?: ComponentLink[];
   mcp_links?: ComponentLink[];
   supported_ides?: string[];
@@ -104,13 +104,13 @@ export function AgentEditForm({
   const vd = versionDetail;
   const initialDescription = vd?.description ?? agent.description ?? "";
   const initialModelName = vd?.model_name ?? agent.model_name ?? "";
+  const initialModelsByIde = (vd?.models_by_ide ?? agent.models_by_ide ?? {}) as Record<string, string>;
   const initialPrompt = vd?.prompt ?? agent.prompt ?? "";
-  const initialSupportedIdes = vd?.supported_ides ?? agent.supported_ides ?? [];
 
   // ── Form state ───────────────────────────────────────────────
   const [description, setDescription] = useState(initialDescription);
   const [modelName, setModelName] = useState(initialModelName);
-  const [supportedIdes, setSupportedIdes] = useState<string[]>(initialSupportedIdes);
+  const [modelsByIde, setModelsByIde] = useState<Record<string, string>>(initialModelsByIde);
   const [activeTab, setActiveTab] = useState<RegistryType>("mcps");
   const [selectedComponents, setSelectedComponents] = useState<
     Record<string, RegistryItem[]>
@@ -127,7 +127,7 @@ export function AgentEditForm({
   const initialStateRef = useRef({
     description: initialDescription,
     modelName: initialModelName,
-    supportedIdes: initialSupportedIdes,
+    modelsByIde: initialModelsByIde,
     prompt: initialPrompt,
     selectedComponents: {} as Record<string, RegistryItem[]>,
   });
@@ -142,7 +142,6 @@ export function AgentEditForm({
   const createVersion = useCreateAgentVersion();
   const updateAgent = useUpdateAgent();
   const { data: versionSuggestions } = useVersionSuggestions(agentId);
-  const { data: ideList } = useIdes();
 
   // ── Initialize form from agent data ──────────────────────────
   const fingerprint = useMemo(
@@ -152,9 +151,8 @@ export function AgentEditForm({
         currentVersion,
         versionDetail?.description,
         versionDetail?.model_name,
+        versionDetail?.models_by_ide,
         versionDetail?.prompt,
-        versionDetail?.supported_ides,
-        agent.supported_ides,
         versionDetail?.components,
       ]),
     [agent.name, currentVersion, versionDetail],
@@ -164,7 +162,7 @@ export function AgentEditForm({
     // Reset description / modelName from latest props
     setDescription(initialDescription);
     setModelName(initialModelName);
-    setSupportedIdes(initialSupportedIdes);
+    setModelsByIde(initialModelsByIde);
 
     const links: ComponentLink[] = versionDetail?.components
       ? versionDetail.components.map((component) => ({
@@ -197,7 +195,7 @@ export function AgentEditForm({
     initialStateRef.current = {
       description: initialDescription,
       modelName: initialModelName,
-      supportedIdes: initialSupportedIdes,
+      modelsByIde: initialModelsByIde,
       prompt: initialPrompt,
       selectedComponents: grouped,
     };
@@ -211,11 +209,11 @@ export function AgentEditForm({
     const dirty =
       description !== init.description ||
       modelName !== init.modelName ||
-      JSON.stringify(supportedIdes) !== JSON.stringify(init.supportedIdes) ||
+      JSON.stringify(modelsByIde) !== JSON.stringify(init.modelsByIde) ||
       prompt !== init.prompt ||
       JSON.stringify(selectedComponents) !== JSON.stringify(init.selectedComponents);
     setIsDirty(dirty);
-  }, [description, modelName, supportedIdes, prompt, selectedComponents]);
+  }, [description, modelName, modelsByIde, prompt, selectedComponents]);
 
   // ── Debounced validation ──────────────────────────────────────
   useEffect(() => {
@@ -284,12 +282,6 @@ export function AgentEditForm({
     }));
   }, []);
 
-  function toggleTargetIde(ide: string) {
-    setSupportedIdes((prev) =>
-      prev.includes(ide) ? prev.filter((i) => i !== ide) : [...prev, ide],
-    );
-  }
-
   const handleReorder = useCallback(
     (type: string) => (items: { id: string; name: string }[]) => {
       setSelectedComponents((prev) => {
@@ -323,9 +315,9 @@ export function AgentEditForm({
       prompt: prompt.trim(),
       model_name: modelName,
       model_config_json: {},
-      models_by_ide: {},
+      models_by_ide: modelsByIde,
       external_mcps: [],
-      supported_ides: supportedIdes,
+      supported_ides: agent.supported_ides ?? [],
       components: components.length > 0 ? components : [],
       yaml_snapshot: null,
       is_prerelease: false,
@@ -342,7 +334,7 @@ export function AgentEditForm({
       initialStateRef.current = {
         description,
         modelName,
-        supportedIdes,
+        modelsByIde,
         prompt,
         selectedComponents,
       };
@@ -364,7 +356,7 @@ export function AgentEditForm({
       initialStateRef.current = {
         description,
         modelName,
-        supportedIdes,
+        modelsByIde,
         prompt,
         selectedComponents,
       };
@@ -387,7 +379,7 @@ export function AgentEditForm({
     const init = initialStateRef.current;
     setDescription(init.description);
     setModelName(init.modelName);
-    setSupportedIdes(init.supportedIdes);
+    setModelsByIde(init.modelsByIde);
     setPrompt(init.prompt ?? "");
     setSelectedComponents(
       Object.keys(init.selectedComponents).length > 0
@@ -432,35 +424,13 @@ export function AgentEditForm({
           />
         </div>
 
-        <div className="max-w-lg">
+        <div className="max-w-2xl">
           <ModelPicker
             modelName={modelName}
             onModelNameChange={setModelName}
+            modelsByIde={modelsByIde}
+            onModelsByIdeChange={setModelsByIde}
           />
-        </div>
-
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">Target IDEs</Label>
-          <div className="flex flex-wrap gap-1.5">
-            {(ideList ?? []).map((ide) => (
-              <button
-                key={ide.name}
-                type="button"
-                onClick={() => toggleTargetIde(ide.name)}
-                className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
-                  supportedIdes.includes(ide.name)
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-muted/50 text-muted-foreground hover:bg-muted"
-                }`}
-              >
-                {ide.display_name}
-              </button>
-            ))}
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Leave empty for portable agents. Pick one or more when this agent is
-            meant for specific harnesses.
-          </p>
         </div>
       </section>
 

--- a/web/src/components/registry/agent-edit-form.tsx
+++ b/web/src/components/registry/agent-edit-form.tsx
@@ -47,6 +47,8 @@ import type {
   ValidationResult,
 } from "@/lib/types";
 import type { RegistryType } from "@/lib/api";
+import { useIdes } from "@/hooks/use-ides";
+import { ModelPicker } from "@/components/builder/model-picker";
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
 import { ValidationPanel } from "@/components/builder/validation-panel";
 import { COMPONENT_TYPES, REVERSE_TYPE_MAP, TYPE_MAP } from "@/components/registry/agent-component-constants";
@@ -103,10 +105,12 @@ export function AgentEditForm({
   const initialDescription = vd?.description ?? agent.description ?? "";
   const initialModelName = vd?.model_name ?? agent.model_name ?? "";
   const initialPrompt = vd?.prompt ?? agent.prompt ?? "";
+  const initialSupportedIdes = vd?.supported_ides ?? agent.supported_ides ?? [];
 
   // ── Form state ───────────────────────────────────────────────
   const [description, setDescription] = useState(initialDescription);
   const [modelName, setModelName] = useState(initialModelName);
+  const [supportedIdes, setSupportedIdes] = useState<string[]>(initialSupportedIdes);
   const [activeTab, setActiveTab] = useState<RegistryType>("mcps");
   const [selectedComponents, setSelectedComponents] = useState<
     Record<string, RegistryItem[]>
@@ -123,6 +127,7 @@ export function AgentEditForm({
   const initialStateRef = useRef({
     description: initialDescription,
     modelName: initialModelName,
+    supportedIdes: initialSupportedIdes,
     prompt: initialPrompt,
     selectedComponents: {} as Record<string, RegistryItem[]>,
   });
@@ -137,6 +142,7 @@ export function AgentEditForm({
   const createVersion = useCreateAgentVersion();
   const updateAgent = useUpdateAgent();
   const { data: versionSuggestions } = useVersionSuggestions(agentId);
+  const { data: ideList } = useIdes();
 
   // ── Initialize form from agent data ──────────────────────────
   const fingerprint = useMemo(
@@ -147,6 +153,8 @@ export function AgentEditForm({
         versionDetail?.description,
         versionDetail?.model_name,
         versionDetail?.prompt,
+        versionDetail?.supported_ides,
+        agent.supported_ides,
         versionDetail?.components,
       ]),
     [agent.name, currentVersion, versionDetail],
@@ -156,6 +164,7 @@ export function AgentEditForm({
     // Reset description / modelName from latest props
     setDescription(initialDescription);
     setModelName(initialModelName);
+    setSupportedIdes(initialSupportedIdes);
 
     const links: ComponentLink[] = versionDetail?.components
       ? versionDetail.components.map((component) => ({
@@ -188,6 +197,7 @@ export function AgentEditForm({
     initialStateRef.current = {
       description: initialDescription,
       modelName: initialModelName,
+      supportedIdes: initialSupportedIdes,
       prompt: initialPrompt,
       selectedComponents: grouped,
     };
@@ -201,10 +211,11 @@ export function AgentEditForm({
     const dirty =
       description !== init.description ||
       modelName !== init.modelName ||
+      JSON.stringify(supportedIdes) !== JSON.stringify(init.supportedIdes) ||
       prompt !== init.prompt ||
       JSON.stringify(selectedComponents) !== JSON.stringify(init.selectedComponents);
     setIsDirty(dirty);
-  }, [description, modelName, prompt, selectedComponents]);
+  }, [description, modelName, supportedIdes, prompt, selectedComponents]);
 
   // ── Debounced validation ──────────────────────────────────────
   useEffect(() => {
@@ -273,6 +284,12 @@ export function AgentEditForm({
     }));
   }, []);
 
+  function toggleTargetIde(ide: string) {
+    setSupportedIdes((prev) =>
+      prev.includes(ide) ? prev.filter((i) => i !== ide) : [...prev, ide],
+    );
+  }
+
   const handleReorder = useCallback(
     (type: string) => (items: { id: string; name: string }[]) => {
       setSelectedComponents((prev) => {
@@ -306,8 +323,9 @@ export function AgentEditForm({
       prompt: prompt.trim(),
       model_name: modelName,
       model_config_json: {},
+      models_by_ide: {},
       external_mcps: [],
-      supported_ides: agent.supported_ides ?? [],
+      supported_ides: supportedIdes,
       components: components.length > 0 ? components : [],
       yaml_snapshot: null,
       is_prerelease: false,
@@ -324,6 +342,7 @@ export function AgentEditForm({
       initialStateRef.current = {
         description,
         modelName,
+        supportedIdes,
         prompt,
         selectedComponents,
       };
@@ -345,6 +364,7 @@ export function AgentEditForm({
       initialStateRef.current = {
         description,
         modelName,
+        supportedIdes,
         prompt,
         selectedComponents,
       };
@@ -367,6 +387,7 @@ export function AgentEditForm({
     const init = initialStateRef.current;
     setDescription(init.description);
     setModelName(init.modelName);
+    setSupportedIdes(init.supportedIdes);
     setPrompt(init.prompt ?? "");
     setSelectedComponents(
       Object.keys(init.selectedComponents).length > 0
@@ -411,24 +432,35 @@ export function AgentEditForm({
           />
         </div>
 
-        <div className="space-y-2 max-w-xs">
-          <Label htmlFor="agent-model" className="text-sm font-medium">
-            Model
-          </Label>
-          <Input
-            id="agent-model"
-            list="edit-model-suggestions"
-            placeholder="claude-sonnet-4-20250514"
-            value={modelName}
-            onChange={(e) => setModelName(e.target.value)}
+        <div className="max-w-lg">
+          <ModelPicker
+            modelName={modelName}
+            onModelNameChange={setModelName}
           />
-          <datalist id="edit-model-suggestions">
-            <option value="claude-opus-4-6-20250725" />
-            <option value="claude-sonnet-4-6-20250725" />
-            <option value="claude-sonnet-4-20250514" />
-            <option value="claude-opus-4-20250514" />
-            <option value="claude-haiku-4-5-20251001" />
-          </datalist>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Target IDEs</Label>
+          <div className="flex flex-wrap gap-1.5">
+            {(ideList ?? []).map((ide) => (
+              <button
+                key={ide.name}
+                type="button"
+                onClick={() => toggleTargetIde(ide.name)}
+                className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                  supportedIdes.includes(ide.name)
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted/50 text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                {ide.display_name}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Leave empty for portable agents. Pick one or more when this agent is
+            meant for specific harnesses.
+          </p>
         </div>
       </section>
 

--- a/web/src/components/registry/status-badge.tsx
+++ b/web/src/components/registry/status-badge.tsx
@@ -16,6 +16,7 @@ const statusConfig: Record<string, { bg: string; text: string; dot?: string; pin
   completed: { bg: "bg-light-green",  text: "text-dark-green" },
   success:   { bg: "bg-light-green",  text: "text-dark-green" },
   archived:  { bg: "bg-light-yellow", text: "text-dark-yellow" },
+  deleted:   { bg: "bg-light-red",    text: "text-dark-red" },
 };
 
 const fallback = { bg: "bg-muted", text: "text-muted-foreground" };

--- a/web/src/hooks/use-agents-api.ts
+++ b/web/src/hooks/use-agents-api.ts
@@ -41,6 +41,14 @@ export function useArchivedAgents(enabled = true) {
   });
 }
 
+export function useDeletedAgents(enabled = true) {
+  return useQuery({
+    queryKey: ["registry", "agents", "deleted"],
+    queryFn: () => registry.deletedAgents(),
+    enabled,
+  });
+}
+
 export function useAgentResolve(id: string) {
   return useQuery({
     queryKey: ["agent-resolve", id],
@@ -110,6 +118,34 @@ export function useUnarchiveAgent() {
     },
     onError: (err: Error) => {
       toast.error(err.message || "Failed to restore agent");
+    },
+  });
+}
+
+export function useRestoreDeletedAgent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { id: string; name?: string }) => registry.restoreDeletedAgent(vars.id, vars.name ? { name: vars.name } : undefined),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
+      toast.success("Agent restored");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to restore agent");
+    },
+  });
+}
+
+export function useDeleteAgent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => registry.delete("agents", id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
+      toast.success("Agent deleted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to delete agent");
     },
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -425,8 +425,10 @@ export const registry = {
 		),
 	my: (type?: RegistryType) => get<RegistryItem[]>(`/${type ?? "agents"}/my`),
 	archived: () => get<RegistryItem[]>("/agents/archived"),
+	deletedAgents: () => get<RegistryItem[]>("/agents/deleted"),
 	archive: (id: string) => patch(`/agents/${id}/archive`),
 	unarchive: (id: string) => patch(`/agents/${id}/unarchive`),
+	restoreDeletedAgent: (id: string, body?: { name?: string }) => patch(`/agents/${id}/restore`, body ?? {}),
 	archiveComponent: (type: RegistryType, id: string) => patch(`/${type}/${id}/archive`),
 	unarchiveComponent: (type: RegistryType, id: string) => patch(`/${type}/${id}/unarchive`),
 	draft: (body: unknown, type?: RegistryType) =>

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -44,7 +44,6 @@ import {
 import { PageHeader } from "@/components/layouts/page-header";
 import { useRegistryItem, useAgentValidation, useWhoami, useSaveDraft, useUpdateDraft, useStartEdit } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
-import { useIdes } from "@/hooks/use-ides";
 import { registry, type RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
 import type { ValidationResult } from "@/lib/types";
@@ -89,7 +88,6 @@ function AgentBuilderInner() {
   const isEditMode = !!editId;
 
   const { data: whoami } = useWhoami();
-  const { data: ideList } = useIdes();
   const { data: existingAgent } = useRegistryItem("agents", editId ?? draftParam ?? undefined);
 
   const [name, setName] = useState("");
@@ -99,7 +97,7 @@ function AgentBuilderInner() {
   const [version, setVersion] = useState("1.0.0");
   const [category, setCategory] = useState("");
   const [modelName, setModelName] = useState("");
-  const [supportedIdes, setSupportedIdes] = useState<string[]>([]);
+  const [modelsByIde, setModelsByIde] = useState<Record<string, string>>({});
   const [publishing, setPublishing] = useState(false);
   const [activeTab, setActiveTab] = useState<RegistryType>("mcps");
 
@@ -157,8 +155,10 @@ function AgentBuilderInner() {
     if (typeof agentVersion === "string") setVersion(agentVersion);
     const agentModel = (existingAgent as Record<string, unknown>).model_name;
     if (typeof agentModel === "string") setModelName(agentModel);
-    const agentSupportedIdes = (existingAgent as Record<string, unknown>).supported_ides;
-    if (Array.isArray(agentSupportedIdes)) setSupportedIdes(agentSupportedIdes as string[]);
+    const agentModelsByIde = (existingAgent as Record<string, unknown>).models_by_ide;
+    if (agentModelsByIde && typeof agentModelsByIde === "object" && !Array.isArray(agentModelsByIde)) {
+      setModelsByIde(agentModelsByIde as Record<string, string>);
+    }
     const agentCategory = (existingAgent as Record<string, unknown>).category;
     if (typeof agentCategory === "string") setCategory(agentCategory);
 
@@ -286,7 +286,7 @@ function AgentBuilderInner() {
 
     autoSaveTimerRef.current = setTimeout(() => {
       const hasContent = name || description || modelName || version !== "1.0.0" ||
-        supportedIdes.length > 0 ||
+        Object.keys(modelsByIde).length > 0 ||
         Object.values(selectedComponents).some((items) => items.length > 0) ||
         systemPrompt.trim().length > 0;
 
@@ -298,7 +298,7 @@ function AgentBuilderInner() {
           description,
           version,
           model_name: modelName,
-          supported_ides: supportedIdes,
+          models_by_ide: modelsByIde,
           components: selectedComponents,
           prompt: systemPrompt,
           draft_id: draftId,
@@ -313,7 +313,7 @@ function AgentBuilderInner() {
     return () => {
       if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
     };
-  }, [name, description, version, modelName, supportedIdes, selectedComponents, systemPrompt, draftId, isEditMode]);
+  }, [name, description, version, modelName, modelsByIde, selectedComponents, systemPrompt, draftId, isEditMode]);
 
   function restoreLocalDraft() {
     try {
@@ -324,7 +324,9 @@ function AgentBuilderInner() {
       if (draft.description) setDescription(draft.description);
       if (draft.version) setVersion(draft.version);
       if (draft.model_name) setModelName(draft.model_name);
-      if (Array.isArray(draft.supported_ides)) setSupportedIdes(draft.supported_ides);
+      if (draft.models_by_ide && typeof draft.models_by_ide === "object") {
+        setModelsByIde(draft.models_by_ide);
+      }
       if (draft.components) setSelectedComponents(draft.components);
       if (typeof draft.prompt === "string") setSystemPrompt(draft.prompt);
       if (draft.draft_id) setDraftId(draft.draft_id);
@@ -406,12 +408,6 @@ function AgentBuilderInner() {
     }));
   }, []);
 
-  function toggleTargetIde(ide: string) {
-    setSupportedIdes((prev) =>
-      prev.includes(ide) ? prev.filter((i) => i !== ide) : [...prev, ide],
-    );
-  }
-
   const handleReorder = useCallback(
     (type: string) => (items: { id: string; name: string }[]) => {
       setSelectedComponents((prev) => {
@@ -447,8 +443,7 @@ function AgentBuilderInner() {
       owner: whoami?.username || whoami?.email || "unknown",
       prompt: systemPrompt.trim(),
       model_name: modelName,
-      models_by_ide: {},
-      supported_ides: supportedIdes,
+      models_by_ide: modelsByIde,
       components: components.length > 0 ? components : [],
     };
   }
@@ -678,31 +673,10 @@ function AgentBuilderInner() {
                   <ModelPicker
                     modelName={modelName}
                     onModelNameChange={setModelName}
+                    modelsByIde={modelsByIde}
+                    onModelsByIdeChange={setModelsByIde}
                   />
                 </div>
-              </div>
-              <div className="space-y-2">
-                <Label className="text-sm font-medium">Target IDEs</Label>
-                <div className="flex flex-wrap gap-1.5">
-                  {(ideList ?? []).map((ide) => (
-                    <button
-                      key={ide.name}
-                      type="button"
-                      onClick={() => toggleTargetIde(ide.name)}
-                      className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
-                        supportedIdes.includes(ide.name)
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-muted/50 text-muted-foreground hover:bg-muted"
-                      }`}
-                    >
-                      {ide.display_name}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  Leave empty for portable agents. Pick Kiro, Claude Code, or
-                  any set when the agent is intentionally harness-specific.
-                </p>
               </div>
             </section>
 
@@ -872,7 +846,6 @@ function AgentBuilderInner() {
                   }).map(([k, v]) => [k, v])
                 )}
                 prompt={systemPrompt}
-                targetIdes={supportedIdes}
                 pendingComponentBodies={Object.fromEntries(pendingComponents.map((pc) => [pc.id, pc.body]))}
                 validationResult={validationResult}
               />

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -44,6 +44,7 @@ import {
 import { PageHeader } from "@/components/layouts/page-header";
 import { useRegistryItem, useAgentValidation, useWhoami, useSaveDraft, useUpdateDraft, useStartEdit } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
+import { useIdes } from "@/hooks/use-ides";
 import { registry, type RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
 import type { ValidationResult } from "@/lib/types";
@@ -88,6 +89,7 @@ function AgentBuilderInner() {
   const isEditMode = !!editId;
 
   const { data: whoami } = useWhoami();
+  const { data: ideList } = useIdes();
   const { data: existingAgent } = useRegistryItem("agents", editId ?? draftParam ?? undefined);
 
   const [name, setName] = useState("");
@@ -97,7 +99,7 @@ function AgentBuilderInner() {
   const [version, setVersion] = useState("1.0.0");
   const [category, setCategory] = useState("");
   const [modelName, setModelName] = useState("");
-  const [modelsByIde, setModelsByIde] = useState<Record<string, string>>({});
+  const [supportedIdes, setSupportedIdes] = useState<string[]>([]);
   const [publishing, setPublishing] = useState(false);
   const [activeTab, setActiveTab] = useState<RegistryType>("mcps");
 
@@ -155,10 +157,8 @@ function AgentBuilderInner() {
     if (typeof agentVersion === "string") setVersion(agentVersion);
     const agentModel = (existingAgent as Record<string, unknown>).model_name;
     if (typeof agentModel === "string") setModelName(agentModel);
-    const agentModelsByIde = (existingAgent as Record<string, unknown>).models_by_ide;
-    if (agentModelsByIde && typeof agentModelsByIde === "object" && !Array.isArray(agentModelsByIde)) {
-      setModelsByIde(agentModelsByIde as Record<string, string>);
-    }
+    const agentSupportedIdes = (existingAgent as Record<string, unknown>).supported_ides;
+    if (Array.isArray(agentSupportedIdes)) setSupportedIdes(agentSupportedIdes as string[]);
     const agentCategory = (existingAgent as Record<string, unknown>).category;
     if (typeof agentCategory === "string") setCategory(agentCategory);
 
@@ -286,6 +286,7 @@ function AgentBuilderInner() {
 
     autoSaveTimerRef.current = setTimeout(() => {
       const hasContent = name || description || modelName || version !== "1.0.0" ||
+        supportedIdes.length > 0 ||
         Object.values(selectedComponents).some((items) => items.length > 0) ||
         systemPrompt.trim().length > 0;
 
@@ -297,7 +298,7 @@ function AgentBuilderInner() {
           description,
           version,
           model_name: modelName,
-          models_by_ide: modelsByIde,
+          supported_ides: supportedIdes,
           components: selectedComponents,
           prompt: systemPrompt,
           draft_id: draftId,
@@ -312,7 +313,7 @@ function AgentBuilderInner() {
     return () => {
       if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
     };
-  }, [name, description, version, modelName, selectedComponents, systemPrompt, draftId, isEditMode]);
+  }, [name, description, version, modelName, supportedIdes, selectedComponents, systemPrompt, draftId, isEditMode]);
 
   function restoreLocalDraft() {
     try {
@@ -323,9 +324,7 @@ function AgentBuilderInner() {
       if (draft.description) setDescription(draft.description);
       if (draft.version) setVersion(draft.version);
       if (draft.model_name) setModelName(draft.model_name);
-      if (draft.models_by_ide && typeof draft.models_by_ide === "object") {
-        setModelsByIde(draft.models_by_ide);
-      }
+      if (Array.isArray(draft.supported_ides)) setSupportedIdes(draft.supported_ides);
       if (draft.components) setSelectedComponents(draft.components);
       if (typeof draft.prompt === "string") setSystemPrompt(draft.prompt);
       if (draft.draft_id) setDraftId(draft.draft_id);
@@ -407,7 +406,11 @@ function AgentBuilderInner() {
     }));
   }, []);
 
-
+  function toggleTargetIde(ide: string) {
+    setSupportedIdes((prev) =>
+      prev.includes(ide) ? prev.filter((i) => i !== ide) : [...prev, ide],
+    );
+  }
 
   const handleReorder = useCallback(
     (type: string) => (items: { id: string; name: string }[]) => {
@@ -444,7 +447,8 @@ function AgentBuilderInner() {
       owner: whoami?.username || whoami?.email || "unknown",
       prompt: systemPrompt.trim(),
       model_name: modelName,
-      models_by_ide: modelsByIde,
+      models_by_ide: {},
+      supported_ides: supportedIdes,
       components: components.length > 0 ? components : [],
     };
   }
@@ -674,10 +678,31 @@ function AgentBuilderInner() {
                   <ModelPicker
                     modelName={modelName}
                     onModelNameChange={setModelName}
-                    modelsByIde={modelsByIde}
-                    onModelsByIdeChange={setModelsByIde}
                   />
                 </div>
+              </div>
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Target IDEs</Label>
+                <div className="flex flex-wrap gap-1.5">
+                  {(ideList ?? []).map((ide) => (
+                    <button
+                      key={ide.name}
+                      type="button"
+                      onClick={() => toggleTargetIde(ide.name)}
+                      className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                        supportedIdes.includes(ide.name)
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted/50 text-muted-foreground hover:bg-muted"
+                      }`}
+                    >
+                      {ide.display_name}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Leave empty for portable agents. Pick Kiro, Claude Code, or
+                  any set when the agent is intentionally harness-specific.
+                </p>
               </div>
             </section>
 
@@ -847,6 +872,7 @@ function AgentBuilderInner() {
                   }).map(([k, v]) => [k, v])
                 )}
                 prompt={systemPrompt}
+                targetIdes={supportedIdes}
                 pendingComponentBodies={Object.fromEntries(pendingComponents.map((pc) => [pc.id, pc.body]))}
                 validationResult={validationResult}
               />

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -609,7 +609,7 @@ function AgentBuilderInner() {
                   <p className="text-sm text-destructive">{nameError}</p>
                 )}
               </div>
-              <div className="space-y-2">
+              <div className="space-y-2 max-w-3xl">
                 <Label
                   htmlFor="agent-description"
                   className="text-sm font-medium"
@@ -623,11 +623,11 @@ function AgentBuilderInner() {
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   rows={3}
-                  className="max-w-lg resize-y"
+                  className="resize-y"
                 />
               </div>
-              <div className="flex gap-4">
-                <div className="space-y-2 flex-1 max-w-[200px]">
+              <div className="grid gap-4 max-w-3xl sm:grid-cols-2">
+                <div className="space-y-2">
                   <Label htmlFor="agent-version" className="text-sm font-medium">
                     Version
                   </Label>
@@ -638,7 +638,7 @@ function AgentBuilderInner() {
                     onChange={(e) => setVersion(e.target.value)}
                   />
                 </div>
-                <div className="space-y-2 flex-1 max-w-[200px]">
+                <div className="space-y-2">
                   <Label htmlFor="agent-category" className="text-sm font-medium">
                     Category
                   </Label>
@@ -669,14 +669,14 @@ function AgentBuilderInner() {
                     </SelectContent>
                   </Select>
                 </div>
-                <div className="flex-1">
-                  <ModelPicker
-                    modelName={modelName}
-                    onModelNameChange={setModelName}
-                    modelsByIde={modelsByIde}
-                    onModelsByIdeChange={setModelsByIde}
-                  />
-                </div>
+              </div>
+              <div className="max-w-3xl">
+                <ModelPicker
+                  modelName={modelName}
+                  onModelNameChange={setModelName}
+                  modelsByIde={modelsByIde}
+                  onModelsByIdeChange={setModelsByIde}
+                />
               </div>
             </section>
 

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
-import { Link, useParams } from "@tanstack/react-router";
+import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import {
   ArrowDownToLine,
   Puzzle,
@@ -40,6 +40,7 @@ import {
   useGenerateInsight,
   useInsightsStatus,
   useArchiveAgent,
+  useDeleteAgent,
   useUnarchiveAgent,
 } from "@/hooks/use-api";
 import { getUserRole } from "@/lib/api";
@@ -359,10 +360,10 @@ function AgentVersionContents({
 
 function AgentDeleteButton({ agentId, agentName, onSuccess }: { agentId: string; agentName: string; onSuccess: () => void }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const archiveMutation = useArchiveAgent();
+  const deleteMutation = useDeleteAgent();
 
   function submit() {
-    archiveMutation.mutate(agentId, {
+    deleteMutation.mutate(agentId, {
       onSuccess: () => {
         setConfirmOpen(false);
         onSuccess();
@@ -372,7 +373,7 @@ function AgentDeleteButton({ agentId, agentName, onSuccess }: { agentId: string;
 
   return (
     <>
-      <Button variant="destructive" size="sm" className="h-8" onClick={() => setConfirmOpen(true)} disabled={archiveMutation.isPending}>
+      <Button variant="destructive" size="sm" className="h-8" onClick={() => setConfirmOpen(true)} disabled={deleteMutation.isPending}>
         <Trash2 className="mr-1 h-3.5 w-3.5" />
         Delete
       </Button>
@@ -383,12 +384,12 @@ function AgentDeleteButton({ agentId, agentName, onSuccess }: { agentId: string;
             <DialogTitle>Delete {agentName}?</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            This archives the agent and hides it from registry lists. It can be restored later.
+            This soft deletes the agent, hides it from registry lists, and frees the name for reuse.
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>Cancel</Button>
-            <Button variant="destructive" onClick={submit} disabled={archiveMutation.isPending}>
-              {archiveMutation.isPending ? <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Deleting...</> : "Delete"}
+            <Button variant="destructive" onClick={submit} disabled={deleteMutation.isPending}>
+              {deleteMutation.isPending ? <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Deleting...</> : "Delete"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -597,6 +598,7 @@ function InsightsTab({ agentId, agentVersion }: { agentId: string; agentVersion?
 
 export default function AgentDetailPage() {
   const { agentId: id } = useParams({ from: "/_authed/agents/$agentId" });
+  const navigate = useNavigate();
   const {
     data: agent,
     isLoading,
@@ -1047,7 +1049,7 @@ export default function AgentDetailPage() {
                       <div className="flex flex-wrap gap-2">
                         <AgentArchiveButton agentId={id} agentName={agentName} status={agentStatus} onSuccess={() => refetch()} />
                         {agentStatus === "approved" && (
-                          <AgentDeleteButton agentId={id} agentName={agentName} onSuccess={() => refetch()} />
+                          <AgentDeleteButton agentId={id} agentName={agentName} onSuccess={() => navigate({ to: "/agents" })} />
                         )}
                       </div>
                     </div>

--- a/web/src/pages/registry/agents/index.tsx
+++ b/web/src/pages/registry/agents/index.tsx
@@ -30,7 +30,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useRegistryList, useMyAgents, useArchivedAgents, useWhoami, useArchiveAgent, useUnarchiveAgent, useSubmitDraft } from "@/hooks/use-api";
+import { useRegistryList, useMyAgents, useArchivedAgents, useDeletedAgents, useWhoami, useArchiveAgent, useUnarchiveAgent, useDeleteAgent, useRestoreDeletedAgent, useSubmitDraft } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import {
@@ -68,24 +68,16 @@ const roleSub = (cb: () => void) => {
 
 function DeleteAgentButton({ agent }: { agent: RegistryItem }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const qc = useQueryClient();
+  const deleteMutation = useDeleteAgent();
   const { data: whoami } = useWhoami();
   const isAdmin = useSyncExternalStore(roleSub, () => hasMinRole(getUserRole(), "admin"), () => false);
   const canDelete = isAdmin || (whoami?.id && agent.created_by && whoami.id === String(agent.created_by));
 
   async function handleDelete(e: React.MouseEvent) {
     e.stopPropagation();
-    setDeleting(true);
-    try {
-      await registry.delete("agents", agent.id);
-      qc.invalidateQueries({ queryKey: ["registry", "agents"] });
-      toast.success("Agent deleted");
-      setConfirmOpen(false);
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to delete");
-      setDeleting(false);
-    }
+    deleteMutation.mutate(agent.id, {
+      onSuccess: () => setConfirmOpen(false),
+    });
   }
 
   if (!canDelete) return null;
@@ -117,12 +109,12 @@ function DeleteAgentButton({ agent }: { agent: RegistryItem }) {
             <DialogTitle>Delete {agent.name}?</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            This will permanently delete this agent. This action cannot be undone.
+            This soft deletes the agent, hides it from registry lists, and frees the name for reuse.
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>Cancel</Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
-              {deleting ? "Deleting..." : "Delete"}
+            <Button variant="destructive" onClick={handleDelete} disabled={deleteMutation.isPending}>
+              {deleteMutation.isPending ? "Deleting..." : "Delete"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -188,6 +180,23 @@ function ArchiveAgentButton({ agent }: { agent: RegistryItem }) {
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function RestoreDeletedAgentButton({ agent }: { agent: RegistryItem }) {
+  const restoreMutation = useRestoreDeletedAgent();
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="h-7 text-xs"
+      onClick={() => restoreMutation.mutate({ id: agent.id })}
+      disabled={restoreMutation.isPending}
+    >
+      <ArchiveRestore className="mr-1 h-3 w-3" />
+      {restoreMutation.isPending ? "Restoring..." : "Restore"}
+    </Button>
   );
 }
 
@@ -429,9 +438,11 @@ function AgentListContent() {
   const { data: myAgents } = useMyAgents();
   const isAdmin = useSyncExternalStore(roleSub, () => hasMinRole(getUserRole(), "admin"), () => false);
   const { data: allArchivedAgents } = useArchivedAgents(isAdmin);
+  const { data: deletedAgents = [] } = useDeletedAgents();
   const submitDraft = useSubmitDraft();
   const [draftsExpanded, setDraftsExpanded] = useState(true);
   const [archivedExpanded, setArchivedExpanded] = useState(false);
+  const [deletedExpanded, setDeletedExpanded] = useState(false);
   const [deletingDraftId, setDeletingDraftId] = useState<string | null>(null);
   const qc = useQueryClient();
 
@@ -665,6 +676,62 @@ function AgentListContent() {
                     <div className="flex items-center gap-2 shrink-0">
                       <UnarchiveAgentButton agent={agent} />
                       <DeleteAgentButton agent={agent} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Deleted */}
+        {deletedAgents.length > 0 && (
+          <div className="rounded-lg border border-border bg-card">
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm font-medium hover:bg-accent/40 transition-colors rounded-t-lg"
+              onClick={() => setDeletedExpanded((prev) => !prev)}
+            >
+              {deletedExpanded ? (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              )}
+              <Trash2 className="h-4 w-4 text-muted-foreground" />
+              Deleted
+              <span className="ml-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
+                {deletedAgents.length}
+              </span>
+            </button>
+            {deletedExpanded && (
+              <div className="divide-y divide-border border-t">
+                {deletedAgents.map((agent) => (
+                  <div key={agent.id} className="flex items-center gap-4 px-4 py-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-sm font-medium">{agent.name}</p>
+                        <StatusBadge status="deleted" />
+                      </div>
+                      {agent.description && (
+                        <p className="truncate text-xs text-muted-foreground mt-0.5">
+                          {agent.description}
+                        </p>
+                      )}
+                      <div className="flex items-center gap-2 mt-1">
+                        {isAdmin && ((agent.created_by_email as string) || (agent.created_by_username as string)) && (
+                          <p className="text-[11px] text-muted-foreground">
+                            by {(agent.created_by_username as string) || (agent.created_by_email as string)}
+                          </p>
+                        )}
+                        {typeof agent.deleted_at === "string" && (
+                          <p className="text-[11px] text-muted-foreground">
+                            deleted {new Date(agent.deleted_at).toLocaleDateString()}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <RestoreDeletedAgentButton agent={agent} />
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Purpose / Description
Improve agent authoring, harness previews, and agent deletion semantics.

Agent authors can now enter harness-specific model strings without relying on models.dev values, set per harness model overrides from the allowed IDE list, and see previews generated by the same server path used for install. Agent deletion is now a reversible soft delete that frees names for reuse.

## Fixes
* Fixes: None

## Approach
- Replaced the builder model select with a plain model string input so users can enter the exact value accepted by each harness.
- Removed models.dev dropdown usage from the agent builder model picker.
- Restored per harness model overrides using the server-provided IDE list and default IDE ordering.
- Show all available harnesses in the per harness override selector, with unsupported model-choice harnesses disabled in the input.
- Removed target IDE controls from agent create and edit.
- Tightened the agent builder form layout so metadata and model controls do not leave a large awkward gap.
- Updated the inline preview to use server-generated config instead of client-side hardcoded harness templates.
- Removed rate limiting from preview config and now include every configured IDE, including Copilot CLI.
- Updated Cursor generation to emit `.cursor/agents/<name>.md` subagent files instead of treating Observal agents as Cursor rules.
- Updated Codex preview and install output to use custom agent TOML files under `.codex/agents/` or `~/.codex/agents/` instead of `AGENTS.md`.
- Updated Copilot VS Code output to use `.github/agents/<name>.agent.md` custom agent profiles with `target: vscode`.
- Updated Copilot CLI metadata to use `.github/agents/<name>.agent.md` custom agent profile paths.
- Updated Antigravity to generate global CLI agent files at `~/.gemini/antigravity-cli/agents/<name>/agent.json`.
- Updated Antigravity global config paths for MCP, skills, and hooks under `~/.gemini/config/`.
- Added `agents.deleted_at`, a partial active-name unique index, and deleted agent restore support.
- Changed agent delete to soft delete, hide deleted agents from default routes, and allow owner or admin restore when the name is free.

No hard-to-understand code paths were added, so no extra inline comments were needed.

## How Has This Been Tested?

Ran:

```bash
pnpm -C web typecheck
pnpm -C web lint
cd observal-server && uv run ruff check models/agent.py schemas/agent.py api/routes/agent/crud.py api/routes/agent/helpers.py alembic/versions/1caa45d85720_soft_delete_agents.py ../tests/test_global_unique_names.py ../tests/test_integration.py ../tests/test_agent_name_lookup.py ../tests/test_agent_review.py ../tests/test_sec027_registry_sc.py ../tests/test_draft_workflow.py
cd observal-server && uv run pytest ../tests/test_global_unique_names.py ../tests/test_agent_name_lookup.py ../tests/test_agent_review.py ../tests/test_sec027_registry_sc.py ../tests/test_draft_workflow.py ../tests/test_integration.py::TestAgentLifecycle -q
cd observal-server && uv run pytest ../tests/test_ide_config_e2e.py::TestGenerateCodexConfig ../tests/test_ide_config_e2e.py::TestPullCodex ../tests/test_ide_config_e2e.py::TestPullDryRunAllIdes ../tests/test_agent_config_generator.py::TestGenerateCodex ../tests/test_agent_config_generator.py::TestBuilderCodex ../tests/test_agent_composition.py ../tests/test_pull_and_agent_cli.py::TestPullCodex ../tests/test_cli_ide_adapters.py ../tests/test_model_registry.py::TestBuilderModelEmission::test_codex_toml_carries_model -q
cd observal-server && REDIS_URL=memory:// uv run pytest ../tests/test_preview_config.py -q
cd observal-server && uv run pytest ../tests/test_agent_config_generator.py::TestGenerateCopilot ../tests/test_agent_config_generator.py::TestBuilderCopilot ../tests/test_ide_config_e2e.py::TestGenerateCopilotConfig ../tests/test_ide_config_e2e.py::TestGenerateCopilotCliConfig ../tests/test_agent_composition.py::TestGenerateIdeAgentFiles::test_copilot_generates_agent_md ../tests/test_antigravity_adapter.py ../tests/test_constants_sync.py -q
```

Latest UI and Antigravity check:

```bash
pnpm -C web typecheck
pnpm -C web lint
cd observal-server && uv run ruff check services/ide/antigravity.py schemas/ide_registry.py ../observal_cli/ide/antigravity.py ../observal_cli/ide_registry.py ../tests/test_antigravity_adapter.py
cd observal-server && uv run pytest ../tests/test_antigravity_adapter.py ../tests/test_constants_sync.py -q
cd observal-server && REDIS_URL=memory:// uv run pytest ../tests/test_preview_config.py -q
```

Results:

- Web typecheck passed.
- Web lint passed.
- Ruff passed.
- Agent lifecycle and access tests passed, 38 passed and 2 skipped.
- Targeted harness tests passed, 175 tests.
- Preview config tests passed, 7 tests.
- Latest Antigravity and constants tests passed, 36 tests.

UI screenshots were not captured. The user will add screenshots if required.

## Learning (optional, can help others)
Cursor documentation confirms:

- Project rules are `.cursor/rules/*.mdc` files.
- Custom agents are Cursor subagents in `.cursor/agents/*.md`.
- Skills are loaded from `.cursor/skills/<name>/SKILL.md`.

Codex documentation confirms:

- Project guidance uses `AGENTS.md`.
- Custom agents use TOML files in `~/.codex/agents/` or `.codex/agents/`.

Copilot documentation confirms:

- VS Code custom agents use `.agent.md` files under `.github/agents/`.
- Copilot CLI custom agents use `.agent.md` files under `.github/agents/` or `~/.copilot/agents/`.
- Copilot CLI MCP user config is `~/.copilot/mcp-config.json`.

Antigravity documentation and CLI output confirm:

- Global CLI agents live under `~/.gemini/antigravity-cli/agents/<agent-name>/agent.json`.
- Project skills live under `.agents/skills/`.
- Global skills live under `~/.gemini/config/skills/`.
- Global MCP config lives under `~/.gemini/config/mcp_config.json`.
- Hooks live in `.agents/hooks.json` or `~/.gemini/config/hooks.json`.

Models.dev remains in the codebase for `/api/v1/models`, admin diagnostics, CLI model catalog lookup, and model validation/formatting services. It is no longer used as the agent builder dropdown source. LiteLLM insights use the configured insights model string and do not directly depend on the builder dropdown.

References:

- https://cursor.com/docs/rules
- https://cursor.com/docs/subagents.md
- https://cursor.com/docs/skills
- https://developers.openai.com/codex/subagents
- https://code.visualstudio.com/docs/agent-customization/custom-agents
- https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli
- https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
- https://codelabs.developers.google.com/getting-started-google-antigravity

<img width="1931" height="1362" alt="image" src="https://github.com/user-attachments/assets/858679b8-f12d-4e6d-b5ce-82c757287da3" />


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
