### PR TITLE
feat(auth): add self registration

### DIFF
--- a/docs/self-hosting/authentication.md
+++ b/docs/self-hosting/authentication.md
@@ -7,14 +7,40 @@ How Observal authenticates users and signs tokens, and how to wire up SSO.
 
 ## Authentication modes
 
-`DEPLOYMENT_MODE` controls what auth methods are allowed:
+Observal supports password auth, API keys, OAuth / OIDC, and SAML. The public login page shows only the methods enabled for the deployment.
 
-| Mode | Self-registration | Bootstrap admin | Email + password | API key | OAuth / OIDC |
-| --- | --- | --- | --- | --- | --- |
-| `local` (default) | Yes | Yes | Yes | Yes | Yes (if configured) |
-| `enterprise` | No | No | No | No | Yes (required) |
+| Method | How it is enabled | Notes |
+| --- | --- | --- |
+| Email + password | Default password auth | Used by bootstrap admins and locally managed users |
+| Self registration | `auth.self_registration_enabled=true` | Creates standard `user` accounts only |
+| OAuth / OIDC | `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_SERVER_METADATA_URL` | Uses IdP discovery metadata |
+| SAML | SAML dynamic settings | Enterprise SAML setup |
+| API keys | User generated after login | Inherits the user's role |
 
-Flip to `enterprise` once you're ready to require SSO for all access.
+Use `deployment.sso_only=true` when password login should be hidden and only SSO should be available.
+
+## Self registration {#self-registration}
+
+Controls whether visitors can create their own Observal account from the login page.
+
+| Value | Effect |
+|-------|--------|
+| `true` | Shows a **Register** button on the login page and allows public account creation |
+| `false` (default) | Hides registration and blocks `POST /api/v1/auth/register` |
+
+You can set this in the web UI at **Admin → Settings → Authentication → Self Registration Enabled**. If you prefer the CLI, set the same dynamic setting directly:
+
+```bash
+observal admin set auth.self_registration_enabled true
+```
+
+New accounts are created with the built-in `user` role. They cannot review submissions, manage users, or change server settings unless an admin promotes them later.
+
+Disable it again with:
+
+```bash
+observal admin set auth.self_registration_enabled false
+```
 
 ## The bootstrap flow
 
@@ -120,7 +146,7 @@ Auth endpoints are rate-limited to slow brute-force attempts:
 | Setting | Default | Scope |
 | --- | --- | --- |
 | `RATE_LIMIT_AUTH` | `10/minute` | General auth endpoints |
