### PR TITLE
fix(cli): remove ops overview command

### DIFF
--- a/docs/cli/ops.md
+++ b/docs/cli/ops.md
@@ -9,26 +9,14 @@ Operational and observability commands: dashboards, traces, spans, metrics, feed
 
 | Command | Description |
 | --- | --- |
-| [`ops overview`](#observal-ops-overview) | Dashboard summary stats |
 | [`ops metrics`](#observal-ops-metrics) | Metrics for one MCP or agent |
 | [`ops top`](#observal-ops-top) | Top items by usage |
 | [`ops traces`](#observal-ops-traces) | List recent traces |
 | [`ops spans`](#observal-ops-spans) | Spans for one trace |
 | [`ops rate`](#observal-ops-rate) | Rate an MCP or agent (1–5 stars) |
 | [`ops feedback`](#observal-ops-feedback) | View feedback for an MCP or agent |
-| [`ops sync`](#observal-ops-sync) | Flush locally buffered telemetry |
 | [`ops telemetry status`](#observal-ops-telemetry-status) | Telemetry pipeline status |
 | [`ops telemetry test`](#observal-ops-telemetry-test) | Send a test telemetry event |
-
----
-
-## `observal ops overview`
-
-Summary stats across your server: total traces, active agents, error rate, top MCPs.
-
-```bash
-observal ops overview
-```
 
 ---
 
@@ -114,18 +102,6 @@ View aggregate feedback (average stars, comments).
 ```bash
 observal ops feedback <id-or-name> [--type mcp|agent]
 ```
-
----
-
-## `observal ops sync`
-
-Flush the local telemetry buffer. When the Observal server is unreachable, hook events accumulate in `~/.observal/telemetry_buffer.db`. This command sends them in batches.
-
-```bash
-observal ops sync
-```
-
-Auto-flush also happens on the next successful CLI invocation, so you rarely need to run this manually.
 
 ---
 

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -96,11 +96,7 @@ observal auth status
 observal ops telemetry status
 ```
 
-Flush manually:
-
-```bash
-observal ops sync
-```
+Flush happens automatically the next time the server is reachable.
 
 ## Deployment mode
 

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -108,7 +108,7 @@ If you're restoring from backup after a catastrophic failure:
 3. Restore `pgdata` (Postgres).
 4. Restore `chdata` (ClickHouse).
 5. Bring up the stack: `docker compose up -d`.
-6. Smoke test: `observal auth login`, `observal ops overview`.
+6. Smoke test: `observal auth login`, `observal auth status`.
 
 Skipping step 2 works but every user has to re-login.
 

--- a/docs/self-hosting/docker-compose.md
+++ b/docs/self-hosting/docker-compose.md
@@ -103,7 +103,6 @@ The CLI detects that no users exist and interactively creates the first admin. T
 observal auth whoami
 observal auth status
 
-observal ops overview              # summary dashboard
 observal registry mcp list         # empty list - you haven't added anything yet
 ```
 

--- a/docs/self-hosting/telemetry-pipeline.md
+++ b/docs/self-hosting/telemetry-pipeline.md
@@ -70,7 +70,7 @@ Operational knobs:
 
 - **Server address**: `OBSERVAL_SERVER_URL` on the CLI user's machine. The shim picks this up from `~/.observal/config.json` or the env var.
 - **API key**: the shim uses the user's stored credentials. No extra setup.
-- **Offline behavior**: if the server is unreachable, telemetry is buffered at `~/.observal/telemetry_buffer.db` and flushed later. Flush manually with `observal ops sync`. Check the buffer size with `observal auth status`.
+- **Offline behavior**: if the server is unreachable, telemetry is buffered at `~/.observal/telemetry_buffer.db` and flushed later. Check the buffer size with `observal auth status`.
 
 ## High-volume tuning
 

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -116,13 +116,10 @@ Run through, in order:
 # 1. Are traces arriving at all?
 observal ops telemetry status
 
-# 2. Is the telemetry buffer flushing?
-observal ops sync
-
-# 3. Is the shim wired in?
+# 2. Is the shim wired in?
 observal doctor --harness <harness>
 
-# 4. Is the API reachable from where the shim runs?
+# 3. Is the API reachable from where the shim runs?
 curl http://localhost/health
 ```
 

--- a/docs/use-cases/team-registry.md
+++ b/docs/use-cases/team-registry.md
@@ -108,7 +108,6 @@ Because every engineer's shim streams into the same server, `observal ops` becom
 ```bash
 observal ops top --type agent           # most-used agents across the team
 observal ops top --type mcp             # hottest MCP servers
-observal ops overview                   # summary stats
 ```
 
 Filters in the web UI let you slice by user, agent, harness, and time range.

--- a/observal_cli/README.md
+++ b/observal_cli/README.md
@@ -79,7 +79,6 @@ observal ops review approve <id>   # approve
 observal ops review reject <id> --reason "..."  # reject
 observal ops telemetry status      # check telemetry flow
 observal ops telemetry test        # send a test event
-observal ops overview              # system-wide stats
 observal ops metrics <id>          # metrics for an MCP or agent
 ```
 

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -328,36 +328,6 @@ def telemetry_test():
     rprint(f"[green]✓ Test event sent![/green] Ingested: {result.get('ingested', 0)}")
 
 
-# ── Dashboard (on ops_app) ──────────────────────────────
-
-
-@ops_app.command(name="overview")
-def _overview(output: str = typer.Option("table", "--output", "-o")):
-    """Show enterprise overview stats.
-
-    Displays high-level platform totals: MCP servers, agents, users,
-    tool calls, and agent interactions.
-
-    Examples:
-
-        observal ops overview
-
-        observal ops overview --output json
-    """
-    with spinner("Loading overview..."):
-        data = client.get("/api/v1/overview/stats")
-    if output == "json":
-        output_json(data)
-        return
-    rprint()
-    rprint(f"  [bold cyan]MCP Servers[/bold cyan]     {data.get('total_mcps', 0)}")
-    rprint(f"  [bold magenta]Agents[/bold magenta]          {data.get('total_agents', 0)}")
-    rprint(f"  [bold]Users[/bold]           {data.get('total_users', 0)}")
-    rprint(f"  [bold green]Tool calls[/bold green]      {data.get('total_tool_calls', 0)}")
-    rprint(f"  [bold yellow]Interactions[/bold yellow]    {data.get('total_agent_interactions', 0)}")
-    rprint()
-
-
 @ops_app.command(name="metrics")
 def _metrics(
     item_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),

--- a/observal_cli/cmd_reconcile.py
+++ b/observal_cli/cmd_reconcile.py
@@ -8,8 +8,7 @@
 
 Two responsibilities:
 1. Discovery helpers (_find_claude_sessions_dir, _find_recent_sessions,
-   _find_session_file, _parse_session_file) used by the reconcile pipeline
-   and the `observal ops overview` command.
+   _find_session_file, _parse_session_file) used by the reconcile pipeline.
 2. Crash recovery: on the next UserPromptSubmit hook after a session was
    killed before its Stop hook fired, this module detects the stale cursor
    and pushes the remaining JSONL lines so no turns are lost.

--- a/observal_cli/skills/observal-ops/SKILL.md
+++ b/observal_cli/skills/observal-ops/SKILL.md
@@ -21,7 +21,6 @@ owner: observal
 ## Procedure: Observe
 
 ```bash
-observal ops overview --output json
 observal ops metrics ITEM_NAME --type agent --output json
 observal ops metrics ITEM_NAME --type mcp --watch
 observal ops top --type agent --output json

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -102,7 +102,6 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal ops telemetry test`: Send a test telemetry event.
   - `observal ops feedback`: Show feedback for an MCP server or agent.
   - `observal ops metrics`: Show metrics for an MCP server or agent.
-  - `observal ops overview`: Show enterprise overview stats.
   - `observal ops rate`: Rate an MCP server, agent, or component.
   - `observal ops rate-delete`: Delete your review for an item.
   - `observal ops rate-update`: Update your existing review for an item.


### PR DESCRIPTION
## Purpose / Description
Remove the useless `observal ops overview` CLI command and clear stale docs and bundled skill references that pointed users at unavailable ops commands.

## Fixes
No issue linked.

## Approach
- Deleted the `ops overview` Typer command.
- Removed docs references to `observal ops overview`.
- Removed stale `observal ops sync` docs references while touching the same ops docs.
- Regenerated the bundled Observal command reference.

## How Has This Been Tested?

Ran:

```bash
observal ops --help
observal ops overview --help
rg 'ops overview|observal ops overview|overview --output|Show enterprise overview stats|Dashboard summary stats|Dashboard overview stats' README.md SETUP.md docs observal_cli/README.md observal_cli/skills observal_cli/cmd_*.py tests --glob '!**/*.log'
uv run ruff check observal_cli/cmd_ops.py observal_cli/cmd_reconcile.py
uv run pytest tests/test_observal_skill.py tests/test_observal_skill_sync.py -q
```

Results:
- `observal ops --help` no longer lists `overview`.
- `observal ops overview --help` returns `No such command 'overview'`.
- Ripgrep finds no stale command refs.
- Ruff passed.
- Skill tests passed, 15 passed.

## Learning (optional, can help others)
No external research needed. This was a CLI and docs cleanup.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. No new complex code was added.
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). No UI changes.

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
