### PR TITLE
fix(exec): cache management insights

### DIFF
--- a/ee/observal_server/routes/exec_dashboard.py
+++ b/ee/observal_server/routes/exec_dashboard.py
@@ -4,14 +4,15 @@
 
 """Executive Dashboard API endpoints."""
 
+import json
 import uuid
 from datetime import UTC, timedelta
 from datetime import datetime as dt
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi_cache.decorator import cache
 from pydantic import BaseModel
+from redis.exceptions import RedisError
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,6 +24,7 @@ from models.exec_config import ExecDashboardConfig
 from models.feedback import Feedback
 from models.user import User, UserRole
 from models.user_group import UserGroup
+from services.redis import get_redis
 
 logger = structlog.get_logger(__name__)
 
@@ -1886,19 +1888,54 @@ class AIInsightsResponse(BaseModel):
     automation_opportunity: dict
     usage_pattern: dict
     generated: bool
+    generated_at: str | None = None
+
+
+def _ai_insights_cache_key(current_user: User) -> str:
+    owner_id = current_user.org_id or current_user.id
+    return f"exec.ai_insights.{owner_id}"
+
+
+def _empty_ai_insights_response() -> AIInsightsResponse:
+    detail = "Generate an executive insight report to see LLM-powered strategic recommendations."
+    return AIInsightsResponse(
+        quick_wins=[],
+        adoption_gaps=[],
+        platform_insight={"title": "No cached report", "detail": detail},
+        model_insight={"title": "No cached report", "detail": detail},
+        automation_opportunity={"title": "No cached report", "detail": detail},
+        usage_pattern={"title": "No cached report", "detail": detail},
+        generated=False,
+    )
 
 
 @router.get("/ai-insights", response_model=AIInsightsResponse)
