### PR TITLE
bump(release): v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.9.0] - 2026-06-22
+## [1.9.1] - 2026-06-22
 
 ### Added
 
@@ -895,6 +895,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- select pnpm binary by arch (**docker**) ([9b3345b](https://github.com/BlazeUp-AI/Observal/commit/9b3345b2ea2c5f6f975a7a327a354f107fd4e085))
 - propagate MCP auth headers during agent pull (**pull**) ([7de9cb0](https://github.com/BlazeUp-AI/Observal/commit/7de9cb0e6d93f80f925f75fcce0e4492f0357cdc))
 - finish install terminology (**harness**) ([1aa0c0f](https://github.com/BlazeUp-AI/Observal/commit/1aa0c0faa4ec1aff36ef392bf4643f61b505e4f5))
 - restore json agent profiles (**kiro**) ([345b148](https://github.com/BlazeUp-AI/Observal/commit/345b148cde939a04dbec84bfb0f94dc1a112731d))

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.9.0"
+version = "1.9.1"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "AGPL-3.0-only"

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1684,7 +1684,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.9.0"
+version = "1.9.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [
     "pi-package",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.9.0"
+version = "1.9.1"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Release v1.9.1 (patch)

Bumps version `1.9.0` → `1.9.1` and regenerates changelog.

**Merging this PR will automatically trigger the release pipeline.**

### What happens after merge
- CLI binaries built for 6 platforms (Linux/macOS/Windows, x64/arm64)
- Docker images pushed to GHCR
- Server deployment tarball packaged
- PyPI package published
- **Approval required** in the `production` environment before GitHub Release publishes