### PR TITLE
feat(web): add skill script code editor

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,21 @@ importers:
       '@codemirror/autocomplete':
         specifier: ^6.20.3
         version: 6.20.3
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
       '@codemirror/lang-json':
         specifier: ^6.0.2
         version: 6.0.2
+      '@codemirror/lang-python':
+        specifier: ^6.2.1
+        version: 6.2.1
       '@codemirror/language':
         specifier: ^6.12.4
         version: 6.12.4
+      '@codemirror/legacy-modes':
+        specifier: ^6.5.3
+        version: 6.5.3
       '@codemirror/state':
         specifier: ^6.7.0
         version: 6.7.0
@@ -306,11 +315,20 @@ packages:
   '@codemirror/commands@6.10.4':
     resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
 
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
   '@codemirror/lang-json@6.0.2':
     resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
 
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
   '@codemirror/language@6.12.4':
     resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/legacy-modes@6.5.3':
+    resolution: {integrity: sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==}
 
   '@codemirror/lint@6.9.7':
     resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
@@ -604,11 +622,17 @@ packages:
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
   '@lezer/json@1.0.3':
     resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
 
   '@lezer/lr@1.4.10':
     resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/python@1.1.19':
+    resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -3065,10 +3089,28 @@ snapshots:
       '@codemirror/view': 6.43.3
       '@lezer/common': 1.5.2
 
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.3
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
   '@codemirror/lang-json@6.0.2':
     dependencies:
       '@codemirror/language': 6.12.4
       '@lezer/json': 1.0.3
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.19
 
   '@codemirror/language@6.12.4':
     dependencies:
@@ -3078,6 +3120,10 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
       style-mod: 4.1.3
+
+  '@codemirror/legacy-modes@6.5.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
 
   '@codemirror/lint@6.9.7':
     dependencies:
@@ -3307,6 +3353,12 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.2
 
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/json@1.0.3':
     dependencies:
       '@lezer/common': 1.5.2
@@ -3316,6 +3368,12 @@ snapshots:
   '@lezer/lr@1.4.10':
     dependencies:
       '@lezer/common': 1.5.2
+
+  '@lezer/python@1.1.19':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@marijn/find-cluster-break@1.0.2': {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -17,8 +17,11 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",
+    "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lang-python": "^6.2.1",
     "@codemirror/language": "^6.12.4",
+    "@codemirror/legacy-modes": "^6.5.3",
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.3",
     "@dnd-kit/core": "^6.3.1",

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -16,7 +16,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { CodeEditor } from "@/components/ui/code-editor";
+import {
+	CodeEditor,
+	codeLanguageFromFilename,
+	codeLanguageLabel,
+} from "@/components/ui/code-editor";
 import { PickerSelect } from "@/components/ui/picker-select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Check, Info, Loader2, Plus, X } from "lucide-react";
