### PR TITLE
fix: use dots for Claude model versions in kiro harness

### DIFF
--- a/observal-server/services/model_catalog.py
+++ b/observal-server/services/model_catalog.py
@@ -91,6 +91,10 @@ def format_for_harness(model_id: str, provider: str, harness: str) -> str:
         return model_id
     if harness == "opencode":
         return model_id if "/" in model_id else f"{provider}/{model_id}"
+    if harness == "kiro":
+        from services.model_resolver import kiro_model_format
+
+        return kiro_model_format(model_id)
     return model_id
 
 

--- a/observal-server/services/model_resolver.py
+++ b/observal-server/services/model_resolver.py
@@ -7,7 +7,13 @@
 
 from __future__ import annotations
 
+import re
+
 from schemas.harness_registry import HARNESS_REGISTRY, has_model_selection
+
+# Pre-compiled pattern: claude-<family>-<major>-<minor><optional-date-suffix>
+# All digit groups are bounded to prevent polynomial backtracking on adversarial input.
+_KIRO_MODEL_RE = re.compile(r"^(claude-[a-z]+-\d{1,3})-(\d{1,3})(-\d{8})?$")
 
 
 def _format_for_harness(model: str, provider: str, harness: str) -> str:
@@ -18,6 +24,22 @@ def _format_for_harness(model: str, provider: str, harness: str) -> str:
                 return alias
     if harness == "opencode":
         return model if "/" in model else f"{provider}/{model}"
+    if harness == "kiro":
+        return kiro_model_format(model)
+    return model
+
+
+def kiro_model_format(model: str) -> str:
+    """Convert canonical dash-version model IDs to kiro's dot-version format.
+
+    Kiro uses dots for minor versions (e.g. claude-sonnet-4.5) while the
+    canonical catalog uses dashes (claude-sonnet-4-5). This handles any
+    Claude family name (sonnet, opus, haiku, fable, mythos, etc.).
+    """
+    m = _KIRO_MODEL_RE.match(model)
+    if m:
+        suffix = m.group(3) or ""
+        return f"{m.group(1)}.{m.group(2)}{suffix}"
     return model
 
 
@@ -74,7 +96,9 @@ async def resolve_model_for_harness(
     candidate = override or _candidate_for_harness(harness, models_by_harness, model_name)
     if not candidate or candidate == "inherit":
         return None, warnings
-    if not _supported(harness, candidate):
+    # Normalize the candidate to the harness-expected format before checking support
+    formatted = _format_for_harness(candidate, _provider_for(harness, candidate), harness)
+    if not _supported(harness, formatted):
         warnings.append(f"Model '{candidate}' is not in the {harness} harness registry. Falling back to auto/default.")
         return None, warnings
-    return _format_for_harness(candidate, _provider_for(harness, candidate), harness), warnings
+    return formatted, warnings

--- a/packages/observal-shared/observal_shared/harness_models/kiro.json
+++ b/packages/observal-shared/observal_shared/harness_models/kiro.json
@@ -14,45 +14,45 @@
       "provider": "kiro"
     },
     {
-      "id": "claude-sonnet-4-5",
+      "id": "claude-sonnet-4.5",
       "kind": "exact",
-      "label": "claude-sonnet-4-5",
+      "label": "claude-sonnet-4.5",
       "provider": "kiro"
     },
     {
-      "id": "claude-sonnet-4-6",
+      "id": "claude-sonnet-4.6",
       "kind": "exact",
-      "label": "claude-sonnet-4-6",
+      "label": "claude-sonnet-4.6",
       "provider": "kiro"
     },
     {
-      "id": "claude-haiku-4-5",
+      "id": "claude-haiku-4.5",
       "kind": "exact",
-      "label": "claude-haiku-4-5",
+      "label": "claude-haiku-4.5",
       "provider": "kiro"
     },
     {
-      "id": "claude-opus-4-5",
+      "id": "claude-opus-4.5",
       "kind": "exact",
-      "label": "claude-opus-4-5",
+      "label": "claude-opus-4.5",
       "provider": "kiro"
     },
     {
-      "id": "claude-opus-4-6",
+      "id": "claude-opus-4.6",
       "kind": "exact",
-      "label": "claude-opus-4-6",
+      "label": "claude-opus-4.6",
       "provider": "kiro"
     },
     {
-      "id": "claude-opus-4-7",
+      "id": "claude-opus-4.7",
       "kind": "exact",
-      "label": "claude-opus-4-7",
+      "label": "claude-opus-4.7",
       "provider": "kiro"
     },
     {
-      "id": "claude-opus-4-8",
+      "id": "claude-opus-4.8",
       "kind": "exact",
-      "label": "claude-opus-4-8",
+      "label": "claude-opus-4.8",
       "provider": "kiro"
     },
     {

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -51,7 +51,7 @@ async def test_resolver_validates_against_harness_registry():
     from services.model_resolver import resolve_model_for_harness
 
     emitted, warnings = await resolve_model_for_harness("kiro", models_by_harness={"kiro": "claude-sonnet-4-6"})
-    assert emitted == "claude-sonnet-4-6"
+    assert emitted == "claude-sonnet-4.6"
     assert warnings == []
 
     emitted, warnings = await resolve_model_for_harness("kiro", models_by_harness={"kiro": "not-real"})


### PR DESCRIPTION
## Purpose / Description
The kiro harness model list in `packages/observal-shared/observal_shared/harness_models/kiro.json` incorrectly uses dashes for Claude model version separators (e.g., `claude-sonnet-4-5`) instead of dots (e.g., `claude-sonnet-4.5`). This causes the per-IDE model override feature to populate wrong model identifiers for the kiro harness.

Additionally, the server-side `format_for_harness` and `model_resolver` were passing model IDs verbatim to kiro without converting the canonical dash format to kiro's dot format.

## Fixes
* Fixes #1495

## Approach
1. Updated `kiro.json` harness registry to use dot-format model IDs (kiro's native format).
2. Added a single `kiro_model_format()` function in `model_resolver.py` that converts canonical `claude-<family>-<major>-<minor>` to `claude-<family>-<major>.<minor>`. Uses a generic regex with bounded quantifiers that works for any future Claude family name (fable, mythos, etc.) without polynomial backtracking risk.
3. `model_catalog.py` imports and calls the same function (DRY — single source of truth).
4. The conversion is applied before the harness registry lookup, so stored dash-format model names resolve correctly against the dot-format registry.

**Why kiro.json has dots:** Because kiro-cli natively uses dot-format model names. The harness registry reflects what the harness actually accepts. The conversion layer bridges the gap between the canonical catalog format (dashes) and kiro's native format (dots).

## How Has This Been Tested?

Verified locally with `observal agent pull sdsad --harness kiro` — see comment below for terminal output.

Before fix: `"model": "claude-sonnet-4-5"` (wrong — kiro rejects this)
After fix: `"model": "claude-sonnet-4.5"` (correct)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes (Kiro CLI)
- [x] Was the generated code manually reviewed and tested?