### PR TITLE
docs(integrations): document harness attribution

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -57,6 +57,11 @@
 * [Backup and restore](self-hosting/backup-and-restore.md)
 * [Troubleshooting](self-hosting/troubleshooting.md)
 
+## Integrations
+
+* [Kiro](integrations/kiro.md)
+* [OpenCode](integrations/opencode.md)
+
 ## Reference
 
 * [Environment variables](reference/environment-variables.md)

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -73,13 +73,12 @@ observal agent pull <agent-name> --harness kiro --scope project
 
 Project agents are written to `.kiro/agents/{name}.json`.
 
-### 4. Patch existing Kiro hooks
+### 4. Refresh Kiro hooks
 
-```bash
-observal doctor patch --all --harness kiro
-```
+Pull the agent again to refresh its Observal hook commands.
 
-This updates Observal hook entries and keeps other hook entries unchanged.
+Kiro attribution is installed per pulled agent because each hook command carries
+that agent's Observal UUID. `doctor patch` does not install generic Kiro hooks.
 
 ---
 
@@ -91,8 +90,8 @@ This updates Observal hook entries and keeps other hook entries unchanged.
 | Guidance files | `.kiro/steering/*.md`, `AGENTS.md` | `~/.kiro/steering/*.md` |
 | MCP config | `.kiro/settings/mcp.json` | `~/.kiro/settings/mcp.json` |
 | Skill definition | `.kiro/skills/{name}/SKILL.md` | `~/.kiro/skills/{name}/SKILL.md` |
-| Hook config | `.kiro/hooks/{name}.json` | `~/.kiro/hooks/{name}.json` |
-| Hook scripts | `.kiro/hooks/` | `~/.kiro/hooks/` |
+| Hook config | Embedded in `.kiro/agents/{name}.json` | Embedded in `~/.kiro/agents/{name}.json` |
+| Custom hook scripts | `.kiro/hooks/` | `~/.kiro/hooks/` |
 | Session JSONL | `~/.kiro/sessions/cli/{session_id}.jsonl` | `~/.kiro/sessions/cli/{session_id}.jsonl` |
 | Credit metadata | `~/.kiro/sessions/cli/{session_id}.json` | `~/.kiro/sessions/cli/{session_id}.json` |
 | Observal credentials | `~/.observal/config.json` | `~/.observal/config.json` |
@@ -104,20 +103,22 @@ Kiro MCP configs use the `mcpServers` key.
 
 ## Hook spec
 
-Observal writes standalone hook JSON like this:
+Observal writes the telemetry hooks inside each Kiro agent JSON:
 
 ```json
 {
-  "userPromptSubmit": [
-    {
-      "command": "python -m observal_cli.hooks.kiro_session_push"
-    }
-  ],
-  "stop": [
-    {
-      "command": "python -m observal_cli.hooks.kiro_session_push"
-    }
-  ]
+  "hooks": {
+    "userPromptSubmit": [
+      {
+        "command": "OBSERVAL_AGENT_ID=<agent-uuid> python -m observal_cli.hooks.kiro_session_push"
+      }
+    ],
+    "stop": [
+      {
+        "command": "OBSERVAL_AGENT_ID=<agent-uuid> python -m observal_cli.hooks.kiro_session_push"
+      }
+    ]
+  }
 }
 ```
 
@@ -125,8 +126,20 @@ On non-Windows platforms, generated server config may use `python3` instead of
 `python`. During `observal pull`, the CLI rewrites Observal hook commands to use
 the active Python interpreter.
 
-When an agent name is available, the hook command sets `OBSERVAL_AGENT_NAME` for
-agent attribution.
+### Attribution
+
+Kiro does not expose a reliable active Observal agent in its session JSONL. The
+per-agent hook command is the source of truth.
+
+1. `observal agent pull` writes the agent UUID into the Kiro hook command as
+   `OBSERVAL_AGENT_ID`.
+2. `kiro_session_push` reads that UUID when Kiro fires `userPromptSubmit` or
+   `stop`.
+3. The CLI looks up the UUID in `~/.observal/lockfile.json` under the `kiro`
+   harness.
+4. The session payload is sent with the lockfile agent id and version.
+5. If the UUID is missing or no lockfile entry exists, the session is left
+   unattributed instead of guessing from the current directory.
 
 ### Event map
 
