### PR TITLE
fix(settings): restore harness settings

### DIFF
--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -220,6 +220,8 @@ DEFAULTS: dict[str, str] = {
     "observability.enable_openapi": "false",
     "observability.enable_metrics": "false",
     # Misc
+    "misc.harness_allowlist": "",
+    "misc.default_harness": "",
     "misc.git_mirror_base_path": "",
 }
 

--- a/web/src/components/builder/model-picker.tsx
+++ b/web/src/components/builder/model-picker.tsx
@@ -9,13 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { useHarnesses } from "@/hooks/use-harnesses";
 import { cn } from "@/lib/utils";
 
@@ -63,31 +57,32 @@ function ModelCombobox({ value, models, placeholder, onChange }: ModelComboboxPr
           </button>
         </div>
       </PopoverAnchor>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-1">
-        <div className="max-h-60 overflow-y-auto">
-          {filteredModels.length ? (
-            filteredModels.map((model) => (
-              <button
-                key={model}
-                type="button"
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => {
-                  onChange(model);
-                  setOpen(false);
-                }}
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left font-mono text-xs hover:bg-accent hover:text-accent-foreground",
-                  value === model && "bg-accent text-accent-foreground",
-                )}
-              >
-                <Check className={cn("h-3.5 w-3.5", value === model ? "opacity-100" : "opacity-0")} />
-                <span className="truncate">{model}</span>
-              </button>
-            ))
-          ) : (
-            <div className="px-2 py-3 text-xs text-muted-foreground">No registry suggestion. Custom value is allowed.</div>
-          )}
-        </div>
+      <PopoverContent
+        align="start"
+        className="max-h-[min(24rem,var(--radix-popover-content-available-height))] w-[var(--radix-popover-trigger-width)] overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {filteredModels.length ? (
+          filteredModels.map((model) => (
+            <button
+              key={model}
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => {
+                onChange(model);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left font-mono text-xs hover:bg-accent hover:text-accent-foreground",
+                value === model && "bg-accent text-accent-foreground",
+              )}
+            >
+              <Check className={cn("h-3.5 w-3.5", value === model ? "opacity-100" : "opacity-0")} />
+              <span className="truncate">{model}</span>
+            </button>
+          ))
+        ) : (
+          <div className="px-2 py-3 text-xs text-muted-foreground">No registry suggestion. Custom value is allowed.</div>
+        )}
       </PopoverContent>
     </Popover>
   );
