### PR TITLE
fix(docker): select pnpm binary by arch

### DIFF
--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -5,10 +5,17 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 FROM node:24-alpine AS base
+ARG TARGETARCH
 ARG PNPM_VERSION=10.34.4
-ARG PNPM_SHA256=15092b4d71f1192f67501116dd87dd20be8c4238434371959820255a374219c1
+ARG PNPM_SHA256_AMD64=15092b4d71f1192f67501116dd87dd20be8c4238434371959820255a374219c1
+ARG PNPM_SHA256_ARM64=9513a31bc1e166f5f6e6dbaadca91fa05b44e919ea53685c754ab0acd5501514
 RUN apk add --no-cache wget && \
-    wget -q "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linuxstatic-x64" -O /usr/local/bin/pnpm && \
+    case "$TARGETARCH" in \
+        amd64) PNPM_ARCH=x64; PNPM_SHA256="$PNPM_SHA256_AMD64" ;; \
+        arm64) PNPM_ARCH=arm64; PNPM_SHA256="$PNPM_SHA256_ARM64" ;; \
+        *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    wget -q "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linuxstatic-${PNPM_ARCH}" -O /usr/local/bin/pnpm && \
     echo "${PNPM_SHA256}  /usr/local/bin/pnpm" | sha256sum -c - && \
     chmod +x /usr/local/bin/pnpm
 


### PR DESCRIPTION
## Purpose / Description
Fix the release Docker build for the web arm64 image. The Dockerfile always downloaded the x64 pnpm static binary, so the arm64 job failed when running `pnpm install`.

## Fixes
No linked issue.

## Approach
Use Docker BuildKit `TARGETARCH` to choose the matching pnpm static binary and checksum for `amd64` and `arm64`. Unsupported architectures fail explicitly.

## How Has This Been Tested?

- `docker buildx build --platform linux/amd64 --file docker/Dockerfile.web --target deps --progress=plain .`
- Verified the pnpm 10.34.4 arm64 checksum by downloading `pnpm-linuxstatic-arm64` and hashing it locally.
- Tried a local arm64 Docker build, but this workstation has no arm64 binfmt support, so it failed before the Dockerfile logic with `exec /bin/sh: exec format error`. The failing GitHub Actions job runs on a native arm64 runner, so this limitation does not apply there.

## Learning (optional, can help others)
The release job runs `web-arm64` on `ubuntu-24.04-arm`. A static x64 binary can pass checksum validation but still fail at execution time inside an arm64 image.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. Not applicable, the Dockerfile change is a small architecture switch.
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). Not applicable, no UI changes.

## AI Assistance

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