@@ -570,6 +574,8 @@ export function SubmitComponentDialog({
 
 	const submitError = validateForSubmit();
 	const jsonExample = mcpExampleConfig(isEditMode, name);
+	const skillScriptLanguage = codeLanguageFromFilename(skillScriptFilename);
+	const skillScriptLanguageName = codeLanguageLabel(skillScriptLanguage);
 
 	return (
 		<Dialog
@@ -967,17 +973,18 @@ export function SubmitComponentDialog({
 										</p>
 									</div>
 									<div className="space-y-1.5">
-										<Label htmlFor="skill-script-content">Script (optional)</Label>
-										<Textarea
+										<Label htmlFor="skill-script-content">
+											Script (optional, {skillScriptLanguageName})
+										</Label>
+										<CodeEditor
 											id="skill-script-content"
 											value={skillScriptContent}
-											onChange={(e) => setSkillScriptContent(e.target.value)}
-											placeholder={"#!/bin/bash\n# Script that the skill can invoke\n# Stored in the registry and delivered on install"}
-											rows={8}
-											className="font-mono text-xs"
+											onChange={setSkillScriptContent}
+											language={skillScriptLanguage}
+											placeholder="Paste or type the skill script here."
 										/>
 										<p className="text-xs text-muted-foreground">
-											Script content stored in the registry and delivered on install. Similar to hook scripts.
+											Detected from filename. Use .sh for Bash, .py for Python, or .mjs/.js for JavaScript.
 										</p>
 									</div>
 								</TabsContent>

--- a/web/src/components/ui/code-editor.tsx
+++ b/web/src/components/ui/code-editor.tsx
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import { javascript } from "@codemirror/lang-javascript";
 import { json } from "@codemirror/lang-json";
-import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { python } from "@codemirror/lang-python";
+import { HighlightStyle, StreamLanguage, syntaxHighlighting } from "@codemirror/language";
+import { shell } from "@codemirror/legacy-modes/mode/shell";
 import type { Extension } from "@codemirror/state";
 import { highlightActiveLine, keymap, lineNumbers, placeholder } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
@@ -11,11 +14,13 @@ import { EditorView, minimalSetup } from "codemirror";
 import { useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
 
+export type CodeEditorLanguage = "bash" | "javascript" | "json" | "plain" | "python";
+
 interface CodeEditorProps {
 	id?: string;
 	value: string;
 	onChange: (value: string) => void;
-	language?: "json";
+	language?: CodeEditorLanguage;
 	placeholder?: string;
 	minHeightClassName?: string;
 	className?: string;
@@ -75,13 +80,50 @@ const theme = EditorView.theme({
 });
 
 const highlightStyle = HighlightStyle.define([
+	{ tag: tags.keyword, color: "oklch(var(--primary-accent))" },
 	{ tag: tags.propertyName, color: "oklch(var(--info))" },
+	{ tag: tags.variableName, color: "oklch(var(--info))" },
 	{ tag: tags.string, color: "oklch(var(--success))" },
 	{ tag: tags.number, color: "oklch(var(--primary-accent))" },
 	{ tag: tags.bool, color: "oklch(var(--warning))" },
 	{ tag: tags.null, color: "oklch(var(--muted-foreground))" },
+	{ tag: tags.comment, color: "oklch(var(--muted-foreground))", fontStyle: "italic" },
 	{ tag: tags.punctuation, color: "oklch(var(--foreground) / 0.7)" },
 ]);
+
+export function codeLanguageFromFilename(filename: string): CodeEditorLanguage {
+	const lower = filename.toLowerCase().trim();
+	if (/\.(bash|sh|zsh)$/.test(lower)) return "bash";
+	if (/\.py$/.test(lower)) return "python";
+	if (/\.(cjs|js|jsx|mjs|ts|tsx)$/.test(lower)) return "javascript";
+	if (/\.json$/.test(lower)) return "json";
+	return "plain";
+}
+
+export function codeLanguageLabel(language: CodeEditorLanguage) {
+	return {
+		bash: "Bash",
+		javascript: "JavaScript",
+		json: "JSON",
+		plain: "plain text",
+		python: "Python",
+	}[language];
+}
+
+function languageExtension(language: CodeEditorLanguage): Extension | null {
+	switch (language) {
+		case "bash":
+			return StreamLanguage.define(shell);
+		case "javascript":
+			return javascript({ jsx: true, typescript: true });
+		case "json":
+			return json();
+		case "python":
+			return python();
+		case "plain":
+			return null;
+	}
+}
 
 export function CodeEditor({
 	id,
@@ -111,7 +153,8 @@ export function CodeEditor({
 				if (update.docChanged) onChangeRef.current(update.state.doc.toString());
 			}),
 		];
-		if (language === "json") items.push(json());
+		const languageSupport = languageExtension(language);
+		if (languageSupport) items.push(languageSupport);
 		if (placeholderText) items.push(placeholder(placeholderText));
 		return items;
 	}, [language, placeholderText]);


### PR DESCRIPTION
## Purpose / Description
Make skill script submission use the same editor-quality input as MCP config paste. Script authors can paste or type scripts with syntax highlighting and editor behavior, while the UI detects the language from the script filename.

## Fixes
No linked issue.

## Approach
- Reused the shared CodeMirror `CodeEditor` component for skill script content.
- Added filename-based language detection helpers to the editor module.
- Detects Bash, Python, JavaScript, JSON, and falls back to plain text.
- Shows the detected language in the script field label.
- Added language packages for JavaScript, Python, and shell highlighting.

## How Has This Been Tested?

Ran these checks from the repository root:

```bash
pnpm -C web typecheck
pnpm -C web lint
pnpm -C web build
```

All passed. The Vite build still reports existing large chunk warnings.
<img width="1564" height="1000" alt="image" src="https://github.com/user-attachments/assets/c3caeeee-cb95-4dc5-9b36-6b7a232cd07d" />

## Learning (optional, can help others)
Reusing the existing CodeMirror component keeps MCP config and skill script editing consistent. Filename detection avoids adding a manual language picker while still covering the common script extensions.

References:
- https://codemirror.net/
- https://codemirror.net/docs/ref/

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)


## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| @codemirror/lang-javascript | CodeMirror JavaScript and TypeScript language support | [MIT License](https://github.com/codemirror/lang-javascript/blob/main/LICENSE) |
| @codemirror/lang-python | CodeMirror Python language support | [MIT License](https://github.com/codemirror/lang-python/blob/main/LICENSE) |
| @codemirror/legacy-modes | CodeMirror legacy language modes, used for shell scripts | [MIT License](https://github.com/codemirror/legacy-modes/blob/main/LICENSE) |

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
