### PR TITLE
fix(pull): propagate MCP auth headers during agent pull

### DIFF
--- a/observal-server/api/routes/agent/install.py
+++ b/observal-server/api/routes/agent/install.py
@@ -191,6 +191,7 @@ async def install_agent(
         mcp_listings=mcp_listings_map,
         component_names=name_map,
         env_values=req.env_values,
+        header_values=req.header_values,
         options=install_options,
         platform=req.platform,
         skill_listings=skill_listings_map,

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -208,6 +208,7 @@ class ValidationResult(BaseModel):
 class AgentInstallRequest(BaseModel):
     harness: str
     env_values: dict[str, dict[str, str]] = {}  # {mcp_listing_id: {VAR: value}}
+    header_values: dict[str, dict[str, str]] = {}  # {mcp_listing_id: {Header-Name: value}}
     # harness-specific install options (e.g. scope, model, tools, color for Claude Code)
     options: dict = {}
     platform: str = ""  # e.g. "win32", "darwin", "linux" - empty = Unix default

--- a/observal-server/services/harness/__init__.py
+++ b/observal-server/services/harness/__init__.py
@@ -75,6 +75,7 @@ def generate_agent_config(
     mcp_listings: dict | None = None,
     component_names: dict | None = None,
     env_values: dict | None = None,
+    header_values: dict | None = None,
     options: dict | None = None,
     platform: str = "",
     skill_listings: dict | None = None,
@@ -99,7 +100,9 @@ def generate_agent_config(
     )
 
     safe_name = _sanitize_name(agent.name)
-    mcp_configs = _build_mcp_configs(agent, harness, observal_url, mcp_listings=mcp_listings, env_values=env_values)
+    mcp_configs = _build_mcp_configs(
+        agent, harness, observal_url, mcp_listings=mcp_listings, env_values=env_values, header_values=header_values
+    )
 
     if sandbox_listings:
         sandbox_mcp = _build_sandbox_mcp_entry(sandbox_listings, harness)

--- a/observal-server/services/harness/claude_code.py
+++ b/observal-server/services/harness/claude_code.py
@@ -34,10 +34,14 @@ class ClaudeCodeAdapter:
         setup_commands = []
         claude_mcps = {}
         for name, cfg in mcp_configs.items():
-            cmd = cfg.get("command", "observal-shim")
-            args = cfg.get("args", [])
-            setup_commands.append(["claude", "mcp", "add", name, "--", cmd, *args])
-            claude_mcps[name] = {"command": cmd, "args": args, "env": cfg.get("env", {})}
+            if cfg.get("url") or cfg.get("type") in ("sse", "streamable-http"):
+                # SSE/streamable-http entry: preserve as-is (url, headers, env)
+                claude_mcps[name] = cfg
+            else:
+                cmd = cfg.get("command", "observal-shim")
+                args = cfg.get("args", [])
+                setup_commands.append(["claude", "mcp", "add", name, "--", cmd, *args])
+                claude_mcps[name] = {"command": cmd, "args": args, "env": cfg.get("env", {})}
 
         scope = options.get("scope", HARNESS_REGISTRY["claude-code"]["default_scope"])
         tools = options.get("tools", "")

--- a/observal-server/services/harness/helpers.py
+++ b/observal-server/services/harness/helpers.py
@@ -482,6 +482,7 @@ def _build_mcp_configs(
     observal_url: str,
     mcp_listings: dict | None = None,
     env_values: dict | None = None,
+    header_values: dict | None = None,
 ) -> dict:
     """Build MCP server configs from registry components + external MCPs.
 
@@ -491,10 +492,13 @@ def _build_mcp_configs(
             pre-loads these to avoid N+1 queries in a sync context.
         env_values: optional {mcp_listing_id_str: {VAR: value}} map of user-supplied
             environment variable values for each MCP.
+        header_values: optional {mcp_listing_id_str: {Header-Name: value}} map of
+            user-supplied header values for each MCP (e.g. Authorization tokens).
     """
     mcp_configs = {}
     mcp_listings = mcp_listings or {}
     env_values = env_values or {}
+    header_values = header_values or {}
 
     optic.debug(
         "building MCP configs for agent '{}' (ide={}, {} components)",
@@ -510,7 +514,10 @@ def _build_mcp_configs(
         if not listing:
             continue
         mcp_env = env_values.get(str(listing.id), {})
-        cfg = generate_config(listing, harness, observal_url=observal_url, env_values=mcp_env)
+        mcp_headers = header_values.get(str(listing.id), {})
+        cfg = generate_config(
+            listing, harness, observal_url=observal_url, env_values=mcp_env, header_values=mcp_headers
+        )
         if "mcpServers" in cfg:
             mcp_configs.update(cfg["mcpServers"])
         elif "mcp" in cfg:
@@ -524,6 +531,8 @@ def _build_mcp_configs(
             if listing.url:
                 # SSE/streamable-http listing - no shim needed
                 entry: dict = {"type": (listing.transport or "sse").lower(), "url": listing.url}
+                if mcp_headers:
+                    entry["headers"] = mcp_headers
                 if mcp_env:
                     entry["env"] = mcp_env
                 if listing.auto_approve:

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -192,6 +192,82 @@ def _collect_mcp_env_vars(
     return env_values
 
 
+def _collect_mcp_headers(
+    agent_detail: dict, *, no_prompt: bool = False, header_overrides: dict[str, str] | None = None
+) -> dict[str, dict[str, str]]:
+    """Discover MCP headers from agent components and prompt the user for values.
+
+    When *no_prompt* is True, uses values from *header_overrides* for known headers
+    and skips prompting entirely. Missing headers are omitted.
+
+    Returns {mcp_listing_id: {Header-Name: value}} for all MCPs that have headers.
+    """
+    optic.trace("agent_detail={}", agent_detail)
+    header_values: dict[str, dict[str, str]] = {}
+    _overrides = header_overrides or {}
+
+    # Collect MCP component IDs from both mcp_links and component_links
+    mcp_ids: list[tuple[str, str]] = []
+    for link in agent_detail.get("mcp_links", []):
+        mcp_ids.append((str(link["mcp_listing_id"]), link.get("mcp_name", "")))
+    for link in agent_detail.get("component_links", []):
+        if link.get("component_type") == "mcp":
+            cid = str(link["component_id"])
+            if not any(mid == cid for mid, _ in mcp_ids):
+                mcp_ids.append((cid, link.get("component_name", "")))
+
+    if not mcp_ids:
+        return header_values
+
+    for listing_id, display_name in mcp_ids:
+        try:
+            listing = client.get(f"/api/v1/mcps/{listing_id}")
+        except (Exception, SystemExit):
+            continue
+
+        header_list = listing.get("headers") or []
+        if not header_list:
+            continue
+
+        required = [h for h in header_list if h.get("required", True)]
+        optional = [h for h in header_list if not h.get("required", True)]
+        mcp_name = display_name or listing.get("name", listing_id[:8])
+        mcp_hdrs: dict[str, str] = {}
+
+        if no_prompt:
+            for h in required + optional:
+                if h["name"] in _overrides:
+                    mcp_hdrs[h["name"]] = _overrides[h["name"]]
+        else:
+            if required:
+                rprint(f"\n[bold]{mcp_name}[/bold] requires {len(required)} header(s):")
+                for h in required:
+                    if h["name"] in _overrides:
+                        mcp_hdrs[h["name"]] = _overrides[h["name"]]
+                        rprint(f"  [green]\u2713[/green] {h['name']} [dim](from --header)[/dim]")
+                    else:
+                        desc = f" [dim]({h['description']})[/dim]" if h.get("description") else ""
+                        val = text_input(f"  {h['name']}{desc}")
+                        mcp_hdrs[h["name"]] = val
+
+            if optional:
+                rprint(f"\n[dim]{mcp_name}: {len(optional)} optional header(s):[/dim]")
+                for h in optional:
+                    if h["name"] in _overrides:
+                        mcp_hdrs[h["name"]] = _overrides[h["name"]]
+                        rprint(f"  [green]\u2713[/green] {h['name']} [dim](from --header)[/dim]")
+                    else:
+                        desc = f" [dim]({h['description']})[/dim]" if h.get("description") else ""
+                        val = text_input(f"  {h['name']}{desc} (press Enter to skip)", default="")
+                        if val:
+                            mcp_hdrs[h["name"]] = val
+
+        if mcp_hdrs:
+            header_values[listing_id] = mcp_hdrs
+
+    return header_values
+
+
 def _dict_to_toml(d: dict) -> str:
     """Very basic TOML serializer for MCP configs."""
     optic.trace("d={}", d)
@@ -478,6 +554,9 @@ def register_pull(app: typer.Typer):
         env: list[str] | None = typer.Option(
             None, "--env", "-e", help="MCP environment variable (KEY=VALUE, repeatable)"
         ),
+        header: list[str] | None = typer.Option(
+            None, "--header", "-H", help="MCP header value (Header-Name=value, repeatable)"
+        ),
         version: str | None = typer.Option(
             None, "--version", "-V", help="Install a specific version (e.g. '1.2.0'). Defaults to latest."
         ),
@@ -489,8 +568,9 @@ def register_pull(app: typer.Typer):
         directory.  Use --dry-run to preview without writing.
 
         Use --env KEY=VALUE to pass MCP environment variables non-interactively
-        (repeatable). When --no-prompt is set, env var prompts are skipped and
-        only values from --env flags are used.
+        (repeatable). Use --header Header-Name=value to pass MCP auth headers
+        non-interactively (repeatable). When --no-prompt is set, env var and
+        header prompts are skipped and only values from flags are used.
 
         Examples:
           observal agent pull my-agent --harness claude-code --no-prompt
@@ -498,6 +578,7 @@ def register_pull(app: typer.Typer):
           observal agent pull my-agent --harness kiro --no-prompt --scope user
           observal agent pull my-agent --harness cursor --no-prompt --dry-run
           observal agent pull my-agent --harness kiro --no-prompt --env API_KEY=sk-123 --env SECRET=abc
+          observal agent pull my-agent --harness cursor --header Authorization="Bearer sk-123"
         """
         resolved = config.resolve_alias(agent_id)
         target_dir = Path(directory).resolve()
@@ -509,11 +590,21 @@ def register_pull(app: typer.Typer):
             if k:
                 env_overrides[k.strip()] = v
 
+        # Parse --header flags into overrides dict
+        header_overrides: dict[str, str] = {}
+        for item in header or []:
+            k, _, v = item.partition("=")
+            if k:
+                header_overrides[k.strip()] = v
+
         # Fetch agent details to discover MCP env vars
         with spinner("Fetching agent details..."):
             agent_detail = client.get(f"/api/v1/agents/{resolved}")
 
         env_values = _collect_mcp_env_vars(agent_detail, no_prompt=no_prompt, env_overrides=env_overrides or None)
+        header_values = _collect_mcp_headers(
+            agent_detail, no_prompt=no_prompt, header_overrides=header_overrides or None
+        )
 
         rprint(f"\n[bold]Install options for [cyan]{harness}[/cyan]:[/bold]")
         if refresh_models:
@@ -539,6 +630,7 @@ def register_pull(app: typer.Typer):
             install_body: dict = {
                 "harness": harness,
                 "env_values": env_values,
+                "header_values": header_values,
                 "options": options,
                 "platform": sys.platform,
             }

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -35,11 +35,13 @@ observal agent pull AGENT_NAME --harness kiro --no-prompt --dir .
 ```
 
 **Flags:**
-- `--harness` (required): `claude-code`, `kiro`, `cursor`, `gemini-cli`, `vscode`, `codex`, `copilot`, `copilot-cli`, `opencode`
+- `--harness` (required): `claude-code`, `kiro`, `cursor`, `gemini-cli`, `vscode`, `codex`, `copilot`, `copilot-cli`, `opencode`, `antigravity`, `pi`
 - `--version <semver>`: install a specific version (e.g. `1.2.0`). Omit for latest.
 - `--scope user|project`: install scope (Claude Code, Kiro, Gemini only)
 - `--model <name>` or `--model <harness>=<name>`: override saved model (repeatable)
 - `--tools t1,t2`: Claude Code tool whitelist
+- `--env KEY=VALUE`: MCP environment variable value (repeatable)
+- `--header Header-Name=VALUE`: MCP auth header value (repeatable)
 - `--dry-run`: preview file writes without touching disk
 - `--no-prompt`: skip interactive confirmation
 - `--dir <path>`: target directory (default: current)

--- a/tests/test_agent_config_generator.py
+++ b/tests/test_agent_config_generator.py
@@ -572,6 +572,13 @@ class TestMcpListingClaudeCodeFallback:
         listing = MagicMock()
         listing.name = "my-mcp"
         listing.id = comp_id
+        listing.url = None
+        listing.command = "npx"
+        listing.args = ["-y", "my-mcp"]
+        listing.framework = None
+        listing.docker_image = None
+        listing.auto_approve = None
+        listing.environment_variables = []
 
         comp = _make_component("mcp", comp_id)
         agent = _make_agent(components=[comp])

--- a/tests/test_harness_config_e2e.py
+++ b/tests/test_harness_config_e2e.py
@@ -1220,3 +1220,88 @@ class TestCodexInstallCliPathHint:
         # Find the harness_config_paths dict in the install function's source
         source = inspect.getsource(cmd_mcp_module)
         assert '"codex": "~/.codex/config.toml"' in source or "'codex': '~/.codex/config.toml'" in source
+
+
+class TestMcpAuthHeadersInAgentPull:
+    """Verify that MCP header_values propagate through generate_agent_config."""
+
+    def _make_sse_listing(self, listing_id):
+        listing = MagicMock()
+        listing.id = listing_id
+        listing.name = "auth-mcp"
+        listing.url = "https://api.example.com/mcp"
+        listing.transport = "sse"
+        listing.command = None
+        listing.args = None
+        listing.framework = None
+        listing.docker_image = None
+        listing.auto_approve = None
+        listing.environment_variables = []
+        return listing
+
+    def test_header_values_included_in_cursor_config(self):
+        """header_values should appear in mcpServers config for Cursor."""
+        listing_id = uuid.uuid4()
+        agent = _make_agent(
+            components=[_make_component("mcp", listing_id)],
+        )
+        listing = self._make_sse_listing(listing_id)
+        header_vals = {str(listing_id): {"Authorization": "Bearer sk-test-123"}}
+
+        config = generate_agent_config(
+            agent,
+            "cursor",
+            mcp_listings={listing_id: listing},
+            header_values=header_vals,
+        )
+
+        mcp_content = config["mcp_config"]["content"]
+        servers = mcp_content.get("mcpServers", {})
+        assert "auth-mcp" in servers
+        entry = servers["auth-mcp"]
+        assert entry.get("headers") == {"Authorization": "Bearer sk-test-123"}
+
+    def test_header_values_included_in_claude_code_config(self):
+        """header_values should appear in mcpServers config for Claude Code."""
+        listing_id = uuid.uuid4()
+        agent = _make_agent(
+            components=[_make_component("mcp", listing_id)],
+        )
+        listing = self._make_sse_listing(listing_id)
+        header_vals = {str(listing_id): {"Authorization": "Bearer sk-test-456"}}
+
+        config = generate_agent_config(
+            agent,
+            "claude-code",
+            mcp_listings={listing_id: listing},
+            header_values=header_vals,
+        )
+
+        # Claude Code SSE MCPs go in mcp_config directly
+        mcp_servers = config["mcp_config"]
+        assert "auth-mcp" in mcp_servers
+        entry = mcp_servers["auth-mcp"]
+        assert entry.get("headers") == {"Authorization": "Bearer sk-test-456"}
+        assert entry.get("type") == "sse"
+        assert entry.get("url") == "https://api.example.com/mcp"
+
+    def test_no_headers_when_header_values_empty(self):
+        """No headers key emitted when header_values is empty."""
+        listing_id = uuid.uuid4()
+        agent = _make_agent(
+            components=[_make_component("mcp", listing_id)],
+        )
+        listing = self._make_sse_listing(listing_id)
+
+        config = generate_agent_config(
+            agent,
+            "cursor",
+            mcp_listings={listing_id: listing},
+            header_values={},
+        )
+
+        mcp_content = config["mcp_config"]["content"]
+        servers = mcp_content.get("mcpServers", {})
+        assert "auth-mcp" in servers
+        entry = servers["auth-mcp"]
+        assert "headers" not in entry


### PR DESCRIPTION
## Purpose / Description

When pulling an agent via `observal pull`, MCP servers with SSE/HTTP transport that require Authorization headers (or other custom headers) were silently dropped. The `headers` field was never collected from the user, never sent in the install request, and never passed through the config generation pipeline. This meant any MCP with env-variable-based auth in its Authorization block would produce a broken config on pull.

## Fixes

* Fixes MCP auth header env variable not being pulled into server.json

## Approach

The fix threads `header_values` through the entire agent install pipeline (mirroring how `env_values` already works):

1. **Schema**: Added `header_values: dict[str, dict[str, str]]` to `AgentInstallRequest`
2. **Server orchestrator**: `generate_agent_config` and `_build_mcp_configs` now accept and forward `header_values` to `generate_config`
3. **Claude Code adapter**: Fixed SSE/streamable-http entries to be preserved as-is instead of being wrapped in command-based format (which lost `url`, `type`, and `headers` fields)
4. **CLI**: Added `_collect_mcp_headers()` function that prompts users for required/optional headers at pull time (same UX pattern as env var collection), and a `--header/-H` flag for non-interactive use

## How Has This Been Tested?

- Added 3 new tests in `test_ide_config_e2e.py::TestMcpAuthHeadersInAgentPull`:
  - `test_header_values_included_in_cursor_config`: verifies headers appear in Cursor mcpServers output
  - `test_header_values_included_in_claude_code_config`: verifies headers appear in Claude Code mcp_config output with correct SSE structure
  - `test_no_headers_when_header_values_empty`: verifies no `headers` key emitted when none are provided
- Full test suite passes (228 tests across pull, IDE config, and CLI adapter tests)
- Ruff lint and format checks pass on all modified files

## Learning (optional, can help others)

The `generate_config` function already supported `header_values` for individual MCP installs (`POST /mcps/{id}/install`). The gap was that the agent-level install path (`POST /agents/{id}/install`) never collected or forwarded them. The Claude Code adapter also had a secondary bug where it converted all MCP entries to command-based format, losing SSE-specific fields.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes (Pi coding agent)
- [x] Was the generated code manually reviewed and tested?