@@ -180,18 +175,12 @@ export function ModelPicker({
           </div>
 
           <div className="grid gap-2 md:grid-cols-[minmax(160px,220px)_minmax(0,1fr)_auto]">
-            <Select value={selectedHarness} onValueChange={setSelectedHarness}>
-              <SelectTrigger className="h-9">
-                <SelectValue placeholder="Select harness" />
-              </SelectTrigger>
-              <SelectContent>
-                {allHarnesses.map((harness) => (
-                  <SelectItem key={harness.name} value={harness.name}>
-                    {harness.display_name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <PickerSelect
+              value={selectedHarness}
+              onValueChange={setSelectedHarness}
+              placeholder="Select harness"
+              options={allHarnesses.map((harness) => ({ value: harness.name, label: harness.display_name }))}
+            />
 
             <ModelCombobox
               value={selectedModel}

--- a/web/src/components/registry/component-install-command.tsx
+++ b/web/src/components/registry/component-install-command.tsx
@@ -6,13 +6,7 @@ import { Check, Copy, Terminal } from "lucide-react";
 import { toast } from "sonner";
 import { copyToClipboard } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { useHarnesses } from "@/hooks/use-harnesses";
 
 interface ComponentInstallCommandProps {
@@ -52,18 +46,13 @@ export function ComponentInstallCommand({ componentType, componentName }: Compon
         <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
         <span className="text-xs font-medium text-muted-foreground">Install</span>
         <div className="ml-auto">
-          <Select value={effectiveHarness} onValueChange={setHarness}>
-            <SelectTrigger className="h-7 w-[130px] text-xs border-border">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {(harnesses ?? []).map((i) => (
-                <SelectItem key={i.name} value={i.name}>
-                  {i.display_name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <PickerSelect
+            value={effectiveHarness}
+            onValueChange={setHarness}
+            className="w-[130px]"
+            inputClassName="h-7 border-border text-xs"
+            options={(harnesses ?? []).map((i) => ({ value: i.name, label: i.display_name }))}
+          />
         </div>
       </div>
       <div className="flex items-center gap-2 p-3">

--- a/web/src/components/registry/pull-command.tsx
+++ b/web/src/components/registry/pull-command.tsx
@@ -7,13 +7,7 @@ import { Check, Copy, Terminal } from "lucide-react";
 import { toast } from "sonner";
 import { copyToClipboard } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { useHarnesses } from "@/hooks/use-harnesses";
 
 interface PullCommandProps {
@@ -56,18 +50,13 @@ export function PullCommand({ agentName, currentVersion, latestVersion }: PullCo
         <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
         <span className="text-xs font-medium text-muted-foreground">Install</span>
         <div className="ml-auto flex items-center gap-2">
-          <Select value={effectiveHarness} onValueChange={setHarness}>
-            <SelectTrigger className="h-7 w-[130px] text-xs border-border">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {(harnesses ?? []).map((i) => (
-                <SelectItem key={i.name} value={i.name}>
-                  {i.display_name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <PickerSelect
+            value={effectiveHarness}
+            onValueChange={setHarness}
+            className="w-[130px]"
+            inputClassName="h-7 border-border text-xs"
+            options={(harnesses ?? []).map((i) => ({ value: i.name, label: i.display_name }))}
+          />
         </div>
       </div>
       <div className="flex items-center gap-2 p-3">

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -16,13 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Check, Info, Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
@@ -615,18 +609,11 @@ export function SubmitComponentDialog({
 						<>
 							<div className="space-y-1.5">
 								<Label>Category</Label>
-								<Select value={category} onValueChange={setCategory}>
-									<SelectTrigger>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{MCP_CATEGORIES.map((c) => (
-											<SelectItem key={c} value={c}>
-												{c}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
+								<PickerSelect
+									value={category}
+									onValueChange={setCategory}
+									options={MCP_CATEGORIES.map((c) => ({ value: c, label: c }))}
+								/>
 							</div>
 
 							{/* ── JSON paste mode (default) ─────────────── */}
@@ -692,22 +679,14 @@ export function SubmitComponentDialog({
 
 									<div className="space-y-1.5">
 										<Label>Transport</Label>
-										<Select
+										<PickerSelect
 											value={transport || "auto"}
 											onValueChange={(v) => setTransport(v === "auto" ? "" : v)}
-										>
-											<SelectTrigger>
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												<SelectItem value="auto">Auto-detect</SelectItem>
-												{MCP_TRANSPORTS.map((t) => (
-													<SelectItem key={t} value={t}>
-														{t}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
+											options={[
+												{ value: "auto", label: "Auto-detect" },
+												...MCP_TRANSPORTS.map((t) => ({ value: t, label: t })),
+											]}
+										/>
 									</div>
 
 									<div className="space-y-1.5">
@@ -761,24 +740,14 @@ export function SubmitComponentDialog({
 									<div className="grid grid-cols-2 gap-3">
 										<div className="space-y-1.5">
 											<Label>Framework</Label>
-											<Select
+											<PickerSelect
 												value={framework || "none"}
-												onValueChange={(v) =>
-													setFramework(v === "none" ? "" : v)
-												}
-											>
-												<SelectTrigger>
-													<SelectValue />
-												</SelectTrigger>
-												<SelectContent>
-													<SelectItem value="none">None</SelectItem>
-													{MCP_FRAMEWORKS.map((f) => (
-														<SelectItem key={f} value={f}>
-															{f}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
+												onValueChange={(v) => setFramework(v === "none" ? "" : v)}
+												options={[
+													{ value: "none", label: "None" },
+													...MCP_FRAMEWORKS.map((f) => ({ value: f, label: f })),
+												]}
+											/>
 										</div>
 										<div className="space-y-1.5">
 											<Label htmlFor="mcp-docker">Docker Image</Label>
@@ -857,18 +826,11 @@ export function SubmitComponentDialog({
 						<>
 							<div className="space-y-1.5">
 								<Label>Task Type</Label>
-								<Select value={taskType} onValueChange={setTaskType}>
-									<SelectTrigger>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{SKILL_TASK_TYPES.map((t) => (
-											<SelectItem key={t} value={t}>
-												{t}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
+								<PickerSelect
+									value={taskType}
+									onValueChange={setTaskType}
+									options={SKILL_TASK_TYPES.map((t) => ({ value: t, label: t }))}
+								/>
 							</div>
 
 							<Tabs value={skillMode} onValueChange={(v) => setSkillMode(v as "git" | "paste")} className="w-full">
@@ -996,68 +958,37 @@ export function SubmitComponentDialog({
 							<div className="grid grid-cols-2 gap-3">
 								<div className="space-y-1.5">
 									<Label>Event</Label>
-									<Select value={event} onValueChange={setEvent}>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{HOOK_EVENTS.map((e) => (
-												<SelectItem key={e} value={e}>
-													{e}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+									<PickerSelect
+										value={event}
+										onValueChange={setEvent}
+										options={HOOK_EVENTS.map((e) => ({ value: e, label: e }))}
+									/>
 								</div>
 								<div className="space-y-1.5">
 									<Label>Handler Type</Label>
-									<Select value={handlerType} onValueChange={setHandlerType}>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{HOOK_HANDLER_TYPES.map((h) => (
-												<SelectItem key={h} value={h}>
-													{h}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+									<PickerSelect
+										value={handlerType}
+										onValueChange={setHandlerType}
+										options={HOOK_HANDLER_TYPES.map((h) => ({ value: h, label: h }))}
+									/>
 								</div>
 							</div>
 							<div className="grid grid-cols-2 gap-3">
 								<div className="space-y-1.5">
 									<Label>Execution Mode</Label>
-									<Select
+									<PickerSelect
 										value={executionMode}
 										onValueChange={setExecutionMode}
-									>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{HOOK_EXECUTION_MODES.map((m) => (
-												<SelectItem key={m} value={m}>
-													{m}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+										options={HOOK_EXECUTION_MODES.map((m) => ({ value: m, label: m }))}
+									/>
 								</div>
 								<div className="space-y-1.5">
 									<Label>Scope</Label>
-									<Select value={hookScope} onValueChange={setHookScope}>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{HOOK_SCOPES.map((s) => (
-												<SelectItem key={s} value={s}>
-													{s}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+									<PickerSelect
+										value={hookScope}
+										onValueChange={setHookScope}
+										options={HOOK_SCOPES.map((s) => ({ value: s, label: s }))}
+									/>
 								</div>
 							</div>
 							<div className="space-y-1.5">
@@ -1112,21 +1043,11 @@ export function SubmitComponentDialog({
 						<>
 							<div className="space-y-1.5">
 								<Label>Category</Label>
-								<Select
+								<PickerSelect
 									value={promptCategory}
 									onValueChange={setPromptCategory}
-								>
-									<SelectTrigger>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{PROMPT_CATEGORIES.map((c) => (
-											<SelectItem key={c} value={c}>
-												{c}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
+									options={PROMPT_CATEGORIES.map((c) => ({ value: c, label: c }))}
+								/>
 							</div>
 							<div className="space-y-1.5">
 								<Label htmlFor="prompt-template">Template *</Label>
@@ -1150,36 +1071,19 @@ export function SubmitComponentDialog({
 							<div className="grid grid-cols-2 gap-3">
 								<div className="space-y-1.5">
 									<Label>Runtime Type</Label>
-									<Select value={runtimeType} onValueChange={setRuntimeType}>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{SANDBOX_RUNTIME_TYPES.map((r) => (
-												<SelectItem key={r} value={r}>
-													{r}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+									<PickerSelect
+										value={runtimeType}
+										onValueChange={setRuntimeType}
+										options={SANDBOX_RUNTIME_TYPES.map((r) => ({ value: r, label: r }))}
+									/>
 								</div>
 								<div className="space-y-1.5">
 									<Label>Network Policy</Label>
-									<Select
+									<PickerSelect
 										value={networkPolicy}
 										onValueChange={setNetworkPolicy}
-									>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{SANDBOX_NETWORK_POLICIES.map((p) => (
-												<SelectItem key={p} value={p}>
-													{p}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+										options={SANDBOX_NETWORK_POLICIES.map((p) => ({ value: p, label: p }))}
+									/>
 								</div>
 							</div>
 							<div className="grid grid-cols-2 gap-3">

--- a/web/src/components/registry/version-dropdown.tsx
+++ b/web/src/components/registry/version-dropdown.tsx
@@ -5,13 +5,7 @@
 import { useMemo } from "react";
 import { AlertTriangle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import type { AgentVersionSummary } from "@/lib/types";
 
 interface VersionDropdownProps {
@@ -53,23 +47,17 @@ export function VersionDropdown({ versions, currentVersion, onSelect }: VersionD
 
   return (
     <div className="flex items-center gap-2">
-      <Select value={currentVersion} onValueChange={onSelect}>
-        <SelectTrigger className="h-7 w-[140px] text-xs">
-          <SelectValue placeholder="Version" />
-        </SelectTrigger>
-        <SelectContent>
-          {approvedVersions.map((v) => (
-            <SelectItem key={v.id} value={v.version}>
-              <span className="flex items-center gap-2">
-                <span>v{v.version}</span>
-                {v.version === latestApproved && (
-                  <Badge variant="outline" className="text-[9px] px-1 py-0">latest</Badge>
-                )}
-              </span>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <PickerSelect
+        value={currentVersion}
+        onValueChange={onSelect}
+        placeholder="Version"
+        className="w-[140px]"
+        inputClassName="h-7 text-xs"
+        options={approvedVersions.map((v) => ({
+          value: v.version,
+          label: v.version === latestApproved ? `v${v.version} latest` : `v${v.version}`,
+        }))}
+      />
       {isOlderVersion && (
         <span className="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
           <AlertTriangle className="h-3 w-3" />

--- a/web/src/components/traces/span-tree.tsx
+++ b/web/src/components/traces/span-tree.tsx
@@ -5,13 +5,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { cn } from "@/lib/utils";
 
 export interface Span {
@@ -310,34 +304,24 @@ export function SpanTree({ spans, selectedId, onSelect }: SpanTreeProps) {
       {hasFilterableData && (
         <div className="flex items-center gap-2 px-2 pb-2">
           {agentNames.length > 0 && (
-            <Select value={agentFilter} onValueChange={setAgentFilter}>
-              <SelectTrigger className="h-7 w-[160px] text-xs">
-                <SelectValue placeholder="Agent" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all" className="text-xs">All agents</SelectItem>
-                {agentNames.map((name) => (
-                  <SelectItem key={name} value={name} className="text-xs">
-                    {name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <PickerSelect
+              value={agentFilter}
+              onValueChange={setAgentFilter}
+              placeholder="Agent"
+              className="w-[160px]"
+              inputClassName="h-7 text-xs"
+              options={[{ value: "all", label: "All agents" }, ...agentNames.map((name) => ({ value: name, label: name }))]}
+            />
           )}
           {modelNames.length > 0 && (
-            <Select value={modelFilter} onValueChange={setModelFilter}>
-              <SelectTrigger className="h-7 w-[160px] text-xs">
-                <SelectValue placeholder="Model" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all" className="text-xs">All models</SelectItem>
-                {modelNames.map((name) => (
-                  <SelectItem key={name} value={name} className="text-xs">
-                    {name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <PickerSelect
+              value={modelFilter}
+              onValueChange={setModelFilter}
+              placeholder="Model"
+              className="w-[160px]"
+              inputClassName="h-7 text-xs"
+              options={[{ value: "all", label: "All models" }, ...modelNames.map((name) => ({ value: name, label: name }))]}
+            />
           )}
           {filtersActive && (
             <Button

--- a/web/src/components/ui/picker-select.tsx
+++ b/web/src/components/ui/picker-select.tsx
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { useEffect, useMemo, useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+export interface PickerSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface PickerSelectProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  options: PickerSelectOption[];
+  placeholder?: string;
+  emptyLabel?: string;
+  disabled?: boolean;
+  className?: string;
+  inputClassName?: string;
+}
+
+export function PickerSelect({
+  value,
+  onValueChange,
+  options,
+  placeholder = "Select...",
+  emptyLabel = "No matches",
+  disabled,
+  className,
+  inputClassName,
+}: PickerSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const selected = options.find((option) => option.value === value);
+
+  const filteredOptions = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return options;
+    return options.filter((option) => `${option.label} ${option.value}`.toLowerCase().includes(needle));
+  }, [options, query]);
+
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
+
+  const choose = (next: string) => {
+    onValueChange(next);
+    setOpen(false);
+  };
+  const scrollList = filteredOptions.length > 12;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div className={cn("relative", className)}>
+          <Input
+            value={open ? query : selected?.label ?? ""}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                const first = filteredOptions.find((option) => !option.disabled);
+                if (first) choose(first.value);
+              }
+              if (event.key === "Escape") setOpen(false);
+            }}
+            placeholder={placeholder}
+            disabled={disabled}
+            className={cn("pr-9", inputClassName)}
+          />
+          <button
+            type="button"
+            onClick={() => setOpen((current) => !current)}
+            disabled={disabled}
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+            aria-label="Show options"
+          >
+            <ChevronsUpDown className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        className={cn(
+          "w-[var(--radix-popover-trigger-width)] p-1",
+          scrollList && "max-h-[min(24rem,var(--radix-popover-content-available-height))] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        )}
+      >
+        {filteredOptions.length ? (
+          filteredOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              disabled={option.disabled}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => choose(option.value)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50",
+                value === option.value && "bg-accent text-accent-foreground",
+              )}
+            >
+              <Check className={cn("h-3.5 w-3.5", value === option.value ? "opacity-100" : "opacity-0")} />
+              <span className="truncate">{option.label}</span>
+            </button>
+          ))
+        ) : (
+          <div className="px-2 py-3 text-xs text-muted-foreground">{emptyLabel}</div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/pages/admin/security-events.tsx
+++ b/web/src/pages/admin/security-events.tsx
@@ -12,9 +12,7 @@ import { Button } from "@/components/ui/button";
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
-import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -158,30 +156,22 @@ export default function SecurityEventsPage() {
       <div className="p-6 w-full mx-auto space-y-4">
         {/* Filters */}
         <div className="flex flex-wrap gap-3 items-center">
-          <Select value={eventType} onValueChange={(v) => { setEventType(v); setPage(0); }}>
-            <SelectTrigger className="h-9 w-[220px] text-xs">
-              <SelectValue placeholder="Event type" />
-            </SelectTrigger>
-            <SelectContent>
-              {EVENT_TYPES.map((t) => (
-                <SelectItem key={t} value={t} className="text-xs">
-                  {t === "all" ? "All event types" : t}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={severity} onValueChange={(v) => { setSeverity(v); setPage(0); }}>
-            <SelectTrigger className="h-9 w-[140px] text-xs">
-              <SelectValue placeholder="Severity" />
-            </SelectTrigger>
-            <SelectContent>
-              {SEVERITIES.map((s) => (
-                <SelectItem key={s} value={s} className="text-xs">
-                  {s === "all" ? "All severities" : s}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <PickerSelect
+            value={eventType}
+            onValueChange={(v) => { setEventType(v); setPage(0); }}
+            placeholder="Event type"
+            className="w-[220px]"
+            inputClassName="h-9 text-xs"
+            options={EVENT_TYPES.map((t) => ({ value: t, label: t === "all" ? "All event types" : t }))}
+          />
+          <PickerSelect
+            value={severity}
+            onValueChange={(v) => { setSeverity(v); setPage(0); }}
+            placeholder="Severity"
+            className="w-[140px]"
+            inputClassName="h-9 text-xs"
+            options={SEVERITIES.map((s) => ({ value: s, label: s === "all" ? "All severities" : s }))}
+          />
           <div className="relative">
             <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
             <Input

--- a/web/src/pages/admin/settings.tsx
+++ b/web/src/pages/admin/settings.tsx
@@ -48,13 +48,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -152,17 +146,15 @@ function HarnessAllowlistEditor({
 				)}
 			</div>
 			<div className="flex items-center gap-2">
-				<Select value="" onValueChange={addHarness}>
-					<SelectTrigger className="h-8 text-sm flex-1">
-						<SelectValue placeholder={selected.length === 0 ? "Restrict to specific harnesses" : "Add harness"} />
-					</SelectTrigger>
-					<SelectContent>
-						{available.map((harness) => (
-							<SelectItem key={harness.name} value={harness.name}>{harness.display_name}</SelectItem>
-						))}
-						{available.length === 0 && <SelectItem value="__none__" disabled>All listed harnesses selected</SelectItem>}
-					</SelectContent>
-				</Select>
+				<PickerSelect
+					value=""
+					onValueChange={addHarness}
+					placeholder={selected.length === 0 ? "Restrict to specific harnesses" : "Add harness"}
+					className="flex-1"
+					inputClassName="h-8 text-sm"
+					emptyLabel="All listed harnesses selected"
+					options={available.map((harness) => ({ value: harness.name, label: harness.display_name }))}
+				/>
 				{selected.length > 0 && (
 					<Button type="button" variant="ghost" size="sm" className="h-8" onClick={() => onChange("")}>Allow all</Button>
 				)}
@@ -598,17 +590,17 @@ export default function SettingsPage() {
 		}
 		if (key === "misc.default_harness") {
 			return (
-				<Select value={editingValue || "__none__"} onValueChange={(value) => setEditingValue(value === "__none__" ? "" : value)}>
-					<SelectTrigger className="h-8 text-sm flex-1">
-						<SelectValue placeholder="Choose default harness" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectItem value="__none__">Use first allowed harness</SelectItem>
-						{harnesses.map((harness) => (
-							<SelectItem key={harness.name} value={harness.name}>{harness.display_name}</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
+				<PickerSelect
+					value={editingValue || "__none__"}
+					onValueChange={(value) => setEditingValue(value === "__none__" ? "" : value)}
+					placeholder="Choose default harness"
+					className="flex-1"
+					inputClassName="h-8 text-sm"
+					options={[
+						{ value: "__none__", label: "Use first allowed harness" },
+						...harnesses.map((harness) => ({ value: harness.name, label: harness.display_name })),
+					]}
+				/>
 			);
 		}
 		return (

--- a/web/src/pages/admin/users.tsx
+++ b/web/src/pages/admin/users.tsx
@@ -22,9 +22,7 @@ import {
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
-import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { PageHeader } from "@/components/layouts/page-header";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -45,24 +43,14 @@ function RoleSelect({ userId, currentRole }: { userId: string; currentRole: stri
   const assignable = useAssignableRoles();
 
   return (
-    <Select
+    <PickerSelect
       value={currentRole}
       onValueChange={(value) => mutation.mutate({ id: userId, role: value })}
       disabled={mutation.isPending}
-    >
-      <SelectTrigger className="h-7 w-[140px] text-xs">
-        <SelectValue>
-          {ROLE_LABELS[currentRole as Role] ?? currentRole}
-        </SelectValue>
-      </SelectTrigger>
-      <SelectContent>
-        {assignable.map((r) => (
-          <SelectItem key={r} value={r} className="text-xs">
-            {ROLE_LABELS[r]}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+      className="w-[140px]"
+      inputClassName="h-7 text-xs"
+      options={assignable.map((r) => ({ value: r, label: ROLE_LABELS[r] }))}
+    />
   );
 }
 
@@ -356,18 +344,12 @@ export default function UsersPage() {
               </div>
               <div className="space-y-2">
                 <label className="text-xs font-medium text-muted-foreground">Role</label>
-                <Select value={role} onValueChange={setRole}>
-                  <SelectTrigger className="h-8 text-sm">
-                    <SelectValue>
-                      {ROLE_LABELS[role as Role] ?? role}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {assignableRoles.map((r) => (
-                      <SelectItem key={r} value={r}>{ROLE_LABELS[r]}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <PickerSelect
+                  value={role}
+                  onValueChange={setRole}
+                  inputClassName="h-8 text-sm"
+                  options={assignableRoles.map((r) => ({ value: r, label: ROLE_LABELS[r] }))}
+                />
               </div>
               <DialogFooter>
                 <Button variant="ghost" size="sm" onClick={closeDialog}>Cancel</Button>

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -25,15 +25,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { Separator } from "@/components/ui/separator";
 import {
   Tabs,
@@ -60,6 +52,18 @@ import { ComponentPicker } from "@/components/registry/component-picker";
 import { VersionBumpDialog } from "@/components/registry/version-bump-dialog";
 
 const AGENT_NAME_REGEX = /^[a-z0-9][a-z0-9_-]*$/;
+const CATEGORIES = [
+  "Code Review",
+  "Testing",
+  "Documentation",
+  "DevOps",
+  "Security",
+  "Data",
+  "Incident Response",
+  "Deployment",
+  "Cost Optimization",
+  "Other",
+];
 
 function slugifyName(raw: string): string {
   return raw
@@ -642,32 +646,15 @@ function AgentBuilderInner() {
                   <Label htmlFor="agent-category" className="text-sm font-medium">
                     Category
                   </Label>
-                  <Select
+                  <PickerSelect
                     value={category || "__none__"}
                     onValueChange={(v) => setCategory(v === "__none__" ? "" : v)}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select category..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectItem value="__none__">Select category...</SelectItem>
-                      </SelectGroup>
-                      <SelectGroup>
-                        <SelectLabel>Categories</SelectLabel>
-                        <SelectItem value="Code Review">Code Review</SelectItem>
-                        <SelectItem value="Testing">Testing</SelectItem>
-                        <SelectItem value="Documentation">Documentation</SelectItem>
-                        <SelectItem value="DevOps">DevOps</SelectItem>
-                        <SelectItem value="Security">Security</SelectItem>
-                        <SelectItem value="Data">Data</SelectItem>
-                        <SelectItem value="Incident Response">Incident Response</SelectItem>
-                        <SelectItem value="Deployment">Deployment</SelectItem>
-                        <SelectItem value="Cost Optimization">Cost Optimization</SelectItem>
-                        <SelectItem value="Other">Other</SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
+                    placeholder="Select category..."
+                    options={[
+                      { value: "__none__", label: "Select category..." },
+                      ...CATEGORIES.map((item) => ({ value: item, label: item })),
+                    ]}
+                  />
                 </div>
               </div>
               <div className="max-w-3xl">


### PR DESCRIPTION
## Purpose / Description
Restore the renamed harness settings and make dropdown pickers use the same searchable picker treatment across the web UI.

## Fixes
No linked issue.

## Approach
Added `misc.harness_allowlist` and `misc.default_harness` back to dynamic settings defaults so the settings schema exposes them again.

Added a shared `PickerSelect` component based on the model picker interaction, then replaced current Radix Select usages in forms, filters, install commands, version selection, and trace filters. Picker lists now use available popover height with hidden scrollbar chrome instead of an obvious nested list scrollbar.

## How Has This Been Tested?

Ran:

```bash
cd web && pnpm typecheck
cd web && pnpm lint
```

Also verified the dynamic settings schema includes:

```text
misc.harness_allowlist
misc.default_harness
```

<img width="1392" height="633" alt="image" src="https://github.com/user-attachments/assets/bab4b823-7cd1-4477-897e-3500ec2688b1" />


## Learning (optional, can help others)
Reused the existing model picker Popover and Input pattern to keep the UI vocabulary consistent without adding a new dependency.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