@@ -205,9 +218,9 @@ Run `pytest -q` from the project root.
 **Guidance files are scan-only.** Observal layers Kiro steering files and
 `AGENTS.md` as context, but does not overwrite them during pull.
 
-**Existing hooks need patching.** Pulling a new agent includes hooks
-automatically. Existing hooks can be patched with
-`observal doctor patch --all --harness kiro`.
+**Hooks are per agent.** Pulling a new agent includes telemetry hooks
+automatically. Pull the agent again to refresh its Observal hook command.
+`doctor patch` does not install generic Kiro attribution hooks.
 
 **Default scope is user.** `observal agent pull <agent-name> --harness kiro`
 writes to `~/.kiro/agents/` unless `--scope project` is set.

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -1,0 +1,193 @@
+<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# OpenCode
+
+OpenCode is a first-class Observal harness integration. Observal can install
+OpenCode agents, configure MCP servers, expose skills, install hook plugins, and
+collect OpenCode session telemetry.
+
+---
+
+## Overview
+
+OpenCode agent profiles are Markdown files. Project agents live in
+`.opencode/agents/`. User agents live in `~/.config/opencode/agents/`.
+
+OpenCode session telemetry uses an in-process TypeScript plugin. The plugin is
+installed by `observal auth login` or `observal doctor patch`. Agent pulls write
+agent profiles and update the Observal lockfile, but they do not embed the
+telemetry plugin in each agent file.
+
+The plugin listens to OpenCode session and message events, reads message data
+through the OpenCode client API, converts new messages into Observal session
+lines, and sends them to Observal.
+
+---
+
+## Supported capabilities
+
+| Capability | Support |
+|---|---|
+| Agent profiles | Project and user scope |
+| Hook bridge | OpenCode plugin |
+| Plugin events | `session.created`, `session.idle`, `message.updated` |
+| MCP servers | `opencode.json` and `~/.config/opencode/opencode.json` |
+| Agent prompt | Registry prompts are written into the generated OpenCode agent profile |
+| Skills | `.opencode/skills/{name}/SKILL.md` and `~/.config/opencode/skills/{name}/SKILL.md` |
+| Session parsing | OpenCode plugin exports JSONL-compatible session lines |
+| Telemetry | MCP telemetry through `observal-shim`; session telemetry through the plugin |
+| Model selection | Registry-backed OpenCode model catalog |
+
+---
+
+## Setup
+
+### 1. Install the Observal CLI
+
+```bash
+uv tool install observal-cli
+# or: pipx install observal-cli
+```
+
+### 2. Authenticate
+
+```bash
+observal auth login
+```
+
+This writes credentials to `~/.observal/config.json`. If OpenCode is detected,
+login can install the Observal plugin.
+
+### 3. Pull an agent into OpenCode
+
+```bash
+observal agent pull <agent-name> --harness opencode
+```
+
+OpenCode's default scope is user scope. By default, the agent is written to
+`~/.config/opencode/agents/{name}.md`.
+
+To install into the current project:
+
+```bash
+observal agent pull <agent-name> --harness opencode --scope project
+```
+
+Project agents are written to `.opencode/agents/{name}.md`.
+
+### 4. Install or refresh the OpenCode plugin
+
+```bash
+observal doctor patch --all --harness opencode
+```
+
+This installs or updates `observal-plugin.ts` when the plugin is missing, stale,
+or different from the bundled source.
+
+---
+
+## Config paths
+
+| Purpose | Project scope | User scope |
+|---|---|---|
+| Agent profile | `.opencode/agents/{name}.md` | `~/.config/opencode/agents/{name}.md` |
+| MCP config | `opencode.json` | `~/.config/opencode/opencode.json` |
+| Skill definition | `.opencode/skills/{name}/SKILL.md` | `~/.config/opencode/skills/{name}/SKILL.md` |
+| Plugin hooks | `.opencode/plugins/{name}.ts` | `~/.config/opencode/plugins/{name}.ts` |
+| Observal plugin | `.opencode/plugins/observal-plugin.ts` | `~/.config/opencode/plugins/observal-plugin.ts` |
+| Observal credentials | `~/.observal/config.json` | `~/.observal/config.json` |
+| Observal lockfile | `~/.observal/lockfile.json` | `~/.observal/lockfile.json` |
+
+OpenCode MCP configs use the `mcp` key.
+
+---
+
+## Plugin spec
+
+Observal installs a TypeScript plugin named `observal-plugin.ts`. The plugin
+subscribes to OpenCode runtime events:
+
+| OpenCode event | Observal use |
+|---|---|
+| `session.created` | Capture the active OpenCode agent name for the session |
+| `message.updated` | Mark the session as having new data to push |
+| `session.idle` | Fetch new messages and send them to Observal |
+| `session.updated` | Refresh active agent tracking when emitted by OpenCode |
+| `session.next.agent.switched` | Refresh active agent tracking when the active agent changes |
+
+The bundled spec version is checked by `doctor patch`, along with the plugin
+content hash, so stale local copies are replaced.
+
+---
+
+## Attribution
+
+OpenCode exposes the active agent name in session events, not an Observal UUID.
+The Observal lockfile maps that OpenCode agent name back to the registry agent
+id and installed version.
+
+1. `observal agent pull` writes the OpenCode agent profile and records the
+   agent name, id, version, scope, and project directory in
+   `~/.observal/lockfile.json`.
+2. The OpenCode plugin receives `session.created` or agent switch events and
+   reads the active OpenCode agent name.
+3. Built-in OpenCode agents such as `build`, `plan`, `general`, `explore`,
+   `scout`, `compaction`, `title`, and `summary` are ignored.
+4. The plugin searches `~/.observal/lockfile.json` under the `opencode` harness
+   for an entry whose `name` or `id` matches the active agent.
+5. If multiple entries match, a project-scoped entry for the current directory
+   wins, then a user-scoped entry, then the first match.
+6. The session payload is sent with the resolved `agent_id` and
+   `agent_version`.
+7. If no lockfile match exists, the plugin skips attribution for that session
+   instead of guessing.
+
+---
+
+## Session push behavior
+
+The OpenCode plugin works as follows:
+
+1. Load `~/.observal/config.json` for server URL and API key.
+2. Track active sessions in memory.
+3. Resolve the active OpenCode agent name through `~/.observal/lockfile.json`.
+4. On `session.idle`, fetch messages from `client.session.messages`.
+5. Convert messages into JSONL-compatible Observal session lines.
+6. Send only messages that have not already been pushed for that session.
+7. Mark the final payload when OpenCode reports completion.
+
+The plugin keeps a small in-memory session cache and drops the oldest tracked
+session when the cache is full.
+
+---
+
+## Agent profile format
+
+OpenCode agents are Markdown files. Observal writes the agent prompt into the
+profile selected by scope:
+
+```markdown
+---
+name: my-agent
+---
+
+You are an OpenCode agent with the following specialization...
+```
+
+---
+
+## Caveats
+
+**The plugin is shared per OpenCode install.** It is installed by auth login or
+`doctor patch`, not by each agent pull.
+
+**Attribution depends on the lockfile.** If an agent profile is copied by hand
+without running `observal agent pull`, the plugin may see the OpenCode agent
+name but have no Observal id or version to send.
+
+**Built-in OpenCode agents are ignored.** Sessions for built-in agents are not
+attributed to registry agents.
+
+**MCP config is OpenCode-specific.** OpenCode uses `opencode.json` and the
+`mcp` key, not Kiro or Claude Code MCP paths.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
Document how Kiro and OpenCode session attribution works after the recent agent id attribution fixes, so future harness work has one reference point.

## Fixes
* No issue linked.

## Approach
Updated the Kiro integration guide to describe per-agent `OBSERVAL_AGENT_ID` hooks, lockfile lookup, and the no-guessing behavior for unattributed sessions.

Added an OpenCode integration guide covering plugin installation, event handling, lockfile attribution by active agent name, built-in agent handling, and session push behavior.

Added both integration guides to `docs/SUMMARY.md`.

## How Has This Been Tested?

Ran:

```bash
git diff --check -- docs/integrations/kiro.md docs/integrations/opencode.md docs/SUMMARY.md
python - <<'PY'
from pathlib import Path
for p in [Path('docs/integrations/kiro.md'), Path('docs/integrations/opencode.md'), Path('docs/SUMMARY.md')]:
    text = p.read_text()
    assert '\u2014' not in text, p
    print(p, 'ok')
PY
```

## Learning (optional, can help others)
Kiro attribution is UUID based through per-agent hook commands. OpenCode attribution is name based through runtime session events, then resolved through the Observal lockfile.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

No code changes. No UI changes.

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
