### PR TITLE
fix: hide deleted agents from leaderboards

### DIFF
--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -34,6 +34,7 @@ from schemas.agent import (
     AgentSummary,
     AgentUpdateRequest,
 )
+from services.cache import invalidate_namespace
 from services.config_generator import validate_mcp_command
 from services.harness_capability_inference import compute_supported_harnesses, infer_required_features
 from services.registry_telemetry import emit_registry_event
@@ -744,6 +745,7 @@ async def delete_agent(
 
     agent.deleted_at = datetime.now(UTC)
     await db.commit()
+    await invalidate_namespace("dashboard")
 
     emit_registry_event(
         action="agent.delete",
@@ -792,6 +794,7 @@ async def restore_deleted_agent(
     agent.name = restore_name
     agent.deleted_at = None
     await db.commit()
+    await invalidate_namespace("dashboard")
 
     emit_registry_event(
         action="agent.restore",

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -111,7 +111,7 @@ async def overview_stats(
     total_agents_coro = db.scalar(
         select(func.count(Agent.id))
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
-        .where(AgentVersion.status == AgentStatus.approved)
+        .where(AgentVersion.status == AgentStatus.approved, Agent.deleted_at.is_(None))
     )
     total_users_coro = db.scalar(select(func.count(User.id)))
     tool_rows_coro = _ch_json(
@@ -171,7 +171,7 @@ async def top_agents(
         )
         .join(Agent, AgentDownloadRecord.agent_id == Agent.id)
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
-        .where(AgentVersion.status == AgentStatus.approved)
+        .where(AgentVersion.status == AgentStatus.approved, Agent.deleted_at.is_(None))
         .group_by(AgentDownloadRecord.agent_id, Agent.name, AgentVersion.description, Agent.owner, AgentVersion.version)
         .order_by(func.count(AgentDownloadRecord.id).desc())
         .limit(limit)
@@ -224,7 +224,7 @@ async def agent_leaderboard(
         )
         .join(Agent, AgentDownloadRecord.agent_id == Agent.id)
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
-        .where(AgentVersion.status == AgentStatus.approved)
+        .where(AgentVersion.status == AgentStatus.approved, Agent.deleted_at.is_(None))
     )
     if user:
         stmt = stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{escape_like(user)}%"))
@@ -268,7 +268,11 @@ async def agent_leaderboard(
         extra_stmt = (
             select(Agent)
             .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
-            .where(AgentVersion.status == AgentStatus.approved, Agent.id.notin_(existing_ids))
+            .where(
+                AgentVersion.status == AgentStatus.approved,
+                Agent.deleted_at.is_(None),
+                Agent.id.notin_(existing_ids),
+            )
         )
         if user:
             extra_stmt = extra_stmt.join(User, Agent.created_by == User.id).where(
@@ -354,7 +358,11 @@ async def component_leaderboard(
             .join(AgentDownloadRecord, AgentDownloadRecord.agent_id == Agent.id)
             .join(listing_model, AgentComponent.component_id == listing_model.id)
             .join(version_model, listing_model.latest_version_id == version_model.id)
-            .where(AgentComponent.component_type == type_label, version_model.status == ListingStatus.approved)
+            .where(
+                AgentComponent.component_type == type_label,
+                version_model.status == ListingStatus.approved,
+                Agent.deleted_at.is_(None),
+            )
         )
         if user:
             stmt = stmt.join(User, listing_model.submitted_by == User.id).where(

--- a/tests/test_dashboard_leaderboard.py
+++ b/tests/test_dashboard_leaderboard.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+from api.routes.dashboard import agent_leaderboard, component_leaderboard, top_agents
+
+
+class _EmptyResult:
+    def all(self):
+        return []
+
+    def scalars(self):
+        return self
+
+
+class _CaptureDb:
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        return _EmptyResult()
+
+
+def _sql(stmt) -> str:
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+
+async def test_agent_leaderboard_excludes_deleted_agents():
+    db = _CaptureDb()
+
+    await agent_leaderboard.__wrapped__(window="all", limit=20, user=None, db=db)
+
+    assert db.statements
+    assert all("agents.deleted_at IS NULL" in _sql(stmt) for stmt in db.statements)
+
+
+async def test_top_agents_excludes_deleted_agents():
+    db = _CaptureDb()
+
+    await top_agents.__wrapped__(limit=6, db=db)
+
+    assert db.statements
+    assert "agents.deleted_at IS NULL" in _sql(db.statements[0])
+
+
+async def test_component_leaderboard_ignores_downloads_from_deleted_agents():
+    db = _CaptureDb()
+
+    await component_leaderboard.__wrapped__(window="all", limit=20, user=None, db=db)
+
+    download_queries = [stmt for stmt in db.statements if "agent_download_records" in _sql(stmt)]
+    assert len(download_queries) == 5
+    assert all("agents.deleted_at IS NULL" in _sql(stmt) for stmt in download_queries)


### PR DESCRIPTION
## Purpose / Description
Deleted agents could remain visible on leaderboard surfaces because dashboard queries only checked the latest version status. Clicking those entries led to a 404 because detail routes correctly hide soft-deleted agents.

## Fixes
No issue linked.

## Approach
Filter soft-deleted agents out of dashboard agent counts, top agents, leaderboard rows, zero-download leaderboard backfill, and component leaderboard download attribution. Invalidate the dashboard cache when an agent is deleted or restored so stale leaderboard entries are cleared.

## How Has This Been Tested?
Before:
<img width="1284" height="290" alt="image" src="https://github.com/user-attachments/assets/32237e16-d1cb-48ff-80b1-44e0fc7abb65" />

After:
<img width="1282" height="230" alt="image" src="https://github.com/user-attachments/assets/dab38f37-fff7-405a-890a-148e0b885ca7" />
## Learning (optional, can help others)
The root cause was missing `Agent.deleted_at.is_(None)` filters in dashboard queries. Existing agent detail lookup already excludes deleted agents, which is why leaderboard links returned 404.

No external resources were used.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. Not applicable: no hard-to-understand code added.
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). 

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