-@cache(expire=1800, namespace="ai-insights")
 async def get_ai_insights(
+    current_user: User = Depends(require_role(UserRole.admin)),
+):
+    """Return the cached executive AI insight report without generating a new one."""
+    try:
+        cached = await get_redis().get(_ai_insights_cache_key(current_user))
+    except RedisError as e:
+        logger.error("exec_ai_insights_cache_read_failed", error=str(e))
+        raise HTTPException(status_code=503, detail="Executive AI insights cache is unavailable") from e
+
+    if not cached:
+        return _empty_ai_insights_response()
+
+    try:
+        return AIInsightsResponse.model_validate(json.loads(cached))
+    except (json.JSONDecodeError, TypeError, ValueError) as e:
+        logger.error("exec_ai_insights_cache_invalid", error=str(e))
+        raise HTTPException(status_code=500, detail="Cached executive AI insights report is invalid") from e
+
+
+@router.post("/ai-insights", response_model=AIInsightsResponse)
+async def generate_ai_insights(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
-    """Generate LLM-powered strategic insights from org telemetry.
-
-    Collects metrics from multiple sources, sends to the eval model,
-    and returns business-language recommendations.
-    """
+    """Generate and cache LLM-powered strategic insights from org telemetry."""
     from services.strategic_insights import generate_strategic_insights
 
     org_id = current_user.org_id
@@ -2066,29 +2103,12 @@ async def get_ai_insights(
     result = await generate_strategic_insights(metrics_data)
 
     if not result:
-        return AIInsightsResponse(
-            quick_wins=[],
-            adoption_gaps=[],
-            platform_insight={
-                "title": "Insufficient data",
-                "detail": "Configure insights models in Settings to enable AI insights.",
-            },
-            model_insight={
-                "title": "Insufficient data",
-                "detail": "Configure insights models in Settings to enable AI insights.",
-            },
-            automation_opportunity={
-                "title": "Insufficient data",
-                "detail": "Configure insights models in Settings to enable AI insights.",
-            },
-            usage_pattern={
-                "title": "Insufficient data",
-                "detail": "Configure insights models in Settings to enable AI insights.",
-            },
-            generated=False,
+        raise HTTPException(
+            status_code=503,
+            detail="Insights model is not configured or failed to generate a report",
         )
 
-    return AIInsightsResponse(
+    response = AIInsightsResponse(
         quick_wins=result.get("quick_wins", []),
         adoption_gaps=result.get("adoption_gaps", []),
         platform_insight=result.get("platform_insight", {}),
@@ -2096,4 +2116,13 @@ async def get_ai_insights(
         automation_opportunity=result.get("automation_opportunity", {}),
         usage_pattern=result.get("usage_pattern", {}),
         generated=True,
+        generated_at=dt.now(UTC).isoformat(),
     )
+
+    try:
+        await get_redis().set(_ai_insights_cache_key(current_user), json.dumps(response.model_dump(mode="json")))
+    except RedisError as e:
+        logger.error("exec_ai_insights_cache_write_failed", error=str(e))
+        raise HTTPException(status_code=503, detail="Executive AI insights cache is unavailable") from e
+
+    return response

--- a/observal-server/tests/test_exec_formulas.py
+++ b/observal-server/tests/test_exec_formulas.py
@@ -108,3 +108,32 @@ class TestPeriodBounds:
     def test_none_uses_7d(self):
         cs, ce, ps, pe = _period_bounds(None)
         assert (ce - cs).days == 7
+
+
+class TestAIInsightsCacheResponse:
+    def test_empty_response_is_not_generated(self):
+        from ee.observal_server.routes.exec_dashboard import _empty_ai_insights_response
+
+        response = _empty_ai_insights_response()
+
+        assert response.generated is False
+        assert response.generated_at is None
+        assert response.platform_insight["title"] == "No cached report"
+
+    def test_legacy_cached_payload_without_generated_at_validates(self):
+        from ee.observal_server.routes.exec_dashboard import AIInsightsResponse
+
+        response = AIInsightsResponse.model_validate(
+            {
+                "quick_wins": [],
+                "adoption_gaps": [],
+                "platform_insight": {},
+                "model_insight": {},
+                "automation_opportunity": {},
+                "usage_pattern": {},
+                "generated": True,
+            }
+        )
+
+        assert response.generated is True
+        assert response.generated_at is None

--- a/web/src/hooks/use-dashboard-api.ts
+++ b/web/src/hooks/use-dashboard-api.ts
@@ -11,8 +11,11 @@
 
 
 import {
+  useMutation,
   useQuery,
+  useQueryClient,
 } from "@tanstack/react-query";
+import { toast } from "sonner";
 import {
   dashboard,
   exec,
@@ -111,5 +114,25 @@ export function useExecTimeToValue() {
 }
 
 export function useExecAIInsights() {
-  return useQuery({ queryKey: ["exec", "ai-insights"], queryFn: exec.aiInsights, staleTime: 10 * 60 * 1000 });
+  return useQuery({
+    queryKey: ["exec", "ai-insights"],
+    queryFn: exec.aiInsights,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+}
+
+export function useGenerateExecAIInsights() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: exec.generateAiInsights,
+    onSuccess: (data) => {
+      qc.setQueryData(["exec", "ai-insights"], data);
+      toast.success("Executive insight report generated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to generate executive insight report");
+    },
+  });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -979,6 +979,7 @@ export const exec = {
 	inactivityAlerts: () => get<ExecInactivityAlerts>("/exec/inactivity-alerts"),
 	timeToValue: () => get<ExecTimeToValueResponse>("/exec/time-to-value"),
 	aiInsights: () => get<ExecAIInsightsResponse>("/exec/ai-insights"),
+	generateAiInsights: () => post<ExecAIInsightsResponse>("/exec/ai-insights"),
 	config: () => get<ExecConfig | null>("/exec/config"),
 	updateConfig: (data: Partial<ExecConfig>) =>
 		put<ExecConfig>("/exec/config", data),

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -528,4 +528,5 @@ export interface ExecAIInsightsResponse {
 	automation_opportunity: { title: string; detail: string };
 	usage_pattern: { title: string; detail: string };
 	generated: boolean;
+	generated_at?: string | null;
 }

--- a/web/src/pages/admin/dashboard/components/insights-tab.tsx
+++ b/web/src/pages/admin/dashboard/components/insights-tab.tsx
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 
-import { useExecAIInsights, useExecDeveloperBreakdown } from "@/hooks/use-api";
-import { Zap, AlertTriangle, TrendingUp, Users, Cpu, Crown, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useExecAIInsights, useExecDeveloperBreakdown, useGenerateExecAIInsights } from "@/hooks/use-api";
+import { Zap, AlertTriangle, TrendingUp, Users, Cpu, Crown, Loader2, RefreshCw } from "lucide-react";
 
 const effortColors: Record<string, { bg: string; text: string; label: string }> = {
   low: { bg: "bg-emerald-500/10", text: "text-emerald-500", label: "Quick Win" },
@@ -76,6 +77,16 @@ function DeveloperBreakdown() {
 
 export function InsightsTab() {
   const { data: insights, isLoading, isError } = useExecAIInsights();
+  const generateInsights = useGenerateExecAIInsights();
+  const generatedAt = insights?.generated_at
+    ? new Date(insights.generated_at).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    })
+    : null;
 
   if (isError) {
     return (
@@ -90,8 +101,8 @@ export function InsightsTab() {
       <div className="space-y-6 pt-4">
         <div className="rounded-lg border border-border p-8 flex flex-col items-center justify-center text-center">
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground mb-3" />
-          <p className="text-sm font-medium">Generating AI Insights...</p>
-          <p className="text-xs text-muted-foreground mt-1">Analyzing your organization&apos;s telemetry data</p>
+          <p className="text-sm font-medium">Loading cached AI insights...</p>
+          <p className="text-xs text-muted-foreground mt-1">No new report is generated until you request one.</p>
         </div>
       </div>
     );
@@ -102,8 +113,20 @@ export function InsightsTab() {
       <div className="space-y-6 pt-4">
         <div className="rounded-md border border-border p-8 text-center text-muted-foreground">
           <Cpu className="h-8 w-8 mx-auto mb-3 opacity-50" />
-          <p className="text-sm font-medium mb-1">AI Insights not available</p>
-          <p className="text-xs">Configure insights models in Settings to enable LLM-powered strategic recommendations.</p>
+          <p className="text-sm font-medium mb-1">No cached AI insights report</p>
+          <p className="text-xs mb-4">Generate a report when you want fresh executive recommendations.</p>
+          <Button
+            size="sm"
+            disabled={generateInsights.isPending}
+            onClick={() => generateInsights.mutate()}
+          >
+            {generateInsights.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3.5 w-3.5" />
+            )}
+            Generate report
+          </Button>
         </div>
       </div>
     );
@@ -111,15 +134,31 @@ export function InsightsTab() {
 
   return (
     <div className="space-y-6 pt-4">
-      {/* Header */}
       <div className="rounded-lg border border-border p-5">
-        <div className="flex items-center gap-3">
-          <div className="w-2.5 h-2.5 rounded-full bg-emerald-400" />
-          <h2 className="text-base font-semibold">AI Insights</h2>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3">
+              <div className="w-2.5 h-2.5 rounded-full bg-emerald-400" />
+              <h2 className="text-base font-semibold">AI Insights</h2>
+            </div>
+            <p className="text-sm text-muted-foreground mt-1">
+              Showing the cached executive report{generatedAt ? ` generated ${generatedAt}` : ""}.
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={generateInsights.isPending}
+            onClick={() => generateInsights.mutate()}
+          >
+            {generateInsights.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3.5 w-3.5" />
+            )}
+            Generate new report
+          </Button>
         </div>
-        <p className="text-sm text-muted-foreground mt-1">
-          Strategic recommendations based on usage patterns across your organization. Updated on each refresh.
-        </p>
       </div>
 
       {/* Quick Wins */}


### PR DESCRIPTION
## Purpose / Description
Management Insights on the executive dashboard regenerated on page load, which made the UX feel uncontrolled and could replace the report without an explicit user action.

This changes executive AI insights to match agent insights: users see the cached report by default and generate a fresh report only from a button press.

## Fixes
No linked issue.

## Approach
- Split executive AI insights into read and generate paths.
- `GET /api/v1/exec/ai-insights` now returns only the cached report.
- `POST /api/v1/exec/ai-insights` now generates and caches a fresh report.
- Added generated timestamps so the UI can show which cached report is displayed.
- Updated the dashboard tab to show cached state, empty cached state, and explicit generate buttons.
- Disabled focus and reconnect refetch for this report query so viewing the tab is not treated as a refresh decision.

## How Has This Been Tested?

<img width="1293" height="615" alt="image" src="https://github.com/user-attachments/assets/8e2d1f43-9a39-4951-a198-91eb6c868272" />

## Learning (optional, can help others)
Agent insights already use an explicit generation model. The executive dashboard now follows that same interaction pattern instead of generating work during report reads.

No external references used.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)


## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