-| `RATE_LIMIT_AUTH_STRICT` | `5/minute` | Login and password reset |
+| `RATE_LIMIT_AUTH_STRICT` | `5/minute` | Login, registration, and password reset |
 
 Tighten for public-facing deployments.
 

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -40,6 +40,7 @@ from schemas.auth import (
     LoginRequest,
     LogoutRequest,
     RefreshRequest,
+    RegisterRequest,
     RevokeRequest,
     TokenRequest,
     TokenResponse,
@@ -89,8 +90,8 @@ _COMMON_WEAK_PASSWORDS = frozenset(
 
 def _validate_password_strength(password: str) -> None:
     optic.debug("_validate_password_strength called")
-    if len(password) < 12:
-        raise HTTPException(status_code=422, detail="Password must be at least 12 characters")
+    if len(password) < 8:
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
     if not re.search(r"[A-Z]", password):
         raise HTTPException(status_code=422, detail="Password must contain at least one uppercase letter")
     if not re.search(r"[0-9]", password):
@@ -203,6 +204,55 @@ async def bootstrap(request: Request, db: AsyncSession = Depends(get_db)):
         raise HTTPException(status_code=409, detail="System already initialized")
     await db.refresh(user)
 
+    access_token, refresh_token, expires_in = await _issue_tokens(user)
+    return InitResponse(
+        user=UserResponse.model_validate(user),
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_in=expires_in,
+    )
+
+
+@router.post("/register", response_model=InitResponse, dependencies=[Depends(require_password_auth)])
+@limiter.limit(ds.get_sync("security.rate_limit_auth_strict", "5/minute"))
+async def register(request: Request, req: RegisterRequest, db: AsyncSession = Depends(get_db)):
+    """Create a self-registered user when public registration is enabled."""
+    optic.debug("auth register attempt")
+    if not await ds.get_bool("auth.self_registration_enabled"):
+        raise HTTPException(status_code=403, detail="Registration is disabled")
+
+    _validate_password_strength(req.password)
+    source_ip, user_agent = _extract_request_info(request)
+    default_org = await get_or_create_default_org(db)
+    username = req.username or await generate_unique_username(req.email, db)
+    user = User(
+        email=req.email,
+        username=username,
+        name=req.name,
+        role=UserRole.user,
+        org_id=default_org.id,
+    )
+    user.set_password(req.password)
+    db.add(user)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Email or username already exists")
+    await db.refresh(user)
+
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.REGISTRATION,
+            severity=Severity.INFO,
+            outcome="success",
+            actor_id=str(user.id),
+            actor_email=user.email,
+            actor_role=user.role.value,
+            source_ip=source_ip,
+            user_agent=user_agent,
+        )
+    )
     access_token, refresh_token, expires_in = await _issue_tokens(user)
     return InitResponse(
         user=UserResponse.model_validate(user),

--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -134,11 +134,13 @@ async def get_public_config(db=Depends(get_db)):
     exec_dashboard_available = "all" in licensed_features or "exec_dashboard" in licensed_features
 
     sso_only = await ds.get_bool("deployment.sso_only")
+    self_registration_enabled = await ds.get_bool("auth.self_registration_enabled")
 
     return {
         "licensed": licensed,
         "sso_enabled": bool(settings.OAUTH_CLIENT_ID),
         "sso_only": sso_only,
+        "self_registration_enabled": self_registration_enabled,
         "saml_enabled": saml_enabled,
         "exec_dashboard_available": exec_dashboard_available,
         "licensed_features": licensed_features,

--- a/observal-server/schemas/auth.py
+++ b/observal-server/schemas/auth.py
@@ -56,6 +56,23 @@ class LoginRequest(BaseModel):
         return v.strip().lower() if isinstance(v, str) else v
 
 
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    name: str
+    username: str | None = None
+    password: str
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize(cls, v: str) -> str:
+        return _normalize_email(v)
+
+    @field_validator("username", mode="before")
+    @classmethod
+    def _validate_un(cls, v: str | None) -> str | None:
+        return _validate_username(v)
+
+
 class UserResponse(BaseModel):
     id: uuid.UUID
     email: str

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -167,6 +167,8 @@ DEFAULTS: dict[str, str] = {
     "insights.min_sessions": "5",
     "insights.facet_max_calls": "100",
     "insights.facet_concurrency": "25",
+    # Auth
+    "auth.self_registration_enabled": "false",
     # Deployment (runtime-tunable, mode itself is boot-time env var)
     "deployment.sso_only": "false",
     "deployment.frontend_url": "http://localhost",
@@ -271,6 +273,14 @@ def settings_schema() -> list[dict[str, Any]]:
 
 
 SECTIONS: list[dict[str, Any]] = [
+    {
+        "id": "auth",
+        "title": "Authentication",
+        "description": "Authentication policy for public entry points.",
+        "icon": "key",
+        "danger": True,
+        "keys": [k for k in DEFAULTS if k.startswith("auth.")],
+    },
     {
         "id": "insights",
         "title": "Agent Insights",

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -220,9 +220,6 @@ DEFAULTS: dict[str, str] = {
     "observability.enable_openapi": "false",
     "observability.enable_metrics": "false",
     # Misc
-    "misc.max_cli_version": "",  # empty = no upper bound
-    "misc.api_version": "2026-05-01",  # date-based, bumped on breaking changes
-    "misc.frontend_version": "",  # expected frontend build version (empty = same as server)
     "misc.git_mirror_base_path": "",
 }
 

--- a/tests/test_sec006_password_policy.py
+++ b/tests/test_sec006_password_policy.py
@@ -27,7 +27,7 @@ def test_password_too_short_raises_422():
     with pytest.raises(HTTPException) as exc_info:
         validator("Short1!")
     assert exc_info.value.status_code == 422
-    assert "12 characters" in exc_info.value.detail
+    assert "8 characters" in exc_info.value.detail
 
 
 def test_password_no_uppercase_raises_422():

--- a/tests/test_self_registration.py
+++ b/tests/test_self_registration.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _init_key_manager(tmp_path_factory):
+    from services.crypto import init_key_manager
+
+    key_dir = tmp_path_factory.mktemp("keys")
+    init_key_manager(key_dir=str(key_dir), key_password=None)
+
+
+def _client():
+    from httpx import ASGITransport, AsyncClient
+
+    from api.ratelimit import limiter
+    from main import app
+
+    limiter.enabled = False
+    return AsyncClient(transport=ASGITransport(app=app, raise_app_exceptions=False), base_url="http://test")
+
+
+def _db_override():
+    from api.deps import get_db
+    from main import app
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+
+    async def refresh(user):
+        user.id = uuid.uuid4()
+        user.created_at = datetime.now(UTC)
+
+    db.refresh = AsyncMock(side_effect=refresh)
+
+    async def get_mock_db():
+        yield db
+
+    app.dependency_overrides[get_db] = get_mock_db
+    return db
+
+
+def _cleanup():
+    from main import app
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_register_disabled_returns_403():
+    _db_override()
+    try:
+
+        async def get_bool(key):
+            return False
+
+        with patch("api.routes.auth.ds.get_bool", new=AsyncMock(side_effect=get_bool)):
+            async with _client() as client:
+                resp = await client.post(
+                    "/api/v1/auth/register",
+                    json={
+                        "email": "new@example.com",
+                        "name": "New User",
+                        "password": "Str0ng!P",
+                    },
+                )
+
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Registration is disabled"
+    finally:
+        _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_register_creates_user_role():
+    from models.user import UserRole
+
+    db = _db_override()
+    org_id = uuid.uuid4()
+    try:
+
+        async def get_bool(key):
+            return key == "auth.self_registration_enabled"
+
+        with (
+            patch("api.routes.auth.ds.get_bool", new=AsyncMock(side_effect=get_bool)),
+            patch("api.routes.auth.get_or_create_default_org", new=AsyncMock(return_value=SimpleNamespace(id=org_id))),
+            patch("api.routes.auth._issue_tokens", new=AsyncMock(return_value=("access", "refresh", 3600))),
+            patch("api.routes.auth.emit_security_event", new=AsyncMock()),
+        ):
+            async with _client() as client:
+                resp = await client.post(
+                    "/api/v1/auth/register",
+                    json={
+                        "email": "new@example.com",
+                        "name": "New User",
+                        "username": "new-user",
+                        "password": "Str0ng!P",
+                    },
+                )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["user"]["role"] == UserRole.user.value
+        assert body["access_token"] == "access"
+        db.add.assert_called_once()
+        created_user = db.add.call_args.args[0]
+        assert created_user.email == "new@example.com"
+        assert created_user.role == UserRole.user
+        assert created_user.org_id == org_id
+    finally:
+        _cleanup()

--- a/web/src/hooks/use-deployment-config.ts
+++ b/web/src/hooks/use-deployment-config.ts
@@ -19,6 +19,7 @@ export function useDeploymentConfig() {
 		licensed: data?.licensed ?? false,
 		ssoEnabled: data?.sso_enabled ?? false,
 		ssoOnly: data?.sso_only ?? false,
+		selfRegistrationEnabled: data?.self_registration_enabled ?? false,
 		samlEnabled: data?.saml_enabled ?? false,
 		licensedFeatures: data?.licensed_features ?? [],
 		brandingLogo: data?.branding_logo ?? null,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -355,6 +355,8 @@ export const auth = {
 			"/auth/login",
 			body,
 		),
+	register: (body: { email: string; name: string; username?: string; password: string }) =>
+		post<AuthResponse>("/auth/register", body),
 	whoami: () =>
 		get<{
 			id: string;
@@ -786,6 +788,7 @@ export type PublicConfig = {
 	licensed: boolean;
 	sso_enabled: boolean;
 	sso_only: boolean;
+	self_registration_enabled: boolean;
 	saml_enabled: boolean;
 	exec_dashboard_available: boolean;
 	licensed_features: string[];

--- a/web/src/lib/docs-map.ts
+++ b/web/src/lib/docs-map.ts
@@ -20,6 +20,9 @@ export interface DocRef {
  * When a setting card is clicked in help mode, we load the referenced doc + anchor.
  */
 export const SETTING_DOCS: Record<string, DocRef> = {
+	// Authentication
+	"auth.self_registration_enabled": { file: "self-hosting/authentication.md", anchor: "self-registration", label: "Self Registration" },
+
 	// Insights
 	"insights.api_key": { file: "insights-config.md", anchor: "api-key", label: "API Key" },
 	"insights.api_base": { file: "insights-config.md", anchor: "api-base-url", label: "API Base URL" },
@@ -100,6 +103,7 @@ export const SETTING_DOCS: Record<string, DocRef> = {
  * Map from section title to its doc reference (for section-level help).
  */
 export const SECTION_DOCS: Record<string, DocRef> = {
+	"Authentication": { file: "self-hosting/authentication.md", label: "Authentication Settings" },
 	"Agent Insights": { file: "insights-config.md", label: "AI Insights Configuration" },
 	"Deployment": { file: "self-hosting/deployment-settings.md", label: "Deployment Settings" },
 	"Security": { file: "self-hosting/trusted-proxies.md", label: "Trusted Proxies & Network Security" },

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -7,7 +7,7 @@
 
 
 import { Suspense, useState, useEffect } from "react";
-import { useRouter, useSearch } from "@tanstack/react-router";
+import { Link, useRouter, useSearch } from "@tanstack/react-router";
 import { Eye, EyeOff, ArrowRight, Loader2, AlertCircle, RefreshCw, CheckCircle2, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { auth, config as configApi, setTokens, clearSession, setUserRole, getUserRole, setUserName, setUserEmail, setUserUsername, setUserAvatar } from "@/lib/api";
@@ -21,7 +21,15 @@ import { Label } from "@/components/ui/label";
 function LoginContent() {
   const router = useRouter();
   const searchParams = useSearch({ from: "/(auth)/login" });
-  const { ssoEnabled, ssoOnly, samlEnabled, brandingAppName, brandingLogo, brandingWordmark } = useDeploymentConfig();
+  const {
+    ssoEnabled,
+    ssoOnly,
+    selfRegistrationEnabled,
+    samlEnabled,
+    brandingAppName,
+    brandingLogo,
+    brandingWordmark,
+  } = useDeploymentConfig();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -465,11 +473,11 @@ function LoginContent() {
                 )}
 
                 {(ssoOnly || ssoEnabled) && (
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center">
                     <Button
                       type="button"
                       variant={ssoOnly ? "default" : "outline"}
-                      className="flex-1"
+                      className="relative flex-1 pr-10"
                       onClick={handleSsoLogin}
                       disabled={loading || ssoLoading}
                     >
@@ -479,38 +487,38 @@ function LoginContent() {
                         <RefreshCw className="mr-2 h-4 w-4" />
                       )}
                       Sign in with SSO
+                      {ssoHealthLoading ? (
+                        <Loader2 className="absolute right-3 h-5 w-5 animate-spin text-muted-foreground" />
+                      ) : ssoHealth?.oidc && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="absolute right-3">
+                                {ssoHealth.oidc.ok ? (
+                                  <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                                ) : (
+                                  <XCircle className="h-5 w-5 text-destructive" />
+                                )}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="right" className="max-w-xs text-xs">
+                              {ssoHealth.oidc.ok
+                                ? `OIDC config verified (${ssoHealth.oidc.latency_ms}ms), does not test a full user login`
+                                : ssoHealth.oidc.error}
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
                     </Button>
-                    {ssoHealthLoading ? (
-                      <Loader2 className="h-5 w-5 shrink-0 animate-spin text-muted-foreground" />
-                    ) : ssoHealth?.oidc && (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="shrink-0">
-                              {ssoHealth.oidc.ok ? (
-                                <CheckCircle2 className="h-5 w-5 text-emerald-500" />
-                              ) : (
-                                <XCircle className="h-5 w-5 text-destructive" />
-                              )}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="right" className="max-w-xs text-xs">
-                            {ssoHealth.oidc.ok
-                              ? `OIDC config verified (${ssoHealth.oidc.latency_ms}ms) — does not test a full user login`
-                              : ssoHealth.oidc.error}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    )}
                   </div>
                 )}
 
                 {samlEnabled && (
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center">
                     <Button
                       type="button"
                       variant={ssoOnly ? "default" : "outline"}
-                      className="flex-1"
+                      className="relative flex-1 pr-10"
                       onClick={() => {
                         const nextParam = searchParams.next;
                         const samlUrl = nextParam && nextParam.startsWith("/")
@@ -521,35 +529,42 @@ function LoginContent() {
                       disabled={loading || ssoLoading}
                     >
                       Sign in with SAML SSO
+                      {ssoHealthLoading ? (
+                        <Loader2 className="absolute right-3 h-5 w-5 animate-spin text-muted-foreground" />
+                      ) : ssoHealth?.saml && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="absolute right-3">
+                                {ssoHealth.saml.ok ? (
+                                  <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                                ) : (
+                                  <XCircle className="h-5 w-5 text-destructive" />
+                                )}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="right" className="max-w-xs text-xs">
+                              {ssoHealth.saml.ok
+                                ? `SAML config verified (${ssoHealth.saml.latency_ms}ms), does not test a full user login`
+                                : ssoHealth.saml.error}
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
                     </Button>
-                    {ssoHealthLoading ? (
-                      <Loader2 className="h-5 w-5 shrink-0 animate-spin text-muted-foreground" />
-                    ) : ssoHealth?.saml && (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="shrink-0">
-                              {ssoHealth.saml.ok ? (
-                                <CheckCircle2 className="h-5 w-5 text-emerald-500" />
-                              ) : (
-                                <XCircle className="h-5 w-5 text-destructive" />
-                              )}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="right" className="max-w-xs text-xs">
-                            {ssoHealth.saml.ok
-                              ? `SAML config verified (${ssoHealth.saml.latency_ms}ms) — does not test a full user login`
-                              : ssoHealth.saml.error}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    )}
                   </div>
                 )}
               </div>
 
               {!ssoOnly && (
-                <div className="animate-in stagger-3 text-center">
+                <div className="animate-in stagger-3 space-y-3 text-center">
+                  {selfRegistrationEnabled && (
+                    <Button asChild variant="outline" className="w-full">
+                      <Link to="/register" search={searchParams.next ? { next: searchParams.next } : undefined}>
+                        Register
+                      </Link>
+                    </Button>
+                  )}
                   <p className="text-sm text-muted-foreground/60">
                     Forgot password? Contact your admin.
                   </p>

--- a/web/src/pages/register.tsx
+++ b/web/src/pages/register.tsx
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { Suspense, useEffect, useState } from "react";
+import { Link, useRouter, useSearch } from "@tanstack/react-router";
+import { ArrowRight, CheckCircle2, Eye, EyeOff, Loader2, ShieldCheck, AlertCircle } from "lucide-react";
+import { toast } from "sonner";
+import { auth, setTokens, setUserRole, setUserName, setUserEmail, setUserUsername, setUserAvatar } from "@/lib/api";
+import { useDeploymentConfig } from "@/hooks/use-deployment-config";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const PASSWORD_RULES = [
+  { id: "len", label: "At least 8 characters", test: (p: string) => p.length >= 8 },
+  { id: "upper", label: "One uppercase letter", test: (p: string) => /[A-Z]/.test(p) },
+  { id: "digit", label: "One number", test: (p: string) => /[0-9]/.test(p) },
+  { id: "special", label: "One special character", test: (p: string) => /[^A-Za-z0-9]/.test(p) },
+];
+
+function passwordIsStrong(password: string) {
+  return PASSWORD_RULES.every((rule) => rule.test(password));
+}
+
+function RegisterContent() {
+  const router = useRouter();
+  const searchParams = useSearch({ from: "/(auth)/register" });
+  const { selfRegistrationEnabled, brandingAppName, brandingLogo, brandingWordmark, loading: configLoading } = useDeploymentConfig();
+  const appName = brandingAppName || "Observal";
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [passwordTouched, setPasswordTouched] = useState(false);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const passwordStrong = passwordIsStrong(password);
+  const passwordsMatch = password === confirmPassword;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hasToken = !!sessionStorage.getItem("observal_access_token");
+    if (hasToken) router.navigate({ to: "/", replace: true });
+  }, [router]);
+
+  async function handleRegister() {
+    setError("");
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+    if (!passwordStrong) {
+      setError("Password does not meet the requirements");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await auth.register({
+        email,
+        name,
+        username: username.trim() || undefined,
+        password,
+      });
+      setTokens(res.access_token, res.refresh_token);
+      setUserRole(res.user.role);
+      setUserName(res.user.name);
+      setUserEmail(res.user.email);
+      if (res.user.username) setUserUsername(res.user.username);
+      if (res.user.avatar_url) setUserAvatar(res.user.avatar_url);
+      toast.success("Account created");
+      const nextPath = searchParams.next;
+      router.navigate({ to: (nextPath && nextPath.startsWith("/") ? nextPath : "/") as "/" });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Registration failed";
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (configLoading) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-surface-sunken p-6">
+        <div className="flex items-center gap-3 rounded-lg border bg-card px-4 py-3 text-sm text-muted-foreground shadow-sm">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Checking registration policy
+        </div>
+      </div>
+    );
+  }
+
+  if (!selfRegistrationEnabled) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-surface-sunken p-6">
+        <div className="w-full max-w-md rounded-lg border bg-card p-8 text-center shadow-sm">
+          <ShieldCheck className="mx-auto h-10 w-10 text-muted-foreground" />
+          <h1 className="mt-4 text-2xl font-semibold tracking-tight">Registration is closed</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Ask your admin for access, or sign in if you already have an account.
+          </p>
+          <Button asChild className="mt-6 w-full">
+            <Link to="/login">Back to sign in</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-surface-sunken p-6">
+      <div className="grid w-full max-w-5xl overflow-hidden rounded-xl border bg-card shadow-sm md:grid-cols-[0.9fr_1.1fr]">
+        <aside className="hidden border-r bg-muted/30 p-8 md:flex md:flex-col md:justify-between">
+          <div>
+            <div className="flex items-center gap-3">
+              {brandingLogo ? (
+                <img loading="lazy" src={brandingLogo} alt="" width={32} height={32} className="object-contain" />
+              ) : (
+                <img loading="lazy" src="/observal-logo.svg" alt="" width={32} height={32} className="object-contain" />
+              )}
+              <span className="text-lg font-semibold tracking-tight">{appName}</span>
+            </div>
+            <h1 className="mt-10 max-w-sm text-3xl font-semibold tracking-tight text-balance">
+              Governed agent access, without waiting on setup.
+            </h1>
+            <p className="mt-4 max-w-sm text-sm leading-6 text-muted-foreground">
+              Create a standard user account for browsing the registry, viewing traces, and using approved agent context.
+            </p>
+          </div>
+          <ul className="space-y-3 text-sm text-muted-foreground">
+            {["Standard access by default", "Registry browsing ready", "You can request more permissions later"].map((item) => (
+              <li key={item} className="flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4 text-success" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </aside>
+
+        <main className="p-8 sm:p-10">
+          <div className="mx-auto max-w-md">
+            <div className="flex flex-col items-center gap-2 text-center md:items-start md:text-left">
+              {brandingWordmark ? (
+                <img loading="lazy" src={brandingWordmark} alt={appName} width={192} height={24} className="h-6 max-w-48 object-contain md:hidden" />
+              ) : (
+                <span className="text-xl font-semibold tracking-tight md:hidden">{appName}</span>
+              )}
+              <h2 className="text-2xl font-semibold tracking-tight">Create your account</h2>
+              <p className="text-sm text-muted-foreground">You will start with standard user permissions.</p>
+            </div>
+
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleRegister();
+              }}
+              className="mt-8 space-y-4"
+            >
+              <div className="space-y-2">
+                <Label htmlFor="name">Full name</Label>
+                <Input id="name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Ada Lovelace" required autoFocus />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@company.com" required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="username">Username <span className="text-muted-foreground">optional</span></Label>
+                <Input id="username" value={username} onChange={(e) => setUsername(e.target.value)} placeholder="ada-lovelace" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <div className="relative">
+                  <Input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      setPasswordTouched(true);
+                    }}
+                    placeholder="At least 8 characters"
+                    required
+                    className={`pr-10 ${
+                      passwordTouched && password
+                        ? passwordStrong
+                          ? "border-green-500 focus-visible:ring-green-500"
+                          : "border-destructive focus-visible:ring-destructive"
+                        : ""
+                    }`}
+                  />
+                  <button
+                    type="button"
+                    tabIndex={-1}
+                    className="absolute right-0 top-0 flex h-full w-10 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
+                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                {passwordTouched && password && (
+                  <ul className="mt-2 space-y-1">
+                    {PASSWORD_RULES.map((rule) => {
+                      const ok = rule.test(password);
+                      return (
+                        <li
+                          key={rule.id}
+                          className={`flex items-center gap-1.5 text-xs ${
+                            ok ? "text-green-600 dark:text-green-400" : "text-muted-foreground"
+                          }`}
+                        >
+                          <span>{ok ? "✓" : "○"}</span>
+                          {rule.label}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="confirm-password">Confirm password</Label>
+                <Input
+                  id="confirm-password"
+                  type={showPassword ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  placeholder="Repeat your password"
+                  required
+                  className={
+                    confirmPassword
+                      ? passwordsMatch
+                        ? "border-green-500 focus-visible:ring-green-500"
+                        : "border-destructive focus-visible:ring-destructive"
+                      : ""
+                  }
+                />
+                {confirmPassword && !passwordsMatch && (
+                  <p className="mt-1 text-xs text-destructive">Passwords do not match</p>
+                )}
+              </div>
+
+              {error && (
+                <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{error}</span>
+                </div>
+              )}
+
+              <Button type="submit" disabled={loading || configLoading || !selfRegistrationEnabled || !passwordStrong || !passwordsMatch} className="w-full">
+                {loading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <>
+                    Create account
+                    <ArrowRight className="ml-1 h-4 w-4" />
+                  </>
+                )}
+              </Button>
+            </form>
+
+            <p className="mt-6 text-center text-sm text-muted-foreground">
+              Already have an account?{" "}
+              <Link to="/login" search={searchParams.next ? { next: searchParams.next } : undefined} className="font-medium text-foreground underline-offset-4 hover:underline">
+                Sign in
+              </Link>
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <Suspense>
+      <RegisterContent />
+    </Suspense>
+  );
+}

--- a/web/src/pages/user/account.tsx
+++ b/web/src/pages/user/account.tsx
@@ -323,8 +323,8 @@ function ChangeUsernameSection() {
 const PASSWORD_RULES = [
 	{
 		id: "len",
-		label: "At least 12 characters",
-		test: (p: string) => p.length >= 12,
+		label: "At least 8 characters",
+		test: (p: string) => p.length >= 8,
 	},
 	{
 		id: "upper",
@@ -419,7 +419,7 @@ function ChangePasswordSection() {
 										: "border-destructive focus-visible:ring-destructive"
 									: ""
 							}`}
-							placeholder="At least 12 characters"
+							placeholder="At least 8 characters"
 						/>
 						{/* Requirements checklist — shown once user starts typing */}
 						{touched && newPassword && (

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AuthedIndexRouteImport } from './routes/_authed/index'
 import { Route as AuthedLeaderboardRouteImport } from './routes/_authed/leaderboard'
 import { Route as AuthedUserRouteImport } from './routes/_authed/_user'
 import { Route as AuthedAdminRouteImport } from './routes/_authed/_admin'
+import { Route as authRegisterRouteImport } from './routes/(auth)/register'
 import { Route as authLoginRouteImport } from './routes/(auth)/login'
 import { Route as authDeviceRouteImport } from './routes/(auth)/device'
 import { Route as AuthedWikiIndexRouteImport } from './routes/_authed/wiki/index'
@@ -57,6 +58,11 @@ const AuthedUserRoute = AuthedUserRouteImport.update({
 const AuthedAdminRoute = AuthedAdminRouteImport.update({
   id: '/_admin',
   getParentRoute: () => AuthedRoute,
+} as any)
+const authRegisterRoute = authRegisterRouteImport.update({
+  id: '/(auth)/register',
+  path: '/register',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const authLoginRoute = authLoginRouteImport.update({
   id: '/(auth)/login',
@@ -171,6 +177,7 @@ export interface FileRoutesByFullPath {
   '/': typeof AuthedIndexRoute
   '/device': typeof authDeviceRoute
   '/login': typeof authLoginRoute
+  '/register': typeof authRegisterRoute
   '/leaderboard': typeof AuthedLeaderboardRoute
   '/audit-log': typeof AuthedAdminAuditLogRoute
   '/dashboard': typeof AuthedAdminDashboardRoute
@@ -195,6 +202,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/device': typeof authDeviceRoute
   '/login': typeof authLoginRoute
+  '/register': typeof authRegisterRoute
   '/': typeof AuthedIndexRoute
   '/leaderboard': typeof AuthedLeaderboardRoute
   '/audit-log': typeof AuthedAdminAuditLogRoute
@@ -222,6 +230,7 @@ export interface FileRoutesById {
   '/_authed': typeof AuthedRouteWithChildren
   '/(auth)/device': typeof authDeviceRoute
   '/(auth)/login': typeof authLoginRoute
+  '/(auth)/register': typeof authRegisterRoute
   '/_authed/_admin': typeof AuthedAdminRouteWithChildren
   '/_authed/_user': typeof AuthedUserRouteWithChildren
   '/_authed/leaderboard': typeof AuthedLeaderboardRoute
@@ -252,6 +261,7 @@ export interface FileRouteTypes {
     | '/'
     | '/device'
     | '/login'
+    | '/register'
     | '/leaderboard'
     | '/audit-log'
     | '/dashboard'
@@ -276,6 +286,7 @@ export interface FileRouteTypes {
   to:
     | '/device'
     | '/login'
+    | '/register'
     | '/'
     | '/leaderboard'
     | '/audit-log'
@@ -302,6 +313,7 @@ export interface FileRouteTypes {
     | '/_authed'
     | '/(auth)/device'
     | '/(auth)/login'
+    | '/(auth)/register'
     | '/_authed/_admin'
     | '/_authed/_user'
     | '/_authed/leaderboard'
@@ -331,6 +343,7 @@ export interface RootRouteChildren {
   AuthedRoute: typeof AuthedRouteWithChildren
   authDeviceRoute: typeof authDeviceRoute
   authLoginRoute: typeof authLoginRoute
+  authRegisterRoute: typeof authRegisterRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -369,6 +382,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof AuthedAdminRouteImport
       parentRoute: typeof AuthedRoute
+    }
+    '/(auth)/register': {
+      id: '/(auth)/register'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof authRegisterRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/(auth)/login': {
       id: '/(auth)/login'
@@ -609,6 +629,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthedRoute: AuthedRouteWithChildren,
   authDeviceRoute: authDeviceRoute,
   authLoginRoute: authLoginRoute,
+  authRegisterRoute: authRegisterRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/web/src/routes/(auth)/register.tsx
+++ b/web/src/routes/(auth)/register.tsx
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { createFileRoute } from "@tanstack/react-router";
+import { Suspense, lazy } from "react";
+import { Toaster } from "@/components/ui/sonner";
+
+const RegisterPage = lazy(() => import("@/pages/register"));
+
+export type RegisterSearch = {
+  next?: string;
+};
+
+function RegisterRoute() {
+  return (
+    <div className="min-h-dvh bg-background">
+      <Suspense fallback={<div className="flex h-screen w-full items-center justify-center" />}>
+        <RegisterPage />
+      </Suspense>
+      <Toaster visibleToasts={1} />
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/(auth)/register")({
+  component: RegisterRoute,
+  validateSearch: (search: Record<string, unknown>): RegisterSearch => ({
+    next: (search.next as string) || undefined,
+  }),
+});


### PR DESCRIPTION
## Purpose / Description
Add optional public self registration so admins can allow users to create their own standard Observal accounts from the login flow. Add authentication help docs for the settings UI and remove version stub settings from the Miscellaneous section.

## Fixes
No linked issue.

## Approach
- Added `auth.self_registration_enabled` as a dynamic setting with a disabled default.
- Added `POST /api/v1/auth/register`, guarded by that setting and password auth policy.
- Created self registered users with the existing `user` role.
- Exposed the setting in public frontend config.
- Added a `/register` page and a conditional Register button on the login page.
- Moved SSO health status inside the SSO button so the login actions align cleanly.
- Matched register password validation with the account password checklist and lowered the minimum length to 8 characters.
- Added Authentication help docs wiring for the settings UI and expanded `docs/self-hosting/authentication.md`.
- Removed `misc.max_cli_version`, `misc.api_version`, and `misc.frontend_version` from dynamic settings defaults so they no longer appear as editable settings.

## How Has This Been Tested?

<img width="2559" height="1395" alt="image" src="https://github.com/user-attachments/assets/d3210acf-1540-498e-9e80-1f6b7cca599f" />
<img width="2559" height="1399" alt="image" src="https://github.com/user-attachments/assets/1cdd3dde-d1ef-4a86-bed1-95595b8bdb66" />

## Learning (optional, can help others)
No external research needed. This follows the existing dynamic settings, auth route, TanStack route, docs map, and account password validation patterns.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)


## AI Assistance

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
